### PR TITLE
Implement TallyResource and provide examples

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -43,7 +43,7 @@ paths:
           description: "The level of granularity to return."
         - name: beginning
           in: query
-          required: false
+          required: true
           schema:
             type: string
             format: date-time
@@ -51,7 +51,7 @@ paths:
             format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z"
         - name: ending
           in: query
-          required: false
+          required: true
           schema:
             type: string
             format: date-time

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -64,6 +64,32 @@ paths:
             application/vnd.api+json:
               schema:
                 $ref: "#/components/schemas/TallyReport"
+              example:
+                data:
+                  - date: '2017-08-04T17:32:05Z'
+                    instance_count: 5
+                    cores: 10
+                  - date: '2017-08-05T17:31:04Z'
+                    instance_count: 7
+                    cores: 14
+                  - date: '2017-08-06T17:32:03Z'
+                    instance_count: 20
+                    cores: 20
+                  - date: '2017-08-07T17:34:02Z'
+                    instance_count: 7
+                    cores: 14
+                  - date: '2017-08-08T17:32:01Z'
+                    instance_count: 5
+                    cores: 10
+                links:
+                  first: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
+                  last: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  previous: null
+                  next: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                meta:
+                  resultSetSize: 10
+                  product: RHEL
+                  granularity: DAILY
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -87,7 +87,7 @@ paths:
                   previous: null
                   next: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                 meta:
-                  resultSetSize: 10
+                  count: 10
                   product: RHEL
                   granularity: DAILY
         '400':
@@ -197,7 +197,7 @@ components:
         meta:
           type: object
           properties:
-            resultSetSize:
+            count:
               type: integer
             product:
               type: string
@@ -207,7 +207,7 @@ components:
                 seven day period."
               type: string
           required:
-            - resultSetSize
+            - count
             - product
             - granularity
     TallySnapshot:

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -69,18 +69,23 @@ paths:
                   - date: '2017-08-04T17:32:05Z'
                     instance_count: 5
                     cores: 10
+                    sockets: 5
                   - date: '2017-08-05T17:31:04Z'
                     instance_count: 7
                     cores: 14
+                    sockets: 7
                   - date: '2017-08-06T17:32:03Z'
                     instance_count: 20
                     cores: 20
+                    sockets: 10
                   - date: '2017-08-07T17:34:02Z'
                     instance_count: 7
                     cores: 14
+                    sockets: 7
                   - date: '2017-08-08T17:32:01Z'
                     instance_count: 5
                     cores: 10
+                    sockets: 5
                 links:
                   first: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
                   last: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
@@ -230,6 +235,10 @@ components:
           format: int32
           minimum: 0
         cores:
+          type: integer
+          format: int32
+          minimum: 0
+        sockets:
           type: integer
           format: int32
           minimum: 0

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -25,6 +25,8 @@ import org.candlepin.subscriptions.db.model.AccountMaxValues;
 import org.candlepin.subscriptions.db.model.TallyGranularity;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -39,10 +41,10 @@ import java.util.stream.Stream;
  * Interface that Spring Data will turn into a DAO for us.
  */
 public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UUID> {
-
-    List<TallySnapshot> findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween(
+    Page<TallySnapshot>
+        findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
         String accountNumber, String productId, TallyGranularity granularity, OffsetDateTime beginning,
-        OffsetDateTime ending);
+        OffsetDateTime ending, Pageable pageable);
 
     void deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(String accountNumber,
         TallyGranularity granularity, OffsetDateTime cutoffDate);

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -141,4 +141,14 @@ public class TallySnapshot implements Serializable {
     public void setGranularity(TallyGranularity granularity) {
         this.granularity = granularity;
     }
+
+    public org.candlepin.subscriptions.utilization.api.model.TallySnapshot asApiSnapshot() {
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot snapshot =
+            new org.candlepin.subscriptions.utilization.api.model.TallySnapshot();
+
+        snapshot.setDate(this.getSnapshotDate());
+        snapshot.setCores(this.getCores());
+        snapshot.setInstanceCount(this.getInstanceCount());
+        return snapshot;
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -148,6 +148,7 @@ public class TallySnapshot implements Serializable {
 
         snapshot.setDate(this.getSnapshotDate());
         snapshot.setCores(this.getCores());
+        snapshot.setSockets(this.getSockets());
         snapshot.setInstanceCount(this.getInstanceCount());
         return snapshot;
     }

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -20,16 +20,30 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.exception.ErrorCode;
+import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.candlepin.subscriptions.utilization.api.resources.TallyApi;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
 
 /**
  * Tally API implementation.
@@ -37,13 +51,76 @@ import javax.ws.rs.core.SecurityContext;
 @Component
 public class TallyResource implements TallyApi {
 
+    private static final Integer DEFAULT_LIMIT = 50;
+
     @Context
     SecurityContext securityContext;
 
-    @Override
-    public TallyReport getTallyReport(String productId, @NotNull String granularity, Integer offset,
-        Integer limit, @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending) {
-        // TODO pull accountNumber from context
-        return null; // TODO implement
+    @Context
+    UriInfo uriInfo;
+
+    private final TallySnapshotRepository repository;
+    private final PageLinkCreator pageLinkCreator;
+
+    public TallyResource(TallySnapshotRepository repository, PageLinkCreator pageLinkCreator) {
+        this.repository = repository;
+        this.pageLinkCreator = pageLinkCreator;
     }
+
+
+    @Override
+    public TallyReport getTallyReport(String productId, @NotNull String granularity,
+        @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset, Integer limit) {
+
+        if (limit == null) {
+            limit = DEFAULT_LIMIT;
+        }
+
+        if (offset == null) {
+            offset = 0;
+        }
+
+        if (offset % limit != 0) {
+            throw new SubscriptionsException(
+                ErrorCode.VALIDATION_FAILED_ERROR,
+                Response.Status.BAD_REQUEST,
+                "Offset must be divisible by limit",
+                "Arbitrary offsets are not currently supported by this API"
+            );
+        }
+
+        Pageable pageable = PageRequest.of(offset / limit, limit);
+
+        String accountNumber = getAccountNumber();
+        TallyGranularity granularityValue = TallyGranularity.valueOf(granularity.toUpperCase());
+        Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+
+            accountNumber,
+            productId,
+            granularityValue,
+            beginning,
+            ending,
+            pageable);
+
+        List<TallySnapshot> snapshots = snapshotPage
+            .stream()
+            .map(org.candlepin.subscriptions.db.model.TallySnapshot::asApiSnapshot)
+            .collect(Collectors.toList());
+
+        TallyReport report = new TallyReport();
+        report.setData(snapshots);
+        report.setLinks(pageLinkCreator.getPaginationLinks(uriInfo, snapshotPage));
+        report.setMeta(new TallyReportMeta());
+        report.getMeta().setGranularity(granularity);
+        report.getMeta().setProduct(productId);
+        report.getMeta().setCount((int) snapshotPage.getTotalElements());
+
+        return report;
+    }
+
+    private String getAccountNumber() {
+        return securityContext.getUserPrincipal().getName();
+    }
+
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -42,7 +42,7 @@ public class TallyResource implements TallyApi {
 
     @Override
     public TallyReport getTallyReport(String productId, @NotNull String granularity, Integer offset,
-        Integer limit, OffsetDateTime beginning, OffsetDateTime ending) {
+        Integer limit, @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending) {
         // TODO pull accountNumber from context
         return null; // TODO implement
     }

--- a/src/main/java/org/candlepin/subscriptions/resteasy/OffsetDateTimeParamConverterProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/OffsetDateTimeParamConverterProvider.java
@@ -20,15 +20,12 @@
  */
 package org.candlepin.subscriptions.resteasy;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
@@ -41,16 +38,10 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class OffsetDateTimeParamConverterProvider implements ParamConverterProvider {
 
-    private final ObjectMapper mapper;
-
-    public OffsetDateTimeParamConverterProvider(ObjectMapper mapper) {
-        this.mapper = mapper;
-    }
-
     @Override
     public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
         if (rawType.isAssignableFrom(OffsetDateTime.class)) {
-            return (ParamConverter<T>) new OffsetDateTimeParamConverter(mapper);
+            return (ParamConverter<T>) new OffsetDateTimeParamConverter();
         }
         return null;
     }
@@ -60,30 +51,22 @@ public class OffsetDateTimeParamConverterProvider implements ParamConverterProvi
      */
     public static class OffsetDateTimeParamConverter implements ParamConverter<OffsetDateTime> {
 
-        private final ObjectMapper mapper;
-
-        public OffsetDateTimeParamConverter(ObjectMapper mapper) {
-            this.mapper = mapper;
-        }
-
         @Override
         public OffsetDateTime fromString(String value) {
-            try {
-                return mapper.readValue(value, OffsetDateTime.class);
+            if (value == null) {
+                return null;
             }
-            catch (IOException e) {
+            try {
+                return OffsetDateTime.parse(value);
+            }
+            catch (DateTimeParseException e) {
                 throw new IllegalArgumentException(e);
             }
         }
 
         @Override
         public String toString(OffsetDateTime value) {
-            try {
-                return mapper.writeValueAsString(value);
-            }
-            catch (JsonProcessingException e) {
-                throw new IllegalArgumentException(e);
-            }
+            return value.toString();
         }
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/resteasy/OffsetDateTimeParamConverterProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/OffsetDateTimeParamConverterProvider.java
@@ -66,6 +66,9 @@ public class OffsetDateTimeParamConverterProvider implements ParamConverterProvi
 
         @Override
         public String toString(OffsetDateTime value) {
+            if (value == null) {
+                return null;
+            }
             return value.toString();
         }
     }

--- a/src/main/java/org/candlepin/subscriptions/resteasy/PageLinkCreator.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/PageLinkCreator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resteasy;
+
+import org.candlepin.subscriptions.exception.ErrorCode;
+import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportLinks;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * Utility to create page links for paginated APIs.
+ */
+@Component
+public class PageLinkCreator {
+
+    /**
+     * Create a Links object with first, last, previous, next API links.
+     *
+     * @param uriInfo pre-existing URI to be used as a template for the page links
+     * @param page Spring Data JPA page object
+     *
+     * @return a populate TallyReportLinks object
+     */
+    public TallyReportLinks getPaginationLinks(UriInfo uriInfo, Page page) {
+        TallyReportLinks links = new TallyReportLinks();
+        if (page.previousPageable() != Pageable.unpaged()) {
+            links.setPrevious(formatUri(uriWithOffset(uriInfo, page.previousPageable().getOffset())));
+        }
+        if (page.nextPageable() != Pageable.unpaged()) {
+            links.setNext(formatUri(uriWithOffset(uriInfo, page.nextPageable().getOffset())));
+        }
+        links.setFirst(formatUri(uriWithOffset(uriInfo, 0)));
+        int lastPage = page.getTotalPages() - 1;
+        if (lastPage < 0) {
+            lastPage = 0;
+        }
+        int lastOffset =
+            (int) PageRequest.of(lastPage, page.getPageable().getPageSize()).getOffset();
+        links.setLast(formatUri(uriWithOffset(uriInfo, lastOffset)));
+        return links;
+    }
+
+    private URI uriWithOffset(UriInfo uriInfo, long newOffset) {
+        return uriInfo.getRequestUriBuilder().replaceQueryParam("offset", newOffset).build();
+    }
+
+    private String formatUri(URI uri) {
+        try {
+            URI serverUri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), "/",
+                null, null);
+            return String.format("/%s", serverUri.relativize(uri).toString());
+        }
+        catch (URISyntaxException e) {
+            throw new SubscriptionsException(
+                ErrorCode.REQUEST_PROCESSING_ERROR,
+                Response.Status.INTERNAL_SERVER_ERROR,
+                "Unable to format URI",
+                e
+            );
+        }
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -31,6 +31,7 @@ import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,13 +74,14 @@ public class TallySnapshotRepositoryTest {
         repository.flush();
 
         List<TallySnapshot> found = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween(
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
             "Bugs",
             "Bunny",
             TallyGranularity.DAILY,
             LONG_AGO,
-            FAR_FUTURE
-        );
+            FAR_FUTURE,
+            PageRequest.of(0, 10)
+        ).stream().collect(Collectors.toList());
         assertEquals(1, found.size());
         TallySnapshot snapshot = found.get(0);
         assertEquals(9999, (int) snapshot.getCores());

--- a/src/test/java/org/candlepin/subscriptions/resteasy/IdentityHeaderAuthFilterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/IdentityHeaderAuthFilterTest.java
@@ -64,7 +64,7 @@ public class IdentityHeaderAuthFilterTest {
         Mockito.when(requestContext.getHeaderString("x-rh-identity")).thenReturn(mockHeader);
         Mockito.when(requestContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockUriInfo.getMatchedResources()).thenReturn(
-            Collections.singletonList(new TallyResource()));
+            Collections.singletonList(new TallyResource(null, null)));
         filter.filter(requestContext);
         ArgumentCaptor<SecurityContext> securityContextArgument =
             ArgumentCaptor.forClass(SecurityContext.class);
@@ -81,7 +81,7 @@ public class IdentityHeaderAuthFilterTest {
         Mockito.when(requestContext.getHeaderString("x-rh-identity")).thenReturn(null);
         Mockito.when(requestContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockUriInfo.getMatchedResources()).thenReturn(
-            Collections.singletonList(new TallyResource()));
+            Collections.singletonList(new TallyResource(null, null)));
         SubscriptionsException e = assertThrows(SubscriptionsException.class,
             () -> filter.filter(requestContext));
         assertEquals(Response.Status.UNAUTHORIZED, e.getStatus());

--- a/src/test/java/org/candlepin/subscriptions/resteasy/PageLinkCreatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/PageLinkCreatorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resteasy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.subscriptions.utilization.api.model.TallyReportLinks;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import org.jboss.resteasy.specimpl.ResteasyUriBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import javax.ws.rs.core.UriInfo;
+
+@ExtendWith(MockitoExtension.class)
+class PageLinkCreatorTest {
+    @Mock
+    UriInfo uriInfo;
+
+    @BeforeEach
+    void setupUriInfo() {
+        Mockito.when(uriInfo.getRequestUriBuilder()).thenReturn(new ResteasyUriBuilder());
+    }
+
+    @Test
+    void testNoResultsOffsets() {
+        Pageable pageable = PageRequest.of(0, 50);
+        Page<TallySnapshot> page = new PageImpl<>(Collections.emptyList(), pageable, 0);
+        TallyReportLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
+        assertEquals("/?offset=0", links.getFirst());
+        assertEquals("/?offset=0", links.getLast());
+        assertNull(links.getPrevious());
+        assertNull(links.getNext());
+    }
+
+    @Test
+    void testPagingWorksFromFirstPage() {
+        Pageable pageable = PageRequest.of(0, 1);
+        Page<TallySnapshot> page = new PageImpl<>(Arrays.asList(new TallySnapshot(), new TallySnapshot(),
+            new TallySnapshot()), pageable, 3);
+        TallyReportLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
+        assertEquals("/?offset=0", links.getFirst());
+        assertEquals("/?offset=2", links.getLast());
+        assertNull(links.getPrevious());
+        assertEquals("/?offset=1", links.getNext());
+    }
+
+    @Test
+    void testPagingWorksFromLastPage() {
+        Pageable pageable = PageRequest.of(2, 1);
+        Page<TallySnapshot> page = new PageImpl<>(Arrays.asList(new TallySnapshot(), new TallySnapshot(),
+            new TallySnapshot()), pageable, 3);
+        TallyReportLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
+        assertEquals("/?offset=0", links.getFirst());
+        assertEquals("/?offset=2", links.getLast());
+        assertEquals("/?offset=1", links.getPrevious());
+        assertNull(links.getNext());
+    }
+
+    @Test
+    void testPagingWorksFromMiddlePage() {
+        Pageable pageable = PageRequest.of(1, 1);
+        Page<TallySnapshot> page = new PageImpl<>(Arrays.asList(new TallySnapshot(), new TallySnapshot(),
+            new TallySnapshot()), pageable, 3);
+        TallyReportLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
+        assertEquals("/?offset=0", links.getFirst());
+        assertEquals("/?offset=2", links.getLast());
+        assertEquals("/?offset=0", links.getPrevious());
+        assertEquals("/?offset=2", links.getNext());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -81,9 +82,10 @@ public class MonthlySnapshotRollerTest {
 
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> monthlySnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
+        List<TallySnapshot> monthlySnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, monthlySnaps.size());
 
         TallySnapshot result = monthlySnaps.get(0);
@@ -108,9 +110,10 @@ public class MonthlySnapshotRollerTest {
 
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> monthlySnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
+        List<TallySnapshot> monthlySnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, monthlySnaps.size());
         TallySnapshot monthlyToBeUpdated = monthlySnaps.get(0);
 
@@ -126,9 +129,10 @@ public class MonthlySnapshotRollerTest {
 
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> updatedMonthlySnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
+        List<TallySnapshot> updatedMonthlySnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedMonthlySnaps.size());
 
         TallySnapshot updated = updatedMonthlySnaps.get(0);

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +42,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 
@@ -72,10 +74,10 @@ public class QuarterlySnapshotRollerTest {
         setupYearsWorthOfMonthlySnaps("A1", clock.now().plusYears(1));
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> quarterlySnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+        List<TallySnapshot> quarterlySnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, TallyGranularity.QUARTERLY, clock.startOfCurrentQuarter(),
-            clock.endOfCurrentQuarter());
+            clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, quarterlySnaps.size());
 
         TallySnapshot secondQuarter = quarterlySnaps.get(0);
@@ -93,10 +95,10 @@ public class QuarterlySnapshotRollerTest {
         setupYearsWorthOfMonthlySnaps("A1", clock.now().plusYears(1));
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> originalSnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+        List<TallySnapshot> originalSnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, TallyGranularity.QUARTERLY, clock.startOfCurrentQuarter(),
-            clock.endOfCurrentQuarter());
+            clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
 
         TallySnapshot toUpdate = originalSnaps.get(0);
@@ -115,10 +117,10 @@ public class QuarterlySnapshotRollerTest {
         roller.rollSnapshots(Arrays.asList("A1"));
 
         // Check the yearly again. Should still be a single instance, but have updated values.
-        List<TallySnapshot> updatedSnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+        List<TallySnapshot> updatedSnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, TallyGranularity.QUARTERLY, clock.startOfCurrentQuarter(),
-            clock.endOfCurrentQuarter());
+            clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
 
         TallySnapshot updated = updatedSnaps.get(0);

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +42,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @SpringBootTest
@@ -71,9 +73,10 @@ public class WeeklySnapshotRollerTest {
 
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> weeklySnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
+        List<TallySnapshot> weeklySnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, weeklySnaps.size());
 
         TallySnapshot result = weeklySnaps.get(0);
@@ -94,9 +97,10 @@ public class WeeklySnapshotRollerTest {
 
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> weeklySnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
+        List<TallySnapshot> weeklySnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, weeklySnaps.size());
         TallySnapshot result = weeklySnaps.get(0);
         assertEquals("A1", result.getAccountNumber());
@@ -116,9 +120,10 @@ public class WeeklySnapshotRollerTest {
         roller.rollSnapshots(Arrays.asList("A1"));
 
         // Check the weekly again. Should still be a single instance, but have updated values.
-        List<TallySnapshot> updatedWeeklySnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
+        List<TallySnapshot> updatedWeeklySnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedWeeklySnaps.size());
 
         TallySnapshot updated = updatedWeeklySnaps.get(0);

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +42,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @SpringBootTest
@@ -71,9 +73,10 @@ public class YearlySnapshotRollerTest {
         setupYearsWorthOfMonthlySnaps("A1", clock.now().plusYears(1));
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> yearlySnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear());
+        List<TallySnapshot> yearlySnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, yearlySnaps.size());
 
         TallySnapshot result = yearlySnaps.get(0);
@@ -91,9 +94,10 @@ public class YearlySnapshotRollerTest {
         setupYearsWorthOfMonthlySnaps("A1", clock.now().plusYears(1));
         roller.rollSnapshots(Arrays.asList("A1"));
 
-        List<TallySnapshot> originalSnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear());
+        List<TallySnapshot> originalSnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
 
         TallySnapshot toUpdate = originalSnaps.get(0);
@@ -112,9 +116,10 @@ public class YearlySnapshotRollerTest {
         roller.rollSnapshots(Arrays.asList("A1"));
 
         // Check the yearly again. Should still be a single instance, but have updated values.
-        List<TallySnapshot> updatedSnaps =
-            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
-            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear());
+        List<TallySnapshot> updatedSnaps = repository
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
+            PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
 
         TallySnapshot updated = updatedSnaps.get(0);


### PR DESCRIPTION
This PR does several things:
 1) Adds example output to the OpenAPI spec.
 2) Implements the resource using the repository.
 3) Makes beginning and ending required in the API.
 4) Fixes date parsing.

I'm going to work on some sample data and some Ansible scripts to get those deployed in the C-I environment in our deploy repo.

I could be convinced to split this into smaller PRs if desired.