### PR TITLE
Add pagination information; remove account number from API.

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -12,21 +12,25 @@ servers:
   - url: https://cloud.redhat.com/api/rhsm-subscriptions/v1
 
 paths:
-  /tally/accounts/{account_number}/products/{product_id}:
+  /tally/products/{product_id}:
     description: "Operations for a tally report of a specific account and product."
     parameters:
-      - name: account_number
-        in: path
-        required: true
-        schema:
-          type: string
-        description: "Account number to fetch data for. Must match the authenticated account number."
       - name: product_id
         in: path
         required: true
         schema:
           type: string
         description: "The ID for the product we wish to query"
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: "The number of items to skip before starting to collect the result set"
+      - name: limit
+        in: query
+        schema:
+          type: integer
+        description: "The numbers of items to return"
     get:
       summary: "Fetch a tally report for an account and product."
       operationId: getTallyReport
@@ -138,22 +142,48 @@ components:
         application/vnd.api+json:
           schema:
             $ref: "#/components/schemas/Errors"
-
   schemas:
+    # If we need additional responses, look at
+    # https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/ to reduce
+    # redundancy
     TallyReport:
       properties:
-        product:
-          type: string
-        granularity:
-          description: "Describes the significance of each date in the TallySnapshot list. For example if the
-            granularity is set to 'weekly', the dates in the TallySnapshot list will represent the start of a
-            seven day period."
-          type: string
-        tally_snapshots:
+        data:
           type: array
           items:
             $ref: "#/components/schemas/TallySnapshot"
-
+        links:
+          type: object
+          properties:
+            first:
+              type: string
+            last:
+              type: string
+            previous:
+              type: string
+            next:
+              type: string
+          required:
+            - first
+            - previous
+            - last
+            - next
+        meta:
+          type: object
+          properties:
+            resultSetSize:
+              type: integer
+            product:
+              type: string
+            granularity:
+              description: "Describes the significance of each date in the TallySnapshot list. For example if the
+                granularity is set to 'weekly', the dates in the TallySnapshot list will represent the start of a
+                seven day period."
+              type: string
+          required:
+            - resultSetSize
+            - product
+            - granularity
     TallySnapshot:
       # Container for fields we capture from the IT endpoint for upload to inventory service.  The element
       # being reported should be the only non-required element.  E.g. snapshots containing memory will have
@@ -177,7 +207,6 @@ components:
           type: integer
           format: int32
           minimum: 0
-
     Errors:
       required:
         - errors
@@ -186,7 +215,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Error"
-
     Error:
       required:
         - status

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -20,8 +20,6 @@
  */
 package org.candlepin.subscriptions.resource;
 
-import org.candlepin.subscriptions.exception.ErrorCode;
-import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.resources.TallyApi;
 
@@ -31,7 +29,6 @@ import java.time.OffsetDateTime;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
 /**
@@ -43,19 +40,10 @@ public class TallyResource implements TallyApi {
     @Context
     SecurityContext securityContext;
 
-    private void checkPermission(String accountNumber) {
-        String authAccountNumber = securityContext.getUserPrincipal().getName();
-        if (!accountNumber.equals(authAccountNumber)) {
-            throw new SubscriptionsException(ErrorCode.VALIDATION_FAILED_ERROR,
-                Response.Status.FORBIDDEN, "Unauthorized",
-                String.format("%s not authorized to access %s", authAccountNumber, accountNumber));
-        }
-    }
-
     @Override
-    public TallyReport getTallyReport(String accountNumber, String productId, @NotNull String granularity,
-        OffsetDateTime beginning, OffsetDateTime ending) {
-        checkPermission(accountNumber);
+    public TallyReport getTallyReport(String productId, @NotNull String granularity, Integer offset,
+        Integer limit, OffsetDateTime beginning, OffsetDateTime ending) {
+        // TODO pull accountNumber from context
         return null; // TODO implement
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -20,51 +20,11 @@
  */
 package org.candlepin.subscriptions.resource;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.candlepin.subscriptions.exception.SubscriptionsException;
-
 import org.junit.jupiter.api.Test;
 
-import java.security.Principal;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-
 public class TallyResourceTest {
-
     @Test
-    public void testAccountNumberMustMatchHeader() {
-        TallyResource resource = new TallyResource();
-        resource.securityContext = new SecurityContext() {
-
-            @Override
-            public Principal getUserPrincipal() {
-                return () -> "123456";
-            }
-
-            @Override
-            public boolean isUserInRole(String role) {
-                return false;
-            }
-
-            @Override
-            public boolean isSecure() {
-                return false;
-            }
-
-            @Override
-            public String getAuthenticationScheme() {
-                return null;
-            }
-        };
-        SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource.getTallyReport(
-            "42",
-            "product1",
-            "daily",
-            null,
-            null
-        ));
-        assertEquals(Response.Status.FORBIDDEN, e.getStatus());
+    public void testGetTallyReport() {
+        // TODO add a test
     }
 }


### PR DESCRIPTION
Insights has a standard for responses that we are supposed to follow.
That standard includes allowing for pagination in requests and returning
a block of navigation links in responses.

This commit also removes the account number as a path parameter from the
API.  The account number that is delivered via the x-rh-identity header
is the only account the API will service.