### PR TITLE
Implemented snapshot rolling

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -27,6 +27,7 @@ import org.candlepin.subscriptions.files.RhelProductListSource;
 import org.candlepin.subscriptions.jackson.ObjectMapperContextResolver;
 import org.candlepin.subscriptions.retention.TallyRetentionPolicy;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.jboss.resteasy.springboot.ResteasyAutoConfiguration;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -43,7 +44,6 @@ import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.io.IOException;
-import java.time.Clock;
 
 import javax.validation.Validator;
 
@@ -69,16 +69,14 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public Clock clock() {
-        return Clock.systemUTC();
+    public ApplicationClock applicationClock() {
+        return new ApplicationClock();
     }
 
     @Bean
     public TallyRetentionPolicy tallyRetentionPolicy(ApplicationProperties applicationProperties,
-        Clock clock) {
-
-        return new TallyRetentionPolicy(clock,
-            applicationProperties.getTallyRetentionPolicy());
+        ApplicationClock applicationClock) {
+        return new TallyRetentionPolicy(applicationClock, applicationProperties.getTallyRetentionPolicy());
     }
 
     @Bean
@@ -118,7 +116,7 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
 
     @Bean
     public FactNormalizer factNormalizer(ApplicationProperties applicationProperties,
-        RhelProductListSource prodListSource, Clock clock) throws IOException {
+        RhelProductListSource prodListSource, ApplicationClock clock) throws IOException {
         return new FactNormalizer(applicationProperties, prodListSource, clock);
     }
 

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -21,20 +21,25 @@
 
 package org.candlepin.subscriptions.db;
 
+import org.candlepin.subscriptions.db.model.AccountMaxValues;
 import org.candlepin.subscriptions.db.model.TallyGranularity;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * Interface that Spring Data will turn into a DAO for us.
  */
 public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UUID> {
+
     List<TallySnapshot> findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween(
         String accountNumber, String productId, TallyGranularity granularity, OffsetDateTime beginning,
         OffsetDateTime ending);
@@ -42,8 +47,19 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
     void deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(String accountNumber,
         TallyGranularity granularity, OffsetDateTime cutoffDate);
 
-    List<TallySnapshot> findByAccountNumberInAndProductIdAndGranularityAndSnapshotDateBetween(
+    Stream<TallySnapshot> findByAccountNumberInAndProductIdAndGranularityAndSnapshotDateBetween(
         Collection<String> accountNumbers, String productId, TallyGranularity granularity,
         OffsetDateTime beginning, OffsetDateTime ending);
 
+    @SuppressWarnings("indentation")
+    @Query("select " +
+               "new org.candlepin.subscriptions.db.model.AccountMaxValues(" +
+                    "s.accountNumber, s.ownerId, max(s.cores), max(s.instanceCount)) " +
+           "from TallySnapshot s " +
+           "where s.granularity=:granularity and s.accountNumber in (:accounts) " +
+               "and s.productId = :product and s.snapshotDate between :beginning and :ending " +
+           "group by s.accountNumber, s.ownerId order by s.accountNumber")
+    List<AccountMaxValues> getMaxValuesForAccounts(@Param("accounts") Collection<String> accountNumbers,
+        @Param("product") String productId, @Param("granularity") TallyGranularity granularity,
+        @Param("beginning") OffsetDateTime beginning, @Param("ending") OffsetDateTime ending);
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/AccountMaxValues.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/AccountMaxValues.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import org.candlepin.subscriptions.tally.ProductUsageCalculation;
+
+/**
+ * A class that hold the max values for a particular account. This object is primarily used when
+ * querying the max values from the database.
+ */
+public class AccountMaxValues {
+
+    private String accountNumber;
+    private String ownerId;
+    private Integer maxCores;
+    private Integer maxInstances;
+
+    public AccountMaxValues(String accountNumber, String ownerId, Integer maxCores, Integer maxInstances) {
+        this.accountNumber = accountNumber;
+        this.ownerId = ownerId;
+        this.maxCores = maxCores;
+        this.maxInstances = maxInstances;
+    }
+
+    public AccountMaxValues(ProductUsageCalculation calc) {
+        this(calc.getAccount(), calc.getOwner(), calc.getTotalCores(), calc.getInstanceCount());
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public Integer getMaxCores() {
+        return maxCores;
+    }
+
+    public void setMaxCores(Integer maxCores) {
+        this.maxCores = maxCores;
+    }
+
+    public Integer getMaxInstances() {
+        return maxInstances;
+    }
+
+    public void setMaxInstances(Integer maxInstances) {
+        this.maxInstances = maxInstances;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -24,6 +24,7 @@ import org.candlepin.subscriptions.inventory.db.model.InventoryHost;
 
 import org.springframework.data.repository.Repository;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -34,4 +35,5 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
 
     Stream<InventoryHost> findByAccount(String account);
 
+    Stream<InventoryHost> findByAccountIn(List<String> accounts);
 }

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
@@ -21,8 +21,8 @@
 package org.candlepin.subscriptions.retention;
 
 import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
-import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoField;
@@ -38,11 +38,11 @@ import java.time.temporal.TemporalAdjusters;
  */
 public class TallyRetentionPolicy {
 
-    private final Clock clock;
+    private final ApplicationClock applicationClock;
     private final TallyRetentionPolicyProperties config;
 
-    public TallyRetentionPolicy(Clock clock, TallyRetentionPolicyProperties config) {
-        this.clock = clock;
+    public TallyRetentionPolicy(ApplicationClock applicationClock, TallyRetentionPolicyProperties config) {
+        this.applicationClock = applicationClock;
         this.config = config;
     }
 
@@ -55,7 +55,7 @@ public class TallyRetentionPolicy {
      * @return cutoff date (i.e. dates less than this are candidates for removal), or null
      */
     public OffsetDateTime getCutoffDate(TallyGranularity granularity) {
-        OffsetDateTime today = OffsetDateTime.now(clock).truncatedTo(ChronoUnit.DAYS);
+        OffsetDateTime today = OffsetDateTime.now(applicationClock.getClock()).truncatedTo(ChronoUnit.DAYS);
         switch (granularity) {
             case DAILY:
                 if (config.getDaily() == null) {

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
@@ -22,13 +22,16 @@ package org.candlepin.subscriptions.tally;
 
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
-import org.candlepin.subscriptions.db.model.TallyGranularity;
-import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.exception.SnapshotProducerException;
 import org.candlepin.subscriptions.files.AccountListSource;
 import org.candlepin.subscriptions.inventory.db.InventoryRepository;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
-import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.candlepin.subscriptions.tally.roller.DailySnapshotRoller;
+import org.candlepin.subscriptions.tally.roller.MonthlySnapshotRoller;
+import org.candlepin.subscriptions.tally.roller.QuarterlySnapshotRoller;
+import org.candlepin.subscriptions.tally.roller.WeeklySnapshotRoller;
+import org.candlepin.subscriptions.tally.roller.YearlySnapshotRoller;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import com.google.common.collect.Iterables;
 
@@ -39,41 +42,39 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.time.Clock;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
- * Produces UsageSnapshots for an organization.
+ * Produces usage snapshot for all configured accounts.
  */
 @Component
 public class UsageSnapshotProducer {
 
     private static final Logger log = LoggerFactory.getLogger(UsageSnapshotProducer.class);
 
-    private final FactNormalizer factNormalizer;
+    private static final String RHEL = "RHEL";
+
     private final AccountListSource accountListSource;
-    private final InventoryRepository inventoryRepository;
-    private final TallySnapshotRepository tallyRepo;
-    private final Clock clock;
     private final int accountBatchSize;
+
+    private final DailySnapshotRoller dailyRoller;
+    private final WeeklySnapshotRoller weeklyRoller;
+    private final MonthlySnapshotRoller monthlyRoller;
+    private final YearlySnapshotRoller yearlyRoller;
+    private final QuarterlySnapshotRoller quarterlyRoller;
 
     @Autowired
     public UsageSnapshotProducer(FactNormalizer factNormalizer, AccountListSource accountListSource,
-        InventoryRepository inventoryRepository, TallySnapshotRepository tallyRepo, Clock clock,
+        InventoryRepository inventoryRepository, TallySnapshotRepository tallyRepo, ApplicationClock clock,
         ApplicationProperties applicationProperties) {
-        this.factNormalizer = factNormalizer;
         this.accountListSource = accountListSource;
-        this.inventoryRepository = inventoryRepository;
-        this.tallyRepo = tallyRepo;
-        this.clock = clock;
         this.accountBatchSize = applicationProperties.getAccountBatchSize();
+
+        dailyRoller = new DailySnapshotRoller(RHEL, inventoryRepository,
+            tallyRepo, factNormalizer, clock);
+        weeklyRoller = new WeeklySnapshotRoller(RHEL, tallyRepo, clock);
+        monthlyRoller = new MonthlySnapshotRoller(RHEL, tallyRepo, clock);
+        yearlyRoller = new YearlySnapshotRoller(RHEL, tallyRepo, clock);
+        quarterlyRoller = new QuarterlySnapshotRoller(RHEL, tallyRepo, clock);
     }
 
     @Transactional
@@ -83,10 +84,15 @@ public class UsageSnapshotProducer {
             // the calculations.
             log.info("Batch producing snapshots.");
             Iterables.partition(accountListSource.list(), accountBatchSize).forEach(accounts -> {
-                log.info("Processing snapshots for the next {} accounts.", accounts.size());
-                batchProduceDailySnapshots(getCalculationsForAccounts(accounts));
+                log.info("Producing snapshots for the next {} accounts.", accounts.size());
+                dailyRoller.rollSnapshots(accounts);
+                weeklyRoller.rollSnapshots(accounts);
+                monthlyRoller.rollSnapshots(accounts);
+                yearlyRoller.rollSnapshots(accounts);
+                quarterlyRoller.rollSnapshots(accounts);
             });
-            log.info("Finished producing snapshots for all configured accounts.");
+            log.info("Finished producing snapshots for all accounts.");
+
         }
         catch (IOException ioe) {
             throw new SnapshotProducerException(
@@ -94,94 +100,4 @@ public class UsageSnapshotProducer {
         }
     }
 
-    @Transactional(value = "inventoryTransactionManager", readOnly = true)
-    public List<ProductUsageCalculation> getCalculationsForAccounts(List<String> accounts) {
-        List<ProductUsageCalculation> calculations = new LinkedList<>();
-        for (String accountNumber : accounts) {
-            // NOTE: When we start counting for other products, consider adding additional
-            //       calculators to a list and applying the host to each.
-            ProductUsageCalculation rhelUsageCalculation = new ProductUsageCalculation(accountNumber, "RHEL");
-            inventoryRepository.findByAccount(accountNumber)
-                .forEach(host -> {
-                    NormalizedFacts facts = factNormalizer.normalize(host);
-                    if (facts.getProducts().contains(rhelUsageCalculation.getProductId())) {
-                        rhelUsageCalculation.addCores(facts.getCores() != null ? facts.getCores() : 0);
-                        rhelUsageCalculation.addInstance();
-                    }
-
-                    // Validate and set the owner.
-                    String owner = facts.getOwner();
-                    if (owner == null) {
-                        // Don't set null owner as it may overwrite an existing value.
-                        // Likely won't happen, but there could be stale data in inventory
-                        // with no owner set.
-                        return;
-                    }
-
-                    String currentOwner = rhelUsageCalculation.getOwner();
-                    if (currentOwner != null && !currentOwner.equalsIgnoreCase(owner)) {
-                        throw new IllegalStateException(
-                            String.format("Attempt to set a different owner for an account: %s:%s",
-                                currentOwner, owner));
-                    }
-                    rhelUsageCalculation.setOwner(owner);
-                });
-
-            log.debug("Found {} cores of RHEL for account: {}", rhelUsageCalculation.getTotalCores(),
-                rhelUsageCalculation.getAccount());
-            calculations.add(rhelUsageCalculation);
-        }
-        return calculations;
-    }
-
-    private void batchProduceDailySnapshots(List<ProductUsageCalculation> calculations) {
-        // Update snapshots that need updating.
-        Set<String> snapshotAccounts = calculations.stream()
-            .map(ProductUsageCalculation::getAccount)
-            .collect(Collectors.toSet());
-
-        log.debug("Fetching existing daily snapshots for {} accounts.", snapshotAccounts.size());
-        Map<String, TallySnapshot> existingRhelSnapsForToday = getSnapshotsForToday(snapshotAccounts, "RHEL");
-        log.debug("Found {} existing snapshots for today.", existingRhelSnapsForToday.size());
-
-        List<TallySnapshot> toPersist = new LinkedList<>();
-        calculations.forEach(calc -> {
-            TallySnapshot snapshot = existingRhelSnapsForToday.containsKey(calc.getAccount()) ?
-                existingRhelSnapsForToday.get(calc.getAccount()) : new TallySnapshot();
-            snapshot.setProductId(calc.getProductId());
-            snapshot.setCores(calc.getTotalCores());
-            snapshot.setGranularity(TallyGranularity.DAILY);
-            snapshot.setAccountNumber(calc.getAccount());
-            snapshot.setOwnerId(calc.getOwner());
-            snapshot.setInstanceCount(calc.getInstanceCount());
-            snapshot.setSnapshotDate(OffsetDateTime.now(clock));
-            toPersist.add(snapshot);
-        });
-
-        log.debug("Persisting {} snapshots.", toPersist.size());
-        tallyRepo.saveAll(toPersist);
-        log.debug("Snapshots persisted.");
-    }
-
-    private Map<String, TallySnapshot> getSnapshotsForToday(Set<String> accounts, String productId) {
-        Map<String, TallySnapshot> accountToSnap = new HashMap<>();
-        tallyRepo.findByAccountNumberInAndProductIdAndGranularityAndSnapshotDateBetween(accounts,
-            productId, TallyGranularity.DAILY, startOfToday(), endOfToday()).forEach(s -> {
-                if (accountToSnap.containsKey(s.getAccountNumber())) {
-                    log.warn("Multiple daily snapshots have been found for account: {}. " +
-                        "Last one found will be used.", s.getAccountNumber());
-                }
-                accountToSnap.put(s.getAccountNumber(), s);
-            }
-        );
-        return accountToSnap;
-    }
-
-    private OffsetDateTime startOfToday() {
-        return OffsetDateTime.from(LocalTime.MIDNIGHT.adjustInto(OffsetDateTime.now(clock)));
-    }
-
-    private OffsetDateTime endOfToday() {
-        return OffsetDateTime.from(LocalTime.MAX.adjustInto(OffsetDateTime.now(clock)));
-    }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -26,12 +26,12 @@ import org.candlepin.subscriptions.inventory.db.model.InventoryHost;
 import org.candlepin.subscriptions.tally.facts.normalizer.FactSetNormalizer;
 import org.candlepin.subscriptions.tally.facts.normalizer.QpcFactNormalizer;
 import org.candlepin.subscriptions.tally.facts.normalizer.RhsmFactNormalizer;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,7 +48,7 @@ public class FactNormalizer {
     private Map<String, FactSetNormalizer> normalizers;
 
     public FactNormalizer(ApplicationProperties props, RhelProductListSource rhelProductListSource,
-        Clock clock) throws IOException {
+        ApplicationClock clock) throws IOException {
         normalizers = new HashMap<>();
         normalizers.put(FactSetNamespace.RHSM, new RhsmFactNormalizer(props.getHostLastSyncThresholdHours(),
             rhelProductListSource.list(), clock));

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizer.java
@@ -22,8 +22,8 @@ package org.candlepin.subscriptions.tally.facts.normalizer;
 
 import org.candlepin.subscriptions.tally.facts.FactSetNamespace;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
-import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -41,10 +41,11 @@ public class RhsmFactNormalizer implements FactSetNormalizer {
     public static final String SYNC_TIMESTAMP = "SYNC_TIMESTAMP";
 
     private final List<String> configuredRhelProducts;
-    private final Clock clock;
+    private final ApplicationClock clock;
     private final int hostSyncThresholdHours;
 
-    public RhsmFactNormalizer(int hostSyncThresholdHours, List<String> configuredRhelProducts, Clock clock) {
+    public RhsmFactNormalizer(int hostSyncThresholdHours, List<String> configuredRhelProducts,
+        ApplicationClock clock) {
         this.hostSyncThresholdHours = hostSyncThresholdHours;
         this.configuredRhelProducts = configuredRhelProducts;
         this.clock = clock;
@@ -101,10 +102,7 @@ public class RhsmFactNormalizer implements FactSetNormalizer {
         if (lastSync == null) {
             return false;
         }
-        return lastSync.isBefore(getLastSyncThreshold());
+        return lastSync.isBefore(clock.now().minusHours(hostSyncThresholdHours));
     }
 
-    private OffsetDateTime getLastSyncThreshold() {
-        return OffsetDateTime.now(clock).minusHours(hostSyncThresholdHours);
-    }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.AccountMaxValues;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Base class for all usage snapshot rollers. A snapshot roller is responsible compressing
+ * finer granularity snapshots into more compressed snapshots. For example, rolling daily
+ * snapshots into weekly snapshots or rolling weekly snapshots into monthly snapshots.
+ */
+public abstract class BaseSnapshotRoller {
+
+    private static final Logger log = LoggerFactory.getLogger(BaseSnapshotRoller.class);
+
+    protected  TallySnapshotRepository tallyRepo;
+    protected ApplicationClock clock;
+    protected String product;
+
+    public BaseSnapshotRoller(String product, TallySnapshotRepository tallyRepo,
+        ApplicationClock clock) {
+        this.tallyRepo = tallyRepo;
+        this.clock = clock;
+        this.product = product;
+    }
+
+    /**
+     * Roll the snapshots for the given account.
+     *
+     * @param accounts the accounts of the snapshots to roll.
+     */
+    public abstract void rollSnapshots(List<String> accounts);
+
+    protected TallySnapshot createSnapshotFromMaxValues(AccountMaxValues maxValues,
+        TallyGranularity granularity) {
+        TallySnapshot snapshot = new TallySnapshot();
+        snapshot.setProductId(this.product);
+        snapshot.setGranularity(granularity);
+        updateWithMax(snapshot, maxValues);
+        return snapshot;
+    }
+
+    protected void updateWithMax(TallySnapshot snapshot, AccountMaxValues maxValues) {
+        snapshot.setInstanceCount(maxValues.getMaxInstances());
+        snapshot.setCores(maxValues.getMaxCores());
+        snapshot.setOwnerId(maxValues.getOwnerId());
+        snapshot.setAccountNumber(maxValues.getAccountNumber());
+        snapshot.setSnapshotDate(getSnapshotDate(snapshot.getGranularity()));
+    }
+
+    protected void updateSnapshots(Map<String, TallySnapshot> existingSnapsByAccount,
+        Map<String, AccountMaxValues> maxValuesByAccount, TallyGranularity targetGranularity) {
+        List<TallySnapshot> snapshots = new LinkedList<>();
+        for (Entry<String, AccountMaxValues> next : maxValuesByAccount.entrySet()) {
+            TallySnapshot snap = existingSnapsByAccount.get(next.getKey());
+            if (snap == null) {
+                snap = createSnapshotFromMaxValues(next.getValue(), targetGranularity);
+            }
+            else {
+                updateWithMax(snap, next.getValue());
+            }
+            snapshots.add(snap);
+        }
+        log.debug("Persisting {} {} snapshots.", snapshots.size(), targetGranularity);
+        tallyRepo.saveAll(snapshots);
+    }
+
+    protected OffsetDateTime getSnapshotDate(TallyGranularity granularity) {
+        switch (granularity) {
+            case QUARTERLY:
+                return clock.startOfCurrentQuarter();
+            case WEEKLY:
+                return clock.startOfCurrentWeek();
+            case MONTHLY:
+                return clock.startOfCurrentMonth();
+            case YEARLY:
+                return clock.startOfCurrentYear();
+            default:
+                return clock.now();
+        }
+    }
+
+    protected void updateSnapshots(Collection<String> accounts, TallyGranularity maxValueGranularity,
+        TallyGranularity targetGranularity, OffsetDateTime begin, OffsetDateTime end) {
+        Map<String, AccountMaxValues> maxValues = getMaxValuesByAccount(accounts, maxValueGranularity, begin,
+            end);
+
+        Map<String, TallySnapshot> existingTargetSnaps = getCurrentSnapshotsByAccount(accounts,
+            targetGranularity, begin, end);
+
+        updateSnapshots(existingTargetSnaps, maxValues, targetGranularity);
+    }
+
+    @SuppressWarnings("indentation")
+    protected Map<String, AccountMaxValues> getMaxValuesByAccount(Collection<String> accounts,
+        TallyGranularity granularity, OffsetDateTime begin, OffsetDateTime end) {
+        try (Stream<AccountMaxValues> maxValueStream =
+            tallyRepo.getMaxValuesForAccounts(accounts, this.product, granularity, begin, end).stream()) {
+            return maxValueStream.collect(Collectors.toMap(AccountMaxValues::getAccountNumber,
+                Function.identity()));
+        }
+    }
+
+    @SuppressWarnings("indentation")
+    protected Map<String, TallySnapshot> getCurrentSnapshotsByAccount(Collection<String> accounts,
+        TallyGranularity granularity, OffsetDateTime begin, OffsetDateTime end) {
+        try (Stream<TallySnapshot> snapStream =
+            tallyRepo.findByAccountNumberInAndProductIdAndGranularityAndSnapshotDateBetween(
+                accounts, this.product, granularity, begin, end)) {
+            return snapStream.collect(Collectors.toMap(TallySnapshot::getAccountNumber, Function.identity()));
+        }
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.AccountMaxValues;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.inventory.db.InventoryRepository;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHost;
+import org.candlepin.subscriptions.tally.ProductUsageCalculation;
+import org.candlepin.subscriptions.tally.facts.FactNormalizer;
+import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Produces daily usage snapshots based on data stored in the inventory service.
+ */
+public class DailySnapshotRoller extends BaseSnapshotRoller {
+
+    private static final Logger log = LoggerFactory.getLogger(DailySnapshotRoller.class);
+
+    private InventoryRepository inventoryRepository;
+    private FactNormalizer factNormalizer;
+
+    public DailySnapshotRoller(String product, InventoryRepository inventoryRepository,
+        TallySnapshotRepository tallyRepo, FactNormalizer factNormalizer, ApplicationClock clock) {
+        super(product, tallyRepo, clock);
+        this.inventoryRepository = inventoryRepository;
+        this.factNormalizer = factNormalizer;
+    }
+
+    @Override
+    @Transactional
+    public void rollSnapshots(List<String> accounts) {
+        log.info("Producing daily snapshots for {} account.", accounts.size());
+        produceDailySnapshots(accounts, calculateMaxValuesFromInventory(accounts));
+    }
+
+    @Transactional(value = "inventoryTransactionManager", readOnly = true)
+    public Collection<ProductUsageCalculation> calculateMaxValuesFromInventory(List<String> accounts) {
+        Map<String, ProductUsageCalculation> calcsByAccount = new HashMap<>();
+        try (Stream<InventoryHost> hostStream = inventoryRepository.findByAccountIn(accounts)) {
+            hostStream.forEach(host -> {
+                String account = host.getAccount();
+                if (!calcsByAccount.containsKey(account)) {
+                    calcsByAccount.put(account, new ProductUsageCalculation(account, this.product));
+                }
+
+                ProductUsageCalculation calc = calcsByAccount.get(account);
+                NormalizedFacts facts = factNormalizer.normalize(host);
+                if (facts.getProducts().contains(calc.getProductId())) {
+                    calc.addCores(facts.getCores() != null ? facts.getCores() : 0);
+                    calc.addInstance();
+                }
+
+                // Validate and set the owner.
+                String owner = facts.getOwner();
+                if (owner == null) {
+                    // Don't set null owner as it may overwrite an existing value.
+                    // Likely won't happen, but there could be stale data in inventory
+                    // with no owner set.
+                    return;
+                }
+
+                String currentOwner = calc.getOwner();
+                if (currentOwner != null && !currentOwner.equalsIgnoreCase(owner)) {
+                    throw new IllegalStateException(
+                        String.format("Attempt to set a different owner for an account: %s:%s",
+                            currentOwner, owner));
+                }
+                calc.setOwner(owner);
+            });
+        }
+
+        if (log.isDebugEnabled()) {
+            for (ProductUsageCalculation calc : calcsByAccount.values()) {
+                log.info("Account: {}, Cores: {}, Instances: {}", calc.getAccount(), calc.getTotalCores(),
+                    calc.getInstanceCount());
+            }
+        }
+        return calcsByAccount.values();
+    }
+
+    private void produceDailySnapshots(List<String> accounts,
+        Collection<ProductUsageCalculation> calculations) {
+
+        Map<String, AccountMaxValues> maxValues = calculations.stream()
+            .map(AccountMaxValues::new)
+            .collect(Collectors.toMap(AccountMaxValues::getAccountNumber, Function.identity()));
+
+        Map<String, TallySnapshot> existingSnapsForToday = getCurrentSnapshotsByAccount(accounts,
+            TallyGranularity.DAILY, clock.startOfToday(), clock.endOfToday());
+
+        updateSnapshots(existingSnapsForToday, maxValues, TallyGranularity.DAILY);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/**
+ * Produces monthly usage snapshots based on the existing daily snapshots for the current month.
+ */
+public class MonthlySnapshotRoller extends BaseSnapshotRoller {
+
+    private static final Logger log = LoggerFactory.getLogger(MonthlySnapshotRoller.class);
+
+    public MonthlySnapshotRoller(String product, TallySnapshotRepository tallyRepo,
+        ApplicationClock clock) {
+        super(product, tallyRepo, clock);
+    }
+
+    @Override
+    @Transactional
+    public void rollSnapshots(List<String> accounts) {
+        log.info("Producing monthly snapshots for {} accounts.", accounts.size());
+
+        updateSnapshots(accounts, TallyGranularity.DAILY, TallyGranularity.MONTHLY,
+            clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/**
+ * Produces quarterly usage snapshots based on the existing monthly snapshots for the current quarter.
+ * A quarter is considered to be chunked by a 3 month interval. In a given year, the quarters are defined as:
+ * Jan-Mar, Apr-Jun, Jul-Sept, Oct-Dec
+ *
+ * Quarterly snapshots are created as the current date enters the quarter.
+ */
+public class QuarterlySnapshotRoller extends BaseSnapshotRoller {
+    private static final Logger log = LoggerFactory.getLogger(QuarterlySnapshotRoller.class);
+
+    public QuarterlySnapshotRoller(String product, TallySnapshotRepository tallyRepo,
+        ApplicationClock clock) {
+        super(product, tallyRepo, clock);
+    }
+
+    @Override
+    @Transactional
+    public void rollSnapshots(List<String> accounts) {
+        log.info("Producing quarterly snapshots for {} accounts.", accounts.size());
+
+        updateSnapshots(accounts, TallyGranularity.MONTHLY, TallyGranularity.QUARTERLY,
+            clock.startOfCurrentQuarter(), clock.endOfCurrentQuarter());
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/**
+ * Produces weekly usage snapshots based on the existing Daily snapshots for the current week.
+ */
+public class WeeklySnapshotRoller extends BaseSnapshotRoller {
+
+    private static final Logger log = LoggerFactory.getLogger(WeeklySnapshotRoller.class);
+
+    public WeeklySnapshotRoller(String product, TallySnapshotRepository tallyRepo,
+        ApplicationClock clock) {
+        super(product, tallyRepo, clock);
+    }
+
+    @Override
+    @Transactional
+    public void rollSnapshots(List<String> accounts) {
+        log.info("Producing weekly snapshots for {} accounts.", accounts.size());
+
+        // Fetch snapshots for this week. There should only be one snapshot per account for this week.
+        updateSnapshots(accounts, TallyGranularity.DAILY, TallyGranularity.WEEKLY,
+            clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/**
+ * Produces yearly usage snapshots based on the existing Monthly snapshots.
+ */
+public class YearlySnapshotRoller extends BaseSnapshotRoller {
+
+    private static final Logger log = LoggerFactory.getLogger(YearlySnapshotRoller.class);
+
+    public YearlySnapshotRoller(String product, TallySnapshotRepository tallyRepo,
+        ApplicationClock clock) {
+        super(product, tallyRepo, clock);
+    }
+
+    @Override
+    @Transactional
+    public void rollSnapshots(List<String> accounts) {
+        log.info("Producing yearly snapshots for {} accounts.", accounts.size());
+
+        updateSnapshots(accounts, TallyGranularity.MONTHLY, TallyGranularity.YEARLY,
+            clock.startOfCurrentYear(), clock.endOfCurrentYear());
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * The single date and time source to be used by the application.
+ *
+ * All start* methods return the time at midnight - 2019-04-19 00:00:00.0
+ * All end* methods return the max time of the day - 2019-04-19 23:59:59.999999999Z
+ */
+public class ApplicationClock {
+
+    private Clock clock;
+
+    public ApplicationClock() {
+        this.clock = Clock.systemUTC();
+    }
+
+    public ApplicationClock(Clock clock) {
+        this.clock = clock;
+    }
+
+    public Clock getClock() {
+        return this.clock;
+    }
+
+    public OffsetDateTime now() {
+        return OffsetDateTime.now(getClock());
+    }
+
+    public OffsetDateTime startOfToday() {
+        return startOfDay(now());
+    }
+
+    public OffsetDateTime startOfDay(OffsetDateTime anyDay) {
+        return OffsetDateTime.from(LocalTime.MIDNIGHT.adjustInto(anyDay));
+    }
+
+    public OffsetDateTime endOfToday() {
+        return endOfDay(now());
+    }
+
+    public OffsetDateTime endOfDay(OffsetDateTime anyDay) {
+        return OffsetDateTime.from(LocalTime.MAX.adjustInto(anyDay));
+    }
+
+    public OffsetDateTime endOfCurrentWeek() {
+        return endOfWeek(now());
+    }
+
+    public OffsetDateTime endOfWeek(OffsetDateTime anyDayInWeek) {
+        return endOfDay(anyDayInWeek.with(DayOfWeek.SATURDAY));
+    }
+
+    public OffsetDateTime startOfCurrentWeek() {
+        return startOfWeek(now());
+    }
+
+    public OffsetDateTime startOfWeek(OffsetDateTime anyDayOfWeek) {
+        return startOfDay(anyDayOfWeek.with(DayOfWeek.SUNDAY).minusDays(7L));
+    }
+
+    public OffsetDateTime endOfCurrentMonth() {
+        return endOfMonth(now());
+    }
+
+    public OffsetDateTime endOfMonth(OffsetDateTime anyDayOfMonth) {
+        return OffsetDateTime.from(LocalTime.MAX.adjustInto(anyDayOfMonth))
+            .with(TemporalAdjusters.lastDayOfMonth());
+    }
+
+    public OffsetDateTime startOfCurrentMonth() {
+        return startOfMonth(now());
+    }
+
+    public OffsetDateTime startOfMonth(OffsetDateTime anyDayOfMonth) {
+        return OffsetDateTime.from(LocalTime.MIDNIGHT.adjustInto(anyDayOfMonth))
+            .with(TemporalAdjusters.firstDayOfMonth());
+    }
+
+    public OffsetDateTime startOfCurrentYear() {
+        return startOfYear(now());
+    }
+
+    public OffsetDateTime startOfYear(OffsetDateTime anyDay) {
+        return startOfDay(anyDay).with(TemporalAdjusters.firstDayOfYear());
+    }
+
+    public OffsetDateTime endOfCurrentYear() {
+        return endOfYear(now());
+    }
+
+    public OffsetDateTime endOfYear(OffsetDateTime anyDay) {
+        return endOfDay(anyDay).with(TemporalAdjusters.lastDayOfYear());
+    }
+
+    public OffsetDateTime startOfCurrentQuarter() {
+        return startOfQuarter(now());
+    }
+
+    public OffsetDateTime endOfCurrentQuarter() {
+        return endOfQuarter(now());
+    }
+
+    public OffsetDateTime startOfQuarter(OffsetDateTime anyDay) {
+        OffsetDateTime startOfDay = startOfDay(anyDay);
+        return startOfDay.with(startOfDay.getMonth().firstMonthOfQuarter())
+            .with(TemporalAdjusters.firstDayOfMonth());
+    }
+
+    public OffsetDateTime endOfQuarter(OffsetDateTime anyDay) {
+        OffsetDateTime endOfDay = endOfDay(anyDay);
+        return endOfDay.with(endOfDay.getMonth().firstMonthOfQuarter())
+            .plusMonths(2).with(TemporalAdjusters.lastDayOfMonth());
+    }
+}

--- a/src/main/resources/liquibase/201906181633-create-schema.xml
+++ b/src/main/resources/liquibase/201906181633-create-schema.xml
@@ -29,5 +29,6 @@
             <column name="product_id"/>
         </createIndex>
     </changeSet>
+
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/201907121110-add-snapshot-date-index.xml
+++ b/src/main/resources/liquibase/201907121110-add-snapshot-date-index.xml
@@ -6,7 +6,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <include file="liquibase/201906181633-create-schema.xml"/>
-    <include file="liquibase/201907121110-add-snapshot-date-index.xml"/>
+    <changeSet id="201907121110-1" author="mstead">
+        <comment>Add an index on snapshot_date column in the tally_snapshots table</comment>
+        <createIndex indexName="snapshot_date_idx" tableName="tally_snapshots"
+                     unique="false">
+            <column name="snapshot_date"/>
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/FixedClockConfiguration.java
+++ b/src/test/java/org/candlepin/subscriptions/FixedClockConfiguration.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions;
 
+import org.candlepin.subscriptions.util.ApplicationClock;
+
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -32,12 +34,14 @@ import java.time.ZoneOffset;
 
 @TestConfiguration
 public class FixedClockConfiguration {
+
     @Bean
     @Primary
-    public Clock fixedClock() {
-        return Clock.fixed(
+    public ApplicationClock fixedClock() {
+        return new ApplicationClock(Clock.fixed(
             Instant.from(OffsetDateTime.of(2019, 5, 24, 12, 35, 0, 0, ZoneOffset.UTC)),
-            ZoneId.of("UTC")
+            ZoneId.of("UTC"))
         );
     }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,8 @@ import java.time.ZoneOffset;
 
 class TallyRetentionPolicyTest {
     public TallyRetentionPolicy createTestPolicy(TallyRetentionPolicyProperties config) {
-        return new TallyRetentionPolicy(new FixedClockConfiguration().fixedClock(), config);
+        ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+        return new TallyRetentionPolicy(clock, config);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -27,6 +27,7 @@ import org.candlepin.subscriptions.files.RhelProductListSource;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHost;
 import org.candlepin.subscriptions.tally.facts.normalizer.QpcFactNormalizer;
 import org.candlepin.subscriptions.tally.facts.normalizer.RhsmFactNormalizer;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.core.io.FileSystemResourceLoader;
 
 import java.io.IOException;
-import java.time.Clock;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -56,7 +56,7 @@ public class FactNormalizerTest {
         source.setResourceLoader(new FileSystemResourceLoader());
         source.init();
 
-        normalizer = new FactNormalizer(new ApplicationProperties(), source, Clock.systemUTC());
+        normalizer = new FactNormalizer(new ApplicationProperties(), source, new ApplicationClock());
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizerTest.java
@@ -29,13 +29,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.tally.facts.FactSetNamespace;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -47,7 +47,7 @@ import java.util.Map;
 public class RhsmFactNormalizerTest {
 
     private RhsmFactNormalizer normalizer;
-    private Clock clock;
+    private ApplicationClock clock;
 
     @BeforeAll
     public void setupTests() {
@@ -100,7 +100,7 @@ public class RhsmFactNormalizerTest {
 
     @Test
     public void testIgnoresHostWhenLastSyncIsOutOfConfiguredThreshold() {
-        OffsetDateTime lastSynced = OffsetDateTime.now(clock).minusDays(2);
+        OffsetDateTime lastSynced = clock.now().minusDays(2);
         Map<String, Object> facts = createRhsmFactSet(Arrays.asList("P1"), 4);
         facts.put(RhsmFactNormalizer.SYNC_TIMESTAMP, lastSynced);
 
@@ -112,7 +112,7 @@ public class RhsmFactNormalizerTest {
 
     @Test
     public void testIncludesHostWhenLastSyncIsWithinTheConfiguredThreshold() {
-        OffsetDateTime lastSynced = OffsetDateTime.now(clock).minusDays(1);
+        OffsetDateTime lastSynced = clock.now().minusDays(1);
         Map<String, Object> facts = createRhsmFactSet(Arrays.asList("P1"), 4);
         facts.put(RhsmFactNormalizer.SYNC_TIMESTAMP, lastSynced);
 

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+
+
+@SpringBootTest
+// The transactional annotation will rollback the transaction at the end of every test.
+@Transactional
+@TestPropertySource("classpath:/test.properties")
+@TestInstance(Lifecycle.PER_CLASS)
+public class MonthlySnapshotRollerTest {
+
+    private static final String TEST_PRODUCT = "TEST_PROD";
+
+    @Autowired
+    private TallySnapshotRepository repository;
+
+    private ApplicationClock clock;
+
+    private MonthlySnapshotRoller roller;
+
+    @BeforeAll
+    public void setupAllTests() {
+        this.clock = new FixedClockConfiguration().fixedClock();
+        this.roller = new MonthlySnapshotRoller(TEST_PRODUCT, repository, clock);
+    }
+
+    @SuppressWarnings("indentation")
+    @Test
+    public void testMonthlySnapshotProducer() {
+        List<TallySnapshot> forMonth = setupDailySnapsForMonth("A1");
+        TallySnapshot max = forMonth.stream()
+            .filter(t -> t.getCores() != null &&
+                t.getSnapshotDate().getMonth().equals(clock.now().getMonth()) &&
+                TallyGranularity.DAILY.equals(t.getGranularity()))
+            .max(Comparator.comparingInt(TallySnapshot::getCores))
+            .get();
+
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> monthlySnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
+        assertEquals(1, monthlySnaps.size());
+
+        TallySnapshot result = monthlySnaps.get(0);
+        assertEquals("A1", result.getAccountNumber());
+        assertEquals(TallyGranularity.MONTHLY, result.getGranularity());
+        assertEquals(TEST_PRODUCT, result.getProductId());
+        // Cores and instance count should both come from the weekly snap with the largest cores count.
+        assertEquals(max.getCores(), result.getCores());
+        assertEquals(max.getInstanceCount(), result.getInstanceCount());
+    }
+
+    @SuppressWarnings("indentation")
+    @Test
+    public void testMonthlySnapIsUpdatedWhenItAlreadyExists() {
+        List<TallySnapshot> forMonth = setupDailySnapsForMonth("A1");
+
+        TallySnapshot max = forMonth.stream()
+            .filter(t -> t.getCores() != null &&
+                 t.getSnapshotDate().getMonth().equals(clock.now().getMonth()) &&
+                 TallyGranularity.DAILY.equals(t.getGranularity()))
+            .max(Comparator.comparingInt(TallySnapshot::getCores))
+            .get();
+
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> monthlySnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
+        assertEquals(1, monthlySnaps.size());
+
+        TallySnapshot firstUpdate = monthlySnaps.get(0);
+
+        // Update the max so it is no longer the max. The new max should be 1 day behind
+        // and will be one less than the max.
+        Integer expectedUpdatedCoresAndInstance = max.getCores() - 1;
+        max.setCores(12);
+        max.setInstanceCount(12);
+        repository.saveAndFlush(max);
+
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> updatedMonthlySnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
+        assertEquals(1, updatedMonthlySnaps.size());
+
+        TallySnapshot updated = updatedMonthlySnaps.get(0);
+        assertEquals(firstUpdate.getId(), updated.getId());
+        assertEquals("A1", updated.getAccountNumber());
+        assertEquals(TallyGranularity.MONTHLY, updated.getGranularity());
+        assertEquals(TEST_PRODUCT, updated.getProductId());
+        // Cores and instance count should both come from the weekly snap with the largest cores count.
+        assertEquals(expectedUpdatedCoresAndInstance, updated.getCores());
+        assertEquals(expectedUpdatedCoresAndInstance, updated.getInstanceCount());
+    }
+
+    private List<TallySnapshot> setupDailySnapsForMonth(String account) {
+        OffsetDateTime firstDayOfFistWeekInMonth = clock.startOfWeek(clock.startOfCurrentMonth());
+        OffsetDateTime lastDayOfLastWeekInMonth = clock.endOfWeek(clock.endOfCurrentMonth());
+
+        int count = 0;
+        OffsetDateTime next = firstDayOfFistWeekInMonth;
+        List<TallySnapshot> dailies = new LinkedList<>();
+        List<TallySnapshot> weeklies = new LinkedList<>();
+        while (!next.isAfter(lastDayOfLastWeekInMonth)) {
+            count++;
+            dailies.add(createUnpersisted(account, TEST_PRODUCT, TallyGranularity.DAILY, count, count, next));
+
+            OffsetDateTime peek = next.plusDays(1L);
+            if (peek.getDayOfWeek().equals(DayOfWeek.SUNDAY)) {
+                weeklies.add(createUnpersisted(account, TEST_PRODUCT, TallyGranularity.WEEKLY, count, count,
+                    clock.startOfWeek(next)));
+            }
+            next = OffsetDateTime.from(peek);
+        }
+
+        List<TallySnapshot> all = new LinkedList<>(dailies);
+        all.addAll(weeklies);
+
+        return repository.saveAll(all);
+    }
+
+    private TallySnapshot createUnpersisted(String account, String product, TallyGranularity granularity,
+        int cores, int instanceCount, OffsetDateTime date) {
+        TallySnapshot tally = new TallySnapshot();
+        tally.setAccountNumber(account);
+        tally.setProductId(product);
+        tally.setOwnerId("N/A");
+        tally.setCores(cores);
+        tally.setGranularity(granularity);
+        tally.setInstanceCount(instanceCount);
+        tally.setSnapshotDate(date);
+        return tally;
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+
+@SpringBootTest
+// The transactional annotation will rollback the transaction at the end of every test.
+@Transactional
+@TestPropertySource("classpath:/test.properties")
+@TestInstance(Lifecycle.PER_CLASS)
+public class QuarterlySnapshotRollerTest {
+
+    private static final String TEST_PRODUCT = "TEST_PROD";
+
+    @Autowired
+    private TallySnapshotRepository repository;
+
+    private ApplicationClock clock;
+    private QuarterlySnapshotRoller roller;
+
+    @BeforeEach
+    public void setupTest() {
+        this.clock = new FixedClockConfiguration().fixedClock();
+        this.roller = new QuarterlySnapshotRoller(TEST_PRODUCT, repository, clock);
+    }
+
+    @Test
+    public void testQuarterlySnapshotProduction() {
+        setupYearsWorthOfMonthlySnaps("A1", clock.now().minusYears(1));
+        setupYearsWorthOfMonthlySnaps("A1", clock.now());
+        setupYearsWorthOfMonthlySnaps("A1", clock.now().plusYears(1));
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> quarterlySnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.QUARTERLY, clock.startOfCurrentQuarter(),
+            clock.endOfCurrentQuarter());
+        assertEquals(1, quarterlySnaps.size());
+
+        TallySnapshot secondQuarter = quarterlySnaps.get(0);
+        assertEquals(TallyGranularity.QUARTERLY, secondQuarter.getGranularity());
+        assertEquals(TEST_PRODUCT, secondQuarter.getProductId());
+        assertEquals(Integer.valueOf(5), secondQuarter.getCores());
+        assertEquals(Integer.valueOf(5), secondQuarter.getInstanceCount());
+    }
+
+    @Test
+    public void testQuarterlySnapIsUpdatedWhenItAlreadyExists() {
+        setupYearsWorthOfMonthlySnaps("A1", clock.now().minusYears(1));
+        List<TallySnapshot> monthlies = setupYearsWorthOfMonthlySnaps("A1", clock.now());
+        setupYearsWorthOfMonthlySnaps("A1", clock.now().plusYears(1));
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> originalSnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.QUARTERLY, clock.startOfCurrentQuarter(),
+            clock.endOfCurrentQuarter());
+        assertEquals(1, originalSnaps.size());
+
+        TallySnapshot toUpdate = originalSnaps.get(0);
+        assertEquals(TallyGranularity.QUARTERLY, toUpdate.getGranularity());
+        assertEquals(TEST_PRODUCT, toUpdate.getProductId());
+        assertEquals(Integer.valueOf(5), toUpdate.getCores());
+        assertEquals(Integer.valueOf(5), toUpdate.getInstanceCount());
+
+        TallySnapshot secondQuarterMonthlyToUpdate = monthlies.get(5);
+        secondQuarterMonthlyToUpdate.setCores(100);
+        secondQuarterMonthlyToUpdate.setInstanceCount(50);
+        repository.saveAndFlush(secondQuarterMonthlyToUpdate);
+
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        // Check the yearly again. Should still be a single instance, but have updated values.
+        List<TallySnapshot> updatedSnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.QUARTERLY, clock.startOfCurrentQuarter(),
+            clock.endOfCurrentQuarter());
+        assertEquals(1, originalSnaps.size());
+
+        TallySnapshot updated = updatedSnaps.get(0);
+        assertEquals(toUpdate.getId(), updated.getId());
+        assertEquals("A1", toUpdate.getAccountNumber());
+        assertEquals(TallyGranularity.QUARTERLY, updated.getGranularity());
+        assertEquals(secondQuarterMonthlyToUpdate.getProductId(), updated.getProductId());
+        assertEquals(secondQuarterMonthlyToUpdate.getCores(), updated.getCores());
+        assertEquals(secondQuarterMonthlyToUpdate.getInstanceCount(), updated.getInstanceCount());
+    }
+
+    private List<TallySnapshot> setupYearsWorthOfMonthlySnaps(String account, OffsetDateTime anyDayOfWeek) {
+        OffsetDateTime startOfYear = clock.startOfYear(anyDayOfWeek);
+
+        List<TallySnapshot> monthlyForYear = new LinkedList<>();
+        IntStream.rangeClosed(0, 11).forEach(i -> {
+            monthlyForYear.add(createUnpersisted(account, TEST_PRODUCT, TallyGranularity.MONTHLY, i,
+                i, startOfYear.plusMonths(i)));
+        });
+
+        repository.saveAll(monthlyForYear);
+        repository.flush();
+
+        return monthlyForYear;
+    }
+
+    private TallySnapshot createUnpersisted(String account, String product, TallyGranularity granularity,
+        int cores, int instanceCount, OffsetDateTime date) {
+        TallySnapshot tally = new TallySnapshot();
+        tally.setAccountNumber(account);
+        tally.setProductId(product);
+        tally.setOwnerId("N/A");
+        tally.setCores(cores);
+        tally.setGranularity(granularity);
+        tally.setInstanceCount(instanceCount);
+        tally.setSnapshotDate(date);
+        return tally;
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+// The transactional annotation will rollback the transaction at the end of every test.
+@Transactional
+@TestPropertySource("classpath:/test.properties")
+@TestInstance(Lifecycle.PER_CLASS)
+public class WeeklySnapshotRollerTest {
+
+    private static final String TEST_PRODUCT = "TEST_PROD";
+
+    @Autowired
+    private TallySnapshotRepository repository;
+
+    private ApplicationClock clock;
+
+    private WeeklySnapshotRoller roller;
+
+    @BeforeAll
+    public void setupAllTests() {
+        this.clock = new FixedClockConfiguration().fixedClock();
+        this.roller = new WeeklySnapshotRoller(TEST_PRODUCT, repository, clock);
+    }
+
+    @Test
+    public void testWeeklySnapshotProduction() {
+        setupWeeksWorthOfDailySnaps("A1", clock.now());
+
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> weeklySnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
+        assertEquals(1, weeklySnaps.size());
+
+        TallySnapshot result = weeklySnaps.get(0);
+        assertEquals(TallyGranularity.WEEKLY, result.getGranularity());
+        assertEquals(TEST_PRODUCT, result.getProductId());
+        // Cores and instance count should both come from the daily snap with the largest cores count.
+        assertEquals(Integer.valueOf(6), result.getCores());
+        assertEquals(Integer.valueOf(6), result.getInstanceCount());
+    }
+
+    @Test
+    public void testWeeklySnapIsUpdatedWhenItAlreadyExists() {
+        // Set up three weeks of daily snaps
+        OffsetDateTime now = clock.now();
+        List<TallySnapshot> dailies = setupWeeksWorthOfDailySnaps("A1", now);
+        setupWeeksWorthOfDailySnaps("A1", now.minusDays(7));
+        setupWeeksWorthOfDailySnaps("A1", now.minusDays(14));
+
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> weeklySnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
+        assertEquals(1, weeklySnaps.size());
+        TallySnapshot result = weeklySnaps.get(0);
+        assertEquals("A1", result.getAccountNumber());
+        assertEquals(TallyGranularity.WEEKLY, result.getGranularity());
+        assertEquals(TEST_PRODUCT, result.getProductId());
+        // Cores and instance count should both come from the daily snap with the largest cores count.
+        assertEquals(Integer.valueOf(6), result.getCores());
+        assertEquals(Integer.valueOf(6), result.getInstanceCount());
+
+        // Update the daily and run again
+        TallySnapshot dailyToUpdate = dailies.get(0);
+        dailyToUpdate.setCores(124);
+        dailyToUpdate.setInstanceCount(20);
+        repository.saveAndFlush(dailyToUpdate);
+
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        // Check the weekly again. Should still be a single instance, but have updated values.
+        List<TallySnapshot> updatedWeeklySnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
+        assertEquals(1, updatedWeeklySnaps.size());
+
+        TallySnapshot updated = updatedWeeklySnaps.get(0);
+        assertEquals(result.getId(), updated.getId());
+        assertEquals("A1", result.getAccountNumber());
+        assertEquals(TallyGranularity.WEEKLY, updated.getGranularity());
+        assertEquals(dailyToUpdate.getProductId(), updated.getProductId());
+        assertEquals(dailyToUpdate.getCores(), updated.getCores());
+        assertEquals(dailyToUpdate.getInstanceCount(), updated.getInstanceCount());
+    }
+
+    private List<TallySnapshot> setupWeeksWorthOfDailySnaps(String account, OffsetDateTime anyDayOfWeek) {
+        OffsetDateTime endOfWeek = clock.endOfWeek(anyDayOfWeek);
+        OffsetDateTime startOfWeek = clock.startOfWeek(anyDayOfWeek);
+        System.out.println(String.format("WEEK: %s -> %s", startOfWeek, endOfWeek));
+
+        List<TallySnapshot> dailyForWeek = new LinkedList<>();
+        IntStream.rangeClosed(0, 6).forEach(i -> {
+            dailyForWeek.add(createUnpersisted(account, TEST_PRODUCT, TallyGranularity.DAILY, i,
+                i, startOfWeek.plusDays(i)));
+        });
+
+        repository.saveAll(dailyForWeek);
+        repository.flush();
+
+        return dailyForWeek;
+    }
+
+    private TallySnapshot createUnpersisted(String account, String product, TallyGranularity granularity,
+        int cores, int instanceCount, OffsetDateTime date) {
+        TallySnapshot tally = new TallySnapshot();
+        tally.setAccountNumber(account);
+        tally.setProductId(product);
+        tally.setOwnerId("N/A");
+        tally.setCores(cores);
+        tally.setGranularity(granularity);
+        tally.setInstanceCount(instanceCount);
+        tally.setSnapshotDate(date);
+        return tally;
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.roller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+// The transactional annotation will rollback the transaction at the end of every test.
+@Transactional
+@TestPropertySource("classpath:/test.properties")
+@TestInstance(Lifecycle.PER_CLASS)
+public class YearlySnapshotRollerTest {
+
+    private static final String TEST_PRODUCT = "TEST_PROD";
+
+    @Autowired
+    private TallySnapshotRepository repository;
+
+    private ApplicationClock clock;
+    private YearlySnapshotRoller roller;
+
+    @BeforeEach
+    public void setupTest() {
+        this.clock = new FixedClockConfiguration().fixedClock();
+        this.roller = new YearlySnapshotRoller(TEST_PRODUCT, repository, clock);
+    }
+
+    @Test
+    public void testYearlySnapshotProduction() {
+        setupYearsWorthOfMonthlySnaps("A1", clock.now().minusYears(1));
+        setupYearsWorthOfMonthlySnaps("A1", clock.now());
+        setupYearsWorthOfMonthlySnaps("A1", clock.now().plusYears(1));
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> yearlySnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear());
+        assertEquals(1, yearlySnaps.size());
+
+        TallySnapshot result = yearlySnaps.get(0);
+        assertEquals(TallyGranularity.YEARLY, result.getGranularity());
+        assertEquals(TEST_PRODUCT, result.getProductId());
+        assertEquals(Integer.valueOf(11), result.getCores());
+        assertEquals(Integer.valueOf(11), result.getInstanceCount());
+    }
+
+    @Test
+    public void testYearlySnapIsUpdatedWhenItAlreadyExists() {
+        setupYearsWorthOfMonthlySnaps("A1", clock.now().minusYears(1));
+        List<TallySnapshot> monthlies = setupYearsWorthOfMonthlySnaps("A1", clock.now());
+        setupYearsWorthOfMonthlySnaps("A1", clock.now().plusYears(1));
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        List<TallySnapshot> originalSnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear());
+        assertEquals(1, originalSnaps.size());
+
+        TallySnapshot toUpdate = originalSnaps.get(0);
+        assertEquals(TallyGranularity.YEARLY, toUpdate.getGranularity());
+        assertEquals(TEST_PRODUCT, toUpdate.getProductId());
+        assertEquals(Integer.valueOf(11), toUpdate.getCores());
+        assertEquals(Integer.valueOf(11), toUpdate.getInstanceCount());
+
+        TallySnapshot monthlyToUpdate = monthlies.get(0);
+        monthlyToUpdate.setCores(100);
+        monthlyToUpdate.setInstanceCount(50);
+        repository.saveAndFlush(monthlyToUpdate);
+
+        roller.rollSnapshots(Arrays.asList("A1"));
+
+        // Check the yearly again. Should still be a single instance, but have updated values.
+        List<TallySnapshot> updatedSnaps =
+            repository.findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetween("A1",
+            TEST_PRODUCT, TallyGranularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear());
+        assertEquals(1, originalSnaps.size());
+
+        TallySnapshot updated = updatedSnaps.get(0);
+        assertEquals(toUpdate.getId(), updated.getId());
+        assertEquals("A1", toUpdate.getAccountNumber());
+        assertEquals(TallyGranularity.YEARLY, updated.getGranularity());
+        assertEquals(monthlyToUpdate.getProductId(), updated.getProductId());
+        assertEquals(monthlyToUpdate.getCores(), updated.getCores());
+        assertEquals(monthlyToUpdate.getInstanceCount(), updated.getInstanceCount());
+    }
+
+    private List<TallySnapshot> setupYearsWorthOfMonthlySnaps(String account, OffsetDateTime anyDayOfWeek) {
+        OffsetDateTime startOfYear = clock.startOfYear(anyDayOfWeek);
+
+        List<TallySnapshot> monthlyForYear = new LinkedList<>();
+        IntStream.rangeClosed(0, 11).forEach(i -> {
+            monthlyForYear.add(createUnpersisted(account, TEST_PRODUCT, TallyGranularity.MONTHLY, i,
+                i, startOfYear.plusMonths(i)));
+        });
+
+        repository.saveAll(monthlyForYear);
+        repository.flush();
+
+        return monthlyForYear;
+    }
+
+    private TallySnapshot createUnpersisted(String account, String product, TallyGranularity granularity,
+        int cores, int instanceCount, OffsetDateTime date) {
+        TallySnapshot tally = new TallySnapshot();
+        tally.setAccountNumber(account);
+        tally.setProductId(product);
+        tally.setOwnerId("N/A");
+        tally.setCores(cores);
+        tally.setGranularity(granularity);
+        tally.setInstanceCount(instanceCount);
+        tally.setSnapshotDate(date);
+        return tally;
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+
+public class ApplicationClockTest {
+
+    private ApplicationClock clock;
+
+    public ApplicationClockTest() {
+        // 2019-5-24 12:35:00 UTC
+        clock = new FixedClockConfiguration().fixedClock();
+    }
+
+    @Test
+    public void testNow() {
+        assertDate(2019, 5, 24, 12, 35, 0, 0, clock.now());
+    }
+
+    @Test
+    public void testStartOfToday() {
+        assertStartOfDay(2019, 5, 24, clock.startOfToday());
+    }
+
+    @Test
+    public void testStartOfDay() {
+        assertStartOfDay(2019, 5, 25, clock.startOfDay(clock.now().plusDays(1)));
+    }
+
+    @Test
+    public void testEndOfToday() {
+        assertEndOfDay(2019, 5, 24, clock.endOfToday());
+    }
+
+    @Test
+    public void testEndOfDay() {
+        assertEndOfDay(2019, 5, 25, clock.endOfDay(clock.now().plusDays(1)));
+    }
+
+    @Test
+    public void testStartOfCurrentWeek() {
+        assertStartOfDay(2019, 5, 19, clock.startOfCurrentWeek());
+    }
+
+    @Test
+    public void testStartOfWeek() {
+        assertStartOfDay(2019, 4, 28, clock.startOfWeek(clock.now().minusWeeks(3)));
+    }
+
+    @Test
+    public void testEndOfCurrentWeek() {
+        assertEndOfDay(2019, 5, 25, clock.endOfCurrentWeek());
+    }
+
+    @Test
+    public void testEndOfWeek() {
+        assertEndOfDay(2019, 5, 4, clock.endOfWeek(clock.now().minusWeeks(3)));
+    }
+
+    @Test
+    public void testStartOfCurrentMonth() {
+        assertStartOfDay(2019, 5, 1, clock.startOfCurrentMonth());
+    }
+
+    @Test
+    public void testStartOfMonth() {
+        assertStartOfDay(2019, 4, 1, clock.startOfMonth(clock.now().minusMonths(1)));
+    }
+
+    @Test
+    public void testEndOfCurrentMonth() {
+        assertEndOfDay(2019, 5, 31, clock.endOfCurrentMonth());
+    }
+
+    @Test
+    public void testEndOfMonth() {
+        assertEndOfDay(2019, 2, 28, clock.endOfMonth(clock.now().minusMonths(3)));
+    }
+
+    @Test
+    public void testStartOfCurrentYear() {
+        assertStartOfDay(2019, 1, 1, clock.startOfCurrentYear());
+    }
+
+    @Test
+    public void testStartOfYear() {
+        assertStartOfDay(2018, 1, 1, clock.startOfYear(clock.now().minusYears(1)));
+    }
+
+    @Test
+    public void testEndOfCurrentYear() {
+        assertEndOfDay(2019, 12, 31, clock.endOfCurrentYear());
+    }
+
+    @Test
+    public void testEndOfYear() {
+        assertEndOfDay(2018, 12, 31, clock.endOfYear(clock.now().minusYears(1)));
+    }
+
+    @Test
+    public void startOfQuarter() {
+        assertStartOfDay(2019, 1, 1, clock.startOfQuarter(clock.startOfCurrentYear()));
+        assertStartOfDay(2019, 4, 1, clock.startOfQuarter(clock.startOfCurrentYear().plusMonths(3)));
+        assertStartOfDay(2019, 7, 1, clock.startOfQuarter(clock.startOfCurrentYear().plusMonths(6)));
+        assertStartOfDay(2019, 10, 1, clock.startOfQuarter(clock.startOfCurrentYear().plusMonths(9)));
+    }
+
+    @Test
+    public void endOfQuarter() {
+        assertEndOfDay(2019, 3, 31, clock.endOfQuarter(clock.startOfCurrentYear()));
+        assertEndOfDay(2019, 6, 30, clock.endOfQuarter(clock.startOfCurrentYear().plusMonths(3)));
+        assertEndOfDay(2019, 9, 30, clock.endOfQuarter(clock.startOfCurrentYear().plusMonths(6)));
+        assertEndOfDay(2019, 12, 31, clock.endOfQuarter(clock.startOfCurrentYear().plusMonths(9)));
+    }
+
+    @Test
+    public void testStartCurrentQuarter() {
+        assertStartOfDay(2019, 4, 1, clock.startOfCurrentQuarter());
+    }
+
+    @Test
+    public void testEndOfCurrentQuarter() {
+        assertEndOfDay(2019, 6, 30, clock.endOfCurrentQuarter());
+    }
+
+    private void assertDate(int year, int month, int day, int hour, int minute, int seconds, int millis,
+        OffsetDateTime date) {
+        assertEquals(year, date.getYear());
+        assertEquals(month, date.getMonthValue());
+        assertEquals(day, date.getDayOfMonth());
+        assertEquals(hour, date.getHour());
+        assertEquals(minute, date.getMinute());
+        assertEquals(seconds, date.getSecond());
+        assertEquals(millis, date.getNano());
+    }
+
+    private void assertStartOfDay(int year, int month, int day, OffsetDateTime date) {
+        assertDate(year, month, day, 0, 0, 0, 0, date);
+    }
+
+    private void assertEndOfDay(int year, int month, int day, OffsetDateTime date) {
+        LocalDateTime max = LocalDateTime.MAX;
+        assertDate(year, month, day, max.getHour(), max.getMinute(), max.getSecond(), max.getNano(), date);
+    }
+}


### PR DESCRIPTION
Snapshot rolling is the concept of rolling snapshot data finer grained
snapshots to larger grained snapshots. For example, rolling daily
snapshots into weekly snapshots. Or, weekly snapshots into monthly
snapshots.

Roller implementation details:
* DAILY - Pulls data from the inventory service and for each host
  found, it computes the max cores/instances and creates a new
  daily snapshot.
* WEEKLY - Finds the maximum cores/instances from the existing daily
  snapshots for the current week and creates/updates the snapshot for
  the week.
* MONTHLY - Finds the maximum cores/instances from the existing daily
  snapshots for the current month and creates/updates the snapshot for
  the month.
* YEARLY - Finds the maximum cores/instances from the existing monthly
  snapshots for the current year and creates/updates the snapshot for
  the year.
* QUARTERLY - Finds the maximum cores/instances from the existing monthly
  snapshots for the current quarter and creates/updates the snapshot for
  the quarter. A quarter is defined as ever 3 month period throughout the
  year; Jan-Mar, Apr-Jun, Jul-Sept, Oct-Dec

It is important to restate that all rollers will roll up data based
on the current day, week, month, year, and quarter, and each is
dependent on data from the other. Because of this it is important
that each roller runs in a specific order.

Other notes:
* An ApplicationClock class has been created to wrap a single Clock
  instance for the application. Here we can create any helper style
  time based methods required by the application. While it provides
  a common place for date/time related functionality, it is also
  easier to test.