### PR TITLE
Count sockets and add to snapshots and rollups

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -54,7 +54,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
     @SuppressWarnings("indentation")
     @Query("select " +
                "new org.candlepin.subscriptions.db.model.AccountMaxValues(" +
-                    "s.accountNumber, s.ownerId, max(s.cores), max(s.instanceCount)) " +
+                    "s.accountNumber, s.ownerId, max(s.cores), max(s.sockets), max(s.instanceCount)) " +
            "from TallySnapshot s " +
            "where s.granularity=:granularity and s.accountNumber in (:accounts) " +
                "and s.productId = :product and s.snapshotDate between :beginning and :ending " +

--- a/src/main/java/org/candlepin/subscriptions/db/model/AccountMaxValues.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/AccountMaxValues.java
@@ -31,17 +31,21 @@ public class AccountMaxValues {
     private String accountNumber;
     private String ownerId;
     private Integer maxCores;
+    private Integer maxSockets;
     private Integer maxInstances;
 
-    public AccountMaxValues(String accountNumber, String ownerId, Integer maxCores, Integer maxInstances) {
+    public AccountMaxValues(String accountNumber, String ownerId, Integer maxCores, Integer maxSockets,
+        Integer maxInstances) {
         this.accountNumber = accountNumber;
         this.ownerId = ownerId;
         this.maxCores = maxCores;
+        this.maxSockets = maxSockets;
         this.maxInstances = maxInstances;
     }
 
     public AccountMaxValues(ProductUsageCalculation calc) {
-        this(calc.getAccount(), calc.getOwner(), calc.getTotalCores(), calc.getInstanceCount());
+        this(calc.getAccount(), calc.getOwner(), calc.getTotalCores(), calc.getTotalSockets(),
+            calc.getInstanceCount());
     }
 
     public String getAccountNumber() {
@@ -58,6 +62,14 @@ public class AccountMaxValues {
 
     public void setMaxCores(Integer maxCores) {
         this.maxCores = maxCores;
+    }
+
+    public Integer getMaxSockets() {
+        return maxSockets;
+    }
+
+    public void setMaxSockets(Integer maxSockets) {
+        this.maxSockets = maxSockets;
     }
 
     public Integer getMaxInstances() {

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -54,6 +54,9 @@ public class TallySnapshot implements Serializable {
     @Column(name = "cores")
     private Integer cores;
 
+    @Column(name = "sockets")
+    private Integer sockets;
+
     @Column(name = "product_id")
     private String productId;
 
@@ -97,6 +100,14 @@ public class TallySnapshot implements Serializable {
 
     public void setCores(Integer cores) {
         this.cores = cores;
+    }
+
+    public Integer getSockets() {
+        return sockets;
+    }
+
+    public void setSockets(Integer sockets) {
+        this.sockets = sockets;
     }
 
     public String getProductId() {

--- a/src/main/java/org/candlepin/subscriptions/tally/ProductUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/ProductUsageCalculation.java
@@ -29,12 +29,14 @@ public class ProductUsageCalculation {
     private String owner;
     private String productId;
     private int totalCores;
+    private int totalSockets;
     private int instanceCount;
 
     public ProductUsageCalculation(String account, String productId) {
         this.account = account;
         this.productId = productId;
         this.totalCores = 0;
+        this.totalSockets = 0;
         this.instanceCount = 0;
     }
 
@@ -53,6 +55,14 @@ public class ProductUsageCalculation {
 
     public int getTotalCores() {
         return totalCores;
+    }
+
+    public int getTotalSockets() {
+        return totalSockets;
+    }
+
+    public void addSockets(int socketsToAdd) {
+        this.totalSockets += socketsToAdd;
     }
 
     public void addInstance() {

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -32,10 +32,12 @@ public class NormalizedFacts {
 
     public static final String PRODUCTS_KEY = "products";
     public static final String CORES_KEY = "cores";
+    public static final String SOCKETS_KEY = "sockets";
     public static final String OWNER_KEY = "owner";
 
     private Set<String> products;
     private Integer cores;
+    private Integer sockets;
     private String owner;
 
     public NormalizedFacts() {
@@ -68,6 +70,14 @@ public class NormalizedFacts {
 
     public void setOwner(String owner) {
         this.owner = owner;
+    }
+
+    public Integer getSockets() {
+        return sockets;
+    }
+
+    public void setSockets(Integer sockets) {
+        this.sockets = sockets;
     }
 
     public Map<String, Object> toInventoryPayload() {

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizer.java
@@ -36,6 +36,8 @@ public class RhsmFactNormalizer implements FactSetNormalizer {
 
     public static final String RH_PRODUCTS = "RH_PROD";
     public static final String CPU_CORES = "CPU_CORES";
+    public static final String CPU_SOCKETS = "CPU_SOCKETS";
+
     // TODO: This should be uppercase in conduit.
     public static final String ORG_ID = "orgId";
     public static final String SYNC_TIMESTAMP = "SYNC_TIMESTAMP";
@@ -71,8 +73,10 @@ public class RhsmFactNormalizer implements FactSetNormalizer {
             normalizedFacts.addProduct("RHEL");
         }
 
-        // Check for cores. If not included, default to 0 cores.
+        // Check for cores and sockets. If not included, default to 0.
         normalizedFacts.setCores(rhsmFacts.containsKey(CPU_CORES) ? (Integer) rhsmFacts.get(CPU_CORES) : 0);
+        normalizedFacts.setSockets(rhsmFacts.containsKey(CPU_SOCKETS) ?
+            (Integer) rhsmFacts.get(CPU_SOCKETS) : 0);
         normalizedFacts.setOwner((String) rhsmFacts.get(ORG_ID));
     }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -78,6 +78,7 @@ public abstract class BaseSnapshotRoller {
     protected void updateWithMax(TallySnapshot snapshot, AccountMaxValues maxValues) {
         snapshot.setInstanceCount(maxValues.getMaxInstances());
         snapshot.setCores(maxValues.getMaxCores());
+        snapshot.setSockets(maxValues.getMaxSockets());
         snapshot.setOwnerId(maxValues.getOwnerId());
         snapshot.setAccountNumber(maxValues.getAccountNumber());
         snapshot.setSnapshotDate(getSnapshotDate(snapshot.getGranularity()));

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
@@ -67,6 +67,7 @@ public class DailySnapshotRoller extends BaseSnapshotRoller {
         produceDailySnapshots(accounts, calculateMaxValuesFromInventory(accounts));
     }
 
+    @SuppressWarnings("squid:S3776")
     @Transactional(value = "inventoryTransactionManager", readOnly = true)
     public Collection<ProductUsageCalculation> calculateMaxValuesFromInventory(List<String> accounts) {
         Map<String, ProductUsageCalculation> calcsByAccount = new HashMap<>();
@@ -79,8 +80,10 @@ public class DailySnapshotRoller extends BaseSnapshotRoller {
 
                 ProductUsageCalculation calc = calcsByAccount.get(account);
                 NormalizedFacts facts = factNormalizer.normalize(host);
+
                 if (facts.getProducts().contains(calc.getProductId())) {
                     calc.addCores(facts.getCores() != null ? facts.getCores() : 0);
+                    calc.addSockets(facts.getSockets() != null ? facts.getSockets() : 0);
                     calc.addInstance();
                 }
 
@@ -105,8 +108,8 @@ public class DailySnapshotRoller extends BaseSnapshotRoller {
 
         if (log.isDebugEnabled()) {
             for (ProductUsageCalculation calc : calcsByAccount.values()) {
-                log.info("Account: {}, Cores: {}, Instances: {}", calc.getAccount(), calc.getTotalCores(),
-                    calc.getInstanceCount());
+                log.info("Account: {}, Cores: {}, Sockets: {}, Instances: {}", calc.getAccount(),
+                    calc.getTotalCores(), calc.getTotalSockets(), calc.getInstanceCount());
             }
         }
         return calcsByAccount.values();

--- a/src/main/resources/liquibase/201907121757-add-sockets-column.xml
+++ b/src/main/resources/liquibase/201907121757-add-sockets-column.xml
@@ -6,9 +6,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <include file="liquibase/201906181633-create-schema.xml"/>
-    <include file="liquibase/201907121110-add-snapshot-date-index.xml"/>
-    <include file="liquibase/201907121757-add-sockets-column.xml"/>
+    <changeSet id="201907121757-1" author="mstead">
+        <comment>Add sockets column to tally_snapshots table</comment>
+        <addColumn tableName="tally_snapshots">
+            <column name="sockets" type="INT" />
+        </addColumn>
+    </changeSet>
 
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/tally/ProductUsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/ProductUsageCalculationTest.java
@@ -44,4 +44,12 @@ public class ProductUsageCalculationTest {
         assertEquals(expectedCores, calculation.getTotalCores());
     }
 
+    @Test
+    public void testAddingSockets() {
+        ProductUsageCalculation calculation = new ProductUsageCalculation("Account", "Product");
+        int expectedSockets = 10;
+        IntStream.rangeClosed(0, 4).forEach(i -> calculation.addSockets(i));
+        assertEquals(expectedSockets, calculation.getTotalSockets());
+    }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -82,6 +82,7 @@ public class QuarterlySnapshotRollerTest {
         assertEquals(TallyGranularity.QUARTERLY, secondQuarter.getGranularity());
         assertEquals(TEST_PRODUCT, secondQuarter.getProductId());
         assertEquals(Integer.valueOf(5), secondQuarter.getCores());
+        assertEquals(Integer.valueOf(6), secondQuarter.getSockets());
         assertEquals(Integer.valueOf(5), secondQuarter.getInstanceCount());
     }
 
@@ -102,10 +103,12 @@ public class QuarterlySnapshotRollerTest {
         assertEquals(TallyGranularity.QUARTERLY, toUpdate.getGranularity());
         assertEquals(TEST_PRODUCT, toUpdate.getProductId());
         assertEquals(Integer.valueOf(5), toUpdate.getCores());
+        assertEquals(Integer.valueOf(6), toUpdate.getSockets());
         assertEquals(Integer.valueOf(5), toUpdate.getInstanceCount());
 
         TallySnapshot secondQuarterMonthlyToUpdate = monthlies.get(5);
         secondQuarterMonthlyToUpdate.setCores(100);
+        secondQuarterMonthlyToUpdate.setSockets(200);
         secondQuarterMonthlyToUpdate.setInstanceCount(50);
         repository.saveAndFlush(secondQuarterMonthlyToUpdate);
 
@@ -124,6 +127,7 @@ public class QuarterlySnapshotRollerTest {
         assertEquals(TallyGranularity.QUARTERLY, updated.getGranularity());
         assertEquals(secondQuarterMonthlyToUpdate.getProductId(), updated.getProductId());
         assertEquals(secondQuarterMonthlyToUpdate.getCores(), updated.getCores());
+        assertEquals(secondQuarterMonthlyToUpdate.getSockets(), updated.getSockets());
         assertEquals(secondQuarterMonthlyToUpdate.getInstanceCount(), updated.getInstanceCount());
     }
 
@@ -133,7 +137,7 @@ public class QuarterlySnapshotRollerTest {
         List<TallySnapshot> monthlyForYear = new LinkedList<>();
         IntStream.rangeClosed(0, 11).forEach(i -> {
             monthlyForYear.add(createUnpersisted(account, TEST_PRODUCT, TallyGranularity.MONTHLY, i,
-                i, startOfYear.plusMonths(i)));
+                i + 1, i, startOfYear.plusMonths(i)));
         });
 
         repository.saveAll(monthlyForYear);
@@ -143,12 +147,13 @@ public class QuarterlySnapshotRollerTest {
     }
 
     private TallySnapshot createUnpersisted(String account, String product, TallyGranularity granularity,
-        int cores, int instanceCount, OffsetDateTime date) {
+        int cores, int sockets, int instanceCount, OffsetDateTime date) {
         TallySnapshot tally = new TallySnapshot();
         tally.setAccountNumber(account);
         tally.setProductId(product);
         tally.setOwnerId("N/A");
         tally.setCores(cores);
+        tally.setSockets(sockets);
         tally.setGranularity(granularity);
         tally.setInstanceCount(instanceCount);
         tally.setSnapshotDate(date);

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -79,8 +79,8 @@ public class WeeklySnapshotRollerTest {
         TallySnapshot result = weeklySnaps.get(0);
         assertEquals(TallyGranularity.WEEKLY, result.getGranularity());
         assertEquals(TEST_PRODUCT, result.getProductId());
-        // Cores and instance count should both come from the daily snap with the largest cores count.
         assertEquals(Integer.valueOf(6), result.getCores());
+        assertEquals(Integer.valueOf(7), result.getSockets());
         assertEquals(Integer.valueOf(6), result.getInstanceCount());
     }
 
@@ -102,13 +102,14 @@ public class WeeklySnapshotRollerTest {
         assertEquals("A1", result.getAccountNumber());
         assertEquals(TallyGranularity.WEEKLY, result.getGranularity());
         assertEquals(TEST_PRODUCT, result.getProductId());
-        // Cores and instance count should both come from the daily snap with the largest cores count.
         assertEquals(Integer.valueOf(6), result.getCores());
+        assertEquals(Integer.valueOf(7), result.getSockets());
         assertEquals(Integer.valueOf(6), result.getInstanceCount());
 
         // Update the daily and run again
         TallySnapshot dailyToUpdate = dailies.get(0);
         dailyToUpdate.setCores(124);
+        dailyToUpdate.setSockets(248);
         dailyToUpdate.setInstanceCount(20);
         repository.saveAndFlush(dailyToUpdate);
 
@@ -126,6 +127,7 @@ public class WeeklySnapshotRollerTest {
         assertEquals(TallyGranularity.WEEKLY, updated.getGranularity());
         assertEquals(dailyToUpdate.getProductId(), updated.getProductId());
         assertEquals(dailyToUpdate.getCores(), updated.getCores());
+        assertEquals(dailyToUpdate.getSockets(), updated.getSockets());
         assertEquals(dailyToUpdate.getInstanceCount(), updated.getInstanceCount());
     }
 
@@ -137,7 +139,7 @@ public class WeeklySnapshotRollerTest {
         List<TallySnapshot> dailyForWeek = new LinkedList<>();
         IntStream.rangeClosed(0, 6).forEach(i -> {
             dailyForWeek.add(createUnpersisted(account, TEST_PRODUCT, TallyGranularity.DAILY, i,
-                i, startOfWeek.plusDays(i)));
+                i + 1, i, startOfWeek.plusDays(i)));
         });
 
         repository.saveAll(dailyForWeek);
@@ -147,12 +149,13 @@ public class WeeklySnapshotRollerTest {
     }
 
     private TallySnapshot createUnpersisted(String account, String product, TallyGranularity granularity,
-        int cores, int instanceCount, OffsetDateTime date) {
+        int cores, int sockets, int instanceCount, OffsetDateTime date) {
         TallySnapshot tally = new TallySnapshot();
         tally.setAccountNumber(account);
         tally.setProductId(product);
         tally.setOwnerId("N/A");
         tally.setCores(cores);
+        tally.setSockets(sockets);
         tally.setGranularity(granularity);
         tally.setInstanceCount(instanceCount);
         tally.setSnapshotDate(date);

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -80,6 +80,7 @@ public class YearlySnapshotRollerTest {
         assertEquals(TallyGranularity.YEARLY, result.getGranularity());
         assertEquals(TEST_PRODUCT, result.getProductId());
         assertEquals(Integer.valueOf(11), result.getCores());
+        assertEquals(Integer.valueOf(12), result.getSockets());
         assertEquals(Integer.valueOf(11), result.getInstanceCount());
     }
 
@@ -99,10 +100,12 @@ public class YearlySnapshotRollerTest {
         assertEquals(TallyGranularity.YEARLY, toUpdate.getGranularity());
         assertEquals(TEST_PRODUCT, toUpdate.getProductId());
         assertEquals(Integer.valueOf(11), toUpdate.getCores());
+        assertEquals(Integer.valueOf(12), toUpdate.getSockets());
         assertEquals(Integer.valueOf(11), toUpdate.getInstanceCount());
 
         TallySnapshot monthlyToUpdate = monthlies.get(0);
         monthlyToUpdate.setCores(100);
+        monthlyToUpdate.setSockets(200);
         monthlyToUpdate.setInstanceCount(50);
         repository.saveAndFlush(monthlyToUpdate);
 
@@ -120,6 +123,7 @@ public class YearlySnapshotRollerTest {
         assertEquals(TallyGranularity.YEARLY, updated.getGranularity());
         assertEquals(monthlyToUpdate.getProductId(), updated.getProductId());
         assertEquals(monthlyToUpdate.getCores(), updated.getCores());
+        assertEquals(monthlyToUpdate.getSockets(), updated.getSockets());
         assertEquals(monthlyToUpdate.getInstanceCount(), updated.getInstanceCount());
     }
 
@@ -129,7 +133,7 @@ public class YearlySnapshotRollerTest {
         List<TallySnapshot> monthlyForYear = new LinkedList<>();
         IntStream.rangeClosed(0, 11).forEach(i -> {
             monthlyForYear.add(createUnpersisted(account, TEST_PRODUCT, TallyGranularity.MONTHLY, i,
-                i, startOfYear.plusMonths(i)));
+                i + 1, i, startOfYear.plusMonths(i)));
         });
 
         repository.saveAll(monthlyForYear);
@@ -139,12 +143,13 @@ public class YearlySnapshotRollerTest {
     }
 
     private TallySnapshot createUnpersisted(String account, String product, TallyGranularity granularity,
-        int cores, int instanceCount, OffsetDateTime date) {
+        int cores, int sockets, int instanceCount, OffsetDateTime date) {
         TallySnapshot tally = new TallySnapshot();
         tally.setAccountNumber(account);
         tally.setProductId(product);
         tally.setOwnerId("N/A");
         tally.setCores(cores);
+        tally.setSockets(sockets);
         tally.setGranularity(granularity);
         tally.setInstanceCount(instanceCount);
         tally.setSnapshotDate(date);


### PR DESCRIPTION
Sockets are counted from inventory hosts and stored in the
daily snapshots. When the daily snapshots are rolled, the
max value of the sockets for the time period is used.