### PR TITLE
Fixed sonarcloud.io project link

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
         stage('SonarQube Quality Gate') {
             steps {
                 withSonarQubeEnv('sonarcloud.io') {
-                    echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=org.candlepin%3Arhsm-subscriptions"
+                    echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
                 }
                 timeout(time: 1, unit: 'HOURS') {
                     waitForQualityGate abortPipeline: true


### PR DESCRIPTION
The project link produced after quality gate has run was incorrect. Updated to point at the correct location.

If you take a look at the 'Detals' page on jenkins, take a look at the link output from the 'SonarQube Quality Gate' 'Print Message' dropdown.