### PR TITLE
Parse sync timestamps as Strings

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizer.java
@@ -64,7 +64,8 @@ public class RhsmFactNormalizer implements FactSetNormalizer {
         //
         // NOTE: This logic is applied since currently the inventory service does not prune inventory
         //       records once a host no longer exists.
-        if (hostUnregistered((OffsetDateTime) rhsmFacts.get(SYNC_TIMESTAMP))) {
+        String syncTimestamp = (String) rhsmFacts.getOrDefault(SYNC_TIMESTAMP, "");
+        if (!syncTimestamp.isEmpty() && hostUnregistered(OffsetDateTime.parse(syncTimestamp))) {
             return;
         }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/normalizer/RhsmFactNormalizerTest.java
@@ -119,7 +119,7 @@ public class RhsmFactNormalizerTest {
     public void testIgnoresHostWhenLastSyncIsOutOfConfiguredThreshold() {
         OffsetDateTime lastSynced = clock.now().minusDays(2);
         Map<String, Object> facts = createRhsmFactSet(Arrays.asList("P1"), 4, 8);
-        facts.put(RhsmFactNormalizer.SYNC_TIMESTAMP, lastSynced);
+        facts.put(RhsmFactNormalizer.SYNC_TIMESTAMP, lastSynced.toString());
 
         NormalizedFacts normalized = new NormalizedFacts();
         normalizer.normalize(normalized, FactSetNamespace.RHSM, facts);
@@ -131,7 +131,7 @@ public class RhsmFactNormalizerTest {
     public void testIncludesHostWhenLastSyncIsWithinTheConfiguredThreshold() {
         OffsetDateTime lastSynced = clock.now().minusDays(1);
         Map<String, Object> facts = createRhsmFactSet(Arrays.asList("P1"), 4, 8);
-        facts.put(RhsmFactNormalizer.SYNC_TIMESTAMP, lastSynced);
+        facts.put(RhsmFactNormalizer.SYNC_TIMESTAMP, lastSynced.toString());
 
         NormalizedFacts normalized = new NormalizedFacts();
         normalizer.normalize(normalized, FactSetNamespace.RHSM, facts);


### PR DESCRIPTION
Fixes

```
java.lang.ClassCastException: java.lang.String cannot be cast to java.time.OffsetDateTime
    at org.candlepin.subscriptions.tally.facts.normalizer.RhsmFactNormalizer.normalize(RhsmFactNormalizer.java:67)
```