### PR TITLE
Disable jobs via config property

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.jobs;
 
 import org.quartz.JobDetail;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.autoconfigure.quartz.QuartzDataSource;
 import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomizer;
@@ -77,6 +78,7 @@ public class JobsConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "true")
     public JobDetailFactoryBean orgSyncJobDetail() {
         JobDetailFactoryBean jobDetail = new JobDetailFactoryBean();
         jobDetail.setDurability(true);
@@ -86,6 +88,7 @@ public class JobsConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "true")
     public JobDetailFactoryBean purgeJobDetail() {
         JobDetailFactoryBean jobDetail = new JobDetailFactoryBean();
         jobDetail.setDurability(true);
@@ -95,6 +98,7 @@ public class JobsConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "true")
     public CronTriggerFactoryBean orgSyncTrigger(JobDetail orgSyncJobDetail, JobProperties jobProperties) {
         CronTriggerFactoryBean trigger = new CronTriggerFactoryBean();
         trigger.setJobDetail(orgSyncJobDetail);
@@ -103,6 +107,7 @@ public class JobsConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "true")
     public CronTriggerFactoryBean purgeTrigger(JobDetail purgeJobDetail, JobProperties jobProperties) {
         CronTriggerFactoryBean trigger = new CronTriggerFactoryBean();
         trigger.setJobDetail(purgeJobDetail);

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -30,6 +30,7 @@ import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.candlepin.subscriptions.utilization.api.resources.TallyApi;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -49,6 +50,8 @@ import javax.ws.rs.core.UriInfo;
  * Tally API implementation.
  */
 @Component
+@ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "false",
+    matchIfMissing = true)
 public class TallyResource implements TallyApi {
 
     private static final Integer DEFAULT_LIMIT = 50;


### PR DESCRIPTION
A configuration property (rhsm-subscriptions.enableJobProcessing=true|false)
was added to disable job scheduling when the application is started.
This allows dedicating an application instance to handling requests
while not having the burden of running jobs.

**NOTE:**
When jobs are disabled, we are unfortunately still spinning up a quartz scheduler. To avoid this, we would have to find a way to remove the quartz config from the application.yaml and move it to our properties file. I've left this out of the PR given our time constraints. I'd prefer to make this change at a later date, but let me know if we should invest the time to do it now.
