### PR TITLE
Include empty collections in JSON data

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolver.java
+++ b/src/main/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolver.java
@@ -48,7 +48,6 @@ public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper
         objectMapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
         objectMapper.configure(SerializationFeature.INDENT_OUTPUT, applicationProperties.isPrettyPrintJson());
         objectMapper.setSerializationInclusion(Include.NON_NULL);
-        objectMapper.setSerializationInclusion(Include.NON_EMPTY);
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         // Tell the mapper to check the classpath for any serialization/deserialization modules

--- a/src/test/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolverTest.java
+++ b/src/test/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolverTest.java
@@ -92,11 +92,11 @@ public class ObjectMapperContextResolverTest {
     }
 
     @Test
-    public void ensureSerializedObjectsDoNotIncludePropsWithEmptyValues() throws Exception {
+    public void ensureSerializedObjectsIncludePropsWithEmptyValues() throws Exception {
         String v2 = "bar";
         TestPojo pojo = new TestPojo("", v2);
         String data = mapper.writeValueAsString(pojo);
-        assertDoesNotContainProperty(data, "value1");
+        assertContainsProperty(data, "value1", "");
         assertContainsProperty(data, "value2", v2);
     }
 
@@ -118,6 +118,15 @@ public class ObjectMapperContextResolverTest {
         assertEquals("value2", pojo.getValue2());
     }
 
+    @Test
+    public void ensureSerializedObjectsIncludeEmptyList() throws Exception {
+        TestPojo pojo = new TestPojo("foo", "bar");
+        String data = mapper.writeValueAsString(pojo);
+        assertContainsProperty(data, "value1", "foo");
+        assertContainsProperty(data, "value2", "bar");
+        assertIncludesCollection(data, "valueList", "[]");
+    }
+
     private void assertContainsProperty(String data, String key, String value)  throws Exception {
         String toFind = String.format("\"%s\":\"%s\"", key, value);
         assertTrue(data.contains(toFind));
@@ -125,6 +134,11 @@ public class ObjectMapperContextResolverTest {
 
     private void assertDoesNotContainProperty(String data, String property) throws Exception {
         assertFalse(data.contains(property));
+    }
+
+    private void assertIncludesCollection(String data, String key, String collectionValue) {
+        String toFind = String.format("\"%s\":%s", key, collectionValue);
+        assertTrue(data.contains(toFind));
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/jackson/TestPojo.java
+++ b/src/test/java/org/candlepin/subscriptions/jackson/TestPojo.java
@@ -20,9 +20,13 @@
  */
 package org.candlepin.subscriptions.jackson;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TestPojo {
     private String value1;
     private String value2;
+    private List<String> valueList = new ArrayList<>();
 
     public TestPojo() { }
 
@@ -45,5 +49,13 @@ public class TestPojo {
 
     public void setValue2(String value2) {
         this.value2 = value2;
+    }
+
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
     }
 }


### PR DESCRIPTION
There is a trade off with this fix in that properties with
empty string values will be included in the JSON output,
but any properties with a null value will not.