### PR TITLE
Add DatabaseAccountListSource

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -22,10 +22,13 @@ package org.candlepin.subscriptions;
 
 import org.candlepin.insights.inventory.client.HostsApiFactory;
 import org.candlepin.insights.inventory.client.InventoryServiceProperties;
-import org.candlepin.subscriptions.files.AccountListSource;
+import org.candlepin.subscriptions.files.FileAccountListSource;
 import org.candlepin.subscriptions.files.RhelProductListSource;
+import org.candlepin.subscriptions.inventory.db.InventoryRepository;
 import org.candlepin.subscriptions.jackson.ObjectMapperContextResolver;
 import org.candlepin.subscriptions.retention.TallyRetentionPolicy;
+import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.tally.DatabaseAccountListSource;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
@@ -110,8 +113,14 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public AccountListSource accountListSource(ApplicationProperties applicationProperties) {
-        return new AccountListSource(applicationProperties);
+    public AccountListSource accountListSource(ApplicationProperties applicationProperties,
+        InventoryRepository inventoryRepository) {
+        if (applicationProperties.getAccountListResourceLocation() != null) {
+            return new FileAccountListSource(applicationProperties);
+        }
+        else {
+            return new DatabaseAccountListSource(inventoryRepository);
+        }
     }
 
     @Bean

--- a/src/main/java/org/candlepin/subscriptions/controller/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/TallyRetentionController.java
@@ -22,8 +22,8 @@ package org.candlepin.subscriptions.controller;
 
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.TallyGranularity;
-import org.candlepin.subscriptions.files.AccountListSource;
 import org.candlepin.subscriptions.retention.TallyRetentionPolicy;
+import org.candlepin.subscriptions.tally.AccountListSource;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
@@ -22,13 +22,13 @@ package org.candlepin.subscriptions.files;
 
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.tally.AccountListSource;
 
 /**
- * Reads a set of RHEL product IDs from a file. Each line is a single
- * product ID.
+ * Reads a set of accounts from a file. Each line is a single account.
  */
-public class AccountListSource extends PerLineFileSource {
-    public AccountListSource(ApplicationProperties applicationProperties) {
+public class FileAccountListSource extends PerLineFileSource implements AccountListSource {
+    public FileAccountListSource(ApplicationProperties applicationProperties) {
         super(applicationProperties.getAccountListResourceLocation());
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -26,8 +26,10 @@ import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -38,5 +40,9 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
 
     @Query(nativeQuery = true)
     Stream<InventoryHostFacts> getFacts(@Param("accounts") Collection<String> accounts);
+
+    @Transactional(readOnly = true, transactionManager = "inventoryTransactionManager")
+    @Query("select distinct h.account from InventoryHost h")
+    List<String> listAccounts();
 
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountListSource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Provides a list of accounts to run Tally against.
+ */
+public interface AccountListSource {
+    List<String> list() throws IOException;
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/DatabaseAccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/DatabaseAccountListSource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import org.candlepin.subscriptions.inventory.db.InventoryRepository;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Gathers all accounts in the host inventory DB as the list to tally.
+ */
+public class DatabaseAccountListSource implements AccountListSource {
+
+    private final InventoryRepository repository;
+
+    public DatabaseAccountListSource(InventoryRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<String> list() throws IOException {
+        return repository.listAccounts();
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.tally;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.exception.SnapshotProducerException;
-import org.candlepin.subscriptions.files.AccountListSource;
 import org.candlepin.subscriptions.inventory.db.InventoryRepository;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.tally.roller.DailySnapshotRoller;

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -14,7 +14,6 @@ rhsm-subscriptions.inventory-service.datasource.platform=postgresql
 
 # Use Spring Resource notation for this (e.g. "classpath:" or "file:")
 rhsm-subscriptions.rhelProductListResourceLocation=classpath:empty-rhel-product-list.txt
-rhsm-subscriptions.accountListResourceLocation=classpath:empty-rhel-product-list.txt
 
 rhsm-subscriptions.datasource.url=jdbc:postgresql://${POSTGRESQL_SERVICE_HOST:localhost}:\
   ${POSTGRESQL_SERVICE_PORT:5432}/${DATABASE_NAME:rhsm-subscriptions}

--- a/src/test/java/org/candlepin/subscriptions/controller/TallyRetentionControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/TallyRetentionControllerTest.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.*;
 
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.TallyGranularity;
-import org.candlepin.subscriptions.files.AccountListSource;
 import org.candlepin.subscriptions.retention.TallyRetentionPolicy;
+import org.candlepin.subscriptions.tally.AccountListSource;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/candlepin/subscriptions/files/FileAccountListSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/FileAccountListSourceTest.java
@@ -32,14 +32,14 @@ import org.springframework.core.io.FileSystemResourceLoader;
 import java.util.List;
 
 
-public class AccountListSourceTest {
+public class FileAccountListSourceTest {
 
     @Test
     public void ensureResourcePathComesFromApplicationProperty() throws Exception {
         ApplicationProperties props = new ApplicationProperties();
         props.setAccountListResourceLocation("classpath:account_list.txt");
 
-        AccountListSource source = new AccountListSource(props);
+        FileAccountListSource source = new FileAccountListSource(props);
         source.setResourceLoader(new FileSystemResourceLoader());
         source.init();
 


### PR DESCRIPTION
I refactored so that `AccountListSource` is just a generic interface,
and now the `ApplicationConfiguration` configures a `FileAccountListSource`
if `rhsm-subscriptions.accountListResourceLocation` is specified,
or a `DatabaseAccountListSource` otherwise.