### PR TITLE
Process system profile only if it has RHEL IDs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -56,7 +56,8 @@ import javax.persistence.Table;
                 @ColumnResult(name = "system_profile_cores_per_socket"),
                 @ColumnResult(name = "system_profile_sockets"),
                 @ColumnResult(name = "qpc_products"),
-                @ColumnResult(name = "qpc_product_ids")
+                @ColumnResult(name = "qpc_product_ids"),
+                @ColumnResult(name = "system_profile_product_ids")
             }
         )
     }
@@ -76,7 +77,8 @@ import javax.persistence.Table;
         "h.system_profile_facts->>'number_of_sockets' as system_profile_sockets, " +
         "rhsm_products.products, " +
         "qpc_prods.qpc_products, " +
-        "qpc_certs.qpc_product_ids " +
+        "qpc_certs.qpc_product_ids, " +
+        "system_profile.system_profile_product_ids " +
         "from hosts h " +
         "cross join lateral ( " +
         "    select string_agg(items, ',') as products " +
@@ -87,6 +89,9 @@ import javax.persistence.Table;
         "cross join lateral ( " +
         "    select string_agg(items, ',') as qpc_product_ids " +
         "    from jsonb_array_elements_text(h.facts->'qpc'->'rh_product_certs') as items) qpc_certs " +
+        "cross join lateral ( " +
+        "    select string_agg(items->>'id', ',') as system_profile_product_ids " +
+        "    from jsonb_array_elements(h.system_profile_facts->'installed_products') as items) system_profile " +
         "where account IN (:accounts)",
     resultSetMapping = "inventoryHostFactsMapping")
 public class InventoryHost implements Serializable {

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -40,11 +40,12 @@ public class InventoryHostFacts {
     private int systemProfileSockets;
     private Set<String> qpcProducts;
     private Set<String> qpcProductIds;
+    private Set<String> systemProfileProductIds;
 
     @SuppressWarnings("squid:S00107")
     public InventoryHostFacts(String account, String displayName, String orgId, String cores, String sockets,
         String products, String syncTimestamp, String systemProfileCores, String systemProfileSockets,
-        String qpcProducts, String qpcProductIds) {
+        String qpcProducts, String qpcProductIds, String systemProfileProductIds) {
 
         this.account = account;
         this.displayName = displayName;
@@ -57,6 +58,7 @@ public class InventoryHostFacts {
         this.syncTimestamp = StringUtils.hasText(syncTimestamp) ? syncTimestamp : "";
         this.systemProfileCoresPerSocket = asInt(systemProfileCores);
         this.systemProfileSockets = asInt(systemProfileSockets);
+        this.systemProfileProductIds = asStringSet(systemProfileProductIds);
     }
 
     public String getAccount() {
@@ -144,5 +146,9 @@ public class InventoryHostFacts {
 
     public Set<String> getQpcProductIds() {
         return qpcProductIds;
+    }
+
+    public Set<String> getSystemProfileProductIds() {
+        return systemProfileProductIds;
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -166,7 +166,7 @@ public class InventoryAccountUsageCollectorTest {
             String.valueOf(sockets),
             StringUtils.collectionToCommaDelimitedString(Arrays.asList(product)),
             OffsetDateTime.now().toString(), String.valueOf(systemProfileCoresPerSocket),
-            String.valueOf(systemProfileSockets), null, null);
+            String.valueOf(systemProfileSockets), null, null, null);
     }
 
     private void assertCalculation(AccountUsageCalculation calc, String account, String owner, String product,

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -88,7 +89,7 @@ public class FactNormalizerTest {
 
     @Test
     public void testSystemProfileNormalization() {
-        InventoryHostFacts host = createSystemProfileHost(4, 2);
+        InventoryHostFacts host = createSystemProfileHost(Collections.singletonList("P1"), 4, 2);
         NormalizedFacts normalized = normalizer.normalize(host);
         assertThat(normalized.getProducts(), Matchers.hasItem("RHEL"));
         assertEquals(Integer.valueOf(8), normalized.getCores());
@@ -101,6 +102,15 @@ public class FactNormalizerTest {
         assertThat(normalized.getProducts(), Matchers.empty());
         assertEquals(Integer.valueOf(4), normalized.getCores());
         assertEquals(Integer.valueOf(8), normalized.getSockets());
+    }
+
+    @Test
+    void testSystemProfileNonRhelProduct() {
+        NormalizedFacts normalized =
+            normalizer.normalize(createSystemProfileHost(Collections.singletonList("NonRHEL"), 2, 4));
+        assertThat(normalized.getProducts(), Matchers.empty());
+        assertEquals(Integer.valueOf(8), normalized.getCores());
+        assertEquals(Integer.valueOf(4), normalized.getSockets());
     }
 
     @Test
@@ -172,17 +182,18 @@ public class FactNormalizerTest {
     private InventoryHostFacts createRhsmHost(List<String> products, Integer cores, Integer sockets) {
         return new InventoryHostFacts("Account", "Test System", "test_org", String.valueOf(cores),
             String.valueOf(sockets), StringUtils.collectionToCommaDelimitedString(products),
-            clock.now().toString(), null, null, null, null);
+            clock.now().toString(), null, null, null, null, null);
     }
 
     private InventoryHostFacts createQpcHost(String qpcProducts) {
         return new InventoryHostFacts("Account", "Test System", "test_org", null,
-            null, null, clock.now().toString(), qpcProducts, null, qpcProducts, null);
+            null, null, clock.now().toString(), qpcProducts, null, qpcProducts, null, null);
     }
 
-    private InventoryHostFacts createSystemProfileHost(Integer coresPerSocket, Integer sockets) {
+    private InventoryHostFacts createSystemProfileHost(List<String> products, Integer coresPerSocket,
+        Integer sockets) {
         return new InventoryHostFacts("Account", "Test System", "test_org", null,
             null, null, clock.now().toString(), String.valueOf(coresPerSocket),
-            String.valueOf(sockets), null, null);
+            String.valueOf(sockets), null, null, StringUtils.collectionToCommaDelimitedString(products));
     }
 }


### PR DESCRIPTION
# Testing

I recommend you set up the service to hit our inventory DB clone, and see that the service still records fresh snapshots. You can look for or create records in inventory service that have product IDs reported to use as a test case for the query.