### PR TITLE
Fixed missing transaction issue when purging snapshots

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/controller/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/TallyRetentionController.java
@@ -26,7 +26,6 @@ import org.candlepin.subscriptions.retention.TallyRetentionPolicy;
 import org.candlepin.subscriptions.tally.AccountListSource;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -56,7 +55,6 @@ public class TallyRetentionController {
         accountList.forEach(this::cleanStaleSnapshotsForAccount);
     }
 
-    @Transactional
     public void cleanStaleSnapshotsForAccount(String accountNumber) {
         for (TallyGranularity granularity : TallyGranularity.values()) {
             OffsetDateTime cutoffDate = policy.getCutoffDate(granularity);

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -27,6 +27,7 @@ import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
@@ -42,6 +43,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
         String accountNumber, String productId, TallyGranularity granularity, OffsetDateTime beginning,
         OffsetDateTime ending, Pageable pageable);
 
+    @Transactional
     void deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(String accountNumber,
         TallyGranularity granularity, OffsetDateTime cutoffDate);
 


### PR DESCRIPTION
Spring does not honor @Transactional when the method it is on
is called from within the same class. In this particular case,
we would have to mark purgeSnapshots to make it work. Since we
want a transaction around the purge for each account, the
annotation was placed on the repository method itself.

See Pitfall#2:
https://codete.com/blog/5-common-spring-transactional-pitfalls/