### PR TITLE
Create Version resource that echoes the same data as the info actuator

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -12,6 +12,22 @@ servers:
   - url: https://cloud.redhat.com/api/rhsm-subscriptions/v1
 
 paths:
+  /version:
+    description: "Provides version and build information about the deployed application."
+    get:
+      summary: "Request version and build information about the deployed application."
+      operationId: getVersion
+      tags:
+        - version
+      responses:
+        '200':
+          description: 'The request for version information was successful.'
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/VersionInfo"
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /tally/products/{product_id}:
     description: "Operations for a tally report of a specific account and product."
     parameters:
@@ -174,6 +190,23 @@ components:
           schema:
             $ref: "#/components/schemas/Errors"
   schemas:
+    VersionInfo:
+      properties:
+        build:
+          type: object
+          properties:
+            version:
+              type: string
+            gitDescription:
+              type: string
+            artifact:
+              type: string
+            name:
+              type: string
+            group:
+              type: string
+            gitHash:
+              type: string
     # If we need additional responses, look at
     # https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/ to reduce
     # redundancy

--- a/src/main/java/org/candlepin/subscriptions/resource/VersionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/VersionResource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.resource;
+
+import org.candlepin.subscriptions.utilization.api.model.VersionInfo;
+import org.candlepin.subscriptions.utilization.api.model.VersionInfoBuild;
+import org.candlepin.subscriptions.utilization.api.resources.VersionApi;
+
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Return the version information for the application
+ */
+@Component
+public class VersionResource implements VersionApi {
+
+    private final BuildProperties buildProperties;
+
+    public VersionResource(BuildProperties buildProperties) {
+        this.buildProperties = buildProperties;
+    }
+
+    @Override
+    public VersionInfo getVersion() {
+        VersionInfoBuild versionInfoBuild = new VersionInfoBuild();
+        versionInfoBuild.setVersion(buildProperties.getVersion());
+        versionInfoBuild.setArtifact(buildProperties.getArtifact());
+        versionInfoBuild.setName(buildProperties.getName());
+        versionInfoBuild.setGroup(buildProperties.getGroup());
+
+        versionInfoBuild.setGitDescription(buildProperties.get("gitDescription"));
+        versionInfoBuild.setGitHash(buildProperties.get("gitHash"));
+
+        VersionInfo versionInfo = new VersionInfo();
+        versionInfo.setBuild(versionInfoBuild);
+        return versionInfo;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -24,6 +24,7 @@ package org.candlepin.subscriptions.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -114,7 +115,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .anonymous()  // Creates an anonymous user if no header is present at all. Prevents NPEs basically
             .and()
             .authorizeRequests()
-                .antMatchers("/**/openapi.*", "/actuator/**").permitAll()
+                // Allow access to Actuator endpoints here
+                .requestMatchers(EndpointRequest.to("health", "info", "prometheus")).permitAll()
+                .antMatchers("/**/openapi.*", "/**/version").permitAll()
                 .anyRequest().authenticated();
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.subscriptions.utilization.api.model.VersionInfo;
+import org.candlepin.subscriptions.utilization.api.model.VersionInfoBuild;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
+public class VersionResourceTest {
+    @MockBean BuildProperties buildProperties;
+
+    @Autowired VersionResource versionResource;
+
+    @Test
+    void getVersion() {
+        when(buildProperties.getVersion()).thenReturn("VERSION");
+        when(buildProperties.getArtifact()).thenReturn("ARTIFACT");
+        when(buildProperties.getName()).thenReturn("NAME");
+        when(buildProperties.getGroup()).thenReturn("GROUP");
+        when(buildProperties.get(eq("gitDescription"))).thenReturn("GIT_DESCRIPTION");
+        when(buildProperties.get(eq("gitHash"))).thenReturn("GIT_HASH");
+
+        VersionInfo versionInfo = versionResource.getVersion();
+        VersionInfoBuild expected = versionInfo.getBuild();
+        assertEquals("VERSION", expected.getVersion());
+        assertEquals("ARTIFACT", expected.getArtifact());
+        assertEquals("NAME", expected.getName());
+        assertEquals("GROUP", expected.getGroup());
+        assertEquals("GIT_DESCRIPTION", expected.getGitDescription());
+        assertEquals("GIT_HASH", expected.getGitHash());
+    }
+}


### PR DESCRIPTION
# Testing
1. Deploy the application
```
$ ./gradlew clean bootRun --args="--server.port=9166"
```

2. Compare the actuator output with the Version resource output
```
$ diff -s <(curl -s http://localhost:9166/api/rhsm-subscriptions/v1/version) <(curl -s http://localhost:9166/actuator/info)
Files /proc/self/fd/11 and /proc/self/fd/12 are identical
```

3. Examine the Version resource output yourself
```
$ curl -s http://localhost:9166/api/rhsm-subscriptions/v1/version
```