### PR TITLE
Optionally fill in gaps in tally report periods

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -48,7 +48,8 @@ paths:
           type: integer
         description: "The numbers of items to return"
     get:
-      summary: "Fetch a tally report for an account and product."
+      summary: "Fetch a tally report for an account and product. If page header parameters are omitted,
+                then any gaps in the resulting report snapshots are filled with a default fake snapshot."
       operationId: getTallyReport
       parameters:
         - name: granularity
@@ -363,6 +364,8 @@ components:
           type: integer
           format: int32
           minimum: 0
+        has_data:
+          type: boolean
     CapacityReport:
       properties:
         data:

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -150,6 +150,7 @@ public class TallySnapshot implements Serializable {
         snapshot.setCores(this.getCores());
         snapshot.setSockets(this.getSockets());
         snapshot.setInstanceCount(this.getInstanceCount());
+        snapshot.setHasData(id != null);
         return snapshot;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/DailyReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/DailyReportFiller.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+
+/**
+ * A ReportFiller instance that will fill the given TallyReport's snapshots based on a DAILY granularity.
+ * The offset between the snapshots in the report is 1 day.
+ */
+public class DailyReportFiller extends ReportFiller {
+
+    public DailyReportFiller(ApplicationClock clock) {
+        super(clock);
+    }
+
+    @Override
+    TemporalAmount getSnapshotOffset() {
+        return Period.ofDays(1);
+    }
+
+    @Override
+    OffsetDateTime adjustToPeriodStart(OffsetDateTime startDate) {
+        return clock.startOfDay(startDate);
+    }
+
+    @Override
+    OffsetDateTime adjustToPeriodEnd(OffsetDateTime toAdjust) {
+        return clock.endOfDay(toAdjust);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFiller.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+
+/**
+ * A ReportFiller instance that will fill the given TallyReport's snapshots based on a MONTHLY granularity.
+ */
+public class MonthlyReportFiller extends ReportFiller {
+
+    public MonthlyReportFiller(ApplicationClock clock) {
+        super(clock);
+    }
+
+    @Override
+    public TemporalAmount getSnapshotOffset() {
+        return Period.ofMonths(1);
+    }
+
+    @Override
+    public OffsetDateTime adjustToPeriodStart(OffsetDateTime toAdjust) {
+        return clock.startOfMonth(toAdjust);
+    }
+
+    @Override
+    public OffsetDateTime adjustToPeriodEnd(OffsetDateTime toAdjust) {
+        return clock.endOfMonth(toAdjust);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFiller.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+
+/**
+ * A ReportFiller instance that will fill the given TallyReport's snapshots based on a QUARTERLY granularity.
+ */
+public class QuarterlyReportFiller extends ReportFiller {
+
+    public QuarterlyReportFiller(ApplicationClock clock) {
+        super(clock);
+    }
+
+    @Override
+    public OffsetDateTime adjustToPeriodStart(OffsetDateTime toAdjust) {
+        return clock.startOfQuarter(toAdjust);
+    }
+
+    @Override
+    public TemporalAmount getSnapshotOffset() {
+        return Period.ofMonths(3);
+    }
+
+    @Override
+    public OffsetDateTime adjustToPeriodEnd(OffsetDateTime toAdjust) {
+        return clock.endOfQuarter(toAdjust);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Given a granularity, date range and existing snaps for the period, fills out any gaps in a TallyReport.
+ *
+ */
+public abstract class ReportFiller {
+    private static final Logger log = LoggerFactory.getLogger(ReportFiller.class);
+
+    protected ApplicationClock clock;
+
+    public ReportFiller(ApplicationClock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Get the TemporalAmount that represents the offset period between each report snapshot. A snapshot
+     * offset is defined by the amount of time between each snapshot in a report. For example, filling in a
+     * report for Daily granularity, the offset would be 1 DAY given that each daily snapshot spans one full
+     * day.
+     *
+     * @return a temporal amount representing the period offset.
+     */
+    abstract TemporalAmount getSnapshotOffset();
+
+    /**
+     * Adjust the given date to the start of this filler's snapshot period. For example, filling in a report
+     * for Daily granularity, the adjusted date would be at the start of the day.
+     *
+     * @param toAdjust the date to adjust
+     * @return the adjusted date instance
+     */
+    abstract OffsetDateTime adjustToPeriodStart(OffsetDateTime toAdjust);
+
+    /**
+     * Adjust the given date to the end of this filler's snapshot period. For example, filling in a report
+     * for Daily granularity, the adjusted date would be at the end of the day.
+     *
+     * @param toAdjust the date to adjust
+     * @return the adjusted date instance
+     */
+    abstract OffsetDateTime adjustToPeriodEnd(OffsetDateTime toAdjust);
+
+    @SuppressWarnings("squid:S2583")
+    public void fillGaps(TallyReport report, OffsetDateTime start, OffsetDateTime end) {
+        List<TallySnapshot> result = new ArrayList<>();
+        TemporalAmount offset = getSnapshotOffset();
+
+        OffsetDateTime firstDate = adjustToPeriodStart(start);
+        OffsetDateTime lastDate = adjustToPeriodEnd(end);
+
+        List<TallySnapshot> existingSnaps = report.getData();
+        if (existingSnaps == null || existingSnaps.isEmpty()) {
+            result.addAll(fillWithRange(firstDate, lastDate, offset));
+        }
+        else {
+            OffsetDateTime nextDate = firstDate;
+            OffsetDateTime lastSnapDate = null;
+
+            for (TallySnapshot snapshot : existingSnaps) {
+                OffsetDateTime snapDate = snapshot.getDate();
+
+                // Should never happen, but if the Filler is given a snapshot without a date
+                // it can't be slotted into the date range. Warn, and skip the snapshot.
+                if (snapDate == null) {
+                    // NOTE: Sonarcloud notes snapDate == null as always resulting to false. This
+                    // is incorrect so the warning has been suppressed (squid:S2583).
+                    log.warn("Encountered snapshot without date set. Skipping.");
+                    continue;
+                }
+
+                lastSnapDate = adjustToPeriodStart(snapDate);
+                // Fill report up until the next snapshot, then add the snapshot to the report list.
+                result.addAll(fillWithRange(nextDate, lastSnapDate.minus(offset), offset));
+                result.add(snapshot);
+                nextDate = lastSnapDate.plus(offset);
+            }
+
+            // If no snaps contain dates, just use the start of the range. Otherwise,
+            // fill from the date of the last snapshot found, to the end of the range.
+            if (lastSnapDate == null) {
+                result.addAll(fillWithRange(firstDate, lastDate, offset));
+            }
+            else if (lastSnapDate.isBefore(lastDate)) {
+                result.addAll(fillWithRange(lastSnapDate.plus(offset), lastDate, offset));
+            }
+        }
+        report.setData(result);
+    }
+
+    private TallySnapshot createDefaultSnapshot(OffsetDateTime snapshotDate) {
+        return new TallySnapshot()
+            .date(snapshotDate)
+            .cores(0)
+            .sockets(0)
+            .instanceCount(0)
+            .hasData(false);
+    }
+
+    private List<TallySnapshot> fillWithRange(OffsetDateTime start, OffsetDateTime end,
+        TemporalAmount offset) {
+        List<TallySnapshot> result = new ArrayList<>();
+        OffsetDateTime next = OffsetDateTime.from(start);
+        while (next.isBefore(end) || next.isEqual(end)) {
+            result.add(createDefaultSnapshot(clock.startOfDay(next)));
+            next = clock.startOfDay(next.plus(offset));
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+
+/**
+ * Responsible for creating ReportFiller objects based on granularity.
+ */
+public class ReportFillerFactory {
+
+    private ReportFillerFactory() {
+        throw new IllegalStateException("Utility class; should never be instantiated!");
+    }
+
+    /**
+     * Creates an instance of a ReportFiller based on a TallyGranularity.
+     *
+     * @param clock an application clock instance to base dates off of.
+     * @param granularity the target granularity
+     * @return a ReportFiller instance for the specified granularity.
+     */
+    public static ReportFiller getInstance(ApplicationClock clock, TallyGranularity granularity) {
+        switch (granularity) {
+            case DAILY:
+                return new DailyReportFiller(clock);
+            case WEEKLY:
+                return new WeeklyReportFiller(clock);
+            case MONTHLY:
+                return new MonthlyReportFiller(clock);
+            case YEARLY:
+                return new YearlyReportFiller(clock);
+            case QUARTERLY:
+                return new QuarterlyReportFiller(clock);
+            default:
+        }
+        throw new IllegalArgumentException("Unsupported granularity while filling report: " + granularity);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFiller.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+
+/**
+ * A ReportFiller instance that will fill the given TallyReport's snapshots based on a WEEKLY granularity.
+ */
+public class WeeklyReportFiller extends ReportFiller {
+
+    public WeeklyReportFiller(ApplicationClock clock) {
+        super(clock);
+    }
+
+    @Override
+    public TemporalAmount getSnapshotOffset() {
+        return Period.ofWeeks(1);
+    }
+
+    @Override
+    public OffsetDateTime adjustToPeriodStart(OffsetDateTime startDate) {
+        return clock.startOfWeek(startDate);
+    }
+
+    @Override
+    public OffsetDateTime adjustToPeriodEnd(OffsetDateTime toAdjust) {
+        return clock.endOfWeek(toAdjust);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/YearlyReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/YearlyReportFiller.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+
+
+/**
+ * A ReportFiller instance that will fill the given TallyReport's snapshots based on a MONTHLY granularity.
+ */
+public class YearlyReportFiller extends ReportFiller {
+
+    public YearlyReportFiller(ApplicationClock clock) {
+        super(clock);
+    }
+
+    @Override
+    public TemporalAmount getSnapshotOffset() {
+        return Period.ofYears(1);
+    }
+
+    @Override
+    public OffsetDateTime adjustToPeriodStart(OffsetDateTime toAdjust) {
+        return clock.startOfYear(toAdjust);
+    }
+
+    @Override
+    public OffsetDateTime adjustToPeriodEnd(OffsetDateTime toAdjust) {
+        return clock.endOfYear(toAdjust);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -25,6 +25,8 @@ import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.TemporalField;
+import java.time.temporal.WeekFields;
 
 /**
  * The single date and time source to be used by the application.
@@ -35,6 +37,9 @@ import java.time.temporal.TemporalAdjusters;
 public class ApplicationClock {
 
     private Clock clock;
+
+    // Ensure the week starts with Sunday.
+    private TemporalField week = WeekFields.of(DayOfWeek.SUNDAY, 1).dayOfWeek();
 
     public ApplicationClock() {
         this.clock = Clock.systemUTC();
@@ -73,7 +78,7 @@ public class ApplicationClock {
     }
 
     public OffsetDateTime endOfWeek(OffsetDateTime anyDayInWeek) {
-        return endOfDay(anyDayInWeek.with(DayOfWeek.SATURDAY));
+        return endOfDay(anyDayInWeek.with(week, 7));
     }
 
     public OffsetDateTime startOfCurrentWeek() {
@@ -81,7 +86,7 @@ public class ApplicationClock {
     }
 
     public OffsetDateTime startOfWeek(OffsetDateTime anyDayOfWeek) {
-        return startOfDay(anyDayOfWeek.with(DayOfWeek.SUNDAY).minusDays(7L));
+        return startOfDay(anyDayOfWeek.with(week, 1));
     }
 
     public OffsetDateTime endOfCurrentMonth() {
@@ -137,4 +142,5 @@ public class ApplicationClock {
         return endOfDay.with(endOfDay.getMonth().firstMonthOfQuarter())
             .plusMonths(2).with(TemporalAdjusters.lastDayOfMonth());
     }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/Assertions.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/Assertions.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import java.time.OffsetDateTime;
+
+public class Assertions {
+
+    private Assertions() {
+        throw new IllegalStateException("Utility class; should never be instantiated!");
+    }
+
+    /**
+     * Assert the state of a given snapshot.
+     *
+     * @param snap the snapshot under test
+     * @param date the expected snapshot date
+     * @param cores the expected snapshot cores
+     * @param sockets the expected snapshot sockets
+     * @param instanceCount the expected snapshot instance count
+     * @param hasData whether the snapshot was expected to have been generated.
+     */
+    public static void assertSnapshot(TallySnapshot snap, OffsetDateTime date, Integer cores, Integer sockets,
+        Integer instanceCount, Boolean hasData) {
+        assertEquals(date, snap.getDate(), "Invalid snapshot date");
+        assertEquals(cores, snap.getCores(), "Invalid snapshot cores");
+        assertEquals(sockets, snap.getSockets(), "Invalid snapshot sockets");
+        assertEquals(instanceCount, snap.getInstanceCount(), "Invalid snapshot instance count");
+        assertEquals(hasData, snap.getHasData());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+public class DailyReportFillerTest {
+
+    private ApplicationClock clock;
+    private ReportFiller filler;
+
+    public DailyReportFillerTest() {
+        clock = new FixedClockConfiguration().fixedClock();
+        filler = ReportFillerFactory.getInstance(clock, TallyGranularity.DAILY);
+    }
+
+    @Test
+    public void noExistingSnapsShouldfillWithDailyGranularity() {
+        OffsetDateTime start = clock.now();
+        OffsetDateTime end = start.plusDays(3);
+
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), clock.startOfDay(start), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), clock.startOfDay(start.plusDays(1)), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), clock.startOfDay(start.plusDays(3)), 0, 0, 0, false);
+    }
+
+    @Test
+    public void shouldFillGapsBasedOnExistingSnapshotsForDailyGranularity() {
+        OffsetDateTime start = clock.now();
+        OffsetDateTime snap1Date = start.plusDays(1);
+        OffsetDateTime end = start.plusDays(3);
+
+        TallySnapshot snap1 = new TallySnapshot().date(snap1Date).cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().date(end).cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), clock.startOfDay(start), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
+            snap1.getInstanceCount(), true);
+        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
+            snap2.getInstanceCount(), true);
+    }
+
+    @Test
+    public void testSnapshotsIgnoredWhenNoDatesSet() {
+        OffsetDateTime start = clock.startOfToday();
+        OffsetDateTime end = start.plusDays(3);
+
+        TallySnapshot snap1 = new TallySnapshot().cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusDays(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusDays(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusDays(3), 0, 0, 0, false);
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+public class MonthlyReportFillerTest {
+
+    private ApplicationClock clock;
+    private ReportFiller filler;
+
+    public MonthlyReportFillerTest() {
+        clock = new FixedClockConfiguration().fixedClock();
+        filler = ReportFillerFactory.getInstance(clock, TallyGranularity.MONTHLY);
+    }
+
+    @Test
+    public void noExistingSnapsShouldFillWithMonthlyGranularity() {
+        OffsetDateTime start = clock.startOfCurrentMonth();
+        OffsetDateTime end = start.plusMonths(3);
+
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusMonths(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusMonths(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusMonths(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void startAndEndDatesForMonthlyAreResetWhenDateIsMidMonth() {
+        // Mid month start
+        OffsetDateTime start = clock.now();
+        // Mid month end
+        OffsetDateTime end = start.plusMonths(3);
+
+        // Expected to start on the beginning of the month.
+        OffsetDateTime expectedStart = clock.startOfMonth(start);
+
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), expectedStart, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), expectedStart.plusMonths(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), expectedStart.plusMonths(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), expectedStart.plusMonths(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void testSnapshotsIgnoredWhenNoDatesSet() {
+        OffsetDateTime start = clock.startOfCurrentMonth();
+        OffsetDateTime end = start.plusMonths(3);
+
+        TallySnapshot snap1 = new TallySnapshot().cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusMonths(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusMonths(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusMonths(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void shouldFillGapsBasedOnExistingSnapshotsForMonthlyGranularity() {
+        OffsetDateTime start = clock.startOfCurrentMonth();
+        OffsetDateTime snap1Date = start.plusMonths(1);
+        OffsetDateTime end = start.plusMonths(3);
+
+        TallySnapshot snap1 = new TallySnapshot().date(snap1Date).cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().date(end).cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
+            snap1.getInstanceCount(), true);
+        assertSnapshot(filled.get(2), start.plusMonths(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
+            snap2.getInstanceCount(), true);
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+public class QuarterlyReportFillerTest {
+
+    private ApplicationClock clock;
+    private ReportFiller filler;
+
+    public QuarterlyReportFillerTest() {
+        clock = new FixedClockConfiguration().fixedClock();
+        filler = ReportFillerFactory.getInstance(clock, TallyGranularity.QUARTERLY);
+    }
+
+    @Test
+    public void noExistingSnapsShouldFillWithQuarterlyGranularity() {
+        OffsetDateTime start = clock.startOfCurrentQuarter();
+        OffsetDateTime end = start.plusYears(1);
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(5, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusMonths(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusMonths(6), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusMonths(9), 0, 0, 0, false);
+        assertSnapshot(filled.get(4), start.plusMonths(12), 0, 0, 0, false);
+    }
+
+    @Test
+    public void startAndEndDatesForQuarterlyAreResetWhenDateIsMidQuarter() {
+        // Mid year start
+        OffsetDateTime start = clock.now();
+        // Mid year end
+        OffsetDateTime end = start.plusYears(1);
+        // Expected to start on the beginning of the year.
+        OffsetDateTime expectedStart = clock.startOfQuarter(start);
+
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(5, filled.size());
+        assertSnapshot(filled.get(0), expectedStart, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), expectedStart.plusMonths(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), expectedStart.plusMonths(6), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), expectedStart.plusMonths(9), 0, 0, 0, false);
+        assertSnapshot(filled.get(4), expectedStart.plusMonths(12), 0, 0, 0, false);
+    }
+
+    @Test
+    public void testSnapshotsIgnoredWhenNoDatesSet() {
+        OffsetDateTime start = clock.startOfCurrentQuarter();
+        OffsetDateTime end = start.plusYears(1);
+
+        TallySnapshot snap1 = new TallySnapshot().cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(5, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusMonths(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusMonths(6), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusMonths(9), 0, 0, 0, false);
+        assertSnapshot(filled.get(4), start.plusMonths(12), 0, 0, 0, false);
+    }
+
+    @Test
+    public void shouldFillGapsBasedOnExistingSnapshotsForQuarterlyGranularity() {
+        OffsetDateTime start = clock.startOfCurrentQuarter();
+        OffsetDateTime snap1Date = start.plusMonths(3);
+        OffsetDateTime end = start.plusYears(1);
+
+        TallySnapshot snap1 = new TallySnapshot().date(snap1Date).cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().date(end).cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(5, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
+            snap1.getInstanceCount(), true);
+        assertSnapshot(filled.get(2), start.plusMonths(6), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusMonths(9), 0, 0, 0, false);
+        assertSnapshot(filled.get(4), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
+            snap2.getInstanceCount(), true);
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.junit.jupiter.api.Test;
+
+public class ReportFillerFactoryTest {
+
+    private ApplicationClock clock;
+
+    public ReportFillerFactoryTest() {
+        clock = new FixedClockConfiguration().fixedClock();
+    }
+
+    @Test
+    public void testDailyReportFillerCreation() {
+        ReportFiller filler = ReportFillerFactory.getInstance(clock, TallyGranularity.DAILY);
+        assertTrue(filler instanceof DailyReportFiller);
+    }
+
+    @Test
+    public void testWeeklyReportFillerCreation() {
+        ReportFiller filler = ReportFillerFactory.getInstance(clock, TallyGranularity.WEEKLY);
+        assertTrue(filler instanceof WeeklyReportFiller);
+    }
+
+    @Test
+    public void testMonthlyReportFillerCreation() {
+        ReportFiller filler = ReportFillerFactory.getInstance(clock, TallyGranularity.MONTHLY);
+        assertTrue(filler instanceof MonthlyReportFiller);
+    }
+
+    @Test
+    public void testYearlyReportFillerCreation() {
+        ReportFiller filler = ReportFillerFactory.getInstance(clock, TallyGranularity.YEARLY);
+        assertTrue(filler instanceof YearlyReportFiller);
+    }
+
+    @Test
+    public void testQuarterlyReportFillerCreation() {
+        ReportFiller filler = ReportFillerFactory.getInstance(clock, TallyGranularity.QUARTERLY);
+        assertTrue(filler instanceof QuarterlyReportFiller);
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+public class WeeklyReportFillerTest {
+
+    private ApplicationClock clock;
+    private ReportFiller filler;
+
+    public WeeklyReportFillerTest() {
+        clock = new FixedClockConfiguration().fixedClock();
+        filler = ReportFillerFactory.getInstance(clock, TallyGranularity.WEEKLY);
+    }
+
+    @Test
+    public void noExistingSnapsShouldFillWithWeeklyGranularity() {
+        OffsetDateTime start = clock.startOfCurrentWeek();
+        OffsetDateTime end = start.plusWeeks(3);
+
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusWeeks(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusWeeks(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusWeeks(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void startAndEndDatesForWeeklyAreResetWhenDateIsMidWeek() {
+        // Mid week start
+        OffsetDateTime start = clock.now();
+        // Mid week end
+        OffsetDateTime end = start.plusWeeks(3);
+
+        // Expected to start on the beginning of the week.
+        OffsetDateTime expectedStart = clock.startOfWeek(start);
+
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), expectedStart, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), expectedStart.plusWeeks(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), expectedStart.plusWeeks(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), expectedStart.plusWeeks(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void testSnapshotsIgnoredWhenNoDatesSet() {
+        OffsetDateTime start = clock.startOfCurrentWeek();
+        OffsetDateTime end = start.plusWeeks(3);
+
+        TallySnapshot snap1 = new TallySnapshot().cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusWeeks(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusWeeks(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusWeeks(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void shouldFillGapsBasedOnExistingSnapshotsForWeeklyGranularity() {
+        OffsetDateTime start = clock.startOfCurrentWeek();
+        OffsetDateTime snap1Date = start.plusWeeks(1);
+        OffsetDateTime end = start.plusWeeks(3);
+
+        TallySnapshot snap1 = new TallySnapshot().date(snap1Date).cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().date(end).cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
+            snap1.getInstanceCount(), true);
+        assertSnapshot(filled.get(2), start.plusWeeks(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
+            snap2.getInstanceCount(), true);
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class YearlyReportFillerTest {
+
+    private ApplicationClock clock;
+    private ReportFiller filler;
+
+    public YearlyReportFillerTest() {
+        clock = new FixedClockConfiguration().fixedClock();
+        filler = ReportFillerFactory.getInstance(clock, TallyGranularity.YEARLY);
+    }
+
+    @Test
+    public void noExistingSnapsShouldFillWithYearlyGranularity() {
+        OffsetDateTime start = clock.startOfCurrentYear();
+        OffsetDateTime end = start.plusYears(3);
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusYears(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusYears(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusYears(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void startAndEndDatesForYearlyAreResetWhenDateIsMidYear() {
+        // Mid year start
+        OffsetDateTime start = clock.now();
+        // Mid year end
+        OffsetDateTime end = start.plusYears(3);
+        // Expected to start on the beginning of the year.
+        OffsetDateTime expectedStart = clock.startOfYear(start);
+
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), expectedStart, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), expectedStart.plusYears(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), expectedStart.plusYears(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), expectedStart.plusYears(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void testSnapshotsIgnoredWhenNoDatesSet() {
+        OffsetDateTime start = clock.startOfCurrentYear();
+        OffsetDateTime end = start.plusYears(3);
+
+        TallySnapshot snap1 = new TallySnapshot().cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusYears(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusYears(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusYears(3), 0, 0, 0, false);
+    }
+
+    @Test
+    public void shouldFillGapsBasedOnExistingSnapshotsForYearlyGranularity() {
+        OffsetDateTime start = clock.startOfCurrentYear();
+        OffsetDateTime snap1Date = start.plusYears(1);
+        OffsetDateTime end = start.plusYears(3);
+
+        TallySnapshot snap1 = new TallySnapshot().date(snap1Date).cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().date(end).cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
+            snap1.getInstanceCount(), true);
+        assertSnapshot(filled.get(2), start.plusYears(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
+            snap2.getInstanceCount(), true);
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -75,6 +75,12 @@ public class ApplicationClockTest {
     }
 
     @Test
+    public void testStartOfWeekWhenDateIsTheStartOfTheWeek() {
+        OffsetDateTime startOfWeek = clock.now().withYear(2019).withMonth(5).withDayOfMonth(12);
+        assertStartOfDay(2019, 5, 12, clock.startOfWeek(startOfWeek));
+    }
+
+    @Test
     public void testEndOfCurrentWeek() {
         assertEndOfDay(2019, 5, 25, clock.endOfCurrentWeek());
     }
@@ -82,6 +88,12 @@ public class ApplicationClockTest {
     @Test
     public void testEndOfWeek() {
         assertEndOfDay(2019, 5, 4, clock.endOfWeek(clock.now().minusWeeks(3)));
+    }
+
+    @Test
+    public void testEndOfWeekWhenDateIsTheEndOfTheWeek() {
+        OffsetDateTime endOfWeek = clock.now().withYear(2019).withMonth(5).withDayOfMonth(18);
+        assertEndOfDay(2019, 5, 18, clock.endOfWeek(endOfWeek));
     }
 
     @Test


### PR DESCRIPTION
When paging parameters are not included in tally report request,
paging is ignored and the report will have any gaps in the snapshots
filled with dummy snapshots for the requested range.