### PR TITLE
Add logic to get effective products for a subscription

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityProductExtractor.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityProductExtractor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.capacity;
+
+import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
+
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Given a list of product IDs provided by a given product/subscription, returns the effective view of
+ * products for capacity.
+ */
+@Component
+public class CapacityProductExtractor {
+
+    private final Map<Integer, List<String>> productIdToProductsMap;
+
+    public CapacityProductExtractor(ProductIdToProductsMapSource productIdToProductsMapSource)
+        throws IOException {
+
+        this.productIdToProductsMap = productIdToProductsMapSource.getValue();
+    }
+
+    public Set<String> getProducts(Collection<Integer> productIds) {
+        // NOTE: this logic can grow over time (e.g. to blacklist certain combinations, etc).
+        return productIds.stream()
+            .map(productIdToProductsMap::get).filter(Objects::nonNull).flatMap(List::stream)
+            .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.capacity;
+
+import static org.hamcrest.MatcherAssert.*;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.core.io.FileSystemResourceLoader;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CapacityProductExtractorTest {
+
+    private CapacityProductExtractor extractor;
+
+    @BeforeAll
+    void setup() throws IOException {
+        ApplicationProperties props = new ApplicationProperties();
+        props.setProductIdToProductsMapResourceLocation("classpath:test_product_id_to_products_map.yaml");
+        props.setRoleToProductsMapResourceLocation("classpath:test_role_to_products_map.yaml");
+
+        ProductIdToProductsMapSource productIdToProductsMapSource = new ProductIdToProductsMapSource(props);
+        productIdToProductsMapSource.setResourceLoader(new FileSystemResourceLoader());
+        productIdToProductsMapSource.init();
+
+        extractor = new CapacityProductExtractor(productIdToProductsMapSource);
+    }
+
+    @Test
+    void productExtractorReturnsExpectedProducts() {
+        Set<String> products = extractor.getProducts(Arrays.asList(6, 9, 10));
+        assertThat(products, Matchers.containsInAnyOrder("RHEL", "NOT RHEL", "RHEL Workstation",
+            "RHEL Server"));
+    }
+
+    @Test
+    void productExtractorReturnsNoProductsIfNoProductIdsMatch() {
+        Set<String> products = extractor.getProducts(Collections.singletonList(42));
+        assertThat(products, Matchers.empty());
+    }
+}


### PR DESCRIPTION
This is decoupled from the actual pool/subscription representation, and
is intended to plugged into later work.