### PR TITLE
Restrict tally/capacity report API to admins

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -23,16 +23,16 @@ package org.candlepin.subscriptions;
 import org.candlepin.subscriptions.retention.TallyRetentionPolicyProperties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 /**
  * POJO to hold property values via Spring's "Type-Safe Configuration Properties" pattern
  */
-@Component
 @ConfigurationProperties(prefix = "rhsm-subscriptions")
 public class ApplicationProperties {
 
     private boolean prettyPrintJson = false;
+
+    private boolean devMode = false;
 
     private final TallyRetentionPolicyProperties tallyRetentionPolicy = new TallyRetentionPolicyProperties();
 
@@ -113,6 +113,14 @@ public class ApplicationProperties {
 
     public void setAccountBatchSize(int accountBatchSize) {
         this.accountBatchSize = accountBatchSize;
+    }
+
+    public boolean isDevMode() {
+        return devMode;
+    }
+
+    public void setDevMode(boolean devMode) {
+        this.devMode = devMode;
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.db.model.TallyGranularity;
+import org.candlepin.subscriptions.security.auth.AdminOnly;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReport;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
@@ -44,6 +45,7 @@ import javax.validation.constraints.NotNull;
 public class CapacityResource implements CapacityApi {
 
     @Override
+    @AdminOnly
     public CapacityReport getCapacityReport(String productId, @NotNull String granularity,
         @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset, Integer limit) {
 

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -25,6 +25,7 @@ import org.candlepin.subscriptions.db.model.TallyGranularity;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
+import org.candlepin.subscriptions.security.auth.AdminOnly;
 import org.candlepin.subscriptions.tally.filler.ReportFiller;
 import org.candlepin.subscriptions.tally.filler.ReportFillerFactory;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -73,6 +74,7 @@ public class TallyResource implements TallyApi {
     }
 
     @Override
+    @AdminOnly
     public TallyReport getTallyReport(String productId, @NotNull String granularity,
         @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset, Integer limit) {
         // When limit and offset are not specified, we will fill the report with dummy

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedCredentialsNotFoundException;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
 import org.springframework.util.StringUtils;
 
 import java.io.IOException;
@@ -64,7 +65,8 @@ public class IdentityHeaderAuthenticationManager implements AuthenticationManage
     public Authentication authenticate(Authentication authentication) {
         PreAuthenticatedAuthenticationToken token = (PreAuthenticatedAuthenticationToken) authentication;
         byte[] decodedHeader = (byte[]) token.getPrincipal();
-
+        PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails details =
+            (PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails) authentication.getDetails();
         try {
             Map authObject = mapper.readValue(decodedHeader, Map.class);
             Map identity = (Map) authObject.getOrDefault("identity", Collections.emptyMap());
@@ -75,7 +77,8 @@ public class IdentityHeaderAuthenticationManager implements AuthenticationManage
                     " contains no principal");
             }
 
-            token = new PreAuthenticatedAuthenticationToken(accountNumber, token.getCredentials());
+            token = new PreAuthenticatedAuthenticationToken(accountNumber, token.getCredentials(),
+                details.getGrantedAuthorities());
             token.setAuthenticated(true);
             return token;
 

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -21,6 +21,8 @@
 
 package org.candlepin.subscriptions.security;
 
+import org.candlepin.subscriptions.ApplicationProperties;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +50,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Autowired
     private ObjectMapper mapper;
 
+    @SuppressWarnings("squid:S3305")
+    @Autowired
+    private ApplicationProperties appProps;
+
     @Override
     public void configure(AuthenticationManagerBuilder auth) {
         auth.authenticationProvider(preAuthenticatedAuthenticationProvider());
@@ -73,7 +79,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Bean
     public IdentityHeaderAuthenticationDetailsSource detailsSource() {
         return new IdentityHeaderAuthenticationDetailsSource(
-            mapper, identityHeaderAuthoritiesMapper()
+            appProps, mapper, identityHeaderAuthoritiesMapper()
         );
     }
 

--- a/src/main/java/org/candlepin/subscriptions/security/auth/AdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/AdminOnly.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security.auth;
+
+import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationDetailsSource;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A security annotation ensuring that the user must have an admin role in order to execute
+ * the method.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "')")
+public @interface AdminOnly {
+}

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -27,11 +27,13 @@ import org.candlepin.subscriptions.db.model.TallyGranularity;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
+import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationDetailsSource;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -56,6 +58,9 @@ public class TallyResourceTest {
     @MockBean
     PageLinkCreator pageLinkCreator;
 
+    @MockBean
+    BuildProperties buildProperties;
+
     @Autowired
     TallyResource resource;
 
@@ -63,7 +68,8 @@ public class TallyResourceTest {
     private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
 
     @Test
-    @WithMockUser("123456")
+    @WithMockUser(value = "123456",
+        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void testShouldUseQueryBasedOnHeaderAndParameters() {
         TallySnapshot snap = new TallySnapshot();
 
@@ -99,7 +105,8 @@ public class TallyResourceTest {
     }
 
     @Test
-    @WithMockUser("123456")
+    @WithMockUser(value = "123456",
+        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void testShouldThrowExceptionOnBadOffset() {
         SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource.getTallyReport(
             "product1",
@@ -113,7 +120,8 @@ public class TallyResourceTest {
     }
 
     @Test
-    @WithMockUser("123456")
+    @WithMockUser(value = "123456",
+        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void reportDataShouldGetFilledWhenPagingParametersAreNotPassed() {
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSourceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+public class IdentityHeaderAuthenticationDetailsSourceTest {
+
+    // {"identity":{"account_number":"TEST_ACCOUNT", "user":{"is_org_admin":true}}}
+    private final String ADMIN_ONLY =
+        "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IlRFU1RfQUNDT1VOVCIsICJ1c2VyIjp7Imlz" +
+        "X29yZ19hZG1pbiI6dHJ1ZX19fQo=";
+
+    // {"identity":{"account_number":"TEST_ACCOUNT", "user":{"is_internal":true}}}
+    private static final String INTERNAL_ONLY =
+        "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IlRFU1RfQUNDT1VOVCIsICJ1c2VyIjp7Imlz" +
+        "X2ludGVybmFsIjp0cnVlfX19Cg==";
+
+    // {"identity":{"account_number":"TEST_ACCOUNT"}}
+    public static final String ACCOUNT_ONLY =
+        "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IlRFU1RfQUNDT1VOVCJ9fQo=";
+
+    @Test
+    public void testAdminRoleGranted() {
+        assertRoles(ADMIN_ONLY, false, IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE);
+    }
+
+    @Test
+    public void testInternalRoleGranted() {
+        assertRoles(INTERNAL_ONLY, false, IdentityHeaderAuthenticationDetailsSource.INTERNAL_ROLE);
+    }
+
+    @Test
+    public void testDevModeGrantsAllRoles() {
+        assertRoles(ADMIN_ONLY, true, IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE,
+            IdentityHeaderAuthenticationDetailsSource.INTERNAL_ROLE);
+        assertRoles(INTERNAL_ONLY, true, IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE,
+            IdentityHeaderAuthenticationDetailsSource.INTERNAL_ROLE);
+        assertRoles(ACCOUNT_ONLY, true, IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE,
+            IdentityHeaderAuthenticationDetailsSource.INTERNAL_ROLE);
+    }
+
+    private void assertRoles(String identity, boolean devMode, String ... expectedRoles) {
+        HttpServletRequest context = mock(HttpServletRequest.class);
+        when(context.getHeader(IdentityHeaderAuthenticationFilter.RH_IDENTITY_HEADER)).thenReturn(identity);
+
+        ApplicationProperties props = new ApplicationProperties();
+        props.setDevMode(devMode);
+        IdentityHeaderAuthenticationDetailsSource source = new IdentityHeaderAuthenticationDetailsSource(
+            props, new ObjectMapper(), new IdentityHeaderAuthoritiesMapper()
+        );
+        Collection<String> roles = source.getUserRoles(context);
+        assertEquals(expectedRoles.length, roles.size());
+        assertThat(roles, Matchers.containsInAnyOrder(expectedRoles));
+    }
+}


### PR DESCRIPTION
* The following resources are now restricted to admin-only
  + GET /tally/products/:product_id
  + GET /capacity/products/:product_id
* New annotation AdminOnly can be applied to any resource method to
  restrict it to admin users only.
* Fixed bug where granted authorities were not getting passed along
  in the auth token.
* Added dev-mode=[true|false] that will grant all roles to a user
  provided that an identity header is specified with at least the
  account number.

## Testing

### Admin

```bash
$ echo eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjUzNTUzNzUiLCAidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9fX0K | base64 --decode
{"identity":{"account_number":"5355375", "user":{"is_org_admin":true}}}

$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjUzNTUzNzUiLCAidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9fX0K" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=monthly&beginning=2019-07-01T00:00:00.000Z&ending=2019-09-15T23:59:59.999Z" | python -mjson.tool

{
    "data": [
        {
            "date": "2019-06-30T21:00:00-03:00",
            "instance_count": 23,
            "cores": 102,
            "sockets": 60,
            "has_data": true
        },
        {
            "date": "2019-07-31T21:00:00-03:00",
            "instance_count": 30,
            "cores": 130,
            "sockets": 74,
            "has_data": true
        },
        {
            "date": "2019-08-31T21:00:00-03:00",
            "instance_count": 30,
            "cores": 130,
            "sockets": 74,
            "has_data": true
        },
        {
            "date": "2019-09-01T00:00:00-03:00",
            "instance_count": 0,
            "cores": 0,
            "sockets": 0,
            "has_data": false
        }
    ],
    "meta": {
        "count": 4,
        "product": "RHEL",
        "granularity": "monthly"
    }
}

```

### Non Admin
```bash
$ echo eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjYyMDU2NDcifX0K | base64 --decode
{"identity":{"account_number":"6205647"}}

$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjYyMDU2NDcifX0K" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-19T00:00:00.000Z&ending=2019-07-30T23:59:59.999Z" | python -mjson.tool
 
{
    "errors": [
        {
            "status": "500",
            "code": "SUBSCRIPTIONS1000",
            "title": "An internal server error has occurred. Check the server logs for further details.",
            "detail": "Access is denied"
        }
    ]
}
```
## Testing in dev mode
Add the following to rhsm-subscriptions.properties and restart the app.
```
rhsm-subscriptions.dev-mode=true
```

### Non Admin User
```bash
$ echo eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjYyMDU2NDcifX0K | base64 --decode
{"identity":{"account_number":"6205647"}}

$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjYyMDU2NDcifX0K" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-19T00:00:00.000Z&ending=2019-07-30T23:59:59.999Z" | python -mjson.tool

{
    "data": [
        {
            "date": "2019-06-19T00:00:00Z",
            "instance_count": 0,
            "cores": 0,
            "sockets": 0,
            "has_data": false
        },
        {
            "date": "2019-06-20T00:00:00Z",
            "instance_count": 0,
            "cores": 0,
            "sockets": 0,
            "has_data": false
        },
        {
            "date": "2019-06-21T00:00:00Z",
            "instance_count": 0,
            "cores": 0,
            "sockets": 0,
            "has_data": false
        },
        
        ...

    ],
    "meta": {
        "count": 42,
        "product": "RHEL",
        "granularity": "daily"
    }
}

```