### PR TITLE
Add ingress API and implementations

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -220,6 +220,40 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       tags:
         - capacity
+  /ingress/candlepin_pools/{org_id}:
+    description: "Integration endpoint for updating an account's subscription capacity from
+      Candlepin pool data."
+    parameters:
+      - name: org_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: "The org ID of the pool data"
+    post:
+      summary: "Update an account's subscription capacity from Candlepin pool data."
+      operationId: updateCapacityFromCandlepinPools
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/CandlepinPool'
+      responses:
+        '204':
+          description: 'Subscription capacity for the account updated successfully.'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      tags:
+        - ingress
   /openapi.json:
     get:
       description: "Get the OpenAPI spec in JSON format."
@@ -445,6 +479,50 @@ components:
             If there is an infinite quantity subscription involved, there is no meaningful number for
             capacity."
           type: boolean
+    CandlepinPool:
+      description: Subset of Candlepin pool data that rhsm-subscriptions understands.
+      properties:
+        accountNumber:
+          type: string
+        activeSubscription:
+          type: boolean
+        startDate:
+          type: string
+          format: date-time
+        endDate:
+          type: string
+          format: date-time
+        quantity:
+          type: integer
+          format: int32
+        productId:
+          type: string
+        productAttributes:
+          type: array
+          items:
+            $ref: "#/components/schemas/CandlepinProductAttribute"
+        providedProducts:
+          type: array
+          items:
+            $ref: "#/components/schemas/CandlepinProvidedProduct"
+        derivedProvidedProducts:
+          type: array
+          items:
+            $ref: "#/components/schemas/CandlepinProvidedProduct"
+        subscriptionId:
+          type: string
+        type:
+          type: string
+    CandlepinProductAttribute:
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+    CandlepinProvidedProduct:
+      properties:
+        productId:
+          type: string
     Errors:
       required:
         - errors

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -494,7 +494,7 @@ components:
           format: date-time
         quantity:
           type: integer
-          format: int32
+          format: int64
         productId:
           type: string
         productAttributes:

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -63,6 +63,11 @@ public class ApplicationProperties {
      */
     private int accountBatchSize = 500;
 
+    /**
+     * Whether the ingress endpoint is enabled on this instance of rhsm-subscriptions or not.
+     */
+    private boolean enableIngressEndpoint;
+
     public boolean isPrettyPrintJson() {
         return prettyPrintJson;
     }
@@ -123,4 +128,11 @@ public class ApplicationProperties {
         this.devMode = devMode;
     }
 
+    public boolean isEnableIngressEndpoint() {
+        return enableIngressEndpoint;
+    }
+
+    public void setEnableIngressEndpoint(boolean enableIngressEndpoint) {
+        this.enableIngressEndpoint = enableIngressEndpoint;
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource;
+
+import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
+import org.candlepin.subscriptions.utilization.api.resources.IngressApi;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import javax.validation.Valid;
+
+/**
+ * Updates subscription capacity based on Candlepin pool data.
+ */
+@Component
+@ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableIngressEndpoint", havingValue = "true")
+public class IngressResource implements IngressApi {
+
+    @Override
+    public void updateCapacityFromCandlepinPools(String orgId, @Valid List<CandlepinPool> candlepinPool) {
+        // to be implemented in later work
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -50,7 +50,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Autowired
     private ObjectMapper mapper;
 
-    @SuppressWarnings("squid:S3305")
     @Autowired
     private ApplicationProperties appProps;
 
@@ -124,6 +123,17 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 // Allow access to Actuator endpoints here
                 .requestMatchers(EndpointRequest.to("health", "info", "prometheus")).permitAll()
                 .antMatchers("/**/openapi.*", "/**/version", "/api-docs/**", "/webjars/**").permitAll()
+                // ingress security is done via server settings (require ssl cert auth), so permit all here
+                .antMatchers("/api/rhsm-subscriptions/v1/ingress/**").permitAll()
                 .anyRequest().authenticated();
+        if (appProps.isEnableIngressEndpoint()) {
+            configureForIngressEndpoint(http);
+        }
+    }
+
+    @SuppressWarnings("squid:S4502")
+    private void configureForIngressEndpoint(HttpSecurity http) throws Exception {
+        // CSRF isn't helpful for the machine-to-machine ingress endpoint
+        http.csrf().disable();
     }
 }

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -29,3 +29,5 @@ rhsm-subscriptions.jobs.captureSnapshotSchedule=0 0/5 * * * ?
 # Default Quartz datasource.  Override by pulling in another rhsm-subscriptions.properties file via an
 # -Dspring.config.additional-location argument
 rhsm-subscriptions.quartz.datasource.platform=hsqldb
+
+rhsm-subscriptions.enableIngressEndpoint=false

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -3,3 +3,5 @@ rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:testdb
 rhsm-subscriptions.datasource.username=
 rhsm-subscriptions.datasource.password=
 rhsm-subscriptions.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
+
+rhsm-subscriptions.enableIngressEndpoint=true


### PR DESCRIPTION
The idea is that we will have at least two deployment types (think
subscriptions vs. subscriptions-jobs deployment configs). In the general
API case, the API will not be present. In the other case, we'll
configure the server to require client cert auth (and actually the
endpoint).

To test the stub endpoint, set `rhsm-subscriptions.enableIngressEndpoint=true`
in `config/application.properties`