### PR TITLE
Skip Satellite 6 offerings in capacity calculations.

### DIFF
--- a/src/main/resources/product_id_to_products_map.yaml
+++ b/src/main/resources/product_id_to_products_map.yaml
@@ -41,3 +41,9 @@
 479:  # Red Hat Enterprise Linux for x86_64 (RHEL8)
   - RHEL
   - RHEL for x86
+
+250:  # Red Hat Satellite
+  - Satellite 6
+
+269:  # Red Hat Satellite Capsule
+  - Satellite 6 Capsule

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
@@ -34,6 +34,7 @@ import org.springframework.core.io.FileSystemResourceLoader;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -65,5 +66,28 @@ class CapacityProductExtractorTest {
     void productExtractorReturnsNoProductsIfNoProductIdsMatch() {
         Set<String> products = extractor.getProducts(Collections.singletonList(42));
         assertThat(products, Matchers.empty());
+    }
+
+    @Test
+    void productSetIsInvalid() {
+        Set<String> products = new HashSet<>();
+        products.add("RHEL Workstation");
+        products.add("Satellite 6");
+        assertThat(extractor.setIsInvalid(products), Matchers.is(true));
+    }
+
+    @Test
+    void productSetIsValid() {
+        Set<String> products = new HashSet<>();
+        products.add("RHEL Workstation");
+        products.add("RHEL");
+        products.add("RHEL for x86");
+        assertThat(extractor.setIsInvalid(products), Matchers.is(false));
+    }
+
+    @Test
+    void productExtractorReturnsExpectedProductsWhenSatellitePresent() {
+        Set<String> products = extractor.getProducts(Arrays.asList(12));
+        assertThat(products, Matchers.containsInAnyOrder("Satellite Server"));
     }
 }

--- a/src/test/resources/test_product_id_to_products_map.yaml
+++ b/src/test/resources/test_product_id_to_products_map.yaml
@@ -16,3 +16,8 @@
 10:
   - RHEL
   - RHEL Server
+11:
+  - My Custom Satellite Server
+12:
+  - RHEL
+  - Satellite Server


### PR DESCRIPTION
Since the RHEL provided with a Satellite 6 instance is meant to be tied
to the Satellite 6 usage, we don't want to consider it in the general
capacity calculations.