### PR TITLE
Skip RHEL when Satellite product is present

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 /**
@@ -76,7 +77,22 @@ public class FactNormalizer {
         normalizeQpcFacts(normalizedFacts, hostFacts);
         normalizeSocketCount(normalizedFacts);
         normalizeConflictingOrMissingRhelVariants(normalizedFacts);
+        pruneProducts(normalizedFacts);
         return normalizedFacts;
+    }
+
+    @SuppressWarnings("indentation")
+    private void pruneProducts(NormalizedFacts normalizedFacts) {
+        // If a Satellite product was found, do not include RHEL or its variants.
+        boolean hasSatellite = normalizedFacts.getProducts().stream()
+            .anyMatch(s -> s.startsWith("Satellite"));
+        if (hasSatellite) {
+            normalizedFacts.setProducts(
+                normalizedFacts.getProducts().stream()
+                    .filter(prod -> !"RHEL".equalsIgnoreCase(prod) && !isRhelVariant(prod))
+                    .collect(Collectors.toSet())
+            );
+        }
     }
 
     private void normalizeSocketCount(NormalizedFacts normalizedFacts) {

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
@@ -88,6 +88,6 @@ class CapacityProductExtractorTest {
     @Test
     void productExtractorReturnsExpectedProductsWhenSatellitePresent() {
         Set<String> products = extractor.getProducts(Arrays.asList(12));
-        assertThat(products, Matchers.containsInAnyOrder("Satellite Server"));
+        assertThat(products, Matchers.containsInAnyOrder("Satellite 6 Capsule"));
     }
 }

--- a/src/test/resources/test_product_id_to_products_map.yaml
+++ b/src/test/resources/test_product_id_to_products_map.yaml
@@ -17,7 +17,7 @@
   - RHEL
   - RHEL Server
 11:
-  - My Custom Satellite Server
+  - Satellite 6
 12:
   - RHEL
-  - Satellite Server
+  - Satellite 6 Capsule


### PR DESCRIPTION
Since RHEL is provided with Satellite, we do not want
to include a snapshot for RHEL as well. Therefore, we filter
the RHEL product when normalizing the product facts.