### PR TITLE
Apply @Min to resource impls

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -43,6 +43,7 @@ import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
@@ -70,7 +71,8 @@ public class CapacityResource implements CapacityApi {
     @Override
     @AdminOnly
     public CapacityReport getCapacityReport(String productId, @NotNull String granularity,
-        @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset, Integer limit) {
+        @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset,
+        @Min(1) Integer limit) {
 
         Granularity granularityValue = Granularity.valueOf(granularity.toUpperCase());
 

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -41,6 +41,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
@@ -69,7 +70,8 @@ public class TallyResource implements TallyApi {
     @Override
     @AdminOnly
     public TallyReport getTallyReport(String productId, @NotNull String granularity,
-        @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset, Integer limit) {
+        @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset,
+        @Min(1) Integer limit) {
         // When limit and offset are not specified, we will fill the report with dummy
         // records from beginning to ending dates. Otherwise we page as usual.
         Pageable pageable = null;


### PR DESCRIPTION
This fixes:

```
javax.validation.ConstraintDeclarationException: HV000151: A method overriding another method must not redefine the parameter constraint configuration, but method TallyResource#getTallyReport(String, String, OffsetDateTime, OffsetDateTime, Integer, Integer) redefines the configuration of TallyApi#getTallyReport(String, String, OffsetDateTime, OffsetDateTime, Integer, Integer).
```

errors (and similar for capacity).