### PR TITLE
Add PoolIngressController and use in resource

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -52,6 +52,12 @@ public class ApplicationProperties {
     private String accountListResourceLocation;
 
     /**
+     * Resource location of a file containing a list of products (SKUs) to process. If not specified, all
+     * products will be processed.
+     */
+    private String productWhitelistResourceLocation;
+
+    /**
      * An hour based threshold used to determine whether an inventory host record's rhsm facts are outdated.
      * The host's rhsm.SYNC_TIMESTAMP fact is checked against this threshold. The default is 24 hours.
      */
@@ -134,5 +140,13 @@ public class ApplicationProperties {
 
     public void setEnableIngressEndpoint(boolean enableIngressEndpoint) {
         this.enableIngressEndpoint = enableIngressEndpoint;
+    }
+
+    public String getProductWhitelistResourceLocation() {
+        return productWhitelistResourceLocation;
+    }
+
+    public void setProductWhitelistResourceLocation(String productWhitelistResourceLocation) {
+        this.productWhitelistResourceLocation = productWhitelistResourceLocation;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/controller/PoolIngressController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/PoolIngressController.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.controller;
+
+import org.candlepin.subscriptions.capacity.CandlepinPoolCapacityMapper;
+import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
+import org.candlepin.subscriptions.files.ProductWhitelist;
+import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Controller for ingesting subscription information from Candlepin pools.
+ */
+@Component
+public class PoolIngressController {
+
+    private static final Logger log = LoggerFactory.getLogger(PoolIngressController.class);
+
+    private final SubscriptionCapacityRepository repository;
+    private final CandlepinPoolCapacityMapper capacityMapper;
+    private final ProductWhitelist productWhitelist;
+
+    public PoolIngressController(SubscriptionCapacityRepository repository,
+        CandlepinPoolCapacityMapper capacityMapper, ProductWhitelist productWhitelist) {
+
+        this.repository = repository;
+        this.capacityMapper = capacityMapper;
+        this.productWhitelist = productWhitelist;
+    }
+
+    public void updateCapacityForOrg(String orgId, List<CandlepinPool> pools) {
+        List<CandlepinPool> whitelistedPools = pools.stream()
+            .filter(pool -> productWhitelist.productIdMatches(pool.getProductId()))
+            .collect(Collectors.toList());
+
+        List<SubscriptionCapacity> capacities = whitelistedPools.stream()
+            .map(pool -> capacityMapper.mapPoolToSubscriptionCapacity(orgId, pool))
+            .flatMap(Collection::stream).collect(Collectors.toList());
+
+        capacities.forEach(repository::save);
+
+        log.info(
+            "Update for org {} processed {} of {} posted pools, resulting in {} capacity records.",
+            orgId,
+            whitelistedPools.size(),
+            pools.size(),
+            capacities.size()
+        );
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.files;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * List of products to be considered for capacity calculations.
+ */
+@Component
+public class ProductWhitelist implements ResourceLoaderAware {
+
+    private static Logger log = LoggerFactory.getLogger(ProductWhitelist.class);
+
+    private final Set<String> whitelistProducts = new HashSet<>();
+    private final PerLineFileSource source;
+
+    public ProductWhitelist(ApplicationProperties properties) {
+        if (properties.getProductWhitelistResourceLocation() != null) {
+            source = new PerLineFileSource(
+                properties.getProductWhitelistResourceLocation());
+        }
+        else {
+            source = null;
+        }
+    }
+
+    public boolean productIdMatches(String productId) {
+        if (source == null) {
+            return true;
+        }
+        boolean whitelisted = whitelistProducts.contains(productId);
+        if (!whitelisted && log.isDebugEnabled()) {
+            log.debug("Product ID {} not in whitelist", productId);
+        }
+        return whitelisted;
+    }
+
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        if (source != null) {
+            source.setResourceLoader(resourceLoader);
+        }
+    }
+
+    @PostConstruct
+    public void init() throws IOException {
+        if (source != null) {
+            source.init();
+            whitelistProducts.addAll(source.list());
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import org.candlepin.subscriptions.controller.PoolIngressController;
 import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
 import org.candlepin.subscriptions.utilization.api.resources.IngressApi;
 
@@ -37,8 +38,14 @@ import javax.validation.Valid;
 @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableIngressEndpoint", havingValue = "true")
 public class IngressResource implements IngressApi {
 
+    private final PoolIngressController controller;
+
+    public IngressResource(PoolIngressController controller) {
+        this.controller = controller;
+    }
+
     @Override
-    public void updateCapacityFromCandlepinPools(String orgId, @Valid List<CandlepinPool> candlepinPool) {
-        // to be implemented in later work
+    public void updateCapacityFromCandlepinPools(String orgId, @Valid List<CandlepinPool> pools) {
+        controller.updateCapacityForOrg(orgId, pools);
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.controller;
+
+import static org.mockito.Mockito.*;
+
+import org.candlepin.subscriptions.capacity.CandlepinPoolCapacityMapper;
+import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
+import org.candlepin.subscriptions.files.ProductWhitelist;
+import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
+import org.candlepin.subscriptions.utilization.api.model.CandlepinProductAttribute;
+import org.candlepin.subscriptions.utilization.api.model.CandlepinProvidedProduct;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Collections;
+
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
+class PoolIngressControllerTest {
+
+    @Autowired
+    PoolIngressController controller;
+
+    @MockBean
+    SubscriptionCapacityRepository repository;
+
+    @MockBean
+    CandlepinPoolCapacityMapper mapper;
+
+    @MockBean
+    ProductWhitelist whitelist;
+
+    @Test
+    void testNothingSavedIfFilteredByWhitelist() {
+        when(whitelist.productIdMatches(any())).thenReturn(false);
+
+        CandlepinPool pool = createTestPool();
+        controller.updateCapacityForOrg("org", Collections.singletonList(pool));
+
+        verifyZeroInteractions(mapper);
+        verifyZeroInteractions(repository);
+    }
+
+    @Test
+    void testSavesPoolsProvidedByMapper() {
+        when(whitelist.productIdMatches(any())).thenReturn(true);
+        SubscriptionCapacity capacity = new SubscriptionCapacity();
+        when(mapper.mapPoolToSubscriptionCapacity(anyString(), any()))
+            .thenReturn(Collections.singletonList(capacity));
+
+        CandlepinPool pool = createTestPool();
+        controller.updateCapacityForOrg("org", Collections.singletonList(pool));
+
+        verify(repository).save(eq(capacity));
+    }
+
+    private CandlepinPool createTestPool() {
+        CandlepinPool pool = new CandlepinPool();
+        pool.setAccountNumber("account-1234");
+        pool.setActiveSubscription(true);
+        CandlepinProvidedProduct providedProduct = new CandlepinProvidedProduct();
+        providedProduct.setProductId("product-1");
+        pool.setProvidedProducts(Collections.singletonList(providedProduct));
+        pool.setQuantity(4L);
+        CandlepinProductAttribute socketAttribute = new CandlepinProductAttribute();
+        socketAttribute.setName("sockets");
+        socketAttribute.setValue("4");
+        pool.setProductAttributes(Collections.singletonList(socketAttribute));
+        return pool;
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.FileSystemResourceLoader;
+
+import java.io.IOException;
+
+class ProductWhitelistTest {
+
+    @Test
+    void testUnspecifiedLocationAllowsArbitraryProducts() throws IOException {
+        ProductWhitelist whitelist = initProductWhitelist(null);
+        assertTrue(whitelist.productIdMatches("whee!"));
+    }
+
+    @Test
+    void testAllowsProductsSpecified() throws IOException {
+        ProductWhitelist whitelist = initProductWhitelist("classpath:item_per_line.txt");
+        assertTrue(whitelist.productIdMatches("I1"));
+        assertTrue(whitelist.productIdMatches("I2"));
+        assertTrue(whitelist.productIdMatches("I3"));
+    }
+
+    @Test
+    void testDisallowsProductsNotInWhitelist() throws IOException {
+        ProductWhitelist whitelist = initProductWhitelist("classpath:item_per_line.txt");
+        assertFalse(whitelist.productIdMatches("not on the list :-("));
+    }
+
+    private ProductWhitelist initProductWhitelist(String resourceLocation) throws IOException {
+        ApplicationProperties props = new ApplicationProperties();
+        props.setProductWhitelistResourceLocation(resourceLocation);
+        ProductWhitelist whitelist = new ProductWhitelist(props);
+        whitelist.setResourceLoader(new FileSystemResourceLoader());
+        whitelist.init();
+        return whitelist;
+    }
+}


### PR DESCRIPTION
PoolIngressController performs the high-level logic of mapping Candlepin
pools to subscription capacities.

To test, use `rhsm-subscriptions.enableIngressEndpoint=true` in
`config/application.properties`

This JSON should demonstrate the endpoint in action (swagger-ui
recommended):

```json
[
  {
    "accountNumber": "123456",
    "activeSubscription": true,
    "startDate": "2019-10-07T19:06:08.816Z",
    "endDate": "2019-10-07T19:06:08.816Z",
    "quantity": 100,
    "productId": "RH0000001",
    "productAttributes": [
      {
        "name": "sockets",
        "value": "12"
      }
    ],
    "providedProducts": [
      {
        "productId": "71"
      }
    ],
    "derivedProvidedProducts": [
      {
        "productId": "71"
      }
    ],
    "subscriptionId": "4",
    "type": "NORMAL"
  }
]
```