### PR TITLE
Awood/500 errors

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/exception/ExceptionUtil.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ExceptionUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.exception;
+
+import org.candlepin.subscriptions.utilization.api.model.Error;
+import org.candlepin.subscriptions.utilization.api.model.Errors;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Utility class for constructing the JSON responses to send when exceptions are thrown.
+ */
+public class ExceptionUtil {
+    // Media type required per the jsonapi.org API spec. JAXRS doesn't provide
+    // this type as a constant, so we define it ourselves.
+    protected static final String MEDIA_TYPE = "application/vnd.api+json";
+
+    private ExceptionUtil() {
+        // only static methods available on this class
+    }
+
+    public static Response toResponse(Error error) {
+        // IMPL NOTE:
+        //   The jsonapi.org spec requires that an Error response should be a
+        //   collection of Error objects in a dictionary with an 'errors' key
+        //   in case the server should want to return multiple errors in a single
+        //   response. While we likely won't ever need to do this, we'll conform
+        //   to the spec anyhow.
+        Errors errors = new Errors().errors(new ArrayList<>(Collections.singleton(error)));
+        return Response.status(Integer.parseInt(error.getStatus()))
+            .entity(errors)
+            .type(MEDIA_TYPE)
+            .build();
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/AccessDeniedExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/AccessDeniedExceptionMapper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.exception.mapper;
+
+import org.candlepin.subscriptions.security.RestAccessDeniedHandler;
+import org.candlepin.subscriptions.utilization.api.model.Error;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This handler catches AccessDeniedExceptions that are thrown when access is denied  by the annotation-based
+ * security system.  When AccessDeniedExceptions are thrown due to violations of the declarative security
+ * constraints defined in the JavaConfig (e.g. using <code>hasRole()</code>), the exception is handled by the
+ * AccessDeniedHandler defined on the ExceptionTranslationFilter.  Annotation based restrictions use a
+ * different pathway.  Theoretically, the exception could be handled by adding an ExceptionHandler annotation
+ * to the {@link org.springframework.security.web.access.AccessDeniedHandler#handle(HttpServletRequest,
+ * HttpServletResponse, AccessDeniedException)} method, but since we aren't doing that anywhere else that
+ * would add an additional exception handling path for just one circumstance.  Instead, the easiest thing to
+ * do is to let the AccessDeniedException get thrown, leave Spring, and get handled by JAX-RS like the rest of
+ * our exceptions.  It is important to remember, however, that AccessDeniedExceptions can still occur during
+ * the regular authentication/authorization process and those will still be handled by our implementation of
+ * the AccessDeniedHandler interface, {@link org.candlepin.subscriptions.security.RestAccessDeniedHandler}
+ *
+ * @see <a href="https://stackoverflow.com/a/43452573">https://stackoverflow.com/a/43452573</a>
+ */
+@Component
+@Provider
+public class AccessDeniedExceptionMapper extends BaseExceptionMapper<AccessDeniedException> {
+    @Override
+    protected Error buildError(AccessDeniedException exception) {
+        return RestAccessDeniedHandler.buildError(exception);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
@@ -56,7 +56,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest servletRequest, HttpServletResponse servletResponse,
         AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        Error error = buildError(accessDeniedException);
+        Error error = RestAccessDeniedHandler.buildError(accessDeniedException);
         log.error(error.getTitle(), accessDeniedException);
 
         Response r = ExceptionUtil.toResponse(error);
@@ -68,7 +68,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
         out.flush();
     }
 
-    protected Error buildError(AccessDeniedException exception) {
+    public static Error buildError(AccessDeniedException exception) {
         return new Error()
             .code(ErrorCode.REQUEST_PROCESSING_ERROR.getCode())
             .status(String.valueOf(Status.FORBIDDEN.getStatusCode()))

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public AuthenticationEntryPoint restAuthenticationEntryPoint() {
-        return new RestAuthenticationEntryPoint(mapper);
+        return new RestAuthenticationEntryPoint(new IdentityHeaderAuthenticationFailureHandler(mapper));
     }
 
     @Override


### PR DESCRIPTION
Test like so:
```
$ ./gradlew bootRun --args="--server.port=9167" &
$ curl -v "http://localhost:9167/api/rhsm-subscriptions/v1/tally/products/123?granularity=DAILY&beginning=2017-07-21T17:30:30Z&ending=2018-07-27T17:30:00Z"  # Returns a 401

$ curl -v -H "x-rh-identity: asd" "http://localhost:9167/api/rhsm-subscriptions/v1/tally/products/123?granularity=DAILY&beginning=2017-07-21T17:30:30Z&ending=2018-07-27T17:30:00Z"  # Returns a 401

$ curl -v -H "x-rh-identity: $(echo -n '{"identity": {"account_number": "234"}}' | base64 -w0 -)" "http://localhost:9167/api/rhsm-subscriptions/v1/tally/products/123?granularity=DAILY&beginning=2017-07-21T17:30:30Z&ending=2018-07-27T17:30:00Z"  # Returns a 403 

$ curl -v -H "x-rh-identity: $(echo -n '{"identity":{"account_number":"234", "user":{"is_org_admin":true}}}' | base64 -w0 -)" "http://localhost:9167/api/rhsm-subscriptions/v1/tally/products/123?granularity=DAILY&beginning=2017-07-21T17:30:30Z&ending=2018-07-27T17:30:00Z" # Works!
```