### PR TITLE
Use orgId over accountNumber.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -37,8 +37,8 @@ public interface SubscriptionCapacityRepository extends
 
     @Transactional
     List<SubscriptionCapacity>
-        findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-        String accountNumber,
+        findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+        String ownerId,
         String productId,
         OffsetDateTime begin,
         OffsetDateTime end

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -39,8 +39,8 @@ import java.util.stream.Stream;
  */
 public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UUID> {
     Page<TallySnapshot>
-        findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-        String accountNumber, String productId, Granularity granularity, OffsetDateTime beginning,
+        findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+        String ownerId, String productId, Granularity granularity, OffsetDateTime beginning,
         OffsetDateTime ending, Pageable pageable);
 
     @Transactional

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
@@ -37,11 +37,6 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "subscription_capacity")
 public class SubscriptionCapacity implements Serializable {
-
-    @Id
-    @Column(name = "account_number")
-    private String accountNumber;
-
     @Id
     @Column(name = "product_id")
     private String productId;
@@ -50,8 +45,12 @@ public class SubscriptionCapacity implements Serializable {
     @Column(name = "subscription_id")
     private String subscriptionId;
 
+    @Id
     @Column(name = "owner_id")
     private String ownerId;
+
+    @Column(name = "account_number")
+    private String accountNumber;
 
     @Column(name = "physical_sockets")
     private Integer physicalSockets;

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityKey.java
@@ -30,8 +30,8 @@ import javax.persistence.Column;
  */
 public class SubscriptionCapacityKey implements Serializable {
 
-    @Column(name = "account_number")
-    private String accountNumber;
+    @Column(name = "owner_id")
+    private String ownerId;
 
     @Column(name = "product_id")
     private String productId;
@@ -47,12 +47,12 @@ public class SubscriptionCapacityKey implements Serializable {
         this.productId = productId;
     }
 
-    public String getAccountNumber() {
-        return accountNumber;
+    public String getOwnerId() {
+        return ownerId;
     }
 
-    public void setAccountNumber(String accountNumber) {
-        this.accountNumber = accountNumber;
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
     }
 
     public String getSubscriptionId() {
@@ -65,7 +65,7 @@ public class SubscriptionCapacityKey implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountNumber, productId, subscriptionId);
+        return Objects.hash(ownerId, productId, subscriptionId);
     }
 
     @Override
@@ -77,7 +77,7 @@ public class SubscriptionCapacityKey implements Serializable {
             return false;
         }
         SubscriptionCapacityKey other = (SubscriptionCapacityKey) obj;
-        return Objects.equals(getAccountNumber(), other.getAccountNumber()) &&
+        return Objects.equals(getOwnerId(), other.getOwnerId()) &&
             Objects.equals(getProductId(), other.getProductId()) &&
             Objects.equals(getSubscriptionId(), other.getSubscriptionId());
     }

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -76,8 +76,8 @@ public class CapacityResource implements CapacityApi {
 
         Granularity granularityValue = Granularity.valueOf(granularity.toUpperCase());
 
-        String accountNumber = ResourceUtils.getAccountNumber();
-        List<CapacitySnapshot> capacities = getCapacities(accountNumber, productId, granularityValue,
+        String ownerId = ResourceUtils.getOwnerId();
+        List<CapacitySnapshot> capacities = getCapacities(ownerId, productId, granularityValue,
             beginning, ending);
 
         List<CapacitySnapshot> data;
@@ -113,12 +113,12 @@ public class CapacityResource implements CapacityApi {
         return capacities.subList(offset, lastIndex);
     }
 
-    private List<CapacitySnapshot> getCapacities(String accountNumber, String productId,
+    private List<CapacitySnapshot> getCapacities(String ownerId, String productId,
         Granularity granularity, @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending) {
 
         List<SubscriptionCapacity> matches =
-            repository.findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-            accountNumber,
+            repository.findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            ownerId,
             productId,
             beginning,
             ending);

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -43,11 +43,11 @@ public class ResourceUtils {
     }
 
     /**
-     * Get the account number of the authenticated user.
+     * Get the owner ID of the authenticated user.
      *
-     * @return account number as a String
+     * @return ownerId as a String
      */
-    static String getAccountNumber() {
+    static String getOwnerId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         return auth.getName();
     }

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -81,11 +81,11 @@ public class TallyResource implements TallyApi {
         }
 
 
-        String accountNumber = ResourceUtils.getAccountNumber();
+        String ownerId = ResourceUtils.getOwnerId();
         Granularity granularityValue = Granularity.valueOf(granularity.toUpperCase());
         Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-            accountNumber,
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+            ownerId,
             productId,
             granularityValue,
             beginning,

--- a/src/main/resources/liquibase/201910291044-alter-capacity-pk-and-tally-idx.xml
+++ b/src/main/resources/liquibase/201910291044-alter-capacity-pk-and-tally-idx.xml
@@ -1,0 +1,25 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="201910291044-1" author="awood">
+        <comment>Use owner id in the primary key as some subscriptions have no account number</comment>
+        <dropPrimaryKey constraintName="subs_cap_pkey"
+            tableName="subscription_capacity"/>
+
+        <addPrimaryKey constraintName="subs_cap_pkey"
+            tableName="subscription_capacity"
+            columnNames="owner_id,product_id,subscription_id"/>
+    </changeSet>
+
+    <changeSet id="201910291044-2" author="awood">
+        <createIndex indexName="owner_and_product_idx" tableName="tally_snapshots"
+            unique="false">
+            <column name="owner_id"/>
+            <column name="product_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -12,6 +12,6 @@
     <include file="liquibase/201909162045-add-capacity-table.xml"/>
     <include file="liquibase/201910021550-add-physical-counts-columns.xml"/>
     <include file="liquibase/201910091200-add-hypervisor-counts-columns.xml"/>
-
+    <include file="liquibase/201910291044-alter-capacity-pk-and-tally-idx.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
@@ -93,3 +93,4 @@ class PoolIngressControllerTest {
         return pool;
     }
 }
+

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -65,8 +65,8 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-            "account",
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            "ownerId",
             "product",
             NOWISH,
             FAR_FUTURE);
@@ -77,7 +77,7 @@ class SubscriptionCapacityRepositoryTest {
         assertEquals("subscription", capacity.getSubscriptionId());
         assertEquals(4, capacity.getPhysicalSockets().intValue());
         assertEquals(20, capacity.getVirtualSockets().intValue());
-        assertEquals("owner_id", capacity.getOwnerId());
+        assertEquals("ownerId", capacity.getOwnerId());
         assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
         assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
         assertFalse(capacity.getHasUnlimitedGuestSockets());
@@ -91,8 +91,8 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-            "account",
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            "ownerId",
             "product",
             NOWISH,
             FAR_FUTURE);
@@ -103,7 +103,7 @@ class SubscriptionCapacityRepositoryTest {
         assertEquals("subscription", capacity.getSubscriptionId());
         assertEquals(4, capacity.getPhysicalSockets().intValue());
         assertEquals(20, capacity.getVirtualSockets().intValue());
-        assertEquals("owner_id", capacity.getOwnerId());
+        assertEquals("ownerId", capacity.getOwnerId());
         assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
         assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
         assertFalse(capacity.getHasUnlimitedGuestSockets());
@@ -117,8 +117,8 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-            "account",
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            "ownerId",
             "product",
             NOWISH,
             FAR_FUTURE);
@@ -129,7 +129,7 @@ class SubscriptionCapacityRepositoryTest {
         assertEquals("subscription", capacity.getSubscriptionId());
         assertEquals(4, capacity.getPhysicalSockets().intValue());
         assertEquals(20, capacity.getVirtualSockets().intValue());
-        assertEquals("owner_id", capacity.getOwnerId());
+        assertEquals("ownerId", capacity.getOwnerId());
         assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
         assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
         assertFalse(capacity.getHasUnlimitedGuestSockets());
@@ -143,8 +143,8 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-            "account",
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            "ownerId",
             "product",
             NOWISH,
             FAR_FUTURE);
@@ -155,7 +155,7 @@ class SubscriptionCapacityRepositoryTest {
         assertEquals("subscription", capacity.getSubscriptionId());
         assertEquals(4, capacity.getPhysicalSockets().intValue());
         assertEquals(20, capacity.getVirtualSockets().intValue());
-        assertEquals("owner_id", capacity.getOwnerId());
+        assertEquals("ownerId", capacity.getOwnerId());
         assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
         assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
         assertFalse(capacity.getHasUnlimitedGuestSockets());
@@ -169,8 +169,8 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-            "account",
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            "ownerId",
             "product",
             NOWISH,
             FAR_FUTURE);
@@ -185,16 +185,31 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-            "account",
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            "ownerId",
             "product",
             NOWISH,
             FAR_FUTURE);
         assertEquals(0, found.size());
     }
 
-    private SubscriptionCapacity createUnpersisted(OffsetDateTime begin, OffsetDateTime end) {
+    @Test
+    void testAllowsNullAccountNumber() {
+        SubscriptionCapacity c = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        c.setAccountNumber(null);
+        repository.save(c);
+        repository.flush();
 
+        List<SubscriptionCapacity> found = repository
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            "ownerId",
+            "product",
+            NOWISH,
+            FAR_FUTURE);
+        assertEquals(1, found.size());
+    }
+
+    private SubscriptionCapacity createUnpersisted(OffsetDateTime begin, OffsetDateTime end) {
         SubscriptionCapacity capacity = new SubscriptionCapacity();
         capacity.setAccountNumber("account");
         capacity.setProductId("product");
@@ -202,7 +217,7 @@ class SubscriptionCapacityRepositoryTest {
         capacity.setBeginDate(begin);
         capacity.setEndDate(end);
         capacity.setHasUnlimitedGuestSockets(false);
-        capacity.setOwnerId("owner_id");
+        capacity.setOwnerId("ownerId");
         capacity.setPhysicalSockets(4);
         capacity.setVirtualSockets(20);
         return capacity;

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -57,23 +57,25 @@ public class TallySnapshotRepositoryTest {
 
     @Test
     public void testSave() {
-        TallySnapshot t = createUnpersisted("Hello", "World", Granularity.DAILY, 2, 3, 4,
+        TallySnapshot t = createUnpersisted("Hello", "HelloOwner", "World", Granularity.DAILY, 2, 3, 4,
             OffsetDateTime.now());
         TallySnapshot saved = repository.saveAndFlush(t);
         assertNotNull(saved.getId());
     }
 
     @Test
-    public void testFindByAccountNumberAndProduct() {
-        TallySnapshot t1 = createUnpersisted("Hello", "World", Granularity.DAILY, 2, 3, 4, NOWISH);
-        TallySnapshot t2 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, 9999, 999, 99, NOWISH);
+    public void testFindByOwnerIdAndProduct() {
+        TallySnapshot t1 = createUnpersisted("Hello", "HelloOwner", "World", Granularity.DAILY, 2, 3, 4,
+            NOWISH);
+        TallySnapshot t2 = createUnpersisted("Bugs", "BugsOwner", "Bunny", Granularity.DAILY, 9999, 999, 99,
+            NOWISH);
 
         repository.saveAll(Arrays.asList(t1, t2));
         repository.flush();
 
         List<TallySnapshot> found = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-            "Bugs",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+            "BugsOwner",
             "Bunny",
             Granularity.DAILY,
             LONG_AGO,
@@ -85,7 +87,7 @@ public class TallySnapshotRepositoryTest {
         assertEquals(9999, (int) snapshot.getCores());
         assertEquals("Bugs", snapshot.getAccountNumber());
         assertEquals("Bunny", snapshot.getProductId());
-        assertEquals("N/A", snapshot.getOwnerId());
+        assertEquals("BugsOwner", snapshot.getOwnerId());
         assertEquals(NOWISH, found.get(0).getSnapshotDate());
     }
 
@@ -94,22 +96,25 @@ public class TallySnapshotRepositoryTest {
         String product1 = "Product1";
         String product2 = "Product2";
         // Will not be found - out of date range.
-        TallySnapshot t1 = createUnpersisted("Account1", product1, Granularity.DAILY, 2, 3, 4,
+        TallySnapshot t1 = createUnpersisted("Account1", "Acc1Owner", product1, Granularity.DAILY, 2, 3, 4,
             LONG_AGO);
         // Will be found.
-        TallySnapshot t2 = createUnpersisted("Account2", product1, Granularity.DAILY, 9, 10, 11,
+        TallySnapshot t2 = createUnpersisted("Account2", "Acc2Owner", product1, Granularity.DAILY, 9, 10, 11,
             NOWISH);
         // Will be found.
-        TallySnapshot t3 = createUnpersisted("Account2", product2, Granularity.DAILY, 19, 20, 21,
+        TallySnapshot t3 = createUnpersisted("Account2", "Acc2Owner", product2, Granularity.DAILY, 19, 20, 21,
             NOWISH);
         // Will not be found, incorrect granularity
-        TallySnapshot t4 = createUnpersisted("Account2", product2, Granularity.WEEKLY, 19, 20, 21,
+        TallySnapshot t4 = createUnpersisted("Account2", "Acc2Owner", product2, Granularity.WEEKLY, 19, 20,
+            21,
             NOWISH);
         // Will not be in result - Account not in query
-        TallySnapshot t5 = createUnpersisted("Account3", product1, Granularity.DAILY, 99, 100, 101,
+        TallySnapshot t5 = createUnpersisted("Account3", "Acc2Owner", product1, Granularity.DAILY, 99, 100,
+            101,
             FAR_FUTURE);
         // Will not be found - incorrect granularity
-        TallySnapshot t6 = createUnpersisted("Account2", product1, Granularity.WEEKLY, 20, 22, 23,
+        TallySnapshot t6 = createUnpersisted("Account2", "Acc2Owner", product1, Granularity.WEEKLY, 20, 22,
+            23,
             NOWISH);
 
         repository.saveAll(Arrays.asList(t1, t2, t3, t4, t5, t6));
@@ -134,12 +139,12 @@ public class TallySnapshotRepositoryTest {
         assertEquals(Integer.valueOf(11), found.get(0).getInstanceCount());
     }
 
-    private TallySnapshot createUnpersisted(String account, String product, Granularity granularity,
-        int cores, int sockets, int instances, OffsetDateTime date) {
+    private TallySnapshot createUnpersisted(String account, String owner, String product,
+        Granularity granularity, int cores, int sockets, int instances, OffsetDateTime date) {
         TallySnapshot tally = new TallySnapshot();
         tally.setAccountNumber(account);
         tally.setProductId(product);
-        tally.setOwnerId("N/A");
+        tally.setOwnerId(owner);
         tally.setCores(cores);
         tally.setSockets(sockets);
         tally.setGranularity(granularity);

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -66,7 +66,7 @@ class CapacityResourceTest {
     CapacityResource resource;
 
     @Test
-    @WithMockUser(value = "123456",
+    @WithMockUser(value = "owner123456",
         authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     void testShouldUseQueryBasedOnHeaderAndParameters() {
         SubscriptionCapacity capacity = new SubscriptionCapacity();
@@ -74,8 +74,8 @@ class CapacityResourceTest {
         capacity.setEndDate(max);
 
         Mockito.when(repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-            Mockito.eq("123456"),
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            Mockito.eq("owner123456"),
             Mockito.eq("product1"),
             Mockito.eq(min),
             Mockito.eq(max)))
@@ -94,7 +94,7 @@ class CapacityResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "123456",
+    @WithMockUser(value = "owner123456",
         authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     void testShouldCalculateCapacityBasedOnMultipleSubscriptions() {
         SubscriptionCapacity capacity = new SubscriptionCapacity();
@@ -110,8 +110,8 @@ class CapacityResourceTest {
         capacity2.setEndDate(max);
 
         Mockito.when(repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-                Mockito.eq("123456"),
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+                Mockito.eq("owner123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(min),
                 Mockito.eq(max)))
@@ -132,7 +132,7 @@ class CapacityResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "123456",
+    @WithMockUser(value = "owner123456",
         authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     void testShouldThrowExceptionOnBadOffset() {
         SubscriptionsException e = assertThrows(SubscriptionsException.class, () ->
@@ -147,7 +147,7 @@ class CapacityResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "123456",
+    @WithMockUser(value = "owner123456",
         authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     void testShouldRespectOffsetAndLimit() {
         SubscriptionCapacity capacity = new SubscriptionCapacity();
@@ -155,8 +155,8 @@ class CapacityResourceTest {
         capacity.setEndDate(max);
 
         Mockito.when(repository
-            .findSubscriptionCapacitiesByAccountNumberAndProductIdAndEndDateAfterAndBeginDateBefore(
-                Mockito.eq("123456"),
+            .findSubscriptionCapacitiesByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+                Mockito.eq("owner123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(min),
                 Mockito.eq(max)))

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -68,14 +68,14 @@ public class TallyResourceTest {
     private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
 
     @Test
-    @WithMockUser(value = "123456",
+    @WithMockUser(value = "owner123456",
         authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void testShouldUseQueryBasedOnHeaderAndParameters() {
         TallySnapshot snap = new TallySnapshot();
 
         Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-            Mockito.eq("123456"),
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+            Mockito.eq("owner123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(min),
@@ -94,8 +94,8 @@ public class TallyResourceTest {
 
         Pageable expectedPageable = PageRequest.of(1, 10);
         Mockito.verify(repository)
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-            Mockito.eq("123456"),
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+            Mockito.eq("owner123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(min),
@@ -105,7 +105,7 @@ public class TallyResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "123456",
+    @WithMockUser(value = "owner123456",
         authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void testShouldThrowExceptionOnBadOffset() {
         SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource.getTallyReport(
@@ -120,12 +120,12 @@ public class TallyResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "123456",
+    @WithMockUser(value = "owner123456",
         authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void reportDataShouldGetFilledWhenPagingParametersAreNotPassed() {
         Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-                 Mockito.eq("123456"),
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+                 Mockito.eq("owner123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
                  Mockito.eq(min),

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -73,15 +73,15 @@ public class DailySnapshotRollerTest {
     @SuppressWarnings("indentation")
     @Test
     public void testDailySnapshotProducer() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> dailySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
                 TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, dailySnaps.size());
@@ -93,15 +93,15 @@ public class DailySnapshotRollerTest {
     @SuppressWarnings("indentation")
     @Test
     public void testDailySnapIsUpdatedWhenItAlreadyExists() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> dailySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
                 TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, dailySnaps.size());
@@ -114,7 +114,7 @@ public class DailySnapshotRollerTest {
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedDailySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
                 TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedDailySnaps.size());
@@ -130,15 +130,15 @@ public class DailySnapshotRollerTest {
 
     @Test
     public void ensureCurrentDailyUpdatedRegardlessOfWhetherIncomingCalculationsAreLessThanTheExisting() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 100, 200, 10);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> dailySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, dailySnaps.size());
@@ -149,11 +149,11 @@ public class DailySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 3, 4));
+        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 3, 4));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedDailySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedDailySnaps.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -79,15 +79,15 @@ public class MonthlySnapshotRollerTest {
     @SuppressWarnings("indentation")
     @Test
     public void testMonthlySnapshotProducer() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> monthlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, monthlySnaps.size());
@@ -99,15 +99,15 @@ public class MonthlySnapshotRollerTest {
     @SuppressWarnings("indentation")
     @Test
     public void testMonthlySnapIsUpdatedWhenItAlreadyExists() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> monthlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, monthlySnaps.size());
@@ -119,7 +119,7 @@ public class MonthlySnapshotRollerTest {
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedMonthlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedMonthlySnaps.size());
@@ -139,15 +139,15 @@ public class MonthlySnapshotRollerTest {
         int expectedSockets = 200;
         int expectedInstances = 10;
 
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, expectedCores, expectedSockets, expectedInstances);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> monthlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(),
             clock.endOfCurrentMonth(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, monthlySnaps.size());
@@ -158,11 +158,11 @@ public class MonthlySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 2, 2));
+        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 2, 2));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedMonthlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(),
             clock.endOfCurrentMonth(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedMonthlySnaps.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -72,15 +72,15 @@ public class QuarterlySnapshotRollerTest {
 
     @Test
     public void testQuarterlySnapshotProduction() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> quarterlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, quarterlySnaps.size());
@@ -92,15 +92,15 @@ public class QuarterlySnapshotRollerTest {
 
     @Test
     public void testQuarterlySnapIsUpdatedWhenItAlreadyExists() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(owner), accountCalcs);
 
         List<TallySnapshot> originalSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
@@ -114,7 +114,7 @@ public class QuarterlySnapshotRollerTest {
 
         // Check the yearly again. Should still be a single instance, but have updated values.
         List<TallySnapshot> updatedSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
@@ -134,15 +134,15 @@ public class QuarterlySnapshotRollerTest {
         int expectedSockets = 200;
         int expectedInstances = 10;
 
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, expectedCores, expectedSockets, expectedInstances);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(owner), accountCalcs);
 
         List<TallySnapshot> quarterlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, quarterlySnaps.size());
@@ -153,11 +153,11 @@ public class QuarterlySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 2, 2));
+        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 2, 2));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedQuarterlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedQuarterlySnaps.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -72,15 +72,15 @@ public class WeeklySnapshotRollerTest {
 
     @Test
     public void testWeeklySnapshotProduction() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 6, 7, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> weeklySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, weeklySnaps.size());
@@ -91,15 +91,15 @@ public class WeeklySnapshotRollerTest {
 
     @Test
     public void testWeeklySnapIsUpdatedWhenItAlreadyExists() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 6, 7, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> weeklySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, weeklySnaps.size());
@@ -114,7 +114,7 @@ public class WeeklySnapshotRollerTest {
 
         // Check the weekly again. Should still be a single instance, but have updated values.
         List<TallySnapshot> updatedWeeklySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedWeeklySnaps.size());
@@ -134,15 +134,15 @@ public class WeeklySnapshotRollerTest {
         int expectedSockets = 200;
         int expectedInstances = 10;
 
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, expectedCores, expectedSockets, expectedInstances);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> weeklySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, weeklySnaps.size());
@@ -153,11 +153,11 @@ public class WeeklySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 2, 2));
+        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 2, 2));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedWeeklySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedWeeklySnaps.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -68,15 +68,15 @@ public class YearlySnapshotRollerTest {
 
     @Test
     public void testYearlySnapshotProduction() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> yearlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, yearlySnaps.size());
@@ -87,15 +87,15 @@ public class YearlySnapshotRollerTest {
 
     @Test
     public void testYearlySnapIsUpdatedWhenItAlreadyExists() {
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> originalSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
@@ -109,7 +109,7 @@ public class YearlySnapshotRollerTest {
 
         // Check the yearly again. Should still be a single instance, but have updated values.
         List<TallySnapshot> updatedSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
@@ -129,15 +129,15 @@ public class YearlySnapshotRollerTest {
         int expectedSockets = 200;
         int expectedInstances = 10;
 
-        String account = "A1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
+        String owner = "O1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
             TEST_PRODUCT, expectedCores, expectedSockets, expectedInstances);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
+        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> yearlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, yearlySnaps.size());
@@ -148,11 +148,11 @@ public class YearlySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 2, 2));
+        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 2, 2));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedYearlySnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedYearlySnaps.size());


### PR DESCRIPTION
In certain cases, a pool may be missing an account number.  For example,
if a customer acquires a developer subscription and then buys from Red
Hat, the developer subscription won't be updated with their account
number.  Consequently, relying on the account number as a component
of a primary key in a table is undesirable.

This patch changes the capacity table to use the orgId (which should
always be present) as a part of the composite primary key.
Additionally, it ties the principal to the orgId from the authentication
header and performs necessary queries with it.