### PR TITLE
Rework tally to use account number, drop account not null

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -299,10 +299,25 @@ components:
       type: apiKey
       in: header
       name: x-rh-identity
-      description: >-
+      description: |
         Base64-encoded JSON identity header provided by 3Scale. Contains an
         account number of the user issuing the request. Format of the JSON:
-        {"identity": {"account_number": "12345678"}}
+        ```
+        {
+            "identity": {
+                "account_number": "account123",
+                "type": "User",
+                "user" : {
+                    "is_org_admin": true
+                },
+                "internal" : {
+                    "org_id": "org123"
+                }
+            }
+        }
+        ```
+        Encoded (via `base64 -w0`):
+        `eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=`
   responses:
     InternalServerError:
       description: "An internal server error has occurred and is not recoverable."

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -39,8 +39,8 @@ import java.util.stream.Stream;
  */
 public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UUID> {
     Page<TallySnapshot>
-        findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-        String ownerId, String productId, Granularity granularity, OffsetDateTime beginning,
+        findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+        String accountNumber, String productId, Granularity granularity, OffsetDateTime beginning,
         OffsetDateTime ending, Pageable pageable);
 
     @Transactional

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.security.InsightsUserPrincipal;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -49,7 +50,19 @@ public class ResourceUtils {
      */
     static String getOwnerId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        return auth.getName();
+        InsightsUserPrincipal principal = (InsightsUserPrincipal) auth.getPrincipal();
+        return principal.getOwnerId();
+    }
+
+    /**
+     * Get the account number of the authenticated user.
+     *
+     * @return account number as a String
+     */
+    static String getAccountNumber() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        InsightsUserPrincipal principal = (InsightsUserPrincipal) auth.getPrincipal();
+        return principal.getAccountNumber();
     }
 
     /**

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -81,11 +81,11 @@ public class TallyResource implements TallyApi {
         }
 
 
-        String ownerId = ResourceUtils.getOwnerId();
+        String accountNumber = ResourceUtils.getAccountNumber();
         Granularity granularityValue = Granularity.valueOf(granularity.toUpperCase());
         Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-            ownerId,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+            accountNumber,
             productId,
             granularityValue,
             beginning,

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
@@ -94,6 +94,7 @@ public class IdentityHeaderAuthenticationManager implements AuthenticationManage
         try {
             Map authObject = mapper.readValue(decodedHeader, Map.class);
             Map identity = (Map) authObject.getOrDefault("identity", Collections.emptyMap());
+            String accountNumber = (String) identity.get("account_number");
             Map internal = (Map) identity.getOrDefault("internal", Collections.emptyMap());
             String orgId = (String) internal.get("org_id");
 
@@ -101,9 +102,13 @@ public class IdentityHeaderAuthenticationManager implements AuthenticationManage
                 throw new PreAuthenticatedCredentialsNotFoundException(RH_IDENTITY_HEADER +
                     " contains no owner ID for the principal");
             }
+            if (StringUtils.isEmpty(accountNumber)) {
+                throw new PreAuthenticatedCredentialsNotFoundException(RH_IDENTITY_HEADER +
+                    " contains no principal");
+            }
 
-            token = new PreAuthenticatedAuthenticationToken(orgId, token.getCredentials(),
-                details.getGrantedAuthorities());
+            token = new PreAuthenticatedAuthenticationToken(new InsightsUserPrincipal(orgId, accountNumber),
+                token.getCredentials(), details.getGrantedAuthorities());
             token.setAuthenticated(true);
             return token;
 

--- a/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import java.util.Objects;
+
+/**
+ * Represents the subset of data we depend on in the x-rh-identity header.
+ */
+public class InsightsUserPrincipal {
+
+    private final String ownerId;
+    private final String accountNumber;
+
+    public InsightsUserPrincipal(String ownerId, String accountNumber) {
+        this.ownerId = ownerId;
+        this.accountNumber = accountNumber;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public String toString() {
+        return String.format("[Account: %s, Owner: %s]", accountNumber, ownerId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof InsightsUserPrincipal)) {
+            return false;
+        }
+        InsightsUserPrincipal principal = (InsightsUserPrincipal) o;
+        return Objects.equals(getOwnerId(), principal.getOwnerId()) &&
+            Objects.equals(getAccountNumber(), principal.getAccountNumber());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getOwnerId(), getAccountNumber());
+    }
+}

--- a/src/main/resources/liquibase/201911061510-drop-account-not-null.xml
+++ b/src/main/resources/liquibase/201911061510-drop-account-not-null.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="201911061510-1" author="khowell">
+        <comment>Drop not null constraint on account_number</comment>
+        <dropNotNullConstraint tableName="subscription_capacity" columnName="account_number"/>
+    </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -13,5 +13,6 @@
     <include file="liquibase/201910021550-add-physical-counts-columns.xml"/>
     <include file="liquibase/201910091200-add-hypervisor-counts-columns.xml"/>
     <include file="liquibase/201910291044-alter-capacity-pk-and-tally-idx.xml"/>
+    <include file="liquibase/201911061510-drop-account-not-null.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -57,25 +57,23 @@ public class TallySnapshotRepositoryTest {
 
     @Test
     public void testSave() {
-        TallySnapshot t = createUnpersisted("Hello", "HelloOwner", "World", Granularity.DAILY, 2, 3, 4,
+        TallySnapshot t = createUnpersisted("Hello", "World", Granularity.DAILY, 2, 3, 4,
             OffsetDateTime.now());
         TallySnapshot saved = repository.saveAndFlush(t);
         assertNotNull(saved.getId());
     }
 
     @Test
-    public void testFindByOwnerIdAndProduct() {
-        TallySnapshot t1 = createUnpersisted("Hello", "HelloOwner", "World", Granularity.DAILY, 2, 3, 4,
-            NOWISH);
-        TallySnapshot t2 = createUnpersisted("Bugs", "BugsOwner", "Bunny", Granularity.DAILY, 9999, 999, 99,
-            NOWISH);
+    public void testFindByAccountNumberAndProduct() {
+        TallySnapshot t1 = createUnpersisted("Hello", "World", Granularity.DAILY, 2, 3, 4, NOWISH);
+        TallySnapshot t2 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, 9999, 999, 99, NOWISH);
 
         repository.saveAll(Arrays.asList(t1, t2));
         repository.flush();
 
         List<TallySnapshot> found = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-            "BugsOwner",
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+            "Bugs",
             "Bunny",
             Granularity.DAILY,
             LONG_AGO,
@@ -87,7 +85,7 @@ public class TallySnapshotRepositoryTest {
         assertEquals(9999, (int) snapshot.getCores());
         assertEquals("Bugs", snapshot.getAccountNumber());
         assertEquals("Bunny", snapshot.getProductId());
-        assertEquals("BugsOwner", snapshot.getOwnerId());
+        assertEquals("N/A", snapshot.getOwnerId());
         assertEquals(NOWISH, found.get(0).getSnapshotDate());
     }
 
@@ -96,25 +94,22 @@ public class TallySnapshotRepositoryTest {
         String product1 = "Product1";
         String product2 = "Product2";
         // Will not be found - out of date range.
-        TallySnapshot t1 = createUnpersisted("Account1", "Acc1Owner", product1, Granularity.DAILY, 2, 3, 4,
+        TallySnapshot t1 = createUnpersisted("Account1", product1, Granularity.DAILY, 2, 3, 4,
             LONG_AGO);
         // Will be found.
-        TallySnapshot t2 = createUnpersisted("Account2", "Acc2Owner", product1, Granularity.DAILY, 9, 10, 11,
+        TallySnapshot t2 = createUnpersisted("Account2", product1, Granularity.DAILY, 9, 10, 11,
             NOWISH);
         // Will be found.
-        TallySnapshot t3 = createUnpersisted("Account2", "Acc2Owner", product2, Granularity.DAILY, 19, 20, 21,
+        TallySnapshot t3 = createUnpersisted("Account2", product2, Granularity.DAILY, 19, 20, 21,
             NOWISH);
         // Will not be found, incorrect granularity
-        TallySnapshot t4 = createUnpersisted("Account2", "Acc2Owner", product2, Granularity.WEEKLY, 19, 20,
-            21,
+        TallySnapshot t4 = createUnpersisted("Account2", product2, Granularity.WEEKLY, 19, 20, 21,
             NOWISH);
         // Will not be in result - Account not in query
-        TallySnapshot t5 = createUnpersisted("Account3", "Acc2Owner", product1, Granularity.DAILY, 99, 100,
-            101,
+        TallySnapshot t5 = createUnpersisted("Account3", product1, Granularity.DAILY, 99, 100, 101,
             FAR_FUTURE);
         // Will not be found - incorrect granularity
-        TallySnapshot t6 = createUnpersisted("Account2", "Acc2Owner", product1, Granularity.WEEKLY, 20, 22,
-            23,
+        TallySnapshot t6 = createUnpersisted("Account2", product1, Granularity.WEEKLY, 20, 22, 23,
             NOWISH);
 
         repository.saveAll(Arrays.asList(t1, t2, t3, t4, t5, t6));
@@ -139,12 +134,12 @@ public class TallySnapshotRepositoryTest {
         assertEquals(Integer.valueOf(11), found.get(0).getInstanceCount());
     }
 
-    private TallySnapshot createUnpersisted(String account, String owner, String product,
-        Granularity granularity, int cores, int sockets, int instances, OffsetDateTime date) {
+    private TallySnapshot createUnpersisted(String account, String product, Granularity granularity,
+        int cores, int sockets, int instances, OffsetDateTime date) {
         TallySnapshot tally = new TallySnapshot();
         tally.setAccountNumber(account);
         tally.setProductId(product);
-        tally.setOwnerId(owner);
+        tally.setOwnerId("N/A");
         tally.setCores(cores);
         tally.setSockets(sockets);
         tally.setGranularity(granularity);

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -26,7 +26,7 @@ import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
-import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationDetailsSource;
+import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReport;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
 
@@ -36,7 +36,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 
 import java.time.OffsetDateTime;
@@ -48,6 +47,7 @@ import javax.ws.rs.core.Response;
 
 @SpringBootTest
 @TestPropertySource("classpath:/test.properties")
+@WithMockRedHatPrincipal("123456")
 class CapacityResourceTest {
 
     private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
@@ -66,8 +66,6 @@ class CapacityResourceTest {
     CapacityResource resource;
 
     @Test
-    @WithMockUser(value = "owner123456",
-        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     void testShouldUseQueryBasedOnHeaderAndParameters() {
         SubscriptionCapacity capacity = new SubscriptionCapacity();
         capacity.setBeginDate(min);
@@ -94,8 +92,6 @@ class CapacityResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "owner123456",
-        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     void testShouldCalculateCapacityBasedOnMultipleSubscriptions() {
         SubscriptionCapacity capacity = new SubscriptionCapacity();
         capacity.setVirtualSockets(5);
@@ -132,8 +128,6 @@ class CapacityResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "owner123456",
-        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     void testShouldThrowExceptionOnBadOffset() {
         SubscriptionsException e = assertThrows(SubscriptionsException.class, () ->
             resource.getCapacityReport(
@@ -147,8 +141,6 @@ class CapacityResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "owner123456",
-        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     void testShouldRespectOffsetAndLimit() {
         SubscriptionCapacity capacity = new SubscriptionCapacity();
         capacity.setBeginDate(min);

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -27,7 +27,7 @@ import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
-import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationDetailsSource;
+import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 
 import org.junit.jupiter.api.Test;
@@ -39,7 +39,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 
 import java.time.OffsetDateTime;
@@ -50,6 +49,7 @@ import javax.ws.rs.core.Response;
 
 @SpringBootTest
 @TestPropertySource("classpath:/test.properties")
+@WithMockRedHatPrincipal("123456")
 public class TallyResourceTest {
 
     @MockBean
@@ -68,14 +68,12 @@ public class TallyResourceTest {
     private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
 
     @Test
-    @WithMockUser(value = "owner123456",
-        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void testShouldUseQueryBasedOnHeaderAndParameters() {
         TallySnapshot snap = new TallySnapshot();
 
         Mockito.when(repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-            Mockito.eq("owner123456"),
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+            Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(min),
@@ -94,8 +92,8 @@ public class TallyResourceTest {
 
         Pageable expectedPageable = PageRequest.of(1, 10);
         Mockito.verify(repository)
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-            Mockito.eq("owner123456"),
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+            Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(min),
@@ -105,8 +103,6 @@ public class TallyResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "owner123456",
-        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void testShouldThrowExceptionOnBadOffset() {
         SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource.getTallyReport(
             "product1",
@@ -120,12 +116,10 @@ public class TallyResourceTest {
     }
 
     @Test
-    @WithMockUser(value = "owner123456",
-        authorities = "ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE)
     public void reportDataShouldGetFilledWhenPagingParametersAreNotPassed() {
         Mockito.when(repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-                 Mockito.eq("owner123456"),
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
+                 Mockito.eq("account123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
                  Mockito.eq(min),

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManagerTest.java
@@ -55,7 +55,10 @@ class IdentityHeaderAuthenticationManagerTest {
 
         Authentication result = manager.authenticate(authentication);
 
-        PreAuthenticatedAuthenticationToken expected = new PreAuthenticatedAuthenticationToken("123", "N/A",
+        InsightsUserPrincipal principal = new InsightsUserPrincipal("123", "acct");
+
+        PreAuthenticatedAuthenticationToken expected = new PreAuthenticatedAuthenticationToken(principal,
+            "N/A",
             Collections.emptyList());
         assertEquals(expected, result);
     }

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockInsightsUserSecurityContextFactory.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockInsightsUserSecurityContextFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class WithMockInsightsUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockRedHatPrincipal> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockRedHatPrincipal annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        String account = String.format("account%s", annotation.value());
+        String ownerId = String.format("owner%s", annotation.value());
+
+        InsightsUserPrincipal principal = new InsightsUserPrincipal(ownerId, account);
+
+        List<SimpleGrantedAuthority> authorities = Arrays.stream(annotation.roles())
+            .map(SimpleGrantedAuthority::new)
+            .collect(Collectors.toList());
+
+        Authentication auth =
+            new UsernamePasswordAuthenticationToken(principal, null, authorities);
+        context.setAuthentication(auth);
+
+        return context;
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Creates a mock Red Hat principal for testing, with account$value and owner$value as account number and
+ * owner ID.
+ *
+ * Defaults to granting ROLE_ORG_ADMIN, but can be overridden.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockInsightsUserSecurityContextFactory.class)
+public @interface WithMockRedHatPrincipal {
+
+    /**
+     * Set account and ownerId to account$value and owner$value respectively.
+     *
+     * @return
+     */
+    String value() default "";
+
+    String[] roles() default {"ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE};
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -73,15 +73,15 @@ public class DailySnapshotRollerTest {
     @SuppressWarnings("indentation")
     @Test
     public void testDailySnapshotProducer() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> dailySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
                 TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, dailySnaps.size());
@@ -93,15 +93,15 @@ public class DailySnapshotRollerTest {
     @SuppressWarnings("indentation")
     @Test
     public void testDailySnapIsUpdatedWhenItAlreadyExists() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> dailySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
                 TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, dailySnaps.size());
@@ -114,7 +114,7 @@ public class DailySnapshotRollerTest {
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedDailySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
                 TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedDailySnaps.size());
@@ -130,15 +130,15 @@ public class DailySnapshotRollerTest {
 
     @Test
     public void ensureCurrentDailyUpdatedRegardlessOfWhetherIncomingCalculationsAreLessThanTheExisting() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 100, 200, 10);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> dailySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, dailySnaps.size());
@@ -149,11 +149,11 @@ public class DailySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 3, 4));
+        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 3, 4));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedDailySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedDailySnaps.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -79,15 +79,15 @@ public class MonthlySnapshotRollerTest {
     @SuppressWarnings("indentation")
     @Test
     public void testMonthlySnapshotProducer() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> monthlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, monthlySnaps.size());
@@ -99,15 +99,15 @@ public class MonthlySnapshotRollerTest {
     @SuppressWarnings("indentation")
     @Test
     public void testMonthlySnapIsUpdatedWhenItAlreadyExists() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> monthlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, monthlySnaps.size());
@@ -119,7 +119,7 @@ public class MonthlySnapshotRollerTest {
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedMonthlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedMonthlySnaps.size());
@@ -139,15 +139,15 @@ public class MonthlySnapshotRollerTest {
         int expectedSockets = 200;
         int expectedInstances = 10;
 
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, expectedCores, expectedSockets, expectedInstances);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> monthlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(),
             clock.endOfCurrentMonth(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, monthlySnaps.size());
@@ -158,11 +158,11 @@ public class MonthlySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 2, 2));
+        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 2, 2));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedMonthlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.MONTHLY, clock.startOfCurrentMonth(),
             clock.endOfCurrentMonth(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedMonthlySnaps.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -72,15 +72,15 @@ public class QuarterlySnapshotRollerTest {
 
     @Test
     public void testQuarterlySnapshotProduction() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> quarterlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, quarterlySnaps.size());
@@ -92,15 +92,15 @@ public class QuarterlySnapshotRollerTest {
 
     @Test
     public void testQuarterlySnapIsUpdatedWhenItAlreadyExists() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(owner), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> originalSnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
@@ -114,7 +114,7 @@ public class QuarterlySnapshotRollerTest {
 
         // Check the yearly again. Should still be a single instance, but have updated values.
         List<TallySnapshot> updatedSnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
@@ -134,15 +134,15 @@ public class QuarterlySnapshotRollerTest {
         int expectedSockets = 200;
         int expectedInstances = 10;
 
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, expectedCores, expectedSockets, expectedInstances);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList(owner), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> quarterlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, quarterlySnaps.size());
@@ -153,11 +153,11 @@ public class QuarterlySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 2, 2));
+        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 2, 2));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedQuarterlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
             clock.endOfCurrentQuarter(), PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedQuarterlySnaps.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -72,15 +72,15 @@ public class WeeklySnapshotRollerTest {
 
     @Test
     public void testWeeklySnapshotProduction() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 6, 7, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> weeklySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, weeklySnaps.size());
@@ -91,15 +91,15 @@ public class WeeklySnapshotRollerTest {
 
     @Test
     public void testWeeklySnapIsUpdatedWhenItAlreadyExists() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 6, 7, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> weeklySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, weeklySnaps.size());
@@ -114,7 +114,7 @@ public class WeeklySnapshotRollerTest {
 
         // Check the weekly again. Should still be a single instance, but have updated values.
         List<TallySnapshot> updatedWeeklySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedWeeklySnaps.size());
@@ -134,15 +134,15 @@ public class WeeklySnapshotRollerTest {
         int expectedSockets = 200;
         int expectedInstances = 10;
 
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, expectedCores, expectedSockets, expectedInstances);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> weeklySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, weeklySnaps.size());
@@ -153,11 +153,11 @@ public class WeeklySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 2, 2));
+        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 2, 2));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedWeeklySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedWeeklySnaps.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -68,15 +68,15 @@ public class YearlySnapshotRollerTest {
 
     @Test
     public void testYearlySnapshotProduction() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> yearlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, yearlySnaps.size());
@@ -87,15 +87,15 @@ public class YearlySnapshotRollerTest {
 
     @Test
     public void testYearlySnapIsUpdatedWhenItAlreadyExists() {
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, 12, 24, 6);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> originalSnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
@@ -109,7 +109,7 @@ public class YearlySnapshotRollerTest {
 
         // Check the yearly again. Should still be a single instance, but have updated values.
         List<TallySnapshot> updatedSnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, originalSnaps.size());
@@ -129,15 +129,15 @@ public class YearlySnapshotRollerTest {
         int expectedSockets = 200;
         int expectedInstances = 10;
 
-        String owner = "O1";
-        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs("A1", owner,
+        String account = "A1";
+        List<AccountUsageCalculation> accountCalcs = createAccountProductCalcs(account, "O1",
             TEST_PRODUCT, expectedCores, expectedSockets, expectedInstances);
         AccountUsageCalculation a1Calc = accountCalcs.get(0);
         ProductUsageCalculation a1ProductCalc = a1Calc.getProductCalculation(TEST_PRODUCT);
-        roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
+        roller.rollSnapshots(Arrays.asList(account), accountCalcs);
 
         List<TallySnapshot> yearlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, yearlySnaps.size());
@@ -148,11 +148,11 @@ public class YearlySnapshotRollerTest {
 
         // Update the values and run again
         accountCalcs.clear();
-        accountCalcs.add(createAccountCalc("A1", owner, TEST_PRODUCT, 2, 2, 2));
+        accountCalcs.add(createAccountCalc(account, "O1", TEST_PRODUCT, 2, 2, 2));
         roller.rollSnapshots(Arrays.asList("A1"), accountCalcs);
 
         List<TallySnapshot> updatedYearlySnaps = repository
-            .findByOwnerIdAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(owner,
+            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
             TEST_PRODUCT, Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(),
             PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedYearlySnaps.size());


### PR DESCRIPTION
Testing the tally change
------------------------
Try the tally API via deployment with `./gradlew bootRun` followed by invocation of APIs through swagger-ui. Be sure to try both tally and capacity APIs.

Testing the DB change
---------------------
Try:

```
liquibase --username rhsm-subscriptions --classpath=/usr/share/java/postgresql-jdbc.jar --url jdbc:postgresql://localhost:5432/rhsm-subscriptions --changeLogFile liquibase/changelog.xml update
```

Observe that the not null constraint is dropped via:

```
psql -U rhsm-subscriptions -h localhost -c '\d subscription_capacity'
```

Note: I added a new annotation: `@WithMockRedHatPrincipal` to replace `@WithMockUser`.