### PR TITLE
Restrict Tally/Capacity APIs to admin + account whitelist

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -58,6 +58,11 @@ public class ApplicationProperties {
     private String productWhitelistResourceLocation;
 
     /**
+     * Resource location of a file containing the whitelisted accounts allowed to run reports.
+     */
+    private String reportingAccountWhitelistResourceLocation;
+
+    /**
      * An hour based threshold used to determine whether an inventory host record's rhsm facts are outdated.
      * The host's rhsm.SYNC_TIMESTAMP fact is checked against this threshold. The default is 24 hours.
      */
@@ -148,5 +153,13 @@ public class ApplicationProperties {
 
     public void setProductWhitelistResourceLocation(String productWhitelistResourceLocation) {
         this.productWhitelistResourceLocation = productWhitelistResourceLocation;
+    }
+
+    public String getReportingAccountWhitelistResourceLocation() {
+        return reportingAccountWhitelistResourceLocation;
+    }
+
+    public void setReportingAccountWhitelistResourceLocation(String location) {
+        this.reportingAccountWhitelistResourceLocation = location;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -48,6 +48,11 @@ public enum ErrorCode {
     VALIDATION_FAILED_ERROR(1002, "Client request failed validation."),
 
     /**
+     * The client's request was denied due to lack of roles/permissions.
+     */
+    REQUEST_DENIED_ERROR(1003, "Request was denied due to lack of roles/permissions."),
+
+    /**
      * An unexpected exception was thrown by the inventory service client.
      */
     INVENTORY_SERVICE_ERROR(2000, "Inventory Service Error"),

--- a/src/main/java/org/candlepin/subscriptions/files/ReportingAccountWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ReportingAccountWhitelist.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.files;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Loads a list of account numbers that are permitted to access the Tally and Capacity API.
+ */
+@Component
+public class ReportingAccountWhitelist implements ResourceLoaderAware {
+
+    private PerLineFileSource source;
+    private boolean isDevMode;
+
+    public ReportingAccountWhitelist(ApplicationProperties props) {
+        String resourceLocation = props.getReportingAccountWhitelistResourceLocation();
+        source = resourceLocation != null ? new PerLineFileSource(resourceLocation) : null;
+        this.isDevMode = props.isDevMode();
+    }
+
+    public boolean hasAccount(String account) throws IOException {
+        // Whitelist any account when running in dev mode!
+        if (isDevMode) {
+            return true;
+        }
+
+        // Currently this list is read on each request. If this presents a problem in the
+        // future, we should consider caching the account list.
+        return source != null && source.list().contains(account);
+    }
+
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        if (source != null) {
+            source.setResourceLoader(resourceLoader);
+        }
+    }
+
+    @PostConstruct
+    public void init() {
+        if (source != null) {
+            source.init();
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
@@ -70,7 +70,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
 
     public static Error buildError(AccessDeniedException exception) {
         return new Error()
-            .code(ErrorCode.REQUEST_PROCESSING_ERROR.getCode())
+            .code(ErrorCode.REQUEST_DENIED_ERROR.getCode())
             .status(String.valueOf(Status.FORBIDDEN.getStatusCode()))
             .title("Access Denied")
             .detail(exception.getMessage());

--- a/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.candlepin.subscriptions.files.ReportingAccountWhitelist;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+/**
+ * Provides a means to validate that an authentication token has a whitelisted account associated with it.
+ * The primary use of this class is to provide a check for expression based security annotations.
+ *
+ * @see org.candlepin.subscriptions.security.auth.AdminOnly
+ */
+@Service("reportAccessService")
+public class WhitelistedAccountReportAccessService {
+
+    private ReportingAccountWhitelist whitelistSource;
+
+    public WhitelistedAccountReportAccessService(ReportingAccountWhitelist whitelistSource) {
+        this.whitelistSource = whitelistSource;
+    }
+
+    public boolean providesAccessTo(Authentication auth) throws IOException {
+        InsightsUserPrincipal principal = (InsightsUserPrincipal) auth.getPrincipal();
+        return whitelistSource.hasAccount(principal.getAccountNumber());
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/security/auth/AdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/AdminOnly.java
@@ -35,6 +35,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "')")
+@PreAuthorize("hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "') and " +
+    "@reportAccessService.providesAccessTo(authentication)")
 public @interface AdminOnly {
 }


### PR DESCRIPTION
Both APIs are now restricted to users having the admin role
as well as their account must be in the configured white list
file.

APIs can now be restricted in this mannor by annotating the API
method with the new annotation: @AdminWithWhitelistedAccountOnly

The white list can be configured by adding a new property to the
config file as follows:

rhsm-subscriptions.reporting_account_whitelist_resource_location=file:<PATH_TO_YOUR_ACCOUNT_LIST_FILE>

This file simply contains a list of accounts that are allowed to access the reporting APIs.

NOTE: When the application is running in dev mode, the account WILL NOT be checked when
the API is invoked.