### PR TITLE
Add cache with default 5m ttl for maps and lists

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -51,7 +51,6 @@ import java.io.IOException;
 
 import javax.validation.Validator;
 
-
 /** Class to hold configuration beans */
 @Configuration
 @Import(ResteasyAutoConfiguration.class) // needed to be able to reference ResteasyApplicationBuilder
@@ -109,22 +108,10 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public ProductIdToProductsMapSource productToProductIdsMapSource(
-        ApplicationProperties applicationProperties) {
-
-        return new ProductIdToProductsMapSource(applicationProperties);
-    }
-
-    @Bean
-    public RoleToProductsMapSource roleToProductMapSource(ApplicationProperties applicationProperties) {
-        return new RoleToProductsMapSource(applicationProperties);
-    }
-
-    @Bean
     public AccountListSource accountListSource(ApplicationProperties applicationProperties,
-        InventoryRepository inventoryRepository) {
+        InventoryRepository inventoryRepository, ApplicationClock clock) {
         if (applicationProperties.getAccountListResourceLocation() != null) {
-            return new FileAccountListSource(applicationProperties);
+            return new FileAccountListSource(applicationProperties, clock);
         }
         else {
             return new DatabaseAccountListSource(inventoryRepository);

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -24,6 +24,8 @@ import org.candlepin.subscriptions.retention.TallyRetentionPolicyProperties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 /**
  * POJO to hold property values via Spring's "Type-Safe Configuration Properties" pattern
  */
@@ -78,6 +80,32 @@ public class ApplicationProperties {
      * Whether the ingress endpoint is enabled on this instance of rhsm-subscriptions or not.
      */
     private boolean enableIngressEndpoint;
+
+    /**
+     * Amount of time to cache the account list, before allowing a re-read from the filesystem.
+     */
+    private Duration accountListCacheTtl = Duration.ofMinutes(5);
+
+    /**
+     * Amount of time to cache the product mapping, before allowing a re-read from the filesystem.
+     */
+    private Duration productIdToProductsMapCacheTtl = Duration.ofMinutes(5);
+
+    /**
+     * Amount of time to cache the product whitelist, before allowing a re-read from the filesystem.
+     */
+    private Duration productWhiteListCacheTtl = Duration.ofMinutes(5);
+
+    /**
+     * Amount of time to cache the syspurpose role to products map, before allowing a re-read from the
+     * filesystem.
+     */
+    private Duration roleToProductsMapCacheTtl = Duration.ofMinutes(5);
+
+    /**
+     * Amount of time to cache the API access whitelist, before allowing a re-read from the filesystem.
+     */
+    private Duration reportingAccountWhitelistCacheTtl = Duration.ofMinutes(5);
 
     public boolean isPrettyPrintJson() {
         return prettyPrintJson;
@@ -161,5 +189,45 @@ public class ApplicationProperties {
 
     public void setReportingAccountWhitelistResourceLocation(String location) {
         this.reportingAccountWhitelistResourceLocation = location;
+    }
+
+    public Duration getAccountListCacheTtl() {
+        return accountListCacheTtl;
+    }
+
+    public void setAccountListCacheTtl(Duration accountListCacheTtl) {
+        this.accountListCacheTtl = accountListCacheTtl;
+    }
+
+    public Duration getProductIdToProductsMapCacheTtl() {
+        return productIdToProductsMapCacheTtl;
+    }
+
+    public void setProductIdToProductsMapCacheTtl(Duration productIdToProductsMapCacheTtl) {
+        this.productIdToProductsMapCacheTtl = productIdToProductsMapCacheTtl;
+    }
+
+    public Duration getProductWhiteListCacheTtl() {
+        return productWhiteListCacheTtl;
+    }
+
+    public void setProductWhiteListCacheTtl(Duration productWhiteListCacheTtl) {
+        this.productWhiteListCacheTtl = productWhiteListCacheTtl;
+    }
+
+    public Duration getRoleToProductsMapCacheTtl() {
+        return roleToProductsMapCacheTtl;
+    }
+
+    public void setRoleToProductsMapCacheTtl(Duration roleToProductsMapCacheTtl) {
+        this.roleToProductsMapCacheTtl = roleToProductsMapCacheTtl;
+    }
+
+    public Duration getReportingAccountWhitelistCacheTtl() {
+        return reportingAccountWhitelistCacheTtl;
+    }
+
+    public void setReportingAccountWhitelistCacheTtl(Duration reportingAccountWhitelistCacheTtl) {
+        this.reportingAccountWhitelistCacheTtl = reportingAccountWhitelistCacheTtl;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/files/Cache.java
+++ b/src/main/java/org/candlepin/subscriptions/files/Cache.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.files;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+/**
+ * Cache for a value that expires after a certain time.
+ *
+ * Uses of this class must check whether the cached value is valid by using isExpired.
+ *
+ * @param <T> type of value to cache.
+ */
+public class Cache<T> {
+    private OffsetDateTime lastCached;
+    private T cachedValue;
+    private final Duration cacheTtl;
+    private final Clock clock;
+
+    public Cache(Clock clock, Duration cacheTtl) {
+        this.clock = clock;
+        this.cacheTtl = cacheTtl;
+    }
+
+    /**
+     * Set the value in the cache and transparently update the TTL on the value.
+     *
+     * @param value value to cache
+     */
+    public void setValue(T value) {
+        cachedValue = value;
+        lastCached = OffsetDateTime.now(clock);
+    }
+
+    /**
+     * Get the cached value.
+     *
+     * @return the cached value
+     */
+    public T getValue() {
+        return cachedValue;
+    }
+
+    /**
+     * Returns whether the TTL has elapsed or not.
+     *
+     * @return boolean indicating TTL expiry
+     */
+    public boolean isExpired() {
+        if (lastCached == null) {
+            return true;
+        }
+        OffsetDateTime expiry = lastCached.plus(cacheTtl);
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        return expiry.isBefore(now) || expiry.isEqual(now);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
@@ -20,15 +20,16 @@
  */
 package org.candlepin.subscriptions.files;
 
-
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 /**
  * Reads a set of accounts from a file. Each line is a single account.
  */
 public class FileAccountListSource extends PerLineFileSource implements AccountListSource {
-    public FileAccountListSource(ApplicationProperties applicationProperties) {
-        super(applicationProperties.getAccountListResourceLocation());
+    public FileAccountListSource(ApplicationProperties applicationProperties, ApplicationClock clock) {
+        super(applicationProperties.getAccountListResourceLocation(), clock.getClock(),
+            applicationProperties.getAccountListCacheTtl());
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.files;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,10 +46,11 @@ public class ProductWhitelist implements ResourceLoaderAware {
     private final Set<String> whitelistProducts = new HashSet<>();
     private final PerLineFileSource source;
 
-    public ProductWhitelist(ApplicationProperties properties) {
+    public ProductWhitelist(ApplicationProperties properties, ApplicationClock clock) {
         if (properties.getProductWhitelistResourceLocation() != null) {
             source = new PerLineFileSource(
-                properties.getProductWhitelistResourceLocation());
+                properties.getProductWhitelistResourceLocation(), clock.getClock(),
+                properties.getProductWhiteListCacheTtl());
         }
         else {
             source = null;

--- a/src/main/java/org/candlepin/subscriptions/files/ReportingAccountWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ReportingAccountWhitelist.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.files;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ResourceLoader;
@@ -39,9 +40,11 @@ public class ReportingAccountWhitelist implements ResourceLoaderAware {
     private PerLineFileSource source;
     private boolean isDevMode;
 
-    public ReportingAccountWhitelist(ApplicationProperties props) {
+    public ReportingAccountWhitelist(ApplicationProperties props, ApplicationClock clock) {
         String resourceLocation = props.getReportingAccountWhitelistResourceLocation();
-        source = resourceLocation != null ? new PerLineFileSource(resourceLocation) : null;
+        source = resourceLocation != null ? new PerLineFileSource(resourceLocation, clock.getClock(),
+            props.getReportingAccountWhitelistCacheTtl()) :
+            null;
         this.isDevMode = props.isDevMode();
     }
 

--- a/src/main/java/org/candlepin/subscriptions/files/RoleToProductsMapSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/RoleToProductsMapSource.java
@@ -21,6 +21,9 @@
 package org.candlepin.subscriptions.files;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,10 +32,12 @@ import java.util.Map;
 /**
  * Loads the mapping of syspurpose role to Tally products from a YAML file.
  */
+@Component
 public class RoleToProductsMapSource extends YamlFileSource<Map<String, List<String>>> {
 
-    public RoleToProductsMapSource(ApplicationProperties properties) {
-        super(properties.getRoleToProductsMapResourceLocation());
+    public RoleToProductsMapSource(ApplicationProperties properties, ApplicationClock clock) {
+        super(properties.getRoleToProductsMapResourceLocation(), clock.getClock(),
+            properties.getRoleToProductsMapCacheTtl());
     }
 
     @Override

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.*;
 
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,6 +33,9 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.core.io.FileSystemResourceLoader;
 
 import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -41,6 +45,7 @@ import java.util.Set;
 class CapacityProductExtractorTest {
 
     private CapacityProductExtractor extractor;
+    private ApplicationClock clock = new ApplicationClock(Clock.fixed(Instant.EPOCH, ZoneOffset.UTC));
 
     @BeforeAll
     void setup() throws IOException {
@@ -48,7 +53,8 @@ class CapacityProductExtractorTest {
         props.setProductIdToProductsMapResourceLocation("classpath:test_product_id_to_products_map.yaml");
         props.setRoleToProductsMapResourceLocation("classpath:test_role_to_products_map.yaml");
 
-        ProductIdToProductsMapSource productIdToProductsMapSource = new ProductIdToProductsMapSource(props);
+        ProductIdToProductsMapSource productIdToProductsMapSource = new ProductIdToProductsMapSource(props,
+            clock);
         productIdToProductsMapSource.setResourceLoader(new FileSystemResourceLoader());
         productIdToProductsMapSource.init();
 

--- a/src/test/java/org/candlepin/subscriptions/files/CacheTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/CacheTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.subscriptions.util.TestClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+class CacheTest {
+
+    @Test
+    void testValueSetIsRetrieved() {
+        Cache<Object> cache = new Cache<>(Clock.fixed(Instant.EPOCH, ZoneOffset.UTC), Duration.ofMinutes(5));
+        Object expected = new Object();
+        cache.setValue(expected);
+        assertEquals(expected, cache.getValue());
+    }
+
+    @Test
+    void testExpiredBeforeSet() {
+        Cache<Object> cache = new Cache<>(Clock.fixed(Instant.EPOCH, ZoneOffset.UTC), Duration.ofMinutes(5));
+        assertTrue(cache.isExpired());
+    }
+
+    @Test
+    void testNotExpiredImmediatelyAfterSetting() {
+        Cache<Object> cache = new Cache<>(Clock.fixed(Instant.EPOCH, ZoneOffset.UTC), Duration.ofMinutes(5));
+        Object expected = new Object();
+        cache.setValue(expected);
+        assertFalse(cache.isExpired());
+    }
+
+    @Test
+    void testNoCachingIfZeroTtl() {
+        Cache<Object> cache = new Cache<>(Clock.fixed(Instant.EPOCH, ZoneOffset.UTC), Duration.ZERO);
+        Object expected = new Object();
+        cache.setValue(expected);
+        assertTrue(cache.isExpired());
+    }
+
+    @Test
+    void testExpiresAfterTtl() {
+        TestClock clock = new TestClock(Instant.EPOCH, ZoneOffset.UTC);
+        Cache<Object> cache = new Cache<>(clock, Duration.ofSeconds(60));
+        Object expected = new Object();
+        cache.setValue(expected);
+        assertFalse(cache.isExpired());
+        clock.setInstant(Instant.EPOCH.plusSeconds(60));
+        assertTrue(cache.isExpired());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/files/FileAccountListSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/FileAccountListSourceTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ public class FileAccountListSourceTest {
         ApplicationProperties props = new ApplicationProperties();
         props.setAccountListResourceLocation("classpath:account_list.txt");
 
-        FileAccountListSource source = new FileAccountListSource(props);
+        FileAccountListSource source = new FileAccountListSource(props, new ApplicationClock());
         source.setResourceLoader(new FileSystemResourceLoader());
         source.init();
 

--- a/src/test/java/org/candlepin/subscriptions/files/PerLineFileResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/PerLineFileResourceTest.java
@@ -27,9 +27,10 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.FileSystemResourceLoader;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-
 
 public class PerLineFileResourceTest {
 
@@ -59,7 +60,8 @@ public class PerLineFileResourceTest {
     }
 
     private PerLineFileSource createSource(String filename) {
-        PerLineFileSource source = new PerLineFileSource(String.format("classpath:%s", filename));
+        PerLineFileSource source = new PerLineFileSource(String.format("classpath:%s", filename),
+            Clock.systemUTC(), Duration.ofMinutes(5));
         source.setResourceLoader(new FileSystemResourceLoader());
         source.init();
         return source;

--- a/src/test/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSourceTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ public class ProductIdToProductsMapSourceTest {
         ApplicationProperties props = new ApplicationProperties();
         props.setProductIdToProductsMapResourceLocation("classpath:test_product_id_to_products_map.yaml");
 
-        ProductIdToProductsMapSource source = new ProductIdToProductsMapSource(props);
+        ProductIdToProductsMapSource source = new ProductIdToProductsMapSource(props, new ApplicationClock());
         source.setResourceLoader(new FileSystemResourceLoader());
         source.init();
 

--- a/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.files;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.FileSystemResourceLoader;
@@ -54,7 +55,7 @@ class ProductWhitelistTest {
     private ProductWhitelist initProductWhitelist(String resourceLocation) throws IOException {
         ApplicationProperties props = new ApplicationProperties();
         props.setProductWhitelistResourceLocation(resourceLocation);
-        ProductWhitelist whitelist = new ProductWhitelist(props);
+        ProductWhitelist whitelist = new ProductWhitelist(props, new ApplicationClock());
         whitelist.setResourceLoader(new FileSystemResourceLoader());
         whitelist.init();
         return whitelist;

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -69,11 +69,12 @@ public class FactNormalizerTest {
         props.setProductIdToProductsMapResourceLocation("classpath:test_product_id_to_products_map.yaml");
         props.setRoleToProductsMapResourceLocation("classpath:test_role_to_products_map.yaml");
 
-        ProductIdToProductsMapSource productIdToProductsMapSource = new ProductIdToProductsMapSource(props);
+        ProductIdToProductsMapSource productIdToProductsMapSource = new ProductIdToProductsMapSource(props,
+            clock);
         productIdToProductsMapSource.setResourceLoader(new FileSystemResourceLoader());
         productIdToProductsMapSource.init();
 
-        RoleToProductsMapSource productToRolesMapSource = new RoleToProductsMapSource(props);
+        RoleToProductsMapSource productToRolesMapSource = new RoleToProductsMapSource(props, clock);
         productToRolesMapSource.setResourceLoader(new FileSystemResourceLoader());
         productToRolesMapSource.init();
 

--- a/src/test/java/org/candlepin/subscriptions/util/TestClock.java
+++ b/src/test/java/org/candlepin/subscriptions/util/TestClock.java
@@ -18,30 +18,41 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.files;
+package org.candlepin.subscriptions.util;
 
-import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.util.ApplicationClock;
-
-import org.springframework.stereotype.Component;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 
 /**
- * Loads the product ID to list of Tally products mapping from a YAML file.
+ * Clock for testing that allows manipulating the time
  */
-@Component
-public class ProductIdToProductsMapSource extends YamlFileSource<Map<Integer, List<String>>> {
+public class TestClock extends Clock {
 
-    public ProductIdToProductsMapSource(ApplicationProperties properties, ApplicationClock clock) {
-        super(properties.getProductIdToProductsMapResourceLocation(), clock.getClock(),
-            properties.getProductIdToProductsMapCacheTtl());
+    private Instant instant;
+    private final ZoneId zone;
+
+    public TestClock(Instant instant, ZoneId zone) {
+        this.instant = instant;
+        this.zone = zone;
+    }
+
+    public void setInstant(Instant instant) {
+        this.instant = instant;
     }
 
     @Override
-    protected Map<Integer, List<String>> getDefault() {
-        return Collections.emptyMap();
+    public ZoneId getZone() {
+        return zone;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zoneId) {
+        return new TestClock(instant, zoneId);
+    }
+
+    @Override
+    public Instant instant() {
+        return instant;
     }
 }


### PR DESCRIPTION
Testing
-------
Create an empty account list in `/tmp/accounts.txt`:

```
touch /tmp/accounts.txt
```

Set up `config/application.properties` with the following:

```
rhsm-subscriptions.account_list_resource_location=file:/tmp/accounts.txt
rhsm-subscriptions.account_list_cache_ttl=30s
rhsm-subscriptions.jobs.captureSnapshotSchedule=* * * * * ?
rhsm-subscriptions.enableJobProcessing=true
```

Run the application (`./gradlew bootRun`). Update `/tmp/accounts.txt`
after it has started:

```
echo "123456" > /tmp/accounts.txt
```

Observe that until the cache expires (30 seconds), account count is 0. After the cache expires, the file will be re-read. and the account count will go to 1.