### PR TITLE
Generate a client for the Cloudigrade concurrent resource.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,13 +256,27 @@ project(":api") {
 project(":insights-inventory-client") {
     apply plugin: "org.openapi.generator"
 
-    // This project should only contain generated code.  No point in running checkstyle
-    checkstyle.sourceSets = []
-
     ext {
         api_spec_path = "https://raw.githubusercontent.com/RedHatInsights/insights-host-inventory/master/swagger/api.spec.yaml"
         config_file = "${projectDir}/insights-inventory-client-config.json"
     }
+}
+
+project(":cloudigrade-client") {
+    apply plugin: "org.openapi.generator"
+
+    ext {
+        api_spec_path = "${projectDir}/cloudigrade-api-spec.yaml"
+        config_file = "${projectDir}/cloudigrade-client-config.json"
+    }
+}
+
+configure(subprojects.findAll { it.name == "insights-inventory-client" || it.name == "cloudigrade-client"}) {
+    apply plugin: "org.openapi.generator"
+    apply plugin: "checkstyle"
+
+    // These projects should only contain generated code.  No point in running checkstyle.
+    checkstyle.sourceSets = []
 
     openApiValidate {
         inputSpec = api_spec_path
@@ -285,10 +299,10 @@ project(":insights-inventory-client") {
         outputDir = "${buildDir}/generated"
         generatorName = "java"
         configOptions = [
-            generatePom: false,
-            library: "resteasy",
-            java8: true,
-            dateLibrary: "java8"
+                generatePom: false,
+                library: "resteasy",
+                java8: true,
+                dateLibrary: "java8"
         ]
     }
 
@@ -309,3 +323,4 @@ project(":insights-inventory-client") {
 
     compileJava.dependsOn tasks.openApiGenerate
 }
+

--- a/cloudigrade-client/cloudigrade-api-spec.yaml
+++ b/cloudigrade-client/cloudigrade-api-spec.yaml
@@ -1,0 +1,106 @@
+# This is a file maintained by the rhsm-subscription project that describes
+# a portion of the Cloudigrade API.
+openapi: "3.0.2"
+info:
+  title: "cloudigrade-api"
+  description: "Third-party specification for Cloudigrade API"
+  version: 1.0.0
+
+paths:
+  /concurrent:
+    description: "Operations on concurrent usages"
+    parameters:
+    - name: limit
+      required: false
+      in: query
+      description: "Number of results to return per page."
+      schema:
+        type: integer
+    - name: offset
+      required: false
+      in: query
+      description: "The initial index from which to return the results."
+      schema:
+        type: integer
+    get:
+      summary: "List daily concurrent usages"
+      operationId: "ListDailyConcurrentUsages"
+      tags:
+        - concurrent
+      responses:
+        '200':
+          description: "The operation completed successfully"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConcurrencyReport'
+
+components:
+  schemas:
+    ConcurrencyReport:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConcurrentUsage"
+        links:
+          type: object
+          properties:
+            first:
+              type: string
+            last:
+              type: string
+            previous:
+              type: string
+            next:
+              type: string
+          required:
+            - first
+            - previous
+            - last
+            - next
+        meta:
+          type: object
+          properties:
+            count:
+              type: integer
+    ConcurrentUsage:
+      required:
+        - date
+        - instances
+        - instances_list
+        - vcpu
+        - memory
+      properties:
+        date:
+          type: string
+          format: date
+        instances:
+          type: integer
+        instances_list:
+          type: array
+          items:
+            $ref: "#/components/schemas/CloudInstance"
+        vcpu:
+          type: integer
+        memory:
+          type: number
+    CloudInstance:
+      properties:
+        cloud_instance_id:
+          type: string
+        cloud_type:
+          type: string
+        rhel_version:
+          type: string
+        syspurpose:
+          $ref: "#/components/schemas/Syspurpose"
+    Syspurpose:
+      type: object
+      properties:
+        role:
+          type: string
+        service_level_agreement:
+          type: string
+        usage:
+          type: string

--- a/cloudigrade-client/cloudigrade-client-config.json
+++ b/cloudigrade-client/cloudigrade-client-config.json
@@ -1,0 +1,8 @@
+{
+  "modelPackage": "org.candlepin.subscriptions.cloudigrade.api.model",
+  "apiPackage": "org.candlepin.subscriptions.cloudigrade.api.resources",
+  "invokerPackage": "org.candlepin.subscriptions.cloudigrade",
+  "groupId": "org.candlepin",
+  "artifactId": "cloudigrade-client",
+  "java8": true
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'rhsm-subscriptions'
-include ':api', ':insights-inventory-client'
+include ':api', ':insights-inventory-client', ':cloudigrade-client'


### PR DESCRIPTION
Cloudigrade does not do spec-first development.  They provide an OpenAPI
specification in JSON that is generated from the source code.
Unfortunately, the generated file does not work properly.  I ran into
multiple issues where OpenAPI complained about having to use
UNKNOWN_BASE_TYPE when generating a client.

Since Cloudigrade is stable and we only use a piece of the API, I've
addressed the issue by simply defining our own specification file.  We
are obligated to keep this file in sync with any changes to the
Cloudigrade API, but hopefully Cloudigrade will move toward a spec-first
development model and then we can consume a working OpenAPI definition
from them.