### PR TITLE
Consider infrastructure_type when classifying as virtual.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -53,6 +53,7 @@ import javax.persistence.Table;
                 @ColumnResult(name = "sockets"),
                 @ColumnResult(name = "products"),
                 @ColumnResult(name = "sync_timestamp"),
+                @ColumnResult(name = "system_profile_infrastructure_type"),
                 @ColumnResult(name = "system_profile_cores_per_socket"),
                 @ColumnResult(name = "system_profile_sockets"),
                 @ColumnResult(name = "qpc_products"),
@@ -82,6 +83,7 @@ import javax.persistence.Table;
         "h.facts->'rhsm'->>'SYNC_TIMESTAMP' as sync_timestamp, " +
         "h.facts->'rhsm'->>'SYSPURPOSE_ROLE' as syspurpose_role, " +
         "h.facts->'qpc'->>'IS_RHEL' as is_rhel, " +
+        "h.system_profile_facts->>'infrastructure_type' as infrastructure_type, " +
         "h.system_profile_facts->>'cores_per_socket' as system_profile_cores_per_socket, " +
         "h.system_profile_facts->>'number_of_sockets' as system_profile_sockets, " +
         "h.canonical_facts->>'subscription_manager_id' as subscription_manager_id, " +

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -36,6 +36,7 @@ public class InventoryHostFacts {
     private Integer sockets;
     private String syncTimestamp;
     private Set<String> products;
+    private String systemProfileInfrastructureType;
     private Integer systemProfileCoresPerSocket;
     private Integer systemProfileSockets;
     private boolean isVirtual;
@@ -53,9 +54,10 @@ public class InventoryHostFacts {
 
     @SuppressWarnings("squid:S00107")
     public InventoryHostFacts(String account, String displayName, String orgId, String cores, String sockets,
-        String products, String syncTimestamp, String systemProfileCores, String systemProfileSockets,
-        String qpcProducts, String qpcProductIds, String systemProfileProductIds, String syspurposeRole,
-        String isVirtual, String hypervisorUuid, String guestId, String subscriptionManagerId) {
+        String products, String syncTimestamp, String systemProfileInfrastructureType,
+        String systemProfileCores, String systemProfileSockets, String qpcProducts, String qpcProductIds,
+        String systemProfileProductIds, String syspurposeRole, String isVirtual, String hypervisorUuid,
+        String guestId, String subscriptionManagerId) {
 
         this.account = account;
         this.displayName = displayName;
@@ -66,6 +68,7 @@ public class InventoryHostFacts {
         this.qpcProducts = asStringSet(qpcProducts);
         this.qpcProductIds = asStringSet(qpcProductIds);
         this.syncTimestamp = StringUtils.hasText(syncTimestamp) ? syncTimestamp : "";
+        this.systemProfileInfrastructureType = systemProfileInfrastructureType;
         this.systemProfileCoresPerSocket = asInt(systemProfileCores);
         this.systemProfileSockets = asInt(systemProfileSockets);
         this.systemProfileProductIds = asStringSet(systemProfileProductIds);
@@ -155,6 +158,15 @@ public class InventoryHostFacts {
         }
         return StringUtils.commaDelimitedListToSet(productJson);
     }
+
+    public String getSystemProfileInfrastructureType() {
+        return systemProfileInfrastructureType;
+    }
+
+    public void setSystemProfileInfrastructureType(String systemProfileInfrastructureType) {
+        this.systemProfileInfrastructureType = systemProfileInfrastructureType;
+    }
+
     public Integer getSystemProfileCoresPerSocket() {
         return systemProfileCoresPerSocket == null ? 0 : systemProfileCoresPerSocket;
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/ClassificationProxyRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/ClassificationProxyRepository.java
@@ -80,8 +80,10 @@ public class ClassificationProxyRepository {
             // considered unknown if the system is virtual (a guest) and either has a null
             // hypervisor UUID OR the guest's hypervisor UUID was not reported by conduit.
             String hypervisorUuid = enhancedFacts.getHypervisorUuid();
-            boolean isHypervisorUnknown =
-                (enhancedFacts.isVirtual() && !StringUtils.hasText(hypervisorUuid)) ||
+            boolean isVirtual = enhancedFacts.isVirtual() ||
+                "virtual".equalsIgnoreCase(enhancedFacts.getSystemProfileInfrastructureType());
+
+            boolean isHypervisorUnknown = (isVirtual && !StringUtils.hasText(hypervisorUuid)) ||
                 missingHypervisors.contains(hypervisorUuid);
             enhancedFacts.setHypervisorUnknown(isHypervisorUnknown);
 

--- a/src/main/java/org/candlepin/subscriptions/tally/ClassifiedInventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/ClassifiedInventoryHostFacts.java
@@ -89,6 +89,10 @@ public class ClassifiedInventoryHostFacts {
         return inventoryHostFacts.getProducts();
     }
 
+    public String getSystemProfileInfrastructureType() {
+        return inventoryHostFacts.getSystemProfileInfrastructureType();
+    }
+
     public Integer getSystemProfileCoresPerSocket() {
         return inventoryHostFacts.getSystemProfileCoresPerSocket();
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -82,10 +82,15 @@ public class FactNormalizer {
         return normalizedFacts;
     }
 
+    private boolean isVirtual(ClassifiedInventoryHostFacts hostFacts) {
+        return hostFacts.isVirtual() ||
+            "virtual".equalsIgnoreCase(hostFacts.getSystemProfileInfrastructureType());
+    }
+
     private void normalizeClassification(NormalizedFacts normalizedFacts,
         ClassifiedInventoryHostFacts hostFacts) {
         normalizedFacts.setHypervisor(hostFacts.isHypervisor());
-        normalizedFacts.setVirtual(hostFacts.isVirtual());
+        normalizedFacts.setVirtual(isVirtual(hostFacts));
         normalizedFacts.setHypervisorUnknown(hostFacts.isHypervisorUnknown());
     }
 
@@ -106,7 +111,7 @@ public class FactNormalizer {
     private void normalizeSocketCount(NormalizedFacts normalizedFacts,
         ClassifiedInventoryHostFacts hostFacts) {
         // modulo-2 rounding only applied to physical or hypervisors
-        if (hostFacts.isHypervisor() || !hostFacts.isVirtual()) {
+        if (hostFacts.isHypervisor() || !isVirtual(hostFacts)) {
             Integer sockets = normalizedFacts.getSockets();
             if (sockets != null && (sockets % 2) == 1) {
                 normalizedFacts.setSockets(sockets + 1);

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -112,7 +112,7 @@ public class InventoryHostFactTestHelper {
         return new ClassifiedInventoryHostFacts(baseFacts);
     }
 
-    private static InventoryHostFacts createBaseHost(String account, String orgId) {
+    public static InventoryHostFacts createBaseHost(String account, String orgId) {
         InventoryHostFacts baseFacts = new InventoryHostFacts();
         baseFacts.setAccount(account);
         baseFacts.setDisplayName("Test System");

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -28,6 +28,7 @@ import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
 import org.candlepin.subscriptions.files.RoleToProductsMapSource;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.candlepin.subscriptions.tally.ClassifiedInventoryHostFacts;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
@@ -126,6 +127,16 @@ public class FactNormalizerTest {
         assertThat(normalized.getProducts(), Matchers.empty());
         assertEquals(Integer.valueOf(8), normalized.getCores());
         assertEquals(Integer.valueOf(4), normalized.getSockets());
+    }
+
+    @Test
+    public void testSystemProfileInfrastructureType() {
+        InventoryHostFacts baseFacts = createBaseHost("Account", "test-org");
+        baseFacts.setSystemProfileInfrastructureType("virtual");
+        baseFacts.setSyncTimestamp(clock.now().toString());
+        ClassifiedInventoryHostFacts systemProfileHost = new ClassifiedInventoryHostFacts(baseFacts);
+        NormalizedFacts normalized = normalizer.normalize(systemProfileHost);
+        assertThat(normalized.isVirtual(), Matchers.is(true));
     }
 
     @Test


### PR DESCRIPTION
Systems that report through system_profile advertise their type through
the "infrastructure_type" setting.  We need to take that into
consideration during fact normalization and during classification.