### PR TITLE
Migrate tally_snapshot measurements (core, etc.) to a new table.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,7 @@ dependencies {
 
     compile "net.logstash.logback:logstash-logback-encoder"
     compile "io.micrometer:micrometer-registry-prometheus"
+    compile "org.liquibase:liquibase-core"
     compile "org.webjars:swagger-ui"
     compile "org.springframework.boot:spring-boot-starter-quartz"
     compile "org.yaml:snakeyaml"
@@ -173,7 +174,6 @@ dependencies {
     testCompile "org.springframework.security:spring-security-test"
 
     runtime "org.postgresql:postgresql"
-    runtime "org.liquibase:liquibase-core"
     runtime("org.jboss.resteasy:resteasy-validator-provider-11") {
         exclude group: 'org.hibernate' // exclude older hibernate validator
     }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -186,7 +186,7 @@
     <module name="ImportOrder">
       <!-- Static imports should go at the top of the import list -->
       <property name="option" value="top"/>
-      <property name="groups" value="/^org\.candlepin/,com,org,net,ch,io,java,javax"/>
+      <property name="groups" value="/^org\.candlepin/,com,org,net,ch,io,liquibase,java,javax"/>
       <property name="separated" value="true"/>
     </module>
 

--- a/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+/**
+ * Class to represent rows in the hardware_measurements table
+ */
+
+@Embeddable
+public class HardwareMeasurement implements Serializable {
+    @Column(name = "instance_count")
+    private int instanceCount;
+    private int cores;
+    private int sockets;
+
+    public int getCores() {
+        return cores;
+    }
+
+    public void setCores(int cores) {
+        this.cores = cores;
+    }
+
+    public int getInstanceCount() {
+        return instanceCount;
+    }
+
+    public void setInstanceCount(int instanceCount) {
+        this.instanceCount = instanceCount;
+    }
+
+    public int getSockets() {
+        return sockets;
+    }
+
+    public void setSockets(int sockets) {
+        this.sockets = sockets;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
@@ -25,19 +25,8 @@ package org.candlepin.subscriptions.db.model;
  * Enum to capture the various types of measurements in the hardware_measurements table
  */
 public enum HardwareMeasurementType {
-    PHYSICAL("physical"),
-    HYPERVISOR("hypervisor"),
-    TOTAL("total");
-
-    private final String type;
-
-    HardwareMeasurementType(String type) {
-        this.type = type;
-    }
-
-    @Override
-    public String toString() {
-        return this.type;
-    }
+    PHYSICAL,
+    HYPERVISOR,
+    TOTAL;
 }
 

--- a/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.db.model;
+
+/**
+ * Enum to capture the various types of measurements in the hardware_measurements table
+ */
+public enum HardwareMeasurementType {
+    PHYSICAL("physical"),
+    HYPERVISOR("hypervisor"),
+    TOTAL("total");
+
+    private final String type;
+
+    HardwareMeasurementType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return this.type;
+    }
+}
+

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.liquibase;
+
+import liquibase.change.custom.CustomTaskChange;
+import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.logging.Logger;
+import liquibase.resource.ResourceAccessor;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * The LiquibaseCustomTask class provides some common utility functions for performing queries or
+ * generating UUIDs for new objects.
+ */
+public abstract class LiquibaseCustomTask implements CustomTaskChange, Closeable {
+    private JdbcConnection connection;
+    protected Logger logger;
+
+    private Map<String, PreparedStatement> preparedStatements;
+
+    public LiquibaseCustomTask() {
+        this.logger = getLogger();
+        this.preparedStatements = new HashMap<>();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            for (PreparedStatement statement : this.preparedStatements.values()) {
+                statement.close();
+            }
+
+            this.preparedStatements.clear();
+        }
+        catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Sets the parameter at the specified index to the given value. This method attempts to perform
+     * safe assignment of parameters across all supported platforms.
+     *
+     * @param statement
+     *  the statement on which to set a parameter
+     *
+     * @param index
+     *  the index of the parameter to set
+     *
+     * @param value
+     *  the value to set
+     *
+     * @throws NullPointerException
+     *  if statement is null
+     *
+     * @return
+     *  the PreparedStatement being updated
+     */
+    protected PreparedStatement setParameter(PreparedStatement statement, int index, Object value)
+        throws SQLException {
+
+        if (value != null) {
+            statement.setObject(index, value);
+        }
+        else {
+            // NB: If Oracle support is ever required, Oracle will want Types.VARCHAR here.  See
+            // http://stackoverflow.com/questions/11793483/setobject-method-of-preparedstatement
+            statement.setNull(index, Types.NULL);
+        }
+
+        return statement;
+    }
+
+    /**
+     * Fills the parameters of a prepared statement with the given arguments
+     *
+     * @param statement
+     *  the statement to fill
+     *
+     * @param argv
+     *  the collection of arguments with which to fill the statement's parameters
+     *
+     * @throws NullPointerException
+     *  if statement is null
+     *
+     * @return
+     *  the provided PreparedStatement
+     */
+    protected PreparedStatement fillStatementParameters(PreparedStatement statement, Object... argv)
+        throws SQLException {
+
+        statement.clearParameters();
+
+        if (argv != null) {
+            for (int i = 0; i < argv.length; ++i) {
+                this.setParameter(statement, i + 1, argv[i]);
+            }
+        }
+
+        return statement;
+    }
+
+    /**
+     * Prepares a statement and populates it with the specified arguments, pulling from cache when
+     * possible.
+     *
+     * @param sql
+     *  The SQL to execute. The given SQL may be parameterized.
+     *
+     * @param argv
+     *  The arguments to use when executing the given query.
+     *
+     * @return
+     *  a PreparedStatement instance representing the specified SQL statement
+     */
+    @SuppressWarnings("squid:S3824")
+    protected PreparedStatement prepareStatement(String sql, Object... argv)
+        throws DatabaseException, SQLException {
+
+        PreparedStatement statement = this.preparedStatements.get(sql);
+        if (statement == null) {
+            statement = this.connection.prepareStatement(sql);
+            this.preparedStatements.put(sql, statement);
+        }
+
+        return this.fillStatementParameters(statement, argv);
+    }
+
+    /**
+     * Executes the given SQL query.
+     *
+     * @param sql
+     *  The SQL to execute. The given SQL may be parameterized.
+     *
+     * @param argv
+     *  The arguments to use when executing the given query.
+     *
+     * @return
+     *  A ResultSet instance representing the result of the query.
+     */
+    protected ResultSet executeQuery(String sql, Object... argv) throws DatabaseException, SQLException {
+        PreparedStatement statement = this.prepareStatement(sql, argv);
+        return statement.executeQuery();
+    }
+
+    protected ResultSet executeQuery(String sql) throws DatabaseException, SQLException {
+        PreparedStatement statement = this.prepareStatement(sql);
+        return statement.executeQuery();
+    }
+    /**
+     * Executes the given SQL update/insert.
+     *
+     * @param sql
+     *  The SQL to execute. The given SQL may be parameterized.
+     *
+     * @param argv
+     *  The arguments to use when executing the given update.
+     *
+     * @return
+     *  The number of rows affected by the update.
+     */
+    protected int executeUpdate(String sql, Object... argv) throws DatabaseException, SQLException {
+        PreparedStatement statement = this.prepareStatement(sql, argv);
+        return statement.executeUpdate();
+    }
+
+    protected int executeUpdate(String sql) throws DatabaseException, SQLException {
+        PreparedStatement statement = this.prepareStatement(sql);
+        return statement.executeUpdate();
+    }
+
+    /**
+     * Generates a 32-character UUID to use with object creation/migration.
+     * <p></p>
+     * The UUID is generated by creating a "standard" UUID and removing the hyphens. The UUID may be
+     * standardized by reinserting the hyphens later, if necessary.
+     *
+     * @return
+     *  a 32-character UUID
+     */
+    protected String generateUUID() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    /**
+     * Executes this liquibase upgrade task.
+     *
+     * @throws DatabaseException
+     *  if an error occurs while performing a database operation
+     *
+     * @throws SQLException
+     *  if an error occurs while executing an SQL statement
+     */
+    public abstract void executeTask(Database database) throws DatabaseException, SQLException;
+
+    @Override
+    public void execute(Database database) throws CustomChangeException {
+        if (database == null) {
+            throw new IllegalArgumentException("database is null");
+        }
+
+        if (!JdbcConnection.class.isAssignableFrom(database.getConnection().getClass())) {
+            throw new CustomChangeException("database connection is not a JDBC connection");
+        }
+
+        this.connection = (JdbcConnection) database.getConnection();
+
+        Boolean autocommit = null;
+        try {
+            // Store the connection's auto commit setting, so we may temporarily clobber it.
+            autocommit = this.connection.getAutoCommit();
+            if (disableAutoCommit()) {
+                this.connection.setAutoCommit(false);
+            }
+            this.executeTask(database);
+        }
+        catch (Exception e) {
+            throw new CustomChangeException(e);
+        }
+        finally {
+            try {
+                if (autocommit != null) {
+                    this.connection.setAutoCommit(autocommit);
+                }
+            }
+            catch (DatabaseException e) {
+                logger.severe("Could not reset autocommit");
+            }
+        }
+    }
+
+    @Override
+    public void setUp() throws SetupException {
+    }
+
+    @Override
+    public void setFileOpener(ResourceAccessor resourceAccessor) {
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return null;
+    }
+
+    public abstract boolean disableAutoCommit();
+
+    public abstract Logger getLogger();
+}

--- a/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.liquibase;
+
+import liquibase.database.Database;
+import liquibase.exception.DatabaseException;
+import liquibase.logging.LogService;
+import liquibase.logging.Logger;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+/**
+ * This class is responsible for moving the various cores/instance_count/sockets columns over to a separate
+ * table to better normalize the database.
+ */
+public class MigrateTallyColumnsTask extends LiquibaseCustomTask {
+
+    @Override
+    public void executeTask(Database database) throws DatabaseException, SQLException {
+
+        int total = 0;
+        ResultSet totalTuple = this.executeQuery(
+            "SELECT id, cores, instance_count, sockets FROM tally_snapshots " +
+            "WHERE cores IS NOT NULL OR instance_count IS NOT NULL OR sockets IS NOT NULL"
+        );
+        total += insertRows("total", totalTuple);
+
+        ResultSet physicalTuple = this.executeQuery(
+            "SELECT id, physical_cores as cores, physical_instance_count as instance_count, " +
+            "physical_sockets as sockets FROM tally_snapshots WHERE physical_cores IS NOT NULL " +
+            "OR physical_instance_count IS NOT NULL OR physical_sockets IS NOT NULL"
+        );
+        total += insertRows("physical", physicalTuple);
+
+        ResultSet hypervisorTuple = this.executeQuery(
+            "SELECT id, hypervisor_cores as cores, hypervisor_instance_count as instance_count, " +
+            "hypervisor_sockets as sockets FROM tally_snapshots WHERE hypervisor_cores IS NOT NULL " +
+            "OR hypervisor_instance_count IS NOT NULL OR hypervisor_sockets IS NOT NULL"
+        );
+        total += insertRows("hypervisor", hypervisorTuple);
+
+
+        this.logger.info(total + " rows inserted into the hardware_measurements table");
+
+    }
+
+    public int insertRows(String discriminator, ResultSet resultSet) throws DatabaseException, SQLException {
+        int total = 0;
+        String insertStatement = "INSERT INTO hardware_measurements (snapshot_id, measurement_type, " +
+            "cores, instance_count, sockets) VALUES (?, ?, ?, ?, ?)";
+        try {
+            while (resultSet.next()) {
+                int cores = resultSet.getInt("cores");
+                int instanceCount = resultSet.getInt("instance_count");
+                int sockets = resultSet.getInt("sockets");
+                UUID snapshotId = resultSet.getObject("id", UUID.class);
+                total += executeUpdate(insertStatement, snapshotId, discriminator, cores, instanceCount,
+                    sockets);
+            }
+
+            return total;
+        }
+        finally {
+            resultSet.close();
+        }
+    }
+
+    @Override
+    public boolean disableAutoCommit() {
+        return true;
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return "Migration of tally_snapshots core/sockets/instance_count columns complete";
+    }
+
+    @Override
+    public Logger getLogger() {
+        return LogService.getLog(MigrateTallyColumnsTask.class);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
@@ -43,21 +43,21 @@ public class MigrateTallyColumnsTask extends LiquibaseCustomTask {
             "SELECT id, cores, instance_count, sockets FROM tally_snapshots " +
             "WHERE cores IS NOT NULL OR instance_count IS NOT NULL OR sockets IS NOT NULL"
         );
-        total += insertRows("total", totalTuple);
+        total += insertRows("TOTAL", totalTuple);
 
         ResultSet physicalTuple = this.executeQuery(
             "SELECT id, physical_cores as cores, physical_instance_count as instance_count, " +
             "physical_sockets as sockets FROM tally_snapshots WHERE physical_cores IS NOT NULL " +
             "OR physical_instance_count IS NOT NULL OR physical_sockets IS NOT NULL"
         );
-        total += insertRows("physical", physicalTuple);
+        total += insertRows("PHYSICAL", physicalTuple);
 
         ResultSet hypervisorTuple = this.executeQuery(
             "SELECT id, hypervisor_cores as cores, hypervisor_instance_count as instance_count, " +
             "hypervisor_sockets as sockets FROM tally_snapshots WHERE hypervisor_cores IS NOT NULL " +
             "OR hypervisor_instance_count IS NOT NULL OR hypervisor_sockets IS NOT NULL"
         );
-        total += insertRows("hypervisor", hypervisorTuple);
+        total += insertRows("HYPERVISOR", hypervisorTuple);
 
 
         this.logger.info(total + " rows inserted into the hardware_measurements table");

--- a/src/main/resources/liquibase/202001141534-add-snapshot-measurements-table.xml
+++ b/src/main/resources/liquibase/202001141534-add-snapshot-measurements-table.xml
@@ -46,19 +46,19 @@
         <createProcedure>
             CREATE FUNCTION copy_measurement() RETURNS trigger AS $$
             BEGIN
-                IF (NEW.measurement_type = 'total') THEN
+                IF (NEW.measurement_type = 'TOTAL') THEN
                     UPDATE tally_snapshots SET
                         cores = NEW.cores,
                         instance_count = NEW.instance_count,
                         sockets = NEW.sockets
                     WHERE id = NEW.snapshot_id;
-                ELSIF (NEW.measurement_type = 'physical') THEN
+                ELSIF (NEW.measurement_type = 'PHYSICAL') THEN
                     UPDATE tally_snapshots SET
                         physical_cores = NEW.cores,
                         physical_instance_count = NEW.instance_count,
                         physical_sockets = NEW.sockets
                     WHERE id = NEW.snapshot_id;
-                ELSIF (NEW.measurement_type = 'hypervisor') THEN
+                ELSIF (NEW.measurement_type = 'HYPERVISOR') THEN
                     UPDATE tally_snapshots SET
                         hypervisor_cores = NEW.cores,
                         hypervisor_instance_count = NEW.instance_count,

--- a/src/main/resources/liquibase/202001141534-add-snapshot-measurements-table.xml
+++ b/src/main/resources/liquibase/202001141534-add-snapshot-measurements-table.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202001141534-1" author="awood">
+        <createTable tableName="hardware_measurements">
+            <column name="snapshot_id" type="UUID">
+                <constraints referencedTableName="tally_snapshots" referencedColumnNames="id"
+                    nullable="false" foreignKeyName="snapshot_measures_fk" deleteCascade="true"/>
+            </column>
+            <column name="measurement_type" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cores" type="INT"/>
+            <column name="instance_count" type="INT"/>
+            <column name="sockets" type="INT"/>
+        </createTable>
+
+        <!-- A unique constraint across these two columns would suffice, but the @ElementCollection needs a
+             primary key in the Embeddable for efficient deletes and updates -->
+        <addPrimaryKey tableName="hardware_measurements" columnNames="snapshot_id, measurement_type"
+            constraintName="hardware_measurements_composite_pk" />
+    </changeSet>
+
+    <changeSet id="202001141534-2" author="awood">
+       <createIndex tableName="hardware_measurements" indexName="snapshot_id_idx">
+           <column name="snapshot_id"/>
+       </createIndex>
+    </changeSet>
+
+    <changeSet id="202001141534-3" author="awood">
+        <addColumn tableName="tally_snapshots">
+            <column name="unit_of_measure" type="VARCHAR(32)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="202001141534-4" author="awood">
+        <customChange class="org.candlepin.subscriptions.liquibase.MigrateTallyColumnsTask"/>
+    </changeSet>
+
+    <changeSet id="202001141534-5" author="awood" dbms="postgresql">
+        <createProcedure>
+            CREATE FUNCTION copy_measurement() RETURNS trigger AS $$
+            BEGIN
+                IF (NEW.measurement_type = 'total') THEN
+                    UPDATE tally_snapshots SET
+                        cores = NEW.cores,
+                        instance_count = NEW.instance_count,
+                        sockets = NEW.sockets
+                    WHERE id = NEW.snapshot_id;
+                ELSIF (NEW.measurement_type = 'physical') THEN
+                    UPDATE tally_snapshots SET
+                        physical_cores = NEW.cores,
+                        physical_instance_count = NEW.instance_count,
+                        physical_sockets = NEW.sockets
+                    WHERE id = NEW.snapshot_id;
+                ELSIF (NEW.measurement_type = 'hypervisor') THEN
+                    UPDATE tally_snapshots SET
+                        hypervisor_cores = NEW.cores,
+                        hypervisor_instance_count = NEW.instance_count,
+                        hypervisor_sockets = NEW.sockets
+                    WHERE id = NEW.snapshot_id;
+                ELSE
+                    RAISE EXCEPTION 'Unknown measurement_type %', NEW.measurement_type;
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        </createProcedure>
+
+        <rollback>
+            DROP FUNCTION copy_measurement();
+        </rollback>
+    </changeSet>
+
+    <changeSet id="202001141534-6" author="awood" dbms="postgresql">
+        <sql>
+            CREATE TRIGGER maintain_measurement_columns_insert BEFORE INSERT ON hardware_measurements FOR EACH
+            ROW EXECUTE PROCEDURE copy_measurement();
+
+            CREATE TRIGGER maintain_measurement_columns_update BEFORE UPDATE ON hardware_measurements FOR EACH
+            ROW EXECUTE PROCEDURE copy_measurement();
+        </sql>
+        <rollback>
+            DROP TRIGGER maintain_measurement_column_insert ON hardware_measurements;
+            DROP TRIGGER maintain_measurement_column_update ON hardware_measurements;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -15,5 +15,6 @@
     <include file="liquibase/201910291044-alter-capacity-pk-and-tally-idx.xml"/>
     <include file="liquibase/201911061510-drop-account-not-null.xml"/>
     <include file="liquibase/201911141401-add-cores-to-subscription-capacity.xml"/>
+    <include file="liquibase/202001141534-add-snapshot-measurements-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTestHelper.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurement;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.tally.AccountUsageCalculation;
 import org.candlepin.subscriptions.tally.ProductUsageCalculation;
@@ -53,25 +55,31 @@ public class SnapshotRollerTestHelper {
     }
 
     public static void assertSnapshot(TallySnapshot snapshot, String expectedProduct,
-        Granularity expectedGranularity, Integer expectedCores, Integer expectedSockets,
-        Integer expectedInstances) {
+        Granularity expectedGranularity, int expectedCores, int expectedSockets,
+        int expectedInstances) {
         assertNotNull(snapshot);
         assertEquals(expectedGranularity, snapshot.getGranularity());
         assertEquals(expectedProduct, snapshot.getProductId());
-        assertEquals(expectedCores, snapshot.getCores());
-        assertEquals(expectedSockets, snapshot.getSockets());
-        assertEquals(expectedInstances, snapshot.getInstanceCount());
+
+        HardwareMeasurement total = snapshot.getHardwareMeasurement(HardwareMeasurementType.TOTAL);
+
+        assertEquals(expectedCores, total.getCores());
+        assertEquals(expectedSockets, total.getSockets());
+        assertEquals(expectedInstances, total.getInstanceCount());
     }
 
     public static void assertSnapshotPhysicalTotals(TallySnapshot snapshot, String expectedProduct,
-        Granularity expectedGranularity, Integer expectedPhysCores, Integer expectedPhysSockets,
-        Integer expectedPhysInstances) {
+        Granularity expectedGranularity, int expectedPhysCores, int expectedPhysSockets,
+        int expectedPhysInstances) {
         assertNotNull(snapshot);
         assertEquals(expectedGranularity, snapshot.getGranularity());
         assertEquals(expectedProduct, snapshot.getProductId());
-        assertEquals(expectedPhysCores, snapshot.getPhysicalCores());
-        assertEquals(expectedPhysSockets, snapshot.getPhysicalSockets());
-        assertEquals(expectedPhysInstances, snapshot.getPhysicalInstanceCount());
+
+        HardwareMeasurement physical = snapshot.getHardwareMeasurement(HardwareMeasurementType.PHYSICAL);
+
+        assertEquals(expectedPhysCores, physical.getCores());
+        assertEquals(expectedPhysSockets, physical.getSockets());
+        assertEquals(expectedPhysInstances, physical.getInstanceCount());
     }
 
     private SnapshotRollerTestHelper() {


### PR DESCRIPTION
The measurements are now stored in snapshot_measurements and mapped with
JPA as embedded object which keeps them tightly coupled to the actual
Snapshot object (e.g. deletions cascade automatically).  The
measurements exist in a map off the snapshot where they are enumerated
by category (physical, total, hypervisor).

----
Note: the trigger functionality doesn't run during tests.  Since those are just temporary procedures that are part of the migration path, it didn't seem necessary to add them during the tests.  If others desire, I can rewrite the functions in whatever the HSQLDB equivalent is so they will be there during tests.

A side-effect of using stored procedures is that there's no real unit testing for the triggers.  I have tested them myself manually and would recommend that the reviewer do as well, but I don't know of a good way to automate it.