### PR TITLE
Divide effective capacity by instance_multiplier

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
@@ -86,14 +86,21 @@ public class CandlepinPoolCapacityMapper {
     }
 
     private Long getCapacityUnit(String unitProperty, CandlepinPool pool) {
-        Integer sockets = pool.getProductAttributes().stream()
+        Integer units = pool.getProductAttributes().stream()
             .filter(attr -> attr.getName().equals(unitProperty))
             .map(CandlepinProductAttribute::getValue).mapToInt(Integer::parseInt).boxed().findFirst()
             .orElse(null);
-        if (sockets != null) {
-            return sockets * pool.getQuantity();
+        if (units != null) {
+            return units * (pool.getQuantity() / getInstanceBasedMultiplier(pool));
         }
         return null;
+    }
+
+    private long getInstanceBasedMultiplier(CandlepinPool pool) {
+        return pool.getProductAttributes().stream()
+            .filter(attr -> attr.getName().equals("instance_multiplier"))
+            .map(CandlepinProductAttribute::getValue).mapToInt(Integer::parseInt).boxed().findFirst()
+            .orElse(1);
     }
 
     private List<String> extractProductIds(Collection<CandlepinProvidedProduct> providedProducts) {

--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -107,7 +108,38 @@ class CandlepinPoolCapacityMapperTest {
         ));
     }
 
+    @Test
+    void testQuantityIsDividedByInstanceMultiplier() {
+        CandlepinPool pool = createTestPool(physicalProductIds, null, 2);
 
+        Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
+            pool);
+
+        SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
+        expectedRhelCapacity.setProductId("RHEL");
+        expectedRhelCapacity.setPhysicalSockets(10);
+        expectedRhelCapacity.setPhysicalCores(20);
+        expectedRhelCapacity.setAccountNumber("account");
+        expectedRhelCapacity.setBeginDate(LONG_AGO);
+        expectedRhelCapacity.setEndDate(NOWISH);
+        expectedRhelCapacity.setSubscriptionId("subId");
+        expectedRhelCapacity.setOwnerId("ownerId");
+
+        SubscriptionCapacity expectedServerCapacity = new SubscriptionCapacity();
+        expectedServerCapacity.setProductId("RHEL Server");
+        expectedServerCapacity.setPhysicalSockets(10);
+        expectedServerCapacity.setPhysicalCores(20);
+        expectedServerCapacity.setAccountNumber("account");
+        expectedServerCapacity.setBeginDate(LONG_AGO);
+        expectedServerCapacity.setEndDate(NOWISH);
+        expectedServerCapacity.setSubscriptionId("subId");
+        expectedServerCapacity.setOwnerId("ownerId");
+
+        assertThat(capacities, Matchers.containsInAnyOrder(
+            expectedRhelCapacity,
+            expectedServerCapacity
+        ));
+    }
 
     @Test
     void testPoolWithVirtualProductsProvidesCapacity() {
@@ -189,6 +221,11 @@ class CandlepinPoolCapacityMapperTest {
     }
 
     private CandlepinPool createTestPool(List<String> physicalProductIds, List<String> derivedProductIds) {
+        return createTestPool(physicalProductIds, derivedProductIds, null);
+    }
+
+    private CandlepinPool createTestPool(List<String> physicalProductIds, List<String> derivedProductIds,
+        Integer instanceMultiplier) {
         CandlepinPool pool = new CandlepinPool();
         pool.setAccountNumber("account");
         pool.setStartDate(LONG_AGO);
@@ -206,10 +243,17 @@ class CandlepinPoolCapacityMapperTest {
                 .collect(Collectors.toList()));
         }
 
-        pool.setProductAttributes(Arrays.asList(
+        List<CandlepinProductAttribute> attributes = new ArrayList<>(Arrays.asList(
             new CandlepinProductAttribute().name("sockets").value("2"),
             new CandlepinProductAttribute().name("cores").value("4")
         ));
+        if (instanceMultiplier != null) {
+            attributes.add(new CandlepinProductAttribute()
+                .name("instance_multiplier")
+                .value(instanceMultiplier.toString())
+            );
+        }
+        pool.setProductAttributes(attributes);
         return pool;
     }
 }


### PR DESCRIPTION
This is necessary as Candlepin pools are made artificially larger than
subscription quantities by a factor of the instance multiplier.