### PR TITLE
Add configuration settings to allow for a TLS connection to PostgreSQL.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,10 +171,10 @@ dependencies {
     compile "org.webjars:swagger-ui"
     compile "org.springframework.boot:spring-boot-starter-quartz"
     compile "org.yaml:snakeyaml"
+    compile "org.postgresql:postgresql"
 
     testCompile "org.springframework.security:spring-security-test"
 
-    runtime "org.postgresql:postgresql"
     runtime("org.jboss.resteasy:resteasy-validator-provider-11") {
         exclude group: 'org.hibernate' // exclude older hibernate validator
     }

--- a/src/main/java/org/candlepin/subscriptions/db/PostgresTlsDataSourceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/db/PostgresTlsDataSourceProperties.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.db;
+
+import org.candlepin.subscriptions.validator.VerificationMode;
+
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Properties class to hold additional TLS information such as verification mode, root CA location, etc.
+ * Generally speaking, the fields in this class correspond one to one with the options on the PostgreSQL
+ * JDBC connection URL.  See https://jdbc.postgresql.org/documentation/head/connect.html#ssl
+ */
+public class PostgresTlsDataSourceProperties extends DataSourceProperties {
+
+    // Require TLS to be actively enabled since doing so requires providing the CA and
+    // other settings. No sense in having it be true but then immediately fail due to a missing CA.
+    private boolean enableTls = false;
+
+    @VerificationMode
+    private String verificationMode = "verify-full";
+
+    @NotBlank
+    private String rootCaLocation = "classpath:/rhsm-subscriptions-ca.crt";
+
+    public boolean isEnableTls() {
+        return enableTls;
+    }
+
+    public void setEnableTls(boolean enableTls) {
+        this.enableTls = enableTls;
+    }
+
+    public String getVerificationMode() {
+        return verificationMode;
+    }
+
+    /**
+     * Possible values include "disable", "allow", "prefer", "require", "verify-ca" and "verify-full". The
+     * "require", "allow", and "prefer" options all default to a non validating SSL factory and do not check
+     * the validity of the certificate or the host name. "verify-ca" validates the certificate, but does not
+     * verify the hostname. "verify-full" will validate that the certificate is correct and verify the host
+     * connected to has the same hostname as the certificate.
+     * @param verificationMode the verification mode to use.  One of "disable", "allow", "prefer", "require",
+     *      "verify-ca" and "verify-full".
+     */
+    public void setVerificationMode(String verificationMode) {
+        this.verificationMode = verificationMode;
+    }
+
+    public String getRootCaLocation() {
+        return rootCaLocation;
+    }
+
+    public void setRootCaLocation(String rootCaLocation) {
+        this.rootCaLocation = rootCaLocation;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/db/PostgresTlsHikariDataSourceFactoryBean.java
+++ b/src/main/java/org/candlepin/subscriptions/db/PostgresTlsHikariDataSourceFactoryBean.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.db;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.IOException;
+
+/**
+ * Class to create the HikariDataSource.  Highly PostgreSQL specific.  Other databases will require their
+ * own FactoryBean.
+ */
+public class PostgresTlsHikariDataSourceFactoryBean extends AbstractFactoryBean<HikariDataSource> implements
+    ResourceLoaderAware {
+    private ResourceLoader resourceLoader = new DefaultResourceLoader();
+
+    private PostgresTlsDataSourceProperties tlsProperties;
+
+    @Override
+    public Class<?> getObjectType() {
+        return HikariDataSource.class;
+    }
+
+    @Override
+    protected HikariDataSource createInstance() throws Exception {
+        DataSourceBuilder<HikariDataSource> builder =
+            tlsProperties.initializeDataSourceBuilder().type(HikariDataSource.class);
+
+        HikariDataSource dataSource = builder.build();
+        // If you set "ssl" to any value at all, the JDBC driver will try to connect over TLS, so do not add
+        // any properties at all if 'enable-tls' isn't true.
+        if ("postgresql".equalsIgnoreCase(tlsProperties.getPlatform()) &&
+            tlsProperties.isEnableTls()) {
+            dataSource.addDataSourceProperty("ssl", tlsProperties.isEnableTls());
+            dataSource.addDataSourceProperty("sslmode", tlsProperties.getVerificationMode());
+            dataSource.addDataSourceProperty("sslrootcert",
+                getRootCaFile(tlsProperties.getRootCaLocation()));
+        }
+
+        return dataSource;
+    }
+
+    /**
+     * Method to return the canonical path to the CA file.  Any overriding implementation should fail fast on
+     * a read error by throwing an exception; it should not return null/empty string as that will only obscure
+     * the actual issue.
+     *
+     * @param rootCaLocation the Spring resource string representing the location of the root CA.  E.g.
+     * "classpath:", "file:", etc. prefixes are accepted.
+     * @return the path on the file-system to the resource.
+     */
+    protected String getRootCaFile(String rootCaLocation) {
+        Resource ca = resourceLoader.getResource(rootCaLocation);
+        try {
+            return ca.getFile().getCanonicalPath();
+        }
+        catch (IOException e) {
+            // If we can't read the CA, just die right now.  Any further error messages will only obscure the
+            // true problem
+            throw new BeanInitializationException("Could not read root CA at " + rootCaLocation, e);
+        }
+    }
+
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    public void setTlsDataSourceProperties(PostgresTlsDataSourceProperties postgresTlsDataSourceProperties) {
+        this.tlsProperties = postgresTlsDataSourceProperties;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
@@ -22,10 +22,7 @@ package org.candlepin.subscriptions.db;
 
 import org.candlepin.subscriptions.jobs.JobProperties;
 
-import com.zaxxer.hikari.HikariDataSource;
-
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
@@ -38,6 +35,7 @@ import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.validation.annotation.Validated;
 
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -56,18 +54,21 @@ import javax.sql.DataSource;
 public class RhsmSubscriptionsDataSourceConfiguration {
 
     @Bean
+    @Validated
     @Primary
     @ConfigurationProperties("rhsm-subscriptions.datasource")
-    public DataSourceProperties rhsmDataSourceProperties() {
-        return new DataSourceProperties();
+    public PostgresTlsDataSourceProperties rhsmDataSourceProperties() {
+        return new PostgresTlsDataSourceProperties();
     }
 
     @Bean(name = "rhsmSubscriptionsDataSource")
     @Primary
-    @ConfigurationProperties("rhsm-subscriptions.datasource.configuration")
-    public HikariDataSource rhsmSubscriptionsDataSource(
-        @Qualifier("rhsmDataSourceProperties") DataSourceProperties rhsmDataSourceProperties) {
-        return rhsmDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+    public PostgresTlsHikariDataSourceFactoryBean rhsmSubscriptionsDataSource(
+        @Qualifier("rhsmDataSourceProperties") PostgresTlsDataSourceProperties rhsmDataSourceProperties) {
+
+        PostgresTlsHikariDataSourceFactoryBean factory = new PostgresTlsHikariDataSourceFactoryBean();
+        factory.setTlsDataSourceProperties(rhsmDataSourceProperties);
+        return factory;
     }
 
     @Bean(name = "rhsmSubscriptionsEntityManagerFactory")

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDataSourceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDataSourceConfiguration.java
@@ -20,8 +20,10 @@
  */
 package org.candlepin.subscriptions.inventory.db;
 
+import org.candlepin.subscriptions.db.PostgresTlsDataSourceProperties;
+import org.candlepin.subscriptions.db.PostgresTlsHikariDataSourceFactoryBean;
+
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +34,7 @@ import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.validation.annotation.Validated;
 
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -48,15 +51,18 @@ import javax.sql.DataSource;
 public class InventoryDataSourceConfiguration {
 
     @Bean
+    @Validated
     @ConfigurationProperties(prefix = "rhsm-subscriptions.inventory-service.datasource")
-    public DataSourceProperties inventoryDataSourceProperties() {
-        return new DataSourceProperties();
+    public PostgresTlsDataSourceProperties inventoryDataSourceProperties() {
+        return new PostgresTlsDataSourceProperties();
     }
 
     @Bean(name = "inventoryDataSource")
-    public DataSource inventoryDataSource(
-        @Qualifier("inventoryDataSourceProperties") DataSourceProperties inventoryDataSourceProperties) {
-        return inventoryDataSourceProperties.initializeDataSourceBuilder().build();
+    public PostgresTlsHikariDataSourceFactoryBean inventoryDataSource(
+        @Qualifier("inventoryDataSourceProperties") PostgresTlsDataSourceProperties dataSourceProperties) {
+        PostgresTlsHikariDataSourceFactoryBean factory = new PostgresTlsHikariDataSourceFactoryBean();
+        factory.setTlsDataSourceProperties(dataSourceProperties);
+        return factory;
     }
 
     @Bean(name = "inventoryEntityManagerFactory")
@@ -74,5 +80,4 @@ public class InventoryDataSourceConfiguration {
         @Qualifier("inventoryEntityManagerFactory") EntityManagerFactory emf) {
         return new JpaTransactionManager(emf);
     }
-
 }

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
@@ -20,6 +20,9 @@
  */
 package org.candlepin.subscriptions.jobs;
 
+import org.candlepin.subscriptions.db.PostgresTlsDataSourceProperties;
+import org.candlepin.subscriptions.db.PostgresTlsHikariDataSourceFactoryBean;
+
 import org.quartz.JobDetail;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,16 +31,14 @@ import org.springframework.boot.autoconfigure.quartz.QuartzDataSource;
 import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomizer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.Properties;
-
-import javax.sql.DataSource;
 
 /**
  * A class to hold all job related configuration.
@@ -48,17 +49,19 @@ import javax.sql.DataSource;
 public class JobsConfiguration {
 
     @Bean
+    @Validated
     @ConfigurationProperties(prefix = "rhsm-subscriptions.quartz.datasource")
-    public DataSourceProperties quartzDataSourceProperties() {
-        return new DataSourceProperties();
+    public PostgresTlsDataSourceProperties quartzDataSourceProperties() {
+        return new PostgresTlsDataSourceProperties();
     }
 
     @Bean(name = "quartz-ds")
     @QuartzDataSource
-    public DataSource quartzDataSource(
-        @Qualifier("quartzDataSourceProperties") DataSourceProperties dataSourceProperties) {
-        DataSourceBuilder builder = dataSourceProperties.initializeDataSourceBuilder();
-        return builder.build();
+    public PostgresTlsHikariDataSourceFactoryBean quartzDataSource(
+        @Qualifier("quartzDataSourceProperties") PostgresTlsDataSourceProperties dataSourceProperties) {
+        PostgresTlsHikariDataSourceFactoryBean factory = new PostgresTlsHikariDataSourceFactoryBean();
+        factory.setTlsDataSourceProperties(dataSourceProperties);
+        return factory;
     }
 
     @Bean

--- a/src/main/java/org/candlepin/subscriptions/validator/VerificationMode.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/VerificationMode.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.validator;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Marks a field as needing validation against the acceptable sslmode values supported by the PostgreSQL
+ * JDBC driver.
+ */
+@Target({ FIELD, TYPE_USE })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = { VerificationModeValidator.class })
+public @interface VerificationMode {
+    String message() default "Must be one of \"disable\", \"allow\", \"prefer\", \"require\", \"verify-ca\"" +
+        " or \"verify-full\".";
+    Class<?>[] groups() default { };
+    Class<? extends Payload>[] payload() default { };
+}
+

--- a/src/main/java/org/candlepin/subscriptions/validator/VerificationModeValidator.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/VerificationModeValidator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.validator;
+
+import org.postgresql.jdbc.SslMode;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Validator to ensure the verification mode option for a postgresql SSL connection is set to an acceptable
+ * value. Possible values include "disable", "allow", "prefer", "require", "verify-ca" and "verify-full". The
+ * "require", "allow", and "prefer" options all default to a non validating SSL factory and do not check
+ * the validity of the certificate or the host name. "verify-ca" validates the certificate, but does not
+ * verify the hostname. "verify-full" will validate that the certificate is correct and verify the host
+ * connected to has the same hostname as the certificate.
+ */
+public class VerificationModeValidator implements ConstraintValidator<VerificationMode, String> {
+    @Override
+    public void initialize(VerificationMode constraintAnnotation) {
+        // No-op implementation.
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // A null or empty value will be considered invalid.
+        for (SslMode mode : SslMode.values()) {
+            if (mode.value.equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -11,3 +11,10 @@ rhsm-subscriptions.inventory-service.datasource.url=jdbc:hsqldb:mem:inventory-te
 rhsm-subscriptions.inventory-service.datasource.username=
 rhsm-subscriptions.inventory-service.datasource.password=
 rhsm-subscriptions.inventory-service.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
+
+rhsm-subscriptions.quartz.datasource.platform=hsqldb
+rhsm-subscriptions.quartz.datasource.url=jdbc:hsqldb:mem:quartz
+rhsm-subscriptions.quartz.datasource.username=
+rhsm-subscriptions.quartz.datasource.password=
+rhsm-subscriptions.quartz.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
+rhsm-subscriptions.quartz.datasource.initialize-schema=always


### PR DESCRIPTION
Enable SSL on postgresql:
  * Set `ssl = on` in `postgresql.conf`.  Set `ssl_cert_file` and `ssl_key_file`.
  * To create a self-signed certificate:
  ```
  openssl req -new -x509 -days 365 -nodes -text -out self-signed.crt -keyout self-signed.key -subj "/CN=localhost"
  ```
  * To create a CA and a leaf certificate:
  ```
  openssl req -new -nodes -text -out root.csr -keyout root.key -subj "/CN=Test CA"
  openssl x509 -req -in root.csr -text -days 3650 -extensions v3_ca   -signkey root.key -out root.crt
  openssl req -new -nodes -text -out leaf.csr -keyout leaf.key -subj "/CN=localhost"
  openssl x509 -req -in leaf.csr -text -days 365 -CA root.crt -CAkey root.key -CAcreateserial -out leaf.crt
  ```

You can then experiment with the `root.crt` and `self-signed.crt`.  If you're using `leaf.crt` on PostgreSQLand `root.crt` isn't given as a `root-ca-location`, the connection should abort (if using the default verification mode).

Note that the first PostgreSQL connection made is for Liquibase!  It uses the same datasource, but occurs pretty early in the application initialization.

This PR is missing tests, but I'm a little undecided on how to provide them.  I'm still thinking that part over, but I'm putting this up for early review.



  

  
