### PR TITLE
Ignore hosts that have been culled in HBI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "insights-host-inventory"]
 	path = insights-host-inventory
 	url = https://github.com/RedHatInsights/insights-host-inventory.git
+	branch = stable

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -107,6 +107,14 @@ public class ApplicationProperties {
      */
     private Duration reportingAccountWhitelistCacheTtl = Duration.ofMinutes(5);
 
+    /**
+     * The number of days after the inventory's stale_timestamp that the record will be culled.
+     * Currently HBI is calculating this value and setting it on messages. Right now the
+     * default is: stale_timestamp + 14 days. Adding this as a configuration setting since
+     * we may need to adjust it at some point to match.
+     */
+    private int cullingOffsetDays = 14;
+
     public boolean isPrettyPrintJson() {
         return prettyPrintJson;
     }
@@ -229,5 +237,13 @@ public class ApplicationProperties {
 
     public void setReportingAccountWhitelistCacheTtl(Duration reportingAccountWhitelistCacheTtl) {
         this.reportingAccountWhitelistCacheTtl = reportingAccountWhitelistCacheTtl;
+    }
+
+    public int getCullingOffsetDays() {
+        return cullingOffsetDays;
+    }
+
+    public void setCullingOffsetDays(int cullingOffsetDays) {
+        this.cullingOffsetDays = cullingOffsetDays;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -39,7 +39,8 @@ import java.util.stream.Stream;
 public interface InventoryRepository extends Repository<InventoryHost, UUID> {
 
     @Query(nativeQuery = true)
-    Stream<InventoryHostFacts> getFacts(@Param("accounts") Collection<String> accounts);
+    Stream<InventoryHostFacts> getFacts(@Param("accounts") Collection<String> accounts,
+        @Param("culledOffsetDays") Integer culledOffsetDays);
 
     @Transactional(readOnly = true, transactionManager = "inventoryTransactionManager")
     @Query("select distinct h.account from InventoryHost h")

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.inventory.db.model;
 
 import org.springframework.util.StringUtils;
 
+import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -48,6 +49,7 @@ public class InventoryHostFacts {
     private Set<String> systemProfileProductIds;
     private String syspurposeRole;
     private String cloudProvider;
+    private OffsetDateTime staleTimestamp;
 
     public InventoryHostFacts() {
         // Used for testing
@@ -58,7 +60,7 @@ public class InventoryHostFacts {
         String products, String syncTimestamp, String systemProfileInfrastructureType,
         String systemProfileCores, String systemProfileSockets, String qpcProducts, String qpcProductIds,
         String systemProfileProductIds, String syspurposeRole, String isVirtual, String hypervisorUuid,
-        String guestId, String subscriptionManagerId, String cloudProvider) {
+        String guestId, String subscriptionManagerId, String cloudProvider, OffsetDateTime staleTimestamp) {
 
         this.account = account;
         this.displayName = displayName;
@@ -79,6 +81,7 @@ public class InventoryHostFacts {
         this.guestId = guestId;
         this.subscriptionManagerId = subscriptionManagerId;
         this.cloudProvider = cloudProvider;
+        this.staleTimestamp = staleTimestamp;
     }
 
     public String getAccount() {
@@ -255,5 +258,13 @@ public class InventoryHostFacts {
 
     public void setCloudProvider(String cloudProvider) {
         this.cloudProvider = cloudProvider;
+    }
+
+    public OffsetDateTime getStaleTimestamp() {
+        return staleTimestamp;
+    }
+
+    public void setStaleTimestamp(OffsetDateTime staleTimestamp) {
+        this.staleTimestamp = staleTimestamp;
     }
 }


### PR DESCRIPTION
Any host that has been culled does not get included in the produced
snapshots. A host's culled timestamp is determined via the host's
stale_timestamp as per HBI's formula:

   culled_timestamp = stale_timestamp + <offset_in_days>

The application's configuration allows us to tune <offset_in_days>
in case the HBI's above changes later. The default offset is 14 days.

NOTE:
This PR filters by stale_timestamp at the query level as well as at
the processing level. This is done so that should we move away from
querying the HBI DB directly, it will will not get missed. It also
acts as a safe guard.