### PR TITLE
Add the sla query parameter and include it in the tally response

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -59,6 +59,11 @@ paths:
           schema:
             type: string
           description: "The level of granularity to return."
+        - name: sla
+          in: query
+          schema:
+            type: string
+          description: "Include only snapshots matching the specified service level."
         - name: beginning
           in: query
           required: true
@@ -118,14 +123,15 @@ paths:
                     cloud_cores: 8
                     cloud_sockets: 4
                 links:
-                  first: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
-                  last: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  first: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
+                  last: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                   previous: null
-                  next: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  next: '/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                 meta:
                   count: 10
                   product: RHEL
                   granularity: DAILY
+                  service_level: Premium
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -401,6 +407,10 @@ components:
             count:
               type: integer
             product:
+              type: string
+            service_level:
+              description: "Describes the service level that the report was made against. Not set if it wasn't
+                specified as a query parameter."
               type: string
             granularity:
               description: "Describes the significance of each date in the TallySnapshot list. For example if the

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -38,10 +38,11 @@ import java.util.stream.Stream;
  * Interface that Spring Data will turn into a DAO for us.
  */
 public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UUID> {
-    Page<TallySnapshot>
-        findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(
-        String accountNumber, String productId, Granularity granularity, OffsetDateTime beginning,
-        OffsetDateTime ending, Pageable pageable);
+
+    @SuppressWarnings("linelength")
+    Page<TallySnapshot> findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+        String accountNumber, String productId, Granularity granularity, String serviceLevel,
+        OffsetDateTime beginning, OffsetDateTime ending, Pageable pageable);
 
     @Transactional
     void deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(String accountNumber,

--- a/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
@@ -40,9 +40,9 @@ public enum ServiceLevel {
     private final String value;
 
     private static final Map<String, ServiceLevel> VALUE_ENUM_MAP = ImmutableMap.of(
-        PREMIUM.value, PREMIUM,
-        STANDARD.value, STANDARD,
-        SELF_SUPPORT.value, SELF_SUPPORT
+        PREMIUM.value.toUpperCase(), PREMIUM,
+        STANDARD.value.toUpperCase(), STANDARD,
+        SELF_SUPPORT.value.toUpperCase(), SELF_SUPPORT
     );
 
     ServiceLevel(String value) {
@@ -57,7 +57,8 @@ public enum ServiceLevel {
      * @return the ServiceLevel enum; UNSPECIFIED if unparseable.
      */
     public static ServiceLevel fromString(String value) {
-        return VALUE_ENUM_MAP.getOrDefault(value, UNSPECIFIED);
+        String key = value == null ? "" : value.toUpperCase();
+        return VALUE_ENUM_MAP.getOrDefault(key, UNSPECIFIED);
     }
 
     public String getValue() {

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -66,7 +66,7 @@ public class TallySnapshot implements Serializable {
     private String accountNumber;
 
     @Column(name = "sla")
-    private String serviceLevel;
+    private String serviceLevel = "_ANY";
 
     @Enumerated(EnumType.STRING)
     @Column(name = "granularity")

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
  * Since the roller tests are very similar, this class provides some common test
  * scenarios.
  */
+@SuppressWarnings("linelength")
 public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     private static final String TEST_PRODUCT = "TEST_PROD";
 
@@ -68,8 +69,8 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
 
         List<TallySnapshot> currentSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(account,
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
         assertSnapshot(currentSnaps.get(0), a1ProductCalc, granularity);
@@ -83,8 +84,8 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
 
         List<TallySnapshot> currentSnaps = repository
-             .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                 TEST_PRODUCT, granularity, startOfGranularPeriod, endOfGranularPeriod,
+             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(account,
+                 TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
                  PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
         TallySnapshot toBeUpdated = currentSnaps.get(0);
@@ -97,8 +98,8 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
 
         List<TallySnapshot> updatedSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(account,
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedSnaps.size());
 
@@ -130,8 +131,8 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1HighCalc));
 
         List<TallySnapshot> currentSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
-                TEST_PRODUCT, granularity, startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
 
@@ -143,8 +144,8 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1LowCalc));
 
         List<TallySnapshot> updatedSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(account,
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedSnaps.size());
 
@@ -164,8 +165,8 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Collections.singletonList("12345678"), Collections.singletonList(calc));
 
         List<TallySnapshot> currentSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndSnapshotDateBetweenOrderBySnapshotDate("A1",
-                TEST_PRODUCT, granularity, startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(0, currentSnaps.size());
     }
@@ -175,9 +176,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     }
 
     private AccountUsageCalculation createTestData() {
-        AccountUsageCalculation calc = createAccountCalc("my_account", "O1", TEST_PRODUCT, 12, 24, 6);
-
-        return calc;
+        return createAccountCalc("my_account", "O1", TEST_PRODUCT, 12, 24, 6);
     }
 
     private AccountUsageCalculation createAccountCalc(String account, String owner, String product,


### PR DESCRIPTION
If null is specified for the sla query parameter, we default to a
value of _ANY, which will be set by the snapshot rollers as a
placeholder for the default sla snapshot total.