### PR TITLE
Add SLA to tally snapshots

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * System purpose service level
+ *
+ * SLA or service level agreement is defined on a given subscription, and can be set as an attribute on a
+ * system to associate it with a specific SLA requirement.
+ */
+public enum ServiceLevel {
+    UNSPECIFIED(""),
+    PREMIUM("Premium"),
+    STANDARD("Standard"),
+    SELF_SUPPORT("Self-Support"),
+    ANY("_ANY");
+
+    private final String value;
+
+    private static final Map<String, ServiceLevel> VALUE_ENUM_MAP = ImmutableMap.of(
+        PREMIUM.value, PREMIUM,
+        STANDARD.value, STANDARD,
+        SELF_SUPPORT.value, SELF_SUPPORT
+    );
+
+    ServiceLevel(String value) {
+        this.value = value;
+    }
+
+    /** Parse the service level from its string representation.
+     *
+     * NOTE: this method will not return the special value ANY, and gives UNSPECIFIED for any invalid value.
+     *
+     * @param value String representation of the SLA, as seen in a host record
+     * @return the ServiceLevel enum; UNSPECIFIED if unparseable.
+     */
+    public static ServiceLevel fromString(String value) {
+        return VALUE_ENUM_MAP.getOrDefault(value, UNSPECIFIED);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -194,4 +194,14 @@ public class TallySnapshot implements Serializable {
         return snapshot;
     }
 
+    @Override
+    public String toString() {
+        return "TallySnapshot{" +
+            "id=" + id +
+            ", snapshotDate=" + snapshotDate +
+            ", granularity=" + granularity +
+            ", accountNumber='" + accountNumber + '\'' +
+            ", productId='" + productId + '\'' +
+            ", serviceLevel='" + serviceLevel + '\'' + '}';
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -60,6 +60,7 @@ import javax.persistence.Table;
                 @ColumnResult(name = "qpc_product_ids"),
                 @ColumnResult(name = "system_profile_product_ids"),
                 @ColumnResult(name = "syspurpose_role"),
+                @ColumnResult(name = "syspurpose_sla"),
                 @ColumnResult(name = "is_virtual"),
                 @ColumnResult(name = "hypervisor_uuid"),
                 @ColumnResult(name = "guest_id"),
@@ -84,6 +85,7 @@ import javax.persistence.Table;
         "h.facts->'rhsm'->>'GUEST_ID' as guest_id, " +
         "h.facts->'rhsm'->>'SYNC_TIMESTAMP' as sync_timestamp, " +
         "h.facts->'rhsm'->>'SYSPURPOSE_ROLE' as syspurpose_role, " +
+        "h.facts->'rhsm'->>'SYSPURPOSE_SLA' as syspurpose_sla, " +
         "h.facts->'qpc'->>'IS_RHEL' as is_rhel, " +
         "h.system_profile_facts->>'infrastructure_type' as system_profile_infrastructure_type, " +
         "h.system_profile_facts->>'cores_per_socket' as system_profile_cores_per_socket, " +

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -48,6 +48,7 @@ public class InventoryHostFacts {
     private Set<String> qpcProductIds;
     private Set<String> systemProfileProductIds;
     private String syspurposeRole;
+    private String syspurposeSla;
     private String cloudProvider;
     private OffsetDateTime staleTimestamp;
 
@@ -59,8 +60,9 @@ public class InventoryHostFacts {
     public InventoryHostFacts(String account, String displayName, String orgId, String cores, String sockets,
         String products, String syncTimestamp, String systemProfileInfrastructureType,
         String systemProfileCores, String systemProfileSockets, String qpcProducts, String qpcProductIds,
-        String systemProfileProductIds, String syspurposeRole, String isVirtual, String hypervisorUuid,
-        String guestId, String subscriptionManagerId, String cloudProvider, OffsetDateTime staleTimestamp) {
+        String systemProfileProductIds, String syspurposeRole, String syspurposeSla,
+        String isVirtual, String hypervisorUuid, String guestId, String subscriptionManagerId,
+        String cloudProvider, OffsetDateTime staleTimestamp) {
 
         this.account = account;
         this.displayName = displayName;
@@ -76,6 +78,7 @@ public class InventoryHostFacts {
         this.systemProfileSockets = asInt(systemProfileSockets);
         this.systemProfileProductIds = asStringSet(systemProfileProductIds);
         this.syspurposeRole = syspurposeRole;
+        this.syspurposeSla = syspurposeSla;
         this.isVirtual = asBoolean(isVirtual);
         this.hypervisorUuid = hypervisorUuid;
         this.guestId = guestId;
@@ -266,5 +269,13 @@ public class InventoryHostFacts {
 
     public void setStaleTimestamp(OffsetDateTime staleTimestamp) {
         this.staleTimestamp = staleTimestamp;
+    }
+
+    public String getSyspurposeSla() {
+        return syspurposeSla;
+    }
+
+    public void setSyspurposeSla(String syspurposeSla) {
+        this.syspurposeSla = syspurposeSla;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,14 +30,16 @@ import java.util.Set;
  */
 public class AccountUsageCalculation {
 
+
     private String account;
     private String owner;
-    private Map<String, ProductUsageCalculation> productCalculations;
-
+    private Map<UsageCalculation.Key, UsageCalculation> calculations;
+    private Set<String> products;
 
     public AccountUsageCalculation(String account) {
         this.account = account;
-        this.productCalculations = new HashMap<>();
+        this.calculations = new HashMap<>();
+        this.products = new HashSet<>();
     }
 
     public String getAccount() {
@@ -51,27 +54,33 @@ public class AccountUsageCalculation {
         this.owner = owner;
     }
 
-    public void addProductCalculation(ProductUsageCalculation calc) {
-        this.productCalculations.put(calc.getProductId(), calc);
+    public void addCalculation(UsageCalculation calc) {
+        String productId = calc.getProductId();
+        this.calculations.put(new UsageCalculation.Key(productId, calc.getSla()), calc);
+        this.products.add(productId);
     }
 
-    public boolean containsProductCalculation(String productId) {
-        return this.productCalculations.containsKey(productId);
+    public boolean containsCalculation(UsageCalculation.Key key) {
+        return this.calculations.containsKey(key);
+    }
+
+    public Set<UsageCalculation.Key> getKeys() {
+        return this.calculations.keySet();
     }
 
     public Set<String> getProducts() {
-        return this.productCalculations.keySet();
+        return this.products;
     }
 
-    public ProductUsageCalculation getProductCalculation(String product) {
-        return this.productCalculations.get(product);
+    public UsageCalculation getCalculation(UsageCalculation.Key key) {
+        return this.calculations.get(key);
     }
 
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append(String.format("[Account: %s, Owner: %s, Calculations: [", account, owner));
-        for (ProductUsageCalculation calc : this.productCalculations.values()) {
+        for (UsageCalculation calc : this.calculations.values()) {
             builder.append(calc);
         }
         builder.append("]");

--- a/src/main/java/org/candlepin/subscriptions/tally/ClassifiedInventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/ClassifiedInventoryHostFacts.java
@@ -129,6 +129,10 @@ public class ClassifiedInventoryHostFacts {
         return inventoryHostFacts.getSyspurposeRole();
     }
 
+    public String getSyspurposeSla() {
+        return inventoryHostFacts.getSyspurposeSla();
+    }
+
     public String getCloudProvider() {
         return inventoryHostFacts.getCloudProvider();
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.collector;
 
-import org.candlepin.subscriptions.tally.ProductUsageCalculation;
+import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 /**
@@ -29,7 +29,7 @@ import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 public class DefaultProductUsageCollector implements ProductUsageCollector {
 
     @Override
-    public void collect(ProductUsageCalculation prodCalc, NormalizedFacts normalizedFacts) {
+    public void collect(UsageCalculation prodCalc, NormalizedFacts normalizedFacts) {
         int cores = normalizedFacts.getCores() != null ? normalizedFacts.getCores() : 0;
         int sockets = normalizedFacts.getSockets() != null ? normalizedFacts.getSockets() : 0;
 

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.collector;
 
-import org.candlepin.subscriptions.tally.ProductUsageCalculation;
+import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 /**
@@ -35,5 +35,5 @@ public interface ProductUsageCollector {
      * @param prodCalc the existing calculations for this product.
      * @param normalizedHostFacts the normalized view of the facts from inventory.
      */
-    void collect(ProductUsageCalculation prodCalc, NormalizedFacts normalizedHostFacts);
+    void collect(UsageCalculation prodCalc, NormalizedFacts normalizedHostFacts);
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.collector;
 
-import org.candlepin.subscriptions.tally.ProductUsageCalculation;
+import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 // NOTE: If we need to eventually reuse these rules/calculations for other products
@@ -32,7 +32,7 @@ import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 public class RHELProductUsageCollector implements ProductUsageCollector {
 
     @Override
-    public void collect(ProductUsageCalculation prodCalc, NormalizedFacts normalizedFacts) {
+    public void collect(UsageCalculation prodCalc, NormalizedFacts normalizedFacts) {
         int cores = normalizedFacts.getCores() != null ? normalizedFacts.getCores() : 0;
         int sockets = normalizedFacts.getSockets() != null ? normalizedFacts.getSockets() : 0;
 

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.tally.facts;
 
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
 import org.candlepin.subscriptions.files.RoleToProductsMapSource;
 import org.candlepin.subscriptions.tally.ClassifiedInventoryHostFacts;
@@ -189,6 +190,16 @@ public class FactNormalizer {
                 normalizedFacts.getProducts().removeIf(FactNormalizer::isRhelVariant);
                 normalizedFacts.getProducts().addAll(
                     roleToProductsMap.getOrDefault(hostFacts.getSyspurposeRole(), Collections.emptyList()));
+            }
+            ServiceLevel effectiveSla = ServiceLevel.fromString(hostFacts.getSyspurposeSla());
+            normalizedFacts.setSla(effectiveSla);
+            if (hostFacts.getSyspurposeSla() != null && effectiveSla == ServiceLevel.UNSPECIFIED) {
+                log.warn(
+                    "Owner {} host {} has unsupported value for SLA: {}",
+                    hostFacts.getOrgId(),
+                    hostFacts.getSubscriptionManagerId(),
+                    hostFacts.getSyspurposeSla()
+                );
             }
         }
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally.facts;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,6 +39,7 @@ public class NormalizedFacts {
     public static final String OWNER_KEY = "owner";
 
     private Set<String> products;
+    private ServiceLevel sla = ServiceLevel.UNSPECIFIED;
     private Integer cores;
     private Integer sockets;
     private String owner;
@@ -116,6 +118,14 @@ public class NormalizedFacts {
 
     public void setCloudProviderType(HardwareMeasurementType cloudProviderType) {
         this.cloudProviderType = cloudProviderType;
+    }
+
+    public ServiceLevel getSla() {
+        return sla;
+    }
+
+    public void setSla(ServiceLevel sla) {
+        this.sla = sla;
     }
 
     public Map<String, Object> toInventoryPayload() {

--- a/src/main/resources/liquibase/202003021107-make-tally-sla-non-null.xml
+++ b/src/main/resources/liquibase/202003021107-make-tally-sla-non-null.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202003021107-1" author="khowell">
+        <comment>Make Tally SLA non-null and default existing to _ANY</comment>
+        <addNotNullConstraint
+            tableName="tally_snapshots"
+            columnName="sla"
+            defaultNullValue="_ANY"/>
+    </changeSet>
+    <changeSet id="202003021107-2" author="khowell">
+        <comment>Create an index on account, product_id, sla, granularity</comment>
+        <createIndex indexName="acct_prod_sla_granularity_idx" tableName="tally_snapshots"
+                     unique="false">
+            <column name="account_number"/>
+            <column name="product_id"/>
+            <column name="sla"/>
+            <column name="granularity"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -19,5 +19,6 @@
     <include file="liquibase/202001141534-add-snapshot-measurements-table.xml"/>
     <include file="liquibase/202002061140-update-copy-measurement-procedure.xml"/>
     <include file="liquibase/202002140932-add-sla-column-to-snapshot-and-capacity-tables.xml"/>
+    <include file="liquibase/202003021107-make-tally-sla-non-null.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -177,6 +177,7 @@ public class TallySnapshotRepositoryTest {
         tally.setProductId(product);
         tally.setOwnerId("N/A");
         tally.setGranularity(granularity);
+        tally.setServiceLevel("");
         tally.setSnapshotDate(date);
 
         HardwareMeasurement total = new HardwareMeasurement();

--- a/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
@@ -23,32 +23,35 @@ package org.candlepin.subscriptions.tally;
 import static org.hamcrest.MatcherAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 public class AccountUsageCalculationTest {
 
     @Test
-    public void testGetProductCalculation() {
+    public void testGetCalculation() {
         String p1 = "Product1";
         AccountUsageCalculation calc = new AccountUsageCalculation("Account1");
-        ProductUsageCalculation prodCalc = new ProductUsageCalculation(p1);
-        calc.addProductCalculation(prodCalc);
+        UsageCalculation prodCalc = new UsageCalculation(createUsageKey(p1));
+        calc.addCalculation(prodCalc);
 
         assertEquals(1, calc.getProducts().size());
-        assertEquals(prodCalc, calc.getProductCalculation(p1));
+        assertEquals(prodCalc, calc.getCalculation(createUsageKey(p1)));
     }
 
     @Test
-    public void testContainsProductCalculation() {
+    public void testContainsCalculation() {
         String p1 = "Product1";
         AccountUsageCalculation calc = new AccountUsageCalculation("Account1");
-        ProductUsageCalculation prodCalc = new ProductUsageCalculation(p1);
-        calc.addProductCalculation(prodCalc);
+        UsageCalculation prodCalc = new UsageCalculation(createUsageKey(p1));
+        calc.addCalculation(prodCalc);
 
         assertEquals(1, calc.getProducts().size());
-        assertTrue(calc.containsProductCalculation(p1));
-        assertFalse(calc.containsProductCalculation("NOT_THERE"));
+        assertTrue(calc.containsCalculation(createUsageKey(p1)));
+        assertFalse(calc.containsCalculation(createUsageKey("NOT_THERE")
+        ));
     }
 
     @Test
@@ -58,11 +61,15 @@ public class AccountUsageCalculationTest {
         String p3 = "Product3";
 
         AccountUsageCalculation calc = new AccountUsageCalculation("Account1");
-        calc.addProductCalculation(new ProductUsageCalculation(p1));
-        calc.addProductCalculation(new ProductUsageCalculation(p2));
-        calc.addProductCalculation(new ProductUsageCalculation(p3));
+        calc.addCalculation(new UsageCalculation(createUsageKey(p1)));
+        calc.addCalculation(new UsageCalculation(createUsageKey(p2)));
+        calc.addCalculation(new UsageCalculation(createUsageKey(p3)));
 
         assertEquals(3, calc.getProducts().size());
         assertThat(calc.getProducts(), Matchers.containsInAnyOrder(p1, p2, p3));
+    }
+
+    private UsageCalculation.Key createUsageKey(String productId) {
+        return new UsageCalculation.Key(productId, ServiceLevel.UNSPECIFIED);
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 
 import org.springframework.util.StringUtils;
@@ -79,11 +80,19 @@ public class InventoryHostFactTestHelper {
 
     public static ClassifiedInventoryHostFacts createRhsmHost(String account, String orgId, String products,
         Integer cores, Integer sockets, String syspurposeRole, OffsetDateTime syncTimeStamp) {
+        return createRhsmHost(account, orgId, products, ServiceLevel.UNSPECIFIED, cores, sockets,
+            syspurposeRole, syncTimeStamp);
+    }
+
+    public static ClassifiedInventoryHostFacts createRhsmHost(String account, String orgId, String products,
+        ServiceLevel sla, Integer cores, Integer sockets, String syspurposeRole,
+        OffsetDateTime syncTimeStamp) {
         InventoryHostFacts baseFacts = createBaseHost(account, orgId);
         baseFacts.setProducts(products);
         baseFacts.setCores(cores);
         baseFacts.setSockets(sockets);
         baseFacts.setSyspurposeRole(syspurposeRole);
+        baseFacts.setSyspurposeSla(sla.getValue());
         baseFacts.setSyncTimestamp(syncTimeStamp.toString());
         return new ClassifiedInventoryHostFacts(baseFacts);
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
@@ -26,16 +26,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.IntStream;
 
-public class ProductUsageCalculationTest {
+public class UsageCalculationTest {
 
     @Test
     public void testDefaults() {
-        ProductUsageCalculation calculation = new ProductUsageCalculation("Test Product");
+        UsageCalculation calculation = new UsageCalculation(createUsageKey("Test Product"));
         assertEquals("Test Product", calculation.getProductId());
 
         for (HardwareMeasurementType type : HardwareMeasurementType.values()) {
@@ -45,7 +46,7 @@ public class ProductUsageCalculationTest {
 
     @Test
     public void testAddToTotal() {
-        ProductUsageCalculation calculation = new ProductUsageCalculation("Product");
+        UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
         IntStream.rangeClosed(0, 4).forEach(i -> calculation.addToTotal(i + 2, i + 1, i));
 
         assertHardwareMeasurementTotals(calculation, HardwareMeasurementType.TOTAL, 15, 20, 10);
@@ -54,7 +55,7 @@ public class ProductUsageCalculationTest {
 
     @Test
     public void testPhysicalSystemTotal() {
-        ProductUsageCalculation calculation = new ProductUsageCalculation("Product");
+        UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
         IntStream.rangeClosed(0, 4).forEach(i -> calculation.addPhysical(i + 2, i + 1, i));
 
         assertHardwareMeasurementTotals(calculation, HardwareMeasurementType.PHYSICAL, 15, 20, 10);
@@ -62,10 +63,13 @@ public class ProductUsageCalculationTest {
         assertNullExcept(calculation, HardwareMeasurementType.TOTAL, HardwareMeasurementType.PHYSICAL);
     }
 
+    private UsageCalculation.Key createUsageKey(String product) {
+        return new UsageCalculation.Key(product, ServiceLevel.UNSPECIFIED);
+    }
 
     @Test
     public void testHypervisorTotal() {
-        ProductUsageCalculation calculation = new ProductUsageCalculation("Product");
+        UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
         IntStream.rangeClosed(0, 4).forEach(i -> calculation.addHypervisor(i + 2, i + 1, i));
 
         assertHardwareMeasurementTotals(calculation, HardwareMeasurementType.HYPERVISOR, 15, 20, 10);
@@ -95,14 +99,14 @@ public class ProductUsageCalculationTest {
 
     @Test
     public void invalidCloudTypeThrowsExcpection() {
-        ProductUsageCalculation calculation = new ProductUsageCalculation("Product");
+        UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
         assertThrows(IllegalArgumentException.class, () -> {
             calculation.addCloudProvider(HardwareMeasurementType.HYPERVISOR, 1, 1, 1);
         });
     }
 
     private void checkCloudProvider(HardwareMeasurementType providerType) {
-        ProductUsageCalculation calculation = new ProductUsageCalculation("Product");
+        UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
         IntStream.rangeClosed(0, 4).forEach(i -> calculation.addCloudProvider(
             providerType, i + 2, i + 1, i));
 

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/Assertions.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/Assertions.java
@@ -25,32 +25,32 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
-import org.candlepin.subscriptions.tally.ProductUsageCalculation;
-import org.candlepin.subscriptions.tally.ProductUsageCalculation.Totals;
+import org.candlepin.subscriptions.tally.UsageCalculation;
+import org.candlepin.subscriptions.tally.UsageCalculation.Totals;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class Assertions {
 
-    public static void assertTotalsCalculation(ProductUsageCalculation calc, int sockets, int cores,
+    public static void assertTotalsCalculation(UsageCalculation calc, int sockets, int cores,
         int instances) {
         assertHardwareMeasurementTotals(calc, HardwareMeasurementType.TOTAL, sockets, cores, instances);
     }
 
-    public static void assertPhysicalTotalsCalculation(ProductUsageCalculation calc, int physSockets,
+    public static void assertPhysicalTotalsCalculation(UsageCalculation calc, int physSockets,
         int physCores, int physInstances) {
         assertHardwareMeasurementTotals(calc, HardwareMeasurementType.PHYSICAL, physSockets, physCores,
             physInstances);
     }
 
-    public static void assertHypervisorTotalsCalculation(ProductUsageCalculation calc, int hypSockets,
+    public static void assertHypervisorTotalsCalculation(UsageCalculation calc, int hypSockets,
         int hypCores, int hypInstances) {
         assertHardwareMeasurementTotals(calc, HardwareMeasurementType.HYPERVISOR, hypSockets, hypCores,
             hypInstances);
     }
 
-    public static void assertHardwareMeasurementTotals(ProductUsageCalculation calc,
+    public static void assertHardwareMeasurementTotals(UsageCalculation calc,
         HardwareMeasurementType type, int sockets, int cores, int instances) {
         Totals totals = calc.getTotals(type);
         assertNotNull(totals, "No totals found for " + type);
@@ -60,7 +60,7 @@ public class Assertions {
         assertEquals(instances, totals.getInstances());
     }
 
-    public static void assertNullExcept(ProductUsageCalculation calc, HardwareMeasurementType ... types) {
+    public static void assertNullExcept(UsageCalculation calc, HardwareMeasurementType ... types) {
         List<HardwareMeasurementType> notNull = Arrays.asList(types);
         for (HardwareMeasurementType type : HardwareMeasurementType.values()) {
             if (notNull.contains(type)) {

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -24,7 +24,8 @@ import static org.candlepin.subscriptions.tally.collector.Assertions.*;
 import static org.candlepin.subscriptions.tally.collector.TestHelper.*;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
-import org.candlepin.subscriptions.tally.ProductUsageCalculation;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ public class DefaultProductUsageCollectorTest {
         // it is considered to be a physical machine.
         NormalizedFacts facts = hypervisorFacts(4, 12);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("NON_RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
         assertTotalsCalculation(calc, 4, 12, 1);
         assertPhysicalTotalsCalculation(calc, 4, 12, 1);
@@ -54,7 +55,7 @@ public class DefaultProductUsageCollectorTest {
     public void testCountsForGuestWithUnknownHypervisor() {
         NormalizedFacts facts = guestFacts(3, 12, false);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("NON_RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
 
         // A guest with a known hypervisor contributes to the overall totals,
@@ -67,7 +68,7 @@ public class DefaultProductUsageCollectorTest {
     public void testCountsForGuestWithKnownHypervisor() {
         NormalizedFacts facts = guestFacts(3, 12, true);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("NON_RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
 
         // A guest with an unknown hypervisor contributes to the overall totals
@@ -80,7 +81,7 @@ public class DefaultProductUsageCollectorTest {
     public void testCountsForPhysicalSystem() {
         NormalizedFacts facts = physicalNonHypervisor(4, 12);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("NON_RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
 
         assertTotalsCalculation(calc, 4, 12, 1);
@@ -95,12 +96,16 @@ public class DefaultProductUsageCollectorTest {
         // along with its cores.
         NormalizedFacts facts = cloudMachineFacts(HardwareMeasurementType.AWS, 4, 12);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("NON_RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
 
         assertTotalsCalculation(calc, 1, 12, 1);
         assertHardwareMeasurementTotals(calc, HardwareMeasurementType.AWS, 1, 12, 1);
         assertNullExcept(calc, HardwareMeasurementType.TOTAL, HardwareMeasurementType.AWS);
+    }
+
+    private UsageCalculation.Key createUsageKey() {
+        return new UsageCalculation.Key("NON_RHEL", ServiceLevel.UNSPECIFIED);
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -26,7 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
-import org.candlepin.subscriptions.tally.ProductUsageCalculation;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ public class RHELProductUsageCollectorTest {
     public void testCountsForHypervisor() {
         NormalizedFacts facts = hypervisorFacts(4, 12);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
         assertTotalsCalculation(calc, 4, 12, 1);
         assertHypervisorTotalsCalculation(calc, 4, 12, 1);
@@ -56,7 +57,7 @@ public class RHELProductUsageCollectorTest {
     public void testCountsForGuestWithKnownHypervisor() {
         NormalizedFacts facts = guestFacts(3, 12, false);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
 
         // A guest with a known hypervisor does not contribute to any counts
@@ -70,7 +71,7 @@ public class RHELProductUsageCollectorTest {
     public void testCountsForGuestWithUnkownHypervisor() {
         NormalizedFacts facts = guestFacts(3, 12, true);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
 
         // A guest with an unknown hypervisor contributes to the overall totals
@@ -85,7 +86,7 @@ public class RHELProductUsageCollectorTest {
     public void testCountsForPhysicalSystem() {
         NormalizedFacts facts = physicalNonHypervisor(4, 12);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
 
         assertTotalsCalculation(calc, 4, 12, 1);
@@ -96,7 +97,7 @@ public class RHELProductUsageCollectorTest {
     @Test
     public void hypervisorReportedWithNoSocketsWillRaiseException() {
         NormalizedFacts facts = hypervisorFacts(0, 0);
-        ProductUsageCalculation calc = new ProductUsageCalculation("RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         assertThrows(IllegalStateException.class, () -> collector.collect(calc, facts));
     }
 
@@ -107,12 +108,16 @@ public class RHELProductUsageCollectorTest {
         // along with its cores.
         NormalizedFacts facts = cloudMachineFacts(HardwareMeasurementType.AWS, 4, 12);
 
-        ProductUsageCalculation calc = new ProductUsageCalculation("RHEL");
+        UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
 
         assertTotalsCalculation(calc, 1, 12, 1);
         assertHardwareMeasurementTotals(calc, HardwareMeasurementType.AWS, 1, 12, 1);
         assertNullExcept(calc, HardwareMeasurementType.TOTAL, HardwareMeasurementType.AWS);
+    }
+
+    private UsageCalculation.Key createUsageKey() {
+        return new UsageCalculation.Key("RHEL", ServiceLevel.UNSPECIFIED);
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -73,4 +73,11 @@ public class DailySnapshotRollerTest {
         tester.performUpdateWithLesserValueTest(Granularity.DAILY, clock.startOfToday(), clock.endOfToday(),
             false);
     }
+
+    @Test
+    @SuppressWarnings("java:S2699") /* NOTE(khowell): have no idea why sonar thinks no assertions */
+    public void testEmptySnapshotsNotPersisted() {
+        tester.performDoesNotPersistEmptySnapshots(Granularity.DAILY, clock.startOfToday(),
+            clock.endOfToday());
+    }
 }


### PR DESCRIPTION
I added an enum: `org.candlepin.subscriptions.db.model.ServiceLevel` which represents all possible values, including special values `UNSPECIFIED` and `ANY`. `ANY` is used to collect all SLAs into Snapshot records.

I renamed `ProductUsageCalculation` to `UsageCalculation` as introducing SLA as a discriminator made it so that UsageCalculations are keyed on the (product, SLA) tuple.

I also modified the table to make the SLA column non-nullable and defaulted existing data to `_ANY`.  FYI, the changeset on a test table w/ ~3.6 million rows took ~233 seconds to complete.

I made testing changes to try to keep it easy to add more fields to the tuple in the future.