### PR TITLE
Created a task framework for updating snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ plugins {
     id "org.springframework.boot" version "2.0.8.RELEASE"
     id "net.researchgate.release" version "2.6.0"
     id "GitProperties"
+    // Only applied for the rhsm-subscriptions-kafka sub project; applied below.
+    id "com.commercehub.gradle.plugin.avro-base" version "0.9.1" apply false
 }
 
 
@@ -35,6 +37,8 @@ ext {
     logstash_logback_encoder_version = "5.3"
     aws_sdk_version = "1.11.32"
     snakeyaml_version = "1.25"
+    kafka_avro_serializer_version = "5.2.1"
+    avro_version = "1.8.2"
 }
 
 
@@ -76,6 +80,8 @@ allprojects {
                 entry "mockito-core"
                 entry "mockito-junit-jupiter"
             }
+            dependency "io.confluent:kafka-avro-serializer:$kafka_avro_serializer_version"
+            dependency "org.apache.avro:avro:$avro_version"
         }
     }
 
@@ -88,6 +94,7 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven { url "http://packages.confluent.io/maven/" }
     }
 
     test {
@@ -157,12 +164,17 @@ dependencies {
 
     compile project(":api")
     compile project(":insights-inventory-client")
+    compile project(":kafka-schema")
 
     // This starter pulls in Spring Boot versions that we don't want.  The actual classes that we need are
     // baked into the starter artifact itself which is peculiar but sometimes that's how the cookie crumbles.
     compile("org.jboss.resteasy:resteasy-spring-boot-starter") {
         exclude group: "org.springframework.boot"
     }
+    compile("io.confluent:kafka-avro-serializer") {
+        exclude group: "org.apache.kafka"
+    }
+
     compile "org.springframework.boot:spring-boot-starter-actuator"
     compile "org.springframework.boot:spring-boot-starter-aop"
     compile "org.springframework.boot:spring-boot-starter-data-jpa"
@@ -170,6 +182,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-web"
     compile "org.springframework.retry:spring-retry"
     compile "org.springframework:spring-context-support"
+    compile "org.springframework.kafka:spring-kafka"
 
     compile "net.logstash.logback:logstash-logback-encoder"
     compile "io.micrometer:micrometer-registry-prometheus"
@@ -179,7 +192,9 @@ dependencies {
     compile "org.yaml:snakeyaml"
     compile "org.postgresql:postgresql"
 
+
     testCompile "org.springframework.security:spring-security-test"
+    testCompile "org.springframework.kafka:spring-kafka-test"
 
     runtime("org.jboss.resteasy:resteasy-validator-provider-11") {
         exclude group: 'org.hibernate' // exclude older hibernate validator
@@ -333,3 +348,20 @@ configure(subprojects.findAll { it.name == "insights-inventory-client" || it.nam
     compileJava.dependsOn tasks.openApiGenerate
 }
 
+project(":kafka-schema") {
+    apply plugin: "com.commercehub.gradle.plugin.avro-base"
+
+    dependencies {
+        compile "org.apache.avro:avro"
+    }
+
+    task generateAvro(type: com.commercehub.gradle.plugin.avro.GenerateAvroJavaTask) {
+        // sub dir needed so that the plugin does not traverse into the build dir (if it exists).
+        source("${projectDir}/avro")
+        outputDir = file("${buildDir}/generated/avro/src/main/java")
+    }
+
+    sourceSets.main.java.srcDirs += "${buildDir}/generated/avro/src/main/java"
+    compileJava.source(generateAvro.outputs)
+    compileJava.dependsOn tasks.generateAvro
+}

--- a/kafka-schema/avro/task_message.avsc
+++ b/kafka-schema/avro/task_message.avsc
@@ -1,0 +1,35 @@
+{
+  "type": "record",
+  "name": "TaskMessage",
+  "namespace": "org.candlepin.subscriptions.task.queue.kafka.message",
+  "fields": [
+    {
+      "name": "groupId",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      }
+    },
+    {
+      "name": "type",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      }
+    },
+    {
+      "name": "args",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "avro.java.string": "String"
+          }
+        },
+        "avro.java.string": "String"
+      }
+    }
+  ]
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'rhsm-subscriptions'
-include ':api', ':insights-inventory-client', ':cloudigrade-client'
+include ':api', ':insights-inventory-client', ':cloudigrade-client', 'kafka-schema'

--- a/src/main/java/org/candlepin/subscriptions/task/Task.java
+++ b/src/main/java/org/candlepin/subscriptions/task/Task.java
@@ -18,30 +18,18 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
+package org.candlepin.subscriptions.task;
 
-import org.candlepin.subscriptions.task.TaskManager;
-
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
 
 /**
- * A quartz job that captures all usage snapshots on a configured schedule.
+ * Defines a unit of async work that is to be performed by rhsm-subscriptions. Task instances are built by
+ * the TaskFactory.
  */
-public class CaptureSnapshotsJob extends QuartzJobBean {
+public interface Task {
 
-    private TaskManager tasks;
-
-    @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
-    }
-
-    @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
-    }
+    /**
+     * Performs the work defined by a Task instance.
+     */
+    void execute();
 
 }

--- a/src/main/java/org/candlepin/subscriptions/task/TaskDescriptor.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskDescriptor.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+import org.springframework.lang.NonNull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+
+/**
+ * A TaskDescriptor describes a Task that is to be stored in a TaskQueue and is to be
+ * eventually executed by a TaskWorker.
+ *
+ * When describing a Task that is the be queued, a descriptor must at least define the
+ * task group that a task belongs to, as well as the TaskType of the Task.
+ *
+ * A TaskDescriptor requires two key pieces of data; a groupId and a TaskType.
+ *
+ * A groupId should be specified so that the TaskQueue can use it for task organization within the queue.
+ *
+ * A TaskType should be specified so that the TaskFactory can use it to build an associated Task object
+ * that defines the actual work that is to be done.
+ *
+ * A descriptor can also specify any task arguments to customize task execution.
+ */
+public class TaskDescriptor {
+
+    private final String groupId;
+    private final TaskType type;
+    private Map<String, List<String>> args;
+
+    private TaskDescriptor(TaskDescriptorBuilder builder) {
+        this.groupId = builder.groupId;
+        this.type = builder.type;
+        this.args = builder.args;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public TaskType getTaskType() {
+        return type;
+    }
+
+    public Map<String, List<String>> getTaskArgs() {
+        return args;
+    }
+
+    public List<String> getArg(String key) {
+        return this.args.get(key);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("TaskDescriptor[");
+        builder.append("groupId: " + groupId);
+        builder.append(", taskType: " + type);
+        builder.append(", args: [");
+
+        Iterator<Entry<String, List<String>>> iter = args.entrySet().iterator();
+        while (iter.hasNext()) {
+            Entry<String, List<String>> argEntry = iter.next();
+            builder.append(argEntry.getKey() + ": [" + String.join(",", argEntry.getValue()) + "]");
+
+            if (iter.hasNext()) {
+                builder.append(", ");
+            }
+        }
+        builder.append("]");
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof TaskDescriptor)) {
+            return false;
+        }
+
+        TaskDescriptor that = (TaskDescriptor) o;
+        return Objects.equals(groupId, that.groupId) &&
+            type == that.type &&
+            Objects.equals(args, that.args);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, type, args);
+    }
+
+    public static TaskDescriptorBuilder builder(TaskType type, String taskGroup) {
+        return new TaskDescriptorBuilder(type, taskGroup);
+    }
+
+    /**
+     * A builder object for building TaskDescriptor objects.
+     */
+    public static class TaskDescriptorBuilder {
+
+        @NonNull
+        private final String groupId;
+
+        @NonNull
+        private final TaskType type;
+
+        private Map<String, List<String>> args;
+
+        private TaskDescriptorBuilder(TaskType type, String groupId) {
+            this.type = type;
+            this.groupId = groupId;
+            this.args = new HashMap<>();
+        }
+
+        public TaskDescriptorBuilder setArg(String name, List<String> values) {
+            this.args.put(name, values);
+            return this;
+        }
+
+        public TaskDescriptorBuilder setSingleValuedArg(String name, String value) {
+            this.args.put(name, Arrays.asList(value));
+            return this;
+        }
+
+        public TaskDescriptorBuilder setArgs(Map<String, List<String>> args) {
+            this.args = new HashMap<>(args);
+            return this;
+        }
+
+        public TaskDescriptor build() {
+            return new TaskDescriptor(this);
+        }
+
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/task/TaskExecutionException.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskExecutionException.java
@@ -18,30 +18,20 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
+package org.candlepin.subscriptions.task;
 
-import org.candlepin.subscriptions.task.TaskManager;
-
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
 
 /**
- * A quartz job that captures all usage snapshots on a configured schedule.
+ * An exception that is thrown when the TaskWorker fails to execute a given Task.
  */
-public class CaptureSnapshotsJob extends QuartzJobBean {
+public class TaskExecutionException extends Exception {
 
-    private TaskManager tasks;
-
-    @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
+    public TaskExecutionException(String message) {
+        super(message);
     }
 
-    @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
+    public TaskExecutionException(String message, Throwable cause) {
+        super(message, cause);
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/task/TaskFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
+import org.candlepin.subscriptions.task.tasks.UpdateAccountSnapshotsTask;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * A class responsible for a TaskDescriptor into actual Task instances. Task instances are build via the
+ * build(TaskDescriptor) method. The type of Task that will be built is determined by the descriptor's
+ * TaskType property.
+ */
+@Component
+public class TaskFactory {
+
+    @Autowired
+    private UsageSnapshotProducer usageSnapshotProducer;
+
+    /**
+     * Builds a Task instance based on the specified TaskDescriptor.
+     *
+     * @param taskDescriptor the task descriptor that is used to customize the Task that is to be created.
+     *
+     * @return the Task defined by the descriptor.
+     */
+    public Task build(TaskDescriptor taskDescriptor) {
+        if (TaskType.UPDATE_SNAPSHOTS.equals(taskDescriptor.getTaskType())) {
+            return new UpdateAccountSnapshotsTask(usageSnapshotProducer, taskDescriptor.getArg("accounts"));
+        }
+        throw new IllegalArgumentException("Could not build task. Unknown task type: " +
+            taskDescriptor.getTaskType());
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
+import org.candlepin.subscriptions.task.queue.TaskQueue;
+
+import com.google.common.collect.Iterables;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A TaskManager is an injectable component that is responsible for putting tasks into
+ * the TaskQueue. This is the entry point into the task system. Any class that would like
+ * to initiate a task within rhsm-subscriptions, should inject this class and call the appropriate
+ * method.
+ */
+@Component
+public class TaskManager {
+    private static final Logger log = LoggerFactory.getLogger(TaskManager.class);
+
+    @Autowired
+    private ApplicationProperties appProperties;
+
+    @Autowired
+    private TaskQueueProperties taskQueueProperties;
+
+    @Autowired
+    private TaskQueue queue;
+
+    @Autowired
+    private UsageSnapshotProducer snapshotProducer;
+
+    @Autowired
+    private AccountListSource accountListSource;
+
+    /**
+     * Initiates a task that will update the snapshots for the specified account.
+     *
+     * @param accountNumber the account number in which to update.
+     */
+    @SuppressWarnings("indentation")
+    public void updateAccountSnapshots(String accountNumber) {
+        queue.enqueue(
+            TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, taskQueueProperties.getTaskGroup())
+                .setSingleValuedArg("accounts", accountNumber)
+                .build()
+        );
+    }
+
+    /**
+     * Queue up tasks to update the snapshots for all configured accounts.
+     *
+     * @throws TaskManagerException
+     */
+    public void updateSnapshotsForAllAccounts() {
+        List<String> accountList;
+        try {
+            accountList = accountListSource.list();
+        }
+        catch (IOException ioe) {
+            throw new TaskManagerException("Could not list accounts for update snapshot task generation",
+                ioe);
+        }
+
+        int accountBatchSize = appProperties.getAccountBatchSize();
+        log.info("Queuing snapshot production for {} accounts in batches of {}.", accountList.size(),
+            accountBatchSize);
+
+        for (List<String> accounts : Iterables.partition(accountList, accountBatchSize)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Queuing snapshot updates for accounts: {}", String.join(",", accounts));
+            }
+
+            try {
+                queue.enqueue(
+                    TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, taskQueueProperties.getTaskGroup())
+                    .setArg("accounts", accounts)
+                    .build()
+                );
+            }
+            catch (Exception e) {
+                log.error("Could not queue snapshot updates for accounts: {}", String.join(",", accounts), e);
+            }
+        }
+        log.info("Done queuing snapshot production for accounts.");
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/task/TaskManagerException.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskManagerException.java
@@ -18,30 +18,15 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
-
-import org.candlepin.subscriptions.task.TaskManager;
-
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
+package org.candlepin.subscriptions.task;
 
 /**
- * A quartz job that captures all usage snapshots on a configured schedule.
+ * Thrown when an error occurs within a TaskManager operation.
  */
-public class CaptureSnapshotsJob extends QuartzJobBean {
+public class TaskManagerException extends RuntimeException {
 
-    private TaskManager tasks;
-
-    @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
-    }
-
-    @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
+    public TaskManagerException(String message, Throwable cause) {
+        super(message, cause);
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/task/TaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskQueueConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+import org.candlepin.subscriptions.task.queue.ExecutorTaskQueue;
+import org.candlepin.subscriptions.task.queue.TaskQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import java.util.concurrent.Executors;
+
+/**
+ * Instantiates/Configures the TaskQueue implementation that should be used. A bean should
+ * be defined with an appropriate @ConditionalOnProperty annotation that matches a possible
+ * rhsm-subscriptions.queue=:QUEUE_KEY property.
+ *
+ * If the 'queue' property is not set, the pass-through queue will be used.
+ *
+ * NOTE:
+ * It is important that only one TaskQueue implementation can be returned based on the conditional
+ * annotation.
+ */
+@EnableConfigurationProperties(TaskQueueProperties.class)
+@PropertySource("classpath:/rhsm-subscriptions.properties")
+@Configuration
+public class TaskQueueConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(TaskQueueConfiguration.class);
+
+    @Bean
+    TaskQueueProperties taskQueueProperties() {
+        return new TaskQueueProperties();
+    }
+
+    /**
+     * Creates an in-memory queue, implemented with {@link java.util.concurrent.ThreadPoolExecutor}.
+     *
+     * Does not block while executing a task. Spin up a new thread for each task, only practically bound by
+     * amount of memory available.
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "in-memory",
+        matchIfMissing = true)
+    TaskQueue inMemoryQueue(TaskFactory taskFactory) {
+        log.info("Configuring an in-memory task queue.");
+        return new ExecutorTaskQueue(
+            Executors.newFixedThreadPool(taskQueueProperties().getExecutorTaskQueueThreadLimit()),
+            taskFactory
+        );
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
@@ -18,30 +18,33 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
+package org.candlepin.subscriptions.task;
 
-import org.candlepin.subscriptions.task.TaskManager;
-
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * A quartz job that captures all usage snapshots on a configured schedule.
+ * Settings particular to the task queue framework.
  */
-public class CaptureSnapshotsJob extends QuartzJobBean {
+@ConfigurationProperties(prefix = "rhsm-subscriptions.tasks")
+public class TaskQueueProperties {
 
-    private TaskManager tasks;
+    private String taskGroup;
 
-    @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
+    private int executorTaskQueueThreadLimit = 20;
+
+    public String getTaskGroup() {
+        return taskGroup;
     }
 
-    @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
+    public void setTaskGroup(String taskGroup) {
+        this.taskGroup = taskGroup;
     }
 
+    public int getExecutorTaskQueueThreadLimit() {
+        return executorTaskQueueThreadLimit;
+    }
+
+    public void setExecutorTaskQueueThreadLimit(int executorTaskQueueThreadLimit) {
+        this.executorTaskQueueThreadLimit = executorTaskQueueThreadLimit;
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/task/TaskType.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskType.java
@@ -18,30 +18,11 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
-
-import org.candlepin.subscriptions.task.TaskManager;
-
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
+package org.candlepin.subscriptions.task;
 
 /**
- * A quartz job that captures all usage snapshots on a configured schedule.
+ * An enumeration representing the types of tasks that can be handled by rhsm-subscriptions.
  */
-public class CaptureSnapshotsJob extends QuartzJobBean {
-
-    private TaskManager tasks;
-
-    @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
-    }
-
-    @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
-    }
-
+public enum TaskType {
+    UPDATE_SNAPSHOTS
 }

--- a/src/main/java/org/candlepin/subscriptions/task/TaskWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskWorker.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+
+/**
+ * A TaskWorker executes a task when it is notified by a processor that a task was received
+ * from a Queue. The task worker should be added as a listener to a TaskQueue's TaskProcessors.
+ */
+public class TaskWorker {
+
+    private final TaskFactory taskFactory;
+
+    public TaskWorker(TaskFactory taskFactory) {
+        this.taskFactory = taskFactory;
+    }
+
+    /**
+     * Executes the Task described by the given TaskDescriptor.
+     *
+     * @param taskDescriptor the descriptor for the task to execute.
+     * @throws TaskExecutionException when an error occurs running the Task.
+     */
+    public void executeTask(TaskDescriptor taskDescriptor) throws TaskExecutionException {
+        try {
+            Task toExecute = taskFactory.build(taskDescriptor);
+            toExecute.execute();
+        }
+        catch (Exception e) {
+            throw new TaskExecutionException(String.format("Error executing task: %s", taskDescriptor), e);
+        }
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueue.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue;
+
+import org.candlepin.subscriptions.task.TaskDescriptor;
+import org.candlepin.subscriptions.task.TaskExecutionException;
+import org.candlepin.subscriptions.task.TaskFactory;
+import org.candlepin.subscriptions.task.TaskWorker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An TaskQueue implementation that uses an {@link ExecutorService} to queue/execute tasks.
+ *
+ * The behavior of the TaskQueue is dependent on the {@link ExecutorService} instance that is passed to the
+ * constructor.
+ *
+ * If configured with {@link Executors#newCachedThreadPool()}, the queuing is done by starting a new thread
+ * for each queued task.
+ *
+ * If configured with {@link Executors#newSingleThreadExecutor()}, then the task queue is backed by an
+ * unbound queue.
+ *
+ * Custom queuing mechanisms can be implemented by configuring a
+ * {@link java.util.concurrent.ThreadPoolExecutor} with a custom implementation of
+ * {@link java.util.concurrent.BlockingQueue}.
+ *
+ * @see ExecutorService
+ * @see Executors
+ */
+public class ExecutorTaskQueue implements TaskQueue {
+    private static final Logger log = LoggerFactory.getLogger(ExecutorTaskQueue.class);
+
+    private final ExecutorService executor;
+    private final TaskFactory taskFactory;
+
+    public ExecutorTaskQueue(ExecutorService executor, TaskFactory taskFactory) {
+        this.executor = executor;
+        this.taskFactory = taskFactory;
+    }
+
+    private void processTask(TaskDescriptor taskDescriptor) {
+        TaskWorker worker = new TaskWorker(taskFactory);
+        try {
+            worker.executeTask(taskDescriptor);
+        }
+        catch (TaskExecutionException e) {
+            log.error("An error occurred running a task.", e);
+        }
+    }
+
+    /**
+     * Shut down the associated executor gracefully, and wait for any pending tasks to complete.
+     *
+     * Used mainly for testing.
+     *
+     * @param timeout the maximum time to wait
+     * @param timeUnit the time unit of the timeout argument
+     * @throws InterruptedException
+     */
+    public void shutdown(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        this.executor.shutdown();
+        this.executor.awaitTermination(timeout, timeUnit);
+    }
+
+    @Override
+    public void enqueue(TaskDescriptor taskDescriptor) {
+        this.executor.execute(() -> this.processTask(taskDescriptor));
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/task/queue/TaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/TaskQueue.java
@@ -18,30 +18,20 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
+package org.candlepin.subscriptions.task.queue;
 
-import org.candlepin.subscriptions.task.TaskManager;
-
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.candlepin.subscriptions.task.TaskDescriptor;
 
 /**
- * A quartz job that captures all usage snapshots on a configured schedule.
+ * A TaskQueue is responsible for storing tasks until they are processed.
  */
-public class CaptureSnapshotsJob extends QuartzJobBean {
+public interface TaskQueue {
 
-    private TaskManager tasks;
-
-    @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
-    }
-
-    @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
-    }
+    /**
+     * Enqueues a task that is to be processed by the registered processor.
+     *
+     * @param taskDescriptor a TaskDescriptor describing the task that is to be processed.
+     */
+    void enqueue(TaskDescriptor taskDescriptor);
 
 }

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializer.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializer.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import javax.xml.bind.DatatypeConverter;
+
+
+/**
+ * A Kafka message deserializer for deserializing Avro generated message objects received
+ * from Kafka. The {@value TARGET_TYPE_CLASS} configuration property must be set to the
+ * class of the intended object to be serialized.
+ *
+ * Based on example found at:
+ *     https://codenotfound.com/spring-kafka-apache-avro-serializer-deserializer-example.html
+ *
+ * @param <T> the object type to serialize.
+ */
+public class AvroDeserializer<T extends SpecificRecordBase> implements Deserializer<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(AvroDeserializer.class);
+
+    public static final String TARGET_TYPE_CLASS = "rhsm-subscriptions.avro.deserializer.target.class";
+
+    private Class<T> targetType;
+
+    @Override
+    public void close() {
+        // No op
+    }
+
+    @Override
+    public void configure(Map<String, ?> config, boolean isKey) {
+        targetType = getTargetType(config);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        if (this.targetType == null) {
+            throw new IllegalStateException("Target type is null.");
+        }
+
+        try {
+            T result = null;
+
+            if (data != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("data='{}'", DatatypeConverter.printHexBinary(data));
+                }
+
+                DatumReader<GenericRecord> datumReader =
+                    new SpecificDatumReader<>(targetType.newInstance().getSchema());
+                Decoder decoder = DecoderFactory.get().binaryDecoder(data, null);
+
+                result = (T) datumReader.read(null, decoder);
+                log.debug("deserialized data='{}'", result);
+            }
+            return result;
+        }
+        catch (Exception ex) {
+            throw new SerializationException(
+                "Can't deserialize data '" + Arrays.toString(data) + "' from topic '" + topic + "'", ex);
+        }
+    }
+
+    public Class<T> getTargetType() {
+        return this.targetType;
+    }
+
+    private Class getTargetType(Map<String, ?> config) {
+        Assert.state(config.containsKey(TARGET_TYPE_CLASS),
+            String.format("Target type class not configured for AvroDeserializer: %s", TARGET_TYPE_CLASS));
+
+        try {
+            Object value = config.get(TARGET_TYPE_CLASS);
+            return value instanceof Class ? (Class<?>) value : ClassUtils.forName((String) value, null);
+        }
+        catch (ClassNotFoundException | LinkageError e) {
+            throw new IllegalStateException("Unable to find AvroDeserializer target class", e);
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializer.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+
+import javax.xml.bind.DatatypeConverter;
+
+
+
+/**
+ * A Kafka message serializer for serializing Avro generated message objects that are sent
+ * to Kafka.
+ *
+ * Based on example found at:
+ *     https://codenotfound.com/spring-kafka-apache-avro-serializer-deserializer-example.html
+ *
+ * @param <T> the object type to serialize.
+ */
+public class AvroSerializer<T extends SpecificRecordBase> implements Serializer<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(AvroSerializer.class);
+
+    @Override
+    public void close() {
+        // No-op
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // Nothing to configure.
+    }
+
+    @Override
+    public byte[] serialize(String topic, T data) {
+        try {
+            byte[] result = null;
+
+            if (data != null) {
+                log.debug("data='{}'", data);
+
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                BinaryEncoder binaryEncoder =
+                    EncoderFactory.get().binaryEncoder(byteArrayOutputStream, null);
+
+                DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(data.getSchema());
+                datumWriter.write(data, binaryEncoder);
+
+                binaryEncoder.flush();
+                byteArrayOutputStream.close();
+
+                result = byteArrayOutputStream.toByteArray();
+
+                if (log.isDebugEnabled()) {
+                    log.debug("serialized data='{}'", DatatypeConverter.printHexBinary(result));
+                }
+            }
+            return result;
+        }
+        catch (Exception ex) {
+            throw new SerializationException(
+                "Can't serialize data='" + data + "' for topic='" + topic + "'", ex);
+        }
+    }
+}
+

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaApplicationListener.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaApplicationListener.java
@@ -18,30 +18,28 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
+package org.candlepin.subscriptions.task.queue.kafka;
 
-import org.candlepin.subscriptions.task.TaskManager;
-
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 
 /**
- * A quartz job that captures all usage snapshots on a configured schedule.
+ * Stops all message consumption when the application is shutting down.
  */
-public class CaptureSnapshotsJob extends QuartzJobBean {
-
-    private TaskManager tasks;
+public class KafkaApplicationListener implements ApplicationListener<ContextClosedEvent> {
+    private static final Logger log = LoggerFactory.getLogger(KafkaApplicationListener.class);
 
     @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
-    }
+    private KafkaListenerEndpointRegistry registry;
+
 
     @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
+    public void onApplicationEvent(ContextClosedEvent event) {
+        log.info("Shutting down kafka consumers...");
+        registry.stop();
     }
-
 }

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+
+import java.util.Map;
+
+/**
+ * Encapsulates the creation of all components required for producing and consuming Kafka
+ * messages for the kafka task queue.
+ */
+public class KafkaConfigurator {
+
+    public DefaultKafkaProducerFactory<String, TaskMessage> defaultProducerFactory(
+        KafkaProperties kafkaProperties) {
+        Map<String, Object> producerConfig = kafkaProperties.buildProducerProperties();
+        boolean bypassRegistry = bypassSchemaRegistry(producerConfig);
+
+        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+            bypassRegistry ? AvroSerializer.class : KafkaAvroSerializer.class);
+        return new DefaultKafkaProducerFactory<>(producerConfig);
+    }
+
+    public ConsumerFactory<String, TaskMessage> defaultConsumerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> consumerConfig = kafkaProperties.buildConsumerProperties();
+        // Task messages should be manually committed once they have been processed.
+        consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        boolean bypassRegistry = bypassSchemaRegistry(consumerConfig);
+
+        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // Prevent the client from continuously replaying a message that fails to deserialize.
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
+
+        // Configure the error handling delegate deserializer classes based on whether the
+        // schema registry is being bypassed.
+        if (bypassRegistry) {
+            consumerConfig.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS, AvroDeserializer.class);
+            consumerConfig.put(AvroDeserializer.TARGET_TYPE_CLASS, TaskMessage.class);
+        }
+        else {
+            consumerConfig.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS,
+                KafkaAvroDeserializer.class);
+            consumerConfig.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true);
+        }
+        return new DefaultKafkaConsumerFactory<>(consumerConfig);
+    }
+
+    public KafkaTemplate<String, TaskMessage> taskMessageKafkaTemplate(
+        ProducerFactory<String, TaskMessage> factory) {
+        return new KafkaTemplate<>(factory);
+    }
+
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, TaskMessage>>
+        defaultListenerContainerFactory(ConsumerFactory<String, TaskMessage> consumerFactory,
+        KafkaProperties kafkaProperties) {
+        ConcurrentKafkaListenerContainerFactory<String, TaskMessage> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        // Concurrency should be set to the number of partitions for the target topic.
+        factory.setConcurrency(kafkaProperties.getListener().getConcurrency());
+
+        // Task message offsets will be manually committed as soon as the message has been acked.
+        factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
+
+    private boolean bypassSchemaRegistry(Map<String, Object> config) {
+        return !config.containsKey(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProcessor.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import org.candlepin.subscriptions.task.TaskDescriptor;
+import org.candlepin.subscriptions.task.TaskExecutionException;
+import org.candlepin.subscriptions.task.TaskFactory;
+import org.candlepin.subscriptions.task.TaskType;
+import org.candlepin.subscriptions.task.TaskWorker;
+import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+
+import io.micrometer.core.annotation.Timed;
+
+/**
+ * Responsible for receiving task messages from Kafka when they become available.
+ */
+public class KafkaTaskProcessor {
+    private static final Logger log = LoggerFactory.getLogger(KafkaTaskProcessor.class);
+
+    private TaskWorker worker;
+
+    public KafkaTaskProcessor(TaskFactory taskFactory) {
+        worker = new TaskWorker(taskFactory);
+    }
+
+    @KafkaListener(id = "rhsm-subscriptions-task-processor",
+        topics = "${rhsm-subscriptions.tasks.task-group}")
+    @Timed("rhsm-subscriptions.task.execution")
+    public void receive(TaskMessage taskMessage, Acknowledgment acknowledgment) {
+        try {
+            log.info("Message received from kafka: {}", taskMessage);
+            worker.executeTask(describe(taskMessage));
+        }
+        catch (TaskExecutionException e) {
+            // If a task fails to execute for any reason, it is logged and will
+            // not get retried.
+            log.error("Failed to execute task: {}", taskMessage, e);
+        }
+        finally {
+            // We always ack the message regardless of if there are failures.
+            // There is no need to retry the message on failure since the task
+            // can either be manually re-triggered or will run on the next schedule.
+            acknowledgment.acknowledge();
+        }
+    }
+
+    private TaskDescriptor describe(TaskMessage message) throws TaskExecutionException {
+        try {
+            return TaskDescriptor.builder(TaskType.valueOf(message.getType()), message.getGroupId())
+                       .setArgs(message.getArgs()).build();
+        }
+        catch (IllegalArgumentException | NullPointerException e) {
+            throw new TaskExecutionException(
+                String.format("Unknown TaskType received from message: %s", message.getType()));
+        }
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueue.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import org.candlepin.subscriptions.task.TaskDescriptor;
+import org.candlepin.subscriptions.task.queue.TaskQueue;
+import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+
+/**
+ * A task queue implementation that is backed by a kafka. Messages are sent to kafka
+ * when queued. The topic that a task is published on is defined by TaskDescriptor.groupId.
+ */
+public class KafkaTaskQueue implements TaskQueue {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaTaskQueue.class);
+
+    @Autowired
+    private KafkaTemplate<String, TaskMessage> producer;
+
+    public KafkaTaskQueue() {
+        log.info("Creating Kafka task queue...");
+    }
+
+    @SuppressWarnings("squid:S4449")
+    @Override
+    public void enqueue(TaskDescriptor taskDescriptor) {
+        log.info("Queuing task: {}", taskDescriptor);
+
+        TaskMessage message = TaskMessage.newBuilder()
+            .setType(taskDescriptor.getTaskType().name())
+            .setGroupId(taskDescriptor.getGroupId())
+            .setArgs(taskDescriptor.getTaskArgs())
+            .build();
+
+        // Message key is auto-generated.
+        producer.send(taskDescriptor.getGroupId(), null, message);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueConfiguration.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import org.candlepin.subscriptions.task.TaskFactory;
+import org.candlepin.subscriptions.task.queue.TaskQueue;
+import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+
+/**
+ * A spring configuration that configures the required Beans to set up a KafkaTaskQueue.
+ *
+ * To enable this queue, set the following in the rhsm-subscriptions.properties file:
+ * <pre>
+ *     rhsm-subscriptions.tasks.queue=kafka
+ * </pre>
+ */
+@EnableKafka
+@Configuration
+@PropertySource("classpath:/rhsm-subscriptions.properties")
+public class KafkaTaskQueueConfiguration {
+
+    // Since the bean is only registered when the kafka task queue is configured, it isn't always
+    // required (i.e When rhsm-subscriptions is running with the in-memory task queue configured).
+    @Autowired(required = false)
+    private KafkaConfigurator kafkaConfigurator;
+
+    @Bean
+    @Primary
+    public KafkaProperties taskQueueKafkaProperties() {
+        return new KafkaProperties();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "kafka")
+    public KafkaConfigurator kafkaConfigurator() {
+        return new KafkaConfigurator();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "kafka")
+    public KafkaApplicationListener gracefulShutdown() {
+        return new KafkaApplicationListener();
+    }
+
+    //
+    // KAFKA PRODUCER CONFIGURATION
+    //
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "kafka")
+    public ProducerFactory<String, TaskMessage> producerFactory(KafkaProperties kafkaProperties) {
+        return kafkaConfigurator.defaultProducerFactory(kafkaProperties);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "kafka")
+    public KafkaTemplate<String, TaskMessage> kafkaProducerTemplate(
+        ProducerFactory<String, TaskMessage> factory) {
+        return kafkaConfigurator.taskMessageKafkaTemplate(factory);
+    }
+
+    //
+    // KAFKA CONSUMER CONFIGURATION
+    //
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "kafka")
+    public ConsumerFactory<String, TaskMessage> consumerFactory(KafkaProperties kafkaProperties) {
+        return kafkaConfigurator.defaultConsumerFactory(kafkaProperties);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "kafka")
+    KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, TaskMessage>>
+        kafkaListenerContainerFactory(ConsumerFactory<String, TaskMessage> consumerFactory,
+        KafkaProperties kafkaProperties) {
+        return kafkaConfigurator.defaultListenerContainerFactory(consumerFactory, kafkaProperties);
+    }
+
+    //
+    // TASK QUEUE CONFIGURATION
+    //
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "kafka")
+    public TaskQueue kafkaTaskQueue() {
+        return new KafkaTaskQueue();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "kafka")
+    public KafkaTaskProcessor taskProcessor(TaskFactory taskFactory) {
+        return new KafkaTaskProcessor(taskFactory);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTask.java
@@ -18,37 +18,33 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jmx;
+package org.candlepin.subscriptions.task.tasks;
 
 import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
-import org.candlepin.subscriptions.task.TaskManager;
+import org.candlepin.subscriptions.task.Task;
 
-import org.springframework.jmx.export.annotation.ManagedOperation;
-import org.springframework.jmx.export.annotation.ManagedResource;
-import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
- * Exposes the ability to trigger a tally for an account from JMX.
+ * Updates the usage snapshots for a given account.
  */
-@Component
-@ManagedResource
-public class TallyJmxBean {
+public class UpdateAccountSnapshotsTask implements Task {
+    private static final Logger log = LoggerFactory.getLogger(UpdateAccountSnapshotsTask.class);
 
+    private final List<String> accountNumbers;
     private final UsageSnapshotProducer snapshotProducer;
-    private final TaskManager tasks;
 
-    public TallyJmxBean(UsageSnapshotProducer snapshotProducer, TaskManager taskManager) {
+    public UpdateAccountSnapshotsTask(UsageSnapshotProducer snapshotProducer, List<String> accountNumbers) {
         this.snapshotProducer = snapshotProducer;
-        this.tasks = taskManager;
+        this.accountNumbers = accountNumbers;
     }
 
-    @ManagedOperation(description = "Trigger a tally for an account")
-    public void tallyAccount(String accountNumber) {
-        snapshotProducer.produceSnapshotsForAccount(accountNumber);
-    }
-
-    @ManagedOperation(description = "Trigger tally for all configured accounts")
-    public void tallyConfiguredAccounts() {
-        tasks.updateSnapshotsForAllAccounts();
+    @Override
+    public void execute() {
+        log.info("Updating snapshots for {} accounts.", accountNumbers.size());
+        snapshotProducer.produceSnapshotsForAccounts(accountNumbers);
     }
 }

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -31,3 +31,31 @@ rhsm-subscriptions.jobs.captureSnapshotSchedule=0 0/5 * * * ?
 rhsm-subscriptions.quartz.datasource.platform=hsqldb
 
 rhsm-subscriptions.enableIngressEndpoint=false
+
+
+##########################
+# kafka configuration
+##########################
+
+# Uncomment to enable Kafka integration
+#rhsm-subscriptions.tasks.queue=kafka
+#rhsm-subscriptions.tasks.task-group=rhsm-subscriptions-tasks
+
+# Required kafka defaults
+spring.kafka.consumer.properties.max.poll.records=1
+spring.kafka.consumer.properties.max.poll.interval.ms=1800000
+
+# The number of threads that will be processing messages (should match
+# the number of partitions on the queue)
+#spring.kafka.listener.concurrency=1
+#spring.kafka.bootstrap-servers=localhost:9092
+#spring.kafka.consumer.properties.reconnect.backoff.ms=2000
+#spring.kafka.consumer.properties.reconnect.backoff.max.ms=10000
+#spring.kafka.consumer.properties.default.api.timeout.ms=480000
+
+###################################
+# Schema Registry configuration
+###################################
+
+#spring.kafka.properties.schema.registry.url=http://localhost:8081
+#spring.kafka.properties.auto.register.schemas=false

--- a/src/test/java/org/candlepin/subscriptions/task/TaskDescriptorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskDescriptorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+
+public class TaskDescriptorTest {
+
+    @Test
+    public void testCreation() {
+        String expectedGroupId = "my-group";
+        TaskType expectedTaskType = TaskType.UPDATE_SNAPSHOTS;
+        String expectedArgKey = "arg1";
+        List<String> expectedArgValues = Arrays.asList("1", "2", "3");
+
+        TaskDescriptor desc = TaskDescriptor.builder(expectedTaskType, expectedGroupId)
+            .setArg(expectedArgKey, expectedArgValues)
+            .build();
+
+        assertEquals(expectedGroupId, desc.getGroupId());
+        assertEquals(expectedTaskType, desc.getTaskType());
+
+        Map<String, List<String>> args = desc.getTaskArgs();
+        assertThat(args, Matchers.hasKey(expectedArgKey));
+        assertEquals(expectedArgValues, args.get(expectedArgKey));
+        assertEquals(expectedArgValues, desc.getArg(expectedArgKey));
+    }
+
+    @Test
+    public void testEquality() {
+        TaskDescriptor d1 = TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group1")
+            .setSingleValuedArg("a1", "a1v")
+            .build();
+
+        TaskDescriptor d1Copy = TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group1")
+            .setSingleValuedArg("a1", "a1v")
+            .build();
+        assertEquals(d1, d1Copy);
+
+        TaskDescriptor differentGroup =
+            TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group2").build();
+        assertNotEquals(d1, differentGroup);
+
+        TaskDescriptor nullGroup = TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, null).build();
+        assertNotEquals(d1, nullGroup);
+
+        TaskDescriptor nullType = TaskDescriptor.builder(null, "group1").build();
+        assertNotEquals(d1, nullType);
+
+        TaskDescriptor argsNotEqual = TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group1").build();
+        assertNotEquals(d1, argsNotEqual);
+
+        TaskDescriptor argValueNotEqual = TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group1")
+            .setSingleValuedArg("a1", "a1v_")
+            .build();
+        assertNotEquals(d1, argValueNotEqual);
+
+        TaskDescriptor differentArgs = TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group1")
+            .setSingleValuedArg("a2", "v2")
+            .build();
+        assertNotEquals(d1, differentArgs);
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/task/TaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.subscriptions.task.tasks.UpdateAccountSnapshotsTask;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+
+
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
+public class TaskFactoryTest {
+
+    @Autowired
+    private TaskFactory factory;
+
+    @Test
+    public void ensureFactoryBuildsUpdateAccountSnapshotTask() {
+        Task task = factory.build(TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "my-group").build());
+        assertThat(task, Matchers.instanceOf(UpdateAccountSnapshotsTask.class));
+    }
+
+    @Test
+    public void ensureIllegalArgumentExceptionWhenTaskTypeIsNull() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            factory.build(TaskDescriptor.builder(null, "my-group").build());
+        });
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
+
+import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.task.queue.TaskQueue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
+public class TaskManagerTest {
+
+    @MockBean
+    private TaskQueue queue;
+
+    @Autowired
+    private TaskManager manager;
+
+    @MockBean
+    private AccountListSource accountListSource;
+
+    @Autowired
+    private TaskQueueProperties taskQueueProperties;
+
+    @Test
+    public void testUpdateForSingleAccount() {
+        String account = "12345";
+        manager.updateAccountSnapshots(account);
+
+        verify(queue).enqueue(eq(createDescriptor(account)));
+    }
+
+    @Test
+    public void ensureUpdateIsRunForEachAccount() throws Exception {
+        List<String> expectedAccounts = Arrays.asList("a1", "a2");
+        when(accountListSource.list()).thenReturn(expectedAccounts);
+
+        manager.updateSnapshotsForAllAccounts();
+
+        verify(queue, times(1)).enqueue(eq(createDescriptor(expectedAccounts)));
+    }
+
+    @Test
+    public void ensureAccountListIsPartitionedWhenSendingTaskMessages() throws Exception {
+        List<String> expectedAccounts = Arrays.asList("a1", "a2", "a3", "a4");
+        when(accountListSource.list()).thenReturn(expectedAccounts);
+
+        manager.updateSnapshotsForAllAccounts();
+
+        // NOTE: Partition size is defined in test.properties
+        verify(queue, times(1)).enqueue(eq(createDescriptor(Arrays.asList("a1", "a2"))));
+        verify(queue, times(1)).enqueue(eq(createDescriptor(Arrays.asList("a3", "a4"))));
+    }
+
+    @Test
+    public void ensureErrorOnUpdateContinuesWithoutFailure() throws Exception {
+        List<String> expectedAccounts = Arrays.asList("a1", "a2", "a3", "a4", "a5", "a6");
+        when(accountListSource.list()).thenReturn(expectedAccounts);
+
+        doThrow(new RuntimeException("Forced!"))
+            .when(queue).enqueue(eq(createDescriptor(Arrays.asList("a3", "a4"))));
+
+        manager.updateSnapshotsForAllAccounts();
+
+        verify(queue, times(1)).enqueue(eq(createDescriptor(Arrays.asList("a1", "a2"))));
+        verify(queue, times(1)).enqueue(eq(createDescriptor(Arrays.asList("a3", "a4"))));
+        // Even though a3,a4 throws exception, a5,a6 should be enqueued.
+        verify(queue, times(1)).enqueue(eq(createDescriptor(Arrays.asList("a5", "a6"))));
+    }
+
+    @Test
+    public void ensureNoUpdatesWhenAccountListCanNotBeRetreived() throws Exception {
+        doThrow(new IOException("Forced!")).when(accountListSource).list();
+
+        assertThrows(TaskManagerException.class, () -> {
+            manager.updateSnapshotsForAllAccounts();
+        });
+
+        verify(queue, never()).enqueue(any());
+    }
+
+    private TaskDescriptor createDescriptor(String account) {
+        return createDescriptor(Arrays.asList(account));
+    }
+
+    private TaskDescriptor createDescriptor(List<String> accounts) {
+        return TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, taskQueueProperties.getTaskGroup())
+            .setArg("accounts", accounts)
+            .build();
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
+public class TaskWorkerTest {
+
+    @MockBean
+    private TaskFactory factory;
+
+    @Mock
+    private Task mockTask;
+
+    @Test
+    public void testExecuteTask() throws Exception {
+        TaskWorker worker = new TaskWorker(factory);
+        when(factory.build(any(TaskDescriptor.class))).thenReturn(mockTask);
+        worker.executeTask(TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group").build());
+        verify(mockTask).execute();
+    }
+
+    @Test
+    public void testThrowsTaskExecutionExceptionOnTaskFailure() throws Exception {
+        TaskWorker worker = new TaskWorker(factory);
+        when(factory.build(any(TaskDescriptor.class))).thenReturn(mockTask);
+        doThrow(RuntimeException.class).when(mockTask).execute();
+        assertThrows(TaskExecutionException.class,
+            () -> worker.executeTask(TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group").build()));
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueueTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueueTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.subscriptions.task.TaskDescriptor;
+import org.candlepin.subscriptions.task.TaskFactory;
+import org.candlepin.subscriptions.task.TaskType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+@ExtendWith(MockitoExtension.class)
+public class ExecutorTaskQueueTest {
+
+    @Mock
+    TaskFactory taskFactory;
+
+    @Test
+    public void ensureTaskIsExecutedPriorToShutdown() throws InterruptedException {
+        ExecutorTaskQueue queue = new ExecutorTaskQueue(Executors.newCachedThreadPool(), taskFactory);
+        TaskDescriptor expectedTaskDesc =
+            TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "my-group").build();
+        final AtomicBoolean done = new AtomicBoolean();
+        Mockito.when(taskFactory.build(Mockito.any())).thenReturn(() -> {
+            done.set(true);
+        });
+        queue.enqueue(expectedTaskDesc);
+        queue.shutdown(2000, TimeUnit.MILLISECONDS);
+        assertTrue(done.get());
+    }
+
+    @Test
+    public void verifyNoExceptionWhenTaskFails() throws InterruptedException {
+        AtomicBoolean failed = new AtomicBoolean();
+        ExecutorTaskQueue queue = new ExecutorTaskQueue(Executors.newCachedThreadPool((runnable) -> {
+            Thread thread = new Thread(runnable);
+            thread.setUncaughtExceptionHandler((_thread, throwable) -> {
+                failed.set(true);
+            });
+            return thread;
+        }), taskFactory);
+        TaskDescriptor expectedTaskDesc =
+            TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "my-group").build();
+        Mockito.when(taskFactory.build(Mockito.any())).thenReturn(() -> {
+            throw new RuntimeException("Error!");
+        });
+        queue.enqueue(expectedTaskDesc);
+        queue.shutdown(2000, TimeUnit.MILLISECONDS);
+        assertFalse(failed.get());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+
+/**
+ * Tests the AvroDeserializer failure logic. Successful deserialization tests
+ * are located in {@link AvroMessageSerializationTest} since both the serialization
+ * and deserialization will be tested together.
+ */
+public class AvroDeserializerTest {
+
+    private AvroDeserializer<TaskMessage> deserializer;
+
+    @BeforeEach
+    public void setupTest() {
+        deserializer = new AvroDeserializer();
+    }
+
+    @Test
+    public void testThrowsSerializationExceptionOnError() {
+        HashMap<String, Object> configs = new HashMap<>();
+        configs.put(AvroDeserializer.TARGET_TYPE_CLASS, TaskMessage.class);
+        deserializer.configure(configs, false);
+
+        TaskMessage mockMessage = mock(TaskMessage.class);
+        assertThrows(SerializationException.class, () -> {
+            // Can not deserialize empty byte array to object.
+            deserializer.deserialize("test", new byte[0]);
+        });
+    }
+
+    @Test
+    public void canConfigureTargetClassWithStringOrClassObject() {
+        // Will throw an exception if invalid.
+        HashMap<String, Object> configs = new HashMap<>();
+
+        // Config by class
+        configs.put(AvroDeserializer.TARGET_TYPE_CLASS, TaskMessage.class);
+        deserializer.configure(configs, false);
+        assertEquals(TaskMessage.class.getCanonicalName(), deserializer.getTargetType().getCanonicalName());
+
+        // Config by String
+        configs.put(AvroDeserializer.TARGET_TYPE_CLASS, TaskMessage.class.getCanonicalName());
+        deserializer.configure(configs, false);
+        assertEquals(TaskMessage.class.getCanonicalName(), deserializer.getTargetType().getCanonicalName());
+    }
+
+    @Test
+    public void throwsExceptionOnDeserializationWhenNotConfigured() {
+        assertThrows(IllegalStateException.class, () -> {
+            deserializer.deserialize("topic", new byte[0]);
+        });
+    }
+
+    @Test
+    public void testMissingTargetClassConfiguration() {
+        assertThrows(IllegalStateException.class, () -> {
+            deserializer.deserialize("test", new byte[0]);
+        });
+    }
+
+    @Test
+    public void testTargetClassNotFound() {
+        HashMap<String, Object> configs = new HashMap<>();
+        configs.put(AvroDeserializer.TARGET_TYPE_CLASS, "not.found.Message");
+
+        assertThrows(IllegalStateException.class, () -> {
+            deserializer.configure(configs, false);
+        });
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroMessageSerializationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroMessageSerializationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+
+public class AvroMessageSerializationTest {
+
+    @Test
+    public void testMessageCanBeSerializedAndThenDeserialized() {
+        AvroSerializer<TaskMessage> serializer = new AvroSerializer<>();
+        AvroDeserializer<TaskMessage> deserializer = new AvroDeserializer<>();
+
+        HashMap<String, List<String>> msgArgs = new HashMap<>();
+        msgArgs.put("arg1", Arrays.asList("arg1-val"));
+
+        TaskMessage message = TaskMessage.newBuilder()
+            .setType("test-type")
+            .setGroupId("test-group")
+            .setArgs(msgArgs)
+            .build();
+
+        AvroSerializer<TaskMessage> ser = new AvroSerializer<>();
+        byte[] messageBytes = ser.serialize("test", message);
+
+        HashMap<String, Object> configs = new HashMap<>();
+        configs.put(AvroDeserializer.TARGET_TYPE_CLASS, TaskMessage.class);
+        deserializer.configure(configs, false);
+
+        TaskMessage ret = deserializer.deserialize("test", messageBytes);
+        assertNotNull(ret);
+        assertEquals(message, ret);
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+
+/**
+ * Tests the AvroSerializer failure logic. Successful serialization tests
+ * are located in {@link AvroMessageSerializationTest} since both the serialization
+ * and deserialization will be tested together.
+ */
+public class AvroSerializerTest {
+
+    private AvroSerializer<TaskMessage> serializer;
+
+    @BeforeEach
+    public void setupTest() {
+        serializer = new AvroSerializer<TaskMessage>();
+    }
+
+    @Test
+    public void testThrowsSerializationException() {
+        TaskMessage mockMessage = mock(TaskMessage.class);
+        when(mockMessage.getSchema()).thenThrow(new RuntimeException("forced"));
+        assertThrows(SerializationException.class, () -> {
+            serializer.serialize("test-topic", mockMessage);
+        });
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+
+import java.util.Map;
+
+
+@SpringBootTest
+@TestPropertySource("classpath:/kafka_schema_registry_test.properties")
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, topics = {"${rhsm-subscriptions.tasks.task-group}"})
+public class KafkaTaskQueueSchemaRegistryTest extends KafkaTaskQueueTester {
+
+    @Test
+    public void testSendAndReceiveTaskMessage() throws InterruptedException {
+        runSendAndReceiveTaskMessageTest();
+    }
+
+    public static class TestingKafkaConfigurator extends KafkaConfigurator {
+
+        private MockSchemaRegistryClient registryClient = new MockSchemaRegistryClient();
+
+        @Override
+        public DefaultKafkaProducerFactory<String, TaskMessage> defaultProducerFactory(
+            KafkaProperties kafkaProperties) {
+            DefaultKafkaProducerFactory<String, TaskMessage> factory =
+                super.defaultProducerFactory(kafkaProperties);
+
+            // Verify that the configuration specifies the correct serializer and that it is
+            // properly configured. Once verified, we can manually instantiate the serializer
+            // with the mock schema registry.
+            Map<String, Object> factoryConfig = factory.getConfigurationProperties();
+            assertEquals(KafkaAvroSerializer.class,
+                factoryConfig.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG));
+            assertThat(factoryConfig,
+                Matchers.hasKey(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG));
+
+            return new DefaultKafkaProducerFactory(factoryConfig, new StringSerializer(),
+                new KafkaAvroSerializer(registryClient, factoryConfig));
+        }
+
+        @Override
+        public ConsumerFactory<String, TaskMessage> defaultConsumerFactory(KafkaProperties kafkaProperties) {
+            ConsumerFactory<String, TaskMessage> factory = super.defaultConsumerFactory(kafkaProperties);
+
+            // Verify that the configuration specifies the correct deserializer and that it is
+            // properly configured. Once verified, we can manually instantiate the deserializer
+            // with the mock schema registry.
+            Map<String, Object> factoryConfig = factory.getConfigurationProperties();
+            assertEquals(ErrorHandlingDeserializer2.class,
+                factoryConfig.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
+            assertEquals(KafkaAvroDeserializer.class,
+                factoryConfig.get(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS));
+            assertThat(factoryConfig,
+                Matchers.hasKey(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG));
+
+            KafkaAvroDeserializer delegate = new KafkaAvroDeserializer(registryClient, factoryConfig);
+            ErrorHandlingDeserializer2 errorDeserializer = new ErrorHandlingDeserializer2(delegate);
+            return new DefaultKafkaConsumerFactory<>(factoryConfig, new StringDeserializer(),
+                errorDeserializer);
+        }
+    }
+
+    @TestConfiguration
+    static class KafkaTaskQueueSchemaRegistryTestConfiguration {
+
+        @Bean
+        @Primary
+        public KafkaConfigurator testingConfigurator() {
+            return new TestingKafkaConfigurator();
+        }
+
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTest.java
@@ -18,30 +18,24 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
+package org.candlepin.subscriptions.task.queue.kafka;
 
-import org.candlepin.subscriptions.task.TaskManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
 
-/**
- * A quartz job that captures all usage snapshots on a configured schedule.
- */
-public class CaptureSnapshotsJob extends QuartzJobBean {
+@SpringBootTest
+@TestPropertySource("classpath:/kafka_test.properties")
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, topics = {"${rhsm-subscriptions.tasks.task-group}"})
+public class KafkaTaskQueueTest extends KafkaTaskQueueTester {
 
-    private TaskManager tasks;
-
-    @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
-    }
-
-    @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
+    @Test
+    public void testSendAndReceiveTaskMessage() throws InterruptedException {
+        runSendAndReceiveTaskMessageTest();
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTester.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTester.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.task.queue.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.subscriptions.task.Task;
+import org.candlepin.subscriptions.task.TaskDescriptor;
+import org.candlepin.subscriptions.task.TaskFactory;
+import org.candlepin.subscriptions.task.TaskManager;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.task.TaskType;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+
+
+/**
+ * Base class for testing message sending and receiving via Kafka.
+ */
+public class KafkaTaskQueueTester {
+
+    @MockBean
+    private TaskFactory factory;
+
+    @Autowired
+    private TaskManager manager;
+
+    @Autowired
+    private TaskQueueProperties taskQueueProperties;
+
+    protected void runSendAndReceiveTaskMessageTest() throws InterruptedException {
+        String account = "12345";
+        TaskDescriptor taskDescriptor = TaskDescriptor.builder(
+            TaskType.UPDATE_SNAPSHOTS, taskQueueProperties.getTaskGroup())
+            .setSingleValuedArg("accounts", account).build();
+
+        // Expect the task to be ran once.
+        CountDownLatch latch = new CountDownLatch(1);
+        CountDownTask cdt = new CountDownTask(latch);
+
+        when(factory.build(eq(taskDescriptor))).thenReturn(cdt);
+
+        manager.updateAccountSnapshots(account);
+
+        // Wait a max of 5 seconds for the task to be executed
+        latch.await(5L, TimeUnit.SECONDS);
+        assertTrue(cdt.taskWasExecuted(), "The task failed to execute. The message was not received.");
+    }
+
+    /**
+     * A testing Task that uses a latch to allow the calling test to know that it has been executed.
+     * It provides an executed field to allow tests to verify that the Task has actually been run
+     * in cases where latch.await(timeout) times out waiting for it to execute.
+     */
+    private class CountDownTask implements Task {
+
+        private CountDownLatch latch;
+        private boolean executed;
+
+        public CountDownTask(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void execute() {
+            executed = true;
+            latch.countDown();
+        }
+
+        public boolean taskWasExecuted() {
+            return executed;
+        }
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTaskTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTaskTest.java
@@ -18,30 +18,33 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.jobs;
+package org.candlepin.subscriptions.task.tasks;
 
-import org.candlepin.subscriptions.task.TaskManager;
+import static org.mockito.BDDMockito.eq;
 
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
 
-/**
- * A quartz job that captures all usage snapshots on a configured schedule.
- */
-public class CaptureSnapshotsJob extends QuartzJobBean {
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-    private TaskManager tasks;
+import java.util.Arrays;
+import java.util.List;
 
-    @Autowired
-    public CaptureSnapshotsJob(TaskManager taskManager) {
-        this.tasks = taskManager;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateAccountSnapshotsTaskTest {
+
+    @Mock
+    private UsageSnapshotProducer snapshotProducer;
+
+    @Test
+    public void testExecute() {
+        List<String> accounts = Arrays.asList("a1", "a2");
+        UpdateAccountSnapshotsTask task = new UpdateAccountSnapshotsTask(snapshotProducer, accounts);
+        task.execute();
+        Mockito.verify(snapshotProducer).produceSnapshotsForAccounts(eq(accounts));
     }
-
-    @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        tasks.updateSnapshotsForAllAccounts();
-    }
-
 }

--- a/src/test/resources/kafka_schema_registry_test.properties
+++ b/src/test/resources/kafka_schema_registry_test.properties
@@ -1,3 +1,4 @@
+# A configuration file to be used when testing kafka integration.
 rhsm-subscriptions.enableIngressEndpoint=true
 
 rhsm-subscriptions.datasource.platform=hsqldb
@@ -19,4 +20,14 @@ rhsm-subscriptions.quartz.datasource.password=
 rhsm-subscriptions.quartz.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
 rhsm-subscriptions.quartz.datasource.initialize-schema=always
 
-rhsm-subscriptions.accountBatchSize=2
+# Configure the kafka task queue and the embedded kafka broker
+rhsm-subscriptions.tasks.queue=kafka
+rhsm-subscriptions.tasks.task-group=rhsm-subscriptions-tasks
+spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
+# In tests, messages may be sent before the listener has been assigned the topic
+# so we ensure that when the listener comes online it starts from first message.
+spring.kafka.consumer.auto-offset-reset=earliest
+
+# Enable the schema registry (registry mock ignores the URL but it must be set
+# to enable registry checking).
+spring.kafka.properties.schema.registry.url=unused

--- a/src/test/resources/kafka_test.properties
+++ b/src/test/resources/kafka_test.properties
@@ -1,3 +1,4 @@
+# A configuration file to be used when testing kafka integration.
 rhsm-subscriptions.enableIngressEndpoint=true
 
 rhsm-subscriptions.datasource.platform=hsqldb
@@ -19,4 +20,10 @@ rhsm-subscriptions.quartz.datasource.password=
 rhsm-subscriptions.quartz.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
 rhsm-subscriptions.quartz.datasource.initialize-schema=always
 
-rhsm-subscriptions.accountBatchSize=2
+# Configure the kafka task queue and the embedded kafka broker
+rhsm-subscriptions.tasks.queue=kafka
+rhsm-subscriptions.tasks.task-group=rhsm-subscriptions-tasks
+spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
+# In tests, messages may be sent before the listener has been assigned the topic
+# so we ensure that when the listener comes online it starts from first message.
+spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
By default, an in-memory TaskQueue implementation is used for task
processing. The absence of a config property results in use of this
queue. Setting the following config property in rhsm-subscriptions.properties
or env var will enabled the queue:
    rhsm-subscriptions.tasks.queue=in-memory

Used Spring Kafka to implement a Kafka TaskQueue implementation.

When the TaskManager queues a task, a message is sent to Kafka
via the rhsm-subscriptions-tasks topic.

A KafkaListener is configured to listen to the rhsm-subscriptions-tasks topic
and is notified when a message is available. The message is then translated
to a Task and is run via the TaskWorker.

If Task execution fails, the error is logged and the message is considered
processed.

To enable this queue, the following property must be set as an env var
or in the rhsm-subscriptions.properties config file:
    rhsm-subscriptions.tasks.queue=kafka

Spring Kafka's auto-configure is used to configure the producer/consumer. Any of the
confurations defined by Spring Kafka are defines with the "spring.kafka" prefix as
per the documentation. Customizing the consumer or producer via properties not included
with auto-configure can be specified via:
   spring.kafka.consunmer.properties.MY_CONSUMER_PROPERTY
   spring.kafka.producer.properties.MY_PRODUCER_PROPERTY

To increase the number of messages that can be processed concurrently, the
topic must be configured with a number of partitions equal to the value of the
spring.kafka.listener.concurrency property.

**TESTING**
```bash
# Run a local instance of kafka
$ docker run --rm --net host landoop/fast-data-dev
```
```properties
# Basic rhsm-subscriptions.properties changes to enable the queue
rhsm-subscriptions.tasks.queue=kafka
rhsm-subscriptions.tasks.task-group=rhsm-subscriptions-tasks
spring.kafka.consumer.properties.max.poll.records=1

# The number of threads that will be processing messages (should match
# the number of partitions on the queue)
spring.kafka.listener.concurrency=24
spring.kafka.bootstrap-servers=localhost:9092
```
Start up the application and let the job run as usual. Make sure that the schedule is property configured!

**A Note On Account Batch Size**
rhsm-subscriptions.accountBatchSize=YOUR_BATCH_SIZE

When a message is sent it will contain at most YOUR_BATCH_SIZE accounts per message and this will be the number of accounts that you will be updating per thread -- all at once.