### PR TITLE
Refactor into spring profiles

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -77,11 +77,6 @@ public class ApplicationProperties {
     private int accountBatchSize = 500;
 
     /**
-     * Whether the ingress endpoint is enabled on this instance of rhsm-subscriptions or not.
-     */
-    private boolean enableIngressEndpoint;
-
-    /**
      * Amount of time to cache the account list, before allowing a re-read from the filesystem.
      */
     private Duration accountListCacheTtl = Duration.ofMinutes(5);
@@ -173,14 +168,6 @@ public class ApplicationProperties {
 
     public void setDevMode(boolean devMode) {
         this.devMode = devMode;
-    }
-
-    public boolean isEnableIngressEndpoint() {
-        return enableIngressEndpoint;
-    }
-
-    public void setEnableIngressEndpoint(boolean enableIngressEndpoint) {
-        this.enableIngressEndpoint = enableIngressEndpoint;
     }
 
     public String getProductWhitelistResourceLocation() {

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.jmx;
 import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
 import org.candlepin.subscriptions.task.TaskManager;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.stereotype.Component;
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Component;
  * Exposes the ability to trigger a tally for an account from JMX.
  */
 @Component
+@Profile({"in-memory-queue", "kafka-queue", "worker"})
 @ManagedResource
 public class TallyJmxBean {
 

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
@@ -25,7 +25,6 @@ import org.candlepin.subscriptions.db.PostgresTlsHikariDataSourceFactoryBean;
 
 import org.quartz.JobDetail;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.autoconfigure.quartz.QuartzDataSource;
 import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomizer;
@@ -33,6 +32,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
@@ -45,6 +45,7 @@ import java.util.Properties;
  */
 @EnableConfigurationProperties(JobProperties.class)
 @Configuration
+@Profile("scheduler")
 @PropertySource("classpath:/rhsm-subscriptions.properties")
 public class JobsConfiguration {
 
@@ -81,7 +82,6 @@ public class JobsConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "true")
     public JobDetailFactoryBean orgSyncJobDetail() {
         JobDetailFactoryBean jobDetail = new JobDetailFactoryBean();
         jobDetail.setDurability(true);
@@ -91,7 +91,6 @@ public class JobsConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "true")
     public JobDetailFactoryBean purgeJobDetail() {
         JobDetailFactoryBean jobDetail = new JobDetailFactoryBean();
         jobDetail.setDurability(true);
@@ -101,7 +100,6 @@ public class JobsConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "true")
     public CronTriggerFactoryBean orgSyncTrigger(JobDetail orgSyncJobDetail, JobProperties jobProperties) {
         CronTriggerFactoryBean trigger = new CronTriggerFactoryBean();
         trigger.setJobDetail(orgSyncJobDetail);
@@ -110,7 +108,6 @@ public class JobsConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "true")
     public CronTriggerFactoryBean purgeTrigger(JobDetail purgeJobDetail, JobProperties jobProperties) {
         CronTriggerFactoryBean trigger = new CronTriggerFactoryBean();
         trigger.setJobDetail(purgeJobDetail);

--- a/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
@@ -24,7 +24,7 @@ import org.candlepin.subscriptions.controller.PoolIngressController;
 import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
 import org.candlepin.subscriptions.utilization.api.resources.IngressApi;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -35,7 +35,7 @@ import javax.validation.Valid;
  * Updates subscription capacity based on Candlepin pool data.
  */
 @Component
-@ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableIngressEndpoint", havingValue = "true")
+@Profile("capacity-ingress")
 public class IngressResource implements IngressApi {
 
     private final PoolIngressController controller;

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -33,7 +33,7 @@ import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.candlepin.subscriptions.utilization.api.resources.TallyApi;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -52,8 +52,7 @@ import javax.ws.rs.core.UriInfo;
  * Tally API implementation.
  */
 @Component
-@ConditionalOnProperty(prefix = "rhsm-subscriptions", name = "enableJobProcessing", havingValue = "false",
-    matchIfMissing = true)
+@Profile("api")
 public class TallyResource implements TallyApi {
 
     @Context UriInfo uriInfo;

--- a/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ import java.util.List;
  * method.
  */
 @Component
+@Profile({"in-memory-queue", "kafka-queue", "worker"})
 public class TaskManager {
     private static final Logger log = LoggerFactory.getLogger(TaskManager.class);
 

--- a/src/main/java/org/candlepin/subscriptions/task/TaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskQueueConfiguration.java
@@ -25,10 +25,10 @@ import org.candlepin.subscriptions.task.queue.TaskQueue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
 import java.util.concurrent.Executors;
@@ -63,8 +63,7 @@ public class TaskQueueConfiguration {
      * amount of memory available.
      */
     @Bean
-    @ConditionalOnProperty(prefix = "rhsm-subscriptions.tasks", name = "queue", havingValue = "in-memory",
-        matchIfMissing = true)
+    @Profile("in-memory-queue")
     TaskQueue inMemoryQueue(TaskFactory taskFactory) {
         log.info("Configuring an in-memory task queue.");
         return new ExecutorTaskQueue(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,7 +21,14 @@ management:
       enabled: true
     prometheus:
       enabled: true
+
 spring:
+  profiles:
+    active:
+      - api
+      - in-memory-queue
+      - scheduler
+      - capacity-ingress
   liquibase:
     change-log: classpath:/liquibase/changelog.xml
   quartz:

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -37,9 +37,12 @@ rhsm-subscriptions.enableIngressEndpoint=false
 # kafka configuration
 ##########################
 
-# Uncomment to enable Kafka integration
-#rhsm-subscriptions.tasks.queue=kafka
+# Use profile "kafka-queue" to enable Kafka integration
+# Use profile "worker" to enable Kafka listeners
 #rhsm-subscriptions.tasks.task-group=rhsm-subscriptions-tasks
+
+# if no offset commit exists yet, set to earliest
+spring.kafka.consumer.properties.auto.offset.reset=earliest
 
 # Required kafka defaults
 spring.kafka.consumer.properties.max.poll.records=1

--- a/src/test/resources/kafka_schema_registry_test.properties
+++ b/src/test/resources/kafka_schema_registry_test.properties
@@ -1,6 +1,4 @@
 # A configuration file to be used when testing kafka integration.
-rhsm-subscriptions.enableIngressEndpoint=true
-
 rhsm-subscriptions.datasource.platform=hsqldb
 rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:testdb
 rhsm-subscriptions.datasource.username=

--- a/src/test/resources/kafka_test.properties
+++ b/src/test/resources/kafka_test.properties
@@ -1,6 +1,4 @@
 # A configuration file to be used when testing kafka integration.
-rhsm-subscriptions.enableIngressEndpoint=true
-
 rhsm-subscriptions.datasource.platform=hsqldb
 rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:testdb
 rhsm-subscriptions.datasource.username=

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,5 +1,3 @@
-rhsm-subscriptions.enableIngressEndpoint=true
-
 rhsm-subscriptions.datasource.platform=hsqldb
 rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:testdb
 rhsm-subscriptions.datasource.username=


### PR DESCRIPTION
The following profiles now exist:

- api: instance should service API requests
- capacity-ingress: instance should accept capacity records
- scheduler: instance should schedule tasks
- worker: instance should pick up tasks from kafka and run them, implies kafka-queue
- in-memory-queue: instance should queue and run tasks in-memory
- kafka-queue: instance should queue tasks to kafka, but doesn't necessarily run them

If you run `./gradlew bootRun`, it will default to:

- api
- capacity-ingress
- scheduler
- in-memory-queue

Below commands show some ways to set profiles, and the combinations I think we need.

```sh
./gradlew bootRun --args=--spring.profiles.active=api  # accept requests and consume tasks from kafka
./gradlew bootRun --args=--spring.profiles.active=capacity-ingress  # accept capacity updates
./gradlew bootRun --args=--spring.profiles.active=scheduler,worker  # schedule tasks and work them
./gradlew bootRun --args=--spring.profiles.active=worker  # pick up tasks from the kafka queue
```

Note: I don't see an immediate use for kafka-queue, but if we ever want to deploy a node which is only a producer, it would be the profile to use (along with scheduler).
Note: we will need to override profile for each deployment type in the openshift deployment configs.