### PR TITLE
Zero out TallySnapshot responses

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -447,60 +447,72 @@ components:
           type: integer
           format: int32
           minimum: 0
+          default: 0
         cores:
           type: integer
           format: int32
           minimum: 0
+          default: 0
         sockets:
           description: "Total number of sockets calculated from systems matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         physical_instance_count:
           description: "Total number of physical systems matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         physical_cores:
           description: "Total number of cores calculated from physical systems matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         physical_sockets:
           description: "Total number of sockets calculated from physical systems matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         hypervisor_instance_count:
           description: "Total number of hypervisors matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         hypervisor_cores:
           description: "Total number of cores calculated from hypervisors matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         hypervisor_sockets:
           description: "Total number of sockets calculated from hypervisors matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         cloud_instance_count:
           description: "Total number of hosts running on a public cloud provider, matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         cloud_cores:
           description: "Total number of cores calculated from hosts running on a public cloud provider, matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         cloud_sockets:
           description: "Total number of sockets calculated from hosts running on a public cloud provider, matching the report criteria on the date of this snapshot."
           type: integer
           format: int32
           minimum: 0
+          default: 0
         has_data:
           type: boolean
     CapacityReport:

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -284,6 +284,22 @@ public class TallyResourceTest {
     }
 
     @Test
+    void testEmptySnapshotFilledWithAllZeroes() {
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot snapshot =
+            new org.candlepin.subscriptions.utilization.api.model.TallySnapshot();
+
+        assertEquals(0, snapshot.getInstanceCount().intValue());
+        assertEquals(0, snapshot.getCores().intValue());
+        assertEquals(0, snapshot.getSockets().intValue());
+        assertEquals(0, snapshot.getHypervisorInstanceCount().intValue());
+        assertEquals(0, snapshot.getHypervisorCores().intValue());
+        assertEquals(0, snapshot.getHypervisorSockets().intValue());
+        assertEquals(0, snapshot.getCloudInstanceCount().intValue());
+        assertEquals(0, snapshot.getCloudCores().intValue());
+        assertEquals(0, snapshot.getCloudSockets().intValue());
+    }
+
+    @Test
     public void ensureBadRequestExceptionIsThrownWhenAnInvalidSlaParameterIsSpecified() {
         assertThrows(BadRequestException.class, () -> {
             resource.getTallyReport(


### PR DESCRIPTION
By setting `default: 0` in the spec, this is taken care of during construction.