### PR TITLE
Only import QuartzAutoConfiguration in scheduler profile

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/BootApplication.java
+++ b/src/main/java/org/candlepin/subscriptions/BootApplication.java
@@ -22,9 +22,10 @@ package org.candlepin.subscriptions;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 
 /** Bootstrapper for Spring Boot. */
-@SpringBootApplication
+@SpringBootApplication(exclude = { QuartzAutoConfiguration.class }) // we manually import in scheduler profile
 @SuppressWarnings("checkstyle:hideutilityclassconstructor")
 public class BootApplication {
     public static void main(String[] args) {

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
@@ -26,12 +26,14 @@ import org.candlepin.subscriptions.db.PostgresTlsHikariDataSourceFactoryBean;
 import org.quartz.JobDetail;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.autoconfigure.quartz.QuartzDataSource;
 import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomizer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
@@ -45,6 +47,7 @@ import java.util.Properties;
  */
 @EnableConfigurationProperties(JobProperties.class)
 @Configuration
+@Import(QuartzAutoConfiguration.class)
 @Profile("scheduler")
 @PropertySource("classpath:/rhsm-subscriptions.properties")
 public class JobsConfiguration {


### PR DESCRIPTION
To test, place `spring.quartz.job-store-type=foobar` in `config/application.properties`.

Note that this property causes a startup issue when run with:

```sh
./gradlew bootRun --args=--spring.profiles.active=scheduler,worker
```

but does not cause a startup issue when run with:

```sh
./gradlew bootRun --args=--spring.profiles.active=api
```