### PR TITLE
Respect SYSPURPOSE_UNITS if present

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -61,6 +61,7 @@ import javax.persistence.Table;
                 @ColumnResult(name = "system_profile_product_ids"),
                 @ColumnResult(name = "syspurpose_role"),
                 @ColumnResult(name = "syspurpose_sla"),
+                @ColumnResult(name = "syspurpose_units"),
                 @ColumnResult(name = "is_virtual"),
                 @ColumnResult(name = "hypervisor_uuid"),
                 @ColumnResult(name = "guest_id"),
@@ -86,6 +87,7 @@ import javax.persistence.Table;
         "h.facts->'rhsm'->>'SYNC_TIMESTAMP' as sync_timestamp, " +
         "h.facts->'rhsm'->>'SYSPURPOSE_ROLE' as syspurpose_role, " +
         "h.facts->'rhsm'->>'SYSPURPOSE_SLA' as syspurpose_sla, " +
+        "h.facts->'rhsm'->>'SYSPURPOSE_UNITS' as syspurpose_units, " +
         "h.facts->'qpc'->>'IS_RHEL' as is_rhel, " +
         "h.system_profile_facts->>'infrastructure_type' as system_profile_infrastructure_type, " +
         "h.system_profile_facts->>'cores_per_socket' as system_profile_cores_per_socket, " +

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -49,6 +49,7 @@ public class InventoryHostFacts {
     private Set<String> systemProfileProductIds;
     private String syspurposeRole;
     private String syspurposeSla;
+    private String syspurposeUnits;
     private String cloudProvider;
     private OffsetDateTime staleTimestamp;
 
@@ -60,7 +61,7 @@ public class InventoryHostFacts {
     public InventoryHostFacts(String account, String displayName, String orgId, String cores, String sockets,
         String products, String syncTimestamp, String systemProfileInfrastructureType,
         String systemProfileCores, String systemProfileSockets, String qpcProducts, String qpcProductIds,
-        String systemProfileProductIds, String syspurposeRole, String syspurposeSla,
+        String systemProfileProductIds, String syspurposeRole, String syspurposeSla, String syspurposeUnits,
         String isVirtual, String hypervisorUuid, String guestId, String subscriptionManagerId,
         String cloudProvider, OffsetDateTime staleTimestamp) {
 
@@ -79,6 +80,7 @@ public class InventoryHostFacts {
         this.systemProfileProductIds = asStringSet(systemProfileProductIds);
         this.syspurposeRole = syspurposeRole;
         this.syspurposeSla = syspurposeSla;
+        this.syspurposeUnits = syspurposeUnits;
         this.isVirtual = asBoolean(isVirtual);
         this.hypervisorUuid = hypervisorUuid;
         this.guestId = guestId;
@@ -277,5 +279,13 @@ public class InventoryHostFacts {
 
     public void setSyspurposeSla(String syspurposeSla) {
         this.syspurposeSla = syspurposeSla;
+    }
+
+    public String getSyspurposeUnits() {
+        return syspurposeUnits;
+    }
+
+    public void setSyspurposeUnits(String syspurposeUnits) {
+        this.syspurposeUnits = syspurposeUnits;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -84,7 +84,25 @@ public class FactNormalizer {
         normalizeSocketCount(normalizedFacts, hostFacts);
         normalizeConflictingOrMissingRhelVariants(normalizedFacts);
         pruneProducts(normalizedFacts);
+        normalizeUnits(normalizedFacts, hostFacts);
         return normalizedFacts;
+    }
+
+    private void normalizeUnits(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
+        if (hostFacts.getSyspurposeUnits() == null) {
+            return;
+        }
+        switch (hostFacts.getSyspurposeUnits()) {
+            case "Sockets":
+                normalizedFacts.setCores(0);
+                break;
+            case "Cores/vCPU":
+                normalizedFacts.setSockets(0);
+                break;
+            default:
+                log.warn("Unsupported value on host w/ subscription-manager ID {} for syspurpose units: {}",
+                    hostFacts.getSubscriptionManagerId(), hostFacts.getSyspurposeUnits());
+        }
     }
 
     private boolean isVirtual(InventoryHostFacts hostFacts) {

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -438,6 +438,53 @@ public class FactNormalizerTest {
         assertClassification(facts, true, true, false);
     }
 
+    @Test
+    void testSyspurposeUnitsSockets() {
+        InventoryHostFacts facts = createBaseHost("A1", "O1");
+        facts.setCores(4);
+        facts.setSockets(2);
+        facts.setSyspurposeUnits("Sockets");
+
+        NormalizedFacts normalized = normalizer.normalize(facts, Collections.emptyMap());
+        assertEquals(2, normalized.getSockets().longValue());
+        assertEquals(0, normalized.getCores().longValue());
+    }
+
+    @Test
+    void testSyspurposeUnitsCores() {
+        InventoryHostFacts facts = createBaseHost("A1", "O1");
+        facts.setCores(4);
+        facts.setSockets(2);
+        facts.setSyspurposeUnits("Cores/vCPU");
+
+        NormalizedFacts normalized = normalizer.normalize(facts, Collections.emptyMap());
+        assertEquals(0, normalized.getSockets().longValue());
+        assertEquals(4, normalized.getCores().longValue());
+    }
+
+    @Test
+    void testSyspurposeUnitsUnknown() {
+        InventoryHostFacts facts = createBaseHost("A1", "O1");
+        facts.setCores(4);
+        facts.setSockets(2);
+        facts.setSyspurposeUnits("Foobar");
+
+        NormalizedFacts normalized = normalizer.normalize(facts, Collections.emptyMap());
+        assertEquals(2, normalized.getSockets().longValue());
+        assertEquals(4, normalized.getCores().longValue());
+    }
+
+    @Test
+    void testSyspurposeUnitsUnspecified() {
+        InventoryHostFacts facts = createBaseHost("A1", "O1");
+        facts.setCores(4);
+        facts.setSockets(2);
+
+        NormalizedFacts normalized = normalizer.normalize(facts, Collections.emptyMap());
+        assertEquals(2, normalized.getSockets().longValue());
+        assertEquals(4, normalized.getCores().longValue());
+    }
+
     private void assertClassification(NormalizedFacts check, boolean isHypervisor,
         boolean isHypervisorUnknown, boolean isVirtual) {
         assertEquals(isHypervisor, check.isHypervisor());


### PR DESCRIPTION
Only count a system as the specified units. If the unit is not recognized, then log a warning.