### PR TITLE
Add DB schema and repository for AdminConfig (opt-in)

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import org.candlepin.subscriptions.db.model.config.AccountConfig;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.stream.Stream;
+
+/**
+ * Defines all operations for storing account config entries.
+ */
+public interface AccountConfigRepository extends JpaRepository<AccountConfig, String> {
+
+    @Query("select distinct c.accountNumber from AccountConfig c where c.syncEnabled = TRUE")
+    Stream<String> findSyncEnabledAccounts();
+
+    @Query(
+        "select case when count(c) > 0 then true else false end from AccountConfig c " +
+        "where c.accountNumber = :account and c.reportingEnabled = TRUE")
+    boolean isReportingEnabled(@Param("account") String accountNumber);
+
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import org.candlepin.subscriptions.db.model.config.OrgConfig;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.stream.Stream;
+
+/**
+ * Defines all operations for storing organization config entries.
+ */
+public interface OrgConfigRepository extends JpaRepository<OrgConfig, String> {
+
+    @Query("select distinct c.orgId from OrgConfig c where c.syncEnabled = TRUE")
+    Stream<String> findSyncEnabledOrgs();
+
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model.config;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+
+/**
+ * Represents the configuration properties for an account.
+ */
+@Entity
+@Table(name = "account_config")
+public class AccountConfig extends BaseConfig {
+
+    @Id
+    @Column(name = "account_number")
+    private String accountNumber;
+
+    @Column(name = "reporting_enabled")
+    private Boolean reportingEnabled;
+
+    public AccountConfig() {
+    }
+
+    public AccountConfig(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public Boolean getReportingEnabled() {
+        return reportingEnabled;
+    }
+
+    public void setReportingEnabled(Boolean reportingEnabled) {
+        this.reportingEnabled = reportingEnabled;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof AccountConfig)) {
+            return false;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        AccountConfig that = (AccountConfig) o;
+        return Objects.equals(accountNumber, that.accountNumber) &&
+                   Objects.equals(reportingEnabled, that.reportingEnabled);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), accountNumber, reportingEnabled);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/BaseConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/BaseConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model.config;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.MappedSuperclass;
+
+
+/**
+ * Base class for configuration DB objects.
+ */
+@MappedSuperclass
+public class BaseConfig implements Serializable {
+
+    @Column(name = "sync_enabled")
+    protected Boolean syncEnabled;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "opt_in_type")
+    protected OptInType optInType;
+
+    @Column(name = "created")
+    protected OffsetDateTime created;
+
+    @Column(name = "updated")
+    protected OffsetDateTime updated;
+
+    public Boolean getSyncEnabled() {
+        return syncEnabled;
+    }
+
+    public void setSyncEnabled(Boolean syncEnabled) {
+        this.syncEnabled = syncEnabled;
+    }
+
+    public OptInType getOptInType() {
+        return optInType;
+    }
+
+    public void setOptInType(OptInType optInType) {
+        this.optInType = optInType;
+    }
+
+    public OffsetDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(OffsetDateTime created) {
+        this.created = created;
+    }
+
+    public OffsetDateTime getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(OffsetDateTime updated) {
+        this.updated = updated;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof BaseConfig)) {
+            return false;
+        }
+
+        BaseConfig that = (BaseConfig) o;
+        return Objects.equals(syncEnabled, that.syncEnabled) &&
+            optInType == that.optInType &&
+            Objects.equals(created, that.created) &&
+            Objects.equals(updated, that.updated);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(syncEnabled, optInType, created, updated);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+/**
+ * Represents how a reporting config entry was created.
+ */
+package org.candlepin.subscriptions.db.model.config;
+
+/**
+ * How the particular account was opted in.
+ */
+public enum OptInType {
+    /**
+     * Manually via the DB itself.
+     */
+    DB,
+
+    /**
+     * Configured via the JMX bean.
+     */
+    JMX,
+
+    /**
+     * Configured by an admin via the API.
+     */
+    API
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model.config;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Represents the configuration properties for an organization (owner).
+ */
+@Entity
+@Table(name = "org_config")
+public class OrgConfig extends BaseConfig {
+
+    @Id
+    @Column(name = "org_id")
+    private String orgId;
+
+    public OrgConfig() {
+    }
+
+    public OrgConfig(String orgId) {
+        this.orgId = orgId;
+    }
+
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof OrgConfig)) {
+            return false;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        OrgConfig orgConfig = (OrgConfig) o;
+        return Objects.equals(orgId, orgConfig.orgId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), orgId);
+    }
+}

--- a/src/main/resources/liquibase/202003261146-add-table-for-account-config.xml
+++ b/src/main/resources/liquibase/202003261146-add-table-for-account-config.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202003261146-1" author="mstead">
+        <comment>Add table for account configuration for tally/conduit</comment>
+        <createTable tableName="account_config">
+            <column name="account_number" type="VARCHAR(255)" />
+            <column name="sync_enabled" type="BOOLEAN">
+                <constraints nullable="false" />
+            </column>
+            <column name="reporting_enabled" type="BOOLEAN">
+                <constraints nullable="false" />
+            </column>
+            <column name="opt_in_type" type="VARCHAR(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="created" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false" />
+            </column>
+            <column name="updated" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="202003261146-2" author="mstead">
+        <addPrimaryKey constraintName="acc_num_pkey"
+                       tableName="account_config"
+                       columnNames="account_number"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/202003271146-add-table-for-org-config.xml
+++ b/src/main/resources/liquibase/202003271146-add-table-for-org-config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202003271146-1" author="mstead">
+        <comment>Add table for org based configuration.</comment>
+        <createTable tableName="org_config">
+            <column name="org_id" type="VARCHAR(255)"/>
+            <column name="sync_enabled" type="BOOLEAN">
+                <constraints nullable="false" />
+            </column>
+            <column name="opt_in_type" type="VARCHAR(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="created" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false" />
+            </column>
+            <column name="updated" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="202003271146-2" author="mstead">
+        <addPrimaryKey constraintName="org_id_pkey"
+                       tableName="org_config"
+                       columnNames="org_id"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -20,5 +20,7 @@
     <include file="liquibase/202002061140-update-copy-measurement-procedure.xml"/>
     <include file="liquibase/202002140932-add-sla-column-to-snapshot-and-capacity-tables.xml"/>
     <include file="liquibase/202003021107-make-tally-sla-non-null.xml"/>
+    <include file="liquibase/202003261146-add-table-for-account-config.xml"/>
+    <include file="liquibase/202003271146-add-table-for-org-config.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.config.AccountConfig;
+import org.candlepin.subscriptions.db.model.config.OptInType;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource("classpath:/test.properties")
+public class AccountConfigRepositoryTest {
+
+    @Autowired
+    private AccountConfigRepository repository;
+    private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+
+    @Test
+    public void saveAndUpdate() {
+        OffsetDateTime creation = clock.now();
+        OffsetDateTime expectedUpdate = creation.plusDays(1);
+
+        String account = "test-account";
+        AccountConfig config = new AccountConfig(account);
+        config.setOptInType(OptInType.JMX);
+        config.setReportingEnabled(true);
+        config.setSyncEnabled(true);
+        config.setCreated(creation);
+        config.setUpdated(expectedUpdate);
+
+        repository.saveAndFlush(config);
+
+        AccountConfig found = repository.getOne(account);
+        assertNotNull(found);
+        assertEquals(config, found);
+
+        found.setReportingEnabled(false);
+        found.setSyncEnabled(false);
+        found.setOptInType(OptInType.API);
+        repository.saveAndFlush(found);
+
+        AccountConfig updated = repository.getOne(account);
+        assertNotNull(updated);
+        assertEquals(Boolean.FALSE, updated.getReportingEnabled());
+        assertEquals(Boolean.FALSE, updated.getSyncEnabled());
+        assertEquals(OptInType.API, updated.getOptInType());
+    }
+
+    @Test
+    public void testDelete() {
+        AccountConfig config = createConfig("an-account", true, true);
+        repository.saveAndFlush(config);
+
+        AccountConfig toDelete = repository.getOne(config.getAccountNumber());
+        assertNotNull(toDelete);
+        repository.delete(toDelete);
+        repository.flush();
+
+        assertEquals(0, repository.count());
+    }
+
+    @Test
+    public void testFindAccountsWithEnabledSync() {
+        repository.saveAll(Arrays.asList(
+            createConfig("A1", true, true),
+            createConfig("A2", true, false),
+            createConfig("A3", false, true),
+            createConfig("A4", false, false)
+        ));
+        repository.flush();
+
+        List<String> accountsWithSync = repository.findSyncEnabledAccounts().collect(Collectors.toList());
+        assertEquals(2, accountsWithSync.size());
+        assertTrue(accountsWithSync.containsAll(Arrays.asList("A1", "A2")));
+    }
+
+    @Test
+    public void testIsReportingEnabled() {
+        repository.saveAll(Arrays.asList(
+            createConfig("A1", true, true),
+            createConfig("A2", true, false),
+            createConfig("A3", false, true),
+            createConfig("A4", false, false)
+        ));
+        repository.flush();
+
+        assertTrue(repository.isReportingEnabled("A1"));
+        assertFalse(repository.isReportingEnabled("A2"));
+        assertTrue(repository.isReportingEnabled("A3"));
+        assertFalse(repository.isReportingEnabled("A4"));
+    }
+
+    private AccountConfig createConfig(String account, boolean canSync, boolean canReport) {
+        AccountConfig config = new AccountConfig(account);
+        config.setOptInType(OptInType.API);
+        config.setSyncEnabled(canSync);
+        config.setReportingEnabled(canReport);
+        config.setCreated(clock.now());
+        config.setUpdated(config.getCreated().plusDays(1));
+        return config;
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.OrgConfigRepository;
+import org.candlepin.subscriptions.db.model.config.OptInType;
+import org.candlepin.subscriptions.db.model.config.OrgConfig;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@SpringBootTest
+@Transactional
+@TestPropertySource("classpath:/test.properties")
+public class OrgConfigRepositoryTest {
+
+    @Autowired
+    private OrgConfigRepository repository;
+    private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+
+    @Test
+    public void saveAndUpdate() {
+        OffsetDateTime creation = clock.now();
+        OffsetDateTime expectedUpdate = creation.plusDays(1);
+
+        String org = "test-org";
+        OrgConfig config = new OrgConfig(org);
+        config.setOptInType(OptInType.JMX);
+        config.setSyncEnabled(true);
+        config.setCreated(creation);
+        config.setUpdated(expectedUpdate);
+
+        repository.saveAndFlush(config);
+
+        OrgConfig found = repository.getOne(org);
+        assertNotNull(found);
+        assertEquals(config, found);
+
+        found.setSyncEnabled(false);
+        found.setOptInType(OptInType.API);
+        repository.saveAndFlush(found);
+
+        OrgConfig updated = repository.getOne(org);
+        assertNotNull(updated);
+        assertEquals(Boolean.FALSE, updated.getSyncEnabled());
+        assertEquals(OptInType.API, updated.getOptInType());
+    }
+
+    @Test
+    public void testDelete() {
+        OrgConfig config = createConfig("an-org", true);
+        repository.saveAndFlush(config);
+
+        OrgConfig toDelete = repository.getOne(config.getOrgId());
+        assertNotNull(toDelete);
+        repository.delete(toDelete);
+        repository.flush();
+
+        assertEquals(0, repository.count());
+    }
+
+    @Test
+    public void testFindOrgsWithEnabledSync() {
+        repository.saveAll(Arrays.asList(
+            createConfig("A1", true),
+            createConfig("A2", true),
+            createConfig("A3", false),
+            createConfig("A4", false)
+        ));
+        repository.flush();
+
+        List<String> orgsWithSync = repository.findSyncEnabledOrgs().collect(Collectors.toList());
+        assertEquals(2, orgsWithSync.size());
+        assertTrue(orgsWithSync.containsAll(Arrays.asList("A1", "A2")));
+    }
+
+    private OrgConfig createConfig(String org, boolean canSync) {
+        OrgConfig config = new OrgConfig(org);
+        config.setOptInType(OptInType.API);
+        config.setSyncEnabled(canSync);
+        config.setCreated(clock.now());
+        config.setUpdated(config.getCreated().plusDays(1));
+        return config;
+    }
+
+}


### PR DESCRIPTION
A AccountConfig entry represents an account/org pair and
the functionality that is allowed for that pair. For example,
should data sync be enabled in tally/conduit? Or is reporting
enabled for that account in tally.

The intent here is to allow a single record to enable the
various configurable bits across both tally and conduit.

**NOTE** This PR is targeting a feature branch `feature/opt-in`