### PR TITLE
Add liquibase-only profile and config update task

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/liquibase/ConfigUpdateException.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/ConfigUpdateException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.liquibase;
+
+/**
+ * Unchecked exception for config not being updated for some reason.
+ *
+ * @see LoadConfigsTask
+ */
+class ConfigUpdateException extends RuntimeException {
+
+    ConfigUpdateException(Exception e) {
+        super(e);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LoadConfigsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LoadConfigsTask.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.liquibase;
+
+import liquibase.database.Database;
+import liquibase.exception.DatabaseException;
+import liquibase.logging.LogService;
+import liquibase.logging.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.util.stream.Stream;
+
+/**
+ * Custom liquibase task for loading org_config and account_config files from text files.
+ *
+ * Reads two environment variables (SWATCH_ACCOUNT_CONFIG_PATH and SWATCH_ORG_CONFIG_PATH) to get the path to
+ */
+public class LoadConfigsTask extends LiquibaseCustomTask {
+
+    private static final String ORG_CONFIG_SQL =
+        "insert into org_config (org_id, sync_enabled, opt_in_type, created, updated) values " +
+        "(?, true, 'DB', now(), now()) on conflict do nothing";
+
+    private static final String ACCOUNT_CONFIG_SQL =
+        "insert into account_config " +
+        "(account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated) values " +
+        "(?, true, true, 'DB', now(), now()) on conflict do nothing";
+
+    @Override
+    public void executeTask(Database database) {
+        populateOrgConfig();
+        populateAccountConfig();
+    }
+
+    private void populateAccountConfig() {
+        String accountConfigPath = System.getenv("SWATCH_ACCOUNT_CONFIG_PATH");
+        if (accountConfigPath != null) {
+            getLogger().info("Updating account_config");
+            try (Stream<String> lines = Files.lines(Paths.get(accountConfigPath))) {
+                Integer rowsModified = lines
+                    .filter(s -> !s.isEmpty() && !s.startsWith("{"))
+                    .map(this::addAccountToConfig)
+                    .reduce(0, Integer::sum);
+                getLogger().info("Added " + rowsModified + " entries to account_config");
+            }
+            catch (IOException e) {
+                throw new ConfigUpdateException(e);
+            }
+        }
+        else {
+            getLogger().debug("SWATCH_ACCOUNT_CONFIG_PATH not defined. account_config will not be updated.");
+        }
+    }
+
+    private int addAccountToConfig(String account) {
+        try {
+            return executeUpdate(ACCOUNT_CONFIG_SQL, account);
+        }
+        catch (DatabaseException | SQLException e) {
+            throw new ConfigUpdateException(e);
+        }
+    }
+
+    private void populateOrgConfig() {
+        String orgConfigPath = System.getenv("SWATCH_ORG_CONFIG_PATH");
+        if (orgConfigPath != null) {
+            getLogger().info("Updating org_config");
+            try (Stream<String> lines = Files.lines(Paths.get(orgConfigPath))) {
+                Integer rowsModified = lines
+                    .filter(s -> !s.isEmpty() && !s.startsWith("Candlepin") && !s.startsWith("{"))
+                    .map(this::addOrgToConfig)
+                    .reduce(0, Integer::sum);
+                getLogger().info("Added " + rowsModified + " entries to org_config");
+            }
+            catch (IOException e) {
+                throw new ConfigUpdateException(e);
+            }
+        }
+        else {
+            getLogger().debug("SWATCH_ORG_CONFIG_PATH not defined. org_config will not be updated.");
+        }
+    }
+
+    private int addOrgToConfig(String orgId) {
+        try {
+            return executeUpdate(ORG_CONFIG_SQL, orgId);
+        }
+        catch (DatabaseException | SQLException e) {
+            throw new ConfigUpdateException(e);
+        }
+    }
+
+    @Override
+    public boolean disableAutoCommit() {
+        return false;
+    }
+
+    @Override
+    public Logger getLogger() {
+        return LogService.getLog(LoadConfigsTask.class);
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return "Loading of org/account configs complete";
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/util/LiquibaseUpdateOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/util/LiquibaseUpdateOnly.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bean that exits the application as soon as it's started.
+ *
+ * Intended to be used to get liquibase updates to run without restarting the application.
+ * If running locally, you may need to adjust the port to avoid conflict with a running instance.
+ */
+@Component
+@Profile("liquibase-only")
+public class LiquibaseUpdateOnly implements CommandLineRunner {
+
+    private static Logger log = LoggerFactory.getLogger(LiquibaseUpdateOnly.class);
+
+    private final ApplicationContext context;
+
+    public LiquibaseUpdateOnly(ApplicationContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void run(String... args) {
+        log.info("Running in liquibase update only mode. Exiting.");
+        SpringApplication.exit(context);
+    }
+}

--- a/src/main/resources/liquibase/202004011513-load-org-account-config.xml
+++ b/src/main/resources/liquibase/202004011513-load-org-account-config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202004011513-1" author="khowell" runAlways="true">
+        <comment>Load org_config and account_config tables from config files</comment>
+        <customChange class="org.candlepin.subscriptions.liquibase.LoadConfigsTask"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -22,5 +22,6 @@
     <include file="liquibase/202003021107-make-tally-sla-non-null.xml"/>
     <include file="liquibase/202003261146-add-table-for-account-config.xml"/>
     <include file="liquibase/202003271146-add-table-for-org-config.xml"/>
+    <include file="liquibase/202004011513-load-org-account-config.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
To test using our internal config repo:

```sh
SWATCH_ACCOUNT_CONFIG_PATH=~/rhsm-conduit-deploy/roles/subscriptions/templates/reporting-api-account-whitelist.txt.j2 SWATCH_ORG_CONFIG_PATH=~/rhsm-conduit-deploy/roles/rhsm-conduit/templates/org_sync_list.csv.j2 ./gradlew bootRun '--args=--spring.profiles.active=liquibase-only --server.port=8090'
```