### PR TITLE
Support use of the AccountConfig repository as the account source

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -22,10 +22,12 @@ package org.candlepin.subscriptions;
 
 import org.candlepin.insights.inventory.client.HostsApiFactory;
 import org.candlepin.insights.inventory.client.InventoryServiceProperties;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.files.FileAccountListSource;
+import org.candlepin.subscriptions.files.FileAccountSyncListSource;
 import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
+import org.candlepin.subscriptions.files.ReportingAccountWhitelist;
 import org.candlepin.subscriptions.files.RoleToProductsMapSource;
-import org.candlepin.subscriptions.inventory.db.InventoryRepository;
 import org.candlepin.subscriptions.jackson.ObjectMapperContextResolver;
 import org.candlepin.subscriptions.retention.TallyRetentionPolicy;
 import org.candlepin.subscriptions.tally.AccountListSource;
@@ -119,12 +121,15 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
 
     @Bean
     public AccountListSource accountListSource(ApplicationProperties applicationProperties,
-        InventoryRepository inventoryRepository, ApplicationClock clock) {
+        AccountConfigRepository accountConfigRepository, ApplicationClock clock) {
         if (applicationProperties.getAccountListResourceLocation() != null) {
-            return new FileAccountListSource(applicationProperties, clock);
+            return new FileAccountListSource(
+                new FileAccountSyncListSource(applicationProperties, clock),
+                new ReportingAccountWhitelist(applicationProperties, clock)
+            );
         }
         else {
-            return new DatabaseAccountListSource(inventoryRepository);
+            return new DatabaseAccountListSource(accountConfigRepository);
         }
     }
 

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -27,6 +27,7 @@ import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -44,7 +45,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
         String accountNumber, String productId, Granularity granularity, String serviceLevel,
         OffsetDateTime beginning, OffsetDateTime ending, Pageable pageable);
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     void deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(String accountNumber,
         Granularity granularity, OffsetDateTime cutoffDate);
 

--- a/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
@@ -20,16 +20,73 @@
  */
 package org.candlepin.subscriptions.files;
 
-import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.tally.AccountListSource;
-import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.tally.AccountListSourceException;
+
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import javax.annotation.PostConstruct;
+
 
 /**
- * Reads a set of accounts from a file. Each line is a single account.
+ * An Account list source that uses a file as its source.
  */
-public class FileAccountListSource extends PerLineFileSource implements AccountListSource {
-    public FileAccountListSource(ApplicationProperties applicationProperties, ApplicationClock clock) {
-        super(applicationProperties.getAccountListResourceLocation(), clock.getClock(),
-            applicationProperties.getAccountListCacheTtl());
+public class FileAccountListSource implements AccountListSource, ResourceLoaderAware {
+
+    private FileAccountSyncListSource syncListSource;
+    private ReportingAccountWhitelist reportingAccountWhitelist;
+
+    public FileAccountListSource(FileAccountSyncListSource syncListSource,
+        ReportingAccountWhitelist reportingAccountWhitelist) {
+        this.syncListSource = syncListSource;
+        this.reportingAccountWhitelist = reportingAccountWhitelist;
+    }
+
+    @Override
+    public Stream<String> syncableAccounts() throws AccountListSourceException {
+        try {
+            return syncListSource.list().stream();
+        }
+        catch (IOException ioe) {
+            throw new AccountListSourceException("Unable to get account sync list!", ioe);
+        }
+    }
+
+    @Override
+    public boolean containsReportingAccount(String accountNumber) throws AccountListSourceException {
+        try {
+            return reportingAccountWhitelist.hasAccount(accountNumber);
+        }
+        catch (IOException ioe) {
+            throw new AccountListSourceException("Unable to determine if account was in whitelist.", ioe);
+        }
+    }
+
+    @Override
+    public Stream<String> purgeReportAccounts() throws AccountListSourceException {
+        try {
+            return syncListSource.list().stream();
+        }
+        catch (IOException ioe) {
+            throw new AccountListSourceException("Unable to get account purge list!", ioe);
+        }
+    }
+
+    @PostConstruct
+    public void init() {
+        // @PostConstruct methods will not get called by these objects since
+        // only the managed beans have this invoked.
+        this.syncListSource.init();
+        this.reportingAccountWhitelist.init();
+    }
+
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.syncListSource.setResourceLoader(resourceLoader);
+        this.reportingAccountWhitelist.setResourceLoader(resourceLoader);
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/files/FileAccountSyncListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/FileAccountSyncListSource.java
@@ -20,33 +20,17 @@
  */
 package org.candlepin.subscriptions.files;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
-import org.springframework.core.io.FileSystemResourceLoader;
+/**
+ * Reads a set of accounts to sync from a file. Each line is a single account.
+ */
+public class FileAccountSyncListSource extends PerLineFileSource {
 
-import java.util.List;
-
-
-public class FileAccountListSourceTest {
-
-    @Test
-    public void ensureResourcePathComesFromApplicationProperty() throws Exception {
-        ApplicationProperties props = new ApplicationProperties();
-        props.setAccountListResourceLocation("classpath:account_list.txt");
-
-        FileAccountListSource source = new FileAccountListSource(props, new ApplicationClock());
-        source.setResourceLoader(new FileSystemResourceLoader());
-        source.init();
-
-        List<String> accountList = source.list();
-        assertEquals(3, accountList.size());
-        assertThat(accountList, Matchers.contains("A1", "A2", "A3"));
+    public FileAccountSyncListSource(ApplicationProperties applicationProperties, ApplicationClock clock) {
+        super(applicationProperties.getAccountListResourceLocation(), clock.getClock(),
+            applicationProperties.getAccountListCacheTtl());
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -26,10 +26,8 @@ import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -42,10 +40,6 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
     @Query(nativeQuery = true)
     Stream<InventoryHostFacts> getFacts(@Param("accounts") Collection<String> accounts,
         @Param("culledOffsetDays") Integer culledOffsetDays);
-
-    @Transactional(readOnly = true, transactionManager = "inventoryTransactionManager")
-    @Query("select distinct h.account from InventoryHost h")
-    List<String> listAccounts();
 
     /**
      * Get a mapping of hypervisor ID to associated hypervisor host's subscription-manager ID.

--- a/src/main/java/org/candlepin/subscriptions/jobs/PurgeSnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/PurgeSnapshotsJob.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.jobs;
 
 import org.candlepin.subscriptions.controller.TallyRetentionController;
 import org.candlepin.subscriptions.exception.JobFailureException;
+import org.candlepin.subscriptions.tally.AccountListSourceException;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -29,8 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.quartz.QuartzJobBean;
-
-import java.io.IOException;
 
 /**
  * A quartz job that purges usage snapshots on a configured schedule.
@@ -52,8 +51,8 @@ public class PurgeSnapshotsJob extends QuartzJobBean {
             retentionController.purgeSnapshots();
             log.info("Snapshot purge complete.");
         }
-        catch (IOException e) {
-            throw new JobFailureException("Could not purge snapshots", e);
+        catch (AccountListSourceException e) {
+            throw new JobFailureException("Could not purge snapshots.", e);
         }
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
@@ -20,13 +20,12 @@
  */
 package org.candlepin.subscriptions.security;
 
-import org.candlepin.subscriptions.files.ReportingAccountWhitelist;
 import org.candlepin.subscriptions.security.auth.ReportingAdminOnly;
+import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.tally.AccountListSourceException;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
-
-import java.io.IOException;
 
 /**
  * Provides a means to validate that an authentication token has a whitelisted account associated with it.
@@ -37,15 +36,15 @@ import java.io.IOException;
 @Service("reportAccessService")
 public class WhitelistedAccountReportAccessService {
 
-    private ReportingAccountWhitelist whitelistSource;
+    private AccountListSource accountSource;
 
-    public WhitelistedAccountReportAccessService(ReportingAccountWhitelist whitelistSource) {
-        this.whitelistSource = whitelistSource;
+    public WhitelistedAccountReportAccessService(AccountListSource accountSource) {
+        this.accountSource = accountSource;
     }
 
-    public boolean providesAccessTo(Authentication auth) throws IOException {
+    public boolean providesAccessTo(Authentication auth) throws AccountListSourceException {
         InsightsUserPrincipal principal = (InsightsUserPrincipal) auth.getPrincipal();
-        return whitelistSource.hasAccount(principal.getAccountNumber());
+        return this.accountSource.containsReportingAccount(principal.getAccountNumber());
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountListSource.java
@@ -20,12 +20,33 @@
  */
 package org.candlepin.subscriptions.tally;
 
-import java.io.IOException;
-import java.util.List;
+import java.util.stream.Stream;
 
 /**
- * Provides a list of accounts to run Tally against.
+ * Provides account lists to various components of Tally.
  */
 public interface AccountListSource {
-    List<String> list() throws IOException;
+    /**
+     * Get a stream of accounts that should have their data synced.
+     * @return Stream<String> of accounts that should have their data synced.
+     * @throws AccountListSourceException if there is an error processing the data.
+     */
+    Stream<String> syncableAccounts() throws AccountListSourceException;
+
+    /**
+     * Determines if the specified account number is in the reporting list.
+     *
+     * @param accountNumber the account number to check.
+     * @return true if the account is in the list, false otherwise.
+     */
+    boolean containsReportingAccount(String accountNumber) throws AccountListSourceException;
+
+    /**
+     * Get a stream of accounts that should have their data purged according
+     * to the retention policy. Any account not in this list will not have
+     * their data purged.
+     * @return a stream of accounts that should have its report data purged.
+     * @throws AccountListSourceException
+     */
+    Stream<String> purgeReportAccounts() throws AccountListSourceException;
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountListSourceException.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountListSourceException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+/**
+ * Represents an exception that occurs when something goes wrong
+ * while pulling account lists.
+ */
+public class AccountListSourceException extends Exception {
+
+    public AccountListSourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
@@ -33,8 +33,9 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -84,36 +85,74 @@ public class TaskManager {
      */
     @Transactional
     public void updateSnapshotsForAllAccounts() {
-        final AtomicInteger count = new AtomicInteger();
-        try (Stream<String> accountList = accountListSource.syncableAccounts()) {
-            int accountBatchSize = appProperties.getAccountBatchSize();
+        int accountBatchSize = appProperties.getAccountBatchSize();
+        AccountUpdateQueue updateQueue = new AccountUpdateQueue(queue, accountBatchSize);
+
+        try (Stream<String> accountStream = accountListSource.syncableAccounts()) {
             log.info("Queuing snapshot production in batches of {}.", accountBatchSize);
 
-            accountList
-                .collect(Collectors.groupingBy(a -> count.getAndIncrement() / accountBatchSize))
-                .values()
-                .forEach(accounts -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Queuing snapshot updates for accounts: {}", String.join(",", accounts));
-                    }
+            long count =
+                accountStream.map(account -> {
+                    updateQueue.queue(account);
+                    return 1;
+                }).count();
 
-                    try {
-                        queue.enqueue(
-                            TaskDescriptor
-                            .builder(TaskType.UPDATE_SNAPSHOTS, taskQueueProperties.getTaskGroup())
-                            .setArg("accounts", accounts)
-                            .build()
-                        );
-                    }
-                    catch (Exception e) {
-                        log.error("Could not queue snapshot updates for accounts: {}",
-                            String.join(",", accounts), e);
-                    }
-                });
+            // The final group of accounts might have be less than the batch size
+            // and need to be flushed.
+            if (!updateQueue.isEmpty()) {
+                updateQueue.flush();
+            }
+
             log.info("Done queuing snapshot production for {} accounts.", count);
         }
         catch (AccountListSourceException e) {
             throw new TaskManagerException("Could not list accounts for update snapshot task generation", e);
         }
+    }
+
+    /**
+     * A class that is used to queue up account numbers as they are streamed from the DB
+     * so that they can be sent for updates in the configured batches.
+     */
+    private class AccountUpdateQueue {
+        private int batchSize;
+        private TaskQueue taskQueue;
+        private List<String> queuedAccounts;
+
+        public AccountUpdateQueue(TaskQueue taskQueue, int batchSize) {
+            this.taskQueue = taskQueue;
+            this.batchSize = batchSize;
+            this.queuedAccounts = new LinkedList<>();
+        }
+
+        public void queue(String account) {
+            queuedAccounts.add(account);
+            if (queuedAccounts.size() == batchSize) {
+                flush();
+            }
+        }
+
+        public void flush() {
+            try {
+                taskQueue.enqueue(
+                    TaskDescriptor
+                    .builder(TaskType.UPDATE_SNAPSHOTS, taskQueueProperties.getTaskGroup())
+                    // clone the list so that we can be sure that we don't clear references
+                    // out from under the task queue should delivery be delayed for any reason.
+                    .setArg("accounts", new ArrayList<>(queuedAccounts))
+                    .build()
+                );
+            }
+            catch (Exception e) {
+                log.error("Could not queue snapshot updates for accounts: {}",
+                    String.join(",", queuedAccounts), e);
+            }
+            queuedAccounts.clear();
+        }
+
+        public boolean isEmpty() {
+            return queuedAccounts.isEmpty();
+        }
+
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/controller/TallyRetentionControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/TallyRetentionControllerTest.java
@@ -74,7 +74,7 @@ class TallyRetentionControllerTest {
         when(policy.getCutoffDate(Granularity.DAILY)).thenReturn(cutoff);
 
         List<String> testList = Arrays.asList("1", "2", "3", "4");
-        when(accountListSource.list()).thenReturn(testList);
+        when(accountListSource.purgeReportAccounts()).thenReturn(testList.stream());
 
         controller.purgeSnapshots();
 

--- a/src/test/java/org/candlepin/subscriptions/files/FileAccountSyncListSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/FileAccountSyncListSourceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.files;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.FileSystemResourceLoader;
+
+import java.util.List;
+
+
+public class FileAccountSyncListSourceTest {
+
+    @Test
+    public void ensureResourcePathComesFromApplicationProperty() throws Exception {
+        ApplicationProperties props = new ApplicationProperties();
+        props.setAccountListResourceLocation("classpath:account_list.txt");
+
+        FileAccountSyncListSource source = new FileAccountSyncListSource(props, new ApplicationClock());
+        source.setResourceLoader(new FileSystemResourceLoader());
+        source.init();
+
+        List<String> accountList = source.list();
+        assertEquals(3, accountList.size());
+        assertThat(accountList, Matchers.contains("A1", "A2", "A3"));
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -27,9 +27,10 @@ import static org.mockito.Mockito.when;
 import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
-import org.candlepin.subscriptions.files.ReportingAccountWhitelist;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
+import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReport;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
 
@@ -42,7 +43,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.TestPropertySource;
 
-import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -66,14 +66,14 @@ class CapacityResourceTest {
     PageLinkCreator pageLinkCreator;
 
     @MockBean
-    ReportingAccountWhitelist accountWhitelist;
+    AccountListSource accountListSource;
 
     @Autowired
     CapacityResource resource;
 
     @BeforeEach
-    public void setupTests() throws IOException {
-        when(accountWhitelist.hasAccount(eq("account123456"))).thenReturn(true);
+    public void setupTests() throws AccountListSourceException {
+        when(accountListSource.containsReportingAccount(eq("account123456"))).thenReturn(true);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -29,9 +29,10 @@ import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
-import org.candlepin.subscriptions.files.ReportingAccountWhitelist;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
+import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
 
@@ -68,7 +69,7 @@ public class TallyResourceTest {
     PageLinkCreator pageLinkCreator;
 
     @MockBean
-    ReportingAccountWhitelist accountWhitelist;
+    AccountListSource accountListSource;
 
     @Autowired
     TallyResource resource;
@@ -77,8 +78,8 @@ public class TallyResourceTest {
     private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
 
     @BeforeEach
-    public void setupTests() throws IOException {
-        when(accountWhitelist.hasAccount(eq("account123456"))).thenReturn(true);
+    public void setupTests() throws AccountListSourceException {
+        when(accountListSource.containsReportingAccount(eq("account123456"))).thenReturn(true);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
@@ -90,6 +90,19 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void ensureLastAccountListPartitionIsIncludedWhenSendingTaskMessages() throws Exception {
+        List<String> expectedAccounts = Arrays.asList("a1", "a2", "a3", "a4", "a5");
+        when(accountListSource.syncableAccounts()).thenReturn(expectedAccounts.stream());
+
+        manager.updateSnapshotsForAllAccounts();
+
+        // NOTE: Partition size is defined in test.properties
+        verify(queue, times(1)).enqueue(eq(createDescriptor(Arrays.asList("a1", "a2"))));
+        verify(queue, times(1)).enqueue(eq(createDescriptor(Arrays.asList("a3", "a4"))));
+        verify(queue, times(1)).enqueue(eq(createDescriptor(Arrays.asList("a5"))));
+    }
+
+    @Test
     public void ensureErrorOnUpdateContinuesWithoutFailure() throws Exception {
         List<String> expectedAccounts = Arrays.asList("a1", "a2", "a3", "a4", "a5", "a6");
         when(accountListSource.syncableAccounts()).thenReturn(expectedAccounts.stream());

--- a/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.when;
 
 import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.task.queue.TaskQueue;
 
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -70,7 +70,7 @@ public class TaskManagerTest {
     @Test
     public void ensureUpdateIsRunForEachAccount() throws Exception {
         List<String> expectedAccounts = Arrays.asList("a1", "a2");
-        when(accountListSource.list()).thenReturn(expectedAccounts);
+        when(accountListSource.syncableAccounts()).thenReturn(expectedAccounts.stream());
 
         manager.updateSnapshotsForAllAccounts();
 
@@ -80,7 +80,7 @@ public class TaskManagerTest {
     @Test
     public void ensureAccountListIsPartitionedWhenSendingTaskMessages() throws Exception {
         List<String> expectedAccounts = Arrays.asList("a1", "a2", "a3", "a4");
-        when(accountListSource.list()).thenReturn(expectedAccounts);
+        when(accountListSource.syncableAccounts()).thenReturn(expectedAccounts.stream());
 
         manager.updateSnapshotsForAllAccounts();
 
@@ -92,7 +92,7 @@ public class TaskManagerTest {
     @Test
     public void ensureErrorOnUpdateContinuesWithoutFailure() throws Exception {
         List<String> expectedAccounts = Arrays.asList("a1", "a2", "a3", "a4", "a5", "a6");
-        when(accountListSource.list()).thenReturn(expectedAccounts);
+        when(accountListSource.syncableAccounts()).thenReturn(expectedAccounts.stream());
 
         doThrow(new RuntimeException("Forced!"))
             .when(queue).enqueue(eq(createDescriptor(Arrays.asList("a3", "a4"))));
@@ -107,7 +107,8 @@ public class TaskManagerTest {
 
     @Test
     public void ensureNoUpdatesWhenAccountListCanNotBeRetreived() throws Exception {
-        doThrow(new IOException("Forced!")).when(accountListSource).list();
+        doThrow(new AccountListSourceException("Forced!", new RuntimeException()))
+            .when(accountListSource).syncableAccounts();
 
         assertThrows(TaskManagerException.class, () -> {
             manager.updateSnapshotsForAllAccounts();


### PR DESCRIPTION
* AccountListSource now general interface for account lists
* File based account list source now combines sync list and
  reporting whitelist file sources.

To enable this  functionality, do not include the **_rhsm-subscriptions.accountListResourceLocation_** property in the config file. Otherwise the account sync list and the reporting sync list will be required as files.

You can manually add/update entries to the DB table (account_confg) to play with this feature.

```sql
insert into account_config (account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated) values ('123456, TRUE, TRUE, 'DB', '2020-04-02 10:04:21.763-03', '2020-04-02 10:04:21.763-03');
```