### PR TITLE
Add a custom filter to prevent CSRF

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -110,6 +110,20 @@ public class ApplicationProperties {
      */
     private int cullingOffsetDays = 14;
 
+    /**
+     * Expected domain suffix for origin or referer headers.
+     *
+     * @see org.candlepin.subscriptions.security.AntiCsrfFilter
+     */
+    private String antiCsrfDomainSuffix = ".redhat.com";
+
+    /**
+     * Expected port for origin or referer headers.
+     *
+     * @see org.candlepin.subscriptions.security.AntiCsrfFilter
+     */
+    private int antiCsrfPort = 443;
+
     public boolean isPrettyPrintJson() {
         return prettyPrintJson;
     }
@@ -232,5 +246,21 @@ public class ApplicationProperties {
 
     public void setCullingOffsetDays(int cullingOffsetDays) {
         this.cullingOffsetDays = cullingOffsetDays;
+    }
+
+    public String getAntiCsrfDomainSuffix() {
+        return antiCsrfDomainSuffix;
+    }
+
+    public void setAntiCsrfDomainSuffix(String antiCsrfDomainSuffix) {
+        this.antiCsrfDomainSuffix = antiCsrfDomainSuffix;
+    }
+
+    public int getAntiCsrfPort() {
+        return antiCsrfPort;
+    }
+
+    public void setAntiCsrfPort(int antiCsrfPort) {
+        this.antiCsrfPort = antiCsrfPort;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/security/AntiCsrfFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/AntiCsrfFilter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.security;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Filter that prevents CSRF by verifying for a valid Origin or Referer header.
+ */
+@Component
+@Order(1)
+public class AntiCsrfFilter extends OncePerRequestFilter {
+
+    private static final List<String> MODIFYING_METHODS = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
+    private static Logger log = LoggerFactory.getLogger(AntiCsrfFilter.class);
+
+    private final boolean disabled;
+
+    AntiCsrfFilter(ApplicationProperties props, ConfigurableEnvironment env) {
+        disabled = props.isDevMode() || Arrays.asList(env.getActiveProfiles()).contains("capacity-ingress");
+        if (disabled) {
+            log.info("Origin & Referer checking (anti-csrf) disabled.");
+        }
+        else {
+            log.info("Origin & Referer checking (anti-csrf) enabled.");
+        }
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        /* origin comes first as it is much faster to parse when present */
+        if (disabled || requestTypeOkay(request) || originMatches(request) || refererMatches(request)) {
+            filterChain.doFilter(request, response);
+        }
+        else {
+            response.sendError(403, "Origin & Referer both bad. Cross origin requests not allowed.");
+        }
+    }
+
+    private boolean requestTypeOkay(HttpServletRequest request) {
+        return !MODIFYING_METHODS.contains(request.getMethod());
+    }
+
+    private boolean refererMatches(HttpServletRequest request) {
+        String referer = request.getHeader("referer");
+        if (referer == null) {
+            return false;
+        }
+        URI uri = URI.create(referer);
+        return uri.getHost().endsWith(".redhat.com") && (uri.getPort() == -1 || uri.getPort() == 443);
+    }
+
+    private boolean originMatches(HttpServletRequest request) {
+        String origin = request.getHeader("origin");
+        return origin != null && (origin.endsWith(".redhat.com") || origin.endsWith(".redhat.com:443"));
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -41,8 +41,6 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesUserDetailsService;
 
-import java.util.Arrays;
-
 /**
  * Configuration class for Spring Security
  */
@@ -123,6 +121,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
             .addFilter(identityHeaderAuthenticationFilter(appProps))
             .authenticationProvider(preAuthenticatedAuthenticationProvider())
+            .csrf().disable()
             .exceptionHandling()
                 .accessDeniedHandler(restAccessDeniedHandler())
                 .authenticationEntryPoint(restAuthenticationEntryPoint())
@@ -136,16 +135,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 // ingress security is done via server settings (require ssl cert auth), so permit all here
                 .antMatchers(String.format("/%s/ingress/**", apiPath)).permitAll()
                 .anyRequest().authenticated();
-        if (appProps.isDevMode() || Arrays.asList(env.getActiveProfiles()).contains("capacity-ingress")) {
-            disableCSRF(http);
-        }
     }
-
-    @SuppressWarnings("squid:S4502")
-    private void disableCSRF(HttpSecurity http) throws Exception {
-        // CSRF isn't helpful for the machine-to-machine ingress endpoint
-        http.csrf().disable();
-    }
-
 
 }


### PR DESCRIPTION
Testing is a little bit complex. Locally I did this:

1. Add an entry to `/etc/hosts`: `127.0.0.1 testcloud.redhat.com`
2. Install nginx (dnf installable), and create a config file that looks
   like this (as test.conf):

```nginx
events {
  worker_connections 1024;
}

http {
  server {
    listen 443;
    location / {
      proxy_pass http://localhost:8080;
    }
  }
}
```

3. Run nginx: `sudo nginx -c $(pwd)/test.conf`
4. Run the service with profile api:

```sh
./gradlew bootRun --args=--spring.profiles.active=api
```

5. Note that you can't PUT without a valid Origin or Referer (e.g.):

```sh
curl -H "Origin: cloud.redhat.com" -X PUT "http://testcloud.redhat.com:443/api/rhsm-subscriptions/v1/opt-in" -H  "accept: application/vnd.api+json" -H  "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
```

vs.

```sh
curl -X PUT "http://testcloud.redhat.com:443/api/rhsm-subscriptions/v1/opt-in" -H  "accept: application/vnd.api+json" -H  "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
```

6. Stop nginx: `sudo nginx -s quit`