### PR TITLE
Add RBAC client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,7 @@ dependencies {
 
     compile project(":api")
     compile project(":insights-inventory-client")
+    compile project(":rbac-client")
     compile project(":kafka-schema")
 
     // This starter pulls in Spring Boot versions that we don't want.  The actual classes that we need are
@@ -286,6 +287,15 @@ project(":insights-inventory-client") {
     }
 }
 
+project(":rbac-client") {
+    apply plugin: "org.openapi.generator"
+
+    ext {
+        api_spec_path = "https://raw.githubusercontent.com/RedHatInsights/insights-rbac/stable/docs/source/specs/openapi.json"
+        config_file = "${projectDir}/rbac-client-config.json"
+    }
+}
+
 project(":cloudigrade-client") {
     apply plugin: "org.openapi.generator"
 
@@ -295,7 +305,7 @@ project(":cloudigrade-client") {
     }
 }
 
-configure(subprojects.findAll { it.name == "insights-inventory-client" || it.name == "cloudigrade-client"}) {
+configure(subprojects.findAll { it.name == "insights-inventory-client" || it.name == "cloudigrade-client" || it.name == 'rbac-client'}) {
     apply plugin: "org.openapi.generator"
     apply plugin: "checkstyle"
 

--- a/rbac-client/rbac-client-config.json
+++ b/rbac-client/rbac-client-config.json
@@ -1,0 +1,8 @@
+{
+  "modelPackage": "org.candlepin.insights.rbac.client.model",
+  "apiPackage": "org.candlepin.insights.rbac.client.resources",
+  "invokerPackage": "org.candlepin.insights.rbac.client",
+  "groupId": "org.candlepin",
+  "artifactId": "rbac-client",
+  "java8": true
+}

--- a/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacApi.java
+++ b/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacApi.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.rbac.client;
+
+import org.candlepin.insights.rbac.client.model.Access;
+
+import java.util.List;
+
+/**
+ * Defines wrapper functions around all RBAC API calls that we want to make.
+ */
+public interface RbacApi {
+
+    List<Access> getCurrentUserAccess(String applicationName) throws RbacApiException;
+
+}

--- a/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacApiException.java
+++ b/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacApiException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.rbac.client;
+
+/**
+ * Thrown when an error occurs making an RBAC API call.
+ */
+public class RbacApiException extends Exception {
+
+    public RbacApiException(String message, Throwable t) {
+        super(message, t);
+    }
+}

--- a/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacApiImpl.java
+++ b/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacApiImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.rbac.client;
+
+import org.candlepin.insights.rbac.client.model.Access;
+import org.candlepin.insights.rbac.client.resources.AccessApi;
+
+import java.util.List;
+
+/**
+ * A wrapper around the RBAC API.
+ */
+public class RbacApiImpl implements RbacApi {
+
+    private AccessApi accessApi;
+
+    public RbacApiImpl(ApiClient client) {
+        accessApi = new AccessApi(client);
+    }
+
+    @Override
+    public List<Access> getCurrentUserAccess(String applicationName) throws RbacApiException {
+        try {
+            return accessApi.getPrincipalAccess(applicationName, null, null, null).getData();
+        }
+        catch (ApiException apie) {
+            throw new RbacApiException("Unable to get current user access.", apie);
+        }
+    }
+}

--- a/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacServiceProperties.java
+++ b/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacServiceProperties.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.rbac.client;
+
+/**
+ * Sub-class for RBAC service properties
+ */
+public class RbacServiceProperties {
+
+    /**
+     * Use the stub RBAC API implementation.
+     */
+    private boolean useStub;
+
+    /**
+     * The URL of the RBAC API.
+     */
+    private String url;
+
+    /**
+     * The RBAC application name that defines the permissions for this application.
+     */
+    private String applicationName = "subscriptions";
+
+    public boolean isUseStub() {
+        return useStub;
+    }
+
+    public void setUseStub(boolean useStub) {
+        this.useStub = useStub;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+}

--- a/rbac-client/src/main/java/org/candlepin/insights/rbac/client/StubRbacApi.java
+++ b/rbac-client/src/main/java/org/candlepin/insights/rbac/client/StubRbacApi.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.rbac.client;
+
+import org.candlepin.insights.rbac.client.model.Access;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Stub implementation of the RbacApi.
+ */
+public class StubRbacApi implements RbacApi {
+
+    @Override
+    public List<Access> getCurrentUserAccess(String applicationName) throws RbacApiException {
+        return Arrays.asList(new Access().permission("subscriptions:*.*"));
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'rhsm-subscriptions'
-include ':api', ':insights-inventory-client', ':cloudigrade-client', 'kafka-schema'
+include ':api', ':insights-inventory-client', ':cloudigrade-client', 'kafka-schema', ':rbac-client'

--- a/src/main/java/org/candlepin/rbac/RBACApiClient.java
+++ b/src/main/java/org/candlepin/rbac/RBACApiClient.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.rbac;
+
+import org.candlepin.insights.rbac.client.ApiClient;
+import org.candlepin.insights.rbac.client.ApiException;
+import org.candlepin.insights.rbac.client.Pair;
+import org.candlepin.subscriptions.resource.ResourceUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.GenericType;
+
+/**
+ * An extension of the generated RBAC ApiClient that ensures that the appropriate
+ * identity header is appended to each request.
+ */
+public class RBACApiClient extends ApiClient {
+
+    @Override
+    public <T> T invokeAPI(
+        String path,
+        String method,
+        List<Pair> queryParams,
+        Object body,
+        Map<String, String> headerParams,
+        Map<String, Object> formParams,
+        String accept,
+        String contentType,
+        String[] authNames,
+        GenericType<T> returnType) throws ApiException {
+
+        String idHeader = ResourceUtils.getIdentityHeader();
+        if (idHeader == null || idHeader.isEmpty()) {
+            throw new BadRequestException("Missing identity header while accessing RBAC service.");
+        }
+
+        headerParams.put("x-rh-identity", idHeader);
+
+        return super.invokeAPI(path, method, queryParams, body, headerParams, formParams, accept,
+            contentType, authNames, returnType);
+    }
+
+}

--- a/src/main/java/org/candlepin/rbac/RbacApiFactory.java
+++ b/src/main/java/org/candlepin/rbac/RbacApiFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.rbac;
+
+import org.candlepin.insights.rbac.client.ApiClient;
+import org.candlepin.insights.rbac.client.RbacApi;
+import org.candlepin.insights.rbac.client.RbacApiImpl;
+import org.candlepin.insights.rbac.client.RbacServiceProperties;
+import org.candlepin.insights.rbac.client.StubRbacApi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Factory that produces inventory service clients using configuration. An
+ * AuthApiClient is used to ensure that the identity header is passed on
+ * with any request to the RBAC API.
+ */
+public class RbacApiFactory implements FactoryBean<RbacApi> {
+
+    private static Logger log = LoggerFactory.getLogger(RbacApiFactory.class);
+
+    private final RbacServiceProperties serviceProperties;
+
+    public RbacApiFactory(RbacServiceProperties serviceProperties) {
+        this.serviceProperties = serviceProperties;
+    }
+
+    @Override
+    public RbacApi getObject() throws Exception {
+        if (serviceProperties.isUseStub()) {
+            log.info("Using stub RBAC client");
+            return new StubRbacApi();
+        }
+        ApiClient apiClient = new RBACApiClient();
+        if (serviceProperties.getUrl() != null) {
+            log.info("RBAC service URL: {}", serviceProperties.getUrl());
+            apiClient.setBasePath(serviceProperties.getUrl());
+        }
+        else {
+            log.warn("RBAC service URL not set...");
+        }
+
+        return new RbacApiImpl(apiClient);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return RbacApi.class;
+    }
+
+}

--- a/src/main/java/org/candlepin/rbac/RbacApiFactory.java
+++ b/src/main/java/org/candlepin/rbac/RbacApiFactory.java
@@ -26,9 +26,19 @@ import org.candlepin.insights.rbac.client.RbacApiImpl;
 import org.candlepin.insights.rbac.client.RbacServiceProperties;
 import org.candlepin.insights.rbac.client.StubRbacApi;
 
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.factory.ApacheHttpClient4EngineFactory;
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.FactoryBean;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 
 /**
  * Factory that produces inventory service clients using configuration. An
@@ -52,6 +62,7 @@ public class RbacApiFactory implements FactoryBean<RbacApi> {
             return new StubRbacApi();
         }
         ApiClient apiClient = new RBACApiClient();
+        apiClient.setHttpClient(buildHttpClient(apiClient));
         if (serviceProperties.getUrl() != null) {
             log.info("RBAC service URL: {}", serviceProperties.getUrl());
             apiClient.setBasePath(serviceProperties.getUrl());
@@ -61,6 +72,33 @@ public class RbacApiFactory implements FactoryBean<RbacApi> {
         }
 
         return new RbacApiImpl(apiClient);
+    }
+
+    /**
+     * Customize the creation of the HTTP client the API will be using.
+     *
+     * @param client the associated ApiClient instance
+     * @return a new Http client instance.
+     */
+    private Client buildHttpClient(ApiClient client) {
+        HttpClientBuilder apacheBuilder = HttpClientBuilder.create();
+
+        // Bump the max connections so that we don't block on multiple async requests
+        // to the RBAC service.
+        apacheBuilder.setMaxConnPerRoute(Integer.MAX_VALUE);
+        apacheBuilder.setMaxConnTotal(Integer.MAX_VALUE);
+        HttpClient httpClient = apacheBuilder.build();
+
+        ClientHttpEngine engine = ApacheHttpClient4EngineFactory.create(httpClient);
+
+        ClientConfiguration clientConfig = new ClientConfiguration(ResteasyProviderFactory.getInstance());
+        clientConfig.register(client.getJSON());
+        if (client.isDebugging()) {
+            clientConfig.register(org.jboss.logging.Logger.class);
+        }
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder().withConfig(clientConfig);
+
+        return ((ResteasyClientBuilder) clientBuilder).httpEngine(engine).build();
     }
 
     @Override

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -22,6 +22,8 @@ package org.candlepin.subscriptions;
 
 import org.candlepin.insights.inventory.client.HostsApiFactory;
 import org.candlepin.insights.inventory.client.InventoryServiceProperties;
+import org.candlepin.insights.rbac.client.RbacServiceProperties;
+import org.candlepin.rbac.RbacApiFactory;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.files.FileAccountListSource;
 import org.candlepin.subscriptions.files.FileAccountSyncListSource;
@@ -95,6 +97,17 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     @Bean
     public HostsApiFactory hostsApiFactory(InventoryServiceProperties properties) {
         return new HostsApiFactory(properties);
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "rhsm-subscriptions.rbac-service")
+    public RbacServiceProperties rbacServiceProperties() {
+        return new RbacServiceProperties();
+    }
+
+    @Bean
+    public RbacApiFactory rbacApiFactory(RbacServiceProperties props) {
+        return new RbacApiFactory(props);
     }
 
     /**

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -22,13 +22,17 @@ package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter;
 import org.candlepin.subscriptions.security.InsightsUserPrincipal;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Response;
 
@@ -63,6 +67,18 @@ public class ResourceUtils {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         InsightsUserPrincipal principal = (InsightsUserPrincipal) auth.getPrincipal();
         return principal.getAccountNumber();
+    }
+
+    /**
+     * Gets the identity header passed when the request was made. Useful
+     * when it has to be forwarded to other APIs.
+     *
+     * @return the encoded identity header.
+     */
+    public static String getIdentityHeader() {
+        HttpServletRequest request =
+            ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+        return request.getHeader(IdentityHeaderAuthenticationFilter.RH_IDENTITY_HEADER);
     }
 
     /**

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
@@ -107,8 +107,11 @@ public class IdentityHeaderAuthenticationManager implements AuthenticationManage
                     " contains no principal");
             }
 
-            token = new PreAuthenticatedAuthenticationToken(new InsightsUserPrincipal(orgId, accountNumber),
-                token.getCredentials(), details.getGrantedAuthorities());
+            token = new PreAuthenticatedAuthenticationToken(
+                new InsightsUserPrincipal(orgId, accountNumber),
+                token.getCredentials(),
+                details.getGrantedAuthorities()
+            );
             token.setAuthenticated(true);
             return token;
 

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -63,3 +63,9 @@ spring.kafka.consumer.properties.max.poll.interval.ms=1800000
 
 #spring.kafka.properties.schema.registry.url=http://localhost:8081
 #spring.kafka.properties.auto.register.schemas=false
+
+###################################
+# RBAC Configuration
+###################################
+#rhsm-subscriptions.rbac-service.useStub=true
+#rhsm-subscriptions.rbac-service.url=http://localhost:8819/api/rbac/v1

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockInsightsUserSecurityContextFactory.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockInsightsUserSecurityContextFactory.java
@@ -53,4 +53,5 @@ public class WithMockInsightsUserSecurityContextFactory implements
 
         return context;
     }
+
 }


### PR DESCRIPTION
This PR adds the RBAC generated API to the project.

* There are multiple API resources generated from the service's openapi spec,
  so a single RbacApi interface was introduced to define the cumulative
  operations that we will be using in rhsm-subscriptions. The default
  implementation instantiates any instances of the generated RBAC API
  objects that are required using the same ApiClient.
* The generated client is extended in order to pass the identity
  header along with every request.
* The IdentityHeaderAuthenticationManager now puts the header bytes
  into the InsightsUserPrincipal so that it can be recalled by any
  client that requires it.

**Testing**
I used the debug pod to gain access to the RBAC API on rhsm-ci and forwarded the port locally to test against a local deployment of rhsm-subscriptions. Since no code is currently using the client, I added some code to the VersionResource to allow me to test that the application can access the API. Here's what I did.

```bash
# Check out the debug pod code and deploy
swatch-debug-pod $ ./tunnel.sh

job.batch/debug-pod created
Forwarding port. Use ctrl+c when done.
Forwarding from 127.0.0.1:2222 -> 2222
Forwarding from [::1]:2222 -> 2222
Handling connection for 2222
```

```bash
# Forward the port using ssh
$ ssh shadowman@localhost -p 2222 -L 8819:rbac.rbac-ci.svc.cluster.local:8080
```

```bash
# Make sure that you can access the service locally
# NOTE: I'm using 'insights' in the API because the 'subscriptions' application in RBAC does not exist yet.
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiI2MzQwMDU2IiwiYXV0aF90aW1lIjowfSwiYWNjb3VudF9udW1iZXIiOiIxNDYwMjkwIiwiYXV0aF90eXBlIjoiYmFzaWMtYXV0aCIsInVzZXIiOnsiZmlyc3RfbmFtZSI6IktldmluIiwibGFzdF9uYW1lIjoiSG93ZWxsIiwiaXNfaW50ZXJuYWwiOnRydWUsImlzX2FjdGl2ZSI6dHJ1ZSwibG9jYWxlIjoiZW5fVVMiLCJpc19vcmdfYWRtaW4iOmZhbHNlLCJ1c2VybmFtZSI6Imtob3dlbGxAcmVkaGF0LmNvbSIsImVtYWlsIjoia2hvd2VsbCtxYUByZWRoYXQuY29tIn0sInR5cGUiOiJVc2VyIn0sImVudGl0bGVtZW50cyI6eyJpbnNpZ2h0cyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImNvc3RfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzZXR0aW5ncyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sIm9wZW5zaGlmdCI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sInNtYXJ0X21hbmFnZW1lbnQiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzdWJzY3JpcHRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX19fQ==" "http://localhost:8819/api/rbac/v1/access/?application=insights" 

{"meta":{"count":1,"limit":1000,"offset":0},"links":{"first":"/api/rbac/v1/access/?application=insights&limit=1000&offset=0","next":null,"previous":null,"last":"/api/rbac/v1/access/?application=insights&limit=1000&offset=0"},"data":[{"permission":"insights:*:*","resourceDefinitions":[]}]}
```
Replace the VersionResource.java code with the following.
```
/*
 * Copyright (c) 2009 - 2019 Red Hat, Inc.
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 *
 * Red Hat trademarks are not licensed under GPLv3. No permission is
 * granted to use or replicate Red Hat trademarks that are incorporated
 * in this software or its documentation.
 */

package org.candlepin.subscriptions.resource;

import org.candlepin.insights.rbac.client.RbacApi;
import org.candlepin.insights.rbac.client.RbacApiException;
import org.candlepin.insights.rbac.client.model.Access;
import org.candlepin.subscriptions.exception.inventory.InventoryServiceRequestException;
import org.candlepin.subscriptions.utilization.api.model.VersionInfo;
import org.candlepin.subscriptions.utilization.api.model.VersionInfoBuild;
import org.candlepin.subscriptions.utilization.api.resources.VersionApi;

import org.slf4j.Logger;
import org.slf4j.LoggerFactory;
import org.springframework.boot.info.BuildProperties;
import org.springframework.stereotype.Component;

import javax.ws.rs.BadRequestException;
import java.util.List;

/**
 * Return the version information for the application
 */
@Component
public class VersionResource implements VersionApi {
    private static Logger log = LoggerFactory.getLogger(VersionResource.class);

    private final BuildProperties buildProperties;
    private final RbacApi rbacApi;

    public VersionResource(BuildProperties buildProperties, RbacApi rbacApi) {
        this.buildProperties = buildProperties;
        this.rbacApi = rbacApi;
    }

    @Override
    public VersionInfo getVersion() {
        try {
            List<Access> accessList = rbacApi.getCurrentUserAccess("insights");
            for (Access access : accessList) {
                log.info("ACCESS: {}", access.toString());
            }
        }
        catch (RbacApiException e) {
            throw new InventoryServiceRequestException("Could not find user access!", e);
        }
        
        VersionInfoBuild versionInfoBuild = new VersionInfoBuild();
        versionInfoBuild.setVersion(buildProperties.getVersion());
        versionInfoBuild.setArtifact(buildProperties.getArtifact());
        versionInfoBuild.setName(buildProperties.getName());
        versionInfoBuild.setGroup(buildProperties.getGroup());

        versionInfoBuild.setGitDescription(buildProperties.get("gitDescription"));
        versionInfoBuild.setGitHash(buildProperties.get("gitHash"));

        VersionInfo versionInfo = new VersionInfo();
        versionInfo.setBuild(versionInfoBuild);
        return versionInfo;
    }
}
```

Set up the following configuration properties in the rhsm-subscriptions.properties file.
```properties
rhsm-subscriptions.rbac-service.url=http://localhost:8819/api/rbac/v1
```

Deploy rhsm-subscriptions and curl the version endpoint with an appropriate header. You'll see the version information if everything goes Ok, BUT notice in the logs that the permissions for 'insights' will be printed; insights:*.*
```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiI2MzQwMDU2IiwiYXV0aF90aW1lIjowfSwiYWNjb3VudF9udW1iZXIiOiIxNDYwMjkwIiwiYXV0aF90eXBlIjoiYmFzaWMtYXV0aCIsInVzZXIiOnsiZmlyc3RfbmFtZSI6IktldmluIiwibGFzdF9uYW1lIjoiSG93ZWxsIiwiaXNfaW50ZXJuYWwiOnRydWUsImlzX2FjdGl2ZSI6dHJ1ZSwibG9jYWxlIjoiZW5fVVMiLCJpc19vcmdfYWRtaW4iOmZhbHNlLCJ1c2VybmFtZSI6Imtob3dlbGxAcmVkaGF0LmNvbSIsImVtYWlsIjoia2hvd2VsbCtxYUByZWRoYXQuY29tIn0sInR5cGUiOiJVc2VyIn0sImVudGl0bGVtZW50cyI6eyJpbnNpZ2h0cyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImNvc3RfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzZXR0aW5ncyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sIm9wZW5zaGlmdCI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sInNtYXJ0X21hbmFnZW1lbnQiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzdWJzY3JpcHRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/version" | python -mjson.tool
```