### PR TITLE
Add configuration setting to disable org admin checks.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -38,7 +38,6 @@ import org.candlepin.subscriptions.util.ApplicationClock;
 import org.jboss.resteasy.springboot.ResteasyAutoConfiguration;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -65,7 +64,6 @@ import javax.validation.Validator;
 @Configuration
 @Import(ResteasyAutoConfiguration.class) // needed to be able to reference ResteasyApplicationBuilder
 @EnableRetry
-@EnableConfigurationProperties(ApplicationProperties.class)
 @EnableAspectJAutoProxy
 // The values in application.yaml should already be loaded by default
 @PropertySource("classpath:/rhsm-subscriptions.properties")

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -23,18 +23,36 @@ package org.candlepin.subscriptions;
 import org.candlepin.subscriptions.retention.TallyRetentionPolicyProperties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 
 /**
  * POJO to hold property values via Spring's "Type-Safe Configuration Properties" pattern
+ *
+ * NB: This class must be labeled as a component, not loaded via the EnableConfigurationProperties annotation.
+ * Loading this class as a component gives the bean a formal name.  Using EnableConfigurationProperties
+ * uses a generated name with a hyphen in it.  From the Spring Boot Docs (section 4.2.8 Type-safe
+ * Configuration):
+ *
+ *     When the @ConfigurationProperties bean is registered using configuration property scanning or via
+ *     @EnableConfigurationProperties, the bean has a conventional name: <prefix>-<fqn>, where <prefix> is
+ *     the environment key prefix specified in the @ConfigurationProperties annotation and <fqn> is the fully
+ *     qualified name of the bean. If the annotation does not provide any prefix, only the fully qualified
+ *     name of the bean is used.
+ *
+ * Unfortunately, "<prefix>-<fqn>" has a hyphen in it which means we can't use the bean name in a SpEL
+ * expression: the hyphen is interpreted as a subtraction operator.
  */
+@Component
 @ConfigurationProperties(prefix = "rhsm-subscriptions")
 public class ApplicationProperties {
 
     private boolean prettyPrintJson = false;
 
     private boolean devMode = false;
+
+    private boolean orgAdminRequired = false;
 
     private final TallyRetentionPolicyProperties tallyRetentionPolicy = new TallyRetentionPolicyProperties();
 
@@ -262,5 +280,17 @@ public class ApplicationProperties {
 
     public void setAntiCsrfPort(int antiCsrfPort) {
         this.antiCsrfPort = antiCsrfPort;
+    }
+
+    public boolean isOrgAdminRequired() {
+        return orgAdminRequired;
+    }
+
+    public boolean isOrgAdminOptional() {
+        return !orgAdminRequired;
+    }
+
+    public void setOrgAdminRequired(boolean orgAdminRequired) {
+        this.orgAdminRequired = orgAdminRequired;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/security/auth/AdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/AdminOnly.java
@@ -35,6 +35,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "')")
+@PreAuthorize("@applicationProperties.isOrgAdminOptional() or " +
+    "hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "')")
 public @interface AdminOnly {
 }

--- a/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAdminOnly.java
@@ -35,7 +35,8 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "') and " +
+@PreAuthorize("@applicationProperties.isOrgAdminOptional() or " +
+    "hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "') and " +
     "@reportAccessService.providesAccessTo(authentication)")
 public @interface ReportingAdminOnly {
 }

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -32,6 +32,7 @@ rhsm-subscriptions.quartz.datasource.platform=hsqldb
 
 rhsm-subscriptions.enableIngressEndpoint=false
 
+rhsm-subscriptions.orgAdminRequired=true
 
 ##########################
 # kafka configuration


### PR DESCRIPTION
TODO: I want to add some unit tests but those are taking me a little bit to figure out with our custom security stuff.   I'll add them in a separate commit if necessary. 

Also note that `orgAdminRequired` is `false` by default in `ApplicationProperties` but `true` in `rhsm-subscriptions.properties`.  Since our deployment uses its own version of `rhsm-subscriptions.properties` this set up allows tests and developer deployment to continue to work normally.

# Testing

### With `org-admin-required` off
* In `config/application.properties` set 
  ```
  rhsm-subscriptions.dev-mode=false
  rhsm-subscriptions.org-admin-required=false
  ```
* Start the application
* Run tests against the GET for tally (ReportingAdminOnly) and the opt-in resource (AdminOnly).  Note I run my application on port 9166; you may need to adjust or just start with `--server.port=9166`
  ```
  $ curl -v -H "x-rh-identity: $(echo '{"identity":{"account_number":"123", "user":{"is_org_admin":false}, "internal": {"org_id": "myOrg"}}}}' | base64 -w0 -)" "http://localhost:9166/api/rhsm-subscriptions/v1/tally/products/123?granularity=DAILY&beginning=2017-07-21T17:30:30Z&ending=2018-07-27T17:30:00Z"
  $ curl -v -H "x-rh-identity: $(echo '{"identity":{"account_number":"123", "user":{"is_org_admin":false}, "internal": {"org_id": "myOrg"}}}}' | base64 -w0 -)" "http://localhost:9166/api/rhsm-subscriptions/v1/opt-in"
  $ curl -v -H "x-rh-identity: $(echo '{"identity":{"account_number":"123", "user":{"is_org_admin":true}, "internal": {"org_id": "myOrg"}}}}' | base64 -w0 -)" "http://localhost:9166/api/rhsm-subscriptions/v1/tally/products/123?granularity=DAILY&beginning=2017-07-21T17:30:30Z&ending=2018-07-27T17:30:00Z"
  $ curl -v -H "x-rh-identity: $(echo '{"identity":{"account_number":"123", "user":{"is_org_admin":true}, "internal": {"org_id": "myOrg"}}}}' | base64 -w0 -)" "http://localhost:9166/api/rhsm-subscriptions/v1/opt-in"
  ```
All the above calls should succeed.

### With `org-admin-required` on

* In `config/application.properties` set 
  ```
  rhsm-subscriptions.dev-mode=false
  rhsm-subscriptions.org-admin-required=true
  ```
* The below call to the OptInResource should succeed:
  ```
  $ curl -v -H "x-rh-identity: $(echo '{"identity":{"account_number":"123", "user":{"is_org_admin":true}, "internal": {"org_id": "myOrg"}}}}' | base64 -w0 -)" "http://localhost:9166/api/rhsm-subscriptions/v1/opt-in"
  ```
* The same request to OptInResource with `is_org_admin` set to false should fail.
* The below calls to the TallyResource should *both* fail since account 123 is not whitelisted

  ```
  $ curl -v -H "x-rh-identity: $(echo '{"identity":{"account_number":"123", "user":{"is_org_admin":false}, "internal": {"org_id": "myOrg"}}}}' | base64 -w0 -)" "http://localhost:9166/api/rhsm-subscriptions/v1/tally/products/123?granularity=DAILY&beginning=2017-07-21T17:30:30Z&ending=2018-07-27T17:30:00Z
  $ curl -v -H "x-rh-identity: $(echo '{"identity":{"account_number":"123", "user":{"is_org_admin":true}, "internal": {"org_id": "myOrg"}}}}' | base64 -w0 -)" "http://localhost:9166/api/rhsm-subscriptions/v1/tally/products/123?granularity=DAILY&beginning=2017-07-21T17:30:30Z&ending=2018-07-27T17:30:00Z
  ```
* Add account 123 to the whitelist you have set for the `rhsm-subscriptions.reportingAccountWhitelistResourceLocation` in `config/properties`.  Now the call with `is_org_admin` set to false should fail and the one with `is_org_admin` set to true should pass.  A call with `is_org_admin` set to true and a different , non-whitelisted account number should fail.