### PR TITLE
1824308: Handle Satellite hypervisor mappings

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -55,6 +55,14 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
                 "from hosts h " +
                     "left outer join hosts h_ on h.facts->'rhsm'->>'VM_HOST_UUID' = h_.canonical_facts->>'subscription_manager_id' " +
                 "where h.facts->'rhsm'->'VM_HOST_UUID' is not null " +
+                    "and h.account IN (:accounts)" +
+                "union all " +
+                "select " +
+                    "distinct h.facts->'satellite'->>'virtual_host_uuid' as hyp_id, " +
+                    "h_.canonical_facts->>'subscription_manager_id' as hyp_subman_id " +
+                "from hosts h " +
+                    "left outer join hosts h_ on h.facts->'satellite'->>'virtual_host_uuid' = h_.canonical_facts->>'subscription_manager_id' " +
+                "where h.facts->'satellite'->'virtual_host_uuid' is not null " +
                     "and h.account IN (:accounts)")
     Stream<Object[]> getReportedHypervisors(@Param("accounts") Collection<String> accounts);
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -64,6 +64,7 @@ import javax.persistence.Table;
                 @ColumnResult(name = "syspurpose_units"),
                 @ColumnResult(name = "is_virtual"),
                 @ColumnResult(name = "hypervisor_uuid"),
+                @ColumnResult(name = "satellite_hypervisor_uuid"),
                 @ColumnResult(name = "guest_id"),
                 @ColumnResult(name = "subscription_manager_id"),
                 @ColumnResult(name = "cloud_provider"),
@@ -83,6 +84,7 @@ import javax.persistence.Table;
         "h.facts->'rhsm'->>'CPU_SOCKETS' as sockets, " +
         "h.facts->'rhsm'->>'IS_VIRTUAL' as is_virtual, " +
         "h.facts->'rhsm'->>'VM_HOST_UUID' as hypervisor_uuid, " +
+        "h.facts->'satellite'->>'virtual_host_uuid' as satellite_hypervisor_uuid, " +
         "h.facts->'rhsm'->>'GUEST_ID' as guest_id, " +
         "h.facts->'rhsm'->>'SYNC_TIMESTAMP' as sync_timestamp, " +
         "h.facts->'rhsm'->>'SYSPURPOSE_ROLE' as syspurpose_role, " +

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -42,6 +42,7 @@ public class InventoryHostFacts {
     private Integer systemProfileSockets;
     private boolean isVirtual;
     private String hypervisorUuid;
+    private String satelliteHypervisorUuid;
     private String guestId;
     private String subscriptionManagerId;
     private Set<String> qpcProducts;
@@ -62,8 +63,8 @@ public class InventoryHostFacts {
         String products, String syncTimestamp, String systemProfileInfrastructureType,
         String systemProfileCores, String systemProfileSockets, String qpcProducts, String qpcProductIds,
         String systemProfileProductIds, String syspurposeRole, String syspurposeSla, String syspurposeUnits,
-        String isVirtual, String hypervisorUuid, String guestId, String subscriptionManagerId,
-        String cloudProvider, OffsetDateTime staleTimestamp) {
+        String isVirtual, String hypervisorUuid, String satelliteHypervisorUuid, String guestId,
+        String subscriptionManagerId, String cloudProvider, OffsetDateTime staleTimestamp) {
 
         this.account = account;
         this.displayName = displayName;
@@ -83,6 +84,7 @@ public class InventoryHostFacts {
         this.syspurposeUnits = syspurposeUnits;
         this.isVirtual = asBoolean(isVirtual);
         this.hypervisorUuid = hypervisorUuid;
+        this.satelliteHypervisorUuid = satelliteHypervisorUuid;
         this.guestId = guestId;
         this.subscriptionManagerId = subscriptionManagerId;
         this.cloudProvider = cloudProvider;
@@ -287,5 +289,13 @@ public class InventoryHostFacts {
 
     public void setSyspurposeUnits(String syspurposeUnits) {
         this.syspurposeUnits = syspurposeUnits;
+    }
+
+    public String getSatelliteHypervisorUuid() {
+        return satelliteHypervisorUuid;
+    }
+
+    public void setSatelliteHypervisorUuid(String satelliteHypervisorUuid) {
+        this.satelliteHypervisorUuid = satelliteHypervisorUuid;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -114,8 +114,13 @@ public class FactNormalizer {
         InventoryHostFacts hostFacts, Map<String, String> mappedHypervisors) {
         boolean isVirtual = isVirtual(hostFacts);
 
-        boolean isHypervisorUnknown = (isVirtual && !StringUtils.hasText(hostFacts.getHypervisorUuid())) ||
-            mappedHypervisors.getOrDefault(hostFacts.getHypervisorUuid(), null) == null;
+        String hypervisorUuid = hostFacts.getSatelliteHypervisorUuid();
+        if (!StringUtils.hasText(hypervisorUuid)) {
+            hypervisorUuid = hostFacts.getHypervisorUuid();
+        }
+
+        boolean isHypervisorUnknown = (isVirtual && !StringUtils.hasText(hypervisorUuid)) ||
+            mappedHypervisors.getOrDefault(hypervisorUuid, null) == null;
 
         boolean isHypervisor = StringUtils.hasText(hostFacts.getSubscriptionManagerId()) &&
             mappedHypervisors.containsKey(hostFacts.getSubscriptionManagerId());

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -421,6 +421,19 @@ public class FactNormalizerTest {
     }
 
     @Test
+    public void testGuestWithUnmappedHypervisorClassificationUsingSatelliteMapping() {
+        InventoryHostFacts guestWithMappedHypervisor = createGuest("mapped-hyp-id", "A1", "O1", 1, 12, 3);
+        guestWithMappedHypervisor.setHypervisorUuid(null);
+        guestWithMappedHypervisor.setSatelliteHypervisorUuid("mapped-hyp-id");
+
+        Map<String, String> mappedHypervisors = new HashMap<>();
+        mappedHypervisors.put(guestWithMappedHypervisor.getSatelliteHypervisorUuid(), null);
+
+        NormalizedFacts facts = normalizer.normalize(guestWithMappedHypervisor, mappedHypervisors);
+        assertClassification(facts, false, true, true);
+    }
+
+    @Test
     public void testGuestWithNullHypIdIsUnmappedHypervisorClassification() {
         InventoryHostFacts guestWithMappedHypervisor = createGuest(null, "A1", "O1", 1, 12, 3);
 


### PR DESCRIPTION
In order to test, I set up two mocked accounts in the inventory DB

Both have:

1. 2 Guests with reported 2 and 4 sockets each
2. 1 physical system with 8 sockets.
3. 1 RHEV-based hypervisor (runs on RHEL) with reported 16 sockets
4. 1 non-RHEV based hypervisor with reported 32 sockets.

The only difference is in how the hypervisor is reported:

- foobar1 uses Satellite
- foobar2 uses rhsm-conduit

SQL below:

```sql
-- guest of hypervisor_uuid11, reported by satellite
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('698758a0-69db-43ec-a106-0b960c552d47', 'foobar1', '{"satellite":{"virtual_host_uuid":"hypervisor_uuid11"},"rhsm":{"RH_PROD":[69]}}','{"subscription_manager_id":"guest11"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
-- guest of hypervisor_uuid12, reported by satellite
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('138d88a0-1f7f-476b-b1e0-f064f2b4c303', 'foobar1', '{"satellite":{"virtual_host_uuid":"hypervisor_uuid12"},"rhsm":{"RH_PROD":[69]}}','{"subscription_manager_id":"guest12"}', '{"cores_per_socket":4,"number_of_sockets":4,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
-- physical host1 - as a control
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('7d190d08-bf1a-480f-9c1d-fd79abff698d', 'foobar1', '{"rhsm":{"RH_PROD":[69]}}', '{"subscription_manager_id":"physical1"}', '{"cores_per_socket":8,"number_of_sockets":8}', now(), now(), now(), 'test');
-- hypervisor_uuid11 - RHEV
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('978593c6-5b75-4c71-a53c-60991f517328', 'foobar1', '{"rhsm":{"RH_PROD":[69]}}', '{"subscription_manager_id":"hypervisor_uuid11"}', '{"cores_per_socket":16,"number_of_sockets":16}', now(), now(), now(), 'test');
-- hypervisor_uuid12 - non-RHEV
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('f0976bfa-8890-4579-ae36-a0e765f885e6', 'foobar1', null, '{"subscription_manager_id":"hypervisor_uuid12"}', '{"cores_per_socket":32,"number_of_sockets":32}', now(), now(), now(), 'test');

-- guest of hypervisor_uuid21, reported by rhsm-conduit
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('56e25bd8-8828-43d0-a114-4c06d6b3d535', 'foobar2', '{"rhsm":{"VM_HOST_UUID":"hypervisor_uuid21","RH_PROD":[69]}}','{"subscription_manager_id":"guest21"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
-- guest of hypervisor uuid22, reported by rhsm-conduit
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('90c04bde-c8af-4d03-bfc4-754e2d7718bd', 'foobar2', '{"rhsm":{"VM_HOST_UUID":"hypervisor_uuid22","RH_PROD":[69]}}','{"subscription_manager_id":"guest22"}', '{"cores_per_socket":4,"number_of_sockets":4,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
-- physical host2 - as a control
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('d2000c34-4733-4285-b22c-282fdc8f4157', 'foobar2', '{"rhsm":{"RH_PROD":[69]}}', '{"subscription_manager_id":"physical1"}', '{"cores_per_socket":8,"number_of_sockets":8}', now(), now(), now(), 'test');
-- hypervisor_uuid21 - RHEV
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('ac7337cf-bd47-4bc0-be29-358f01688f6b', 'foobar2', '{"rhsm":{"RH_PROD":[69]}}', '{"subscription_manager_id":"hypervisor_uuid21"}', '{"cores_per_socket":16,"number_of_sockets":16}', now(), now(), now(), 'test');
-- hypervisor_uuid22 - non-RHEV
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('c82cbcd3-cf19-4a9f-bd5a-c6a3f4a705d6', 'foobar2', null, '{"subscription_manager_id":"hypervisor_uuid22"}', '{"cores_per_socket":32,"number_of_sockets":32}', now(), now(), now(), 'test');
```

With this, use `jconsole` to trigger a tally for both `foobar1` and `foobar2`.

Note that both should produce the same equivalent results. Without this change, they differ; with it they don't.

Also, note that I noticed a general issue with our hypervisor tallies, and opened a separate card for that.