### PR TITLE
1824384: Handle unlimited capacity SKUs properly

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
@@ -74,25 +74,24 @@ public class CandlepinPoolCapacityMapper {
             capacity.setEndDate(pool.getEndDate());
             capacity.setServiceLevel(getSla(pool));
             Long socketCapacity = getCapacityUnit("sockets", pool);
-            if (products.contains(product) && socketCapacity != null && socketCapacity > 0) {
+            if (products.contains(product) && isPositive(socketCapacity)) {
                 capacity.setPhysicalSockets(Math.toIntExact(socketCapacity));
             }
             if (derivedProducts.contains(product)) {
                 if (isVirtUnlimited) {
                     capacity.setHasUnlimitedGuestSockets(true);
                 }
-                else if (socketCapacity != null && socketCapacity > 0) {
+                else if (isPositive(socketCapacity)) {
                     capacity.setVirtualSockets(Math.toIntExact(socketCapacity));
                 }
             }
 
             Long coresCapacity = getCapacityUnit("cores", pool);
-            if (products.contains(product) && coresCapacity != null && coresCapacity > 0) {
+            if (products.contains(product) && isPositive(coresCapacity)) {
                 capacity.setPhysicalCores(Math.toIntExact(coresCapacity));
             }
 
-            if (derivedProducts.contains(product) && coresCapacity != null && coresCapacity > 0
-                && !isVirtUnlimited) {
+            if (derivedProducts.contains(product) && isPositive(coresCapacity) && !isVirtUnlimited) {
 
                 capacity.setVirtualCores(Math.toIntExact(coresCapacity));
             }
@@ -105,6 +104,10 @@ public class CandlepinPoolCapacityMapper {
             }
             return capacity;
         }).collect(Collectors.toList());
+    }
+
+    private boolean isPositive(Long value) {
+        return value != null && value > 0;
     }
 
     private Long getCapacityUnit(String unitProperty, CandlepinPool pool) {

--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -40,6 +40,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -258,6 +259,84 @@ class CandlepinPoolCapacityMapperTest {
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,
             expectedServerCapacity,
+            expectedWorkstationCapacity
+        ));
+    }
+
+    @Test
+    void testPoolWithBadlyDefinedSkuGivesNoCapacity() {
+        CandlepinPool pool = createTestPool(physicalProductIds, virtualProductIds);
+        pool.setQuantity(-1L);
+
+        Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
+            pool);
+
+        SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
+        expectedRhelCapacity.setProductId("RHEL");
+        expectedRhelCapacity.setAccountNumber("account");
+        expectedRhelCapacity.setBeginDate(LONG_AGO);
+        expectedRhelCapacity.setEndDate(NOWISH);
+        expectedRhelCapacity.setSubscriptionId("subId");
+        expectedRhelCapacity.setOwnerId("ownerId");
+        expectedRhelCapacity.setServiceLevel("Premium");
+
+        SubscriptionCapacity expectedWorkstationCapacity = new SubscriptionCapacity();
+        expectedWorkstationCapacity.setProductId("RHEL Workstation");
+        expectedWorkstationCapacity.setAccountNumber("account");
+        expectedWorkstationCapacity.setBeginDate(LONG_AGO);
+        expectedWorkstationCapacity.setEndDate(NOWISH);
+        expectedWorkstationCapacity.setSubscriptionId("subId");
+        expectedWorkstationCapacity.setOwnerId("ownerId");
+        expectedWorkstationCapacity.setServiceLevel("Premium");
+
+        SubscriptionCapacity expectedServerCapacity = new SubscriptionCapacity();
+        expectedServerCapacity.setProductId("RHEL Server");
+        expectedServerCapacity.setAccountNumber("account");
+        expectedServerCapacity.setBeginDate(LONG_AGO);
+        expectedServerCapacity.setEndDate(NOWISH);
+        expectedServerCapacity.setSubscriptionId("subId");
+        expectedServerCapacity.setOwnerId("ownerId");
+        expectedServerCapacity.setServiceLevel("Premium");
+
+        assertThat(capacities, Matchers.containsInAnyOrder(
+            expectedRhelCapacity,
+            expectedServerCapacity,
+            expectedWorkstationCapacity
+        ));
+    }
+
+    @Test
+    void testPoolWithVdcStyleSkuGivesUnlimitedGuestCapacity() {
+        CandlepinPool pool = createTestPool(Collections.emptyList(), virtualProductIds);
+        pool.getProductAttributes().add(
+            new CandlepinProductAttribute().name("virt_limit").value("unlimited")
+        );
+
+        Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
+            pool);
+
+        SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
+        expectedRhelCapacity.setProductId("RHEL");
+        expectedRhelCapacity.setHasUnlimitedGuestSockets(true);
+        expectedRhelCapacity.setAccountNumber("account");
+        expectedRhelCapacity.setBeginDate(LONG_AGO);
+        expectedRhelCapacity.setEndDate(NOWISH);
+        expectedRhelCapacity.setSubscriptionId("subId");
+        expectedRhelCapacity.setOwnerId("ownerId");
+        expectedRhelCapacity.setServiceLevel("Premium");
+
+        SubscriptionCapacity expectedWorkstationCapacity = new SubscriptionCapacity();
+        expectedWorkstationCapacity.setProductId("RHEL Workstation");
+        expectedWorkstationCapacity.setHasUnlimitedGuestSockets(true);
+        expectedWorkstationCapacity.setAccountNumber("account");
+        expectedWorkstationCapacity.setBeginDate(LONG_AGO);
+        expectedWorkstationCapacity.setEndDate(NOWISH);
+        expectedWorkstationCapacity.setSubscriptionId("subId");
+        expectedWorkstationCapacity.setOwnerId("ownerId");
+        expectedWorkstationCapacity.setServiceLevel("Premium");
+
+        assertThat(capacities, Matchers.containsInAnyOrder(
+            expectedRhelCapacity,
             expectedWorkstationCapacity
         ));
     }


### PR DESCRIPTION
This change handles VDC-style SKUs (those which have derived products and are socket based), and also prevents any negative values from being used for capacity.