### PR TITLE
1824384: Stop handling virt-unlimited specially

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -40,7 +40,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -301,42 +300,6 @@ class CandlepinPoolCapacityMapperTest {
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,
             expectedServerCapacity,
-            expectedWorkstationCapacity
-        ));
-    }
-
-    @Test
-    void testPoolWithVdcStyleSkuGivesUnlimitedGuestCapacity() {
-        CandlepinPool pool = createTestPool(Collections.emptyList(), virtualProductIds);
-        pool.getProductAttributes().add(
-            new CandlepinProductAttribute().name("virt_limit").value("unlimited")
-        );
-
-        Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
-            pool);
-
-        SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
-        expectedRhelCapacity.setProductId("RHEL");
-        expectedRhelCapacity.setHasUnlimitedGuestSockets(true);
-        expectedRhelCapacity.setAccountNumber("account");
-        expectedRhelCapacity.setBeginDate(LONG_AGO);
-        expectedRhelCapacity.setEndDate(NOWISH);
-        expectedRhelCapacity.setSubscriptionId("subId");
-        expectedRhelCapacity.setOwnerId("ownerId");
-        expectedRhelCapacity.setServiceLevel("Premium");
-
-        SubscriptionCapacity expectedWorkstationCapacity = new SubscriptionCapacity();
-        expectedWorkstationCapacity.setProductId("RHEL Workstation");
-        expectedWorkstationCapacity.setHasUnlimitedGuestSockets(true);
-        expectedWorkstationCapacity.setAccountNumber("account");
-        expectedWorkstationCapacity.setBeginDate(LONG_AGO);
-        expectedWorkstationCapacity.setEndDate(NOWISH);
-        expectedWorkstationCapacity.setSubscriptionId("subId");
-        expectedWorkstationCapacity.setOwnerId("ownerId");
-        expectedWorkstationCapacity.setServiceLevel("Premium");
-
-        assertThat(capacities, Matchers.containsInAnyOrder(
-            expectedRhelCapacity,
             expectedWorkstationCapacity
         ));
     }


### PR DESCRIPTION
Actually at the moment, there's no real use for capturing virt-unlimited due to the way we handle capacity (we count hypervisor capacity, not guest capacity).