### PR TITLE
Make hypervisors contribute to their guests usage

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -142,7 +142,7 @@ public class InventoryAccountUsageCollector {
                     UsageCalculation usageCalc = getOrCreateCalculation(accountCalc, key);
                     ProductUsageCollector productUsageCollector = ProductUsageCollectorFactory
                         .get(key.getProductId());
-                    productUsageCollector.collectForHypervisor(usageCalc, hypervisor);
+                    productUsageCollector.collectForHypervisor(account, usageCalc, hypervisor);
                 });
             });
         });

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -24,6 +24,7 @@ import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.inventory.db.InventoryRepository;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.candlepin.subscriptions.tally.collector.ProductUsageCollector;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollectorFactory;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
@@ -34,8 +35,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -63,6 +67,8 @@ public class InventoryAccountUsageCollector {
         Collection<String> accounts) {
 
         Map<String, String> hypMapping = new HashMap<>();
+        Map<String, Set<UsageCalculation.Key>> hypervisorUsageKeys = new HashMap<>();
+        Map<String, Map<String, NormalizedFacts>> accountHypervisorFacts = new HashMap<>();
         try (Stream<Object[]> stream = inventoryRepository.getReportedHypervisors(accounts)) {
             stream.forEach(res -> hypMapping.put((String) res[0], (String) res[1]));
         }
@@ -94,19 +100,26 @@ public class InventoryAccountUsageCollector {
                     accountCalc.setOwner(owner);
                 }
 
+                if (facts.isHypervisor()) {
+                    Map<String, NormalizedFacts> idToHypervisorMap = accountHypervisorFacts
+                        .computeIfAbsent(account, a -> new HashMap<>());
+                    idToHypervisorMap.put(hostFacts.getSubscriptionManagerId(), facts);
+                }
+
                 // Calculate for each product.
                 products.forEach(product -> {
                     ServiceLevel[] slas = new ServiceLevel[]{facts.getSla(), ServiceLevel.ANY};
                     for (ServiceLevel sla : slas) {
                         UsageCalculation.Key key = new UsageCalculation.Key(product, sla);
-                        UsageCalculation calc = accountCalc.getCalculation(key);
-                        if (calc == null) {
-                            calc = new UsageCalculation(key);
-                            accountCalc.addCalculation(calc);
-                        }
-
+                        UsageCalculation calc = getOrCreateCalculation(accountCalc, key);
                         if (facts.getProducts().contains(product)) {
                             try {
+                                String hypervisorUuid = facts.getHypervisorUuid();
+                                if (hypervisorUuid != null) {
+                                    Set<UsageCalculation.Key> keys = hypervisorUsageKeys
+                                        .computeIfAbsent(hypervisorUuid, uuid -> new HashSet<>());
+                                    keys.add(key);
+                                }
                                 ProductUsageCollectorFactory.get(product).collect(calc, facts);
                             }
                             catch (Exception e) {
@@ -119,6 +132,21 @@ public class InventoryAccountUsageCollector {
             });
         }
 
+        accountHypervisorFacts.forEach((account, accountHypervisors) -> {
+            AccountUsageCalculation accountCalc = calcsByAccount.get(account);
+            accountHypervisors.forEach((hypervisorUuid, hypervisor) -> {
+                Set<UsageCalculation.Key> usageKeys = hypervisorUsageKeys.getOrDefault(hypervisorUuid,
+                    Collections.emptySet());
+
+                usageKeys.forEach(key -> {
+                    UsageCalculation usageCalc = getOrCreateCalculation(accountCalc, key);
+                    ProductUsageCollector productUsageCollector = ProductUsageCollectorFactory
+                        .get(key.getProductId());
+                    productUsageCollector.collectForHypervisor(usageCalc, hypervisor);
+                });
+            });
+        });
+
         if (log.isDebugEnabled()) {
             calcsByAccount.values().forEach(calc -> log.debug("Account Usage: {}", calc));
         }
@@ -126,4 +154,14 @@ public class InventoryAccountUsageCollector {
         return calcsByAccount.values();
     }
 
+    private UsageCalculation getOrCreateCalculation(AccountUsageCalculation accountCalc,
+        UsageCalculation.Key key) {
+
+        UsageCalculation calc = accountCalc.getCalculation(key);
+        if (calc == null) {
+            calc = new UsageCalculation(key);
+            accountCalc.addCalculation(calc);
+        }
+        return calc;
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
@@ -50,6 +50,10 @@ public class UsageCalculation {
             this.sla = sla;
         }
 
+        public String getProductId() {
+            return productId;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -41,10 +41,15 @@ public class DefaultProductUsageCollector implements ProductUsageCollector {
         else if (!normalizedFacts.isVirtual()) {
             prodCalc.addPhysical(cores, sockets, 1);
         }
-        // Any other system is simply added to the overall total
+        // Any other system should be considered virtual
         else {
-            prodCalc.addToTotal(cores, sockets, 1);
+            prodCalc.addHypervisor(cores, sockets, 1);
         }
+    }
+
+    @Override
+    public void collectForHypervisor(UsageCalculation prodCalc, NormalizedFacts hypervisorFacts) {
+        /* do nothing for hypervisor-guest mappings by default */
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -48,7 +48,9 @@ public class DefaultProductUsageCollector implements ProductUsageCollector {
     }
 
     @Override
-    public void collectForHypervisor(UsageCalculation prodCalc, NormalizedFacts hypervisorFacts) {
+    public void collectForHypervisor(String account, UsageCalculation prodCalc,
+        NormalizedFacts hypervisorFacts) {
+
         /* do nothing for hypervisor-guest mappings by default */
     }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -41,9 +41,9 @@ public class DefaultProductUsageCollector implements ProductUsageCollector {
         else if (!normalizedFacts.isVirtual()) {
             prodCalc.addPhysical(cores, sockets, 1);
         }
-        // Any other system should be considered virtual
+        // Any other system is simply added to the overall total
         else {
-            prodCalc.addHypervisor(cores, sockets, 1);
+            prodCalc.addToTotal(cores, sockets, 1);
         }
     }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
@@ -40,8 +40,9 @@ public interface ProductUsageCollector {
     /**
      * Collect and append usage data based on hypervisor-guest mappings.
      *
+     * @param account the account number
      * @param prodCalc which usage key's calculation to update
      * @param hypervisorFacts facts about the hypervisor
      */
-    void collectForHypervisor(UsageCalculation prodCalc, NormalizedFacts hypervisorFacts);
+    void collectForHypervisor(String account, UsageCalculation prodCalc, NormalizedFacts hypervisorFacts);
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
@@ -36,4 +36,12 @@ public interface ProductUsageCollector {
      * @param normalizedHostFacts the normalized view of the facts from inventory.
      */
     void collect(UsageCalculation prodCalc, NormalizedFacts normalizedHostFacts);
+
+    /**
+     * Collect and append usage data based on hypervisor-guest mappings.
+     *
+     * @param prodCalc which usage key's calculation to update
+     * @param hypervisorFacts facts about the hypervisor
+     */
+    void collectForHypervisor(UsageCalculation prodCalc, NormalizedFacts hypervisorFacts);
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -57,14 +57,16 @@ public class RHELProductUsageCollector implements ProductUsageCollector {
     }
 
     @Override
-    public void collectForHypervisor(UsageCalculation prodCalc, NormalizedFacts hypervisorFacts) {
+    public void collectForHypervisor(String account, UsageCalculation prodCalc,
+        NormalizedFacts hypervisorFacts) {
+
         int cores = hypervisorFacts.getCores() != null ? hypervisorFacts.getCores() : 0;
         int sockets = hypervisorFacts.getSockets() != null ? hypervisorFacts.getSockets() : 0;
 
         if (sockets == 0) {
-            throw new IllegalStateException("Hypervisor has no sockets and will not contribute to the " +
-                "totals. The tally for the RHEL product will not be accurate since all associated " +
-                "guests will not contribute to the tally.");
+            throw new IllegalStateException(String.format("Hypervisor in account %s has no sockets and will" +
+                " not contribute to the totals. The tally for the RHEL product will not be accurate since" +
+                "all associated guests will not contribute to the tally.", account));
         }
 
         prodCalc.addHypervisor(cores, sockets, 1);

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -43,14 +43,6 @@ public class RHELProductUsageCollector implements ProductUsageCollector {
         if (normalizedFacts.getCloudProviderType() != null) {
             prodCalc.addCloudProvider(normalizedFacts.getCloudProviderType(), cores, 1, 1);
         }
-        else if (normalizedFacts.isHypervisor()) {
-            if (sockets == 0) {
-                throw new IllegalStateException("Hypervisor has no sockets and will not contribute to the " +
-                    "totals. The tally for the RHEL product will not be accurate since all associated " +
-                    "guests will not contribute to the tally.");
-            }
-            prodCalc.addHypervisor(cores, sockets, 1);
-        }
         else if (guestWithUnknownHypervisor) {
             // If the hypervisor is unknown for a guest, we consider it as having a
             // unique hypervisor instance contributing to the hypervisor counts.
@@ -64,4 +56,17 @@ public class RHELProductUsageCollector implements ProductUsageCollector {
         }
     }
 
+    @Override
+    public void collectForHypervisor(UsageCalculation prodCalc, NormalizedFacts hypervisorFacts) {
+        int cores = hypervisorFacts.getCores() != null ? hypervisorFacts.getCores() : 0;
+        int sockets = hypervisorFacts.getSockets() != null ? hypervisorFacts.getSockets() : 0;
+
+        if (sockets == 0) {
+            throw new IllegalStateException("Hypervisor has no sockets and will not contribute to the " +
+                "totals. The tally for the RHEL product will not be accurate since all associated " +
+                "guests will not contribute to the tally.");
+        }
+
+        prodCalc.addHypervisor(cores, sockets, 1);
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -118,6 +118,9 @@ public class FactNormalizer {
         if (!StringUtils.hasText(hypervisorUuid)) {
             hypervisorUuid = hostFacts.getHypervisorUuid();
         }
+        if (StringUtils.hasText(hypervisorUuid)) {
+            normalizedFacts.setHypervisorUuid(hypervisorUuid);
+        }
 
         boolean isHypervisorUnknown = (isVirtual && !StringUtils.hasText(hypervisorUuid)) ||
             mappedHypervisors.getOrDefault(hypervisorUuid, null) == null;

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -43,6 +43,7 @@ public class NormalizedFacts {
     private Integer cores;
     private Integer sockets;
     private String owner;
+    private String hypervisorUuid;
     private boolean isVirtual;
     private boolean isHypervisor;
     private boolean isHypervisorUnknown;
@@ -78,6 +79,14 @@ public class NormalizedFacts {
 
     public void setOwner(String owner) {
         this.owner = owner;
+    }
+
+    public String getHypervisorUuid() {
+        return hypervisorUuid;
+    }
+
+    public void setHypervisorUuid(String hypervisorUuid) {
+        this.hypervisorUuid = hypervisorUuid;
     }
 
     public Integer getSockets() {

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -43,6 +43,7 @@ public class NormalizedFacts {
     private Integer cores;
     private Integer sockets;
     private String owner;
+    /** Subscription-manager ID (UUID) of the hypervisor for this system */
     private String hypervisorUuid;
     private boolean isVirtual;
     private boolean isHypervisor;
@@ -81,10 +82,20 @@ public class NormalizedFacts {
         this.owner = owner;
     }
 
+    /**
+     * Get the Subscription-manager ID (UUID) of the hypervisor for this system, if it's a guest and
+     * its hypervisor is known.
+     *
+     * @return hypervisor UUID if known; otherwise, null
+     */
     public String getHypervisorUuid() {
         return hypervisorUuid;
     }
 
+    /**
+     * Set the Subscription-manager ID (UUID) of the hypervisor for this system, if it's a guest and
+     * its hypervisor is known.
+     */
     public void setHypervisorUuid(String hypervisorUuid) {
         this.hypervisorUuid = hypervisorUuid;
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -41,7 +41,9 @@ public class InventoryHostFactTestHelper {
     public static InventoryHostFacts createHypervisor(String account, String orgId, Integer product,
         int cores, int sockets) {
         InventoryHostFacts baseFacts = createBaseHost(account, orgId);
-        baseFacts.setProducts(product.toString());
+        if (product != null) {
+            baseFacts.setProducts(product.toString());
+        }
         baseFacts.setCores(cores);
         baseFacts.setSockets(sockets);
         return baseFacts;

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -59,9 +59,10 @@ public class DefaultProductUsageCollectorTest {
         collector.collect(calc, facts);
 
         // A guest with a known hypervisor contributes to the overall totals,
-        // but does not contribute to the hypervisor or physical totals.
         assertTotalsCalculation(calc, 3, 12, 1);
-        assertNullExcept(calc, HardwareMeasurementType.TOTAL);
+        // For non-RHEL, a guest with a known hypervisor contributes to "virtual" capacity (no-VDC-style
+        // products outside of RHEL)
+        assertHypervisorTotalsCalculation(calc, 3, 12, 1);
     }
 
     @Test
@@ -74,7 +75,8 @@ public class DefaultProductUsageCollectorTest {
         // A guest with an unknown hypervisor contributes to the overall totals
         // but does not contribute to the hypervisor or physical totals.
         assertTotalsCalculation(calc, 3, 12, 1);
-        assertNullExcept(calc, HardwareMeasurementType.TOTAL);
+        assertHypervisorTotalsCalculation(calc, 3, 12, 1);
+        assertNullExcept(calc, HardwareMeasurementType.TOTAL, HardwareMeasurementType.HYPERVISOR);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -59,10 +59,9 @@ public class DefaultProductUsageCollectorTest {
         collector.collect(calc, facts);
 
         // A guest with a known hypervisor contributes to the overall totals,
+        // but does not contribute to the hypervisor or physical totals.
         assertTotalsCalculation(calc, 3, 12, 1);
-        // For non-RHEL, a guest with a known hypervisor contributes to "virtual" capacity (no-VDC-style
-        // products outside of RHEL)
-        assertHypervisorTotalsCalculation(calc, 3, 12, 1);
+        assertNullExcept(calc, HardwareMeasurementType.TOTAL);
     }
 
     @Test
@@ -75,8 +74,7 @@ public class DefaultProductUsageCollectorTest {
         // A guest with an unknown hypervisor contributes to the overall totals
         // but does not contribute to the hypervisor or physical totals.
         assertTotalsCalculation(calc, 3, 12, 1);
-        assertHypervisorTotalsCalculation(calc, 3, 12, 1);
-        assertNullExcept(calc, HardwareMeasurementType.TOTAL, HardwareMeasurementType.HYPERVISOR);
+        assertNullExcept(calc, HardwareMeasurementType.TOTAL);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -47,10 +47,10 @@ public class RHELProductUsageCollectorTest {
         UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
         assertTotalsCalculation(calc, 4, 12, 1);
-        assertHypervisorTotalsCalculation(calc, 4, 12, 1);
+        assertPhysicalTotalsCalculation(calc, 4, 12, 1);
 
-        // Expects no physical totals in this case.
-        assertNull(calc.getTotals(HardwareMeasurementType.PHYSICAL));
+        // Expects no hypervisor totals in this case.
+        assertNull(calc.getTotals(HardwareMeasurementType.HYPERVISOR));
     }
 
     @Test
@@ -97,8 +97,11 @@ public class RHELProductUsageCollectorTest {
     @Test
     public void hypervisorReportedWithNoSocketsWillRaiseException() {
         NormalizedFacts facts = hypervisorFacts(0, 0);
+        NormalizedFacts guestFacts = guestFacts(4, 1, false);
         UsageCalculation calc = new UsageCalculation(createUsageKey());
-        assertThrows(IllegalStateException.class, () -> collector.collect(calc, facts));
+        collector.collect(calc, facts);
+        collector.collect(calc, guestFacts);
+        assertThrows(IllegalStateException.class, () -> collector.collectForHypervisor(calc, facts));
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -101,7 +101,7 @@ public class RHELProductUsageCollectorTest {
         UsageCalculation calc = new UsageCalculation(createUsageKey());
         collector.collect(calc, facts);
         collector.collect(calc, guestFacts);
-        assertThrows(IllegalStateException.class, () -> collector.collectForHypervisor(calc, facts));
+        assertThrows(IllegalStateException.class, () -> collector.collectForHypervisor("foo", calc, facts));
     }
 
     @Test


### PR DESCRIPTION
Specifically this is accomplished by capturing two mappings during tally:

1. A mapping of hypervisor UUIDs to the usage keys (buckets) that a hypervisor contributes to.
2. A per-account mapping of hypervisor UUIDs to normalized facts.

Then as a post-processing step during Tally, the product usage collectors are called once per usage key per hypervisor, in order to adjust the tallies as needed.

I also adjusted the general hypervisor counting, to make sure that hypervisors are counted as physical during the regular tally.

Note that I adjusted the default product collector to simply add to virtual any system reported as virtual.

I only modified the RHEL collector to handle the mapped hypervisor-guest bits, as RHEL is the only product we currently have a requirement to handle hypervisor-guest mappings.

To test locally, set up is the same as #125...

Two accounts with:

1. 2 Guests with reported 2 and 4 sockets each
2. 1 physical system with 8 sockets.
3. 1 RHEV-based hypervisor (runs on RHEL) with reported 16 sockets
4. 1 non-RHEV based hypervisor with reported 32 sockets.

The only difference is in how the hypervisor is reported:

- foobar1 uses Satellite
- foobar2 uses rhsm-conduit

```sql
-- guest of hypervisor_uuid11, reported by satellite
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('698758a0-69db-43ec-a106-0b960c552d47', 'foobar1', '{"satellite":{"virtual_host_uuid":"hypervisor_uuid11"},"rhsm":{"RH_PROD":[69]}}','{"subscription_manager_id":"guest11"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
-- guest of hypervisor_uuid12, reported by satellite
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('138d88a0-1f7f-476b-b1e0-f064f2b4c303', 'foobar1', '{"satellite":{"virtual_host_uuid":"hypervisor_uuid12"},"rhsm":{"RH_PROD":[69]}}','{"subscription_manager_id":"guest12"}', '{"cores_per_socket":4,"number_of_sockets":4,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
-- physical host1 - as a control
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('7d190d08-bf1a-480f-9c1d-fd79abff698d', 'foobar1', '{"rhsm":{"RH_PROD":[69]}}', '{"subscription_manager_id":"physical1"}', '{"cores_per_socket":8,"number_of_sockets":8}', now(), now(), now(), 'test');
-- hypervisor_uuid11 - RHEV
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('978593c6-5b75-4c71-a53c-60991f517328', 'foobar1', '{"rhsm":{"RH_PROD":[69]}}', '{"subscription_manager_id":"hypervisor_uuid11"}', '{"cores_per_socket":16,"number_of_sockets":16}', now(), now(), now(), 'test');
-- hypervisor_uuid12 - non-RHEV
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('f0976bfa-8890-4579-ae36-a0e765f885e6', 'foobar1', null, '{"subscription_manager_id":"hypervisor_uuid12"}', '{"cores_per_socket":32,"number_of_sockets":32}', now(), now(), now(), 'test');

-- guest of hypervisor_uuid21, reported by rhsm-conduit
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('56e25bd8-8828-43d0-a114-4c06d6b3d535', 'foobar2', '{"rhsm":{"VM_HOST_UUID":"hypervisor_uuid21","RH_PROD":[69]}}','{"subscription_manager_id":"guest21"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
-- guest of hypervisor uuid22, reported by rhsm-conduit
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('90c04bde-c8af-4d03-bfc4-754e2d7718bd', 'foobar2', '{"rhsm":{"VM_HOST_UUID":"hypervisor_uuid22","RH_PROD":[69]}}','{"subscription_manager_id":"guest22"}', '{"cores_per_socket":4,"number_of_sockets":4,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
-- physical host2 - as a control
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('d2000c34-4733-4285-b22c-282fdc8f4157', 'foobar2', '{"rhsm":{"RH_PROD":[69]}}', '{"subscription_manager_id":"physical1"}', '{"cores_per_socket":8,"number_of_sockets":8}', now(), now(), now(), 'test');
-- hypervisor_uuid21 - RHEV
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('ac7337cf-bd47-4bc0-be29-358f01688f6b', 'foobar2', '{"rhsm":{"RH_PROD":[69]}}', '{"subscription_manager_id":"hypervisor_uuid21"}', '{"cores_per_socket":16,"number_of_sockets":16}', now(), now(), now(), 'test');
-- hypervisor_uuid22 - non-RHEV
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('c82cbcd3-cf19-4a9f-bd5a-c6a3f4a705d6', 'foobar2', null, '{"subscription_manager_id":"hypervisor_uuid22"}', '{"cores_per_socket":32,"number_of_sockets":32}', now(), now(), now(), 'test');
```

Use `jconsole` to tally both accounts and then observe that the tallies match expected results:

- total instances: 4
- total sockets: 72
- total cores: 1600
- physical instances: 2
- physical sockets: 24
- physical cores: 320
- hypervisor instances: 2
- hypervisor sockets: 48
- hypervisor cores: 1280

Note that this depends on #125 (just for having satellite hypervisor uuid)