### PR TITLE
Move RBAC related classes underneath RBAC project.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -294,6 +294,11 @@ project(":rbac-client") {
         api_spec_path = "https://raw.githubusercontent.com/RedHatInsights/insights-rbac/stable/docs/source/specs/openapi.json"
         config_file = "${projectDir}/rbac-client-config.json"
     }
+
+    dependencies {
+        compileOnly "org.springframework:spring-web"
+        compileOnly "javax.servlet:javax.servlet-api"
+    }
 }
 
 project(":cloudigrade-client") {

--- a/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacApiFactory.java
+++ b/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacApiFactory.java
@@ -18,13 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.rbac;
-
-import org.candlepin.insights.rbac.client.ApiClient;
-import org.candlepin.insights.rbac.client.RbacApi;
-import org.candlepin.insights.rbac.client.RbacApiImpl;
-import org.candlepin.insights.rbac.client.RbacServiceProperties;
-import org.candlepin.insights.rbac.client.StubRbacApi;
+package org.candlepin.insights.rbac.client;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -61,7 +55,7 @@ public class RbacApiFactory implements FactoryBean<RbacApi> {
             log.info("Using stub RBAC client");
             return new StubRbacApi();
         }
-        ApiClient apiClient = new RBACApiClient();
+        ApiClient apiClient = new RbacApiClient();
         apiClient.setHttpClient(buildHttpClient(apiClient));
         if (serviceProperties.getUrl() != null) {
             log.info("RBAC service URL: {}", serviceProperties.getUrl());

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -22,8 +22,8 @@ package org.candlepin.subscriptions;
 
 import org.candlepin.insights.inventory.client.HostsApiFactory;
 import org.candlepin.insights.inventory.client.InventoryServiceProperties;
+import org.candlepin.insights.rbac.client.RbacApiFactory;
 import org.candlepin.insights.rbac.client.RbacServiceProperties;
-import org.candlepin.rbac.RbacApiFactory;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.files.FileAccountListSource;
 import org.candlepin.subscriptions.files.FileAccountSyncListSource;


### PR DESCRIPTION
@mstead what do you think?  There's a little redundancy with the reimplementation of the `getIdentityHeader` method but personally, I think it's worth it to keep all the RBAC stuff contained in one project.