### PR TITLE
Integrate RBAC permissions into application spring roles

### DIFF
--- a/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacService.java
+++ b/rbac-client/src/main/java/org/candlepin/insights/rbac/client/RbacService.java
@@ -20,47 +20,31 @@
  */
 package org.candlepin.insights.rbac.client;
 
+import org.candlepin.insights.rbac.client.model.Access;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
- * Sub-class for RBAC service properties
+ * Provides RBAC functionality.
  */
-public class RbacServiceProperties {
+public class RbacService {
 
-    /**
-     * Use the stub RBAC API implementation.
-     */
-    private boolean useStub;
+    @Autowired
+    private RbacApi api;
 
-    /**
-     * The URL of the RBAC API.
-     */
-    private String url;
-
-    /**
-     * Maximum number of simultaneous connections to the rbac service.
-     */
-    private int maxConnections = 100;
-
-    public boolean isUseStub() {
-        return useStub;
+    public List<String> getPermissions(String rbacAppName) throws RbacApiException {
+        // Get all permissions for the configured application name.
+        try (Stream<Access> accessStream = api.getCurrentUserAccess(rbacAppName).stream()) {
+            return accessStream
+                .filter(access -> access != null && !StringUtils.isEmpty(access.getPermission()))
+                .map(Access::getPermission)
+                .collect(Collectors.toList());
+        }
     }
 
-    public void setUseStub(boolean useStub) {
-        this.useStub = useStub;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public int getMaxConnections() {
-        return maxConnections;
-    }
-
-    public void setMaxConnections(int maxConnections) {
-        this.maxConnections = maxConnections;
-    }
 }

--- a/rbac-client/src/main/java/org/candlepin/insights/rbac/client/StubRbacApi.java
+++ b/rbac-client/src/main/java/org/candlepin/insights/rbac/client/StubRbacApi.java
@@ -32,7 +32,7 @@ public class StubRbacApi implements RbacApi {
 
     @Override
     public List<Access> getCurrentUserAccess(String applicationName) throws RbacApiException {
-        return Arrays.asList(new Access().permission("subscriptions:*.*"));
+        return Arrays.asList(new Access().permission("subscriptions:*:*"));
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -142,6 +142,11 @@ public class ApplicationProperties {
      */
     private int antiCsrfPort = 443;
 
+    /**
+     * The RBAC application name that defines the permissions for this application.
+     */
+    private String rbacApplicationName = "subscriptions";
+
     public boolean isPrettyPrintJson() {
         return prettyPrintJson;
     }
@@ -290,4 +295,11 @@ public class ApplicationProperties {
         return orgAdminOptional;
     }
 
+    public String getRbacApplicationName() {
+        return rbacApplicationName;
+    }
+
+    public void setRbacApplicationName(String rbacApplicationName) {
+        this.rbacApplicationName = rbacApplicationName;
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -53,6 +53,11 @@ public enum ErrorCode {
     REQUEST_DENIED_ERROR(1003, "Request was denied due to lack of roles/permissions."),
 
     /**
+     * The client's request was denied because opt-in has not yet occurred.
+     */
+    OPT_IN_REQUIRED(1004, "Request was denied since opt-in has not yet occurred."),
+
+    /**
      * An unexpected exception was thrown by the inventory service client.
      */
     INVENTORY_SERVICE_ERROR(2000, "Inventory Service Error"),

--- a/src/main/java/org/candlepin/subscriptions/exception/ExternalServiceException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ExternalServiceException.java
@@ -23,7 +23,7 @@ package org.candlepin.subscriptions.exception;
 import javax.ws.rs.core.Response.Status;
 
 /**
- * An exception that is thrown when rhsm-conduit encounters an exception while
+ * An exception that is thrown when rhsm-subscriptions encounters an exception while
  * communicating with an external service such as insights-inventory.
  */
 public class ExternalServiceException extends SubscriptionsException {

--- a/src/main/java/org/candlepin/subscriptions/exception/OptInRequiredException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/OptInRequiredException.java
@@ -18,23 +18,28 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.exception.mapper;
+package org.candlepin.subscriptions.exception;
 
-import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.utilization.api.model.Error;
 
-import org.springframework.stereotype.Component;
+import org.springframework.security.access.AccessDeniedException;
 
-import javax.ws.rs.ext.Provider;
+import javax.ws.rs.core.Response.Status;
 
 /**
- * An exception mapper used to map all SubscriptionsException to an error repsonse.
+ * An exception that represents an access denied exception in cases where
+ * opt-in is required to access an end-point.
  */
-@Component
-@Provider
-public class SubscriptionsExceptionMapper extends BaseExceptionMapper<SubscriptionsException> {
-    @Override
-    protected Error buildError(SubscriptionsException exception) {
-        return exception.error();
+public class OptInRequiredException extends AccessDeniedException {
+    public OptInRequiredException() {
+        super("Opt-in required.");
+    }
+
+    public Error getError() {
+        return new Error()
+           .code(ErrorCode.OPT_IN_REQUIRED.getCode())
+           .status(String.valueOf(Status.FORBIDDEN.getStatusCode()))
+           .title("Access Denied")
+           .detail(this.getMessage());
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
@@ -33,7 +33,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 
 /**
- * The base class for all rhsm-conduit exception mappers. Its intent is to build the same
+ * The base class for all rhsm-subscription exception mappers. Its intent is to build the same
  * response no matter the exception.
  * @param <T> the throwable that is to be mapped
  */

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -25,7 +25,7 @@ import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
-import org.candlepin.subscriptions.security.auth.ReportingAdminOnly;
+import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.SnapshotTimeAdjuster;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReport;
@@ -71,7 +71,7 @@ public class CapacityResource implements CapacityApi {
     }
 
     @Override
-    @ReportingAdminOnly
+    @ReportingAccessRequired
     public CapacityReport getCapacityReport(String productId, @NotNull String granularity,
         @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset,
         @Min(1) Integer limit, String sla) {

--- a/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
@@ -22,7 +22,7 @@ package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.controller.OptInController;
 import org.candlepin.subscriptions.db.model.config.OptInType;
-import org.candlepin.subscriptions.security.auth.AdminOnly;
+import org.candlepin.subscriptions.security.auth.OptInRoleRequired;
 import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
 import org.candlepin.subscriptions.utilization.api.resources.OptInApi;
 
@@ -47,19 +47,19 @@ public class OptInResource implements OptInApi {
         this.controller = controller;
     }
 
-    @AdminOnly
+    @OptInRoleRequired
     @Override
     public void deleteOptInConfig() {
         controller.optOut(validateAccountNumber(), validateOrgId());
     }
 
-    @AdminOnly
+    @OptInRoleRequired
     @Override
     public OptInConfig getOptInConfig() {
         return controller.getOptInConfig(validateAccountNumber(), validateOrgId());
     }
 
-    @AdminOnly
+    @OptInRoleRequired
     @Override
     public OptInConfig putOptInConfig(Boolean enableTallySync, Boolean enableTallyReporting,
         Boolean enableConduitSync) {

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -24,7 +24,7 @@ import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
-import org.candlepin.subscriptions.security.auth.ReportingAdminOnly;
+import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.tally.filler.ReportFiller;
 import org.candlepin.subscriptions.tally.filler.ReportFillerFactory;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -70,7 +70,7 @@ public class TallyResource implements TallyApi {
 
     @SuppressWarnings("linelength")
     @Override
-    @ReportingAdminOnly
+    @ReportingAccessRequired
     public TallyReport getTallyReport(String productId, @NotNull String granularity,
         @NotNull OffsetDateTime beginning, @NotNull OffsetDateTime ending, Integer offset,
         @Min(1) Integer limit, String sla) {

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSource.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSource.java
@@ -21,27 +21,23 @@
 
 package org.candlepin.subscriptions.security;
 
-import static org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter.*;
-
+import org.candlepin.insights.rbac.client.RbacApi;
+import org.candlepin.insights.rbac.client.RbacApiException;
+import org.candlepin.insights.rbac.client.model.Access;
 import org.candlepin.subscriptions.ApplicationProperties;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.Attributes2GrantedAuthoritiesMapper;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedCredentialsNotFoundException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
-import org.springframework.util.StringUtils;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedList;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -56,60 +52,56 @@ public class IdentityHeaderAuthenticationDetailsSource implements
     private static final Logger log =
         LoggerFactory.getLogger(IdentityHeaderAuthenticationDetailsSource.class);
 
-    // NB: Right now there are just two roles.  If we expand on that, we should externalize all the
-    //  roles to an enum, serialize the header JSON to an object, and write an actual predicate method
-    //  isUserInRole
-    public static final String ORG_ADMIN_ROLE = "ORG_ADMIN";
-    public static final String INTERNAL_ROLE = "INTERNAL";
-
-    private ObjectMapper objectMapper;
     private Attributes2GrantedAuthoritiesMapper authMapper;
     private ApplicationProperties props;
+    private RbacApi rbac;
+    private String rbacApplicationName;
+    private RoleProvider roleProvider;
 
-    public IdentityHeaderAuthenticationDetailsSource(ApplicationProperties props, ObjectMapper objectMapper,
-        Attributes2GrantedAuthoritiesMapper authMapper) {
-        this.objectMapper = objectMapper;
+    public IdentityHeaderAuthenticationDetailsSource(ApplicationProperties props,
+        Attributes2GrantedAuthoritiesMapper authMapper,
+        RbacApi rbac, String rbacApplicationName) {
         this.authMapper = authMapper;
         this.props = props;
+        this.rbac = rbac;
+        this.rbacApplicationName = rbacApplicationName;
 
         if (props.isDevMode()) {
             log.info("Running in DEV mode. Security will be disabled.");
         }
+        this.roleProvider = new RoleProvider(rbacApplicationName, props.isDevMode());
     }
 
-    protected Collection<String> getUserRoles(HttpServletRequest context) {
-        ArrayList<String> userRolesList = new ArrayList<>();
-        try {
-            String identityHeader = context.getHeader(RH_IDENTITY_HEADER);
-
-            if (StringUtils.isEmpty(identityHeader)) {
-                return userRolesList;
+    protected Collection<String> getUserRoles() {
+        List<String> permissions = new LinkedList<>();
+        if (!props.isDevMode()) {
+            try {
+                // Get all permissions for the configured application name.
+                List<Access> accessList = rbac.getCurrentUserAccess(rbacApplicationName);
+                for (Access access : accessList) {
+                    if (access.getPermission() != null) {
+                        permissions.add(access.getPermission());
+                    }
+                }
             }
-
-            byte[] decodedHeader = Base64.getDecoder().decode(identityHeader);
-            Map authObject = objectMapper.readValue(decodedHeader, Map.class);
-            Map identity = (Map) authObject.getOrDefault("identity", Collections.emptyMap());
-            Map user = (Map) identity.getOrDefault("user", Collections.emptyMap());
-
-            if (Boolean.TRUE.equals(user.get("is_org_admin")) || props.isDevMode()) {
-                userRolesList.add(ORG_ADMIN_ROLE);
-            }
-
-            if (Boolean.TRUE.equals(user.get("is_internal")) || props.isDevMode()) {
-                userRolesList.add(INTERNAL_ROLE);
+            catch (RbacApiException e) {
+                log.warn("Unable to determine roles from RBAC service.", e);
             }
         }
-        catch (IOException e) {
-            throw new PreAuthenticatedCredentialsNotFoundException(RH_IDENTITY_HEADER + " is not valid JSON");
-        }
-
-        return userRolesList;
+        return roleProvider.getRoles(permissions);
     }
 
     @Override
     public PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails buildDetails(
         HttpServletRequest context) {
-        Collection<String> userRoles = getUserRoles(context);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null) {
+            // We've already populated the roles if the auth has been set in the context.
+            return (PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails) auth.getDetails();
+        }
+
+        Collection<String> userRoles = getUserRoles();
         Collection<? extends GrantedAuthority> userGAs = authMapper.getGrantedAuthorities(userRoles);
 
         log.debug("Roles {} mapped to Granted Authorities: {}", userRoles, userGAs);

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -21,12 +21,16 @@
 
 package org.candlepin.subscriptions.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import org.springframework.util.StringUtils;
 
 import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -37,26 +41,45 @@ public class IdentityHeaderAuthenticationFilter extends AbstractPreAuthenticated
     private static final Logger log = LoggerFactory.getLogger(IdentityHeaderAuthenticationFilter.class);
     public static final String RH_IDENTITY_HEADER = "x-rh-identity";
 
+    private final ObjectMapper mapper;
+
+    public IdentityHeaderAuthenticationFilter(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
     @Override
     protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
         String identityHeader = request.getHeader(RH_IDENTITY_HEADER);
 
+        // If the header is missing it will be passed down the chain.
         if (StringUtils.isEmpty(identityHeader)) {
             log.debug("{} is empty", RH_IDENTITY_HEADER);
-            // Give up and pass responsibility on to the next filter
             return null;
         }
 
         try {
-            return Base64.getDecoder().decode(identityHeader);
+            return createPrincipal(Base64.getDecoder().decode(identityHeader));
         }
-        catch (IllegalArgumentException e) {
-            log.error(RH_IDENTITY_HEADER + " was not valid base64", e);
-            return null;
+        catch (Exception e) {
+            log.error(RH_IDENTITY_HEADER + " was not valid.", e);
+            // Initialize an empty principal. The IdentityHeaderAuthenticationManager will validate it.
+            return new InsightsUserPrincipal();
         }
-
 
     }
+
+    private InsightsUserPrincipal createPrincipal(byte[] decodedHeader) throws Exception {
+        // TODO The identity header should eventually get deserialized into an Object.
+        Map authObject = mapper.readValue(decodedHeader, Map.class);
+        Map identity = (Map) authObject.getOrDefault("identity", Collections.emptyMap());
+        String accountNumber = (String) identity.getOrDefault("account_number", "");
+
+        Map internal = (Map) identity.getOrDefault("internal", Collections.emptyMap());
+        String orgId = (String) internal.getOrDefault("org_id", "");
+
+        return new InsightsUserPrincipal(orgId, accountNumber);
+    }
+
 
     /**
      * Credentials are not applicable in this case, so we return a dummy value.

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
@@ -68,8 +69,8 @@ public class IdentityHeaderAuthenticationFilter extends AbstractPreAuthenticated
 
     }
 
-    private InsightsUserPrincipal createPrincipal(byte[] decodedHeader) throws Exception {
-        // TODO The identity header should eventually get deserialized into an Object.
+    private InsightsUserPrincipal createPrincipal(byte[] decodedHeader) throws IOException {
+        // In the future, the identity header could be deserialized into an Object.
         Map authObject = mapper.readValue(decodedHeader, Map.class);
         Map identity = (Map) authObject.getOrDefault("identity", Collections.emptyMap());
         String accountNumber = (String) identity.getOrDefault("account_number", "");

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -71,11 +71,13 @@ public class IdentityHeaderAuthenticationFilter extends AbstractPreAuthenticated
 
     private InsightsUserPrincipal createPrincipal(byte[] decodedHeader) throws IOException {
         // In the future, the identity header could be deserialized into an Object.
-        Map authObject = mapper.readValue(decodedHeader, Map.class);
-        Map identity = (Map) authObject.getOrDefault("identity", Collections.emptyMap());
+        Map<String, Object> authObject = mapper.readValue(decodedHeader, Map.class);
+        Map<String, Object> identity =
+            (Map<String, Object>) authObject.getOrDefault("identity", Collections.emptyMap());
         String accountNumber = (String) identity.getOrDefault("account_number", "");
 
-        Map internal = (Map) identity.getOrDefault("internal", Collections.emptyMap());
+        Map<String, Object> internal =
+            (Map<String, Object>) identity.getOrDefault("internal", Collections.emptyMap());
         String orgId = (String) internal.getOrDefault("org_id", "");
 
         return new InsightsUserPrincipal(orgId, accountNumber);

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
@@ -21,7 +21,7 @@
 
 package org.candlepin.subscriptions.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter.RH_IDENTITY_HEADER;
 
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -31,19 +31,12 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedC
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
 import org.springframework.util.StringUtils;
 
-import static org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter.RH_IDENTITY_HEADER;
 
 /**
- * This class is in charge of deserializing the bytes from the x-rh-identity header and extracting the
- * account number from them.
+ * This class is responsible for validating the principal. If a valid principal was
+ * found, the request is considered authenticated.
  */
 public class IdentityHeaderAuthenticationManager implements AuthenticationManager {
-
-    private final ObjectMapper mapper;
-
-    public IdentityHeaderAuthenticationManager(ObjectMapper mapper) {
-        this.mapper = mapper;
-    }
 
     /**
      * Validates the incoming principal that was extracted from the x-rh-identity header by
@@ -64,7 +57,7 @@ public class IdentityHeaderAuthenticationManager implements AuthenticationManage
         }
         if (StringUtils.isEmpty(principal.getAccountNumber())) {
             throw new PreAuthenticatedCredentialsNotFoundException(
-                RH_IDENTITY_HEADER + " contains no owner ID for the principal"
+                RH_IDENTITY_HEADER + " contains no account number for the principal"
             );
         }
 

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManager.java
@@ -21,8 +21,6 @@
 
 package org.candlepin.subscriptions.security;
 
-import static org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.security.authentication.AuthenticationManager;
@@ -33,9 +31,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedC
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
+import static org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter.RH_IDENTITY_HEADER;
 
 /**
  * This class is in charge of deserializing the bytes from the x-rh-identity header and extracting the
@@ -50,74 +46,39 @@ public class IdentityHeaderAuthenticationManager implements AuthenticationManage
     }
 
     /**
-     * This method is a little odd.  Since the value of the x-rh-identity header is JSON, there is the
-     * potential for a JSON parsing error.  However, if we parse the JSON in
-     * {@link IdentityHeaderAuthenticationFilter}, when we throw an exception on a parse error, it is not
-     * handled very nicely.  By handling the parsing in an AuthenticationManager we follow the conventions
-     * that Spring Security is expecting, but at the expense of taking the Authentication instance, reading
-     * from it, and then creating a totally new instance. Example of the decoded header:
+     * Validates the incoming principal that was extracted from the x-rh-identity header by
+     * the {@link IdentityHeaderAuthenticationFilter}. The principal is considered authenticated
+     * if the account_number and org_id are present as this would have come from 3Scale.
      *
-     * <pre><code>
-     * {
-     *   "identity": {
-     *     "account_number": "0369233",
-     *     "type": "User",
-     *     "user" : {
-     *       "username": "jdoe",
-     *       "email": "jdoe@acme.com",
-     *       "first_name": "John",
-     *       "last_name": "Doe",
-     *       "is_active": true,
-     *       "is_org_admin": false,
-     *       "is_internal": false,
-     *       "locale": "en_US"
-     *     },
-     *     "internal" : {
-     *       "org_id": "3340851",
-     *       "auth_type": "basic-auth",
-     *       "auth_time": 6300
-     *      }
-     *   }
-     * }
-     * </code></pre>
-     *
-     * @param authentication a byte[] of base64-decoded data from x-rh-identity
+     * @param authentication contains the pre-authenticated principal created from x-rh-identity
      * @return an approved Authentication object
-     * @throws AuthenticationException if the JSON can not be parsed
+     * @throws AuthenticationException if any part of the principal is invalid.
      */
     @Override
     public Authentication authenticate(Authentication authentication) {
-        PreAuthenticatedAuthenticationToken token = (PreAuthenticatedAuthenticationToken) authentication;
-        byte[] decodedHeader = (byte[]) token.getPrincipal();
+        InsightsUserPrincipal principal = (InsightsUserPrincipal) authentication.getPrincipal();
+        if (StringUtils.isEmpty(principal.getOwnerId())) {
+            throw new PreAuthenticatedCredentialsNotFoundException(
+                RH_IDENTITY_HEADER + " contains no owner ID for the principal"
+            );
+        }
+        if (StringUtils.isEmpty(principal.getAccountNumber())) {
+            throw new PreAuthenticatedCredentialsNotFoundException(
+                RH_IDENTITY_HEADER + " contains no owner ID for the principal"
+            );
+        }
+
         PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails details =
             (PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails) authentication.getDetails();
-        try {
-            Map authObject = mapper.readValue(decodedHeader, Map.class);
-            Map identity = (Map) authObject.getOrDefault("identity", Collections.emptyMap());
-            String accountNumber = (String) identity.get("account_number");
-            Map internal = (Map) identity.getOrDefault("internal", Collections.emptyMap());
-            String orgId = (String) internal.get("org_id");
 
-            if (StringUtils.isEmpty(orgId)) {
-                throw new PreAuthenticatedCredentialsNotFoundException(RH_IDENTITY_HEADER +
-                    " contains no owner ID for the principal");
-            }
-            if (StringUtils.isEmpty(accountNumber)) {
-                throw new PreAuthenticatedCredentialsNotFoundException(RH_IDENTITY_HEADER +
-                    " contains no principal");
-            }
-
-            token = new PreAuthenticatedAuthenticationToken(
-                new InsightsUserPrincipal(orgId, accountNumber),
-                token.getCredentials(),
-                details.getGrantedAuthorities()
-            );
-            token.setAuthenticated(true);
-            return token;
-
-        }
-        catch (IOException e) {
-            throw new PreAuthenticatedCredentialsNotFoundException(RH_IDENTITY_HEADER + " is not valid JSON");
-        }
+        // Create a new token that has been authenticated, and has the granted authorities
+        // that were determined in the details source applied. This is required in order
+        // for the roles to be picked up by the security annotations.
+        Authentication authToken =  new PreAuthenticatedAuthenticationToken(
+            principal,
+            authentication.getCredentials(),
+            details.getGrantedAuthorities());
+        authToken.setAuthenticated(true);
+        return authToken;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
@@ -30,6 +30,10 @@ public class InsightsUserPrincipal {
     private final String ownerId;
     private final String accountNumber;
 
+    public InsightsUserPrincipal() {
+        this(null, null);
+    }
+
     public InsightsUserPrincipal(String ownerId, String accountNumber) {
         this.ownerId = ownerId;
         this.accountNumber = accountNumber;
@@ -64,4 +68,5 @@ public class InsightsUserPrincipal {
     public int hashCode() {
         return Objects.hash(getOwnerId(), getAccountNumber());
     }
+
 }

--- a/src/main/java/org/candlepin/subscriptions/security/OptInFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.candlepin.subscriptions.controller.OptInController;
+import org.candlepin.subscriptions.exception.OptInRequiredException;
+import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A request filter that checks to make sure that the authenticated user has
+ * opted in.
+ */
+public class OptInFilter extends OncePerRequestFilter {
+    private static final Logger log = LoggerFactory.getLogger(OptInFilter.class);
+
+    private OptInController optInController;
+
+    public OptInFilter(OptInController optInController) {
+        this.optInController = optInController;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        InsightsUserPrincipal principal = (InsightsUserPrincipal) auth.getPrincipal();
+
+        OptInConfig optin = optInController.getOptInConfig(
+            principal.getAccountNumber(), principal.getOwnerId()
+        );
+
+        if (!optin.getData().getOptInComplete()) {
+            throw new OptInRequiredException();
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/OptInFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInFilter.java
@@ -24,8 +24,6 @@ import org.candlepin.subscriptions.controller.OptInController;
 import org.candlepin.subscriptions.exception.OptInRequiredException;
 import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -42,8 +40,6 @@ import javax.servlet.http.HttpServletResponse;
  * opted in.
  */
 public class OptInFilter extends OncePerRequestFilter {
-    private static final Logger log = LoggerFactory.getLogger(OptInFilter.class);
-
     private OptInController optInController;
 
     public OptInFilter(OptInController optInController) {
@@ -60,7 +56,7 @@ public class OptInFilter extends OncePerRequestFilter {
             principal.getAccountNumber(), principal.getOwnerId()
         );
 
-        if (!optin.getData().getOptInComplete()) {
+        if (Boolean.FALSE.equals(optin.getData().getOptInComplete())) {
             throw new OptInRequiredException();
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.security;
 
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExceptionUtil;
+import org.candlepin.subscriptions.exception.OptInRequiredException;
 import org.candlepin.subscriptions.utilization.api.model.Error;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,6 +57,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest servletRequest, HttpServletResponse servletResponse,
         AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
         Error error = RestAccessDeniedHandler.buildError(accessDeniedException);
         log.error(error.getTitle(), accessDeniedException);
 
@@ -69,6 +71,10 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
     }
 
     public static Error buildError(AccessDeniedException exception) {
+        if (exception instanceof OptInRequiredException) {
+            return ((OptInRequiredException) exception).getError();
+        }
+
         return new Error()
             .code(ErrorCode.REQUEST_DENIED_ERROR.getCode())
             .status(String.valueOf(Status.FORBIDDEN.getStatusCode()))

--- a/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public class RoleProvider {
 
-    public static final String ORG_ADMIN_ROLE = "ORG_ADMIN";
+    public static final String OPT_IN_ROLE = "OPT_IN";
     public static final String REPORTING_ROLE = "REPORTING";
 
     private String rulePrefix;
@@ -45,18 +45,20 @@ public class RoleProvider {
 
     public List<String> getRoles(Collection<String> permissions) {
         if (permissions == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
+        // By default, we look for the subscriptions:*:* permission (unless
+        // configured otherwise).
         if (devModeEnabled || permissions.contains(rulePrefix + ":*:*")) {
-            return adminRoles();
+            return all();
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
-    private List<String> adminRoles() {
+    private List<String> all() {
         return Arrays.asList(
-            ORG_ADMIN_ROLE,
+            OPT_IN_ROLE,
             REPORTING_ROLE
         );
     }

--- a/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builds roles based on the provided RBAC permission list. The intent of this
+ * class is to process the permissions received from RBAC and define which
+ * spring security roles the user should have.
+ */
+public class RoleProvider {
+
+    public static final String ORG_ADMIN_ROLE = "ORG_ADMIN";
+    public static final String REPORTING_ROLE = "REPORTING";
+
+    private String rulePrefix;
+    private boolean devModeEnabled;
+
+    public RoleProvider(String rulePrefix, boolean devModeEnabled) {
+        this.rulePrefix = rulePrefix;
+        this.devModeEnabled = devModeEnabled;
+    }
+
+    public List<String> getRoles(Collection<String> permissions) {
+        if (permissions == null) {
+            return Collections.EMPTY_LIST;
+        }
+
+        if (devModeEnabled || permissions.contains(rulePrefix + ":*:*")) {
+            return adminRoles();
+        }
+        return Collections.EMPTY_LIST;
+    }
+
+    private List<String> adminRoles() {
+        return Arrays.asList(
+            ORG_ADMIN_ROLE,
+            REPORTING_ROLE
+        );
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -90,7 +90,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public IdentityHeaderAuthenticationFilter identityHeaderAuthenticationFilter(
         ApplicationProperties appProps) {
 
-        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter();
+        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
         filter.setCheckForPrincipalChanges(true);
         filter.setAuthenticationManager(identityHeaderAuthenticationManager());
         filter.setAuthenticationDetailsSource(detailsSource(appProps));

--- a/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.security;
 
-import org.candlepin.subscriptions.security.auth.ReportingAdminOnly;
+import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.tally.AccountListSource;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Service;
  * Provides a means to validate that an authentication token has a whitelisted account associated with it.
  * The primary use of this class is to provide a check for expression based security annotations.
  *
- * @see ReportingAdminOnly
+ * @see ReportingAccessRequired
  */
 @Service("reportAccessService")
 public class WhitelistedAccountReportAccessService {

--- a/src/main/java/org/candlepin/subscriptions/security/auth/AdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/AdminOnly.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.security.auth;
 
-import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationDetailsSource;
+import org.candlepin.subscriptions.security.RoleProvider;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -36,6 +36,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @PreAuthorize("@applicationProperties.isOrgAdminOptional() or " +
-    "hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "')")
+    "hasRole('" + RoleProvider.ORG_ADMIN_ROLE + "')")
 public @interface AdminOnly {
 }

--- a/src/main/java/org/candlepin/subscriptions/security/auth/OptInRoleRequired.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/OptInRoleRequired.java
@@ -36,6 +36,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @PreAuthorize("@applicationProperties.isOrgAdminOptional() or " +
-    "hasRole('" + RoleProvider.ORG_ADMIN_ROLE + "')")
-public @interface AdminOnly {
+    "hasRole('" + RoleProvider.OPT_IN_ROLE + "')")
+public @interface OptInRoleRequired {
 }

--- a/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequired.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequired.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @PreAuthorize("(@applicationProperties.isOrgAdminOptional() or " +
-    "hasAnyRole('" + RoleProvider.ORG_ADMIN_ROLE + "', '" + RoleProvider.REPORTING_ROLE + "')) and " +
+    "hasAnyRole('" + RoleProvider.OPT_IN_ROLE + "', '" + RoleProvider.REPORTING_ROLE + "')) and " +
     "@reportAccessService.providesAccessTo(authentication)")
-public @interface ReportingAdminOnly {
+public @interface ReportingAccessRequired {
 }

--- a/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAdminOnly.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.security.auth;
 
-import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationDetailsSource;
+import org.candlepin.subscriptions.security.RoleProvider;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @PreAuthorize("(@applicationProperties.isOrgAdminOptional() or " +
-    "hasRole('" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE + "')) and " +
+    "hasAnyRole('" + RoleProvider.ORG_ADMIN_ROLE + "', '" + RoleProvider.REPORTING_ROLE + "')) and " +
     "@reportAccessService.providesAccessTo(authentication)")
 public @interface ReportingAdminOnly {
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -330,7 +330,7 @@ public class TallyResourceTest {
                  Mockito.eq(null)))
             .thenReturn(new PageImpl<>(Collections.emptyList()));
 
-        resource.getTallyReport(
+        TallyReport report = resource.getTallyReport(
             "product1",
             "daily",
             min,
@@ -339,6 +339,7 @@ public class TallyResourceTest {
             null,
             null
         );
+        assertNotNull(report);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSourceTest.java
@@ -26,24 +26,29 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.insights.rbac.client.RbacApi;
-import org.candlepin.insights.rbac.client.RbacServiceProperties;
+import org.candlepin.insights.rbac.client.RbacService;
 import org.candlepin.insights.rbac.client.model.Access;
 import org.candlepin.subscriptions.ApplicationProperties;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
 public class IdentityHeaderAuthenticationDetailsSourceTest {
 
-    @Mock
+    @MockBean
     private RbacApi rbacApi;
+
+    @Autowired
+    private RbacService rbacService;
 
     @Test
     public void testAdminRoleGranted() throws Exception {
@@ -72,8 +77,7 @@ public class IdentityHeaderAuthenticationDetailsSourceTest {
         ApplicationProperties props = new ApplicationProperties();
         props.setDevMode(devMode);
         IdentityHeaderAuthenticationDetailsSource source = new IdentityHeaderAuthenticationDetailsSource(
-            props, new IdentityHeaderAuthoritiesMapper(), rbacApi,
-            new RbacServiceProperties().getApplicationName()
+            props, new IdentityHeaderAuthoritiesMapper(), rbacService
         );
         Collection<String> roles = source.getUserRoles();
         assertEquals(expectedRoles.length, roles.size());

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSourceTest.java
@@ -51,20 +51,20 @@ public class IdentityHeaderAuthenticationDetailsSourceTest {
             Arrays.asList(new Access().permission("subscriptions:*:*"))
         );
         assertRoles(false,
-            RoleProvider.ORG_ADMIN_ROLE,
+            RoleProvider.OPT_IN_ROLE,
             RoleProvider.REPORTING_ROLE);
     }
 
     @Test
     public void testDevModeGrantsAllRoles() {
         assertRoles(true,
-            RoleProvider.ORG_ADMIN_ROLE,
+            RoleProvider.OPT_IN_ROLE,
             RoleProvider.REPORTING_ROLE);
         assertRoles(true,
-            RoleProvider.ORG_ADMIN_ROLE,
+            RoleProvider.OPT_IN_ROLE,
             RoleProvider.REPORTING_ROLE);
         assertRoles(true,
-            RoleProvider.ORG_ADMIN_ROLE,
+            RoleProvider.OPT_IN_ROLE,
             RoleProvider.REPORTING_ROLE);
     }
 

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import static org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter.RH_IDENTITY_HEADER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.servlet.http.HttpServletRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class IdentityHeaderAuthenticationFilterTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    public void testEmptyHeaderReturnsNullPrincipal() {
+        when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(null);
+        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+        assertNull(filter.getPreAuthenticatedPrincipal(request));
+    }
+
+    @Test
+    public void defaultEmptyPrincipalReturnedWhenExceptionOccursWhileProcessingHeader() {
+        when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn("arandomheadervalue");
+        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+        assertPrincipal(filter.getPreAuthenticatedPrincipal(request), null, null);
+    }
+
+    @Test
+    public void missingIdentityResultsInEmptyOrgAndAccount() {
+        // {}
+        String emptyJson = "e30=";
+        when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(emptyJson);
+        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+        assertPrincipal(filter.getPreAuthenticatedPrincipal(request), "", "");
+    }
+
+    @Test
+    public void testMissingInternalProperty() {
+        // {"identity":{"account_number":"myaccount"}}
+        String missingInternal = "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Im15YWNjb3VudCJ9fQ==";
+        when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(missingInternal);
+        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+        assertPrincipal(filter.getPreAuthenticatedPrincipal(request), "myaccount", "");
+    }
+
+    @Test
+    public void missingOrgInHeaderResultsInEmptyValueInPrincipal() {
+        // {"identity":{"account_number":"myaccount", "internal":{"org_id":""}}}
+        String missingOrgId =
+            "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Im15YWNjb3VudCIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiIifX19";
+        when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(missingOrgId);
+        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+        assertPrincipal(filter.getPreAuthenticatedPrincipal(request), "myaccount", "");
+    }
+
+    @Test
+    public void missingAccountInHeaderResultsInEmptyValueInPrincipal() {
+        //
+        String missingAccount = "eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJteW9yZyJ9fX0=";
+        when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(missingAccount);
+        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+        assertPrincipal(filter.getPreAuthenticatedPrincipal(request), "", "myorg");
+    }
+
+    private void assertPrincipal(Object preAuthPrincipal, String expAccountNumber, String expOrgId) {
+        assertTrue(preAuthPrincipal instanceof InsightsUserPrincipal);
+
+        InsightsUserPrincipal principal = (InsightsUserPrincipal) preAuthPrincipal;
+        assertEquals(expOrgId, principal.getOwnerId());
+        assertEquals(expAccountNumber, principal.getAccountNumber());
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Base64;
+
 import javax.servlet.http.HttpServletRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -60,7 +62,7 @@ public class IdentityHeaderAuthenticationFilterTest {
     @Test
     public void missingIdentityResultsInEmptyOrgAndAccount() {
         // {}
-        String emptyJson = "e30=";
+        String emptyJson = Base64.getEncoder().encodeToString("{}".getBytes());
         when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(emptyJson);
         IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
         assertPrincipal(filter.getPreAuthenticatedPrincipal(request), "", "");
@@ -68,8 +70,8 @@ public class IdentityHeaderAuthenticationFilterTest {
 
     @Test
     public void testMissingInternalProperty() {
-        // {"identity":{"account_number":"myaccount"}}
-        String missingInternal = "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Im15YWNjb3VudCJ9fQ==";
+        String missingInternal = Base64.getEncoder().encodeToString(
+            "{\"identity\":{\"account_number\":\"myaccount\"}}".getBytes());
         when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(missingInternal);
         IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
         assertPrincipal(filter.getPreAuthenticatedPrincipal(request), "myaccount", "");
@@ -77,9 +79,8 @@ public class IdentityHeaderAuthenticationFilterTest {
 
     @Test
     public void missingOrgInHeaderResultsInEmptyValueInPrincipal() {
-        // {"identity":{"account_number":"myaccount", "internal":{"org_id":""}}}
-        String missingOrgId =
-            "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Im15YWNjb3VudCIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiIifX19";
+        String missingOrgId = Base64.getEncoder().encodeToString(
+            "{\"identity\":{\"account_number\":\"myaccount\", \"internal\":{\"org_id\":\"\"}}}".getBytes());
         when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(missingOrgId);
         IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
         assertPrincipal(filter.getPreAuthenticatedPrincipal(request), "myaccount", "");
@@ -88,7 +89,8 @@ public class IdentityHeaderAuthenticationFilterTest {
     @Test
     public void missingAccountInHeaderResultsInEmptyValueInPrincipal() {
         //
-        String missingAccount = "eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJteW9yZyJ9fX0=";
+        String missingAccount = Base64.getEncoder().encodeToString(
+            "{\"identity\":{\"internal\":{\"org_id\":\"myorg\"}}}".getBytes());
         when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(missingAccount);
         IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
         assertPrincipal(filter.getPreAuthenticatedPrincipal(request), "", "myorg");

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManagerTest.java
@@ -21,6 +21,8 @@
 package org.candlepin.subscriptions.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -28,38 +30,46 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
 import org.springframework.test.context.TestPropertySource;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 
 @SpringBootTest
 @TestPropertySource("classpath:/test.properties")
 class IdentityHeaderAuthenticationManagerTest {
 
-    String HEADER_JSON = "{\"identity\":{\"account_number\":\"acct\",\"internal\":{\"org_id\":\"123\"}}}";
-
     @MockBean
     PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails details;
 
+    private IdentityHeaderAuthenticationManager manager =
+        new IdentityHeaderAuthenticationManager(new ObjectMapper());
+
     @Test
-    void testOrgIdExtractedFromHeader() {
-        IdentityHeaderAuthenticationManager manager =
-            new IdentityHeaderAuthenticationManager(new ObjectMapper());
+    public void testMissingOrgId() {
+        AuthenticationException e =
+            assertThrows(AuthenticationException.class, () -> manager.authenticate(token(null, "account")));
+        assertEquals("x-rh-identity contains no owner ID for the principal", e.getMessage());
+    }
 
-        PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
-            HEADER_JSON.getBytes(StandardCharsets.UTF_8), "N/A");
-        authentication.setDetails(details);
+    @Test
+    public void testMissingAccountNumber() {
+        AuthenticationException e =
+            assertThrows(AuthenticationException.class, () -> manager.authenticate(token("123", null)));
+        assertEquals("x-rh-identity contains no account number for the principal", e.getMessage());
+    }
 
-        Authentication result = manager.authenticate(authentication);
+    @Test
+    public void validPrincipalIsAuthenticated() {
+        Authentication result = manager.authenticate(token("123", "acct"));
+        assertTrue(result.isAuthenticated());
+    }
 
-        InsightsUserPrincipal principal = new InsightsUserPrincipal("123", "acct");
-
-        PreAuthenticatedAuthenticationToken expected = new PreAuthenticatedAuthenticationToken(principal,
-            "N/A",
-            Collections.emptyList());
-        assertEquals(expected, result);
+    private PreAuthenticatedAuthenticationToken token(String org, String account) {
+        PreAuthenticatedAuthenticationToken token =
+            new PreAuthenticatedAuthenticationToken(new InsightsUserPrincipal(org, account), "N/A");
+        token.setDetails(details);
+        return token;
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationManagerTest.java
@@ -24,8 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -43,8 +41,7 @@ class IdentityHeaderAuthenticationManagerTest {
     @MockBean
     PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails details;
 
-    private IdentityHeaderAuthenticationManager manager =
-        new IdentityHeaderAuthenticationManager(new ObjectMapper());
+    private IdentityHeaderAuthenticationManager manager = new IdentityHeaderAuthenticationManager();
 
     @Test
     public void testMissingOrgId() {

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
@@ -29,7 +29,7 @@ import java.lang.annotation.RetentionPolicy;
  * Creates a mock Red Hat principal for testing, with account$value and owner$value as account number and
  * owner ID.
  *
- * Defaults to granting ROLE_ORG_ADMIN, but can be overridden.
+ * Defaults to granting ROLE_OPT_IN, but can be overridden.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithMockInsightsUserSecurityContextFactory.class)
@@ -44,5 +44,5 @@ public @interface WithMockRedHatPrincipal {
     boolean nullifyAccount() default false;
     boolean nullifyOwner() default false;
 
-    String[] roles() default {"ROLE_" + RoleProvider.ORG_ADMIN_ROLE};
+    String[] roles() default {"ROLE_" + RoleProvider.OPT_IN_ROLE};
 }

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
@@ -44,5 +44,5 @@ public @interface WithMockRedHatPrincipal {
     boolean nullifyAccount() default false;
     boolean nullifyOwner() default false;
 
-    String[] roles() default {"ROLE_" + IdentityHeaderAuthenticationDetailsSource.ORG_ADMIN_ROLE};
+    String[] roles() default {"ROLE_" + RoleProvider.ORG_ADMIN_ROLE};
 }

--- a/src/test/java/org/candlepin/subscriptions/security/auth/OptInRoleRequiredTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/auth/OptInRoleRequiredTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.*;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.security.WhitelistedAccountReportAccessService;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
-import org.candlepin.subscriptions.security.auth.AdminOnlyTest.AdminOnlyConfiguration;
+import org.candlepin.subscriptions.security.auth.OptInRoleRequiredTest.OptInRoleRequiredConfiguration;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,14 +36,14 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@SpringJUnitConfig(classes = AdminOnlyConfiguration.class)
-public class AdminOnlyTest {
+@SpringJUnitConfig(classes = OptInRoleRequiredConfiguration.class)
+public class OptInRoleRequiredTest {
 
     @Autowired
     ApplicationContext context;
 
     @EnableGlobalMethodSecurity(prePostEnabled = true)
-    protected static class AdminOnlyConfiguration {
+    protected static class OptInRoleRequiredConfiguration {
         @Bean
         public StubResource stubResource() {
             return new StubResource();
@@ -61,7 +61,7 @@ public class AdminOnlyTest {
     }
 
     protected static class StubResource {
-        @AdminOnly
+        @OptInRoleRequired
         public void adminOnlyCall() {
             // Does nothing
         }

--- a/src/test/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequiredTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequiredTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.*;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.security.WhitelistedAccountReportAccessService;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
-import org.candlepin.subscriptions.security.auth.ReportingAdminOnlyTest.ReportingAdminOnlyConfiguration;
+import org.candlepin.subscriptions.security.auth.ReportingAccessRequiredTest.ReportingAdminOnlyConfiguration;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +38,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = ReportingAdminOnlyConfiguration.class)
-public class ReportingAdminOnlyTest {
+public class ReportingAccessRequiredTest {
 
     @Autowired ApplicationContext context;
 
@@ -61,7 +61,7 @@ public class ReportingAdminOnlyTest {
     }
 
     protected static class StubResource {
-        @ReportingAdminOnly
+        @ReportingAccessRequired
         public void reportingAdminOnlyCall() {
             // Does nothing
         }


### PR DESCRIPTION
# PR Details
There are two key pieces to this PR.

**1) Prevent the security checks from happening multiple times per filter**

When the CSRF filter was added, security checks were being performed
multiple times per request, resulting in processing the identity header
multiple times. This was happening because we were setting the decoded
header as the principal and then replacing it with the InsightsUserPrincipal
once the header JSON was was processed. Spring security was checking
to see if the principal had changed between filters and because it was
replaced, it checked it twice.

This PR does the header parsing and principal generation in the
IdentityHeaderAuthenticationFilter. This is in turn passed to the
IdentityHeaderAuthenticationManager which simply validates the data
in the principal and throws appropriate exceptions which trickles
back to the response with the appropriate codes.

By doing this, we do not swap the principal in the context, avoiding
the failed principal equality checks resulting in the extra security
checks.
 

**2) Use RBAC client to determine the user's application roles.**

* Add an OptInFilter (tally/capacity endpoints) that checks to make sure
  that the user's current account has fully opted in. If the opt-in process
  has not been completed, an OptInRequiredException is thrown from the filter
  resulting in a 403 with an appropriate application error code
  (1004: Request was denied since opt-in has not yet occurred.)

* RBAC permissions are being fetched by the RBAC client and are being
  parsed by a RoleProvider class. This class processes the permissions
  provided by RBAC and translates them into our own application roles
  (spring based roles) that are used by our security annotations.

* The subscriptions:*:* permission is the only RBAC permission currently being
  checked. Having this permission grants the OPT_IN and REPORTING application
  roles.

  NOTE: In the permission above, 'subscriptions' is the RBAC application name
        and is configurable.

* It is safe to assume from here out that any 403 (AccessDenied) response is due
  to invalid permissions from RBAC.


# How To Test
I must admit, manually testing this is really cumbersome and requires a few workarounds and app restarts.

Start start by deploying the application with the following config properties set:
```properties
# Use the stub RBAC API
rhsm-subscriptions.rbac-service.useStub=true

# The stub rbac api will return 'subscriptions:*:*' for any user, so we set the expected
# permission  to be 'insights:*:*' to simulate a user without the appropriate permission
rhsm-subscriptions.rbacApplicationName=insights

# This workaround still exists, but let's disable it so that the role is actually checked.
rhsm-subscriptions.orgAdminOptional=false

# Make sure we are not running in dev mode
rhsm-subscriptions.dev-mode=false
```

1) Test that opt-in is checked when a request is made to tally (same applies to capacity). I created a standard ID header with account/org that has no opt-in configuration in the database.

```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NSIsImF1dGhfdGltZSI6MH0sImFjY291bnRfbnVtYmVyIjoiNTU1NTU1In19Cg==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=monthly&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T23:59:59.999Z" | python -mjson.tool

{
    "errors": [
        {
            "code": "SUBSCRIPTIONS1004",
            "detail": "Opt-in required.",
            "status": "403",
            "title": "Access Denied"
        }
    ]
}
```
2) Opt-In will 403 because subscriptions:*:* as returned from the stub client does not match the expected insights:*:* permission.  **Note that I added an 'origin' header to make the csrf check happy.**
```bash
$ curl -X PUT -H "origin: localhost.redhat.com" -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NSIsImF1dGhfdGltZSI6MH0sImFjY291bnRfbnVtYmVyIjoiNTU1NTU1In19Cg==" "http://localhost:8080/api/rhsm-subscriptions/v1/opt-in/" | python -mjson.tool
{
    "errors": [
        {
            "code": "SUBSCRIPTIONS1003",
            "detail": "Access is denied",
            "status": "403",
            "title": "Access Denied"
        }
    ]
}
```

3) Stop the app, comment out **rhsm-subscriptions.rbacApplicationName** property and restart the application.

4) Opting in should now work.
```bash
$ curl -X PUT -H "origin: localhost.redhat.com" -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NSIsImF1dGhfdGltZSI6MH0sImFjY291bnRfbnVtYmVyIjoiNTU1NTU1In19Cg==" "http://localhost:8080/api/rhsm-subscriptions/v1/opt-in/" | python -mjson.tool

{
    "data": {
        "account": {
            "account_number": "555555",
            "created": "2020-04-30T10:15:28.816-03:00",
            "last_updated": "2020-04-30T15:42:10.059Z",
            "opt_in_type": "API",
            "tally_reporting_enabled": true,
            "tally_sync_enabled": true
        },
        "opt_in_complete": true,
        "org": {
            "conduit_sync_enabled": true,
            "created": "2020-04-30T10:15:28.816-03:00",
            "last_updated": "2020-04-30T15:42:10.059Z",
            "opt_in_type": "API",
            "org_id": "12345"
        }
    },
    "meta": {
        "account_number": "555555",
        "org_id": "12345"
    }
}

```

5) Stop the app and re-enable the **rhsm-subscriptions.rbacApplicationName** property and restart the application.

6) Now that opt-in is complete, check to make sure that you can not access the tally api due to permissions.
```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NSIsImF1dGhfdGltZSI6MH0sImFjY291bnRfbnVtYmVyIjoiNTU1NTU1In19Cg==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=monthly&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T23:59:59.999Z" | python -mjson.tool

{
    "errors": [
        {
            "code": "SUBSCRIPTIONS1003",
            "detail": "Access is denied",
            "status": "403",
            "title": "Access Denied"
        }
    ]
}

```

7) Same with capacity.
```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NSIsImF1dGhfdGltZSI6MH0sImFjY291bnRfbnVtYmVyIjoiNTU1NTU1In19Cg==" "http://localhost:8080/api/rhsm-subscriptions/v1/capacity/products/RHEL?granularity=monthly&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T23:59:59.999Z" | python -mjson.tool

{
    "errors": [
        {
            "code": "SUBSCRIPTIONS1003",
            "detail": "Access is denied",
            "status": "403",
            "title": "Access Denied"
        }
    ]
}

```

8) Stop the app, comment out **rhsm-subscriptions.rbacApplicationName** property and restart the application.

9) Because the stub API is now returning the expected permission, both the tally and capacity APIs should be accessible to the user.
```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NSIsImF1dGhfdGltZSI6MH0sImFjY291bnRfbnVtYmVyIjoiNTU1NTU1In19Cg==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=monthly&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T23:59:59.999Z" | python -mjson.tool

{
    "data": [
        {
            "cloud_cores": 0,
            "cloud_instance_count": 0,
            "cloud_sockets": 0,
            "cores": 0,
            "date": "2019-06-01T00:00:00Z",
            "has_data": false,
            "hypervisor_cores": 0,
            "hypervisor_instance_count": 0,
            "hypervisor_sockets": 0,
            "instance_count": 0,
            "physical_cores": 0,
            "physical_instance_count": 0,
            "physical_sockets": 0,
            "sockets": 0
        }
    ],
    "meta": {
        "count": 1,
        "granularity": "MONTHLY",
        "product": "RHEL"
    }
}

$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NSIsImF1dGhfdGltZSI6MH0sImFjY291bnRfbnVtYmVyIjoiNTU1NTU1In19Cg==" "http://localhost:8080/api/rhsm-subscriptions/v1/capacity/products/RHEL?granularity=monthly&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T23:59:59.999Z" | python -mjson.tool

{
    "data": [
        {
            "cores": 0,
            "date": "2019-06-01T00:00:00Z",
            "has_infinite_quantity": false,
            "hypervisor_cores": 0,
            "hypervisor_sockets": 0,
            "physical_cores": 0,
            "physical_sockets": 0,
            "sockets": 0
        }
    ],
    "meta": {
        "count": 1,
        "granularity": "monthly",
        "product": "RHEL"
    }
}

```

# Additional Testing
This same scenario can be tested using an actual RBAC service by following the instructions in the following PR to set up the client. Be sure to set the rbac applicationName property to 'insights' and comment out the property to test the invalid case (subscriptions) since the test service sets the 'insights' permissions and not subscriptions (as of now) .

https://github.com/RedHatInsights/rhsm-subscriptions/pull/121