### PR TITLE
Adjustment: OpenShift subscriptions include RHEL

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityProductExtractor.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityProductExtractor.java
@@ -62,7 +62,7 @@ public class CapacityProductExtractor {
             .collect(Collectors.toSet());
 
         if (setIsInvalid(products)) {
-            // Kick out the RHEL products since it's implicit with the Satellite product being there.
+            // Kick out the RHEL products since it's implicit with the RHEL-included product being there.
             products = products.stream().filter(matchesRhel().negate()).collect(Collectors.toSet());
         }
 
@@ -85,15 +85,16 @@ public class CapacityProductExtractor {
      * @return true if the set is invalid for capacity calculations
      */
     public boolean setIsInvalid(Set<String> products) {
-        return products.stream().anyMatch(matchesRhel()) && products.stream().anyMatch((matchesSatellite()));
+        return products.stream().anyMatch(matchesRhel()) && products.stream()
+            .anyMatch(matchesRhelIncludedProduct());
     }
 
     private Predicate<String> matchesRhel() {
         return x -> x.startsWith("RHEL");
     }
 
-    private Predicate<String> matchesSatellite() {
-        return x -> x.startsWith("Satellite");
+    private Predicate<String> matchesRhelIncludedProduct() {
+        return x -> x.startsWith("Satellite") || x.startsWith("OpenShift");
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -36,7 +36,7 @@ public interface SubscriptionCapacityRepository extends
     JpaRepository<SubscriptionCapacity, SubscriptionCapacityKey> {
 
     @Transactional
-    List<SubscriptionCapacity> findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+    List<SubscriptionCapacity> findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
         String ownerId,
         String productId,
         OffsetDateTime begin,
@@ -44,11 +44,15 @@ public interface SubscriptionCapacityRepository extends
     );
 
     @Transactional
-    List<SubscriptionCapacity> findByOwnerIdAndProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
+    List<SubscriptionCapacity>
+        findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
         String ownerId,
         String productId,
         String serviceLevel,
         OffsetDateTime begin,
         OffsetDateTime end
     );
+
+    List<SubscriptionCapacity> findByKeyOwnerIdAndKeySubscriptionIdIn(String ownerId,
+        List<String> subscriptionIds);
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
@@ -25,29 +25,18 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 
 import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
 import javax.persistence.Table;
 
 /**
  * Capacity provided by a subscription for a given product.
  */
-@IdClass(SubscriptionCapacityKey.class)
 @Entity
 @Table(name = "subscription_capacity")
 public class SubscriptionCapacity implements Serializable {
-    @Id
-    @Column(name = "product_id")
-    private String productId;
-
-    @Id
-    @Column(name = "subscription_id")
-    private String subscriptionId;
-
-    @Id
-    @Column(name = "owner_id")
-    private String ownerId;
+    @EmbeddedId
+    private SubscriptionCapacityKey key;
 
     @Column(name = "account_number")
     private String accountNumber;
@@ -82,6 +71,18 @@ public class SubscriptionCapacity implements Serializable {
     @Column(name = "usage")
     private String usage;
 
+    public SubscriptionCapacity() {
+        key = new SubscriptionCapacityKey();
+    }
+
+    public SubscriptionCapacityKey getKey() {
+        return key;
+    }
+
+    public void setKey(SubscriptionCapacityKey key) {
+        this.key = key;
+    }
+
     public String getAccountNumber() {
         return accountNumber;
     }
@@ -91,27 +92,27 @@ public class SubscriptionCapacity implements Serializable {
     }
 
     public String getProductId() {
-        return productId;
+        return key.getProductId();
     }
 
     public void setProductId(String productId) {
-        this.productId = productId;
+        key.setProductId(productId);
     }
 
     public String getSubscriptionId() {
-        return subscriptionId;
+        return key.getSubscriptionId();
     }
 
     public void setSubscriptionId(String subscriptionId) {
-        this.subscriptionId = subscriptionId;
+        key.setSubscriptionId(subscriptionId);
     }
 
     public String getOwnerId() {
-        return ownerId;
+        return key.getOwnerId();
     }
 
     public void setOwnerId(String ownerId) {
-        this.ownerId = ownerId;
+        key.setOwnerId(ownerId);
     }
 
     public Integer getPhysicalSockets() {
@@ -245,7 +246,8 @@ public class SubscriptionCapacity implements Serializable {
             "subscriptionId=%s, ownerId=%s, physicalSockets=%s, virtualSockets=%s, " +
             "hasUnlimitedGuestSockets=%s, physicalCores=%s, virtualCores=%s, serviceLevel=%s, usage=%s, " +
             "beginDate=%s, endDate=%s}",
-            accountNumber, sku, productId, subscriptionId, ownerId, physicalSockets, virtualSockets,
-            hasUnlimitedGuestSockets, physicalCores, virtualCores, serviceLevel, usage, beginDate, endDate);
+            accountNumber, sku, key.getProductId(), key.getSubscriptionId(), key.getOwnerId(),
+            physicalSockets, virtualSockets, hasUnlimitedGuestSockets, physicalCores, virtualCores,
+            serviceLevel, usage, beginDate, endDate);
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityKey.java
@@ -24,10 +24,12 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import javax.persistence.Column;
+import javax.persistence.Embeddable;
 
 /**
  * Primary key for record of capacity provided by a subscription for a given product.
  */
+@Embeddable
 public class SubscriptionCapacityKey implements Serializable {
 
     @Column(name = "owner_id")

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -129,7 +129,7 @@ public class CapacityResource implements CapacityApi {
 
         List<SubscriptionCapacity> matches;
         if (sla == ServiceLevel.UNSPECIFIED) {
-            matches = repository.findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            matches = repository.findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
                 ownerId,
                 productId,
                 beginning,
@@ -137,7 +137,8 @@ public class CapacityResource implements CapacityApi {
             );
         }
         else {
-            matches = repository.findByOwnerIdAndProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
+            matches = repository
+                .findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
                 ownerId,
                 productId,
                 sla.getValue(),

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -132,10 +132,10 @@ public class FactNormalizer {
 
     @SuppressWarnings("indentation")
     private void pruneProducts(NormalizedFacts normalizedFacts) {
-        // If a Satellite product was found, do not include RHEL or its variants.
-        boolean hasSatellite = normalizedFacts.getProducts().stream()
-            .anyMatch(s -> s.startsWith("Satellite"));
-        if (hasSatellite) {
+        // If a Satellite or OpenShift product was found, do not include RHEL or its variants.
+        boolean hasRhelIncludedProduct = normalizedFacts.getProducts().stream()
+            .anyMatch(s -> s.startsWith("Satellite") || s.startsWith("OpenShift"));
+        if (hasRhelIncludedProduct) {
             normalizedFacts.setProducts(
                 normalizedFacts.getProducts().stream()
                     .filter(prod -> !prod.startsWith("RHEL"))

--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -40,6 +40,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -80,7 +81,7 @@ class CandlepinPoolCapacityMapperTest {
         CandlepinPool pool = createTestPool(physicalProductIds, null);
 
         Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
-            pool);
+            pool, Collections.emptyMap());
 
         SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
         expectedRhelCapacity.setProductId("RHEL");
@@ -115,7 +116,7 @@ class CandlepinPoolCapacityMapperTest {
         CandlepinPool pool = createTestPool(physicalProductIds, null, null, "badSLA");
 
         Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
-            pool);
+            pool, Collections.emptyMap());
 
         SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
         expectedRhelCapacity.setProductId("RHEL");
@@ -148,7 +149,7 @@ class CandlepinPoolCapacityMapperTest {
         CandlepinPool pool = createTestPool(physicalProductIds, null, 2);
 
         Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
-            pool);
+            pool, Collections.emptyMap());
 
         SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
         expectedRhelCapacity.setProductId("RHEL");
@@ -183,7 +184,7 @@ class CandlepinPoolCapacityMapperTest {
         CandlepinPool pool = createTestPool(null, virtualProductIds);
 
         Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
-            pool);
+            pool, Collections.emptyMap());
 
         SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
         expectedRhelCapacity.setProductId("RHEL");
@@ -218,7 +219,7 @@ class CandlepinPoolCapacityMapperTest {
         CandlepinPool pool = createTestPool(physicalProductIds, virtualProductIds);
 
         Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
-            pool);
+            pool, Collections.emptyMap());
 
         SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
         expectedRhelCapacity.setProductId("RHEL");
@@ -268,7 +269,7 @@ class CandlepinPoolCapacityMapperTest {
         pool.setQuantity(-1L);
 
         Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
-            pool);
+            pool, Collections.emptyMap());
 
         SubscriptionCapacity expectedRhelCapacity = new SubscriptionCapacity();
         expectedRhelCapacity.setProductId("RHEL");

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
@@ -83,6 +83,14 @@ class CapacityProductExtractorTest {
     }
 
     @Test
+    void productSetIsInvalidWithOpenShift() {
+        Set<String> products = new HashSet<>();
+        products.add("RHEL Workstation");
+        products.add("OpenShift Container Platform");
+        assertThat(extractor.setIsInvalid(products), Matchers.is(true));
+    }
+
+    @Test
     void productSetIsValid() {
         Set<String> products = new HashSet<>();
         products.add("RHEL Workstation");
@@ -93,7 +101,13 @@ class CapacityProductExtractorTest {
 
     @Test
     void productExtractorReturnsExpectedProductsWhenSatellitePresent() {
-        Set<String> products = extractor.getProducts(Arrays.asList("12"));
+        Set<String> products = extractor.getProducts(Arrays.asList("1", "12"));
         assertThat(products, Matchers.containsInAnyOrder("Satellite 6 Capsule"));
+    }
+
+    @Test
+    void productExtractorReturnsExpectedProductsWhenOpenShiftPresent() {
+        Set<String> products = extractor.getProducts(Arrays.asList("1", "13"));
+        assertThat(products, Matchers.containsInAnyOrder("OpenShift Container Platform"));
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
@@ -25,17 +25,21 @@ import static org.mockito.Mockito.*;
 import org.candlepin.subscriptions.capacity.CandlepinPoolCapacityMapper;
 import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacityKey;
 import org.candlepin.subscriptions.files.ProductWhitelist;
 import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
 import org.candlepin.subscriptions.utilization.api.model.CandlepinProductAttribute;
 import org.candlepin.subscriptions.utilization.api.model.CandlepinProvidedProduct;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.mockito.hamcrest.MockitoHamcrest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 @SpringBootTest
@@ -57,31 +61,85 @@ class PoolIngressControllerTest {
     @Test
     void testNothingSavedIfFilteredByWhitelist() {
         when(whitelist.productIdMatches(any())).thenReturn(false);
+        when(repository.findByKeyOwnerIdAndKeySubscriptionIdIn(anyString(), anyList()))
+            .thenReturn(Collections.emptyList());
 
         CandlepinPool pool = createTestPool();
         controller.updateCapacityForOrg("org", Collections.singletonList(pool));
 
         verifyZeroInteractions(mapper);
-        verifyZeroInteractions(repository);
+        verify(repository).saveAll(eq(Collections.emptyList()));
     }
 
     @Test
     void testSavesPoolsProvidedByMapper() {
         when(whitelist.productIdMatches(any())).thenReturn(true);
+        when(repository.findByKeyOwnerIdAndKeySubscriptionIdIn(anyString(), anyList()))
+            .thenReturn(Collections.emptyList());
         SubscriptionCapacity capacity = new SubscriptionCapacity();
-        when(mapper.mapPoolToSubscriptionCapacity(anyString(), any()))
+        when(mapper.mapPoolToSubscriptionCapacity(anyString(), any(), eq(Collections.emptyMap())))
             .thenReturn(Collections.singletonList(capacity));
 
         CandlepinPool pool = createTestPool();
         controller.updateCapacityForOrg("org", Collections.singletonList(pool));
 
-        verify(repository).save(eq(capacity));
+        verify(repository).saveAll(eq(Collections.singletonList(capacity)));
+    }
+
+    @Test
+    void testRemovesExistingCapacityRecordsIfNoLongerNeeded() {
+        SubscriptionCapacity stale1 = createCapacity("owner", "RHEL");
+        SubscriptionCapacity stale2 = createCapacity("owner", "RHEL Workstation");
+        SubscriptionCapacity expected = createCapacity("owner", "OpenShift Container Platform");
+
+        when(whitelist.productIdMatches(any())).thenReturn(true);
+        when(repository.findByKeyOwnerIdAndKeySubscriptionIdIn(anyString(), anyList()))
+            .thenReturn(Arrays.asList(stale1, stale2, expected));
+        when(mapper.mapPoolToSubscriptionCapacity(anyString(), any(CandlepinPool.class), anyMap()))
+            .thenReturn(Collections.singletonList(expected));
+
+        CandlepinPool pool = createTestPool();
+        controller.updateCapacityForOrg("org", Collections.singletonList(pool));
+
+        verify(repository).saveAll(eq(Collections.singletonList(expected)));
+        verify(repository).deleteAll(MockitoHamcrest.argThat(Matchers.containsInAnyOrder(stale1,
+            stale2)));
+    }
+
+    @Test
+    void testRemovesAllCapacityRecordsIfSkuIsFiltered() {
+        SubscriptionCapacity stale1 = createCapacity("owner", "RHEL");
+        SubscriptionCapacity stale2 = createCapacity("owner", "RHEL Workstation");
+
+        when(whitelist.productIdMatches(anyString())).thenReturn(false);
+        when(repository.findByKeyOwnerIdAndKeySubscriptionIdIn(anyString(), anyList()))
+            .thenReturn(Arrays.asList(stale1, stale2));
+        when(mapper.mapPoolToSubscriptionCapacity(anyString(), any(CandlepinPool.class), anyMap()))
+            .thenReturn(Arrays.asList(stale1, stale2));
+
+        CandlepinPool pool = createTestPool();
+        controller.updateCapacityForOrg("org", Collections.singletonList(pool));
+
+        verify(repository).saveAll(eq(Collections.emptyList()));
+        verify(repository).deleteAll(MockitoHamcrest.argThat(Matchers.containsInAnyOrder(stale1,
+            stale2)));
+    }
+
+    private SubscriptionCapacity createCapacity(String owner, String product) {
+        SubscriptionCapacityKey key = new SubscriptionCapacityKey();
+        key.setOwnerId(owner);
+        key.setProductId(product);
+        key.setSubscriptionId("12345");
+        SubscriptionCapacity capacity = new SubscriptionCapacity();
+        capacity.setKey(key);
+        return capacity;
     }
 
     private CandlepinPool createTestPool() {
         CandlepinPool pool = new CandlepinPool();
         pool.setAccountNumber("account-1234");
         pool.setActiveSubscription(true);
+        pool.setSubscriptionId("12345");
         CandlepinProvidedProduct providedProduct = new CandlepinProvidedProduct();
         providedProduct.setProductId("product-1");
         pool.setProvidedProducts(Collections.singletonList(providedProduct));

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -65,7 +65,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             NOWISH,
@@ -93,7 +93,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             NOWISH,
@@ -121,7 +121,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             NOWISH,
@@ -149,7 +149,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             NOWISH,
@@ -177,7 +177,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             NOWISH,
@@ -193,7 +193,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             NOWISH,
@@ -209,7 +209,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             NOWISH,
@@ -224,7 +224,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             "Standard",
@@ -240,7 +240,7 @@ class SubscriptionCapacityRepositoryTest {
         repository.flush();
 
         List<SubscriptionCapacity> found = repository
-            .findByOwnerIdAndProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
             "Premium",

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -83,7 +83,7 @@ class CapacityResourceTest {
         capacity.setEndDate(max);
 
         when(repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
             Mockito.eq("owner123456"),
             Mockito.eq("product1"),
             Mockito.eq(min),
@@ -110,7 +110,7 @@ class CapacityResourceTest {
         capacity.setEndDate(max);
 
         when(repository
-            .findByOwnerIdAndProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
                 Mockito.eq("owner123456"),
                 Mockito.eq("product1"),
                 Mockito.eq("Premium"),
@@ -138,7 +138,7 @@ class CapacityResourceTest {
         capacity.setEndDate(max);
 
         when(repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
                 Mockito.eq("owner123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(min),
@@ -177,7 +177,7 @@ class CapacityResourceTest {
         capacity2.setEndDate(max);
 
         when(repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
                 Mockito.eq("owner123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(min),
@@ -237,7 +237,7 @@ class CapacityResourceTest {
         capacity.setEndDate(max);
 
         when(repository
-            .findByOwnerIdAndProductIdAndEndDateAfterAndBeginDateBefore(
+            .findByKeyOwnerIdAndKeyProductIdAndEndDateAfterAndBeginDateBefore(
                 Mockito.eq("owner123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(min),

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -264,6 +264,16 @@ public class FactNormalizerTest {
     }
 
     @Test
+    public void testNormalizationDiscardsRHELWhenOpenShiftExists() {
+        NormalizedFacts normalized = normalizer.normalize(createRhsmHost(Arrays.asList(2, 13), 12, 2, null,
+            clock.now()), new HashMap<>());
+        assertEquals(1, normalized.getProducts().size());
+        assertThat(normalized.getProducts(), Matchers.hasItem("OpenShift Container Platform"));
+        assertEquals(Integer.valueOf(12), normalized.getCores());
+        assertEquals(Integer.valueOf(2), normalized.getSockets());
+    }
+
+    @Test
     void testNormalizationDiscardsRHELForArchWhenSatelliteExists() {
         NormalizedFacts normalized = normalizer.normalize(createRhsmHost(Arrays.asList(2, 11, 6789), 12, 2,
             null, clock.now()), new HashMap<>());

--- a/src/test/resources/test_product_id_to_products_map.yaml
+++ b/src/test/resources/test_product_id_to_products_map.yaml
@@ -21,5 +21,7 @@
 12:
   - RHEL
   - Satellite 6 Capsule
+13:
+  - OpenShift Container Platform
 6789:
   - RHEL for x86


### PR DESCRIPTION
Because OpenShift subscriptions run on RHEL, and include RHEL, to simplify tracking, filter out RHEL during Tally or during Capacity calculations.

Also, because this is a change that can cause some pre-existing records to need to be removed, I changed the `PoolIngressController` accordingly.

I had to change `SubscriptionCapacityKey` to an `@EmbeddedId` to make it easier to use as a quick lookup.

Because deletion requires us to query for pre-existing records, I feel this is an area that we should monitor the performance of. Accordingly I added a few metrics:

- `rhsm-subscriptions.capacity.ingress` - timer for how long it takes to
  process an ingress request
- `rhsm-subscriptions.capacity.records_{created,updated,deleted}` -
  counts of capacity record CUD operations
- `rhsm-subscriptions.capacity.pools` - count of pools processed
- `rhsm-subscriptions.capacity.whitelisted_pools` - count of pools we
  actually did work for

To test, mock data in the DB for a subscription with RHEL capacity:

```sql
insert into subscription_capacity (account_number, product_id, subscription_id, owner_id, physical_sockets, has_unlimited_guest_sockets, begin_date, end_date, sku) VALUES ('account1', 'RHEL', 'subscription1', 'org1', 10, false, '2020-01-01 00:00:00.000000', '2023-01-01 00:00:00.000000','RH000test');
```

Then, post an update for a sub that provides both OpenShift and RHEL capacity:

```sh
curl -X POST "http://localhost:8080/api/rhsm-subscriptions/v1/ingress/candlepin_pools/org1" -H  "accept: */*" -H  "Content-Type: application/json" -d "[{\"accountNumber\":\"account1\",\"activeSubscription\":true,\"startDate\":\"2020-01-01T00:00:00Z\",\"endDate\":\"2023-01-01T00:00:00Z\",\"quantity\":1,\"productId\":\"RH000test\",\"productAttributes\":[{\"name\":\"sockets\",\"value\":\"10\"}],\"providedProducts\":[{\"productId\":\"69\"},{\"productId\":\"290\"}],\"subscriptionId\":\"subscription1\",\"type\":\"NORMAL\"}]"
```

JSON (can use swagger-ui instead of curl if desired):
```json
[
  {
    "accountNumber": "account1",
    "activeSubscription": true,
    "startDate": "2020-01-01T00:00:00Z",
    "endDate": "2023-01-01T00:00:00Z",
    "quantity": 1,
    "productId": "RH000test",
    "productAttributes": [
      {
        "name": "sockets",
        "value": "10"
      }
    ],
    "providedProducts": [
      {
        "productId": "69"
      },
      {
        "productId": "290"
      }
    ],
    "subscriptionId": "subscription1",
    "type": "NORMAL"
  }
]
```

Watch the logs/check the capacity to see that the now obsolete RHEL record is removed. Other variations can be tried if desired.