### PR TITLE
Add usage to tally snapshots and API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -176,6 +176,11 @@ paths:
           schema:
             type: string
           description: "Include only snapshots matching the specified service level."
+        - name: usage
+          in: query
+          schema:
+            type: string
+          description: "Include only snapshots matching the specified usage."
         - name: beginning
           in: query
           required: true
@@ -244,6 +249,7 @@ paths:
                   product: RHEL
                   granularity: DAILY
                   service_level: Premium
+                  usage: Production
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -596,6 +602,10 @@ components:
             service_level:
               description: "Describes the service level that the report was made against. Not set if it wasn't
                 specified as a query parameter."
+              type: string
+            usage:
+              description: "Describes the usage that the report was made against. Not set if it wasn't
+                            specified as a query parameter."
               type: string
             granularity:
               description: "Describes the significance of each date in the TallySnapshot list. For example if the

--- a/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
@@ -79,7 +79,7 @@ public class CandlepinPoolCapacityMapper {
         Long socketCapacity = getCapacityUnit("sockets", pool);
         Long coresCapacity = getCapacityUnit("cores", pool);
 
-        String sla = getSla(pool);
+        ServiceLevel sla = getSla(pool);
 
         return allProducts.stream().map(product -> {
             SubscriptionCapacityKey key = new SubscriptionCapacityKey();
@@ -168,7 +168,7 @@ public class CandlepinPoolCapacityMapper {
             .orElse(1);
     }
 
-    private String getSla(CandlepinPool pool) {
+    private ServiceLevel getSla(CandlepinPool pool) {
         Optional<String> sla = pool.getProductAttributes().stream()
             .filter(attr -> attr.getName().equals("support_level")).map(CandlepinProductAttribute::getValue)
             .findFirst();
@@ -179,7 +179,7 @@ public class CandlepinPoolCapacityMapper {
                 log.warn("Product {} has unsupported service level {}", pool.getProductId(), sla.get());
                 return null;
             }
-            return slaValue.getValue();
+            return slaValue;
         }
 
         return null;

--- a/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.db;
 
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityKey;
 
@@ -48,7 +49,7 @@ public interface SubscriptionCapacityRepository extends
         findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
         String ownerId,
         String productId,
-        String serviceLevel,
+        ServiceLevel serviceLevel,
         OffsetDateTime begin,
         OffsetDateTime end
     );

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -22,7 +22,9 @@
 package org.candlepin.subscriptions.db;
 
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,8 +45,8 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
     // suppress line length and params arguments, can't help either easily b/c this is a spring data method
     @SuppressWarnings({"linelength", "java:S107"})
     Page<TallySnapshot> findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-        String accountNumber, String productId, Granularity granularity, String serviceLevel, String usage,
-        OffsetDateTime beginning, OffsetDateTime ending, Pageable pageable);
+        String accountNumber, String productId, Granularity granularity, ServiceLevel serviceLevel,
+        Usage usage, OffsetDateTime beginning, OffsetDateTime ending, Pageable pageable);
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(String accountNumber,

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -40,9 +40,10 @@ import java.util.stream.Stream;
  */
 public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UUID> {
 
-    @SuppressWarnings("linelength")
-    Page<TallySnapshot> findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
-        String accountNumber, String productId, Granularity granularity, String serviceLevel,
+    // suppress line length and params arguments, can't help either easily b/c this is a spring data method
+    @SuppressWarnings({"linelength", "java:S107"})
+    Page<TallySnapshot> findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+        String accountNumber, String productId, Granularity granularity, String serviceLevel, String usage,
         OffsetDateTime beginning, OffsetDateTime ending, Pageable pageable);
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
@@ -24,6 +24,9 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
 /**
  * System purpose service level
  *
@@ -63,5 +66,24 @@ public enum ServiceLevel {
 
     public String getValue() {
         return value;
+    }
+
+    /**
+     * JPA converter for ServiceLevel
+     */
+    @Converter(autoApply = true)
+    public static class EnumConverter implements AttributeConverter<ServiceLevel, String> {
+        @Override
+        public String convertToDatabaseColumn(ServiceLevel attribute) {
+            if (attribute == null) {
+                return null;
+            }
+            return attribute.getValue();
+        }
+
+        @Override
+        public ServiceLevel convertToEntityAttribute(String dbData) {
+            return ServiceLevel.fromString(dbData);
+        }
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
@@ -66,10 +66,10 @@ public class SubscriptionCapacity implements Serializable {
     private String sku;
 
     @Column(name = "sla")
-    private String serviceLevel;
+    private ServiceLevel serviceLevel;
 
     @Column(name = "usage")
-    private String usage;
+    private Usage usage;
 
     public SubscriptionCapacity() {
         key = new SubscriptionCapacityKey();
@@ -179,19 +179,19 @@ public class SubscriptionCapacity implements Serializable {
         this.sku = sku;
     }
 
-    public String getServiceLevel() {
+    public ServiceLevel getServiceLevel() {
         return serviceLevel;
     }
 
-    public void setServiceLevel(String serviceLevel) {
+    public void setServiceLevel(ServiceLevel serviceLevel) {
         this.serviceLevel = serviceLevel;
     }
 
-    public String getUsage() {
+    public Usage getUsage() {
         return usage;
     }
 
-    public void setUsage(String usage) {
+    public void setUsage(Usage usage) {
         this.usage = usage;
     }
 

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -66,10 +66,10 @@ public class TallySnapshot implements Serializable {
     private String accountNumber;
 
     @Column(name = "sla")
-    private String serviceLevel = "_ANY";
+    private ServiceLevel serviceLevel = ServiceLevel.ANY;
 
     @Column(name = "usage")
-    private String usage = "_ANY";
+    private Usage usage = Usage.ANY;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "granularity")
@@ -141,19 +141,19 @@ public class TallySnapshot implements Serializable {
         hardwareMeasurements.put(type, measurement);
     }
 
-    public String getServiceLevel() {
+    public ServiceLevel getServiceLevel() {
         return serviceLevel;
     }
 
-    public void setServiceLevel(String serviceLevel) {
+    public void setServiceLevel(ServiceLevel serviceLevel) {
         this.serviceLevel = serviceLevel;
     }
 
-    public String getUsage() {
+    public Usage getUsage() {
         return usage;
     }
 
-    public void setUsage(String usage) {
+    public void setUsage(Usage usage) {
         this.usage = usage;
     }
 

--- a/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
@@ -24,6 +24,9 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
 /**
  * System purpose usage
  *
@@ -62,5 +65,24 @@ public enum Usage {
 
     public String getValue() {
         return value;
+    }
+
+    /**
+     * JPA converter for Usage
+     */
+    @Converter(autoApply = true)
+    public static class EnumConverter implements AttributeConverter<Usage, String> {
+        @Override
+        public String convertToDatabaseColumn(Usage attribute) {
+            if (attribute == null) {
+                return null;
+            }
+            return attribute.getValue();
+        }
+
+        @Override
+        public Usage convertToEntityAttribute(String dbData) {
+            return Usage.fromString(dbData);
+        }
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -61,6 +61,7 @@ import javax.persistence.Table;
                 @ColumnResult(name = "system_profile_product_ids"),
                 @ColumnResult(name = "syspurpose_role"),
                 @ColumnResult(name = "syspurpose_sla"),
+                @ColumnResult(name = "syspurpose_usage"),
                 @ColumnResult(name = "syspurpose_units"),
                 @ColumnResult(name = "is_virtual"),
                 @ColumnResult(name = "hypervisor_uuid"),
@@ -89,6 +90,7 @@ import javax.persistence.Table;
         "h.facts->'rhsm'->>'SYNC_TIMESTAMP' as sync_timestamp, " +
         "h.facts->'rhsm'->>'SYSPURPOSE_ROLE' as syspurpose_role, " +
         "h.facts->'rhsm'->>'SYSPURPOSE_SLA' as syspurpose_sla, " +
+        "h.facts->'rhsm'->>'SYSPURPOSE_USAGE' as syspurpose_usage, " +
         "h.facts->'rhsm'->>'SYSPURPOSE_UNITS' as syspurpose_units, " +
         "h.facts->'qpc'->>'IS_RHEL' as is_rhel, " +
         "h.system_profile_facts->>'infrastructure_type' as system_profile_infrastructure_type, " +

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -50,6 +50,7 @@ public class InventoryHostFacts {
     private Set<String> systemProfileProductIds;
     private String syspurposeRole;
     private String syspurposeSla;
+    private String syspurposeUsage;
     private String syspurposeUnits;
     private String cloudProvider;
     private OffsetDateTime staleTimestamp;
@@ -62,9 +63,10 @@ public class InventoryHostFacts {
     public InventoryHostFacts(String account, String displayName, String orgId, String cores, String sockets,
         String products, String syncTimestamp, String systemProfileInfrastructureType,
         String systemProfileCores, String systemProfileSockets, String qpcProducts, String qpcProductIds,
-        String systemProfileProductIds, String syspurposeRole, String syspurposeSla, String syspurposeUnits,
-        String isVirtual, String hypervisorUuid, String satelliteHypervisorUuid, String guestId,
-        String subscriptionManagerId, String cloudProvider, OffsetDateTime staleTimestamp) {
+        String systemProfileProductIds, String syspurposeRole, String syspurposeSla,
+        String syspurposeUsage, String syspurposeUnits, String isVirtual, String hypervisorUuid,
+        String satelliteHypervisorUuid, String guestId, String subscriptionManagerId, String cloudProvider,
+        OffsetDateTime staleTimestamp) {
 
         this.account = account;
         this.displayName = displayName;
@@ -81,6 +83,7 @@ public class InventoryHostFacts {
         this.systemProfileProductIds = asStringSet(systemProfileProductIds);
         this.syspurposeRole = syspurposeRole;
         this.syspurposeSla = syspurposeSla;
+        this.syspurposeUsage = syspurposeUsage;
         this.syspurposeUnits = syspurposeUnits;
         this.isVirtual = asBoolean(isVirtual);
         this.hypervisorUuid = hypervisorUuid;
@@ -281,6 +284,14 @@ public class InventoryHostFacts {
 
     public void setSyspurposeSla(String syspurposeSla) {
         this.syspurposeSla = syspurposeSla;
+    }
+
+    public String getSyspurposeUsage() {
+        return syspurposeUsage;
+    }
+
+    public void setSyspurposeUsage(String syspurposeUsage) {
+        this.syspurposeUsage = syspurposeUsage;
     }
 
     public String getSyspurposeUnits() {

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -141,7 +141,7 @@ public class CapacityResource implements CapacityApi {
                 .findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
                 ownerId,
                 productId,
-                sla.getValue(),
+                sla,
                 beginning,
                 ending
             );

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -84,8 +84,8 @@ public class TallyResource implements TallyApi {
         }
 
         String accountNumber = ResourceUtils.getAccountNumber();
-        String serviceLevel = getSnapshotQueryValue(sla);
-        String effectiveUsage = getEffectiveUsage(usage);
+        ServiceLevel serviceLevel = getEffectiveSla(sla);
+        Usage effectiveUsage = getEffectiveUsage(usage);
         Granularity granularityValue = Granularity.valueOf(granularity.toUpperCase());
         Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -109,8 +109,8 @@ public class TallyResource implements TallyApi {
         report.setMeta(new TallyReportMeta());
         report.getMeta().setGranularity(granularityValue.name());
         report.getMeta().setProduct(productId);
-        report.getMeta().setServiceLevel(sla == null ? null : serviceLevel);
-        report.getMeta().setUsage(usage == null ? null : effectiveUsage);
+        report.getMeta().setServiceLevel(sla == null ? null : serviceLevel.getValue());
+        report.getMeta().setUsage(usage == null ? null : effectiveUsage.getValue());
 
         // Only set page links if we are paging (not filling).
         if (pageable != null) {
@@ -129,10 +129,10 @@ public class TallyResource implements TallyApi {
         return report;
     }
 
-    private String getEffectiveUsage(String usage) {
+    private Usage getEffectiveUsage(String usage) {
         // If the sla parameter was not specified, we assume the query param represents ANY.
         if (usage == null) {
-            return Usage.ANY.getValue();
+            return Usage.ANY;
         }
 
         // If the usage parameter is not one that we support, then throw an exception.
@@ -141,13 +141,13 @@ public class TallyResource implements TallyApi {
         if (!usage.isEmpty() && Usage.UNSPECIFIED.equals(sanitized)) {
             throw new BadRequestException("Invalid usage parameter specified.");
         }
-        return sanitized.getValue();
+        return sanitized;
     }
 
-    private String getSnapshotQueryValue(String sla) {
+    private ServiceLevel getEffectiveSla(String sla) {
         // If the sla parameter was not specified, we assume the query param represents ANY.
         if (sla == null) {
-            return ServiceLevel.ANY.getValue();
+            return ServiceLevel.ANY;
         }
 
         // If the sla parameter is not one that we support, then throw an exception.
@@ -156,7 +156,7 @@ public class TallyResource implements TallyApi {
         if (!sla.isEmpty() && ServiceLevel.UNSPECIFIED.equals(sanitized)) {
             throw new BadRequestException("Invalid sla parameter specified.");
         }
-        return sanitized.getValue();
+        return sanitized;
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
@@ -56,7 +56,7 @@ public class AccountUsageCalculation {
 
     public void addCalculation(UsageCalculation calc) {
         String productId = calc.getProductId();
-        this.calculations.put(new UsageCalculation.Key(productId, calc.getSla()), calc);
+        this.calculations.put(new UsageCalculation.Key(productId, calc.getSla(), calc.getUsage()), calc);
         this.products.add(productId);
     }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
@@ -77,17 +77,7 @@ public class UsageCalculation {
         }
 
         public static Key fromTallySnapshot(TallySnapshot snapshot) {
-            ServiceLevel sla = ServiceLevel.ANY;
-            if (!snapshot.getServiceLevel().equals(ServiceLevel.ANY.getValue())) {
-                sla = ServiceLevel.fromString(snapshot.getServiceLevel());
-            }
-
-            Usage usage = Usage.ANY;
-            if (!snapshot.getUsage().equals(Usage.ANY.getValue())) {
-                usage = Usage.fromString(snapshot.getUsage());
-            }
-
-            return new Key(snapshot.getProductId(), sla, usage);
+            return new Key(snapshot.getProductId(), snapshot.getServiceLevel(), snapshot.getUsage());
         }
 
         @Override

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.tally;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -44,10 +45,12 @@ public class UsageCalculation {
     public static class Key {
         private final String productId;
         private final ServiceLevel sla;
+        private final Usage usage;
 
-        public Key(String productId, ServiceLevel sla) {
+        public Key(String productId, ServiceLevel sla, Usage usage) {
             this.productId = productId;
             this.sla = sla;
+            this.usage = usage;
         }
 
         public String getProductId() {
@@ -64,28 +67,35 @@ public class UsageCalculation {
             }
             Key that = (Key) o;
             return Objects.equals(productId, that.productId) &&
-                    Objects.equals(sla, that.sla);
+                Objects.equals(sla, that.sla) &&
+                Objects.equals(usage, that.usage);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(productId, sla);
+            return Objects.hash(productId, sla, usage);
         }
 
         public static Key fromTallySnapshot(TallySnapshot snapshot) {
-            ServiceLevel sla;
-            if (snapshot.getServiceLevel().equals(ServiceLevel.ANY.getValue())) {
-                sla = ServiceLevel.ANY;
-            }
-            else {
+            ServiceLevel sla = ServiceLevel.ANY;
+            if (!snapshot.getServiceLevel().equals(ServiceLevel.ANY.getValue())) {
                 sla = ServiceLevel.fromString(snapshot.getServiceLevel());
             }
-            return new Key(snapshot.getProductId(), sla);
+
+            Usage usage = Usage.ANY;
+            if (!snapshot.getUsage().equals(Usage.ANY.getValue())) {
+                usage = Usage.fromString(snapshot.getUsage());
+            }
+
+            return new Key(snapshot.getProductId(), sla, usage);
         }
 
         @Override
         public String toString() {
-            return "Key{" + "productId='" + productId + '\'' + ", sla=" + sla + '}';
+            return "Key{" +
+                "productId='" + productId + '\'' +
+                ", sla=" + sla +
+                ", usage=" + usage + '}';
         }
     }
 
@@ -135,6 +145,10 @@ public class UsageCalculation {
         return key.sla;
     }
 
+    public Usage getUsage() {
+        return key.usage;
+    }
+
     public Totals getTotals(HardwareMeasurementType type) {
         return mappedTotals.get(type);
     }
@@ -182,7 +196,7 @@ public class UsageCalculation {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append(String.format("[Product: %s, sla: %s", key.productId, key.sla));
+        builder.append(String.format("[Product: %s, sla: %s, usage: %s", key.productId, key.sla, key.usage));
         for (Entry<HardwareMeasurementType, Totals> entry : mappedTotals.entrySet()) {
             builder.append(String.format(", %s: %s", entry.getKey(), entry.getValue()));
         }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -236,8 +236,10 @@ public class FactNormalizer {
 
     private Usage extractRhsmUsage(InventoryHostFacts hostFacts) {
         Usage effectiveUsage = Usage.fromString(hostFacts.getSyspurposeUsage());
-        if (hostFacts.getSyspurposeUsage() != null && effectiveUsage == Usage.UNSPECIFIED) {
-            log.warn(
+        if (hostFacts.getSyspurposeUsage() != null && effectiveUsage == Usage.UNSPECIFIED &&
+            log.isDebugEnabled()) {
+
+            log.debug(
                 "Owner {} host {} has unsupported value for Usage: {}",
                 hostFacts.getOrgId(),
                 hostFacts.getSubscriptionManagerId(),
@@ -249,8 +251,10 @@ public class FactNormalizer {
 
     private ServiceLevel extractRhsmSla(InventoryHostFacts hostFacts) {
         ServiceLevel effectiveSla = ServiceLevel.fromString(hostFacts.getSyspurposeSla());
-        if (hostFacts.getSyspurposeSla() != null && effectiveSla == ServiceLevel.UNSPECIFIED) {
-            log.warn(
+        if (hostFacts.getSyspurposeSla() != null && effectiveSla == ServiceLevel.UNSPECIFIED &&
+            log.isDebugEnabled()) {
+
+            log.debug(
                 "Owner {} host {} has unsupported value for SLA: {}",
                 hostFacts.getOrgId(),
                 hostFacts.getSubscriptionManagerId(),

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.tally.facts;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
 import org.candlepin.subscriptions.files.RoleToProductsMapSource;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
@@ -227,17 +228,36 @@ public class FactNormalizer {
                 normalizedFacts.getProducts().addAll(
                     roleToProductsMap.getOrDefault(hostFacts.getSyspurposeRole(), Collections.emptyList()));
             }
-            ServiceLevel effectiveSla = ServiceLevel.fromString(hostFacts.getSyspurposeSla());
-            normalizedFacts.setSla(effectiveSla);
-            if (hostFacts.getSyspurposeSla() != null && effectiveSla == ServiceLevel.UNSPECIFIED) {
-                log.warn(
-                    "Owner {} host {} has unsupported value for SLA: {}",
-                    hostFacts.getOrgId(),
-                    hostFacts.getSubscriptionManagerId(),
-                    hostFacts.getSyspurposeSla()
-                );
-            }
+
+            normalizedFacts.setSla(extractRhsmSla(hostFacts));
+            normalizedFacts.setUsage(extractRhsmUsage(hostFacts));
         }
+    }
+
+    private Usage extractRhsmUsage(InventoryHostFacts hostFacts) {
+        Usage effectiveUsage = Usage.fromString(hostFacts.getSyspurposeUsage());
+        if (hostFacts.getSyspurposeUsage() != null && effectiveUsage == Usage.UNSPECIFIED) {
+            log.warn(
+                "Owner {} host {} has unsupported value for Usage: {}",
+                hostFacts.getOrgId(),
+                hostFacts.getSubscriptionManagerId(),
+                hostFacts.getSyspurposeUsage()
+            );
+        }
+        return effectiveUsage;
+    }
+
+    private ServiceLevel extractRhsmSla(InventoryHostFacts hostFacts) {
+        ServiceLevel effectiveSla = ServiceLevel.fromString(hostFacts.getSyspurposeSla());
+        if (hostFacts.getSyspurposeSla() != null && effectiveSla == ServiceLevel.UNSPECIFIED) {
+            log.warn(
+                "Owner {} host {} has unsupported value for SLA: {}",
+                hostFacts.getOrgId(),
+                hostFacts.getSubscriptionManagerId(),
+                hostFacts.getSyspurposeSla()
+            );
+        }
+        return effectiveSla;
     }
 
     private void normalizeQpcFacts(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.tally.facts;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,6 +41,7 @@ public class NormalizedFacts {
 
     private Set<String> products;
     private ServiceLevel sla = ServiceLevel.UNSPECIFIED;
+    private Usage usage = Usage.UNSPECIFIED;
     private Integer cores;
     private Integer sockets;
     private String owner;
@@ -146,6 +148,14 @@ public class NormalizedFacts {
 
     public void setSla(ServiceLevel sla) {
         this.sla = sla;
+    }
+
+    public Usage getUsage() {
+        return usage;
+    }
+
+    public void setUsage(Usage usage) {
+        this.usage = usage;
     }
 
     public Map<String, Object> toInventoryPayload() {

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -76,6 +76,7 @@ public abstract class BaseSnapshotRoller {
         TallySnapshot snapshot = new TallySnapshot();
         snapshot.setProductId(productCalc.getProductId());
         snapshot.setServiceLevel(productCalc.getSla().getValue());
+        snapshot.setUsage(productCalc.getUsage().getValue());
         snapshot.setGranularity(granularity);
         snapshot.setOwnerId(owner);
         snapshot.setAccountNumber(account);

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -75,8 +75,8 @@ public abstract class BaseSnapshotRoller {
         UsageCalculation productCalc, Granularity granularity) {
         TallySnapshot snapshot = new TallySnapshot();
         snapshot.setProductId(productCalc.getProductId());
-        snapshot.setServiceLevel(productCalc.getSla().getValue());
-        snapshot.setUsage(productCalc.getUsage().getValue());
+        snapshot.setServiceLevel(productCalc.getSla());
+        snapshot.setUsage(productCalc.getUsage());
         snapshot.setGranularity(granularity);
         snapshot.setOwnerId(owner);
         snapshot.setAccountNumber(account);

--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.capacity;
 
 import static org.hamcrest.MatcherAssert.*;
 
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
 import org.candlepin.subscriptions.utilization.api.model.CandlepinProductAttribute;
@@ -92,7 +93,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedRhelCapacity.setEndDate(NOWISH);
         expectedRhelCapacity.setSubscriptionId("subId");
         expectedRhelCapacity.setOwnerId("ownerId");
-        expectedRhelCapacity.setServiceLevel("Premium");
+        expectedRhelCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         SubscriptionCapacity expectedServerCapacity = new SubscriptionCapacity();
         expectedServerCapacity.setProductId("RHEL Server");
@@ -103,7 +104,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedServerCapacity.setEndDate(NOWISH);
         expectedServerCapacity.setSubscriptionId("subId");
         expectedServerCapacity.setOwnerId("ownerId");
-        expectedServerCapacity.setServiceLevel("Premium");
+        expectedServerCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,
@@ -160,7 +161,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedRhelCapacity.setEndDate(NOWISH);
         expectedRhelCapacity.setSubscriptionId("subId");
         expectedRhelCapacity.setOwnerId("ownerId");
-        expectedRhelCapacity.setServiceLevel("Premium");
+        expectedRhelCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         SubscriptionCapacity expectedServerCapacity = new SubscriptionCapacity();
         expectedServerCapacity.setProductId("RHEL Server");
@@ -171,7 +172,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedServerCapacity.setEndDate(NOWISH);
         expectedServerCapacity.setSubscriptionId("subId");
         expectedServerCapacity.setOwnerId("ownerId");
-        expectedServerCapacity.setServiceLevel("Premium");
+        expectedServerCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,
@@ -195,7 +196,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedRhelCapacity.setEndDate(NOWISH);
         expectedRhelCapacity.setSubscriptionId("subId");
         expectedRhelCapacity.setOwnerId("ownerId");
-        expectedRhelCapacity.setServiceLevel("Premium");
+        expectedRhelCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         SubscriptionCapacity expectedWorkstationCapacity = new SubscriptionCapacity();
         expectedWorkstationCapacity.setProductId("RHEL Workstation");
@@ -206,7 +207,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedWorkstationCapacity.setEndDate(NOWISH);
         expectedWorkstationCapacity.setSubscriptionId("subId");
         expectedWorkstationCapacity.setOwnerId("ownerId");
-        expectedWorkstationCapacity.setServiceLevel("Premium");
+        expectedWorkstationCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,
@@ -232,7 +233,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedRhelCapacity.setEndDate(NOWISH);
         expectedRhelCapacity.setSubscriptionId("subId");
         expectedRhelCapacity.setOwnerId("ownerId");
-        expectedRhelCapacity.setServiceLevel("Premium");
+        expectedRhelCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         SubscriptionCapacity expectedWorkstationCapacity = new SubscriptionCapacity();
         expectedWorkstationCapacity.setProductId("RHEL Workstation");
@@ -243,7 +244,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedWorkstationCapacity.setEndDate(NOWISH);
         expectedWorkstationCapacity.setSubscriptionId("subId");
         expectedWorkstationCapacity.setOwnerId("ownerId");
-        expectedWorkstationCapacity.setServiceLevel("Premium");
+        expectedWorkstationCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         SubscriptionCapacity expectedServerCapacity = new SubscriptionCapacity();
         expectedServerCapacity.setProductId("RHEL Server");
@@ -254,7 +255,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedServerCapacity.setEndDate(NOWISH);
         expectedServerCapacity.setSubscriptionId("subId");
         expectedServerCapacity.setOwnerId("ownerId");
-        expectedServerCapacity.setServiceLevel("Premium");
+        expectedServerCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,
@@ -278,7 +279,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedRhelCapacity.setEndDate(NOWISH);
         expectedRhelCapacity.setSubscriptionId("subId");
         expectedRhelCapacity.setOwnerId("ownerId");
-        expectedRhelCapacity.setServiceLevel("Premium");
+        expectedRhelCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         SubscriptionCapacity expectedWorkstationCapacity = new SubscriptionCapacity();
         expectedWorkstationCapacity.setProductId("RHEL Workstation");
@@ -287,7 +288,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedWorkstationCapacity.setEndDate(NOWISH);
         expectedWorkstationCapacity.setSubscriptionId("subId");
         expectedWorkstationCapacity.setOwnerId("ownerId");
-        expectedWorkstationCapacity.setServiceLevel("Premium");
+        expectedWorkstationCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         SubscriptionCapacity expectedServerCapacity = new SubscriptionCapacity();
         expectedServerCapacity.setProductId("RHEL Server");
@@ -296,7 +297,7 @@ class CandlepinPoolCapacityMapperTest {
         expectedServerCapacity.setEndDate(NOWISH);
         expectedServerCapacity.setSubscriptionId("subId");
         expectedServerCapacity.setOwnerId("ownerId");
-        expectedServerCapacity.setServiceLevel("Premium");
+        expectedServerCapacity.setServiceLevel(ServiceLevel.PREMIUM);
 
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,
@@ -311,7 +312,8 @@ class CandlepinPoolCapacityMapperTest {
 
     private CandlepinPool createTestPool(List<String> physicalProductIds, List<String> derivedProductIds,
         Integer instanceMultiplier) {
-        return createTestPool(physicalProductIds, derivedProductIds, instanceMultiplier, "Premium");
+        return createTestPool(physicalProductIds, derivedProductIds, instanceMultiplier,
+            ServiceLevel.PREMIUM.getValue());
     }
 
     private CandlepinPool createTestPool(List<String> physicalProductIds, List<String> derivedProductIds,

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.db;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 
 import org.junit.jupiter.api.Test;
@@ -227,7 +228,7 @@ class SubscriptionCapacityRepositoryTest {
             .findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
-            "Standard",
+            ServiceLevel.STANDARD,
             NOWISH,
             FAR_FUTURE);
         assertEquals(0, found.size());
@@ -243,7 +244,7 @@ class SubscriptionCapacityRepositoryTest {
             .findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
             "ownerId",
             "product",
-            "Premium",
+            ServiceLevel.PREMIUM,
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
@@ -262,7 +263,7 @@ class SubscriptionCapacityRepositoryTest {
         capacity.setVirtualSockets(20);
         capacity.setPhysicalCores(8);
         capacity.setVirtualCores(40);
-        capacity.setServiceLevel("Premium");
+        capacity.setServiceLevel(ServiceLevel.PREMIUM);
         return capacity;
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -66,21 +66,23 @@ public class TallySnapshotRepositoryTest {
 
     @SuppressWarnings("linelength")
     @Test
-    public void findByAccountNumberAndProductIdAndGranularityAndServiceLevel() {
+    public void findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsage() {
         TallySnapshot t1 = createUnpersisted("Hello", "World", Granularity.DAILY, 2, 3, 4, NOWISH);
         TallySnapshot t2 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, 9999, 999, 99, NOWISH);
-        TallySnapshot t3 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, "standard", 8888, 888, 88,
+        TallySnapshot t3 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, "standard", "production",
+            8888, 888, 88,
             NOWISH);
 
         repository.saveAll(Arrays.asList(t1, t2, t3));
         repository.flush();
 
         List<TallySnapshot> found = repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             "Bugs",
             "Bunny",
             Granularity.DAILY,
             "standard",
+            "production",
             LONG_AGO,
             FAR_FUTURE,
             PageRequest.of(0, 10))
@@ -90,6 +92,7 @@ public class TallySnapshotRepositoryTest {
         assertEquals("Bugs", snapshot.getAccountNumber());
         assertEquals("Bunny", snapshot.getProductId());
         assertEquals("N/A", snapshot.getOwnerId());
+        assertEquals("production", snapshot.getUsage());
         assertEquals(NOWISH, found.get(0).getSnapshotDate());
 
         HardwareMeasurement total = snapshot.getHardwareMeasurement(HardwareMeasurementType.TOTAL);
@@ -98,18 +101,19 @@ public class TallySnapshotRepositoryTest {
 
     @SuppressWarnings("linelength")
     @Test
-    public void testFindByEmptyServiceLevel() {
-        TallySnapshot t1 = createUnpersisted("A1", "P1", Granularity.DAILY, "", 1111, 111, 11,
+    public void testFindByEmptyServiceLevelAndUsage() {
+        TallySnapshot t1 = createUnpersisted("A1", "P1", Granularity.DAILY, "", "", 1111, 111, 11,
             NOWISH);
 
         repository.saveAll(Arrays.asList(t1));
         repository.flush();
 
         List<TallySnapshot> found = repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             "A1",
             "P1",
             Granularity.DAILY,
+            "",
             "",
             LONG_AGO,
             FAR_FUTURE,
@@ -206,17 +210,19 @@ public class TallySnapshotRepositoryTest {
 
     private TallySnapshot createUnpersisted(String account, String product, Granularity granularity,
         int cores, int sockets, int instances, OffsetDateTime date) {
-        return createUnpersisted(account, product, granularity, "premium", cores, sockets, instances, date);
+        return createUnpersisted(account, product, granularity, "premium", "production", cores, sockets,
+            instances, date);
     }
 
     private TallySnapshot createUnpersisted(String account, String product, Granularity granularity,
-        String serviceLevel, int cores, int sockets, int instances, OffsetDateTime date) {
+        String serviceLevel, String usage, int cores, int sockets, int instances, OffsetDateTime date) {
         TallySnapshot tally = new TallySnapshot();
         tally.setAccountNumber(account);
         tally.setProductId(product);
         tally.setOwnerId("N/A");
         tally.setGranularity(granularity);
-        tally.setServiceLevel("");
+        tally.setServiceLevel(serviceLevel);
+        tally.setUsage(usage);
         tally.setSnapshotDate(date);
         tally.setServiceLevel(serviceLevel);
 

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -25,7 +25,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.HardwareMeasurement;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,9 +71,8 @@ public class TallySnapshotRepositoryTest {
     public void findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsage() {
         TallySnapshot t1 = createUnpersisted("Hello", "World", Granularity.DAILY, 2, 3, 4, NOWISH);
         TallySnapshot t2 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, 9999, 999, 99, NOWISH);
-        TallySnapshot t3 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, "standard", "production",
-            8888, 888, 88,
-            NOWISH);
+        TallySnapshot t3 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, ServiceLevel.STANDARD,
+            Usage.PRODUCTION, 8888, 888, 88, NOWISH);
 
         repository.saveAll(Arrays.asList(t1, t2, t3));
         repository.flush();
@@ -81,8 +82,8 @@ public class TallySnapshotRepositoryTest {
             "Bugs",
             "Bunny",
             Granularity.DAILY,
-            "standard",
-            "production",
+            ServiceLevel.STANDARD,
+            Usage.PRODUCTION,
             LONG_AGO,
             FAR_FUTURE,
             PageRequest.of(0, 10))
@@ -92,7 +93,7 @@ public class TallySnapshotRepositoryTest {
         assertEquals("Bugs", snapshot.getAccountNumber());
         assertEquals("Bunny", snapshot.getProductId());
         assertEquals("N/A", snapshot.getOwnerId());
-        assertEquals("production", snapshot.getUsage());
+        assertEquals(Usage.PRODUCTION, snapshot.getUsage());
         assertEquals(NOWISH, found.get(0).getSnapshotDate());
 
         HardwareMeasurement total = snapshot.getHardwareMeasurement(HardwareMeasurementType.TOTAL);
@@ -102,8 +103,8 @@ public class TallySnapshotRepositoryTest {
     @SuppressWarnings("linelength")
     @Test
     public void testFindByEmptyServiceLevelAndUsage() {
-        TallySnapshot t1 = createUnpersisted("A1", "P1", Granularity.DAILY, "", "", 1111, 111, 11,
-            NOWISH);
+        TallySnapshot t1 = createUnpersisted("A1", "P1", Granularity.DAILY, ServiceLevel.UNSPECIFIED,
+            Usage.UNSPECIFIED, 1111, 111, 11, NOWISH);
 
         repository.saveAll(Arrays.asList(t1));
         repository.flush();
@@ -113,8 +114,8 @@ public class TallySnapshotRepositoryTest {
             "A1",
             "P1",
             Granularity.DAILY,
-            "",
-            "",
+            ServiceLevel.UNSPECIFIED,
+            Usage.UNSPECIFIED,
             LONG_AGO,
             FAR_FUTURE,
             PageRequest.of(0, 10))
@@ -210,12 +211,12 @@ public class TallySnapshotRepositoryTest {
 
     private TallySnapshot createUnpersisted(String account, String product, Granularity granularity,
         int cores, int sockets, int instances, OffsetDateTime date) {
-        return createUnpersisted(account, product, granularity, "premium", "production", cores, sockets,
-            instances, date);
+        return createUnpersisted(account, product, granularity, ServiceLevel.PREMIUM, Usage.PRODUCTION, cores,
+            sockets, instances, date);
     }
 
     private TallySnapshot createUnpersisted(String account, String product, Granularity granularity,
-        String serviceLevel, String usage, int cores, int sockets, int instances, OffsetDateTime date) {
+        ServiceLevel serviceLevel, Usage usage, int cores, int sockets, int instances, OffsetDateTime date) {
         TallySnapshot tally = new TallySnapshot();
         tally.setAccountNumber(account);
         tally.setProductId(product);

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
@@ -113,7 +114,7 @@ class CapacityResourceTest {
             .findByKeyOwnerIdAndKeyProductIdAndServiceLevelAndEndDateAfterAndBeginDateBefore(
                 Mockito.eq("owner123456"),
                 Mockito.eq("product1"),
-                Mockito.eq("Premium"),
+                Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(min),
                 Mockito.eq(max)))
             .thenReturn(Collections.singletonList(capacity));

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -94,8 +94,8 @@ public class TallyResourceTest {
                 Mockito.eq("account123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(Granularity.DAILY),
-                Mockito.eq(ServiceLevel.ANY.getValue()),
-                Mockito.eq(Usage.PRODUCTION.getValue()),
+                Mockito.eq(ServiceLevel.ANY),
+                Mockito.eq(Usage.PRODUCTION),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -118,8 +118,8 @@ public class TallyResourceTest {
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.ANY.getValue()),
-            Mockito.eq(Usage.PRODUCTION.getValue()),
+            Mockito.eq(ServiceLevel.ANY),
+            Mockito.eq(Usage.PRODUCTION),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
@@ -140,8 +140,8 @@ public class TallyResourceTest {
                 Mockito.eq("account123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(Granularity.DAILY),
-                Mockito.eq(ServiceLevel.PREMIUM.getValue()),
-                Mockito.eq(Usage.ANY.getValue()),
+                Mockito.eq(ServiceLevel.PREMIUM),
+                Mockito.eq(Usage.ANY),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -164,8 +164,8 @@ public class TallyResourceTest {
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.PREMIUM.getValue()),
-            Mockito.eq(Usage.ANY.getValue()),
+            Mockito.eq(ServiceLevel.PREMIUM),
+            Mockito.eq(Usage.ANY),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
@@ -185,8 +185,8 @@ public class TallyResourceTest {
                  Mockito.eq("account123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
-                 Mockito.eq(ServiceLevel.UNSPECIFIED.getValue()),
-                 Mockito.eq(Usage.PRODUCTION.getValue()),
+                 Mockito.eq(ServiceLevel.UNSPECIFIED),
+                 Mockito.eq(Usage.PRODUCTION),
                  Mockito.eq(min),
                  Mockito.eq(max),
                  Mockito.any(Pageable.class)))
@@ -209,8 +209,8 @@ public class TallyResourceTest {
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.UNSPECIFIED.getValue()),
-            Mockito.eq(Usage.PRODUCTION.getValue()),
+            Mockito.eq(ServiceLevel.UNSPECIFIED),
+            Mockito.eq(Usage.PRODUCTION),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
@@ -229,8 +229,8 @@ public class TallyResourceTest {
                 Mockito.eq("account123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(Granularity.DAILY),
-                Mockito.eq(ServiceLevel.PREMIUM.getValue()),
-                Mockito.eq(Usage.UNSPECIFIED.getValue()),
+                Mockito.eq(ServiceLevel.PREMIUM),
+                Mockito.eq(Usage.UNSPECIFIED),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -253,8 +253,8 @@ public class TallyResourceTest {
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.PREMIUM.getValue()),
-            Mockito.eq(Usage.UNSPECIFIED.getValue()),
+            Mockito.eq(ServiceLevel.PREMIUM),
+            Mockito.eq(Usage.UNSPECIFIED),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
@@ -273,8 +273,8 @@ public class TallyResourceTest {
                  Mockito.eq("account123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
-                 Mockito.eq(ServiceLevel.PREMIUM.getValue()),
-                 Mockito.eq(Usage.PRODUCTION.getValue()),
+                 Mockito.eq(ServiceLevel.PREMIUM),
+                 Mockito.eq(Usage.PRODUCTION),
                  Mockito.eq(min),
                  Mockito.eq(max),
                  Mockito.any(Pageable.class)))
@@ -296,8 +296,8 @@ public class TallyResourceTest {
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.PREMIUM.getValue()),
-            Mockito.eq(Usage.PRODUCTION.getValue()),
+            Mockito.eq(ServiceLevel.PREMIUM),
+            Mockito.eq(Usage.PRODUCTION),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
@@ -316,8 +316,8 @@ public class TallyResourceTest {
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.PREMIUM.getValue()),
-            Mockito.eq(Usage.PRODUCTION.getValue()),
+            Mockito.eq(ServiceLevel.PREMIUM),
+            Mockito.eq(Usage.PRODUCTION),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.any(Pageable.class)))
@@ -340,8 +340,8 @@ public class TallyResourceTest {
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.PREMIUM.getValue()),
-            Mockito.eq(Usage.PRODUCTION.getValue()),
+            Mockito.eq(ServiceLevel.PREMIUM),
+            Mockito.eq(Usage.PRODUCTION),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable));
@@ -369,8 +369,8 @@ public class TallyResourceTest {
                  Mockito.eq("account123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
-                 Mockito.eq(ServiceLevel.ANY.getValue()),
-                 Mockito.eq(Usage.ANY.getValue()),
+                 Mockito.eq(ServiceLevel.ANY),
+                 Mockito.eq(Usage.ANY),
                  Mockito.eq(min),
                  Mockito.eq(max),
                  Mockito.eq(null)))
@@ -429,11 +429,12 @@ public class TallyResourceTest {
     @WithMockRedHatPrincipal(value = "123456", roles = {"ROLE_" + RoleProvider.REPORTING_ROLE})
     public void canReportWithOnlyReportingRole() {
         Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
                  Mockito.eq("account123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
-                 Mockito.eq(ServiceLevel.ANY.getValue()),
+                 Mockito.eq(ServiceLevel.ANY),
+                 Mockito.eq(Usage.ANY),
                  Mockito.eq(min),
                  Mockito.eq(max),
                  Mockito.eq(null)))
@@ -444,6 +445,7 @@ public class TallyResourceTest {
             "daily",
             min,
             max,
+            null,
             null,
             null,
             null

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -28,6 +28,7 @@ import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.RoleProvider;
@@ -89,11 +90,12 @@ public class TallyResourceTest {
         TallySnapshot snap = new TallySnapshot();
 
         Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
                 Mockito.eq("account123456"),
                 Mockito.eq("product1"),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.ANY.getValue()),
+                Mockito.eq(Usage.PRODUCTION.getValue()),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -106,22 +108,71 @@ public class TallyResourceTest {
             max,
             10,
             10,
-            null
+            null,
+            Usage.PRODUCTION.getValue()
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
-        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.ANY.getValue()),
+            Mockito.eq(Usage.PRODUCTION.getValue()),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", null, Granularity.DAILY.name(), 1);
+        assertMetadata(report.getMeta(), "product1", null,
+            Usage.PRODUCTION.getValue(), Granularity.DAILY.name(), 1);
+
+    }
+
+    @Test
+    public void testNullUsageQueryParameter() {
+
+        TallySnapshot snap = new TallySnapshot();
+
+        Mockito.when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                Mockito.eq("account123456"),
+                Mockito.eq("product1"),
+                Mockito.eq(Granularity.DAILY),
+                Mockito.eq(ServiceLevel.PREMIUM.getValue()),
+                Mockito.eq(Usage.ANY.getValue()),
+                Mockito.eq(min),
+                Mockito.eq(max),
+                Mockito.any(Pageable.class)))
+            .thenReturn(new PageImpl<>(Arrays.asList(snap)));
+
+        TallyReport report = resource.getTallyReport(
+            "product1",
+            Granularity.DAILY.name(),
+            min,
+            max,
+            10,
+            10,
+            ServiceLevel.PREMIUM.getValue(),
+            null
+        );
+        assertEquals(1, report.getData().size());
+
+        Pageable expectedPageable = PageRequest.of(1, 10);
+        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+            Mockito.eq("account123456"),
+            Mockito.eq("product1"),
+            Mockito.eq(Granularity.DAILY),
+            Mockito.eq(ServiceLevel.PREMIUM.getValue()),
+            Mockito.eq(Usage.ANY.getValue()),
+            Mockito.eq(min),
+            Mockito.eq(max),
+            Mockito.eq(expectedPageable)
+        );
+
+        assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(), null, Granularity.DAILY.name(),
+            1);
 
     }
 
@@ -130,11 +181,12 @@ public class TallyResourceTest {
         TallySnapshot snap = new TallySnapshot();
 
         Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
                  Mockito.eq("account123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
                  Mockito.eq(ServiceLevel.UNSPECIFIED.getValue()),
+                 Mockito.eq(Usage.PRODUCTION.getValue()),
                  Mockito.eq(min),
                  Mockito.eq(max),
                  Mockito.any(Pageable.class)))
@@ -147,34 +199,82 @@ public class TallyResourceTest {
             max,
             10,
             10,
-            ServiceLevel.UNSPECIFIED.getValue()
+            ServiceLevel.UNSPECIFIED.getValue(),
+            Usage.PRODUCTION.getValue()
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
-        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.UNSPECIFIED.getValue()),
+            Mockito.eq(Usage.PRODUCTION.getValue()),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", "", Granularity.DAILY.name(), 1);
+        assertMetadata(report.getMeta(), "product1", "", Usage.PRODUCTION.getValue(), Granularity.DAILY.name(),
+            1);
     }
 
     @Test
-    public void testSetSlaQueryParameter() {
+    public void testUnsetUsageQueryParameter() {
         TallySnapshot snap = new TallySnapshot();
 
         Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                Mockito.eq("account123456"),
+                Mockito.eq("product1"),
+                Mockito.eq(Granularity.DAILY),
+                Mockito.eq(ServiceLevel.PREMIUM.getValue()),
+                Mockito.eq(Usage.UNSPECIFIED.getValue()),
+                Mockito.eq(min),
+                Mockito.eq(max),
+                Mockito.any(Pageable.class)))
+            .thenReturn(new PageImpl<>(Arrays.asList(snap)));
+
+        TallyReport report = resource.getTallyReport(
+            "product1",
+            Granularity.DAILY.name(),
+            min,
+            max,
+            10,
+            10,
+            ServiceLevel.PREMIUM.getValue(),
+            Usage.UNSPECIFIED.getValue()
+        );
+        assertEquals(1, report.getData().size());
+
+        Pageable expectedPageable = PageRequest.of(1, 10);
+        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+            Mockito.eq("account123456"),
+            Mockito.eq("product1"),
+            Mockito.eq(Granularity.DAILY),
+            Mockito.eq(ServiceLevel.PREMIUM.getValue()),
+            Mockito.eq(Usage.UNSPECIFIED.getValue()),
+            Mockito.eq(min),
+            Mockito.eq(max),
+            Mockito.eq(expectedPageable)
+        );
+
+        assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(), "", Granularity.DAILY.name(),
+            1);
+    }
+
+    @Test
+    public void testSetSlaAndUsageQueryParameters() {
+        TallySnapshot snap = new TallySnapshot();
+
+        Mockito.when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
                  Mockito.eq("account123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
                  Mockito.eq(ServiceLevel.PREMIUM.getValue()),
+                 Mockito.eq(Usage.PRODUCTION.getValue()),
                  Mockito.eq(min),
                  Mockito.eq(max),
                  Mockito.any(Pageable.class)))
@@ -186,23 +286,25 @@ public class TallyResourceTest {
             max,
             10,
             10,
-            ServiceLevel.PREMIUM.getValue()
+            ServiceLevel.PREMIUM.getValue(),
+            Usage.PRODUCTION.getValue()
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
-        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.PREMIUM.getValue()),
+            Mockito.eq(Usage.PRODUCTION.getValue()),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
         );
 
         assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(),
-            Granularity.DAILY.name(), 1);
+            Usage.PRODUCTION.getValue(), Granularity.DAILY.name(), 1);
     }
 
     @Test
@@ -210,11 +312,12 @@ public class TallyResourceTest {
         TallySnapshot snap = new TallySnapshot();
 
         Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.PREMIUM.getValue()),
+            Mockito.eq(Usage.PRODUCTION.getValue()),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.any(Pageable.class)))
@@ -226,17 +329,19 @@ public class TallyResourceTest {
             max,
             10,
             10,
-            ServiceLevel.PREMIUM.getValue()
+            ServiceLevel.PREMIUM.getValue(),
+            Usage.PRODUCTION.getValue()
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
         Mockito.verify(repository)
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
             Mockito.eq("product1"),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.PREMIUM.getValue()),
+            Mockito.eq(Usage.PRODUCTION.getValue()),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable));
@@ -251,7 +356,8 @@ public class TallyResourceTest {
             max,
             11,
             10,
-            ServiceLevel.PREMIUM.getValue()
+            ServiceLevel.PREMIUM.getValue(),
+            Usage.PRODUCTION.getValue()
         ));
         assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
     }
@@ -259,11 +365,12 @@ public class TallyResourceTest {
     @Test
     public void reportDataShouldGetFilledWhenPagingParametersAreNotPassed() {
         Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
                  Mockito.eq("account123456"),
                  Mockito.eq("product1"),
                  Mockito.eq(Granularity.DAILY),
                  Mockito.eq(ServiceLevel.ANY.getValue()),
+                 Mockito.eq(Usage.ANY.getValue()),
                  Mockito.eq(min),
                  Mockito.eq(max),
                  Mockito.eq(null)))
@@ -274,6 +381,7 @@ public class TallyResourceTest {
             "daily",
             min,
             max,
+            null,
             null,
             null,
             null
@@ -311,7 +419,8 @@ public class TallyResourceTest {
                 max,
                 null,
                 null,
-                "foo_sla"
+                "foo_sla",
+                null
             );
         });
     }
@@ -353,6 +462,7 @@ public class TallyResourceTest {
                 max,
                 null,
                 null,
+                null,
                 null
             );
         });
@@ -369,15 +479,17 @@ public class TallyResourceTest {
                 max,
                 null,
                 null,
+                null,
                 null
             );
         });
     }
 
     private void assertMetadata(TallyReportMeta meta, String expectedProd, String expectedSla,
-        String expectedGranularity, Integer expectedCount) {
+        String expectedUsage, String expectedGranularity, Integer expectedCount) {
         assertEquals(expectedProd, meta.getProduct());
         assertEquals(expectedSla, meta.getServiceLevel());
+        assertEquals(expectedUsage, meta.getUsage());
         assertEquals(expectedGranularity, meta.getGranularity());
         assertEquals(expectedCount, meta.getCount());
 

--- a/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,6 @@ public class AccountUsageCalculationTest {
     }
 
     private UsageCalculation.Key createUsageKey(String productId) {
-        return new UsageCalculation.Key(productId, ServiceLevel.UNSPECIFIED);
+        return new UsageCalculation.Key(productId, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally;
 
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 
 import org.springframework.util.StringUtils;
@@ -83,12 +84,22 @@ public class InventoryHostFactTestHelper {
     public static InventoryHostFacts createRhsmHost(String account, String orgId, String products,
         ServiceLevel sla, Integer cores, Integer sockets, String syspurposeRole,
         OffsetDateTime syncTimeStamp) {
+
+        return createRhsmHost(account, orgId, products, sla, Usage.UNSPECIFIED, cores, sockets,
+            syspurposeRole, syncTimeStamp);
+    }
+
+    public static InventoryHostFacts createRhsmHost(String account, String orgId, String products,
+        ServiceLevel sla, Usage usage, Integer cores, Integer sockets, String syspurposeRole,
+        OffsetDateTime syncTimeStamp) {
+
         InventoryHostFacts baseFacts = createBaseHost(account, orgId);
         baseFacts.setProducts(products);
         baseFacts.setCores(cores);
         baseFacts.setSockets(sockets);
         baseFacts.setSyspurposeRole(syspurposeRole);
         baseFacts.setSyspurposeSla(sla.getValue());
+        baseFacts.setSyspurposeUsage(usage.getValue());
         baseFacts.setSyncTimestamp(syncTimeStamp.toString());
         return baseFacts;
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
 
 import org.junit.jupiter.api.Test;
 
@@ -64,7 +65,7 @@ public class UsageCalculationTest {
     }
 
     private UsageCalculation.Key createUsageKey(String product) {
-        return new UsageCalculation.Key(product, ServiceLevel.UNSPECIFIED);
+        return new UsageCalculation.Key(product, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -25,6 +25,7 @@ import static org.candlepin.subscriptions.tally.collector.TestHelper.*;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
@@ -105,7 +106,7 @@ public class DefaultProductUsageCollectorTest {
     }
 
     private UsageCalculation.Key createUsageKey() {
-        return new UsageCalculation.Key("NON_RHEL", ServiceLevel.UNSPECIFIED);
+        return new UsageCalculation.Key("NON_RHEL", ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
@@ -120,7 +121,7 @@ public class RHELProductUsageCollectorTest {
     }
 
     private UsageCalculation.Key createUsageKey() {
-        return new UsageCalculation.Key("RHEL", ServiceLevel.UNSPECIFIED);
+        return new UsageCalculation.Key("RHEL", ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
@@ -30,6 +30,7 @@ import org.candlepin.subscriptions.db.model.HardwareMeasurement;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.tally.AccountUsageCalculation;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.UsageCalculation.Totals;
@@ -69,8 +70,9 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
 
         List<TallySnapshot> currentSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), Usage.UNSPECIFIED.getValue(),
+                startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
         assertSnapshot(currentSnaps.get(0), a1ProductCalc, granularity);
@@ -84,8 +86,9 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
 
         List<TallySnapshot> currentSnaps = repository
-             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                 TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
+             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
+                 TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), Usage.UNSPECIFIED.getValue(),
+                 startOfGranularPeriod, endOfGranularPeriod,
                  PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
         TallySnapshot toBeUpdated = currentSnaps.get(0);
@@ -98,8 +101,9 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
 
         List<TallySnapshot> updatedSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), Usage.UNSPECIFIED.getValue(),
+                startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedSnaps.size());
 
@@ -131,8 +135,9 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1HighCalc));
 
         List<TallySnapshot> currentSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate("A1",
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(),  Usage.UNSPECIFIED.getValue(),
+                startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
 
@@ -144,8 +149,9 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1LowCalc));
 
         List<TallySnapshot> updatedSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(),  Usage.UNSPECIFIED.getValue(),
+                startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedSnaps.size());
 
@@ -165,14 +171,15 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         roller.rollSnapshots(Collections.singletonList("12345678"), Collections.singletonList(calc));
 
         List<TallySnapshot> currentSnaps = repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndSnapshotDateBetweenOrderBySnapshotDate("A1",
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), startOfGranularPeriod, endOfGranularPeriod,
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate("A1",
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(),  Usage.UNSPECIFIED.getValue(),
+                startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(0, currentSnaps.size());
     }
 
     private UsageCalculation.Key createUsageKey(String product) {
-        return new UsageCalculation.Key(product, ServiceLevel.UNSPECIFIED);
+        return new UsageCalculation.Key(product, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
     }
 
     private AccountUsageCalculation createTestData() {

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
@@ -71,7 +71,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> currentSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), Usage.UNSPECIFIED.getValue(),
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
@@ -87,7 +87,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> currentSnaps = repository
              .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                 TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), Usage.UNSPECIFIED.getValue(),
+                 TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED,
                  startOfGranularPeriod, endOfGranularPeriod,
                  PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
@@ -102,7 +102,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> updatedSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(), Usage.UNSPECIFIED.getValue(),
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedSnaps.size());
@@ -136,7 +136,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> currentSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate("A1",
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(),  Usage.UNSPECIFIED.getValue(),
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED,  Usage.UNSPECIFIED,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
@@ -150,7 +150,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> updatedSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(),  Usage.UNSPECIFIED.getValue(),
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED,  Usage.UNSPECIFIED,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedSnaps.size());
@@ -172,7 +172,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> currentSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate("A1",
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED.getValue(),  Usage.UNSPECIFIED.getValue(),
+                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED,  Usage.UNSPECIFIED,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(0, currentSnaps.size());


### PR DESCRIPTION
To test, run the app, trigger a tally via `jconsole`, and try the API via swagger-ui.

If you want to verify the SYSPURPOSE_USAGE field, you can mock up an existing consumer's record in your local inventory DB, e.g.:

```sql
insert into hosts (id, account, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ('56e25bd8-8828-43d0-a114-4c06d6b3d535', 'foobar2', '{"rhsm":{"SYSPURPOSE_USAGE": "Production", "VM_HOST_UUID":"hypervisor_uuid21","RH_PROD":[69]}}','{"subscription_manager_id":"guest21"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test');
```