### PR TITLE
Configure Spring Security to stop using sessions

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -36,7 +36,11 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * Spring Security filter responsible for pulling the principal out of the x-rh-identity header
+ * Spring Security filter responsible for pulling the principal out of the x-rh-identity header.
+ *
+ * Note that we don't register the filter as a bean anywhere, because if we did it would be registered as a
+ * an extraneous ServletFilter in addition to its use in our SpringSecurity config. See
+ * https://stackoverflow.com/a/31571715
  */
 public class IdentityHeaderAuthenticationFilter extends AbstractPreAuthenticatedProcessingFilter {
     private static final Logger log = LoggerFactory.getLogger(IdentityHeaderAuthenticationFilter.class);

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -39,6 +39,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
@@ -98,7 +99,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         );
     }
 
-    @Bean
+    // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application filter
     public IdentityHeaderAuthenticationFilter identityHeaderAuthenticationFilter(
         ApplicationProperties appProps) {
 
@@ -151,6 +152,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .exceptionHandling()
                 .accessDeniedHandler(restAccessDeniedHandler())
                 .authenticationEntryPoint(restAuthenticationEntryPoint())
+            .and()
+            // disable sessions, our API is stateless, and sessions cause RBAC information to be cached
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .anonymous()  // Creates an anonymous user if no header is present at all. Prevents NPEs basically
             .and()


### PR DESCRIPTION
Since our API uses the API gateway for auth, we don't need to use sessions anyways.

Also, made a small tweak to prevent double rbac calls.

I noticed during debugging that the filter was appearing in two chains, once for its configuration in `SecurityConfig.configure` and once by virtue of being a `GenericFilterBean`. I removed the `@Bean` annotation to reduce its use to one time per request.

To verify, you can add run via debug or place a logging statement and verify that the stub RBAC service is called exactly once per request.

If desired, you can also clear cookies for localhost and verify that they do not return when using swagger-ui.