### PR TITLE
Make JPA converters handle _ANY value

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
@@ -52,7 +52,8 @@ public enum ServiceLevel {
         this.value = value;
     }
 
-    /** Parse the service level from its string representation.
+    /**
+     * Parse the service level from its string representation (excluding special value _ANY).
      *
      * NOTE: this method will not return the special value ANY, and gives UNSPECIFIED for any invalid value.
      *
@@ -62,6 +63,23 @@ public enum ServiceLevel {
     public static ServiceLevel fromString(String value) {
         String key = value == null ? "" : value.toUpperCase();
         return VALUE_ENUM_MAP.getOrDefault(key, UNSPECIFIED);
+    }
+
+    /**
+     * Parse the service level from its string representation
+     *
+     * NOTE: this method will return UNSPECIFIED for any invalid value.
+     *
+     * @param value String representation of the service level, as seen in the DB.
+     * @return the ServiceLevel enum; UNSPECIFIED if unparseable.
+     */
+    public static ServiceLevel fromDbString(String value) {
+        if (ServiceLevel.ANY.value.equals(value)) {
+            return ServiceLevel.ANY;
+        }
+        else {
+            return fromString(value);
+        }
     }
 
     public String getValue() {
@@ -83,7 +101,7 @@ public enum ServiceLevel {
 
         @Override
         public ServiceLevel convertToEntityAttribute(String dbData) {
-            return ServiceLevel.fromString(dbData);
+            return ServiceLevel.fromDbString(dbData);
         }
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
@@ -51,7 +51,8 @@ public enum Usage {
         this.value = value;
     }
 
-    /** Parse the usage from its string representation.
+    /**
+     * Parse the usage from its string representation (excluding special value _ANY)
      *
      * NOTE: this method will not return the special value ANY, and gives UNSPECIFIED for any invalid value.
      *
@@ -61,6 +62,23 @@ public enum Usage {
     public static Usage fromString(String value) {
         String key = value == null ? "" : value.toUpperCase();
         return VALUE_ENUM_MAP.getOrDefault(key, UNSPECIFIED);
+    }
+
+    /**
+     * Parse the usage from its string representation.
+     *
+     * NOTE: this method will return UNSPECIFIED for any invalid value.
+     *
+     * @param value String representation of the Usage, as seen in the DB
+     * @return the Usage enum; UNSPECIFIED if unparseable.
+     */
+    public static Usage fromDbString(String value) {
+        if ("_ANY".equals(value)) {
+            return Usage.ANY;
+        }
+        else {
+            return fromString(value);
+        }
     }
 
     public String getValue() {
@@ -82,7 +100,7 @@ public enum Usage {
 
         @Override
         public Usage convertToEntityAttribute(String dbData) {
-            return Usage.fromString(dbData);
+            return Usage.fromDbString(dbData);
         }
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/model/ServiceLevelTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/ServiceLevelTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ServiceLevelTest {
+    @Test
+    void testEachValueSurvivesStringConversion() {
+        ServiceLevel.EnumConverter converter = new ServiceLevel.EnumConverter();
+        for (ServiceLevel sla : ServiceLevel.values()) {
+            assertEquals(converter.convertToDatabaseColumn(sla), sla.getValue());
+            assertEquals(converter.convertToEntityAttribute(sla.getValue()), sla);
+        }
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/db/model/UsageTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/UsageTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class UsageTest {
+    @Test
+    void testEachValueSurvivesStringConversion() {
+        Usage.EnumConverter converter = new Usage.EnumConverter();
+        for (Usage usage : Usage.values()) {
+            assertEquals(converter.convertToDatabaseColumn(usage), usage.getValue());
+            assertEquals(converter.convertToEntityAttribute(usage.getValue()), usage);
+        }
+    }
+}


### PR DESCRIPTION
This is a follow-on to #136.

This was causing issues like the following in rhsm-ci:

```
java.lang.IllegalStateException: Duplicate key TallySnapshot{id=REDACTED, snapshotDate=2020-05-01T00:00Z, granularity=MONTHLY, accountNumber=REDACTED, productId='RHEL', serviceLevel='UNSPECIFIED', usage='UNSPECIFIED'}
```