### PR TITLE
Clean up roles and authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ extended. Please see the
 [documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html)
 for a discussion of extension points.
 
+### RBAC
+
+rhsm-subscriptions uses an RBAC service to determine application authorization. The
+RBAC service connection details is configured in _`rhsm-subscriptions.conf`_ as follows:
+
+```properties
+# The name of the RBAC permission application name (<APP_NAME>:*:*)
+# By default this property is set to 'subscriptions'.
+rhsm-subscriptions.rbacApplicationName=insights
+
+# The path to the RBAC service's API.
+rhsm-subscriptions.rbac-service.url=http://localhost:8819/api/rbac/v1
+
+```
+
+For development purposes, the RBAC service can be stubbed out so that the connection
+to the RBAC service is bypassed and all users recieve the 'subscriptions:*:*' role. This
+can be enabled by setting the following property:
+
+```properties
+rhsm-subscriptions.rbac-service.useStub=true
+```
+
 ## Release Notes
 
 You can perform a release using `./gradlew release` **on the master

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -52,8 +52,6 @@ public class ApplicationProperties {
 
     private boolean devMode = false;
 
-    private boolean orgAdminOptional = true;
-
     private final TallyRetentionPolicyProperties tallyRetentionPolicy = new TallyRetentionPolicyProperties();
 
     /**
@@ -285,14 +283,6 @@ public class ApplicationProperties {
 
     public void setAntiCsrfPort(int antiCsrfPort) {
         this.antiCsrfPort = antiCsrfPort;
-    }
-
-    public void setOrgAdminOptional(boolean orgAdminOptional) {
-        this.orgAdminOptional = orgAdminOptional;
-    }
-
-    public boolean isOrgAdminOptional() {
-        return orgAdminOptional;
     }
 
     public String getRbacApplicationName() {

--- a/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
@@ -22,7 +22,7 @@ package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.controller.OptInController;
 import org.candlepin.subscriptions.db.model.config.OptInType;
-import org.candlepin.subscriptions.security.auth.OptInRoleRequired;
+import org.candlepin.subscriptions.security.auth.SubscriptionWatchAdminOnly;
 import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
 import org.candlepin.subscriptions.utilization.api.resources.OptInApi;
 
@@ -47,19 +47,19 @@ public class OptInResource implements OptInApi {
         this.controller = controller;
     }
 
-    @OptInRoleRequired
+    @SubscriptionWatchAdminOnly
     @Override
     public void deleteOptInConfig() {
         controller.optOut(validateAccountNumber(), validateOrgId());
     }
 
-    @OptInRoleRequired
+    @SubscriptionWatchAdminOnly
     @Override
     public OptInConfig getOptInConfig() {
         return controller.getOptInConfig(validateAccountNumber(), validateOrgId());
     }
 
-    @OptInRoleRequired
+    @SubscriptionWatchAdminOnly
     @Override
     public OptInConfig putOptInConfig(Boolean enableTallySync, Boolean enableTallyReporting,
         Boolean enableConduitSync) {

--- a/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
@@ -20,9 +20,8 @@
  */
 package org.candlepin.subscriptions.security;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -32,8 +31,7 @@ import java.util.List;
  */
 public class RoleProvider {
 
-    public static final String OPT_IN_ROLE = "OPT_IN";
-    public static final String REPORTING_ROLE = "REPORTING";
+    public static final String SWATCH_ADMIN_ROLE = "SUBSCRIPTION_WATCH_ADMIN";
 
     private String rulePrefix;
     private boolean devModeEnabled;
@@ -44,22 +42,17 @@ public class RoleProvider {
     }
 
     public List<String> getRoles(Collection<String> permissions) {
+        List<String> roles  = new ArrayList<>();
         if (permissions == null) {
-            return Collections.emptyList();
+            return roles;
         }
 
         // By default, we look for the subscriptions:*:* permission (unless
         // configured otherwise).
         if (devModeEnabled || permissions.contains(rulePrefix + ":*:*")) {
-            return all();
+            roles.add(SWATCH_ADMIN_ROLE);
         }
-        return Collections.emptyList();
+        return roles;
     }
 
-    private List<String> all() {
-        return Arrays.asList(
-            OPT_IN_ROLE,
-            REPORTING_ROLE
-        );
-    }
 }

--- a/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequired.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequired.java
@@ -30,15 +30,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A security annotation ensuring that the user must have an admin role in order to execute
- * the method.
+ * Must have the SWATCH_ADMIN_ROLE and account must be whitelisted for reporting.
  *
- * Should be the logic (isOrgAdminOptional or isOrgAdmin) and isWhitelisted
+ * @see RoleProvider
+ *
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("(@applicationProperties.isOrgAdminOptional() or " +
-    "hasAnyRole('" + RoleProvider.OPT_IN_ROLE + "', '" + RoleProvider.REPORTING_ROLE + "')) and " +
+@PreAuthorize("hasRole('" + RoleProvider.SWATCH_ADMIN_ROLE + "') and " +
     "@reportAccessService.providesAccessTo(authentication)")
 public @interface ReportingAccessRequired {
 }

--- a/src/main/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnly.java
@@ -30,12 +30,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A security annotation ensuring that the user must have an admin role in order to execute
+ * A security annotation ensuring that the user must have the subscription watch admin in order to execute
  * the method.
+ *
+ * Requires the SWATCH_ADMIN_ROLE and the account
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("@applicationProperties.isOrgAdminOptional() or " +
-    "hasRole('" + RoleProvider.OPT_IN_ROLE + "')")
-public @interface OptInRoleRequired {
+@PreAuthorize("hasRole('" + RoleProvider.SWATCH_ADMIN_ROLE + "')")
+public @interface SubscriptionWatchAdminOnly {
 }

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -32,8 +32,6 @@ rhsm-subscriptions.quartz.datasource.platform=hsqldb
 
 rhsm-subscriptions.enableIngressEndpoint=false
 
-rhsm-subscriptions.orgAdminOptional=false
-
 ##########################
 # kafka configuration
 ##########################

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -426,7 +426,7 @@ public class TallyResourceTest {
     }
 
     @Test
-    @WithMockRedHatPrincipal(value = "123456", roles = {"ROLE_" + RoleProvider.REPORTING_ROLE})
+    @WithMockRedHatPrincipal(value = "123456", roles = {"ROLE_" + RoleProvider.SWATCH_ADMIN_ROLE})
     public void canReportWithOnlyReportingRole() {
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsSourceTest.java
@@ -55,22 +55,12 @@ public class IdentityHeaderAuthenticationDetailsSourceTest {
         when(rbacApi.getCurrentUserAccess(eq("subscriptions"))).thenReturn(
             Arrays.asList(new Access().permission("subscriptions:*:*"))
         );
-        assertRoles(false,
-            RoleProvider.OPT_IN_ROLE,
-            RoleProvider.REPORTING_ROLE);
+        assertRoles(false, RoleProvider.SWATCH_ADMIN_ROLE);
     }
 
     @Test
     public void testDevModeGrantsAllRoles() {
-        assertRoles(true,
-            RoleProvider.OPT_IN_ROLE,
-            RoleProvider.REPORTING_ROLE);
-        assertRoles(true,
-            RoleProvider.OPT_IN_ROLE,
-            RoleProvider.REPORTING_ROLE);
-        assertRoles(true,
-            RoleProvider.OPT_IN_ROLE,
-            RoleProvider.REPORTING_ROLE);
+        assertRoles(true, RoleProvider.SWATCH_ADMIN_ROLE);
     }
 
     private void assertRoles(boolean devMode, String ... expectedRoles) {

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
@@ -44,5 +44,5 @@ public @interface WithMockRedHatPrincipal {
     boolean nullifyAccount() default false;
     boolean nullifyOwner() default false;
 
-    String[] roles() default {"ROLE_" + RoleProvider.OPT_IN_ROLE};
+    String[] roles() default {"ROLE_" + RoleProvider.SWATCH_ADMIN_ROLE};
 }

--- a/src/test/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequiredTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequiredTest.java
@@ -69,93 +69,45 @@ public class ReportingAccessRequiredTest {
 
     /* The reporting admin expression in pseudo-code:
      *
-     *     isOrgAdminOptional or (isOrgAdmin and isWhitelisted).
+     *     isOrgAdmin and isWhitelisted.
      *
      * I've marked the tests with the true/false values for these conditions.
      */
 
-    /** (F || F) && F == F */
+    /** F && F == F */
     @Test
     @WithMockRedHatPrincipal(value = "NotAdmin", roles = {})
     void testFalseOrFalseAndFalseIsFalse() throws Exception {
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(false);
         whitelistOrg(false);
         StubResource stub = context.getBean(StubResource.class);
 
         assertThrows(AccessDeniedException.class, stub::reportingAdminOnlyCall);
     }
 
-    /** (F || F) && T) == F */
+    /** F && T == F */
     @Test
     @WithMockRedHatPrincipal(value = "NotAdmin", roles = {})
     void testFalseOrFalseAndTrueIsFalse() throws Exception {
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(false);
         whitelistOrg(true);
         StubResource stub = context.getBean(StubResource.class);
 
         assertThrows(AccessDeniedException.class, stub::reportingAdminOnlyCall);
     }
 
-    /** (F || T) && F == F */
+    /** T && F == F */
     @Test
     @WithMockRedHatPrincipal("Admin")
     void testFalseOrTrueAndFalseIsFalse() throws Exception {
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(false);
         whitelistOrg(false);
         StubResource stub = context.getBean(StubResource.class);
 
         assertThrows(AccessDeniedException.class, stub::reportingAdminOnlyCall);
     }
 
-    /** (T || F) && F == F */
-    @Test
-    @WithMockRedHatPrincipal(value = "NotAdmin", roles = {})
-    void testTrueOrFalseAndFalseIsTrue() throws Exception {
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(true);
-        whitelistOrg(false);
-        StubResource stub = context.getBean(StubResource.class);
-
-        assertThrows(AccessDeniedException.class, stub::reportingAdminOnlyCall);
-    }
-
-    /** (F || T) && T == T */
+    /** T && T == T */
     @Test
     @WithMockRedHatPrincipal("Admin")
     void testFalseOrTrueAndTrueIsTrue() throws Exception {
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(false);
-        whitelistOrg(true);
-        StubResource stub = context.getBean(StubResource.class);
-
-        assertDoesNotThrow(stub::reportingAdminOnlyCall);
-    }
-
-    /** (T || F) && T == T */
-    @Test
-    @WithMockRedHatPrincipal(value = "NotAdmin", roles = {})
-    void testTrueOrFalseAndTrueIsTrue() throws Exception {
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(true);
-        whitelistOrg(true);
-        StubResource stub = context.getBean(StubResource.class);
-
-        assertDoesNotThrow(stub::reportingAdminOnlyCall);
-    }
-
-    /** (T || T) && F == F */
-    @Test
-    @WithMockRedHatPrincipal("Admin")
-    void testTrueOrTrueAndFalseIsTrue() throws Exception {
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(true);
-        whitelistOrg(false);
-        StubResource stub = context.getBean(StubResource.class);
-
-        assertThrows(AccessDeniedException.class, stub::reportingAdminOnlyCall);
-    }
-
-    /** (T || T) && T == T */
-    @Test
-    @WithMockRedHatPrincipal("Admin")
-    void testTrueOrTrueAndTrueIsTrue() throws Exception {
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(true);
         whitelistOrg(true);
         StubResource stub = context.getBean(StubResource.class);
 

--- a/src/test/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnlyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnlyTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.*;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.security.WhitelistedAccountReportAccessService;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
-import org.candlepin.subscriptions.security.auth.OptInRoleRequiredTest.OptInRoleRequiredConfiguration;
+import org.candlepin.subscriptions.security.auth.SubscriptionWatchAdminOnlyTest.SubscriptionWatchRequiredConfiguration;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,14 +36,14 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@SpringJUnitConfig(classes = OptInRoleRequiredConfiguration.class)
-public class OptInRoleRequiredTest {
+@SpringJUnitConfig(classes = SubscriptionWatchRequiredConfiguration.class)
+class SubscriptionWatchAdminOnlyTest {
 
     @Autowired
     ApplicationContext context;
 
     @EnableGlobalMethodSecurity(prePostEnabled = true)
-    protected static class OptInRoleRequiredConfiguration {
+    protected static class SubscriptionWatchRequiredConfiguration {
         @Bean
         public StubResource stubResource() {
             return new StubResource();
@@ -61,7 +61,7 @@ public class OptInRoleRequiredTest {
     }
 
     protected static class StubResource {
-        @OptInRoleRequired
+        @SubscriptionWatchAdminOnly
         public void adminOnlyCall() {
             // Does nothing
         }
@@ -69,25 +69,17 @@ public class OptInRoleRequiredTest {
 
     @Test
     @WithMockRedHatPrincipal(value = "NotAnAdmin", roles = {})
-    void testAdminOnlyCallWithNonAdmin() throws Exception {
+    void testAdminOnlyCallWithNonAdmin() {
         StubResource stub = context.getBean(StubResource.class);
 
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(false);
         assertThrows(AccessDeniedException.class, stub::adminOnlyCall);
-
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(true);
-        assertDoesNotThrow(stub::adminOnlyCall);
     }
 
     @Test
     @WithMockRedHatPrincipal("Admin")
-    void testAdminOnlyCallWithOrgAdmin() throws Exception {
+    void testAdminOnlyCallWithOrgAdmin() {
         StubResource stub = context.getBean(StubResource.class);
 
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(false);
-        assertDoesNotThrow(stub::adminOnlyCall);
-
-        context.getBean(ApplicationProperties.class).setOrgAdminOptional(true);
         assertDoesNotThrow(stub::adminOnlyCall);
     }
 


### PR DESCRIPTION
* Removed orgAdminRequired functionality now that RBAC is in place.
* Add SWATCH_ADMIN_ROLE instead of granting opt-in and reporting roles.

NOTE:
* The ReportinAccessRequired annotation is required to support the
  account whitelist check when a report is requested. It now checks
  that the user has the SWATCH_ADMIN_ROLE as well as checks that the
  account is in the whitelist.

# Testing
See #121 and #133 