### PR TITLE
Retry SonarQube quality gate check a few times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,8 +61,20 @@ pipeline {
                 withSonarQubeEnv('sonarcloud.io') {
                     echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
                 }
-                timeout(time: 1, unit: 'HOURS') {
-                    waitForQualityGate abortPipeline: true
+                retry(4) {
+                    script {
+                        try {
+                            timeout(time: 5, unit: 'MINUTES') {
+                                waitForQualityGate abortPipeline: true
+                            }
+                        }
+                        catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+                            // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
+                            if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
+                                error("Timeout waiting for SonarQube results")
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This should ensure that even if the webhook isn't functioning correctly,
we can still get a relatively timely finish of the pipeline.

This changes the max time to 20 minutes, with up to 4 checks with 5
minutes between each.

Note that currently we've been seeing occasional issues where the
webhook is delivered to Jenkins successfully (verified via Jenkins
logs), and yet the related job is not notified/updated.