### PR TITLE
Add optional sort and dir params to host API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -404,6 +404,16 @@ paths:
           schema:
             type: string
           description: "Include only hosts for the specified usage level."
+        - name: sort
+          in: query
+          schema:
+            $ref: "#/components/schemas/HostReportSort"
+          description: "What property to sort by (optional)"
+        - name: dir
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+          description: "Which direction to sort by (default: asc)"
       responses:
         '200':
           description: 'The request for hosts was successful.'
@@ -623,6 +633,11 @@ components:
           schema:
             $ref: "#/components/schemas/Errors"
   schemas:
+    SortDirection:
+      type: string
+      enum:
+        - asc
+        - desc
     VersionInfo:
       properties:
         build:
@@ -936,6 +951,14 @@ components:
             If there is an infinite quantity subscription involved, there is no meaningful number for
             capacity."
           type: boolean
+    HostReportSort:
+      type: string
+      enum:
+        - display_name
+        - hardware_type
+        - cores
+        - sockets
+        - last_seen
     HostReport:
       properties:
         data:

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/BadRequestExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/BadRequestExceptionMapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.exception.mapper;
+
+import org.candlepin.subscriptions.exception.ErrorCode;
+import org.candlepin.subscriptions.utilization.api.model.Error;
+
+import org.jboss.resteasy.spi.BadRequestException;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This handler catches RESTEasy BadRequestException.
+ */
+@Component
+@Provider
+public class BadRequestExceptionMapper extends BaseExceptionMapper<BadRequestException> {
+    @Override
+    protected Error buildError(BadRequestException exception) {
+        return new Error()
+            .code(ErrorCode.VALIDATION_FAILED_ERROR.getCode())
+            .status(String.valueOf(Response.Status.BAD_REQUEST.getStatusCode()))
+            .title("Bad Request")
+            .detail(exception.getCause().getMessage());
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -29,6 +29,7 @@ import org.candlepin.subscriptions.security.InsightsUserPrincipal;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -94,6 +95,19 @@ public class ResourceUtils {
      */
     @NotNull
     static Pageable getPageable(Integer offset, Integer limit) {
+        return getPageable(offset, limit, Sort.unsorted());
+    }
+
+    /**
+     * Validates offset, limit, and sort parameters and produces a {@link Pageable} for them.
+     *
+     * @param offset 0-based offset, can be null.
+     * @param limit max number of items per-page, should be non-zero.
+     * @param sort sorting parameters.
+     * @return Pageable holding paging and sorting information.
+     */
+    @NotNull
+    static Pageable getPageable(Integer offset, Integer limit, Sort sort) {
         if (limit == null) {
             limit = DEFAULT_LIMIT;
         }
@@ -110,7 +124,7 @@ public class ResourceUtils {
                 "Arbitrary offsets are not currently supported by this API"
             );
         }
-        return PageRequest.of(offset / limit, limit);
+        return PageRequest.of(offset / limit, limit, sort);
     }
 
     /**

--- a/src/main/java/org/candlepin/subscriptions/resteasy/EnumParamConverterProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/EnumParamConverterProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resteasy;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * ParamConverterProvider to enable use of enums in query providers.
+ */
+@Component
+@Provider
+public class EnumParamConverterProvider implements ParamConverterProvider {
+
+    @Override
+    public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+        if (!rawType.isEnum()) {
+            return null;
+        }
+        return new EnumParamConverter<>(rawType);
+    }
+
+    /**
+     * ParamConverter that uses an ObjectMapper to convert enums to/from String.
+     *
+     * @param <T> the enum type
+     */
+    public static class EnumParamConverter<T> implements ParamConverter<T> {
+
+        private final Map<String, T> stringValueMap = new HashMap<>();
+        private final Class<T> clazz;
+
+        public EnumParamConverter(Class<T> clazz) {
+            this.clazz = clazz;
+            for (T value : clazz.getEnumConstants()) {
+                String stringValue = value.toString();
+                stringValueMap.put(stringValue, value);
+            }
+        }
+
+        @Override
+        public T fromString(String value) {
+            if (value == null) {
+                return null;
+            }
+            if (stringValueMap.containsKey(value)) {
+                return stringValueMap.get(value);
+            }
+            throw new IllegalArgumentException(String.format("%s is not a valid value for %s", value, clazz));
+        }
+
+        @Override
+        public String toString(T value) {
+            if (value == null) {
+                return null;
+            }
+            return value.toString();
+        }
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -28,6 +28,8 @@ import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyHostView;
 import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.resource.HostsResource;
+import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -225,6 +228,66 @@ class HostRepositoryTest {
         assertEquals(uuid, guests.getContent().get(0).getHypervisorUuid());
         assertEquals("guest", guests.getContent().get(0).getInventoryId());
         assertEquals("INSIGHTS_guest", guests.getContent().get(0).getInsightsId());
+    }
+
+    @Transactional
+    @Test
+    void testCanSortByDisplayName() {
+        Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)));
+        List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
+
+        assertEquals(1, found.size());
+        assertTallyHostView(found.get(0), "inventory3");
+    }
+
+    @Transactional
+    @Test
+    void testCanSortByCores() {
+        Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)));
+        List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
+
+        assertEquals(1, found.size());
+        assertTallyHostView(found.get(0), "inventory3");
+    }
+
+    @Transactional
+    @Test
+    void testCanSortBySockets() {
+        Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)));
+        List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
+
+        assertEquals(1, found.size());
+        assertTallyHostView(found.get(0), "inventory3");
+    }
+
+    @Transactional
+    @Test
+    void testCanSortByLastSeen() {
+        Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)));
+        List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
+
+        assertEquals(1, found.size());
+        assertTallyHostView(found.get(0), "inventory3");
+    }
+
+    @Transactional
+    @Test
+    void testCanSortByHardwareType() {
+        Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)));
+        List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
+
+        assertEquals(1, found.size());
+        assertTallyHostView(found.get(0), "inventory3");
     }
 
     @Transactional

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource;
+
+import static org.mockito.Mockito.*;
+
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyHostView;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.resteasy.PageLinkCreator;
+import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
+import org.candlepin.subscriptions.tally.AccountListSource;
+import org.candlepin.subscriptions.tally.AccountListSourceException;
+import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
+import org.candlepin.subscriptions.utilization.api.model.SortDirection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Collections;
+
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
+@WithMockRedHatPrincipal("123456")
+class HostsResourceTest {
+
+    @MockBean
+    HostRepository repository;
+
+    @MockBean
+    PageLinkCreator pageLinkCreator;
+
+    @MockBean
+    AccountListSource accountListSource;
+
+    @Autowired
+    HostsResource resource;
+
+    @BeforeEach
+    public void setup() throws AccountListSourceException {
+        PageImpl<TallyHostView> mockPage = new PageImpl<>(Collections.emptyList());
+        when(repository.getTallyHostViews(any(), any(), any(), any(), any()))
+            .thenReturn(mockPage);
+        when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
+    }
+
+    @Test
+    void testShouldMapDisplayNameAppropriately() {
+        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.DISPLAY_NAME, SortDirection.ASC);
+
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)))
+        );
+    }
+
+    @Test
+    void testShouldMapCoresAppropriately() {
+        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.CORES, SortDirection.ASC);
+
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)))
+        );
+    }
+
+    @Test
+    void testShouldMapSocketsAppropriately() {
+        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.SOCKETS, SortDirection.ASC);
+
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)))
+        );
+    }
+
+    @Test
+    void testShouldMapLastSeenAppropriately() {
+        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.LAST_SEEN, SortDirection.ASC);
+
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)))
+        );
+    }
+
+    @Test
+    void testShouldMapHardwareTypeAppropriately() {
+        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.HARDWARE_TYPE, SortDirection.ASC);
+
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)))
+        );
+    }
+
+    @Test
+    void testShouldDefaultToUnsorted() {
+        resource.getHosts("RHEL", 0, 1, null, null, null, null);
+
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(PageRequest.of(0, 1))
+        );
+    }
+
+    @Test
+    void testShouldDefaultToAscending() {
+        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.DISPLAY_NAME, null);
+
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
+            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)))
+        );
+    }
+}


### PR DESCRIPTION
To test, use swagger-UI with some hosts inserted via
`bin/insert-mock-hosts`.