### PR TITLE
Move config to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,25 +75,57 @@ for a discussion of extension points.
 ### RBAC
 
 rhsm-subscriptions uses an RBAC service to determine application authorization. The
-RBAC service connection details is configured in _`rhsm-subscriptions.conf`_ as follows:
-
-```properties
-# The name of the RBAC permission application name (<APP_NAME>:*:*)
-# By default this property is set to 'subscriptions'.
-rhsm-subscriptions.rbacApplicationName=insights
-
-# The path to the RBAC service's API.
-rhsm-subscriptions.rbac-service.url=http://localhost:8819/api/rbac/v1
-
-```
+RBAC service can via configured by environment variables (see below).
 
 For development purposes, the RBAC service can be stubbed out so that the connection
 to the RBAC service is bypassed and all users recieve the 'subscriptions:*:*' role. This
-can be enabled by setting the following property:
+can be enabled by setting `RBAC_USE_STUB=true`
 
-```properties
-rhsm-subscriptions.rbac-service.useStub=true
+```sh
+RBAC_USE_STUB=true ./gradlew bootRun
 ```
+
+### Environment Variables
+
+* `DEV_MODE`: disable anti-CSRF, account filtering, and RBAC role check
+* `PRETTY_PRINT_JSON`: configure Jackson to indent outputted JSON
+* `APP_NAME`: application name for URLs (default: rhsm-subscriptions)
+* `PATH_PREFIX`: path prefix in the URLs (default: api)
+* `INVENTORY_DATABASE_HOST`: inventory DB host
+* `INVENTORY_DATABASE_DATABASE`: inventory DB database
+* `INVENTORY_DATABASE_USERNAME`: inventory DB user
+* `INVENTORY_DATABASE_PASSWORD`: inventory DB password
+* `PRODUCT_WHITELIST_RESOURCE_LOCATION`: location of the product whitelist
+* `ACCOUNT_LIST_RESOURCE_LOCATION`: location of the account list (opt-in used otherwise)
+* `DATABASE_HOST`: DB host
+* `DATABASE_PORT`: DB port
+* `DATABASE_DATABASE`: DB database
+* `DATABASE_USERNAME`: DB username
+* `DATABASE_PASSWORD`: DB password
+* `CAPTURE_SNAPSHOT_SCHEDULE`: cron schedule for capturing tally snapshots
+* `ACCOUNT_BATCH_SIZE`: number of accounts to tally at once
+* `TALLY_RETENTION_DAILY`: number of daily tallies to keep
+* `TALLY_RETENTION_WEEKLY`: number of weekly tallies to keep
+* `TALLY_RETENTION_MONTHLY`: number of monthly tallies to keep
+* `TALLY_RETENTION_QUARTERLY`: number of quarterly tallies to keep
+* `TALLY_RETENTION_YEARLY`: number of yearly tallies to keep
+* `KAFKA_TASK_GROUP`: kafka task group
+* `KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS`: kafka max poll interval in milliseconds
+* `KAFKA_MESSAGE_THREADS`: number of consumer threads
+* `KAFKA_BOOTSTRAP_HOST`: kafka bootstrap host
+* `KAFKA_BOOTSTRAP_PORT`: kafka boostrap port
+* `KAFKA_CONSUMER_RECONNECT_BACKOFF_MS`: kafka consumer reconnect backoff in milliseconds
+* `KAFKA_CONSUMER_RECONNECT_BACKOFF_MAX_MS`: kafka consumer reconnect max backoff in milliseconds
+* `KAFKA_API_RECONNECT_TIMEOUT_MS`: kafka connection timeout in milliseconds
+* `KAFKA_SCHEMA_REGISTRY_SCHEME`: avro schema server scheme (http or https)
+* `KAFKA_SCHEMA_REGISTRY_HOST`: kafka schema server host
+* `KAFKA_SCHEMA_REGISTRY_PORT`: kafka schema server port
+* `KAFKA_AUTO_REGISTER_SCHEMAS`: enable auto registration of schemas
+* `RBAC_USE_STUB`: stub out the rbac service
+* `RBAC_APPLICATION_NAME`: name of the RBAC permission application name (`<APP_NAME>:*:*`), by default this property is set to 'subscriptions'.
+* `RBAC_HOST`: RBAC service hostname
+* `RBAC_PORT`: RBAC service port
+* `RBAC_MAX_CONNECTIONS`: max concurrent connections to RBAC service
 
 ## Release Notes
 

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -133,7 +133,7 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     @Bean
     public AccountListSource accountListSource(ApplicationProperties applicationProperties,
         AccountConfigRepository accountConfigRepository, ApplicationClock clock) {
-        if (applicationProperties.getAccountListResourceLocation() != null) {
+        if (!applicationProperties.getAccountListResourceLocation().isEmpty()) {
             return new FileAccountListSource(
                 new FileAccountSyncListSource(applicationProperties, clock),
                 new ReportingAccountWhitelist(applicationProperties, clock)

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -133,7 +134,7 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     @Bean
     public AccountListSource accountListSource(ApplicationProperties applicationProperties,
         AccountConfigRepository accountConfigRepository, ApplicationClock clock) {
-        if (!applicationProperties.getAccountListResourceLocation().isEmpty()) {
+        if (StringUtils.hasText(applicationProperties.getAccountListResourceLocation())) {
             return new FileAccountListSource(
                 new FileAccountSyncListSource(applicationProperties, clock),
                 new ReportingAccountWhitelist(applicationProperties, clock)

--- a/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
@@ -42,7 +42,7 @@ public class ProductWhitelist implements ResourceLoaderAware {
     private final PerLineFileSource source;
 
     public ProductWhitelist(ApplicationProperties properties, ApplicationClock clock) {
-        if (properties.getProductWhitelistResourceLocation() != null) {
+        if (!properties.getProductWhitelistResourceLocation().isEmpty()) {
             source = new PerLineFileSource(
                 properties.getProductWhitelistResourceLocation(), clock.getClock(),
                 properties.getProductWhiteListCacheTtl());

--- a/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
 
@@ -42,7 +43,7 @@ public class ProductWhitelist implements ResourceLoaderAware {
     private final PerLineFileSource source;
 
     public ProductWhitelist(ApplicationProperties properties, ApplicationClock clock) {
-        if (!properties.getProductWhitelistResourceLocation().isEmpty()) {
+        if (StringUtils.hasText(properties.getProductWhitelistResourceLocation())) {
             source = new PerLineFileSource(
                 properties.getProductWhitelistResourceLocation(), clock.getClock(),
                 properties.getProductWhiteListCacheTtl());

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -4,33 +4,43 @@
 
 # We're keeping the context-path as "/" so that the actuators we use for OKD liveness/readiness probes have a
 # fixed path.  The actual subscriptions resources will be configured to hang off of the path below.
+
+rhsm-subscriptions.dev-mode=${DEV_MODE:false}
+rhsm-subscriptions.prettyPrintJson=${PRETTY_PRINT_JSON:false}
 rhsm-subscriptions.package_uri_mappings.org.candlepin.subscriptions=${PATH_PREFIX:api}/${APP_NAME:rhsm-subscriptions}/v1
 
-rhsm-subscriptions.inventory-service.datasource.url=jdbc:postgresql://localhost/inventory
-rhsm-subscriptions.inventory-service.datasource.username=insights
-rhsm-subscriptions.inventory-service.datasource.password=insights
+rhsm-subscriptions.inventory-service.datasource.url=jdbc:postgresql://${INVENTORY_DATABASE_HOST:localhost}/${INVENTORY_DATABASE_DATABASE:inventory}
+rhsm-subscriptions.inventory-service.datasource.username=${INVENTORY_DATABASE_USERNAME:insights}
+rhsm-subscriptions.inventory-service.datasource.password=${INVENTORY_DATABASE_PASSWORD:insights}
 rhsm-subscriptions.inventory-service.datasource.driver-class-name=org.postgresql.Driver
 rhsm-subscriptions.inventory-service.datasource.platform=postgresql
 
 # Use Spring Resource notation for this (e.g. "classpath:" or "file:")
 rhsm-subscriptions.product_id_to_products_map_resource_location=classpath:product_id_to_products_map.yaml
 rhsm-subscriptions.role_to_products_map_resource_location=classpath:role_to_products_map.yaml
+rhsm-subscriptions.product_whitelist_resource_location=${PRODUCT_WHITELIST_RESOURCE_LOCATION:}
+rhsm-subscriptions.account_list_resource_location=${ACCOUNT_LIST_RESOURCE_LOCATION:}
 
-rhsm-subscriptions.datasource.url=jdbc:postgresql://${POSTGRESQL_SERVICE_HOST:localhost}:\
-  ${POSTGRESQL_SERVICE_PORT:5432}/${DATABASE_NAME:rhsm-subscriptions}
-rhsm-subscriptions.datasource.username=${DATABASE_USER:rhsm-subscriptions}
+rhsm-subscriptions.datasource.url=jdbc:postgresql://${DATABASE_HOST:localhost}:${DATABASE_PORT:5432}/${DATABASE_DATABASE:rhsm-subscriptions}
+rhsm-subscriptions.datasource.username=${DATABASE_USERNAME:rhsm-subscriptions}
 rhsm-subscriptions.datasource.password=${DATABASE_PASSWORD:rhsm-subscriptions}
 rhsm-subscriptions.datasource.driver-class-name=org.postgresql.Driver
 rhsm-subscriptions.datasource.platform=postgresql
 
 # Capture snapshot schedule
-rhsm-subscriptions.jobs.captureSnapshotSchedule=0 0/5 * * * ?
+rhsm-subscriptions.jobs.captureSnapshotSchedule=${CAPTURE_SNAPSHOT_SCHEDULE:0 0/5 * * * ?}
+rhsm-subscriptions.account-batch-size=${ACCOUNT_BATCH_SIZE:1}
+
+# Tally retention policy
+rhsm-subscriptions.tally-retention-policy.daily=${TALLY_RETENTION_DAILY:37}
+rhsm-subscriptions.tally-retention-policy.weekly=${TALLY_RETENTION_WEEKLY:12}
+rhsm-subscriptions.tally-retention-policy.monthly=${TALLY_RETENTION_MONTHLY:12}
+rhsm-subscriptions.tally-retention-policy.quarterly=${TALLY_RETENTION_QUARTERLY:16}
+rhsm-subscriptions.tally-retention-policy.yearly=${TALLY_RETENTION_YEARLY:5}
 
 # Default Quartz datasource.  Override by pulling in another rhsm-subscriptions.properties file via an
 # -Dspring.config.additional-location argument
 rhsm-subscriptions.quartz.datasource.platform=hsqldb
-
-rhsm-subscriptions.enableIngressEndpoint=false
 
 ##########################
 # kafka configuration
@@ -38,33 +48,34 @@ rhsm-subscriptions.enableIngressEndpoint=false
 
 # Use profile "kafka-queue" to enable Kafka integration
 # Use profile "worker" to enable Kafka listeners
-#rhsm-subscriptions.tasks.task-group=rhsm-subscriptions-tasks
+rhsm-subscriptions.tasks.task-group=${KAFKA_TASK_GROUP:platform.rhsm-subscriptions.tasks}
 
 # if no offset commit exists yet, set to earliest
 spring.kafka.consumer.properties.auto.offset.reset=earliest
 
 # Required kafka defaults
 spring.kafka.consumer.properties.max.poll.records=1
-spring.kafka.consumer.properties.max.poll.interval.ms=1800000
+spring.kafka.consumer.properties.max.poll.interval.ms=${KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS:1800000}
 
 # The number of threads that will be processing messages (should match
 # the number of partitions on the queue)
-#spring.kafka.listener.concurrency=1
-#spring.kafka.bootstrap-servers=localhost:9092
-#spring.kafka.consumer.properties.reconnect.backoff.ms=2000
-#spring.kafka.consumer.properties.reconnect.backoff.max.ms=10000
-#spring.kafka.consumer.properties.default.api.timeout.ms=480000
+spring.kafka.listener.concurrency=${KAFKA_MESSAGE_THREADS:1}
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_HOST:localhost}:${KAFKA_BOOTSTRAP_PORT:9092}
+spring.kafka.consumer.properties.reconnect.backoff.ms=${KAFKA_CONSUMER_RECONNECT_BACKOFF_MS:2000}
+spring.kafka.consumer.properties.reconnect.backoff.max.ms=${KAFKA_CONSUMER_RECONNECT_BACKOFF_MAX_MS:10000}
+spring.kafka.consumer.properties.default.api.timeout.ms=${KAFKA_API_RECONNECT_TIMEOUT_MS:480000}
 
 ###################################
 # Schema Registry configuration
 ###################################
 
-#spring.kafka.properties.schema.registry.url=http://localhost:8081
-#spring.kafka.properties.auto.register.schemas=false
+spring.kafka.properties.schema.registry.url=${KAFKA_SCHEMA_REGISTRY_SCHEME:http}://${KAFKA_SCHEMA_REGISTRY_HOST:localhost}:${KAFKA_SCHEMA_REGISTRY_PORT:8081}
+spring.kafka.properties.auto.register.schemas=${KAFKA_AUTO_REGISTER_SCHEMAS:false}
 
 ###################################
 # RBAC Configuration
 ###################################
-#rhsm-subscriptions.rbac-service.useStub=true
-#rhsm-subscriptions.rbac-service.url=http://localhost:8819/api/rbac/v1
-#rhsm-subscriptions.rbac-service.maxConnections=100
+rhsm-subscriptions.rbacApplicationName=${RBAC_APPLICATION_NAME:subscriptions}
+rhsm-subscriptions.rbac-service.useStub=${RBAC_USE_STUB:false}
+rhsm-subscriptions.rbac-service.url=http://${RBAC_HOST:localhost}:${RBAC_PORT:8819}/api/rbac/v1
+rhsm-subscriptions.rbac-service.maxConnections=${RBAC_MAX_CONNECTIONS:100}

--- a/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
@@ -34,7 +34,7 @@ class ProductWhitelistTest {
 
     @Test
     void testUnspecifiedLocationAllowsArbitraryProducts() throws IOException {
-        ProductWhitelist whitelist = initProductWhitelist(null);
+        ProductWhitelist whitelist = initProductWhitelist("");
         assertTrue(whitelist.productIdMatches("whee!"));
     }
 


### PR DESCRIPTION
I put all of the variables we currently had configured via deployment automation and a few we use regularly during development.

Configuration is still overridable via properties files, so the current `spring.config.additional-location` approach should work, until we move to just environment variables.

See README.md for documentation.