### PR TITLE
Store system table (Hosts) data during tally

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1007,11 +1007,15 @@ components:
             - count
     Host:
       required:
+        - inventory_id
         - insights_id
         - display_name
         - hardware_type
         - last_seen
       properties:
+        inventory_id:
+          description: The HBI identifier for this host.
+          type: string
         insights_id:
           description: The insights identifier for this host, used as ID on cloud.redhat.com.
           type: string
@@ -1033,6 +1037,9 @@ components:
           minimum: 0
         hardware_type:
           description: What the type of the host is (e.g. hypervisor, physical, etc.).
+          type: string
+        measurement_type:
+          description: What was the applied measurement type (e.g. hypervisor, physical, aws, etc ).
           type: string
         number_of_guests:
           description: Number of guests if this host is a hypervisor.

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -413,7 +413,7 @@ paths:
                 $ref: "#/components/schemas/HostReport"
               example:
                 data:
-                  - insights_id: d6214a0b-b344-4778-831c-d53dcacb2da3
+                  - inventory_id: d6214a0b-b344-4778-831c-d53dcacb2da3
                     display_name: rhv.example.com
                     subscription_manager_id: adafd9d5-5b00-42fa-a6c9-75801d45cc6d
                     cores: 4
@@ -421,7 +421,7 @@ paths:
                     hardware_type: hypervisor
                     number_of_guests: 4
                     last_seen: 2020-01-01T00:00:00Z
-                  - insights_id: 9358e312-1c9f-42f4-8910-dcef6e970852
+                  - inventory_id: 9358e312-1c9f-42f4-8910-dcef6e970852
                     display_name: db.example.com
                     subscription_manager_id: b101a72f-1859-4489-acb8-d6d31c2578c4
                     cores: 4
@@ -480,11 +480,11 @@ paths:
                 $ref: "#/components/schemas/HypervisorGuestReport"
               example:
                 data:
-                  - insights_id: d6214a0b-b344-4778-831c-d53dcacb2da3
+                  - inventory_id: d6214a0b-b344-4778-831c-d53dcacb2da3
                     display_name: guest01.example.com
                     subscription_manager_id: adafd9d5-5b00-42fa-a6c9-75801d45cc6d
                     last_seen: 2020-01-01T00:00:00Z
-                  - insights_id: 9358e312-1c9f-42f4-8910-dcef6e970852
+                  - inventory_id: 9358e312-1c9f-42f4-8910-dcef6e970852
                     display_name: guest02.example.com
                     subscription_manager_id: b101a72f-1859-4489-acb8-d6d31c2578c4
                     last_seen: 2020-01-01T00:00:00Z
@@ -1008,7 +1008,6 @@ components:
     Host:
       required:
         - inventory_id
-        - insights_id
         - display_name
         - hardware_type
         - last_seen

--- a/src/main/java/org/candlepin/subscriptions/controller/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/TallySnapshotController.java
@@ -95,7 +95,7 @@ public class TallySnapshotController {
             return;
         }
 
-        snapshotProducer.produceSnapshotsForAccounts(accounts, accountCalcs);
+        snapshotProducer.produceSnapshotsFromCalculations(accounts, accountCalcs);
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/controller/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/TallySnapshotController.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.controller;
+
+import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
+import org.candlepin.subscriptions.files.RoleToProductsMapSource;
+import org.candlepin.subscriptions.tally.AccountUsageCalculation;
+import org.candlepin.subscriptions.tally.InventoryAccountUsageCollector;
+import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.annotation.Timed;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Provides the logic for updating Tally snapshots.
+ */
+@Component
+public class TallySnapshotController {
+
+    private static final Logger log = LoggerFactory.getLogger(TallySnapshotController.class);
+
+    private final InventoryAccountUsageCollector usageCollector;
+    private final UsageSnapshotProducer snapshotProducer;
+    private final RetryTemplate retryTemplate;
+
+    private final Set<String> applicableProducts;
+
+
+    public TallySnapshotController(ProductIdToProductsMapSource productIdToProductsMapSource,
+        RoleToProductsMapSource roleToProductsMapSource,
+        InventoryAccountUsageCollector usageCollector,
+        UsageSnapshotProducer snapshotProducer,
+        @Qualifier("collectorRetryTemplate") RetryTemplate retryTemplate) throws IOException {
+
+        this.applicableProducts = new HashSet<>();
+        productIdToProductsMapSource.getValue().values().forEach(this.applicableProducts::addAll);
+        roleToProductsMapSource.getValue().values().forEach(this.applicableProducts::addAll);
+
+        this.usageCollector = usageCollector;
+        this.snapshotProducer = snapshotProducer;
+        this.retryTemplate = retryTemplate;
+    }
+
+    @Timed("rhsm-subscriptions.snapshots.single")
+    public void produceSnapshotsForAccount(String account) {
+        produceSnapshotsForAccounts(Collections.singletonList(account));
+    }
+
+    @Timed("rhsm-subscriptions.snapshots.collection")
+    public void produceSnapshotsForAccounts(List<String> accounts) {
+        log.info("Producing snapshots for {} accounts.", accounts.size());
+        // Account list could be large. Only print them when debugging.
+        if (log.isDebugEnabled()) {
+            log.debug("Producing snapshots for accounts: {}", String.join(",", accounts));
+        }
+
+        Collection<AccountUsageCalculation> accountCalcs;
+        try {
+            accountCalcs = retryTemplate.execute(context ->
+                usageCollector.collect(this.applicableProducts, accounts)
+            );
+        }
+        catch (Exception e) {
+            log.error("Could not collect existing usage snapshots for accounts {}", accounts, e);
+            return;
+        }
+
+        snapshotProducer.produceSnapshotsForAccounts(accounts, accountCalcs);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/controller/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/TallySnapshotController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -20,9 +20,9 @@
  */
 package org.candlepin.subscriptions.db;
 
-import org.candlepin.subscriptions.db.model.AppliedHost;
 import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyHostView;
 import org.candlepin.subscriptions.db.model.Usage;
 
 import org.springframework.data.domain.Page;
@@ -42,8 +42,9 @@ import java.util.Collection;
 public interface HostRepository extends JpaRepository<Host, String> {
 
     /**
-     * Find all AppliedHosts by bucket criteria. An AppliedHost is a Host representation
-     * detailing what 'bucket' was applied to the current daily snapshots.
+     * Find all Hosts by bucket criteria and return a page of TallyHostView objects.
+     * A TallyHostView is a Host representation detailing what 'bucket' was applied
+     * to the current daily snapshots.
      *
      * @param accountNumber The account number of the hosts to query (required).
      * @param productId The bucket product ID to filter Host by (pass null to ignore).
@@ -57,14 +58,14 @@ public interface HostRepository extends JpaRepository<Host, String> {
                 "b.key.productId = :product and " +
                 "b.key.sla = :sla and b.key.usage = :usage",
         // Because we are using a 'fetch join' to avoid having to lazy load each bucket host,
-        // we need to specify how the Page should gets it's count when the 'limit' parameter
+        // we need to specify how the Page should gets its count when the 'limit' parameter
         // is used.
         countQuery = "select count(b) from HostTallyBucket b join b.key.host h where " +
                      "h.accountNumber = :account and " +
                      "b.key.productId = :product and " +
                      "b.key.sla = :sla and b.key.usage = :usage"
     )
-    Page<AppliedHost> getAppliedHosts(
+    Page<TallyHostView> getTallyHostViews(
         @Param("account") String accountNumber,
         @Param("product") String productId,
         @Param("sla") ServiceLevel sla,

--- a/src/main/java/org/candlepin/subscriptions/db/model/AppliedHost.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/AppliedHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/AppliedHost.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/AppliedHost.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import org.candlepin.subscriptions.utilization.api.model.Host;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.OffsetDateTime;
+
+/**
+ * A data projection around Host and TallyHostBuckets.
+ */
+public interface AppliedHost {
+
+    @Value("#{target.key.host.inventoryId}")
+    String getInventoryId();
+
+    @Value("#{target.key.host.insightsId}")
+    String getInsightsId();
+
+    @Value("#{target.key.host.displayName}")
+    String getDisplayName();
+
+    @Value("#{target.measurementType}")
+    String getHardwareMeasurementType();
+
+    @Value("#{target.key.host.hardwareType}")
+    String getHardwareType();
+
+    @Value("#{target.cores}")
+    int getCores();
+
+    @Value("#{target.sockets}")
+    int getSockets();
+
+    @Value("#{target.key.host.numOfGuests}")
+    int getNumberOfGuests();
+
+    @Value("#{target.key.host.subscriptionManagerId}")
+    String getSubscriptionManagerId();
+
+    @Value("#{target.key.host.lastSeen}")
+    OffsetDateTime getLastSeen();
+
+    default Host asApiHost() {
+        return new Host()
+            .inventoryId(getInventoryId())
+            .insightsId(getInsightsId())
+            .hardwareType(getHardwareType())
+            .measurementType(getHardwareMeasurementType())
+            .cores(getCores())
+            .sockets(getSockets())
+            .displayName(getDisplayName())
+            .subscriptionManagerId(getSubscriptionManagerId())
+            .numberOfGuests(getNumberOfGuests())
+            .lastSeen(getLastSeen());
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostHardwareType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostHardwareType.java
@@ -18,33 +18,13 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.task.tasks;
+package org.candlepin.subscriptions.db.model;
 
-import static org.mockito.BDDMockito.eq;
-
-import org.candlepin.subscriptions.controller.TallySnapshotController;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Arrays;
-import java.util.List;
-
-
-@ExtendWith(MockitoExtension.class)
-public class UpdateAccountSnapshotsTaskTest {
-
-    @Mock
-    private TallySnapshotController snapshotController;
-
-    @Test
-    public void testExecute() {
-        List<String> accounts = Arrays.asList("a1", "a2");
-        UpdateAccountSnapshotsTask task = new UpdateAccountSnapshotsTask(snapshotController, accounts);
-        task.execute();
-        Mockito.verify(snapshotController).produceSnapshotsForAccounts(eq(accounts));
-    }
+/**
+ * The hardware type of a Host.
+ */
+public enum HostHardwareType {
+    PHYSICAL,
+    HYPERVISOR,
+    VIRTUAL
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostHardwareType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostHardwareType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -23,8 +23,11 @@ package org.candlepin.subscriptions.db.model;
 import java.io.Serializable;
 import java.util.Objects;
 
+import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Table;
 
 
@@ -38,11 +41,23 @@ public class HostTallyBucket implements Serializable {
     @EmbeddedId
     private HostBucketKey key;
 
+    private int cores;
+    private int sockets;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "measurement_type")
+    private HardwareMeasurementType measurementType;
+
     public HostTallyBucket() {
     }
 
-    public HostTallyBucket(Host host, String productId, ServiceLevel sla, Usage usage, Boolean asHypervisor) {
+    @SuppressWarnings("java:S107")
+    public HostTallyBucket(Host host, String productId, ServiceLevel sla, Usage usage, Boolean asHypervisor,
+        int cores, int sockets, HardwareMeasurementType type) {
         setKey(new HostBucketKey(host, productId, sla, usage, asHypervisor));
+        this.cores = cores;
+        this.sockets = sockets;
+        this.measurementType = type;
     }
 
     public HostBucketKey getKey() {
@@ -51,6 +66,30 @@ public class HostTallyBucket implements Serializable {
 
     public void setKey(HostBucketKey key) {
         this.key = key;
+    }
+
+    public int getCores() {
+        return cores;
+    }
+
+    public void setCores(int cores) {
+        this.cores = cores;
+    }
+
+    public int getSockets() {
+        return sockets;
+    }
+
+    public void setSockets(int sockets) {
+        this.sockets = sockets;
+    }
+
+    public HardwareMeasurementType getMeasurementType() {
+        return measurementType;
+    }
+
+    public void setMeasurementType(HardwareMeasurementType measurementType) {
+        this.measurementType = measurementType;
     }
 
     @Override
@@ -63,13 +102,16 @@ public class HostTallyBucket implements Serializable {
             return false;
         }
 
-        HostTallyBucket that = (HostTallyBucket) o;
-        return getKey().equals(that.getKey());
+        HostTallyBucket bucket = (HostTallyBucket) o;
+        return cores == bucket.cores &&
+            sockets == bucket.sockets &&
+            Objects.equals(key, bucket.key) &&
+                measurementType == bucket.measurementType;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getKey());
+        return Objects.hash(key, cores, sockets, measurementType);
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallyHostView.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallyHostView.java
@@ -27,9 +27,10 @@ import org.springframework.beans.factory.annotation.Value;
 import java.time.OffsetDateTime;
 
 /**
- * A data projection around Host and TallyHostBuckets.
+ * A data projection around Host and TallyHostBuckets necessary to give us a view of the data to
+ * be returned in the Hosts API.
  */
-public interface AppliedHost {
+public interface TallyHostView {
 
     @Value("#{target.key.host.inventoryId}")
     String getInventoryId();

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
@@ -33,11 +33,11 @@ import java.util.stream.Stream;
  * Isolates readonly transaction for inventory database operations.
  */
 @Component
-public class InventoryTransactionWrapper {
+public class InventoryDatabaseOperations {
 
     private final InventoryRepository repo;
 
-    public InventoryTransactionWrapper(InventoryRepository inventoryRepository) {
+    public InventoryDatabaseOperations(InventoryRepository inventoryRepository) {
         this.repo = inventoryRepository;
     }
 

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryTransactionWrapper.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryTransactionWrapper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.inventory.db;
+
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * Isolates readonly transaction for inventory database operations.
+ */
+@Component
+public class InventoryTransactionWrapper {
+
+    private final InventoryRepository repo;
+
+    public InventoryTransactionWrapper(InventoryRepository inventoryRepository) {
+        this.repo = inventoryRepository;
+    }
+
+    @Transactional(value = "inventoryTransactionManager", readOnly = true)
+    public void processHostFacts(Collection<String> accounts, int culledOffsetDays,
+        Consumer<InventoryHostFacts> consumer) {
+        try (Stream<InventoryHostFacts> hostFactStream = repo.getFacts(accounts, culledOffsetDays)) {
+            hostFactStream.forEach(consumer::accept);
+        }
+    }
+
+    @Transactional(value = "inventoryTransactionManager", readOnly = true)
+    public void reportedHypervisors(Collection<String> accounts, Consumer<Object[]> consumer) {
+        try (Stream<Object[]> stream = repo.getReportedHypervisors(accounts)) {
+            stream.forEach(consumer::accept);
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryTransactionWrapper.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryTransactionWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -46,6 +46,8 @@ import javax.persistence.Table;
         @ConstructorResult(
             targetClass = InventoryHostFacts.class,
             columns = {
+                @ColumnResult(name = "inventory_id", type = UUID.class),
+                @ColumnResult(name = "modified_on", type = OffsetDateTime.class),
                 @ColumnResult(name = "account"),
                 @ColumnResult(name = "display_name"),
                 @ColumnResult(name = "org_id"),
@@ -68,6 +70,7 @@ import javax.persistence.Table;
                 @ColumnResult(name = "satellite_hypervisor_uuid"),
                 @ColumnResult(name = "guest_id"),
                 @ColumnResult(name = "subscription_manager_id"),
+                @ColumnResult(name = "insights_id"),
                 @ColumnResult(name = "cloud_provider"),
                 @ColumnResult(name = "stale_timestamp", type = OffsetDateTime.class)
             }
@@ -79,7 +82,7 @@ import javax.persistence.Table;
  * https://stackoverflow.com/a/28557803/6124862
  */
 @NamedNativeQuery(name = "InventoryHost.getFacts",
-    query = "select h.account, h.display_name, " +
+    query = "select h.id as inventory_id, h.modified_on, h.account, h.display_name, " +
         "h.facts->'rhsm'->>'orgId' as org_id, " +
         "h.facts->'rhsm'->>'CPU_CORES' as cores, " +
         "h.facts->'rhsm'->>'CPU_SOCKETS' as sockets, " +
@@ -98,6 +101,7 @@ import javax.persistence.Table;
         "h.system_profile_facts->>'number_of_sockets' as system_profile_sockets, " +
         "h.system_profile_facts->>'cloud_provider' as cloud_provider, " +
         "h.canonical_facts->>'subscription_manager_id' as subscription_manager_id, " +
+        "h.canonical_facts->>'insights_id' as insights_id, " +
         "rhsm_products.products, " +
         "qpc_prods.qpc_products, " +
         "qpc_certs.qpc_product_ids, " +

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -25,11 +25,14 @@ import org.springframework.util.StringUtils;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Represents an inventory host's facts.
  */
 public class InventoryHostFacts {
+    private UUID inventoryId;
+    private OffsetDateTime modifiedOn;
     private String account;
     private String displayName;
     private String orgId;
@@ -45,6 +48,7 @@ public class InventoryHostFacts {
     private String satelliteHypervisorUuid;
     private String guestId;
     private String subscriptionManagerId;
+    private String insightsId;
     private Set<String> qpcProducts;
     private Set<String> qpcProductIds;
     private Set<String> systemProfileProductIds;
@@ -60,14 +64,16 @@ public class InventoryHostFacts {
     }
 
     @SuppressWarnings("squid:S00107")
-    public InventoryHostFacts(String account, String displayName, String orgId, String cores, String sockets,
+    public InventoryHostFacts(UUID inventoryId, OffsetDateTime modifiedOn, String account,
+        String displayName, String orgId, String cores, String sockets,
         String products, String syncTimestamp, String systemProfileInfrastructureType,
         String systemProfileCores, String systemProfileSockets, String qpcProducts, String qpcProductIds,
         String systemProfileProductIds, String syspurposeRole, String syspurposeSla,
         String syspurposeUsage, String syspurposeUnits, String isVirtual, String hypervisorUuid,
-        String satelliteHypervisorUuid, String guestId, String subscriptionManagerId, String cloudProvider,
-        OffsetDateTime staleTimestamp) {
-
+        String satelliteHypervisorUuid, String guestId, String subscriptionManagerId, String insightsId,
+        String cloudProvider, OffsetDateTime staleTimestamp) {
+        this.inventoryId = inventoryId;
+        this.modifiedOn = modifiedOn;
         this.account = account;
         this.displayName = displayName;
         this.orgId = orgId;
@@ -90,8 +96,25 @@ public class InventoryHostFacts {
         this.satelliteHypervisorUuid = satelliteHypervisorUuid;
         this.guestId = guestId;
         this.subscriptionManagerId = subscriptionManagerId;
+        this.insightsId = insightsId;
         this.cloudProvider = cloudProvider;
         this.staleTimestamp = staleTimestamp;
+    }
+
+    public UUID getInventoryId() {
+        return inventoryId;
+    }
+
+    public void setInventoryId(UUID inventoryId) {
+        this.inventoryId = inventoryId;
+    }
+
+    public OffsetDateTime getModifiedOn() {
+        return modifiedOn;
+    }
+
+    public void setModifiedOn(OffsetDateTime modifiedOn) {
+        this.modifiedOn = modifiedOn;
     }
 
     public String getAccount() {
@@ -260,6 +283,14 @@ public class InventoryHostFacts {
 
     public void setSubscriptionManagerId(String subscriptionManagerId) {
         this.subscriptionManagerId = subscriptionManagerId;
+    }
+
+    public String getInsightsId() {
+        return insightsId;
+    }
+
+    public void setInsightsId(String insightsId) {
+        this.insightsId = insightsId;
     }
 
     public String getCloudProvider() {

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.jmx;
 
-import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
+import org.candlepin.subscriptions.controller.TallySnapshotController;
 import org.candlepin.subscriptions.task.TaskManager;
 
 import org.springframework.context.annotation.Profile;
@@ -36,17 +36,17 @@ import org.springframework.stereotype.Component;
 @ManagedResource
 public class TallyJmxBean {
 
-    private final UsageSnapshotProducer snapshotProducer;
+    private final TallySnapshotController snapshotController;
     private final TaskManager tasks;
 
-    public TallyJmxBean(UsageSnapshotProducer snapshotProducer, TaskManager taskManager) {
-        this.snapshotProducer = snapshotProducer;
+    public TallyJmxBean(TallySnapshotController snapshotController, TaskManager taskManager) {
+        this.snapshotController = snapshotController;
         this.tasks = taskManager;
     }
 
     @ManagedOperation(description = "Trigger a tally for an account")
     public void tallyAccount(String accountNumber) {
-        snapshotProducer.produceSnapshotsForAccount(accountNumber);
+        snapshotController.produceSnapshotsForAccount(accountNumber);
     }
 
     @ManagedOperation(description = "Trigger tally for all configured accounts")

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -21,9 +21,9 @@
 package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.db.HostRepository;
-import org.candlepin.subscriptions.db.model.AppliedHost;
 import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyHostView;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
@@ -70,7 +70,7 @@ public class HostsResource implements HostsApi {
         ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
         Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
         Pageable page = ResourceUtils.getPageable(offset, limit);
-        Page<AppliedHost> hosts = repository.getAppliedHosts(
+        Page<TallyHostView> hosts = repository.getTallyHostViews(
             accountNumber,
             productId,
             sanitizedSla,
@@ -95,7 +95,7 @@ public class HostsResource implements HostsApi {
                     .serviceLevel(sla)
                     .usage(usage)
             )
-            .data(hosts.getContent().stream().map(AppliedHost::asApiHost).collect(Collectors.toList()));
+            .data(hosts.getContent().stream().map(TallyHostView::asApiHost).collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.AppliedHost;
 import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
@@ -60,6 +61,7 @@ public class HostsResource implements HostsApi {
         this.pageLinkCreator = pageLinkCreator;
     }
 
+
     @Override
     @ReportingAccessRequired
     public HostReport getHosts(String productId, Integer offset,
@@ -68,13 +70,11 @@ public class HostsResource implements HostsApi {
         ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
         Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
         Pageable page = ResourceUtils.getPageable(offset, limit);
-        Page<Host> hosts = repository.getHostsByBucketCriteria(
+        Page<AppliedHost> hosts = repository.getAppliedHosts(
             accountNumber,
             productId,
             sanitizedSla,
             sanitizedUsage,
-            null,
-            false,
             page
         );
 
@@ -95,7 +95,7 @@ public class HostsResource implements HostsApi {
                     .serviceLevel(sla)
                     .usage(usage)
             )
-            .data(hosts.getContent().stream().map(Host::asApiHost).collect(Collectors.toList()));
+            .data(hosts.getContent().stream().map(AppliedHost::asApiHost).collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -26,7 +26,7 @@ import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
-import org.candlepin.subscriptions.inventory.db.InventoryTransactionWrapper;
+import org.candlepin.subscriptions.inventory.db.InventoryDatabaseOperations;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollector;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollectorFactory;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
@@ -56,12 +56,12 @@ public class InventoryAccountUsageCollector {
     private static final Logger log = LoggerFactory.getLogger(InventoryAccountUsageCollector.class);
 
     private final FactNormalizer factNormalizer;
-    private final InventoryTransactionWrapper inventory;
+    private final InventoryDatabaseOperations inventory;
     private final HostRepository hostRepository;
     private final int culledOffsetDays;
 
     public InventoryAccountUsageCollector(FactNormalizer factNormalizer,
-        InventoryTransactionWrapper inventory, HostRepository hostRepository,
+        InventoryDatabaseOperations inventory, HostRepository hostRepository,
         ApplicationProperties props) {
         this.factNormalizer = factNormalizer;
         this.inventory = inventory;

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -21,10 +21,12 @@
 package org.candlepin.subscriptions.tally;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
-import org.candlepin.subscriptions.inventory.db.InventoryRepository;
-import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.candlepin.subscriptions.inventory.db.InventoryTransactionWrapper;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollector;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollectorFactory;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
@@ -34,14 +36,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
+
 
 /**
  * Collects the max values from all accounts in the inventory.
@@ -52,33 +56,43 @@ public class InventoryAccountUsageCollector {
     private static final Logger log = LoggerFactory.getLogger(InventoryAccountUsageCollector.class);
 
     private final FactNormalizer factNormalizer;
-    private final InventoryRepository inventoryRepository;
+    private final InventoryTransactionWrapper inventory;
+    private final HostRepository hostRepository;
     private final int culledOffsetDays;
 
     public InventoryAccountUsageCollector(FactNormalizer factNormalizer,
-        InventoryRepository inventoryRepository, ApplicationProperties props) {
+        InventoryTransactionWrapper inventory, HostRepository hostRepository,
+        ApplicationProperties props) {
         this.factNormalizer = factNormalizer;
-        this.inventoryRepository = inventoryRepository;
+        this.inventory = inventory;
+        this.hostRepository = hostRepository;
         this.culledOffsetDays = props.getCullingOffsetDays();
     }
 
     @SuppressWarnings("squid:S3776")
-    @Transactional(value = "inventoryTransactionManager", readOnly = true)
+    @Transactional
     public Collection<AccountUsageCalculation> collect(Collection<String> products,
         Collection<String> accounts) {
+
+        // Delete all of the host records for the specified accounts before starting the
+        // calculation. Applicable hosts will be recreated as usage is calculated.
+        log.info("Deleting existing Hosts: {}", accounts);
+        int deleted = hostRepository.deleteByAccountNumberIn(accounts);
+        log.info("Deleted {} existing Host records.", deleted);
 
         Map<String, String> hypMapping = new HashMap<>();
         Map<String, Set<UsageCalculation.Key>> hypervisorUsageKeys = new HashMap<>();
         Map<String, Map<String, NormalizedFacts>> accountHypervisorFacts = new HashMap<>();
-        try (Stream<Object[]> stream = inventoryRepository.getReportedHypervisors(accounts)) {
-            stream.forEach(res -> hypMapping.put((String) res[0], (String) res[1]));
-        }
+        Map<String, Host> hypervisorHosts = new HashMap<>();
+        Map<String, Integer> hypervisorGuestCounts = new HashMap<>();
+
+        inventory.reportedHypervisors(accounts,
+            reported -> hypMapping.put((String) reported[0], (String) reported[1]));
         log.info("Found {} reported hypervisors.", hypMapping.size());
 
         Map<String, AccountUsageCalculation> calcsByAccount = new HashMap<>();
-        try (Stream<InventoryHostFacts> hostFactStream =
-            inventoryRepository.getFacts(accounts, culledOffsetDays)) {
-            hostFactStream.forEach(hostFacts -> {
+        inventory.processHostFacts(accounts, culledOffsetDays,
+            hostFacts -> {
                 String account = hostFacts.getAccount();
 
                 calcsByAccount.putIfAbsent(account, new AccountUsageCalculation(account));
@@ -101,10 +115,16 @@ public class InventoryAccountUsageCollector {
                     accountCalc.setOwner(owner);
                 }
 
+                Host host = new Host(hostFacts, facts);
                 if (facts.isHypervisor()) {
                     Map<String, NormalizedFacts> idToHypervisorMap = accountHypervisorFacts
                         .computeIfAbsent(account, a -> new HashMap<>());
                     idToHypervisorMap.put(hostFacts.getSubscriptionManagerId(), facts);
+                    hypervisorHosts.put(hostFacts.getSubscriptionManagerId(), host);
+                }
+                else if (facts.isVirtual() && !StringUtils.isEmpty(facts.getHypervisorUuid())) {
+                    Integer guests = hypervisorGuestCounts.getOrDefault(host.getHypervisorUuid(), 0);
+                    hypervisorGuestCounts.put(host.getHypervisorUuid(), ++guests);
                 }
 
                 ServiceLevel[] slas = new ServiceLevel[]{facts.getSla(), ServiceLevel.ANY};
@@ -124,7 +144,9 @@ public class InventoryAccountUsageCollector {
                                             .computeIfAbsent(hypervisorUuid, uuid -> new HashSet<>());
                                         keys.add(key);
                                     }
-                                    ProductUsageCollectorFactory.get(product).collect(calc, facts);
+                                    Optional<HostTallyBucket> appliedBucket =
+                                        ProductUsageCollectorFactory.get(product).collect(calc, facts);
+                                    appliedBucket.ifPresent(host::addBucket);
                                 }
                                 catch (Exception e) {
                                     log.error("Unable to collect usage data for host: {} product: {}",
@@ -134,12 +156,20 @@ public class InventoryAccountUsageCollector {
                         }
                     }
                 });
-            });
-        }
+
+                // Save the host now that the buckets have been determined. Hypervisor hosts will
+                // be persisted once all potential guests have been processed.
+                if (!facts.isHypervisor()) {
+                    hostRepository.save(host);
+                }
+            }
+        );
 
         accountHypervisorFacts.forEach((account, accountHypervisors) -> {
             AccountUsageCalculation accountCalc = calcsByAccount.get(account);
             accountHypervisors.forEach((hypervisorUuid, hypervisor) -> {
+                Host hypHost = hypervisorHosts.get(hypervisorUuid);
+                hypHost.setNumOfGuests(hypervisorGuestCounts.getOrDefault(hypervisorUuid, 0));
                 Set<UsageCalculation.Key> usageKeys = hypervisorUsageKeys.getOrDefault(hypervisorUuid,
                     Collections.emptySet());
 
@@ -147,10 +177,17 @@ public class InventoryAccountUsageCollector {
                     UsageCalculation usageCalc = getOrCreateCalculation(accountCalc, key);
                     ProductUsageCollector productUsageCollector = ProductUsageCollectorFactory
                         .get(key.getProductId());
-                    productUsageCollector.collectForHypervisor(account, usageCalc, hypervisor);
+                    Optional<HostTallyBucket> appliedBucket =
+                        productUsageCollector.collectForHypervisor(account, usageCalc, hypervisor);
+                    appliedBucket.ifPresent(hypHost::addBucket);
                 });
             });
         });
+
+        if (hypervisorHosts.size() > 0) {
+            log.info("Pesisting {} hypervisor hosts.", hypervisorHosts.size());
+            hostRepository.saveAll(hypervisorHosts.values());
+        }
 
         if (log.isDebugEnabled()) {
             calcsByAccount.values().forEach(calc -> log.debug("Account Usage: {}", calc));

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
@@ -61,7 +61,7 @@ public class UsageSnapshotProducer {
     }
 
     @Transactional
-    public void produceSnapshotsForAccounts(Collection<String> accounts,
+    public void produceSnapshotsFromCalculations(Collection<String> accounts,
         Collection<AccountUsageCalculation> accountCalcs) {
         dailyRoller.rollSnapshots(accounts, accountCalcs);
         weeklyRoller.rollSnapshots(accounts, accountCalcs);

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
@@ -20,8 +20,11 @@
  */
 package org.candlepin.subscriptions.tally.collector;
 
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+
+import java.util.Optional;
 
 /**
  * Given a host's facts, collects the usage tally for a product.
@@ -34,8 +37,10 @@ public interface ProductUsageCollector {
      *
      * @param prodCalc the existing calculations for this product.
      * @param normalizedHostFacts the normalized view of the facts from inventory.
+     *
+     * @return HostTallyBucket the bucket representing the counts applied by the specified host
      */
-    void collect(UsageCalculation prodCalc, NormalizedFacts normalizedHostFacts);
+    Optional<HostTallyBucket> collect(UsageCalculation prodCalc, NormalizedFacts normalizedHostFacts);
 
     /**
      * Collect and append usage data based on hypervisor-guest mappings.
@@ -43,6 +48,9 @@ public interface ProductUsageCollector {
      * @param account the account number
      * @param prodCalc which usage key's calculation to update
      * @param hypervisorFacts facts about the hypervisor
+     *
+     * @return HostTallyBucket the bucket representing the counts applied by the specified host
      */
-    void collectForHypervisor(String account, UsageCalculation prodCalc, NormalizedFacts hypervisorFacts);
+    Optional<HostTallyBucket> collectForHypervisor(String account, UsageCalculation prodCalc,
+        NormalizedFacts hypervisorFacts);
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -20,8 +20,12 @@
  */
 package org.candlepin.subscriptions.tally.collector;
 
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+
+import java.util.Optional;
 
 // NOTE: If we need to eventually reuse these rules/calculations for other products
 //       we should consider renaming this class.
@@ -32,43 +36,71 @@ import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 public class RHELProductUsageCollector implements ProductUsageCollector {
 
     @Override
-    public void collect(UsageCalculation prodCalc, NormalizedFacts normalizedFacts) {
-        int cores = normalizedFacts.getCores() != null ? normalizedFacts.getCores() : 0;
-        int sockets = normalizedFacts.getSockets() != null ? normalizedFacts.getSockets() : 0;
+    public Optional<HostTallyBucket> collect(UsageCalculation prodCalc, NormalizedFacts normalizedFacts) {
+        int appliedCores = normalizedFacts.getCores() != null ? normalizedFacts.getCores() : 0;
+        int appliedSockets = normalizedFacts.getSockets() != null ? normalizedFacts.getSockets() : 0;
 
         boolean guestWithUnknownHypervisor =
             normalizedFacts.isVirtual() && normalizedFacts.isHypervisorUnknown();
 
         // Cloud provider hosts only account for a single socket.
         if (normalizedFacts.getCloudProviderType() != null) {
-            prodCalc.addCloudProvider(normalizedFacts.getCloudProviderType(), cores, 1, 1);
+            appliedSockets = 1;
+            prodCalc.addCloudProvider(normalizedFacts.getCloudProviderType(),
+                appliedCores, appliedSockets, 1);
+            return Optional.of(createBucket(prodCalc, true, appliedCores, appliedSockets,
+                normalizedFacts.getCloudProviderType()));
         }
         else if (guestWithUnknownHypervisor) {
             // If the hypervisor is unknown for a guest, we consider it as having a
             // unique hypervisor instance contributing to the hypervisor counts.
             // Since the guest is unmapped, we only contribute a single socket.
-            prodCalc.addHypervisor(cores, 1, 1);
+            appliedSockets = 1;
+            prodCalc.addHypervisor(appliedCores, appliedSockets, 1);
+            return Optional.of(createBucket(prodCalc, true, appliedCores, appliedSockets,
+                HardwareMeasurementType.HYPERVISOR));
         }
         // Accumulate for physical systems.
         else if (!normalizedFacts.isVirtual()) {
             // Physical system so increment the physical system counts.
-            prodCalc.addPhysical(cores, sockets, 1);
+            prodCalc.addPhysical(appliedCores, appliedSockets, 1);
+            return Optional.of(createBucket(prodCalc, true, appliedCores, appliedSockets,
+                HardwareMeasurementType.PHYSICAL));
         }
+
+        // nothing applied to calculation so no bucket to return.
+        return Optional.empty();
     }
 
     @Override
-    public void collectForHypervisor(String account, UsageCalculation prodCalc,
+    public Optional<HostTallyBucket> collectForHypervisor(String account, UsageCalculation prodCalc,
         NormalizedFacts hypervisorFacts) {
 
-        int cores = hypervisorFacts.getCores() != null ? hypervisorFacts.getCores() : 0;
-        int sockets = hypervisorFacts.getSockets() != null ? hypervisorFacts.getSockets() : 0;
+        int appliedCores = hypervisorFacts.getCores() != null ? hypervisorFacts.getCores() : 0;
+        int appliedSockets = hypervisorFacts.getSockets() != null ? hypervisorFacts.getSockets() : 0;
 
-        if (sockets == 0) {
+        if (appliedSockets == 0) {
             throw new IllegalStateException(String.format("Hypervisor in account %s has no sockets and will" +
                 " not contribute to the totals. The tally for the RHEL product will not be accurate since" +
                 "all associated guests will not contribute to the tally.", account));
         }
 
-        prodCalc.addHypervisor(cores, sockets, 1);
+        prodCalc.addHypervisor(appliedCores, appliedSockets, 1);
+        return Optional.of(createBucket(prodCalc, false, appliedCores, appliedSockets,
+            HardwareMeasurementType.HYPERVISOR));
+    }
+
+    private HostTallyBucket createBucket(UsageCalculation currentCalc, boolean asHypervisor,
+        int appliedCores, int appliedSockets, HardwareMeasurementType appliedType) {
+        return new HostTallyBucket(
+            null,
+            currentCalc.getProductId(),
+            currentCalc.getSla(),
+            currentCalc.getUsage(),
+            asHypervisor,
+            appliedCores,
+            appliedSockets,
+            appliedType
+        );
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.tally.facts;
 
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.HostHardwareType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.files.ProductIdToProductsMapSource;
@@ -132,6 +133,21 @@ public class FactNormalizer {
         normalizedFacts.setHypervisor(isHypervisor);
         normalizedFacts.setVirtual(isVirtual);
         normalizedFacts.setHypervisorUnknown(isHypervisorUnknown);
+        normalizedFacts.setHardwareType(determineHardwareType(isHypervisor, isVirtual));
+    }
+
+    private HostHardwareType determineHardwareType(boolean isHypervisor, boolean isVirtual) {
+        HostHardwareType hardwareType;
+        if (isHypervisor) {
+            hardwareType = HostHardwareType.HYPERVISOR;
+        }
+        else if (isVirtual) {
+            hardwareType = HostHardwareType.VIRTUAL;
+        }
+        else {
+            hardwareType = HostHardwareType.PHYSICAL;
+        }
+        return hardwareType;
     }
 
     @SuppressWarnings("indentation")

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally.facts;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.HostHardwareType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
 
@@ -50,6 +51,7 @@ public class NormalizedFacts {
     private boolean isVirtual;
     private boolean isHypervisor;
     private boolean isHypervisorUnknown;
+    private HostHardwareType hardwareType;
     private HardwareMeasurementType cloudProviderType;
 
     public NormalizedFacts() {
@@ -156,6 +158,14 @@ public class NormalizedFacts {
 
     public void setUsage(Usage usage) {
         this.usage = usage;
+    }
+
+    public HostHardwareType getHardwareType() {
+        return hardwareType;
+    }
+
+    public void setHardwareType(HostHardwareType hardwareType) {
+        this.hardwareType = hardwareType;
     }
 
     public Map<String, Object> toInventoryPayload() {

--- a/src/main/java/org/candlepin/subscriptions/task/TaskFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskFactory.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.task;
 
-import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
+import org.candlepin.subscriptions.controller.TallySnapshotController;
 import org.candlepin.subscriptions.task.tasks.UpdateAccountSnapshotsTask;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
 public class TaskFactory {
 
     @Autowired
-    private UsageSnapshotProducer usageSnapshotProducer;
+    private TallySnapshotController snapshotController;
 
     /**
      * Builds a Task instance based on the specified TaskDescriptor.
@@ -47,7 +47,7 @@ public class TaskFactory {
      */
     public Task build(TaskDescriptor taskDescriptor) {
         if (TaskType.UPDATE_SNAPSHOTS.equals(taskDescriptor.getTaskType())) {
-            return new UpdateAccountSnapshotsTask(usageSnapshotProducer, taskDescriptor.getArg("accounts"));
+            return new UpdateAccountSnapshotsTask(snapshotController, taskDescriptor.getArg("accounts"));
         }
         throw new IllegalArgumentException("Could not build task. Unknown task type: " +
             taskDescriptor.getTaskType());

--- a/src/main/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTask.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.task.tasks;
 
-import org.candlepin.subscriptions.tally.UsageSnapshotProducer;
+import org.candlepin.subscriptions.controller.TallySnapshotController;
 import org.candlepin.subscriptions.task.Task;
 
 import org.slf4j.Logger;
@@ -35,16 +35,17 @@ public class UpdateAccountSnapshotsTask implements Task {
     private static final Logger log = LoggerFactory.getLogger(UpdateAccountSnapshotsTask.class);
 
     private final List<String> accountNumbers;
-    private final UsageSnapshotProducer snapshotProducer;
+    private final TallySnapshotController snapshotController;
 
-    public UpdateAccountSnapshotsTask(UsageSnapshotProducer snapshotProducer, List<String> accountNumbers) {
-        this.snapshotProducer = snapshotProducer;
+    public UpdateAccountSnapshotsTask(TallySnapshotController snapshotController,
+        List<String> accountNumbers) {
+        this.snapshotController = snapshotController;
         this.accountNumbers = accountNumbers;
     }
 
     @Override
     public void execute() {
         log.info("Updating snapshots for {} accounts.", accountNumbers.size());
-        snapshotProducer.produceSnapshotsForAccounts(accountNumbers);
+        snapshotController.produceSnapshotsForAccounts(accountNumbers);
     }
 }

--- a/src/main/resources/liquibase/202007140728-change-id-column-on-hosts-table.xml
+++ b/src/main/resources/liquibase/202007140728-change-id-column-on-hosts-table.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202007140728-1" author="mstead">
+        <comment>Drop the existing tables. No data has been persisted by the repo, so this is OK.</comment>
+        <dropTable tableName="host_tally_buckets" />
+        <dropTable tableName="hosts" />
+    </changeSet>
+
+    <changeSet id="202007140728-2" author="mstead">
+        <comment>Recreate the hosts table.</comment>
+        <createTable tableName="hosts">
+            <column name="inventory_id" type="VARCHAR(255)"/>
+            <column name="account_number" type="VARCHAR(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="insights_id" type="VARCHAR(255)"/>
+            <column name="org_id" type="VARCHAR(255)" />
+            <column name="display_name" type="VARCHAR(255)"/>
+            <column name="subscription_manager_id" type="VARCHAR(255)"/>
+            <column name="cores" type="INTEGER"/>
+            <column name="sockets" type="INTEGER"/>
+            <column name="is_guest" type="BOOLEAN"/>
+            <column name="hypervisor_uuid" type="VARCHAR(255)"/>
+            <column name="hardware_type" type="VARCHAR(32)" />
+            <column name="num_of_guests" type="INTEGER"/>
+            <column name="last_seen" type="TIMESTAMP WITH TIME ZONE" />
+        </createTable>
+    </changeSet>
+
+    <changeSet id="202007140728-3" author="mstead">
+        <addPrimaryKey constraintName="inventory_id_pkey" tableName="hosts" columnNames="inventory_id" />
+    </changeSet>
+
+    <changeSet id="202007140728-4" author="mstead">
+        <comment>Create indexes for hosts table.</comment>
+        <createIndex indexName="insights_id_idx" tableName="hosts">
+            <column name="insights_id"/>
+        </createIndex>
+        <createIndex indexName="account_idx" tableName="hosts">
+            <column name="account_number"/>
+        </createIndex>
+        <createIndex indexName="org_id_idx" tableName="hosts">
+            <column name="org_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="202007140728-5" author="mstead">
+        <comment>Add table for host buckets.</comment>
+        <createTable tableName="host_tally_buckets">
+            <column name="host_inventory_id" type="VARCHAR(255)">
+                <constraints referencedTableName="hosts" referencedColumnNames="inventory_id"
+                             nullable="false" foreignKeyName="host_fk" deleteCascade="true"/>
+            </column>
+            <column name="usage" type="VARCHAR(255)" defaultValue="_ANY">
+                <constraints nullable="false"/>
+            </column>
+            <column name="product_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sla" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="as_hypervisor" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cores" type="INTEGER" defaultValue="0" />
+            <column name="sockets" type="INTEGER" defaultValue="0" />
+            <column name="measurement_type" type="VARCHAR(32)" />
+        </createTable>
+    </changeSet>
+
+    <changeSet id="202007140728-6" author="mstead">
+        <addPrimaryKey constraintName="host_tally_bucket_pkey"
+                       tableName="host_tally_buckets"
+                       columnNames="host_inventory_id,product_id,usage,sla,as_hypervisor"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -26,5 +26,6 @@
     <include file="liquibase/202005041611-add-usage-column-to-snapshot-and-capacity-tables.xml"/>
     <include file="liquibase/202005281015-add-host-and-host-tally-bucket-tables.xml" />
     <include file="liquibase/202006180903-add-usage-to-host.xml" />
+    <include file="liquibase/202007140728-change-id-column-on-hosts-table.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -22,6 +22,8 @@ package org.candlepin.subscriptions.db;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.candlepin.subscriptions.db.model.AppliedHost;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -52,6 +54,9 @@ import java.util.stream.Collectors;
 @TestPropertySource("classpath:/test.properties")
 class HostRepositoryTest {
 
+    private final String RHEL = "RHEL";
+    private final String COOL_PROD = "COOL_PROD";
+
     @Autowired
     private HostRepository repo;
 
@@ -60,45 +65,27 @@ class HostRepositoryTest {
     void setupTestData() {
 
         // ACCOUNT 1 HOSTS
-        Host host1 = createHost("insights1", "account1", "org1");
-        addBucketToHost(host1, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
-        addBucketToHost(host1, "Satellite", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
-
-        Host host2 = createHost("insights2", "account1", "org1");
-        addBucketToHost(host2, "RHEL", ServiceLevel.SELF_SUPPORT, Usage.DEVELOPMENT_TEST, false);
-        addBucketToHost(host2, "Satellite", ServiceLevel.SELF_SUPPORT, Usage.DEVELOPMENT_TEST, false);
+        Host host1 = createHost("inventory1", "account1");
+        addBucketToHost(host1, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION);
 
         // ACCOUNT 2 HOSTS
-        Host host3 = createHost("insights3", "account2", "org2");
-        addBucketToHost(host3, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true);
-        addBucketToHost(host3, "Satellite", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
+        Host host2 = createHost("inventory2", "account2");
+        addBucketToHost(host2, COOL_PROD, ServiceLevel.PREMIUM, Usage.PRODUCTION);
 
-        Host host4 = createHost("insights4", "account2", "org2");
-        addBucketToHost(host4, "RHEL", ServiceLevel.SELF_SUPPORT, Usage.DEVELOPMENT_TEST, false);
-        addBucketToHost(host4, "SUPER_COOL_PRODUCT", ServiceLevel.ANY, Usage.ANY, true);
+        Host host3 = createHost("inventory3", "account2");
+        addBucketToHost(host3, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION);
 
-        Host host5 = createHost("insights5", "account2", "org2");
-        addBucketToHost(host5, "Satellite", ServiceLevel.SELF_SUPPORT, Usage.DEVELOPMENT_TEST, false);
+
+        Host host4 = createHost("inventory4", "account2");
+        addBucketToHost(host4, RHEL, ServiceLevel.SELF_SUPPORT, Usage.PRODUCTION);
+
+        Host host5 = createHost("inventory5", "account2");
+        addBucketToHost(host5, RHEL, ServiceLevel.SELF_SUPPORT, Usage.DISASTER_RECOVERY);
 
         // ACCOUNT 3 HOSTS
-        Host host6 = createHost("insights6", "account3", "org3");
-        addBucketToHost(host6, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
+        Host host6 = createHost("inventory6", "account3");
 
-        Host host7 = createHost("insights7", "account3", "org3");
-        addBucketToHost(host7, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true);
-
-        // ACCOUNT 4 HOSTS
-        Host host8 = createHost("insights8", "account4", "org4");
-
-        // ACCOUNT 5 HOSTS
-        Host hypervisor = createHost("hypervisor", "account5", "org5");
-        addBucketToHost(hypervisor, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true);
-        Host guest = createHost("guest", "account5", "org5");
-        guest.setGuest(true);
-        addBucketToHost(guest, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
-
-        List<Host> toSave = Arrays.asList(host1, host2, host3, host4, host5, host6, host7, host8,
-            hypervisor, guest);
+        List<Host> toSave = Arrays.asList(host1, host2, host3, host4, host5, host6);
         repo.saveAll(toSave);
         repo.flush();
     }
@@ -106,11 +93,12 @@ class HostRepositoryTest {
     @Transactional
     @Test
     void testCreate() {
-        Host host = new Host("HOST1", "my_acct", "my_org");
-        host.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
+        Host host = new Host("INV1", "HOST1", "my_acct", "my_org", "sub_id");
+        host.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false, 4, 2,
+            HardwareMeasurementType.PHYSICAL);
         repo.saveAndFlush(host);
 
-        Optional<Host> result = repo.findById(host.getInsightsId());
+        Optional<Host> result = repo.findById(host.getInventoryId());
         assertTrue(result.isPresent());
         Host saved = result.get();
         assertEquals(1, saved.getBuckets().size());
@@ -119,14 +107,17 @@ class HostRepositoryTest {
     @Transactional
     @Test
     void testUpdate() {
-        Host host = new Host("HOST1", "my_acct", "my_org");
+        Host host = new Host("INV1", "HOST1", "my_acct", "my_org", "sub_id");
         host.setSockets(1);
         host.setCores(1);
-        host.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
-        host.addBucket("Satellite", ServiceLevel.PREMIUM, Usage.PRODUCTION, true);
+
+        host.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false, 4, 2,
+            HardwareMeasurementType.PHYSICAL);
+        host.addBucket("Satellite", ServiceLevel.PREMIUM, Usage.PRODUCTION, true, 4, 2,
+            HardwareMeasurementType.PHYSICAL);
         repo.saveAndFlush(host);
 
-        Optional<Host> result = repo.findById(host.getInsightsId());
+        Optional<Host> result = repo.findById(host.getInventoryId());
         assertTrue(result.isPresent());
         Host toUpdate = result.get();
         assertEquals(2, toUpdate.getBuckets().size());
@@ -138,7 +129,7 @@ class HostRepositoryTest {
 
         repo.saveAndFlush(toUpdate);
 
-        Optional<Host> updateResult = repo.findById(toUpdate.getInsightsId());
+        Optional<Host> updateResult = repo.findById(toUpdate.getInventoryId());
         assertTrue(updateResult.isPresent());
         Host updated = updateResult.get();
         assertEquals("updated_acct_num", updated.getAccountNumber());
@@ -150,105 +141,59 @@ class HostRepositoryTest {
 
     @Transactional
     @Test
-    void findHostsByBucketCriteria() {
-        Page<Host> hosts = repo.getHostsByBucketCriteria("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, true, null, PageRequest.of(0, 10));
-        List<Host> found = hosts.stream().collect(Collectors.toList());
+    void testFindHostsWhenAccountIsDifferent() {
+        Page<AppliedHost> hosts = repo.getAppliedHosts("account1", RHEL, ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, PageRequest.of(0, 10));
+        List<AppliedHost> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
-        assertHost(found.get(0), "insights3", "account2", "org2");
+        assertAppliedHost(found.get(0), "inventory1");
     }
 
     @Transactional
     @Test
-    void findHostsByAnyBucketProduct() {
-        Page<Host> hosts = repo.getHostsByBucketCriteria("account2", null, ServiceLevel.SELF_SUPPORT,
-            Usage.DEVELOPMENT_TEST, false, null, PageRequest.of(0, 10));
-        Map<String, Host> found = hosts.stream().collect(
-            Collectors.toMap(Host::getInsightsId, Function.identity()));
+    void testFindHostsWhenProductIsDifferent() {
+        Page<AppliedHost> hosts = repo.getAppliedHosts("account2", COOL_PROD, ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, PageRequest.of(0, 10));
+        List<AppliedHost> found = hosts.stream().collect(Collectors.toList());
 
-        assertEquals(2, found.size());
-        assertHost(found.get("insights4"), "insights4", "account2", "org2");
-        assertHost(found.get("insights5"), "insights5", "account2", "org2");
+        assertEquals(1, found.size());
+        assertAppliedHost(found.get(0), "inventory2");
     }
 
     @Transactional
     @Test
-    void findHostsByAnyBucketSlaAndUsage() {
-        Page<Host> hosts = repo.getHostsByBucketCriteria("account1", "RHEL", null, null, false,
-            null, PageRequest.of(0, 10));
-        Map<String, Host> found = hosts.stream().collect(
-            Collectors.toMap(Host::getInsightsId, Function.identity()));
+    void testFindHostsWhenSLAIsDifferent() {
+        Page<AppliedHost> hosts = repo.getAppliedHosts("account2", RHEL, ServiceLevel.SELF_SUPPORT,
+            Usage.PRODUCTION, PageRequest.of(0, 10));
+        List<AppliedHost> found = hosts.stream().collect(Collectors.toList());
 
-        assertEquals(2, found.size());
-        assertHost(found.get("insights1"), "insights1", "account1", "org1");
-        assertHost(found.get("insights2"), "insights2", "account1", "org1");
+        assertEquals(1, found.size());
+        assertAppliedHost(found.get(0), "inventory4");
     }
 
     @Transactional
     @Test
-    void findHostsByAnyBucketAsHypervisor() {
-        Page<Host> hosts = repo.getHostsByBucketCriteria("account3", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, null, PageRequest.of(0, 10));
-        Map<String, Host> found = hosts.stream().collect(
-            Collectors.toMap(Host::getInsightsId, Function.identity()));
+    void testFindHostsWhenUsageIsDifferent() {
+        Page<AppliedHost> hosts = repo.getAppliedHosts("account2", RHEL, ServiceLevel.SELF_SUPPORT,
+            Usage.DISASTER_RECOVERY, PageRequest.of(0, 10));
+        List<AppliedHost> found = hosts.stream().collect(Collectors.toList());
 
-        assertEquals(2, found.size());
-        assertHost(found.get("insights6"), "insights6", "account3", "org3");
-        assertHost(found.get("insights7"), "insights7", "account3", "org3");
-    }
-
-    @Transactional
-    @Test
-    void findHostsWithoutBucketCriterial() {
-        Page<Host> hosts = repo.getHostsByBucketCriteria("account2", null, null, null, null,
-            null, PageRequest.of(0, 10));
-        Map<String, Host> found =
-            hosts.stream().collect(Collectors.toMap(Host::getInsightsId, Function.identity()));
-
-        assertEquals(3, found.size());
-        assertHost(found.get("insights3"), "insights3", "account2", "org2");
-        assertHost(found.get("insights4"), "insights4", "account2", "org2");
-        assertHost(found.get("insights5"), "insights5", "account2", "org2");
+        assertEquals(1, found.size());
+        assertAppliedHost(found.get(0), "inventory5");
     }
 
     @Transactional
     @Test
     void testNoHostFoundWhenItHasNoBucket() {
-        Optional<Host> existing = repo.findById("insights8");
+        Optional<Host> existing = repo.findById("inventory6");
         assertTrue(existing.isPresent());
-        assertEquals("account4", existing.get().getAccountNumber());
+        assertEquals("account3", existing.get().getAccountNumber());
 
         // When a host has no buckets, it will not be returned.
-        Page<Host> hosts = repo.getHostsByBucketCriteria("account4", null, null, null, null,
-            null, PageRequest.of(0, 10));
+        Page<AppliedHost> hosts = repo.getAppliedHosts("account4", null, null, null,
+            PageRequest.of(0, 10));
         assertEquals(0, hosts.stream().count());
-    }
-
-    @Transactional
-    @Test
-    void testHypervisorFoundWhenGuestFalse() {
-        Page<Host> existing = repo.getHostsByBucketCriteria("account5", "RHEL", null, null, null,
-            false, PageRequest.of(0, 10));
-        assertEquals(1, existing.getTotalElements());
-        assertEquals("hypervisor", existing.getContent().get(0).getInsightsId());
-    }
-
-    @Transactional
-    @Test
-    void testHypervisorFoundWhenGuestTrue() {
-        Page<Host> existing = repo.getHostsByBucketCriteria("account5", "RHEL", null, null, null,
-            true, PageRequest.of(0, 10));
-        assertEquals(1, existing.getTotalElements());
-        assertEquals("guest", existing.getContent().get(0).getInsightsId());
-    }
-
-    @Transactional
-    @Test
-    void testHypervisorAndGuestFoundWhenGuestNull() {
-        Page<Host> existing = repo.getHostsByBucketCriteria("account5", "RHEL", null, null, null,
-            null, PageRequest.of(0, 10));
-        assertEquals(2, existing.getTotalElements());
     }
 
     @Transactional
@@ -257,18 +202,18 @@ class HostRepositoryTest {
         String account = "hostGuestTest";
         String uuid = UUID.randomUUID().toString();
 
-        Host hypervisor = createHost("hypervisor", account, "org");
+        Host hypervisor = createHost("hypervisor", account);
         hypervisor.setSubscriptionManagerId(uuid);
-        addBucketToHost(hypervisor, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true);
+        addBucketToHost(hypervisor, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION);
 
-        Host guest = createHost("guest", account, "org");
+        Host guest = createHost("guest", account);
         guest.setGuest(true);
         guest.setHypervisorUuid(uuid);
-        addBucketToHost(guest, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
+        addBucketToHost(guest, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION);
 
-        Host unmappedGuest = createHost("unmappedGuest", account, "org");
+        Host unmappedGuest = createHost("unmappedGuest", account);
         unmappedGuest.setGuest(true);
-        addBucketToHost(unmappedGuest, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
+        addBucketToHost(unmappedGuest, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION);
 
         List<Host> toSave = Arrays.asList(hypervisor, guest, unmappedGuest);
         repo.saveAll(toSave);
@@ -277,25 +222,92 @@ class HostRepositoryTest {
         Page<Host> guests = repo.getHostsByHypervisor(account, uuid, PageRequest.of(0, 10));
         assertEquals(1, guests.getTotalElements());
         assertEquals(uuid, guests.getContent().get(0).getHypervisorUuid());
-        assertEquals("guest", guests.getContent().get(0).getInsightsId());
+        assertEquals("guest", guests.getContent().get(0).getInventoryId());
+        assertEquals("INSIGHTS_guest", guests.getContent().get(0).getInsightsId());
     }
 
-    private Host createHost(String insightsId, String account, String orgId) {
-        Host host = new Host(insightsId, account, orgId);
+    @Transactional
+    @Test
+    void testDeleteByAccount() {
+        Host h1 = createHost("h1", "A1");
+        Host h2 = createHost("h2", "A2");
+
+        repo.saveAll(Arrays.asList(h1, h2));
+        repo.flush();
+
+        assertTrue(repo.findById(h1.getInventoryId()).isPresent());
+        assertTrue(repo.findById(h2.getInventoryId()).isPresent());
+
+        repo.deleteByAccountNumberIn(Arrays.asList("A1"));
+        repo.flush();
+
+        assertFalse(repo.findById(h1.getInventoryId()).isPresent());
+        assertTrue(repo.findById(h2.getInventoryId()).isPresent());
+    }
+
+    @Transactional
+    @Test
+    void testGetAppliedHosts() {
+        Host host1 = new Host("INV1", "HOST1", "my_acct", "my_org", "sub_id");
+        host1.setSockets(1);
+        host1.setCores(1);
+        host1.setNumOfGuests(4);
+
+        host1.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true, 4, 2,
+            HardwareMeasurementType.PHYSICAL);
+        host1.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, false, 10, 5,
+            HardwareMeasurementType.HYPERVISOR);
+        host1.addBucket("Satellite", ServiceLevel.PREMIUM, Usage.PRODUCTION, true, 4, 2,
+            HardwareMeasurementType.PHYSICAL);
+
+
+        List<Host> toPersist = Arrays.asList(
+            host1,
+            new Host("INV2", "HOST2", "my_acct", "my_org", "sub2_id"),
+            new Host("INV3", "HOST3", "my_acct2", "another_org", "sub3_id")
+        );
+        repo.saveAll(toPersist);
+        repo.flush();
+
+        Page<AppliedHost> results = repo.getAppliedHosts("my_acct", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, PageRequest.of(0, 10));
+        Map<String, AppliedHost> hosts = results.getContent().stream()
+            .collect(Collectors.toMap(AppliedHost::getHardwareMeasurementType, Function.identity()));
+        assertEquals(2, hosts.size());
+
+        assertTrue(hosts.containsKey(HardwareMeasurementType.PHYSICAL.toString()));
+        AppliedHost physical = hosts.get(HardwareMeasurementType.PHYSICAL.toString());
+        assertEquals(host1.getInventoryId(), physical.getInventoryId());
+        assertEquals(host1.getSubscriptionManagerId(), physical.getSubscriptionManagerId());
+        assertEquals(host1.getNumOfGuests().intValue(), physical.getNumberOfGuests());
+        assertEquals(4, physical.getSockets());
+        assertEquals(2, physical.getCores());
+
+        assertTrue(hosts.containsKey(HardwareMeasurementType.HYPERVISOR.toString()));
+        AppliedHost hypervisor = hosts.get(HardwareMeasurementType.HYPERVISOR.toString());
+        assertEquals(host1.getInventoryId(), hypervisor.getInventoryId());
+        assertEquals(host1.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
+        assertEquals(host1.getNumOfGuests().intValue(), hypervisor.getNumberOfGuests());
+        assertEquals(10, hypervisor.getSockets());
+        assertEquals(5, hypervisor.getCores());
+    }
+
+    private Host createHost(String inventoryId, String account) {
+        Host host = new Host(inventoryId, "INSIGHTS_" + inventoryId, account, "ORG_" + account,
+            "SUBMAN_" + inventoryId);
         host.setSockets(1);
         host.setCores(1);
         return host;
     }
 
-    private HostTallyBucket addBucketToHost(Host host, String productId, ServiceLevel sla, Usage usage,
-        Boolean asHypervisor) {
-        return host.addBucket(productId, sla, usage, asHypervisor);
+    private HostTallyBucket addBucketToHost(Host host, String productId, ServiceLevel sla, Usage usage) {
+        return host.addBucket(productId, sla, usage, true, 4, 2, HardwareMeasurementType.PHYSICAL);
     }
 
-    private void assertHost(Host host, String insightsId, String accountNumber, String orgId) {
+    private void assertAppliedHost(AppliedHost host, String inventoryId) {
         assertNotNull(host);
-        assertEquals(insightsId, host.getInsightsId());
-        assertEquals(accountNumber, host.getAccountNumber());
-        assertEquals(orgId, host.getOrgId());
+        assertEquals(inventoryId, host.getInventoryId());
+        assertEquals("INSIGHTS_" + inventoryId, host.getInsightsId());
+        assertEquals("SUBMAN_" + inventoryId, host.getSubscriptionManagerId());
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -130,6 +130,7 @@ public class InventoryHostFactTestHelper {
 
     public static InventoryHostFacts createBaseHost(String account, String orgId) {
         InventoryHostFacts baseFacts = new InventoryHostFacts();
+        baseFacts.setInventoryId(UUID.randomUUID());
         baseFacts.setAccount(account);
         baseFacts.setDisplayName("Test System");
         baseFacts.setOrgId(orgId);


### PR DESCRIPTION
* Pull Insights ID from inventory and store cores/sockets applied
  during tally on buckets.
* Use the HBI record ID as the Host.id since the insights_id is
  not guaranteed to exist based on what apps have reported hosts
  to inventory.
- When migrating the DB, it felt easier to just recreate the hosts
  and host_tally_buckets tables as we have yet to store data via the
  repository at this point. This was required since we changed the
  primary key and changing it became a little complicated.
- Track guest counts on hypervisors during collection.
- Delete all existing Host records before performing calculation
- Snapshot and Host creation/update was broken into separate transactions
  * T1: Update Hosts and perform account calculations.
  * T2: Roll the existing snapshots based on the new calculations
- Use query projection for API conversion.