### PR TITLE
1827686: Fix capacity handling when sla/usage not specified

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -82,6 +82,14 @@ public class CapacityResource implements CapacityApi {
         ServiceLevel sanitizedServiceLevel = ResourceUtils.sanitizeServiceLevel(sla);
         Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
 
+        // capacity records do not include _ANY rows
+        if (sanitizedServiceLevel == ServiceLevel.ANY) {
+            sanitizedServiceLevel = null;
+        }
+        if (sanitizedUsage == Usage.ANY) {
+            sanitizedUsage = null;
+        }
+
         List<CapacitySnapshot> capacities = getCapacities(
             ownerId,
             productId,
@@ -112,11 +120,11 @@ public class CapacityResource implements CapacityApi {
         report.getMeta().setProduct(productId);
         report.getMeta().setCount(report.getData().size());
 
-        if (sanitizedServiceLevel != ServiceLevel.UNSPECIFIED) {
+        if (sanitizedServiceLevel != null) {
             report.getMeta().setServiceLevel(sanitizedServiceLevel.getValue());
         }
 
-        if (sanitizedUsage != Usage.UNSPECIFIED) {
+        if (sanitizedUsage != null) {
             report.getMeta().setUsage(sanitizedUsage.getValue());
         }
 

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -122,6 +122,9 @@ public class ResourceUtils {
      * @return Usage enum
      */
     public static Usage sanitizeUsage(String usage) {
+        if (usage == null) {
+            return Usage.ANY;
+        }
         Usage sanitizedUsage = Usage.fromString(usage);
         // If the usage parameter is not one that we support, then throw an exception.
         // If we don't, the query would default to UNSPECIFIED, which would be confusing.
@@ -140,6 +143,9 @@ public class ResourceUtils {
      * @return ServiceLevel enum
      */
     public static ServiceLevel sanitizeServiceLevel(String sla) {
+        if (sla == null) {
+            return ServiceLevel.ANY;
+        }
         ServiceLevel sanitizedSla = ServiceLevel.fromString(sla);
         // If the sla parameter is not one that we support, then throw an exception.
         // If we don't, the query would default to UNSPECIFIED, which would be confusing.

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -242,8 +242,8 @@ class CapacityResourceTest {
         when(repository.findByOwnerAndProductId(
                 eq("owner123456"),
                 eq("product1"),
-                eq(ServiceLevel.UNSPECIFIED),
-                eq(Usage.UNSPECIFIED),
+                eq(null),
+                eq(null),
                 eq(min),
                 eq(max)))
             .thenReturn(Arrays.asList(capacity, capacity2));


### PR DESCRIPTION
This also makes the defaulting to "_ANY" common to the ResourceUtils method, rather than having it per-resource class. (Meaning this commit fixes the mapping for the hosts API)

(edited 2020-07-28)