### PR TITLE
Fix 500 error with null numberOfGuests

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -25,7 +25,7 @@ def generate_host(insights_id=None, account_number=None, org_id=None, display_na
         'is_guest': is_guest or False,
         'hypervisor_uuid': hypervisor_uuid or None,
         'hardware_type': hardware_type or 'PHYSICAL',
-        'num_of_guests': num_of_guests or 0,
+        'num_of_guests': num_of_guests,
         'last_seen': last_seen or '1993-03-26',
     }
     bucket_fields = {

--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -8,13 +8,15 @@ import sys
 output = sys.stdout
 
 
-def generate_host(insights_id=None, account_number=None, org_id=None, display_name=None,
+def generate_host(inventory_id=None, insights_id=None, account_number=None, org_id=None, display_name=None,
                   subscription_manager_id=None, cores=None, sockets=None, is_guest=None, hypervisor_uuid=None,
                   hardware_type=None, num_of_guests=None, last_seen=None, product=None, sla=None, usage=None):
+    inventory_id=inventory_id or uuid.uuid4()
     insights_id=insights_id or uuid.uuid4()
     if not is_guest:
         hypervisor_uuid = None
     host_fields = {
+        'inventory_id': inventory_id,
         'insights_id': insights_id,
         'account_number': account_number or 'account123',
         'org_id': org_id or 'org123',
@@ -29,7 +31,7 @@ def generate_host(insights_id=None, account_number=None, org_id=None, display_na
         'last_seen': last_seen or '1993-03-26',
     }
     bucket_fields = {
-        'host_insights_id': insights_id,
+        'host_inventory_id': inventory_id,
         'product_id': product or 'RHEL',
         'sla': sla or 'Premium',
         'usage': usage or 'Production'

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallyHostView.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallyHostView.java
@@ -54,7 +54,7 @@ public interface TallyHostView {
     int getSockets();
 
     @Value("#{target.key.host.numOfGuests}")
-    int getNumberOfGuests();
+    Integer getNumberOfGuests();
 
     @Value("#{target.key.host.subscriptionManagerId}")
     String getSubscriptionManagerId();


### PR DESCRIPTION
Fixes:

```
{"errors":[{"status":"500","code":"SUBSCRIPTIONS1000","title":"An internal server error has occurred. Check the server logs for further details.","detail":"Null return value from advice does not match primitive return type for: public abstract int org.candlepin.subscriptions.db.model.TallyHostView.getNumberOfGuests()"}]}
```

To test, use (updated) `bin/insert-mock-hosts --num-physical 1`, then hit the API for that record. With the fix no more error, without it, sadness.