### PR TITLE
Add splunk sidecar to templates

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -28,11 +28,25 @@
     </appender>
     -->
 
+    <appender name="SplunkAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE:-/tmp/rhsm-subscriptions.log}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <!-- daily rollover -->
+        <fileNamePattern>${LOG_FILE:-/tmp/rhsm-subscriptions.log}.%d{yyyy-MM-dd-HH-mm}.log</fileNamePattern>
+        <maxHistory>1</maxHistory>
+        <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'} [thread=%t] [level=%p] [category=%c] %m%n</pattern>
+        </encoder>
+    </appender>
+
     <logger name="org.candlepin" level="INFO"/>
 
     <root level="WARN">
         <appender-ref ref="ConsoleAppender" />
         <!-- The intended usage is to activate *both* CloudWatch appender and ConsoleAppender, so we can see logs in both the application console and CloudWatch -->
         <!--<appender-ref ref="CloudWatchAppender" />-->
+        <appender-ref ref="SplunkAppender" />
     </root>
 </configuration>

--- a/templates/rhsm-subscriptions-api.yml
+++ b/templates/rhsm-subscriptions-api.yml
@@ -31,6 +31,16 @@ parameters:
     value: 200m
   - name: CPU_LIMIT
     value: 300m
+  - name: SPLUNK_FORWARDER_IMAGE
+    value: quay.io/cloudservices/rhsm-splunk-forwarder:8f72cfb
+  - name: SPLUNK_FORWARDER_MEMORY_REQUEST
+    value: 128Mi
+  - name: SPLUNK_FORWARDER_MEMORY_LIMIT
+    value: 256Mi
+  - name: SPLUNK_FORWARDER_CPU_REQUEST
+    value: 50m
+  - name: SPLUNK_FORWARDER_CPU_LIMIT
+    value: 100m
 
 objects:
   - apiVersion: v1
@@ -78,6 +88,8 @@ objects:
             - image: quay.io/cloudservices/rhsm-subscriptions:${IMAGE_TAG}
               name: rhsm-subscriptions-api
               env:
+                - name: LOG_FILE
+                  value: /logs/server.log
                 - name: JAVA_OPTIONS
                   value: -Dspring.profiles.active=api
                 - name: JAVA_MAX_MEM_RATIO
@@ -175,11 +187,42 @@ objects:
               volumeMounts:
                 - name: config
                   mountPath: /config
+                - name: logs
+                  mountPath: /logs
               workingDir: /
+            - name: splunk
+              env:
+                - name: SPLUNKMETA_namespace
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+              image: ${SPLUNK_FORWARDER_IMAGE}
+              resources:
+                requests:
+                  cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                  memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                limits:
+                  cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                  memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /var/log/app
+                  name: logs
+                  readOnly: true
+                - mountPath: /tls/splunk.pem
+                  name: splunk
+                  subPath: splunk.pem
           volumes:
             - name: config
               configMap:
                 name: rhsm-subscriptions-config
+            - name: splunk
+              secret:
+                secretName: splunk
+            - name: logs
+              emptyDir:
           restartPolicy: Always
           terminationGracePeriodSeconds: 75
           imagePullSecrets:

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -22,11 +22,21 @@ parameters:
   - name: MEMORY_REQUEST
     value: 1000Mi
   - name: MEMORY_LIMIT
-    value: 2000Mi
+    value: 1744Mi
   - name: CPU_REQUEST
     value: 500m
   - name: CPU_LIMIT
-    value: '1'
+    value: '900m'
+  - name: SPLUNK_FORWARDER_IMAGE
+    value: quay.io/cloudservices/rhsm-splunk-forwarder:8f72cfb
+  - name: SPLUNK_FORWARDER_MEMORY_REQUEST
+    value: 128Mi
+  - name: SPLUNK_FORWARDER_MEMORY_LIMIT
+    value: 256Mi
+  - name: SPLUNK_FORWARDER_CPU_REQUEST
+    value: 50m
+  - name: SPLUNK_FORWARDER_CPU_LIMIT
+    value: 100m
 
 objects:
   - apiVersion: v1
@@ -53,6 +63,8 @@ objects:
             - image: quay.io/cloudservices/rhsm-subscriptions:${IMAGE_TAG}
               name: rhsm-subscriptions-capacity-ingress
               env:
+                - name: LOG_FILE
+                  value: /logs/server.log
                 - name: JAVA_OPTIONS
                   value: -Dspring.config.additional-location=file:/config/ssl.properties -Dspring.profiles.active=capacity-ingress
                 - name: JAVA_MAX_MEM_RATIO
@@ -168,7 +180,33 @@ objects:
                   mountPath: /ingress
                 - name: capacity-allowlist
                   mountPath: /capacity-allowlist
+                - name: logs
+                  mountPath: /logs
               workingDir: /
+            - name: splunk
+              env:
+                - name: SPLUNKMETA_namespace
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+              image: ${SPLUNK_FORWARDER_IMAGE}
+              resources:
+                requests:
+                  cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                  memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                limits:
+                  cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                  memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /var/log/app
+                  name: logs
+                  readOnly: true
+                - mountPath: /tls/splunk.pem
+                  name: splunk
+                  subPath: splunk.pem
           volumes:
             - name: config
               configMap:
@@ -179,6 +217,11 @@ objects:
             - name: capacity-allowlist
               configMap:
                 name: capacity-allowlist
+            - name: splunk
+              secret:
+                secretName: splunk
+            - name: logs
+              emptyDir:
           restartPolicy: Always
           terminationGracePeriodSeconds: 75
           imagePullSecrets:

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -26,11 +26,21 @@ parameters:
   - name: MEMORY_REQUEST
     value: 1000Mi
   - name: MEMORY_LIMIT
-    value: 2000Mi
+    value: 1744Mi
   - name: CPU_REQUEST
     value: 500m
   - name: CPU_LIMIT
-    value: '2'
+    value: 1900m
+  - name: SPLUNK_FORWARDER_IMAGE
+    value: quay.io/cloudservices/rhsm-splunk-forwarder:8f72cfb
+  - name: SPLUNK_FORWARDER_MEMORY_REQUEST
+    value: 128Mi
+  - name: SPLUNK_FORWARDER_MEMORY_LIMIT
+    value: 256Mi
+  - name: SPLUNK_FORWARDER_CPU_REQUEST
+    value: 50m
+  - name: SPLUNK_FORWARDER_CPU_LIMIT
+    value: 100m
 
 objects:
   - apiVersion: v1
@@ -57,6 +67,8 @@ objects:
             - image: quay.io/cloudservices/rhsm-subscriptions:${IMAGE_TAG}
               name: rhsm-subscriptions-worker
               env:
+                - name: LOG_FILE
+                  value: /logs/server.log
                 - name: JAVA_OPTIONS
                   value: -Dspring.profiles.active=worker
                 - name: JAVA_MAX_MEM_RATIO
@@ -144,11 +156,42 @@ objects:
               volumeMounts:
                 - name: config
                   mountPath: /config
+                - name: logs
+                  mountPath: /logs
               workingDir: /
+            - name: splunk
+              env:
+                - name: SPLUNKMETA_namespace
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+              image: ${SPLUNK_FORWARDER_IMAGE}
+              resources:
+                requests:
+                  cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                  memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                limits:
+                  cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                  memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /var/log/app
+                  name: logs
+                  readOnly: true
+                - mountPath: /tls/splunk.pem
+                  name: splunk
+                  subPath: splunk.pem
           volumes:
             - name: config
               configMap:
                 name: rhsm-subscriptions-config
+            - name: splunk
+              secret:
+                secretName: splunk
+            - name: logs
+              emptyDir:
           restartPolicy: Always
           terminationGracePeriodSeconds: 75
           imagePullSecrets:


### PR DESCRIPTION
Based on work done originally by @patrickeasters in an internal repo.

Note I adjusted all total CPU to be below 2 cores total, and all pods
below 2000Mi total memory.