### PR TITLE
Add uom filter to hosts API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -404,6 +404,11 @@ paths:
           schema:
             type: string
           description: "Include only hosts for the specified usage level."
+        - name: uom
+          in: query
+          schema:
+            $ref: '#/components/schemas/Uom'
+          description: "Filter hosts to those that contribute to a specific unit of measure"
         - name: sort
           in: query
           schema:
@@ -633,6 +638,11 @@ components:
           schema:
             $ref: "#/components/schemas/Errors"
   schemas:
+    Uom:
+      type: string
+      enum:
+        - cores
+        - sockets
     SortDirection:
       type: string
       enum:
@@ -990,6 +1000,8 @@ components:
               description: "Describes the usages that the report was made against. Not set if it wasn't
                    specified as a query parameter."
               type: string
+            uom:
+              $ref: '#/components/schemas/Uom'
           required:
             - count
             - product

--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -22,8 +22,8 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
         'org_id': org_id or 'org123',
         'display_name': display_name or insights_id,
         'subscription_manager_id': subscription_manager_id or uuid.uuid4(),
-        'cores': cores or 4,
-        'sockets': sockets or 1,
+        'cores': cores,
+        'sockets': sockets,
         'is_guest': is_guest or False,
         'hypervisor_uuid': hypervisor_uuid or None,
         'hardware_type': hardware_type or 'PHYSICAL',
@@ -32,9 +32,9 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
     }
 
     _generate_insert('hosts', **host_fields)
-    _generate_buckets(inventory_id, product, sla, usage)
+    _generate_buckets(inventory_id, product, sla, usage, cores=cores, sockets=sockets, measurement_type=hardware_type)
     if hardware_type == 'HYPERVISOR':
-        _generate_buckets(inventory_id, product, sla, usage, as_hypervisor=True)
+        _generate_buckets(inventory_id, product, sla, usage, as_hypervisor=True, cores=cores, sockets=sockets, measurement_type=hardware_type)
     return host_fields
 
 
@@ -54,13 +54,16 @@ def _generate_insert(table, **host_fields):
     values = ','.join(db_repr(value) for value in values)
     output.write(f'insert into {table}({fields}) values ({values});\n')
 
-def _generate_buckets(inventory_id, product, sla, usage, as_hypervisor=False):
+def _generate_buckets(inventory_id, product, sla, usage, as_hypervisor=False, measurement_type=None, cores=None, sockets=None):
   sla = sla or 'Premium'
   usage = usage or 'Production'
   bucket_fields = {
     'host_inventory_id': inventory_id,
     'product_id': product or 'RHEL',
-    'as_hypervisor': as_hypervisor
+    'as_hypervisor': as_hypervisor,
+    'measurement_type': measurement_type,
+    'cores': cores,
+    'sockets': sockets,
   }
   
   sla_vals = ["_ANY", sla]
@@ -104,6 +107,10 @@ parser.add_argument('--sla',
                     help='Set the sla for the inserted hosts')
 parser.add_argument('--usage',
                     help='Set the usage for the inserted hosts')
+parser.add_argument('--cores', default=4,
+                    help='Set the cores for the inserted hosts')
+parser.add_argument('--sockets', default=1,
+                    help='Set the sockets for the inserted hosts')
 parser.add_argument('--output-sql', action='store_true')
 
 args = parser.parse_args()
@@ -119,12 +126,12 @@ if not args.output_sql:
 
 for i in range(args.num_physical):
     generate_host(account_number=args.account, hardware_type='PHYSICAL', product=args.product, sla=args.sla,
-                  usage=args.usage)
+                  usage=args.usage, cores=args.cores, sockets=args.sockets)
 
 hypervisor = None
 for i in range(args.num_hypervisors):
     hypervisor = generate_host(account_number=args.account, hardware_type='HYPERVISOR', product=args.product,
-                               sla=args.sla, usage=args.usage)
+                               sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets)
 for i in range(args.num_guests):
     if args.hypervisor_id:
         hypervisor_uuid = args.hypervisor_id
@@ -133,7 +140,7 @@ for i in range(args.num_guests):
     else:
         hypervisor_uuid = None
     generate_host(account_number=args.account, hardware_type='HYPERVISOR', is_guest=True,
-                  product=args.product, sla=args.sla, usage=args.usage, hypervisor_uuid=hypervisor_uuid)
+                  product=args.product, sla=args.sla, usage=args.usage, hypervisor_uuid=hypervisor_uuid, cores=args.cores, sockets=args.sockets)
 
 if psql:
     psql.stdin.close()

--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -49,6 +49,9 @@ public interface HostRepository extends JpaRepository<Host, String> {
      * @param accountNumber The account number of the hosts to query (required).
      * @param productId The bucket product ID to filter Host by (pass null to ignore).
      * @param sla The bucket service level to filter Hosts by (pass null to ignore).
+     * @param usage The bucket usage to filter Hosts by (pass null to ignore).
+     * @param minCores Filter to Hosts with at least this number of cores.
+     * @param minSockets Filter to Hosts with at least this number of sockets.
      * @param pageable the current paging info for this query.
      * @return a page of Host entities matching the criteria.
      */
@@ -56,20 +59,25 @@ public interface HostRepository extends JpaRepository<Host, String> {
         value = "select b from HostTallyBucket b join fetch b.key.host h where " +
                 "h.accountNumber = :account and " +
                 "b.key.productId = :product and " +
-                "b.key.sla = :sla and b.key.usage = :usage",
+                "b.key.sla = :sla and b.key.usage = :usage and " +
+                "b.cores >= :minCores and b.sockets >= :minSockets",
         // Because we are using a 'fetch join' to avoid having to lazy load each bucket host,
         // we need to specify how the Page should gets its count when the 'limit' parameter
         // is used.
         countQuery = "select count(b) from HostTallyBucket b join b.key.host h where " +
                      "h.accountNumber = :account and " +
                      "b.key.productId = :product and " +
-                     "b.key.sla = :sla and b.key.usage = :usage"
+                     "b.key.sla = :sla and b.key.usage = :usage and " +
+                     "b.cores >= :minCores and b.sockets >= :minSockets"
+
     )
     Page<TallyHostView> getTallyHostViews(
         @Param("account") String accountNumber,
         @Param("product") String productId,
         @Param("sla") ServiceLevel sla,
         @Param("usage") Usage usage,
+        @Param("minCores") int minCores,
+        @Param("minSockets") int minSockets,
         Pageable pageable
     );
 

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -147,7 +147,7 @@ class HostRepositoryTest {
     @Test
     void testFindHostsWhenAccountIsDifferent() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account1", RHEL, ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10));
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -158,7 +158,7 @@ class HostRepositoryTest {
     @Test
     void testFindHostsWhenProductIsDifferent() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", COOL_PROD, ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10));
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -169,7 +169,7 @@ class HostRepositoryTest {
     @Test
     void testFindHostsWhenSLAIsDifferent() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", RHEL, ServiceLevel.SELF_SUPPORT,
-            Usage.PRODUCTION, PageRequest.of(0, 10));
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -180,7 +180,7 @@ class HostRepositoryTest {
     @Test
     void testFindHostsWhenUsageIsDifferent() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", RHEL, ServiceLevel.SELF_SUPPORT,
-            Usage.DISASTER_RECOVERY, PageRequest.of(0, 10));
+            Usage.DISASTER_RECOVERY, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -195,7 +195,7 @@ class HostRepositoryTest {
         assertEquals("account3", existing.get().getAccountNumber());
 
         // When a host has no buckets, it will not be returned.
-        Page<TallyHostView> hosts = repo.getTallyHostViews("account4", null, null, null,
+        Page<TallyHostView> hosts = repo.getTallyHostViews("account4", null, null, null, 0, 0,
             PageRequest.of(0, 10));
         assertEquals(0, hosts.stream().count());
     }
@@ -234,7 +234,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByDisplayName() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -246,7 +246,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByCores() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -258,7 +258,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortBySockets() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -270,7 +270,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByLastSeen() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -282,7 +282,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByHardwareType() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -334,7 +334,7 @@ class HostRepositoryTest {
         repo.flush();
 
         Page<TallyHostView> results = repo.getTallyHostViews("my_acct", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10));
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10));
         Map<String, TallyHostView> hosts = results.getContent().stream()
             .collect(Collectors.toMap(TallyHostView::getHardwareMeasurementType, Function.identity()));
         assertEquals(2, hosts.size());
@@ -371,7 +371,7 @@ class HostRepositoryTest {
         repo.flush();
 
         Page<TallyHostView> results = repo.getTallyHostViews("my_acct", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, PageRequest.of(0, 10));
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10));
         Map<String, TallyHostView> hosts = results.getContent().stream()
             .collect(Collectors.toMap(TallyHostView::getHardwareMeasurementType, Function.identity()));
         assertEquals(1, hosts.size());
@@ -383,6 +383,72 @@ class HostRepositoryTest {
         assertEquals(null, physical.getNumberOfGuests());
         assertEquals(4, physical.getSockets());
         assertEquals(2, physical.getCores());
+    }
+
+    @Transactional
+    @Test
+    void testShouldFilterSockets() {
+        Host coreHost = new Host("INV1", "HOST1", "my_acct", "my_org", "sub_id");
+        coreHost.setSockets(0);
+        coreHost.setCores(1);
+        coreHost.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true, 0, 1,
+            HardwareMeasurementType.PHYSICAL);
+
+        Host socketHost = new Host("INV2", "HOST2", "my_acct", "my_org", "sub_id");
+        socketHost.setSockets(1);
+        socketHost.setCores(0);
+        socketHost.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true, 1, 0,
+            HardwareMeasurementType.PHYSICAL);
+
+        List<Host> toPersist = Arrays.asList(coreHost, socketHost);
+        repo.saveAll(toPersist);
+        repo.flush();
+
+        Page<TallyHostView> results = repo.getTallyHostViews("my_acct", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, 0, 1, PageRequest.of(0, 10));
+        Map<String, TallyHostView> hosts = results.getContent().stream()
+            .collect(Collectors.toMap(TallyHostView::getHardwareMeasurementType, Function.identity()));
+        assertEquals(1, hosts.size());
+
+        assertTrue(hosts.containsKey(HardwareMeasurementType.PHYSICAL.toString()));
+        TallyHostView physical = hosts.get(HardwareMeasurementType.PHYSICAL.toString());
+        assertEquals(socketHost.getInventoryId(), physical.getInventoryId());
+        assertEquals(socketHost.getSubscriptionManagerId(), physical.getSubscriptionManagerId());
+        assertEquals(1, physical.getSockets());
+        assertEquals(0, physical.getCores());
+    }
+
+    @Transactional
+    @Test
+    void testShouldFilterCores() {
+        Host coreHost = new Host("INV1", "HOST1", "my_acct", "my_org", "sub_id");
+        coreHost.setSockets(0);
+        coreHost.setCores(1);
+        coreHost.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true, 0, 1,
+            HardwareMeasurementType.PHYSICAL);
+
+        Host socketHost = new Host("INV2", "HOST2", "my_acct", "my_org", "sub_id");
+        socketHost.setSockets(1);
+        socketHost.setCores(0);
+        socketHost.addBucket("RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION, true, 1, 0,
+            HardwareMeasurementType.PHYSICAL);
+
+        List<Host> toPersist = Arrays.asList(coreHost, socketHost);
+        repo.saveAll(toPersist);
+        repo.flush();
+
+        Page<TallyHostView> results = repo.getTallyHostViews("my_acct", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, 1, 0, PageRequest.of(0, 10));
+        Map<String, TallyHostView> hosts = results.getContent().stream()
+            .collect(Collectors.toMap(TallyHostView::getHardwareMeasurementType, Function.identity()));
+        assertEquals(1, hosts.size());
+
+        assertTrue(hosts.containsKey(HardwareMeasurementType.PHYSICAL.toString()));
+        TallyHostView physical = hosts.get(HardwareMeasurementType.PHYSICAL.toString());
+        assertEquals(coreHost.getInventoryId(), physical.getInventoryId());
+        assertEquals(coreHost.getSubscriptionManagerId(), physical.getSubscriptionManagerId());
+        assertEquals(0, physical.getSockets());
+        assertEquals(1, physical.getCores());
     }
 
     private Host createHost(String inventoryId, String account) {

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -32,6 +32,7 @@ import org.candlepin.subscriptions.tally.AccountListSource;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
+import org.candlepin.subscriptions.utilization.api.model.Uom;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,20 +66,22 @@ class HostsResourceTest {
     @BeforeEach
     public void setup() throws AccountListSourceException {
         PageImpl<TallyHostView> mockPage = new PageImpl<>(Collections.emptyList());
-        when(repository.getTallyHostViews(any(), any(), any(), any(), any()))
+        when(repository.getTallyHostViews(any(), any(), any(), any(), anyInt(), anyInt(), any()))
             .thenReturn(mockPage);
         when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
     }
 
     @Test
     void testShouldMapDisplayNameAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.DISPLAY_NAME, SortDirection.ASC);
+        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.DISPLAY_NAME, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq("RHEL"),
             eq(ServiceLevel.ANY),
             eq(Usage.ANY),
+            eq(0),
+            eq(0),
             eq(PageRequest.of(0, 1, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)))
         );
@@ -86,13 +89,15 @@ class HostsResourceTest {
 
     @Test
     void testShouldMapCoresAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.CORES, SortDirection.ASC);
+        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.CORES, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq("RHEL"),
             eq(ServiceLevel.ANY),
             eq(Usage.ANY),
+            eq(0),
+            eq(0),
             eq(PageRequest.of(0, 1, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)))
         );
@@ -100,13 +105,15 @@ class HostsResourceTest {
 
     @Test
     void testShouldMapSocketsAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.SOCKETS, SortDirection.ASC);
+        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.SOCKETS, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq("RHEL"),
             eq(ServiceLevel.ANY),
             eq(Usage.ANY),
+            eq(0),
+            eq(0),
             eq(PageRequest.of(0, 1, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)))
         );
@@ -114,13 +121,15 @@ class HostsResourceTest {
 
     @Test
     void testShouldMapLastSeenAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.LAST_SEEN, SortDirection.ASC);
+        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.LAST_SEEN, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq("RHEL"),
             eq(ServiceLevel.ANY),
             eq(Usage.ANY),
+            eq(0),
+            eq(0),
             eq(PageRequest.of(0, 1, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)))
         );
@@ -128,13 +137,15 @@ class HostsResourceTest {
 
     @Test
     void testShouldMapHardwareTypeAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.HARDWARE_TYPE, SortDirection.ASC);
+        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.HARDWARE_TYPE, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq("RHEL"),
             eq(ServiceLevel.ANY),
             eq(Usage.ANY),
+            eq(0),
+            eq(0),
             eq(PageRequest.of(0, 1, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)))
         );
@@ -142,28 +153,60 @@ class HostsResourceTest {
 
     @Test
     void testShouldDefaultToUnsorted() {
-        resource.getHosts("RHEL", 0, 1, null, null, null, null);
+        resource.getHosts("RHEL", 0, 1, null, null, null, null, null);
 
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq("RHEL"),
             eq(ServiceLevel.ANY),
             eq(Usage.ANY),
+            eq(0),
+            eq(0),
             eq(PageRequest.of(0, 1))
         );
     }
 
     @Test
     void testShouldDefaultToAscending() {
-        resource.getHosts("RHEL", 0, 1, null, null, HostReportSort.DISPLAY_NAME, null);
+        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.DISPLAY_NAME, null);
 
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq("RHEL"),
             eq(ServiceLevel.ANY),
             eq(Usage.ANY),
+            eq(0),
+            eq(0),
             eq(PageRequest.of(0, 1, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)))
+        );
+    }
+
+    @Test
+    void testShouldUseMinCoresWhenUomIsCores() {
+        resource.getHosts("RHEL", 0, 1, null, null, Uom.CORES, null, null);
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(1),
+            eq(0),
+            eq(PageRequest.of(0, 1))
+        );
+    }
+
+    @Test
+    void testShouldUseMinSocketsWhenUomIsSockets() {
+        resource.getHosts("RHEL", 0, 1, null, null, Uom.SOCKETS, null, null);
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
+            eq("RHEL"),
+            eq(ServiceLevel.ANY),
+            eq(Usage.ANY),
+            eq(0),
+            eq(1),
+            eq(PageRequest.of(0, 1))
         );
     }
 }


### PR DESCRIPTION
Related: RedHatInsights/curiosity-frontend#383

The filter takes two values: `cores`, `sockets` and filters out systems that have a value of 0 of that UOM.

To test:

```
bin/insert-mock-hosts --num-physical 1 --cores 1 --sockets 0
bin/insert-mock-hosts --num-physical 1 --cores 0 --sockets 1
```

Then, deploy:

```
RBAC_USE_STUB=true ./gradlew bootRun
```

And finally, try with and without the uom filter (swagger-ui an option too):

```
curl -X GET "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/RHEL" -H  "accept: application/vnd.api+json" -H  "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
curl -X GET "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/RHEL?uom=cores" -H  "accept: application/vnd.api+json" -H  "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
curl -X GET "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/RHEL?uom=sockets" -H  "accept: application/vnd.api+json" -H  "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
```