### PR TITLE
Support SAML-auth and mTLS auth for Jolokia

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,6 @@ dependencies {
     compile "org.yaml:snakeyaml"
     compile "org.postgresql:postgresql"
 
-
     testCompile "org.springframework.security:spring-security-test"
     testCompile "org.springframework.kafka:spring-kafka-test"
 
@@ -203,6 +202,7 @@ dependencies {
     }
 
     runtime "org.hsqldb:hsqldb"
+    runtime "org.jolokia:jolokia-core"
     runtime "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,7 @@ dependencies {
     compile "org.webjars:swagger-ui"
     compile "org.yaml:snakeyaml"
     compile "org.postgresql:postgresql"
+    compile "io.hawt:hawtio-springboot"
 
     testCompile "org.springframework.security:spring-security-test"
     testCompile "org.springframework.kafka:spring-kafka-test"
@@ -205,7 +206,6 @@ dependencies {
     runtime "org.hsqldb:hsqldb"
     runtime "org.jolokia:jolokia-core"
     runtime "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender"
-    runtime "io.hawt:hawtio-springboot"
 }
 
 // Add a custom task to output dependency info in a machine parseable format. Used to generate dependency

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ allprojects {
             }
             dependency "io.confluent:kafka-avro-serializer:$kafka_avro_serializer_version"
             dependency "org.apache.avro:avro:$avro_version"
+            dependency "io.hawt:hawtio-springboot:2.10.1"
         }
     }
 
@@ -204,6 +205,7 @@ dependencies {
     runtime "org.hsqldb:hsqldb"
     runtime "org.jolokia:jolokia-core"
     runtime "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender"
+    runtime "io.hawt:hawtio-springboot"
 }
 
 // Add a custom task to output dependency info in a machine parseable format. Used to generate dependency

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions;
 
 import org.candlepin.subscriptions.retention.TallyRetentionPolicyProperties;
+import org.candlepin.subscriptions.security.AntiCsrfFilter;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -129,14 +130,14 @@ public class ApplicationProperties {
     /**
      * Expected domain suffix for origin or referer headers.
      *
-     * @see org.candlepin.subscriptions.security.AntiCsrfFilter
+     * @see AntiCsrfFilter
      */
     private String antiCsrfDomainSuffix = ".redhat.com";
 
     /**
      * Expected port for origin or referer headers.
      *
-     * @see org.candlepin.subscriptions.security.AntiCsrfFilter
+     * @see AntiCsrfFilter
      */
     private int antiCsrfPort = 443;
 
@@ -144,6 +145,11 @@ public class ApplicationProperties {
      * The RBAC application name that defines the permissions for this application.
      */
     private String rbacApplicationName = "subscriptions";
+
+    /**
+     * The base path for hawtio. Needed to serve hawtio behind a reverse proxy.
+     */
+    private String hawtioBasePath;
 
     public boolean isPrettyPrintJson() {
         return prettyPrintJson;
@@ -291,5 +297,13 @@ public class ApplicationProperties {
 
     public void setRbacApplicationName(String rbacApplicationName) {
         this.rbacApplicationName = rbacApplicationName;
+    }
+
+    public String getHawtioBasePath() {
+        return hawtioBasePath;
+    }
+
+    public void setHawtioBasePath(String hawtioBasePath) {
+        this.hawtioBasePath = hawtioBasePath;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.jmx;
 
 import org.candlepin.subscriptions.controller.OptInController;
 import org.candlepin.subscriptions.db.model.config.OptInType;
+import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
 
 import org.slf4j.Logger;
@@ -30,7 +31,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedOperationParameter;
 import org.springframework.jmx.export.annotation.ManagedResource;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -59,7 +59,7 @@ public class OptInJmxBean {
     @ManagedOperationParameter(name = "accountNumber", description = "Red Hat Account Number")
     @ManagedOperationParameter(name = "orgId", description = "Red Hat Org ID")
     public void optOut(String accountNumber, String orgId) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Object principal = ResourceUtils.getPrincipal();
         log.info("Opt out for {} triggered via JMX by {}", accountNumber, principal);
         controller.optOut(accountNumber, orgId);
     }
@@ -72,7 +72,7 @@ public class OptInJmxBean {
     @ManagedOperationParameter(name = "enableConduitSync", description = "Turn on Conduit syncing")
     public String createOrUpdateOptInConfig(String accountNumber, String orgId, boolean enableTallySync,
         boolean enableTallyReporting, boolean enableConduitSync) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Object principal = ResourceUtils.getPrincipal();
         log.info("Opt in for account {}, org {} triggered via JMX by {}", accountNumber, orgId, principal);
         log.debug("Creating OptInConfig over JMX for account {}, org {}", accountNumber, orgId);
         OptInConfig config = controller.optIn(accountNumber, orgId, OptInType.JMX, enableTallySync,
@@ -81,4 +81,5 @@ public class OptInJmxBean {
         String text = "Completed opt in for account %s and org %s:\n%s";
         return String.format(text, accountNumber, orgId, config.toString());
     }
+
 }

--- a/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedOperationParameter;
 import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -58,6 +59,8 @@ public class OptInJmxBean {
     @ManagedOperationParameter(name = "accountNumber", description = "Red Hat Account Number")
     @ManagedOperationParameter(name = "orgId", description = "Red Hat Org ID")
     public void optOut(String accountNumber, String orgId) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        log.info("Opt out for {} triggered via JMX by {}", accountNumber, principal);
         controller.optOut(accountNumber, orgId);
     }
 
@@ -69,6 +72,8 @@ public class OptInJmxBean {
     @ManagedOperationParameter(name = "enableConduitSync", description = "Turn on Conduit syncing")
     public String createOrUpdateOptInConfig(String accountNumber, String orgId, boolean enableTallySync,
         boolean enableTallyReporting, boolean enableConduitSync) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        log.info("Opt in for account {}, org {} triggered via JMX by {}", accountNumber, orgId, principal);
         log.debug("Creating OptInConfig over JMX for account {}, org {}", accountNumber, orgId);
         OptInConfig config = controller.optIn(accountNumber, orgId, OptInType.JMX, enableTallySync,
             enableTallyReporting, enableConduitSync);

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.jmx;
 
+import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.spring.QueueProfile;
 import org.candlepin.subscriptions.task.TaskManager;
 
@@ -27,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -48,14 +48,14 @@ public class TallyJmxBean {
 
     @ManagedOperation(description = "Trigger a tally for an account")
     public void tallyAccount(String accountNumber) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Object principal = ResourceUtils.getPrincipal();
         log.info("Tally for account {} triggered over JMX by {}", accountNumber, principal);
         tasks.updateAccountSnapshots(accountNumber);
     }
 
     @ManagedOperation(description = "Trigger tally for all configured accounts")
     public void tallyConfiguredAccounts() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Object principal = ResourceUtils.getPrincipal();
         log.info("Tally for all accounts triggered over JMX by {}", principal);
         tasks.updateSnapshotsForAllAccounts();
     }

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -23,8 +23,11 @@ package org.candlepin.subscriptions.jmx;
 import org.candlepin.subscriptions.spring.QueueProfile;
 import org.candlepin.subscriptions.task.TaskManager;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -35,6 +38,8 @@ import org.springframework.stereotype.Component;
 @ManagedResource
 public class TallyJmxBean {
 
+    private static final Logger log = LoggerFactory.getLogger(TallyJmxBean.class);
+
     private final TaskManager tasks;
 
     public TallyJmxBean(TaskManager taskManager) {
@@ -43,11 +48,15 @@ public class TallyJmxBean {
 
     @ManagedOperation(description = "Trigger a tally for an account")
     public void tallyAccount(String accountNumber) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        log.info("Tally for account {} triggered over JMX by {}", accountNumber, principal);
         tasks.updateAccountSnapshots(accountNumber);
     }
 
     @ManagedOperation(description = "Trigger tally for all configured accounts")
     public void tallyConfiguredAccounts() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        log.info("Tally for all accounts triggered over JMX by {}", principal);
         tasks.updateSnapshotsForAllAccounts();
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -53,6 +53,19 @@ public class ResourceUtils {
     }
 
     /**
+     * Get the authenicated principal.
+     *
+     * Typically one of {@link InsightsUserPrincipal},
+     * {@link org.candlepin.subscriptions.security.RhAssociatePrincipal}, or
+     * {@link org.candlepin.subscriptions.security.X509Principal}
+     *
+     * @return the principal object
+     */
+    public static Object getPrincipal() {
+        return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+
+    /**
      * Get the owner ID of the authenticated user.
      *
      * @return ownerId as a String

--- a/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
@@ -20,35 +20,70 @@
  */
 package org.candlepin.subscriptions.security;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 /**
- * Represents the subset of data we depend on in the x-rh-identity header.
+ * Represents a normal cloud.redhat.com user authenticated via the x-rh-identity header.
  */
-public class InsightsUserPrincipal {
-
-    private final String ownerId;
-    private final String accountNumber;
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InsightsUserPrincipal implements RhIdentity.Identity {
 
     public InsightsUserPrincipal() {
-        this(null, null);
+        // intentionally left empty
     }
 
-    public InsightsUserPrincipal(String ownerId, String accountNumber) {
-        this.ownerId = ownerId;
-        this.accountNumber = accountNumber;
+    // package-private to be used for testing
+    InsightsUserPrincipal(String org, String account) {
+        internal.orgId = org;
+        accountNumber = account;
     }
+
+    /**
+     * POJO representation of "internal" object inside the x-rh-identity object JSON.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Internal {
+        @JsonProperty("org_id")
+        private String orgId;
+
+        public String getOrgId() {
+            return orgId;
+        }
+
+        public void setOrgId(String orgId) {
+            this.orgId = orgId;
+        }
+    }
+
+    @JsonProperty("account_number")
+    private String accountNumber;
+    private Internal internal = new Internal();
 
     public String getOwnerId() {
-        return ownerId;
+        return internal.getOrgId();
     }
 
     public String getAccountNumber() {
         return accountNumber;
     }
 
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public Internal getInternal() {
+        return internal;
+    }
+
+    public void setInternal(Internal internal) {
+        this.internal = internal;
+    }
+
     public String toString() {
-        return String.format("[Account: %s, Owner: %s]", accountNumber, ownerId);
+        return String.format("[Account: %s, Owner: %s]", accountNumber, getOwnerId());
     }
 
     @Override

--- a/src/main/java/org/candlepin/subscriptions/security/RhAssociatePrincipal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RhAssociatePrincipal.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a Red Hat associate authenticated via the x-rh-identity header.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RhAssociatePrincipal implements RhIdentity.Identity {
+
+    /**
+     * Container for SAML assertions relayed by the auth gateway.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class SamlAssertions {
+        @JsonProperty("urn:oid:0.9.2342.19200300.100.1.3") // the OID for email
+        private String email;
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+    }
+
+    @JsonProperty("associate")
+    private SamlAssertions samlAssertions;
+
+    public SamlAssertions getSamlAssertions() {
+        return samlAssertions;
+    }
+
+    public void setSamlAssertions(SamlAssertions samlAssertions) {
+        this.samlAssertions = samlAssertions;
+    }
+
+    public String getEmail() {
+        return samlAssertions.getEmail();
+    }
+
+    @Override
+    public String toString() {
+        return "RhAssociatePrincipal{" + "email='" + getEmail() + '\'' + '}';
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/RhAssociatePrincipal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RhAssociatePrincipal.java
@@ -34,7 +34,6 @@ public class RhAssociatePrincipal implements RhIdentity.Identity {
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class SamlAssertions {
-        @JsonProperty("urn:oid:0.9.2342.19200300.100.1.3") // the OID for email
         private String email;
 
         public String getEmail() {

--- a/src/main/java/org/candlepin/subscriptions/security/RhIdentity.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RhIdentity.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Base type for JSON serializing x-rh-identity header values once base64-decoded
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RhIdentity {
+
+    /**
+     * Abstraction over different auth types that may be present in x-rh-identity header.
+     *
+     * @see InsightsUserPrincipal
+     * @see RhAssociatePrincipal
+     * @see X509Principal
+     */
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type",
+        defaultImpl = InsightsUserPrincipal.class
+    )
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = InsightsUserPrincipal.class, name = "User"),
+        @JsonSubTypes.Type(value = RhAssociatePrincipal.class, name = "Associate"),
+        @JsonSubTypes.Type(value = X509Principal.class, name = "X509")
+    })
+    public interface Identity {}
+
+    private Identity identity;
+
+    public Identity getIdentity() {
+        return identity;
+    }
+
+    public void setIdentity(Identity identity) {
+        this.identity = identity;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -173,9 +173,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .and()
             .authorizeRequests()
                 // Allow access to Actuator endpoints here
-                .requestMatchers(EndpointRequest.to("health", "info", "prometheus")).permitAll()
-                // NOTE EndpointRequest.to("jolokia") does not match subpath (e.g. jolokia/list)
-                .antMatchers("/actuator/jolokia/**").hasRole("RH_INTERNAL")
+                .requestMatchers(EndpointRequest.to(
+                    "health", "info", "prometheus", "jolokia", "hawtio"
+                )).permitAll()
                 .antMatchers("/**/openapi.*", "/**/version", "/api-docs/**", "/webjars/**").permitAll()
                 // ingress security is done via server settings (require ssl cert auth), so permit all here
                 .antMatchers(String.format("/%s/ingress/**", apiPath)).permitAll()

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -83,15 +83,30 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Autowired
     ConfigurableEnvironment env;
 
+    @Autowired
+    RbacService rbacService;
+
     @Override
     public void configure(AuthenticationManagerBuilder auth) {
         // Add our AuthenticationProvider to the Provider Manager's list
-        auth.authenticationProvider(identityHeaderAuthenticationProvider());
+        auth.authenticationProvider(
+            identityHeaderAuthenticationProvider(identityHeaderAuthenticationDetailsService(appProps,
+            rbacService))
+        );
     }
 
     @Bean
-    public AuthenticationProvider identityHeaderAuthenticationProvider() {
-        return new IdentityHeaderAuthenticationProvider();
+    public IdentityHeaderAuthenticationDetailsService identityHeaderAuthenticationDetailsService(
+        ApplicationProperties appProps, RbacService rbacService) {
+        return new IdentityHeaderAuthenticationDetailsService(appProps, identityHeaderAuthoritiesMapper(),
+            rbacService);
+    }
+
+    @Bean
+    public AuthenticationProvider identityHeaderAuthenticationProvider(
+        IdentityHeaderAuthenticationDetailsService detailsService) {
+
+        return new IdentityHeaderAuthenticationProvider(detailsService);
     }
 
     @Bean
@@ -99,23 +114,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         return new RbacService();
     }
 
-    @Bean
-    public IdentityHeaderAuthenticationDetailsSource detailsSource(ApplicationProperties appProps) {
-        return new IdentityHeaderAuthenticationDetailsSource(
-            appProps,
-            identityHeaderAuthoritiesMapper(),
-            rbacService()
-        );
-    }
-
     // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application filter
-    public IdentityHeaderAuthenticationFilter identityHeaderAuthenticationFilter(
-        ApplicationProperties appProps) throws Exception {
+    public IdentityHeaderAuthenticationFilter identityHeaderAuthenticationFilter() throws Exception {
 
         IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
         filter.setCheckForPrincipalChanges(true);
         filter.setAuthenticationManager(authenticationManager());
-        filter.setAuthenticationDetailsSource(detailsSource(appProps));
         filter.setAuthenticationFailureHandler(new IdentityHeaderAuthenticationFailureHandler(mapper));
         filter.setContinueFilterChainOnUnsuccessfulAuthentication(false);
         return filter;
@@ -156,7 +160,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         String apiPath = env.getRequiredProperty(
             "rhsm-subscriptions.package_uri_mappings.org.candlepin.subscriptions");
         http
-            .addFilter(identityHeaderAuthenticationFilter(appProps))
+            .addFilter(identityHeaderAuthenticationFilter())
             .csrf().disable()
             .exceptionHandling()
                 .accessDeniedHandler(restAccessDeniedHandler())
@@ -170,6 +174,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
                 // Allow access to Actuator endpoints here
                 .requestMatchers(EndpointRequest.to("health", "info", "prometheus")).permitAll()
+                // NOTE EndpointRequest.to("jolokia") does not match subpath (e.g. jolokia/list)
+                .antMatchers("/actuator/jolokia/**").hasRole("RH_INTERNAL")
                 .antMatchers("/**/openapi.*", "/**/version", "/api-docs/**", "/webjars/**").permitAll()
                 // ingress security is done via server settings (require ssl cert auth), so permit all here
                 .antMatchers(String.format("/%s/ingress/**", apiPath)).permitAll()

--- a/src/main/java/org/candlepin/subscriptions/security/X509Principal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/X509Principal.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a user or service account authenticated using mTLS.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class X509Principal implements RhIdentity.Identity {
+
+    /**
+     * Container for x509 properties in the x-rh-identity JSON object.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class X509Properties {
+        @JsonProperty("subject_dn")
+        private String subjectDn;
+
+        public String getSubjectDn() {
+            return subjectDn;
+        }
+
+        public void setSubjectDn(String subjectDn) {
+            this.subjectDn = subjectDn;
+        }
+    }
+
+    @JsonProperty("x509")
+    private X509Properties x509Properties;
+
+    public X509Properties getX509Properties() {
+        return x509Properties;
+    }
+
+    public void setX509Properties(X509Properties x509Properties) {
+        this.x509Properties = x509Properties;
+    }
+
+    public String getSubjectDn() {
+        return getX509Properties().getSubjectDn();
+    }
+
+    @Override
+    public String toString() {
+        return "X509Principal{" + "subjectDn='" + getSubjectDn() + '\'' + '}';
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import static io.hawt.web.filters.BaseTagHrefFilter.*;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import io.hawt.web.filters.BaseTagHrefFilter;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+/**
+ * Configuration that modifies the base path used by the Hawtio frontend.
+ *
+ * This enables us to deploy the console behind a reverse proxy with a different prefix.
+ *
+ * For example, if hawtio is deployed at /actuator/hawtio, and the reverse proxy configuration results in a
+ * browser URL of /rhsm-subscriptions/actuator/hawtio, then setting `rhsm-subscriptions.hawtioBasePath` to
+ * /rhsm-subscriptions/actuator/hawtio forces the frontend to return the proper URLs for JavaScript/CSS.
+ */
+@Configuration
+public class HawtioConfiguration {
+    @Autowired
+    public void modifyBaseTagHrefFilter(
+        @Qualifier("baseTagHrefFilter") FilterRegistrationBean<BaseTagHrefFilter> filter,
+        ServletContext servletContext,
+        ApplicationProperties props
+    ) throws ServletException {
+        if (!StringUtils.isEmpty(props.getHawtioBasePath())) {
+            BaseTagHrefFilter baseTagHrefFilter = filter.getFilter();
+            BaseTagHrefFilterConfigOverride filterConfig =
+                new BaseTagHrefFilterConfigOverride(servletContext);
+            filterConfig.setParameter(PARAM_APPLICATION_CONTEXT_PATH, props.getHawtioBasePath());
+            baseTagHrefFilter.init(filterConfig);
+        }
+    }
+
+    private static class BaseTagHrefFilterConfigOverride implements FilterConfig {
+
+        private final ServletContext servletContext;
+        private final Map<String, String> parameters = new HashMap<>();
+
+        public BaseTagHrefFilterConfigOverride(ServletContext servletContext) {
+            this.servletContext = servletContext;
+        }
+
+        @Override
+        public String getFilterName() {
+            // not used
+            return null;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return servletContext;
+        }
+
+        @Override
+        public String getInitParameter(String name) {
+            return parameters.get(name);
+        }
+
+        @Override
+        public Enumeration<String> getInitParameterNames() {
+            return Collections.enumeration(parameters.keySet());
+        }
+
+        public void setParameter(String name, String value) {
+            parameters.put(name, value);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ management:
     web:
       exposure:
         include:
+          - hawtio
           - health
           - info
           - jolokia

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,7 @@ management:
         include:
           - health
           - info
+          - jolokia
           - prometheus
   endpoint:
     shutdown:

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -75,3 +75,10 @@ rhsm-subscriptions.rbacApplicationName=${RBAC_APPLICATION_NAME:subscriptions}
 rhsm-subscriptions.rbac-service.useStub=${RBAC_USE_STUB:false}
 rhsm-subscriptions.rbac-service.url=http://${RBAC_HOST:localhost}:${RBAC_PORT:8819}/api/rbac/v1
 rhsm-subscriptions.rbac-service.maxConnections=${RBAC_MAX_CONNECTIONS:100}
+
+###################################
+# Hawtio Console Configuration
+###################################
+hawtio.authenticationEnabled=false
+# disable the remote connection tab, we do not need it
+hawtio.disableProxy=true

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -82,4 +82,4 @@ rhsm-subscriptions.rbac-service.maxConnections=${RBAC_MAX_CONNECTIONS:100}
 hawtio.authenticationEnabled=false
 # disable the remote connection tab, we do not need it
 hawtio.disableProxy=true
-rhsm-subscriptions.hawtioBasePath=${HAWTIO_BASE_PATH}
+rhsm-subscriptions.hawtioBasePath=${HAWTIO_BASE_PATH:}

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -82,3 +82,4 @@ rhsm-subscriptions.rbac-service.maxConnections=${RBAC_MAX_CONNECTIONS:100}
 hawtio.authenticationEnabled=false
 # disable the remote connection tab, we do not need it
 hawtio.disableProxy=true
+rhsm-subscriptions.hawtioBasePath=${HAWTIO_BASE_PATH}

--- a/src/main/resources/rhsm-subscriptions.properties
+++ b/src/main/resources/rhsm-subscriptions.properties
@@ -79,7 +79,11 @@ rhsm-subscriptions.rbac-service.maxConnections=${RBAC_MAX_CONNECTIONS:100}
 ###################################
 # Hawtio Console Configuration
 ###################################
-hawtio.authenticationEnabled=false
-# disable the remote connection tab, we do not need it
-hawtio.disableProxy=true
+# Base path override for reverse proxy support
 rhsm-subscriptions.hawtioBasePath=${HAWTIO_BASE_PATH:}
+# See https://hawt.io/docs/configuration/ for details on built-in hawtio config
+hawtio.authenticationEnabled=${HAWTIO_AUTHENTICATION_ENABLED:false}
+# disable the remote connection tab, we do not need it
+hawtio.disableProxy=${HAWTIO_DISABLE_PROXY:true}
+hawtio.proxyAllowlist=${HAWTIO_PROXY_ALLOWLIST:localhost,127.0.0.1}
+hawtio.localAddressProbing=${HAWTIO_LOCAL_ADDRESS_PROBING:true}

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
@@ -101,7 +101,7 @@ public class IdentityHeaderAuthenticationFilterTest {
     @Test
     void testRhAssociateHeader() {
         String associate = Base64.getEncoder().encodeToString((
-            "{\"identity\":{\"associate\":{\"urn:oid:0.9.2342.19200300.100.1.3\":\"test@example.com\"}," +
+            "{\"identity\":{\"associate\":{\"email\":\"test@example.com\"}," +
             "\"auth_type\":\"saml-auth\",\"type\": \"Associate\"}}").getBytes());
         when(request.getHeader(RH_IDENTITY_HEADER)).thenReturn(associate);
         IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
@@ -23,16 +23,21 @@ package org.candlepin.subscriptions.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
 import org.springframework.test.context.TestPropertySource;
 
+import java.util.Collections;
 
 @SpringBootTest
 @TestPropertySource("classpath:/test.properties")
@@ -41,7 +46,11 @@ class IdentityHeaderAuthenticationProviderTest {
     @MockBean
     PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails details;
 
-    private IdentityHeaderAuthenticationProvider manager = new IdentityHeaderAuthenticationProvider();
+    @MockBean
+    IdentityHeaderAuthenticationDetailsService detailsService;
+
+    @Autowired
+    AuthenticationProvider manager;
 
     @Test
     void testMissingOrgId() {
@@ -61,6 +70,8 @@ class IdentityHeaderAuthenticationProviderTest {
 
     @Test
     void validPrincipalIsAuthenticated() {
+        when(detailsService.loadUserDetails(any())).thenReturn(new User("N/A", "N/A",
+            Collections.emptyList()));
         Authentication result = manager.authenticate(token("123", "acct"));
         assertTrue(result.isAuthenticated());
     }

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -9,6 +9,8 @@ metadata:
   name: rhsm-subscriptions-worker
 
 parameters:
+  - name: HAWTIO_BASE_PATH
+    value: /rhsm-subscriptions/actuator/hawtio
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -9,6 +9,9 @@ metadata:
   name: rhsm-subscriptions-worker
 
 parameters:
+  # turn off built-in jolokia, so that the spring boot jolokia actuator will work
+  - name: AB_JOLOKIA_OFF
+    value: 'true'
   - name: HAWTIO_BASE_PATH
     value: /rhsm-subscriptions/actuator/hawtio
   - name: LOGGING_LEVEL_ROOT
@@ -151,9 +154,6 @@ objects:
                   memory: ${MEMORY_LIMIT}
               ports:
                 - containerPort: 8080
-                  protocol: TCP
-                - containerPort: 8778
-                  name: jolokia
                   protocol: TCP
               volumeMounts:
                 - name: config

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -13,7 +13,7 @@ parameters:
   - name: AB_JOLOKIA_OFF
     value: 'true'
   - name: HAWTIO_BASE_PATH
-    value: /rhsm-subscriptions/actuator/hawtio
+    value: /app/rhsm-subscriptions/actuator/hawtio
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL


### PR DESCRIPTION
In order to activate jolokia on an actuator, I added a dep for jolokia-core, and modified the application.yaml to enable the endpoint.

I added logging of the principal to the JMX endpoints, which will give us a nice logged record of what principal hit the endpoint. Given that the messages use the toString, the logging will work with either a RhAssociate (internal SAML) or X509 Principal (mTLS) is used.

When either of the two new principal types is used, RBAC is skipped, and a role - `RH_INTERNAL` is added instead.

I changed `IdentityHeaderAuthenticationDetailsSource` to `IdentityHeaderAuthenticationDetailsService`, a change that was
hinted at by @awood. This allowed some separation of creation of the principal and population of the roles. I did not pursue moving the opt-in check into this service in this PR (that looked messy).

I moved to Jackson serialization of the x-rh-identity header object (too much raw JSON manipulation is cumbersome in Java).

To test, launch the application, and then mock some authenticated requests and unauthenticated requests to the jolokia endpoint:

```
DATA='{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccount(java.lang.String)","arguments":["123456"]}'
RH_ASSOCIATE="x-rh-identity: $(echo '{"identity":{"type":"Associate","associate":{"email":"test@example.com"}}}' | base64 -w0)"
INSIGHTS_USER="x-rh-identity: $(echo '{"identity":{"account_number":"myaccount", "internal":{"org_id":"foobar"}}}' | base64 -w0)"
X509_AUTH="x-rh-identity: $(echo '{"identity":{"type":"X509", "x509":{"subject_dn":"/CN=test.example.com"}}}' | base64 -w0)"
curl -H 'Content-Type: application/json' -d $DATA http://localhost:8080/actuator/jolokia  # anonymous
curl -H 'Content-Type: application/json' -d $DATA -H "$INSIGHTS_USER" http://localhost:8080/actuator/jolokia  # insights user
curl -H 'Content-Type: application/json' -d $DATA -H "$RH_ASSOCIATE" http://localhost:8080/actuator/jolokia  # rh associate
curl -H 'Content-Type: application/json' -d $DATA -H "$X509_AUTH" http://localhost:8080/actuator/jolokia  # mTLS auth
```

Related: RedHatInsights/turnpike#11