### PR TITLE
Use generated ID instead of inventory_id for Hosts

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -34,12 +34,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * Provides access to Host database entities.
  */
 @SuppressWarnings({"linelength", "indentation"})
-public interface HostRepository extends JpaRepository<Host, String> {
+public interface HostRepository extends JpaRepository<Host, UUID> {
 
     /**
      * Find all Hosts by bucket criteria and return a page of TallyHostView objects.

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -27,12 +27,15 @@ import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -46,6 +49,9 @@ import javax.persistence.Table;
 public class Host implements Serializable {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
     @Column(name = "inventory_id")
     private String inventoryId;
 
@@ -117,6 +123,14 @@ public class Host implements Serializable {
 
         this.lastSeen = inventoryHostFacts.getModifiedOn();
         this.hardwareType = normalizedFacts.getHardwareType();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
     }
 
     public String getInventoryId() {

--- a/src/main/resources/liquibase/202009041415-use-uuid-for-id-on-hosts-table.xml
+++ b/src/main/resources/liquibase/202009041415-use-uuid-for-id-on-hosts-table.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202009041415-1" author="mstead">
+        <comment>Drop the existing tables. A tally for all accounts will be required post update.</comment>
+        <dropTable tableName="host_tally_buckets" />
+        <dropTable tableName="hosts" />
+    </changeSet>
+
+    <changeSet id="202009041415-2" author="mstead">
+        <comment>Recreate the hosts table.</comment>
+        <createTable tableName="hosts">
+            <column name="id" type="uuid">
+                <constraints nullable="false" />
+            </column>
+            <column name="inventory_id" type="VARCHAR(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="account_number" type="VARCHAR(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="insights_id" type="VARCHAR(255)"/>
+            <column name="org_id" type="VARCHAR(255)" />
+            <column name="display_name" type="VARCHAR(255)"/>
+            <column name="subscription_manager_id" type="VARCHAR(255)"/>
+            <column name="cores" type="INTEGER"/>
+            <column name="sockets" type="INTEGER"/>
+            <column name="is_guest" type="BOOLEAN"/>
+            <column name="hypervisor_uuid" type="VARCHAR(255)"/>
+            <column name="hardware_type" type="VARCHAR(32)" />
+            <column name="num_of_guests" type="INTEGER"/>
+            <column name="last_seen" type="TIMESTAMP WITH TIME ZONE" />
+        </createTable>
+    </changeSet>
+
+    <changeSet id="202009041415-3" author="mstead">
+        <addPrimaryKey constraintName="id_pkey" tableName="hosts" columnNames="id" />
+    </changeSet>
+
+    <changeSet id="202009041415-4" author="mstead">
+        <comment>Create indexes for hosts table.</comment>
+        <createIndex indexName="inventory_id_idx" tableName="hosts">
+            <column name="inventory_id"/>
+        </createIndex>
+        <createIndex indexName="insights_id_idx" tableName="hosts">
+            <column name="insights_id"/>
+        </createIndex>
+        <createIndex indexName="account_idx" tableName="hosts">
+            <column name="account_number"/>
+        </createIndex>
+        <createIndex indexName="org_id_idx" tableName="hosts">
+            <column name="org_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="202009041415-5" author="mstead">
+        <comment>Add table for host buckets.</comment>
+        <createTable tableName="host_tally_buckets">
+            <column name="host_id" type="uuid">
+                <constraints referencedTableName="hosts" referencedColumnNames="id"
+                             nullable="false" foreignKeyName="host_id_fk" deleteCascade="true"/>
+            </column>
+            <column name="usage" type="VARCHAR(255)" defaultValue="_ANY">
+                <constraints nullable="false"/>
+            </column>
+            <column name="product_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sla" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="as_hypervisor" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cores" type="INTEGER" defaultValue="0" />
+            <column name="sockets" type="INTEGER" defaultValue="0" />
+            <column name="measurement_type" type="VARCHAR(32)" />
+        </createTable>
+    </changeSet>
+
+    <changeSet id="202009041415-6" author="mstead">
+        <addPrimaryKey constraintName="host_tally_bucket_pkey"
+                       tableName="host_tally_buckets"
+                       columnNames="host_id,product_id,usage,sla,as_hypervisor"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -27,5 +27,6 @@
     <include file="liquibase/202005281015-add-host-and-host-tally-bucket-tables.xml" />
     <include file="liquibase/202006180903-add-usage-to-host.xml" />
     <include file="liquibase/202007140728-change-id-column-on-hosts-table.xml" />
+    <include file="liquibase/202009041415-use-uuid-for-id-on-hosts-table.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -64,6 +64,8 @@ class HostRepositoryTest {
     @Autowired
     private HostRepository repo;
 
+    private Map<String, Host> existingHostsByInventoryId;
+
     @Transactional
     @BeforeAll
     void setupTestData() {
@@ -90,7 +92,9 @@ class HostRepositoryTest {
         Host host6 = createHost("inventory6", "account3");
 
         List<Host> toSave = Arrays.asList(host1, host2, host3, host4, host5, host6);
-        repo.saveAll(toSave);
+        existingHostsByInventoryId = repo.saveAll(toSave)
+            .stream()
+            .collect(Collectors.toMap(Host::getInventoryId, host -> host));
         repo.flush();
     }
 
@@ -102,7 +106,7 @@ class HostRepositoryTest {
             HardwareMeasurementType.PHYSICAL);
         repo.saveAndFlush(host);
 
-        Optional<Host> result = repo.findById(host.getInventoryId());
+        Optional<Host> result = repo.findById(host.getId());
         assertTrue(result.isPresent());
         Host saved = result.get();
         assertEquals(1, saved.getBuckets().size());
@@ -121,7 +125,7 @@ class HostRepositoryTest {
             HardwareMeasurementType.PHYSICAL);
         repo.saveAndFlush(host);
 
-        Optional<Host> result = repo.findById(host.getInventoryId());
+        Optional<Host> result = repo.findById(host.getId());
         assertTrue(result.isPresent());
         Host toUpdate = result.get();
         assertEquals(2, toUpdate.getBuckets().size());
@@ -133,14 +137,14 @@ class HostRepositoryTest {
 
         repo.saveAndFlush(toUpdate);
 
-        Optional<Host> updateResult = repo.findById(toUpdate.getInventoryId());
+        Optional<Host> updateResult = repo.findById(toUpdate.getId());
         assertTrue(updateResult.isPresent());
         Host updated = updateResult.get();
         assertEquals("updated_acct_num", updated.getAccountNumber());
         assertEquals(4, updated.getSockets().intValue());
         assertEquals(8, updated.getCores().intValue());
         assertEquals(1, updated.getBuckets().size());
-        assertTrue(updated.getBuckets().contains(host.getBuckets().get(1)));
+        assertTrue(updated.getBuckets().contains(host.getBuckets().get(0)));
     }
 
     @Transactional
@@ -190,7 +194,7 @@ class HostRepositoryTest {
     @Transactional
     @Test
     void testNoHostFoundWhenItHasNoBucket() {
-        Optional<Host> existing = repo.findById("inventory6");
+        Optional<Host> existing = repo.findById(existingHostsByInventoryId.get("inventory6").getId());
         assertTrue(existing.isPresent());
         assertEquals("account3", existing.get().getAccountNumber());
 
@@ -299,14 +303,14 @@ class HostRepositoryTest {
         repo.saveAll(Arrays.asList(h1, h2));
         repo.flush();
 
-        assertTrue(repo.findById(h1.getInventoryId()).isPresent());
-        assertTrue(repo.findById(h2.getInventoryId()).isPresent());
+        assertTrue(repo.findById(h1.getId()).isPresent());
+        assertTrue(repo.findById(h2.getId()).isPresent());
 
         repo.deleteByAccountNumberIn(Arrays.asList("A1"));
         repo.flush();
 
-        assertFalse(repo.findById(h1.getInventoryId()).isPresent());
-        assertTrue(repo.findById(h2.getInventoryId()).isPresent());
+        assertFalse(repo.findById(h1.getId()).isPresent());
+        assertTrue(repo.findById(h2.getId()).isPresent());
     }
 
     @Transactional


### PR DESCRIPTION
When an ID is manually set on the Host record, spring-data
repositories will always do a merge when saving an entity.
This results in a select being executed every time a new
host is created which in not necessary since we are
deleting all hosts for an account before a tally is run.

By using a generated ID and storing the inventory_id as a
separate property, we avoid the select statements, which
improves the overall performance.

**NOTE:** I opted to delete the hosts and host_tally_buckets tables via liquibase because it was a lot more difficult to add the ID column with a generated UUID. Because of this, the tally process will need to be re-run to repopulate the host data.