### PR TITLE
Set max page limit to 100 on getHosts API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -389,6 +389,7 @@ paths:
         schema:
           type: integer
           minimum: 1
+          maximum: 100
         description: "The numbers of items to return"
     get:
       summary: "Fetch hosts matching report criteria."

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -47,7 +47,6 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.validation.constraints.Min;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 
@@ -78,7 +77,7 @@ public class HostsResource implements HostsApi {
 
     @Override
     @ReportingAccessRequired
-    public HostReport getHosts(String productId, Integer offset, @Min(1) Integer limit, String sla,
+    public HostReport getHosts(String productId, Integer offset, Integer limit, String sla,
         String usage, Uom uom, HostReportSort sort, SortDirection dir) {
 
         Sort sortValue = Sort.unsorted();


### PR DESCRIPTION
NOTE: Not necessary to have @Min or @Max on the resource class so I removed it.

Test with something like:

```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjY2NzY1ODYiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTMyODQyMzQifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/RHEL?limit=101"
{"errors":[{"status":"400","code":"SUBSCRIPTIONS1002","title":"Client request failed validation.","detail":"getHosts.limit: must be less than or equal to 100"}]}
```