### PR TITLE
Set max limit of 100 on getHypervisorGuests API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -483,6 +483,7 @@ paths:
         schema:
           type: integer
           minimum: 1
+          maximum: 100
         description: "The numbers of items to return"
     get:
       summary: "Fetch guests for this hypervisor."


### PR DESCRIPTION
Test with something like:

```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjY2NzY1ODYiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTMyODQyMzQifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/1234/guests?limit=200"
```