### PR TITLE
1827686: Handle UNSPECIFIED values in capacity queries

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepositoryImpl.java
+++ b/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepositoryImpl.java
@@ -66,13 +66,11 @@ public class CustomizedSubscriptionCapacityRepositoryImpl
         predicates.add(cb.equal(capacity.get("key").get("ownerId"), ownerId));
         predicates.add(cb.equal(capacity.get("key").get("productId"), productId));
 
-        if (serviceLevel != null && serviceLevel != ServiceLevel.ANY &&
-            serviceLevel != ServiceLevel.UNSPECIFIED) {
+        if (serviceLevel != null && serviceLevel != ServiceLevel.ANY) {
             predicates.add(cb.equal(capacity.get("serviceLevel"), serviceLevel));
         }
 
-        if (usage != null && usage != Usage.ANY &&
-            usage != Usage.UNSPECIFIED) {
+        if (usage != null && usage != Usage.ANY) {
             predicates.add(cb.equal(capacity.get("usage"), usage));
         }
 

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -36,6 +36,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 
 @SpringBootTest
@@ -288,6 +289,152 @@ class SubscriptionCapacityRepositoryTest {
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
+    }
+
+    @Test
+    void testCanQueryBySlaNull() {
+        SubscriptionCapacity premium = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity standard = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        premium.setSubscriptionId("premium");
+        premium.setServiceLevel(ServiceLevel.PREMIUM);
+        standard.setSubscriptionId("standard");
+        standard.setServiceLevel(ServiceLevel.STANDARD);
+        unset.setSubscriptionId("unset");
+        unset.setServiceLevel(ServiceLevel.UNSPECIFIED);
+        repository.saveAll(Arrays.asList(premium, standard, unset));
+        repository.flush();
+
+        List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
+            "ownerId",
+            "product",
+            null,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+        assertEquals(3, found.size());
+    }
+
+    @Test
+    void testCanQueryBySlaUnspecified() {
+        SubscriptionCapacity premium = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity standard = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        premium.setSubscriptionId("premium");
+        premium.setServiceLevel(ServiceLevel.PREMIUM);
+        standard.setSubscriptionId("standard");
+        standard.setServiceLevel(ServiceLevel.STANDARD);
+        unset.setSubscriptionId("unset");
+        unset.setServiceLevel(ServiceLevel.UNSPECIFIED);
+        repository.saveAll(Arrays.asList(premium, standard, unset));
+        repository.flush();
+
+        List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
+            "ownerId",
+            "product",
+            ServiceLevel.UNSPECIFIED,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+        assertEquals(1, found.size());
+        assertEquals(ServiceLevel.UNSPECIFIED, found.get(0).getServiceLevel());
+    }
+
+    @Test
+    void testCanQueryBySlaAny() {
+        SubscriptionCapacity premium = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity standard = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        premium.setSubscriptionId("premium");
+        premium.setServiceLevel(ServiceLevel.PREMIUM);
+        standard.setSubscriptionId("standard");
+        standard.setServiceLevel(ServiceLevel.STANDARD);
+        unset.setSubscriptionId("unset");
+        unset.setServiceLevel(ServiceLevel.UNSPECIFIED);
+        repository.saveAll(Arrays.asList(premium, standard, unset));
+        repository.flush();
+
+        List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
+            "ownerId",
+            "product",
+            ServiceLevel.ANY,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+        assertEquals(3, found.size());
+    }
+
+    @Test
+    void testCanQueryByUsageNull() {
+        SubscriptionCapacity production = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity dr = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        production.setSubscriptionId("production");
+        production.setUsage(Usage.PRODUCTION);
+        dr.setSubscriptionId("dr");
+        dr.setUsage(Usage.DISASTER_RECOVERY);
+        unset.setSubscriptionId("unset");
+        unset.setUsage(Usage.UNSPECIFIED);
+        repository.saveAll(Arrays.asList(production, dr, unset));
+        repository.flush();
+
+        List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
+            "ownerId",
+            "product",
+            ServiceLevel.ANY,
+            null,
+            NOWISH,
+            FAR_FUTURE);
+        assertEquals(3, found.size());
+    }
+
+    @Test
+    void testCanQueryByUsageUnspecified() {
+        SubscriptionCapacity production = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity dr = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        production.setSubscriptionId("production");
+        production.setUsage(Usage.PRODUCTION);
+        dr.setSubscriptionId("dr");
+        dr.setUsage(Usage.DISASTER_RECOVERY);
+        unset.setSubscriptionId("unset");
+        unset.setUsage(Usage.UNSPECIFIED);
+        repository.saveAll(Arrays.asList(production, dr, unset));
+        repository.flush();
+
+        List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
+            "ownerId",
+            "product",
+            ServiceLevel.ANY,
+            Usage.UNSPECIFIED,
+            NOWISH,
+            FAR_FUTURE);
+        assertEquals(1, found.size());
+        assertEquals(Usage.UNSPECIFIED, found.get(0).getUsage());
+    }
+
+    @Test
+    void testCanQueryByUsageAny() {
+        SubscriptionCapacity production = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity dr = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+        production.setSubscriptionId("production");
+        production.setUsage(Usage.PRODUCTION);
+        dr.setSubscriptionId("dr");
+        dr.setUsage(Usage.DISASTER_RECOVERY);
+        unset.setSubscriptionId("unset");
+        unset.setUsage(Usage.UNSPECIFIED);
+        repository.saveAll(Arrays.asList(production, dr, unset));
+        repository.flush();
+
+        List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
+            "ownerId",
+            "product",
+            ServiceLevel.ANY,
+            Usage.ANY,
+            NOWISH,
+            FAR_FUTURE);
+        assertEquals(3, found.size());
     }
 
     private SubscriptionCapacity createUnpersisted(OffsetDateTime begin, OffsetDateTime end) {


### PR DESCRIPTION
Previously, we were treating `UNSPECIFIED` the same as `ANY`.

To test, insert a couple of records into the capacity table:

```sql
INSERT INTO subscription_capacity (account_number, product_id, subscription_id, owner_id, physical_sockets, virtual_sockets, has_unlimited_guest_sockets, begin_date, end_date, physical_cores, virtual_cores, sku, sla, usage) VALUES ('account123', 'RHEL', '1827686_prem', 'org123', 5, null, false, '2010-01-01 00:00:00', '2030-01-01 00:00:00', null, null, null, 'Premium', null);
INSERT INTO subscription_capacity (account_number, product_id, subscription_id, owner_id, physical_sockets, virtual_sockets, has_unlimited_guest_sockets, begin_date, end_date, physical_cores, virtual_cores, sku, sla, usage) VALUES ('account123', 'RHEL', '1827686_unspec_sla', 'org123', 5, null, false, '2010-01-01 00:00:00', '2030-01-01 00:00:00', null, null, null, '', null);
INSERT INTO subscription_capacity (account_number, product_id, subscription_id, owner_id, physical_sockets, virtual_sockets, has_unlimited_guest_sockets, begin_date, end_date, physical_cores, virtual_cores, sku, sla, usage) VALUES ('account123', 'RHEL', '1827686_prod', 'org123', 5, null, false, '2010-01-01 00:00:00', '2030-01-01 00:00:00', null, null, null, null, 'Production');
INSERT INTO subscription_capacity (account_number, product_id, subscription_id, owner_id, physical_sockets, virtual_sockets, has_unlimited_guest_sockets, begin_date, end_date, physical_cores, virtual_cores, sku, sla, usage) VALUES ('account123', 'RHEL', '1827686_unspec_usage', 'org123', 5, null, false, '2010-01-01 00:00:00', '2030-01-01 00:00:00', null, null, null, null, '');
```

Deploy with RBAC stubbed: `RBAC_USE_STUB=true ./gradlew bootRun`

Then try some queries:

```
curl "http://localhost:8080/api/rhsm-subscriptions/v1/capacity/products/RHEL?granularity=DAILY&beginning=2017-07-21T17%3A32%3A28Z&ending=2017-07-22T17%3A32%3A28Z" -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
curl "http://localhost:8080/api/rhsm-subscriptions/v1/capacity/products/RHEL?usage=&granularity=DAILY&beginning=2017-07-21T17%3A32%3A28Z&ending=2017-07-22T17%3A32%3A28Z" -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
curl "http://localhost:8080/api/rhsm-subscriptions/v1/capacity/products/RHEL?sla=&granularity=DAILY&beginning=2017-07-21T17%3A32%3A28Z&ending=2017-07-22T17%3A32%3A28Z" -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
```

Observe that ANY (omitting the param) and unspecified have different responses.