### PR TITLE
Override hawtio base path only when management on same port

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
@@ -26,10 +26,14 @@ import org.candlepin.subscriptions.ApplicationProperties;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
+import io.hawt.springboot.HawtioManagementConfiguration;
 import io.hawt.web.filters.BaseTagHrefFilter;
 
 import java.util.Collections;
@@ -51,6 +55,8 @@ import javax.servlet.ServletException;
  * /rhsm-subscriptions/actuator/hawtio forces the frontend to return the proper URLs for JavaScript/CSS.
  */
 @Configuration
+@ConditionalOnManagementPort(ManagementPortType.SAME)
+@AutoConfigureAfter(HawtioManagementConfiguration.class)
 public class HawtioConfiguration {
     @Autowired
     public void modifyBaseTagHrefFilter(


### PR DESCRIPTION
For reasons I still don't completely understand, when you put the
management bits on a different port, the bean is not visible to the
spring context. I spent some time trying to understand exactly why (I
suspect its something like an altogether separate spring context?), but
ultimately, since we're only looking at exposing hawtio on instances
where they're the same, this workaround is acceptable.

To test, try on master:

```
MANAGEMENT_SERVER_PORT=8081 ./gradlew bootRun
```

and observe that it fails to start.

Try again with this fix, and you'll see the app starts up.

Also observe with the fix, without overriding the management port, the
base path override still functions.