### PR TITLE
Apply origin/referer check to all jolokia requests

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/JolokiaRestrictor.java
+++ b/src/main/java/org/candlepin/subscriptions/security/JolokiaRestrictor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+
+import org.jolokia.config.Configuration;
+
+import io.hawt.system.RBACRestrictor;
+
+import java.net.URI;
+
+/**
+ * Apply origin/referer restrictions against all Jolokia requests.
+ */
+public class JolokiaRestrictor extends RBACRestrictor {
+
+    private static ApplicationProperties props;
+
+    public JolokiaRestrictor(Configuration config) {
+        super(config);
+    }
+
+    public static void setApplicationProperties(ApplicationProperties properties) {
+        JolokiaRestrictor.props = properties;
+    }
+
+    @Override
+    public boolean isOriginAllowed(String origin, boolean strictCheck) {
+        if (props == null) {
+            // deny all until configured
+            return false;
+        }
+        if (props.isDevMode()) {
+            return true;
+        }
+        if (props.getAntiCsrfDomainSuffix() == null || origin == null) {
+            return false;
+        }
+        // NOTE: although the method name suggests origin, referer can be passed instead if origin missing.
+        URI uri = URI.create(origin);
+        return uri.getHost().endsWith(props.getAntiCsrfDomainSuffix()) &&
+            (uri.getPort() == -1 || uri.getPort() == props.getAntiCsrfPort());
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.util;
 import static io.hawt.web.filters.BaseTagHrefFilter.*;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.security.JolokiaRestrictor;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -71,6 +72,11 @@ public class HawtioConfiguration {
             filterConfig.setParameter(PARAM_APPLICATION_CONTEXT_PATH, props.getHawtioBasePath());
             baseTagHrefFilter.init(filterConfig);
         }
+    }
+
+    @Autowired
+    public void configureJolokiaRestrictor(ApplicationProperties props) {
+        JolokiaRestrictor.setApplicationProperties(props);
     }
 
     private static class BaseTagHrefFilterConfigOverride implements FilterConfig {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,6 +23,9 @@ management:
       enabled: true
     prometheus:
       enabled: true
+    jolokia:
+      config:
+        restrictorClass: org.candlepin.subscriptions.security.JolokiaRestrictor
 
 spring:
   profiles:


### PR DESCRIPTION
Even GET requests, as those can actually cause bean invocation in Jolokia.

To be consistent with the AntiCsrfFilter, I made it so that `DEV_MODE=true` causes the origin/referer check to be turned off.

To test, try running in the following configurations:

1. `DEV_MODE=true ./gradlew bootRun`: http://localhost:8080/actuator/jolokia will be fully open
2. `./gradlew bootRun`: http://localhost:8080/actuator/hawtio will be non-functional because /actuator/jolokia requests are rejected based on the default origin suffix of .redhat.com w/ port 443.
3. `RHSM_SUBSCRIPTIONS_ANTI_CSRF_DOMAIN_SUFFIX=localhost RHSM_SUBSCRIPTIONS_ANTI_CSRF_PORT=8080 ./gradlew`: http://localhost:8080/actuator/hawtio be functional

Note that there is some nuance, as hitting `/actuator/jolokia` with `GET` (when visiting with a browser), doesn't send an `Origin` header. So with the restrictor turned on, visiting /actuator/jolokia is fruitless even with the correct domain suffix/port set.