### PR TITLE
1827686: Fix capacity SLA/Usage UNSPECIFIED values

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
@@ -180,12 +180,11 @@ public class CandlepinPoolCapacityMapper {
             ServiceLevel slaValue = ServiceLevel.fromString(sla.get());
             if (slaValue == ServiceLevel.UNSPECIFIED) {
                 log.warn("Product {} has unsupported service level {}", pool.getProductId(), sla.get());
-                return null;
             }
             return slaValue;
         }
 
-        return null;
+        return ServiceLevel.UNSPECIFIED;
     }
 
     private Usage getUsage(CandlepinPool pool) {
@@ -197,12 +196,11 @@ public class CandlepinPoolCapacityMapper {
             Usage usageValue = Usage.fromString(usage.get());
             if (usageValue == Usage.UNSPECIFIED) {
                 log.warn("Product {} has unsupported usage {}", pool.getProductId(), usage.get());
-                return null;
             }
             return usageValue;
         }
 
-        return null;
+        return Usage.UNSPECIFIED;
     }
 
     private List<String> extractProductIds(Collection<CandlepinProvidedProduct> providedProducts) {

--- a/src/main/resources/liquibase/202010080931-fix-capacity-unspecified.xml
+++ b/src/main/resources/liquibase/202010080931-fix-capacity-unspecified.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202010080931-1" author="khowell">
+        <comment>Update sla/usage to be not null.</comment>
+        <addNotNullConstraint tableName="subscription_capacity" columnName="sla" defaultNullValue="" />
+        <addNotNullConstraint tableName="subscription_capacity" columnName="usage" defaultNullValue="" />
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -29,5 +29,6 @@
     <include file="liquibase/202007140728-change-id-column-on-hosts-table.xml" />
     <include file="liquibase/202009041415-use-uuid-for-id-on-hosts-table.xml" />
     <include file="liquibase/202008250927-add-cloudigrade-type.xml" />
+    <include file="liquibase/202010080931-fix-capacity-unspecified.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -116,7 +116,7 @@ class CandlepinPoolCapacityMapperTest {
     }
 
     @Test
-    void testBadSlaAndUsageAreWrittenAsNull() {
+    void testBadSlaAndUsageAreWrittenAsEmptyString() {
         CandlepinPool pool = createTestPool(physicalProductIds, null, null, "badSLA", "badUsage");
 
         Collection<SubscriptionCapacity> capacities = mapper.mapPoolToSubscriptionCapacity("ownerId",
@@ -130,6 +130,8 @@ class CandlepinPoolCapacityMapperTest {
         expectedRhelCapacity.setBeginDate(LONG_AGO);
         expectedRhelCapacity.setEndDate(NOWISH);
         expectedRhelCapacity.setSubscriptionId("subId");
+        expectedRhelCapacity.setServiceLevel(ServiceLevel.UNSPECIFIED);
+        expectedRhelCapacity.setUsage(Usage.UNSPECIFIED);
         expectedRhelCapacity.setOwnerId("ownerId");
 
         SubscriptionCapacity expectedServerCapacity = new SubscriptionCapacity();
@@ -141,6 +143,8 @@ class CandlepinPoolCapacityMapperTest {
         expectedServerCapacity.setEndDate(NOWISH);
         expectedServerCapacity.setSubscriptionId("subId");
         expectedServerCapacity.setOwnerId("ownerId");
+        expectedServerCapacity.setServiceLevel(ServiceLevel.UNSPECIFIED);
+        expectedServerCapacity.setUsage(Usage.UNSPECIFIED);
 
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,


### PR DESCRIPTION
Instead of null, for consistency, they should be empty string.

Prior work in #183 doesn't fix the issue described without this change
as well.

To test try:

```
curl -X POST "http://localhost:8080/api/rhsm-subscriptions/v1/ingress/candlepin_pools/org1" -H  "accept: */*" -H  "Content-Type: application/json" -d "[{\"accountNumber\":\"account1\",\"activeSubscription\":true,\"startDate\":\"2020-01-01T00:00:00Z\",\"endDate\":\"2023-01-01T00:00:00Z\",\"quantity\":1,\"productId\":\"RH000test\",\"productAttributes\":[{\"name\":\"sockets\",\"value\":\"10\"},{\"name\":\"usage\",\"value\":\"Production\"}],\"providedProducts\":[{\"productId\":\"69\"},{\"productId\":\"290\"}],\"subscriptionId\":\"subscription1\",\"type\":\"NORMAL\"}]"
```

and observe that the SLA written in the DB is '' rather than null.
Alternatively, you can query back out the capacity for SLA unspecified
w/ the API.