### PR TITLE
Jenkins: Run all gradle steps inside container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,17 +6,17 @@ pipeline {
     stages {
         stage('Clean') {
             steps {
-                sh './gradlew --no-daemon clean'
+                sh "./podman_run.sh ./gradlew --no-daemon clean"
             }
         }
         stage('Build') {
             steps {
-                sh './gradlew --no-daemon assemble'
+                sh "./podman_run.sh ./gradlew --no-daemon assemble"
             }
         }
         stage('Unit tests') {
             steps {
-                sh './gradlew --no-daemon test'
+                sh "./podman_run.sh ./gradlew --no-daemon test"
             }
             post {
                 always {
@@ -26,7 +26,7 @@ pipeline {
         }
         stage('Checkstyle') {
             steps {
-                sh './gradlew --no-daemon checkstyleMain checkstyleTest'
+                sh "./podman_run.sh ./gradlew --no-daemon checkstyleMain checkstyleTest"
             }
             post {
                 always {
@@ -40,7 +40,7 @@ pipeline {
             }
             steps {
                 withSonarQubeEnv('sonarcloud.io') {
-                    sh "./gradlew --no-daemon sonarqube -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                    sh "./podman_run.sh ./gradlew --no-daemon sonarqube -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
                 }
             }
         }
@@ -52,7 +52,7 @@ pipeline {
             }
             steps {
                 withSonarQubeEnv('sonarcloud.io') {
-                    sh "./gradlew --no-daemon sonarqube -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                    sh "./podman_run.sh ./gradlew --no-daemon sonarqube -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
                 }
             }
         }

--- a/podman_run.sh
+++ b/podman_run.sh
@@ -1,0 +1,1 @@
+podman run --user=$UID -e GRADLE_HOME=/workspace/.gradle -w /workspace -v $(pwd):/workspace:Z registry.access.redhat.com/ubi8/openjdk-8 "$@"


### PR DESCRIPTION
This makes it easier to reproduce a Jenkins failure locally, and allows us to more easily update the base we are running on top of,
specifically, when we go to Java 11, it will simply be a matter of replacing `registry.access.redhat.com/ubi8/openjdk-8` with `registry.access.redhat.com/ubi8/openjdk-11`.