### PR TITLE
Add opt in stats to OptInJmxBean

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -26,6 +26,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.stream.Stream;
 
 /**
@@ -40,5 +41,9 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
         "select case when count(c) > 0 then true else false end from AccountConfig c " +
         "where c.accountNumber = :account and c.reportingEnabled = TRUE")
     boolean isReportingEnabled(@Param("account") String accountNumber);
+
+    @Query("select count(c) from AccountConfig c " +
+        "where c.optInType='API' and c.created between :startOfWeek and :endOfWeek")
+    int getCountOfOptInsForDateRange(OffsetDateTime startOfWeek, OffsetDateTime endOfWeek);
 
 }

--- a/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
@@ -94,18 +94,12 @@ public class OptInJmxBean {
 
     @ManagedAttribute(description = "Count of how many orgs opted-in in the previous week.")
     public int getLastWeekOptInCount() {
-        OffsetDateTime oneWeekAgo = OffsetDateTime.now().minusWeeks(1);
-        OffsetDateTime begin = clock.startOfWeek(oneWeekAgo);
-        OffsetDateTime end = clock.endOfWeek(oneWeekAgo);
-        return repo.getCountOfOptInsForDateRange(begin, end);
+        return weekCount(OffsetDateTime.now().minusWeeks(1));
     }
 
     @ManagedAttribute(description = "Count of how many orgs opted-in in the current week.")
     public int getCurrentWeekOptInCount() {
-        OffsetDateTime now = OffsetDateTime.now();
-        OffsetDateTime begin = clock.startOfWeek(now);
-        OffsetDateTime end = clock.endOfWeek(now);
-        return repo.getCountOfOptInsForDateRange(begin, end);
+        return weekCount(OffsetDateTime.now());
     }
 
     @ManagedOperation(description = "Fetch the number of orgs opted-in in a given week.")
@@ -113,8 +107,12 @@ public class OptInJmxBean {
     public int getOptInCountForWeekOf(String weekOf) throws ParseException {
         OffsetDateTime dateInWeek = OffsetDateTime
             .ofInstant(new SimpleDateFormat("yyyy-MM-dd").parse(weekOf).toInstant(), ZoneOffset.UTC);
-        OffsetDateTime begin = clock.startOfWeek(dateInWeek);
-        OffsetDateTime end = clock.endOfWeek(dateInWeek);
+        return weekCount(dateInWeek);
+    }
+
+    protected int weekCount(OffsetDateTime weekDate) {
+        OffsetDateTime begin = clock.startOfWeek(weekDate);
+        OffsetDateTime end = clock.endOfWeek(weekDate);
         return repo.getCountOfOptInsForDateRange(begin, end);
     }
 


### PR DESCRIPTION
To test, run with `./gradlew bootRun`.

Then open http://localhost:8080/actuator/hawtio/jmx/attributes?nid=root-org.candlepin.subscriptions.jmx-OptInJmxBean-optInJmxBean&pref=Connect

Observe the values of two fields:

- Current week opt in count
- Last week opt in count

In a terminal, simulate an opt-in:

```
echo "insert into account_config(account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated) values ('optin0', true, true, 'API', now(), now());" | psql -h localhost -U rhsm-subscriptions
```

and observe that `Current week opt in count` is incremented by one (5 second polling interval in hawtio by default).

Insert a record to mock a previous week's opt-in:

```
echo "insert into account_config(account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated) values ('optin1', true, true, 'API', now() + interval '-7 days', now() + interval '-7 days');" | psql -h localhost -U rhsm-subscriptions
```

and observe that `Last week opt in count` is incremented.

I'm open to making these methods rather than attributes if there is concern about the auto-refresh from hawtio.

Also, try the new JMX operation: `getOptInCountForWeekOf(String)`, passing in the current date in YYYY-MM-DD format.