### PR TITLE
Map "arm64" to RHEL for ARM

### DIFF
--- a/src/main/resources/arch_to_product_map.yaml
+++ b/src/main/resources/arch_to_product_map.yaml
@@ -1,4 +1,5 @@
 aarch64: RHEL for ARM
+arm64: RHEL for ARM
 i386: RHEL for x86
 ppc64: RHEL for IBM Power
 ppc64le: RHEL for IBM Power


### PR DESCRIPTION
Cloudigrade detects ARM machines as arm64, as discovered in testing.