### PR TITLE
Switch to JDK11, but compile against Java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.redhat.io/openjdk/openjdk-8-rhel8
+FROM registry.access.redhat.com/ubi8/openjdk-11
 USER root
 WORKDIR /tmp/src
 ADD . /tmp/src
 RUN ./gradlew assemble
 
-FROM registry.redhat.io/openjdk/openjdk-8-rhel8
+FROM registry.access.redhat.com/ubi8/openjdk-11
 COPY --from=0 /tmp/src/build/libs/* /deployments/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openjdk/openjdk-8-rhel8
+FROM registry.access.redhat.com/ubi8/openjdk-11
 USER root
 WORKDIR /tmp/src
 ADD . /tmp/src

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ allprojects {
 
     tasks.withType(JavaCompile) {
         options.compilerArgs << '-parameters'
+        options.compilerArgs.addAll(['--release', '8'])
     }
 
     repositories {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -35,7 +35,7 @@
 <module name="Checker">
   <module name="SuppressWarningsFilter"/>
   <module name="SuppressionFilter">
-    <property name="file" value="config/checkstyle/suppressions.xml"/>
+    <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
 
   <module name="RegexpSingleline">
@@ -66,7 +66,7 @@
     <property name="header" value="^/\*$\n^ \* Copyright \(c\) 20\d\d - 20\d\d Red Hat, Inc.$"/>
   </module>
   <module name="Header">
-    <property name="headerFile" value="config/checkstyle/HEADER.txt" />
+    <property name="headerFile" value="${config_loc}/HEADER.txt" />
     <!-- The copyright date line gets checked by the RegexpHeader module -->
     <property name="ignoreLines" value="2"/>
   </module>

--- a/podman_run.sh
+++ b/podman_run.sh
@@ -1,1 +1,1 @@
-podman run --user=$UID -e GRADLE_HOME=/workspace/.gradle -w /workspace -v $(pwd):/workspace:Z registry.access.redhat.com/ubi8/openjdk-8 "$@"
+podman run --rm --user=root -e GRADLE_USER_HOME=/workspace/.gradle -w /workspace -v $(pwd):/workspace:Z registry.access.redhat.com/ubi8/openjdk-11 "$@"


### PR DESCRIPTION
This change does the following:

1. Move to registry.access.redhat.com/ubi8/openjdk-11 for all container images.
2. Update build.gradle pass `--release 8` to javac, to keep compiling against Java 8.
3. Update checkstyle config to be jdk11 compatible, by using `config_loc` variable.
4. Update podman command to use the user's UID properly (attempted to do this before, but got it wrong).
5. Update podman command w/ `--rm` to cleanup after itself.
6. Change hacky counting in TaskManager, that for some reason failed tests w/ JDK11.

There is still work to do to fully move to Java 11, but this will get us on an updated JDK in the short-term.

@mstead @awood this is more-or-less a follow-up to #191, I wanted to discover the scope of a JDK11 MVP, and this seemed small enough, I went ahead and made a PR out of it.