### PR TITLE
Cloudigrade: skip serviceType for now

### DIFF
--- a/cloudigrade-client/cloudigrade-api-spec.yaml
+++ b/cloudigrade-client/cloudigrade-api-spec.yaml
@@ -111,6 +111,8 @@ components:
           type: string
         usage:
           type: string
+        service_type:
+          type: string
     IdentityHeader:
       required:
         - identity

--- a/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
@@ -93,6 +93,9 @@ public class CloudigradeAccountUsageCollector {
         cloudigradeUsage.getData().stream().findFirst().ifPresent(usage -> {
             for (UsageCount usageCount : usage.getMaximumCounts()) {
                 try {
+                    if (!"_ANY".equals(usageCount.getServiceType())) {
+                        continue; // skip service-type for now, we don't yet support it
+                    }
                     UsageCalculation.Key key = extractKey(usageCount, archToProductMap, roleToProductsMap);
                     UsageCalculation calculation = usageCalc.getOrCreateCalculation(key);
                     Integer count = usageCount.getInstancesCount();

--- a/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
@@ -93,7 +93,8 @@ public class CloudigradeAccountUsageCollector {
         cloudigradeUsage.getData().stream().findFirst().ifPresent(usage -> {
             for (UsageCount usageCount : usage.getMaximumCounts()) {
                 try {
-                    if (!"_ANY".equals(usageCount.getServiceType())) {
+                    // null service-type may occur if integrating with an older version of cloudigrade
+                    if (!"_ANY".equals(usageCount.getServiceType()) && usageCount.getServiceType() != null) {
                         continue; // skip service-type for now, we don't yet support it
                     }
                     UsageCalculation.Key key = extractKey(usageCount, archToProductMap, roleToProductsMap);


### PR DESCRIPTION
We plan to support serviceType in the future, but we don't yet, but cloudigrade is already collecting it, so we need to simply skip any
entries with a `service_type` other than `_ANY`.

Without this change, even when service type is unset, we end up with two values for it: `''` (unset), and `_ANY` (any/all service types). This was causing us to double count machines.