### PR TITLE
Fix NPE when running JMX operations via JConsole

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -62,7 +62,8 @@ public class ResourceUtils {
      * @return the principal object
      */
     public static Object getPrincipal() {
-        return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return auth != null ? auth.getPrincipal() : null;
     }
 
     /**


### PR DESCRIPTION
When executing a JMX operation via JConsole an Authentication object
is not available in the security context. Because of this there is
no principal to output in the log. In this case we will only print
null.

To test:

Run the app, then launch JConsole and trigger a tally run via JMX.