### PR TITLE
Apply AntiCsrfFilter check to all Jolokia requests.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/GetVerbIncludingAntiCsrfFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/GetVerbIncludingAntiCsrfFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This class includes GET requests in the list of HTTP verbs that must have a matching origin or referrer.
+ * It exists because Jolokia will invoke JMX Beans with GET requests which we want to protect from CSRF
+ * attacks.
+ */
+public class GetVerbIncludingAntiCsrfFilter extends AntiCsrfFilter {
+
+    GetVerbIncludingAntiCsrfFilter(ApplicationProperties props, ConfigurableEnvironment env) {
+        super(props, env);
+    }
+
+    @Override
+    protected boolean requestVerbAllowed(HttpServletRequest request) {
+        String verb = request.getMethod();
+        return !(MODIFYING_VERBS.contains(verb) || "GET".equals(verb));
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -32,6 +32,8 @@ import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointR
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -42,144 +44,198 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 import java.util.Arrays;
 
 /**
- * Configuration class for Spring Security.
- *
- * The architecture here can be confusing due to our use of a custom filter.  Here is a discussion of the
- * Spring Security architecture: https://spring.io/guides/topicals/spring-security-architecture  In our
- * case, requests are pre-authenticated and the relevant information is stored in a custom header.
- *
- * We add the IdentityHeaderAuthenticationFilter as a filter to the Spring Security FilterChainProxy that
- * sits in the standard servlet filter chain and delegates out to all the various Spring Security filters.
- * <ol>
- *   <li>IdentityHeaderAuthenticationFilter parses the servlet request to create the InsightsUserPrincipal
- *       and places it in an Authentication object.</li>
- *   <li>IdentityHeaderAuthenticationFilter's superclass invokes the IdentityHeaderAuthenticationDetailsSource
- *       to populate the Authentication object with the
- *       PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails which contain the roles.</li>
- *   <li>The Authentication object is passed to the Spring Security AuthenticationManager.  In this case,
- *       we're using a ProviderManager with one AuthenticationProvider, IdentityHeaderAuthenticationProvider,
- *       installed.</li>
- *   <li>
- *       The IdentityHeaderAuthenticationProvider is invoked to build a blessed Authentication object.  We
- *       examine the current Authentication and make sure everything we expect is there.  Then we take the
- *       granted authorities provided from the IdentityHeaderAuthenticationDetailsSource and push them and
- *       the InsightsUserPrincipal into a new, blessed Authentication object and return it.</li>
- * </ol>
+ * Holder class for security configurations
  */
-@Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
-    @Autowired
-    private ObjectMapper mapper;
+public class SecurityConfig {
 
-    @Autowired
-    private ApplicationProperties appProps;
-
-    @Autowired
-    ConfigurableEnvironment env;
-
-    @Autowired
-    RbacService rbacService;
-
-    @Override
-    public void configure(AuthenticationManagerBuilder auth) {
-        // Add our AuthenticationProvider to the Provider Manager's list
-        auth.authenticationProvider(
-            identityHeaderAuthenticationProvider(identityHeaderAuthenticationDetailsService(appProps,
-            rbacService))
-        );
+    protected SecurityConfig() {
+        // Container class only
     }
 
-    @Bean
-    public IdentityHeaderAuthenticationDetailsService identityHeaderAuthenticationDetailsService(
-        ApplicationProperties appProps, RbacService rbacService) {
-        return new IdentityHeaderAuthenticationDetailsService(appProps, identityHeaderAuthoritiesMapper(),
-            rbacService);
+    /**
+     * Configuration class for Spring Security.
+     *
+     * The architecture here can be confusing due to our use of a custom filter.  Here is a discussion of the
+     * Spring Security architecture: https://spring.io/guides/topicals/spring-security-architecture  In our
+     * case, requests are pre-authenticated and the relevant information is stored in a custom header.
+     *
+     * We add the IdentityHeaderAuthenticationFilter as a filter to the Spring Security FilterChainProxy that
+     * sits in the standard servlet filter chain and delegates out to all the various Spring Security filters.
+     * <ol>
+     *   <li>IdentityHeaderAuthenticationFilter parses the servlet request to create the InsightsUserPrincipal
+     *       and places it in an Authentication object.</li>
+     *   <li>IdentityHeaderAuthenticationFilter's superclass invokes the
+     *       IdentityHeaderAuthenticationDetailsSource to populate the Authentication object with the
+     *       PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails which contain the roles.</li>
+     *   <li>The Authentication object is passed to the Spring Security AuthenticationManager.  In this case,
+     *       we're using a ProviderManager with one AuthenticationProvider,
+     *       IdentityHeaderAuthenticationProvider, installed.</li>
+     *   <li>
+     *       The IdentityHeaderAuthenticationProvider is invoked to build a blessed Authentication object.  We
+     *       examine the current Authentication and make sure everything we expect is there.  Then we take the
+     *       granted authorities provided from the IdentityHeaderAuthenticationDetailsSource and push them and
+     *       the InsightsUserPrincipal into a new, blessed Authentication object and return it.</li>
+     * </ol>
+     */
+    @Configuration
+    public static class ApiConfiguration extends WebSecurityConfigurerAdapter {
+        @Autowired protected ObjectMapper mapper;
+        @Autowired protected ApplicationProperties appProps;
+        @Autowired protected ConfigurableEnvironment env;
+        @Autowired protected RbacService rbacService;
+
+        @Override
+        public void configure(AuthenticationManagerBuilder auth) {
+            // Add our AuthenticationProvider to the Provider Manager's list
+            auth.authenticationProvider(identityHeaderAuthenticationProvider(
+                identityHeaderAuthenticationDetailsService(appProps, rbacService)));
+        }
+
+        @Bean
+        public IdentityHeaderAuthenticationDetailsService identityHeaderAuthenticationDetailsService(
+            ApplicationProperties appProps, RbacService rbacService) {
+            return new IdentityHeaderAuthenticationDetailsService(appProps, identityHeaderAuthoritiesMapper(),
+                rbacService);
+        }
+
+        @Bean
+        public AuthenticationProvider identityHeaderAuthenticationProvider(
+            IdentityHeaderAuthenticationDetailsService detailsService) {
+
+            return new IdentityHeaderAuthenticationProvider(detailsService);
+        }
+
+        @Bean
+        public RbacService rbacService() {
+            return new RbacService();
+        }
+
+        // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application filter
+        public IdentityHeaderAuthenticationFilter identityHeaderAuthenticationFilter() throws Exception {
+
+            IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+            filter.setCheckForPrincipalChanges(true);
+            filter.setAuthenticationManager(authenticationManager());
+            filter.setAuthenticationFailureHandler(new IdentityHeaderAuthenticationFailureHandler(mapper));
+            filter.setContinueFilterChainOnUnsuccessfulAuthentication(false);
+            return filter;
+        }
+
+        @Bean
+        public IdentityHeaderAuthoritiesMapper identityHeaderAuthoritiesMapper() {
+            return new IdentityHeaderAuthoritiesMapper();
+        }
+
+        @Bean
+        public AccessDeniedHandler restAccessDeniedHandler() {
+            return new RestAccessDeniedHandler(mapper);
+        }
+
+        @Bean
+        public AuthenticationEntryPoint restAuthenticationEntryPoint() {
+            return new RestAuthenticationEntryPoint(new IdentityHeaderAuthenticationFailureHandler(mapper));
+        }
+
+        // NOTE: intentionally *not* annotated with @Bean; @Bean causes an extra use as an application filter
+        public AntiCsrfFilter antiCsrfFilter(ApplicationProperties appProps, ConfigurableEnvironment env) {
+            return new AntiCsrfFilter(appProps, env);
+        }
+
+        @Bean
+        public FilterRegistrationBean<OptInFilter> optInFilterRegistration(OptInController optInController) {
+            String apiPath = env.getRequiredProperty(
+                "rhsm-subscriptions.package_uri_mappings.org.candlepin.subscriptions");
+
+            FilterRegistrationBean<OptInFilter> frb = new FilterRegistrationBean<>();
+            frb.setFilter(new OptInFilter(optInController));
+            frb.setUrlPatterns(Arrays.asList(
+                String.format("/%s/capacity/*", apiPath),
+                String.format("/%s/tally/*", apiPath),
+                String.format("/%s/hosts/*", apiPath)
+            ));
+            return frb;
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            String apiPath = env.getRequiredProperty(
+                "rhsm-subscriptions.package_uri_mappings.org.candlepin.subscriptions");
+            http
+                .addFilter(identityHeaderAuthenticationFilter())
+                .addFilterAfter(antiCsrfFilter(appProps, env), IdentityHeaderAuthenticationFilter.class)
+                .csrf().disable()
+                .exceptionHandling()
+                    .accessDeniedHandler(restAccessDeniedHandler())
+                    .authenticationEntryPoint(restAuthenticationEntryPoint())
+                .and()
+                // disable sessions, our API is stateless, and sessions cause RBAC information to be cached
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .anonymous() // Creates an anonymous user if no header is present at all. Prevents NPEs
+                .and()
+                .authorizeRequests()
+                    .antMatchers("/**/openapi.*", "/**/version", "/api-docs/**", "/webjars/**").permitAll()
+                    // ingress security uses server settings (require ssl cert auth), so permit all here
+                    .antMatchers(String.format("/%s/ingress/**", apiPath)).permitAll()
+                    .requestMatchers(EndpointRequest.to(
+                        "health", "info", "prometheus", "hawtio"
+                    )).permitAll()
+                    .anyRequest().authenticated();
+        }
     }
 
-    @Bean
-    public AuthenticationProvider identityHeaderAuthenticationProvider(
-        IdentityHeaderAuthenticationDetailsService detailsService) {
+    /**
+     * Security configuration for Jolokia Actuator.  Jolokia has GET endpoints that can affect the state of
+     * the application.  We need to protect these endpoints from CSRF attacks.  Normally GET requests are
+     * exempted from CSRF restrictions, so we need to create a special security configuration and use a
+     * special AntiCsrfFilter to guard GET requests on the /actuator/jolokia context.
+     *
+     * This security configuration will be loaded before the normal configuration.
+     */
+    @Order(1)
+    @Configuration
+    @Import(ApiConfiguration.class)
+    public static class JolokiaActuatorConfiguration extends WebSecurityConfigurerAdapter {
+        @Autowired private ApplicationProperties appProps;
+        @Autowired private ConfigurableEnvironment env;
+        @Autowired protected ObjectMapper mapper;
 
-        return new IdentityHeaderAuthenticationProvider(detailsService);
+        // NOTE: intentionally *not* annotated with @Bean; @Bean causes an extra use as an application filter
+        public AntiCsrfFilter getVerbIncludingAntiCsrfFilter(ApplicationProperties appProps,
+            ConfigurableEnvironment env) {
+            return new GetVerbIncludingAntiCsrfFilter(appProps, env);
+        }
+
+
+        // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application filter
+        public IdentityHeaderAuthenticationFilter identityHeaderAuthenticationFilter() throws Exception {
+            IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+            filter.setCheckForPrincipalChanges(true);
+            filter.setAuthenticationManager(authenticationManager());
+            filter.setAuthenticationFailureHandler(new IdentityHeaderAuthenticationFailureHandler(mapper));
+            filter.setContinueFilterChainOnUnsuccessfulAuthentication(false);
+            return filter;
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            // See https://docs.spring.io/spring-security/site/docs/current/reference/html5/#ns-custom-filters
+            // for list of filters and their order
+            http
+                .requestMatchers(matchers ->
+                    matchers.antMatchers("/actuator/**/jolokia", "/actuator/**/jolokia/**"))
+                .csrf().disable()
+                .addFilter(identityHeaderAuthenticationFilter())
+                .addFilterBefore(getVerbIncludingAntiCsrfFilter(appProps, env), LogoutFilter.class)
+                .authorizeRequests()
+                .requestMatchers(EndpointRequest.to("jolokia")).permitAll();
+        }
     }
-
-    @Bean
-    public RbacService rbacService() {
-        return new RbacService();
-    }
-
-    // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application filter
-    public IdentityHeaderAuthenticationFilter identityHeaderAuthenticationFilter() throws Exception {
-
-        IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
-        filter.setCheckForPrincipalChanges(true);
-        filter.setAuthenticationManager(authenticationManager());
-        filter.setAuthenticationFailureHandler(new IdentityHeaderAuthenticationFailureHandler(mapper));
-        filter.setContinueFilterChainOnUnsuccessfulAuthentication(false);
-        return filter;
-    }
-
-    @Bean
-    public IdentityHeaderAuthoritiesMapper identityHeaderAuthoritiesMapper() {
-        return new IdentityHeaderAuthoritiesMapper();
-    }
-
-    @Bean
-    public AccessDeniedHandler restAccessDeniedHandler() {
-        return new RestAccessDeniedHandler(mapper);
-    }
-
-    @Bean
-    public AuthenticationEntryPoint restAuthenticationEntryPoint() {
-        return new RestAuthenticationEntryPoint(new IdentityHeaderAuthenticationFailureHandler(mapper));
-    }
-
-    @Bean
-    public FilterRegistrationBean<OptInFilter> optInFilterRegistration(OptInController optInController) {
-        String apiPath = env.getRequiredProperty(
-            "rhsm-subscriptions.package_uri_mappings.org.candlepin.subscriptions");
-
-        FilterRegistrationBean<OptInFilter> frb = new FilterRegistrationBean<>();
-        frb.setFilter(new OptInFilter(optInController));
-        frb.setUrlPatterns(Arrays.asList(
-            String.format("/%s/capacity/*", apiPath),
-            String.format("/%s/tally/*", apiPath),
-            String.format("/%s/hosts/*", apiPath)
-        ));
-        return frb;
-    }
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        String apiPath = env.getRequiredProperty(
-            "rhsm-subscriptions.package_uri_mappings.org.candlepin.subscriptions");
-        http
-            .addFilter(identityHeaderAuthenticationFilter())
-            .csrf().disable()
-            .exceptionHandling()
-                .accessDeniedHandler(restAccessDeniedHandler())
-                .authenticationEntryPoint(restAuthenticationEntryPoint())
-            .and()
-            // disable sessions, our API is stateless, and sessions cause RBAC information to be cached
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            .and()
-            .anonymous()  // Creates an anonymous user if no header is present at all. Prevents NPEs basically
-            .and()
-            .authorizeRequests()
-                // Allow access to Actuator endpoints here
-                .requestMatchers(EndpointRequest.to(
-                    "health", "info", "prometheus", "jolokia", "hawtio"
-                )).permitAll()
-                .antMatchers("/**/openapi.*", "/**/version", "/api-docs/**", "/webjars/**").permitAll()
-                // ingress security is done via server settings (require ssl cert auth), so permit all here
-                .antMatchers(String.format("/%s/ingress/**", apiPath)).permitAll()
-                .anyRequest().authenticated();
-    }
-
 }


### PR DESCRIPTION
This commit adds a special version of AntiCsrfFilter that includes GET
requests.  Normally GET requests are exempted from CSRF checks as GET
requests are not intended to modify state on the server.  However, with
Jolokia even GET requests can actually cause a JMX bean invocation.

Note browsers don't send Origin or Referer headers when making GET
requests so hitting `/actuator/jolokia` will fail the CSRF filter.
Use curl instead or proxy your JMX request by using the /actuator/hawtio
endpoint.

---
# Testing
Test Requests (DEV_MODE must be false):

1. No auth, but origin for Jolokia GET: `curl -v -H "Origin: localhost:8080" -X GET "http://localhost:8080/actuator/jolokia"`
	Expect: Access allowed
	Actual: Access allowed

2. No auth, no origin for Jolokia GET: `curl -v -X GET "http://localhost:8080/actuator/jolokia"`
	Expect: Access denied - bad origin
	Actual: Access is denied but with a slightly confusing error message.  The error message returned states that the user could not be authenticated. Walking through the debugger shows the failure actually occurs on the origin match, but the error handler that gets invoked is the `IdentityHeaderAuthenticationFailureHandler`.  This is slightly annoying but I don't know that it's worth additional time investment to correct.  If reviewers feel it is worth correcting, just flag the PR as needing changes and comment accordingly.

3. Auth, but no origin for Jolokia GET: `curl -v -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjIzNCIsICJ1c2VyIjp7ImlzX29yZ19hZG1pbiI6dHJ1ZX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIm15T3JnIn19fX0K" -X GET "http://localhost:8080/actuator/jolokia"`
	Expect: Access denied - bad origin
	Actual: Access denied

3. No auth, no origin for other Actuator GET: `curl -v -X GET "http://localhost:8080/actuator/health"`
	Expect: Access allowed
	Actual: Access allowed

4. No auth, no origin for API PUT: `curl -v -X PUT "http://localhost:8080/api/rhsm-subscriptions/v1/opt-in"`
	Expect: Access denied
	Actual: Access denied

5. Auth, no origin for API PUT: `curl -v -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjIzNCIsICJ1c2VyIjp7ImlzX29yZ19hZG1pbiI6dHJ1ZX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIm15T3JnIn19fX0K" -X PUT "http://localhost:8080/api/rhsm-subscriptions/v1/opt-in"`
	Expect: Access denied - bad origin
	Actual: Access denied - bad origin

6. Auth and origin for API PUT: `curl -v -H "Origin: localhost:8080" -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjIzNCIsICJ1c2VyIjp7ImlzX29yZ19hZG1pbiI6dHJ1ZX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIm15T3JnIn19fX0K" -X PUT "http://localhost:8080/api/rhsm-subscriptions/v1/opt-in"`
	Expect: Access allowed
	Actual: Access allowed

7. Auth and no origin for API GET: `curl -v -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjIzNCIsICJ1c2VyIjp7ImlzX29yZ19hZG1pbiI6dHJ1ZX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIm15T3JnIn19fX0K" -X GET "http://localhost:8080/api/rhsm-subscriptions/v1/opt-in"`
	Expect: Access allowed
	Actual: Access allowed

8. No auth and no origin for API GET: `curl -v -X GET "http://localhost:8080/api/rhsm-subscriptions/v1/opt-in"`
	Expect: Access denied
	Actual: Access denied