### PR TITLE
1884770: Consider host as virtual when satellite maps hypervisor

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -108,7 +108,7 @@ public class FactNormalizer {
     }
 
     private boolean isVirtual(InventoryHostFacts hostFacts) {
-        return hostFacts.isVirtual() ||
+        return hostFacts.isVirtual() || StringUtils.hasText(hostFacts.getSatelliteHypervisorUuid()) ||
             "virtual".equalsIgnoreCase(hostFacts.getSystemProfileInfrastructureType());
     }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -535,6 +535,16 @@ public class FactNormalizerTest {
         assertEquals(4, normalized.getCores().longValue());
     }
 
+    @Test
+    void classifyAsVirtualIfSatelliteReportedHypervisorUuidButNotInfrastructureType() {
+        InventoryHostFacts facts = createBaseHost("A1", "O1");
+        facts.setSatelliteHypervisorUuid("SAT_HYPERVISOR");
+        assertFalse(facts.isVirtual());
+        assertNull(facts.getSystemProfileInfrastructureType());
+
+        assertTrue(normalizer.normalize(facts, Collections.emptyMap()).isVirtual());
+    }
+
     private void assertClassification(NormalizedFacts check, boolean isHypervisor,
         boolean isHypervisorUnknown, boolean isVirtual) {
         assertEquals(isHypervisor, check.isHypervisor());


### PR DESCRIPTION
Older versions of satellite will not send the infrastructure type
to inventory, so when a host's facts are normalized, consider the
host as virtual if satellite reported the host's hypervisor UUID.