### PR TITLE
Incorporate opt-in checks into the Spring Security authorization layer

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/OptInChecker.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInChecker.java
@@ -42,10 +42,16 @@ public class OptInChecker {
     }
 
     public boolean checkAccess(Authentication authentication) {
-        InsightsUserPrincipal principal = (InsightsUserPrincipal) authentication.getPrincipal();
+        Object principal = authentication.getPrincipal();
+        if (!InsightsUserPrincipal.class.isAssignableFrom(principal.getClass())) {
+            // Unrecognized principal.  Allow Spring Security to return Access Denied.
+            return false;
+        }
+
+        InsightsUserPrincipal insightsUserPrincipal = (InsightsUserPrincipal) authentication.getPrincipal();
 
         OptInConfig optin = optInController.getOptInConfig(
-            principal.getAccountNumber(), principal.getOwnerId()
+            insightsUserPrincipal.getAccountNumber(), insightsUserPrincipal.getOwnerId()
         );
 
         /* If not opted-in, throw an exception.  Ideally we would just return true/false, but if we return

--- a/src/test/java/org/candlepin/subscriptions/security/OptInCheckerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/OptInCheckerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.subscriptions.controller.OptInController;
+import org.candlepin.subscriptions.exception.OptInRequiredException;
+import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
+import org.candlepin.subscriptions.utilization.api.model.OptInConfigData;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
+class OptInCheckerTest {
+
+    @Autowired OptInChecker checker;
+
+    @MockBean OptInController controller;
+
+    @Test
+    @WithInvalidPrincipal
+    void testBadPrincipal() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertFalse(checker.checkAccess(auth));
+    }
+
+    @Test
+    @WithMockRedHatPrincipal
+    void testNotOptedIn() {
+        OptInConfig config = mock(OptInConfig.class);
+        OptInConfigData configData = mock(OptInConfigData.class);
+
+        when(config.getData()).thenReturn(configData);
+        when(configData.getOptInComplete()).thenReturn(Boolean.FALSE);
+
+        when(controller.getOptInConfig(anyString(), anyString())).thenReturn(config);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThrows(OptInRequiredException.class, () -> checker.checkAccess(auth));
+    }
+
+    @Test
+    @WithMockRedHatPrincipal
+    void testOptedIn() {
+        OptInConfig config = mock(OptInConfig.class);
+        OptInConfigData configData = mock(OptInConfigData.class);
+
+        when(config.getData()).thenReturn(configData);
+        when(configData.getOptInComplete()).thenReturn(Boolean.TRUE);
+
+        when(controller.getOptInConfig(anyString(), anyString())).thenReturn(config);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertTrue(checker.checkAccess(auth));
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/security/WithInvalidPrincipal.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithInvalidPrincipal.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithInvalidPrincipalSecurityContextFactory.class)
+public @interface WithInvalidPrincipal {
+
+}

--- a/src/test/java/org/candlepin/subscriptions/security/WithInvalidPrincipalSecurityContextFactory.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithInvalidPrincipalSecurityContextFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Collections;
+
+public class WithInvalidPrincipalSecurityContextFactory
+    implements WithSecurityContextFactory<WithInvalidPrincipal> {
+    public SecurityContext createSecurityContext(WithInvalidPrincipal annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        // We don't use a User as our principla.  We use a InsightsUserPrincipal, so this principal will
+        // fail the instanceof tests that we use.
+        User principal = new User("bad", "principal", Collections.emptyList());
+
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(),
+            principal.getAuthorities());
+        context.setAuthentication(auth);
+        return context;
+    }
+}


### PR DESCRIPTION
Rather than use a specific filter for the opt-in check, we can use
Spring Security's authorization facilities.  This leads to a cleaner
design and a less confusing architecture.