### PR TITLE
Awood/better logging

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
@@ -20,12 +20,15 @@
  */
 package org.candlepin.subscriptions.exception.mapper;
 
+import static org.candlepin.subscriptions.security.SecurityConfig.*;
+
 import org.candlepin.subscriptions.exception.ExceptionUtil;
 import org.candlepin.subscriptions.utilization.api.model.Error;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.util.StringUtils;
 
 import javax.ws.rs.core.Response;
@@ -46,8 +49,10 @@ public abstract class BaseExceptionMapper<T extends Throwable> implements Except
         String message = StringUtils.hasText(error.getCode()) ?
             String.format("%s: %s", error.getCode(), error.getTitle()) :
             error.getTitle();
-        if (exception instanceof AccessDeniedException) {
-            log.debug(message, exception);
+        Class<?> exClass = exception.getClass();
+        if (AccessDeniedException.class.isAssignableFrom(exClass) ||
+            AuthenticationException.class.isAssignableFrom(exClass)) {
+            log.error(SECURITY_STACKTRACE, message, exception);
         }
         else {
             log.error(message, exception);

--- a/src/main/java/org/candlepin/subscriptions/files/YamlFileSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/YamlFileSource.java
@@ -44,7 +44,7 @@ public abstract class YamlFileSource<T> implements ResourceLoaderAware {
     private ResourceLoader resourceLoader;
     private Resource fileResource;
 
-    public YamlFileSource(String resourceLocation, Clock clock, Duration cacheTtl) {
+    protected YamlFileSource(String resourceLocation, Clock clock, Duration cacheTtl) {
         this.resourceLocation = resourceLocation;
         this.cachedValue = new Cache(clock, cacheTtl);
     }

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
@@ -50,7 +50,7 @@ public abstract class LiquibaseCustomTask implements CustomTaskChange, Closeable
 
     private Map<String, PreparedStatement> preparedStatements;
 
-    public LiquibaseCustomTask() {
+    protected LiquibaseCustomTask() {
         this.logger = getLogger();
         this.preparedStatements = new HashMap<>();
     }

--- a/src/main/java/org/candlepin/subscriptions/security/AntiCsrfFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/AntiCsrfFilter.java
@@ -51,8 +51,7 @@ public class AntiCsrfFilter extends OncePerRequestFilter {
     private final String domainSuffix;
     private final String domainAndPortSuffix;
 
-    AntiCsrfFilter(ApplicationProperties props, ConfigurableEnvironment env) {
-        log.info("Dev mode {}", props.isDevMode());
+    public AntiCsrfFilter(ApplicationProperties props, ConfigurableEnvironment env) {
         disabled = props.isDevMode() || Arrays.asList(env.getActiveProfiles()).contains("capacity-ingress");
         port = props.getAntiCsrfPort();
         domainSuffix = props.getAntiCsrfDomainSuffix();

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFailureHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFailureHandler.java
@@ -21,6 +21,8 @@
 
 package org.candlepin.subscriptions.security;
 
+import static org.candlepin.subscriptions.security.SecurityConfig.*;
+
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExceptionUtil;
 import org.candlepin.subscriptions.utilization.api.model.Error;
@@ -41,7 +43,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 /**
- * Entry point to allow returning a JSON response.
+ * AuthenticationFailureHandler that returns a JSON response.
  */
 public class IdentityHeaderAuthenticationFailureHandler
     implements AuthenticationFailureHandler {
@@ -61,7 +63,7 @@ public class IdentityHeaderAuthenticationFailureHandler
         throws IOException {
 
         Error error = buildError(authException);
-        log.debug(error.getTitle(), authException);
+        log.error(SECURITY_STACKTRACE, "{}: {}", error.getTitle(), error.getDetail(), authException);
 
         Response r = ExceptionUtil.toResponse(error);
         servletResponse.setContentType(r.getMediaType().toString());

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -21,6 +21,8 @@
 
 package org.candlepin.subscriptions.security;
 
+import static org.candlepin.subscriptions.security.SecurityConfig.*;
+
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 
@@ -68,8 +70,8 @@ public class IdentityHeaderAuthenticationFilter extends AbstractPreAuthenticated
             return createPrincipal(Base64.getDecoder().decode(identityHeader));
         }
         catch (Exception e) {
-            log.error(RH_IDENTITY_HEADER + " was not valid.", e);
-            // Initialize an empty principal. The IdentityHeaderAuthenticationManager will validate it.
+            log.error(SECURITY_STACKTRACE, RH_IDENTITY_HEADER + " was not valid.", e);
+            // Initialize an empty principal. The IdentityHeaderAuthenticationProvider will validate it.
             return new InsightsUserPrincipal();
         }
 

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProvider.java
@@ -40,12 +40,7 @@ import org.springframework.util.Assert;
  * authenticate method will build a new Authentication object that is marked as being successfully
  * authenticated ("blessed") and with the granted authorities from the Authentication.
  *
- * Heavily inspired by {@link PreAuthenticatedAuthenticationProvider}.  The major difference is that we
- * don't call out to a UserDetailsService.  The Authentication object carries a principal, credentials,
- * and details field all of type Object.  The UserDetailsService is meant to take the Authentication and
- * sensibly convert all those Object fields into typed fields (String, String, and
- * Collection<GrantedAuthorities> respectively by default).  We don't need to do that.  The principal and
- * details already in the unblessed Authentication.
+ * Heavily inspired by {@link PreAuthenticatedAuthenticationProvider}.
  */
 public class IdentityHeaderAuthenticationProvider implements AuthenticationProvider, Ordered {
     private static final Logger log = LoggerFactory.getLogger(IdentityHeaderAuthenticationProvider.class);
@@ -104,7 +99,7 @@ public class IdentityHeaderAuthenticationProvider implements AuthenticationProvi
         }
         catch (IllegalArgumentException e) {
             throw new PreAuthenticatedCredentialsNotFoundException(
-                RH_IDENTITY_HEADER + " is missing " + "required data", e);
+                RH_IDENTITY_HEADER + " is missing required data", e);
         }
     }
 

--- a/src/main/java/org/candlepin/subscriptions/security/MdcFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/MdcFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Filter to add user authentication information to the logback Mapped Diagnostic Context (MDC)
+ */
+public class MdcFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            MDC.put("user", authentication.getName());
+        }
+        try {
+            filterChain.doFilter(request, response);
+        }
+        finally {
+            // The MDC is stored on a ThreadLocal so we need to clear it at the end of a request since
+            // Tomcat reuses threads.
+            if (authentication != null) {
+                MDC.remove("user");
+            }
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
@@ -21,9 +21,12 @@
 
 package org.candlepin.subscriptions.security;
 
+import static org.candlepin.subscriptions.security.SecurityConfig.*;
+
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExceptionUtil;
 import org.candlepin.subscriptions.exception.OptInRequiredException;
+import org.candlepin.subscriptions.exception.mapper.AccessDeniedExceptionMapper;
 import org.candlepin.subscriptions.utilization.api.model.Error;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -59,7 +62,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
         AccessDeniedException accessDeniedException) throws IOException, ServletException {
 
         Error error = RestAccessDeniedHandler.buildError(accessDeniedException);
-        log.error(error.getTitle(), accessDeniedException);
+        log.error(SECURITY_STACKTRACE, "{}: {}", error.getTitle(), error.getDetail(), accessDeniedException);
 
         Response r = ExceptionUtil.toResponse(error);
         servletResponse.setContentType(r.getMediaType().toString());
@@ -70,6 +73,12 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
         out.flush();
     }
 
+    /**
+     * Static method to construct an Error object.  We actually use this method in the
+     * {@link AccessDeniedExceptionMapper} class as well.
+     * @param exception an AccessDeniedException to build an Error from.
+     * @return a populated Error object.
+     */
     public static Error buildError(AccessDeniedException exception) {
         if (exception instanceof OptInRequiredException) {
             return ((OptInRequiredException) exception).getError();

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -27,6 +27,8 @@ import org.candlepin.subscriptions.rbac.RbacService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -44,7 +46,6 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
-import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.csrf.CsrfFilter;
 
 import java.util.Arrays;
@@ -55,6 +56,7 @@ import java.util.Arrays;
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
+    public static final Marker SECURITY_STACKTRACE = MarkerFactory.getMarker("SECURITY_STACKTRACE");
 
     protected SecurityConfig() {
         // Container class only
@@ -109,7 +111,6 @@ public class SecurityConfig {
         @Bean
         public AuthenticationProvider identityHeaderAuthenticationProvider(
             IdentityHeaderAuthenticationDetailsService detailsService) {
-
             return new IdentityHeaderAuthenticationProvider(detailsService);
         }
 
@@ -120,7 +121,6 @@ public class SecurityConfig {
 
         // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application filter
         public IdentityHeaderAuthenticationFilter identityHeaderAuthenticationFilter() throws Exception {
-
             IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
             filter.setCheckForPrincipalChanges(true);
             filter.setAuthenticationManager(authenticationManager());

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -57,7 +57,7 @@ public abstract class BaseSnapshotRoller {
     protected  TallySnapshotRepository tallyRepo;
     protected ApplicationClock clock;
 
-    public BaseSnapshotRoller(TallySnapshotRepository tallyRepo, ApplicationClock clock) {
+    protected BaseSnapshotRoller(TallySnapshotRepository tallyRepo, ApplicationClock clock) {
         this.tallyRepo = tallyRepo;
         this.clock = clock;
     }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <contextName>rhsm-subscriptions</contextName>
     <appender name="ConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{ISO8601} [thread=%thread] [%X{requestType}=%X{requestUuid}, org=%X{org}, csid=%X{csid}] %-5p %c - %m%n</pattern>
+            <pattern>%d{ISO8601} [thread=%thread] [%-5p] [%c] %X{user}- %m%n</pattern>
         </encoder>
     </appender>
 
@@ -16,7 +16,7 @@
         <totalSizeCap>100MB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'} [thread=%t] [level=%p] [category=%c] %m%n</pattern>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'} [thread=%t] [level=%p] [category=%c] %X{user} - %m%n</pattern>
         </encoder>
     </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -22,7 +22,7 @@
         <totalSizeCap>100MB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'} [thread=%t] [level=%p] [category=%c] %X{user} - %m%n%ex{full, SECURITY_STACKTRACE_EVAL}  </pattern>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'} [thread=%t] [level=%p] [category=%c] %X{user} - %m%n%ex{full, SECURITY_STACKTRACE_EVAL}</pattern>
         </encoder>
     </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <contextName>rhsm-subscriptions</contextName>
+    <evaluator name="SECURITY_STACKTRACE_EVAL" class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+        <marker>SECURITY_STACKTRACE</marker>
+    </evaluator>
+
     <appender name="ConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{ISO8601} [thread=%thread] [%-5p] [%c] %X{user}- %m%n</pattern>
+            <!-- %ex{full, SECURITY_STACKTRACE_EVAL} will display the full stack trace of the exception only
+             if the evaluator called SECURITY_STACKTRACE_EVAL returns false. -->
+            <pattern>%d{ISO8601} [thread=%thread] [%-5p] [%c] %X{user}- %m%n%ex{full, SECURITY_STACKTRACE_EVAL}</pattern>
         </encoder>
     </appender>
 
@@ -16,7 +22,7 @@
         <totalSizeCap>100MB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'} [thread=%t] [level=%p] [category=%c] %X{user} - %m%n</pattern>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'} [thread=%t] [level=%p] [category=%c] %X{user} - %m%n%ex{full, SECURITY_STACKTRACE_EVAL}  </pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
* Suppress Spring Security stacktraces.  The card for the task mentions suppressing stacktraces for validation errors, but I didn't actually see any significant uses of the `@Validated` annotation.  If I'm overlooking a spot, please let me know.

* Add in a filter that places the principal in the logback Mapped Diagnostic Context (MDC) so that we can associate log messages with the user who triggered them.

* Modify log message format somewhat.  Remove some MDC references that we don't even have (likely a copy-paste error from the Candlepin logback.xml) and tidy up for format some.

## Testing
`curl -H "x-rh-identity: $(echo -n '{"identity":{"account_number":"account12345","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' 
| base64 -w 0)" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/RHEL?usage=Production&limit=1"`

That account is not opted-in, so an AccessDeniedException gets thrown.  With this commit, the error message appears, but there should be no accompanying stacktrace in the console log.

You can run some other tests as well.  For example, if you munge the JSON of the curl command to create invalid JSON, you'll see the error message from `org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFailureHandler` has the stacktrace suppressed.  Oddly, you will still see a stacktrace emanating from `org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/].[org.candlepin.subscriptions.JaxrsApplication]` but that's not something we have control over I don't think.  Personally, I think malformed JSON in the headers is rare enough that we should sweat it too much.