### PR TITLE
Always sort hosts by ID initially

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -80,14 +80,16 @@ public class HostsResource implements HostsApi {
     public HostReport getHosts(String productId, Integer offset, Integer limit, String sla,
         String usage, Uom uom, HostReportSort sort, SortDirection dir) {
 
-        Sort sortValue = Sort.unsorted();
         Sort.Direction dirValue = Sort.Direction.ASC;
-
         if (dir == SortDirection.DESC) {
             dirValue = Sort.Direction.DESC;
         }
+        Sort.Order implicitOrder = Sort.Order.by("id");
+        Sort sortValue = Sort.by(implicitOrder);
+
         if (sort != null) {
-            sortValue = Sort.by(dirValue, SORT_PARAM_MAPPING.get(sort));
+            Sort.Order userDefinedOrder = new Sort.Order(dirValue, SORT_PARAM_MAPPING.get(sort));
+            sortValue = Sort.by(userDefinedOrder, implicitOrder);
         }
 
         int minCores = 0;

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -296,6 +296,17 @@ class HostRepositoryTest {
 
     @Transactional
     @Test
+    void testCanSortByIdForImplicitSort() {
+        Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC, "id"));
+        List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
+
+        assertEquals(1, found.size());
+        assertTallyHostView(found.get(0), "inventory3");
+    }
+
+    @Transactional
+    @Test
     void testCanSortByDisplayName() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
             Usage.PRODUCTION, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -63,6 +63,8 @@ class HostsResourceTest {
     @Autowired
     HostsResource resource;
 
+    static final Sort.Order IMPLICIT_ORDER = new Sort.Order(Sort.Direction.ASC, "id");
+
     @BeforeEach
     public void setup() throws AccountListSourceException {
         PageImpl<TallyHostView> mockPage = new PageImpl<>(Collections.emptyList());
@@ -82,8 +84,9 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
-            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)))
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
+            IMPLICIT_ORDER)))
         );
     }
 
@@ -98,8 +101,9 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
-            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)))
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)),
+            IMPLICIT_ORDER)))
         );
     }
 
@@ -114,8 +118,9 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
-            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)))
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)),
+            IMPLICIT_ORDER)))
         );
     }
 
@@ -130,8 +135,9 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
-            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)))
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)),
+            IMPLICIT_ORDER)))
         );
     }
 
@@ -146,13 +152,14 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
-            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)))
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)),
+            IMPLICIT_ORDER)))
         );
     }
 
     @Test
-    void testShouldDefaultToUnsorted() {
+    void testShouldDefaultToImplicitOrder() {
         resource.getHosts("RHEL", 0, 1, null, null, null, null, null);
 
         verify(repository, only()).getTallyHostViews(
@@ -162,7 +169,7 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1))
+            eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
         );
     }
 
@@ -177,8 +184,9 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1, Sort.Direction.ASC,
-            HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)))
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
+            IMPLICIT_ORDER)))
         );
     }
 
@@ -192,7 +200,7 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(1),
             eq(0),
-            eq(PageRequest.of(0, 1))
+            eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
         );
     }
 
@@ -206,7 +214,7 @@ class HostsResourceTest {
             eq(Usage.ANY),
             eq(0),
             eq(1),
-            eq(PageRequest.of(0, 1))
+            eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
         );
     }
 }


### PR DESCRIPTION
That way, there is always a consistent ordering from the API. Without this change, the DB is free to (and has according to ENT-3168), return hosts in a non-deterministic, and unfortunately, inconsistent order which order which causes issues with the table display.