### PR TITLE
Update copyrights

### DIFF
--- a/config/checkstyle/HEADER.txt
+++ b/config/checkstyle/HEADER.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -63,7 +63,7 @@
      ##########################################################################
    -->
   <module name="RegexpHeader">
-    <property name="header" value="^/\*$\n^ \* Copyright \(c\) 20\d\d - 20\d\d Red Hat, Inc.$"/>
+    <property name="header" value="^/\*$\n^ \* Copyright \(c\) 20\d\d( - 20\d\d)? Red Hat, Inc.$"/>
   </module>
   <module name="Header">
     <property name="headerFile" value="${config_loc}/HEADER.txt" />

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/BootApplication.java
+++ b/src/main/java/org/candlepin/subscriptions/BootApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/BootApplication.java
+++ b/src/main/java/org/candlepin/subscriptions/BootApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/JaxrsApplication.java
+++ b/src/main/java/org/candlepin/subscriptions/JaxrsApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/JaxrsApplication.java
+++ b/src/main/java/org/candlepin/subscriptions/JaxrsApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/JaxrsApplicationServletInitializer.java
+++ b/src/main/java/org/candlepin/subscriptions/JaxrsApplicationServletInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/JaxrsApplicationServletInitializer.java
+++ b/src/main/java/org/candlepin/subscriptions/JaxrsApplicationServletInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/ProfileSettingRunListener.java
+++ b/src/main/java/org/candlepin/subscriptions/ProfileSettingRunListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityProductExtractor.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityProductExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityProductExtractor.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityProductExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/cloudigrade/CloudigradeService.java
+++ b/src/main/java/org/candlepin/subscriptions/cloudigrade/CloudigradeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/cloudigrade/ConcurrentApiFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/cloudigrade/ConcurrentApiFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/cloudigrade/StubConcurrentApi.java
+++ b/src/main/java/org/candlepin/subscriptions/cloudigrade/StubConcurrentApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/OpenApiSpecController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/OpenApiSpecController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/OpenApiSpecController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/OpenApiSpecController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/OptInController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/OptInController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/PoolIngressController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/PoolIngressController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/PoolIngressController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/PoolIngressController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/TallyRetentionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/TallyRetentionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/controller/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/controller/TallySnapshotController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepositoryImpl.java
+++ b/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/PostgresTlsDataSourceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/db/PostgresTlsDataSourceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/PostgresTlsHikariDataSourceFactoryBean.java
+++ b/src/main/java/org/candlepin/subscriptions/db/PostgresTlsHikariDataSourceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/Granularity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Granularity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/Granularity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Granularity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostBucketKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostBucketKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostBucketKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostBucketKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostHardwareType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostHardwareType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallyHostView.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallyHostView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/BaseConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/BaseConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/BaseConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/BaseConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/ExceptionUtil.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ExceptionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/ExceptionUtil.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ExceptionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/ExternalServiceException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ExternalServiceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/ExternalServiceException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ExternalServiceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/JobFailureException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/JobFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/JobFailureException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/JobFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/NotReadyException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/NotReadyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/NotReadyException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/NotReadyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/OptInRequiredException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/OptInRequiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/OptInRequiredException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/OptInRequiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/SnapshotProducerException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/SnapshotProducerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/SnapshotProducerException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/SnapshotProducerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/SubscriptionsException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/SubscriptionsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/SubscriptionsException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/SubscriptionsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceRequestException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceRequestException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceUnavailableException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceUnavailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceUnavailableException.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/inventory/InventoryServiceUnavailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/AccessDeniedExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/AccessDeniedExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/AccessDeniedExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/AccessDeniedExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/BadRequestExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/BadRequestExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/ConstraintViolationExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/ConstraintViolationExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/DefaultExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/DefaultExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/DefaultExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/DefaultExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/NotReadyExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/NotReadyExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/NotReadyExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/NotReadyExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/SubscriptionsExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/SubscriptionsExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/SubscriptionsExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/SubscriptionsExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/WebApplicationExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/WebApplicationExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/WebApplicationExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/WebApplicationExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/ArchToProductMapSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ArchToProductMapSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/Cache.java
+++ b/src/main/java/org/candlepin/subscriptions/files/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/Cache.java
+++ b/src/main/java/org/candlepin/subscriptions/files/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/FileAccountListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/FileAccountSyncListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/FileAccountSyncListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/FileAccountSyncListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/FileAccountSyncListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/PerLineFileSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/PerLineFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/PerLineFileSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/PerLineFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductWhitelist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/ReportingAccountWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ReportingAccountWhitelist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/ReportingAccountWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ReportingAccountWhitelist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/RoleToProductsMapSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/RoleToProductsMapSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/RoleToProductsMapSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/RoleToProductsMapSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/YamlFileSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/YamlFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/YamlFileSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/YamlFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/files/YamlFileSource.java
+++ b/src/main/java/org/candlepin/subscriptions/files/YamlFileSource.java
@@ -44,7 +44,7 @@ public abstract class YamlFileSource<T> implements ResourceLoaderAware {
     private ResourceLoader resourceLoader;
     private Resource fileResource;
 
-    public YamlFileSource(String resourceLocation, Clock clock, Duration cacheTtl) {
+    protected YamlFileSource(String resourceLocation, Clock clock, Duration cacheTtl) {
         this.resourceLocation = resourceLocation;
         this.cachedValue = new Cache(clock, cacheTtl);
     }

--- a/src/main/java/org/candlepin/subscriptions/filter/ContentNegotiationRequestFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/filter/ContentNegotiationRequestFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/filter/ContentNegotiationRequestFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/filter/ContentNegotiationRequestFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/http/HttpClient.java
+++ b/src/main/java/org/candlepin/subscriptions/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/http/HttpClientProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/http/HttpClientProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDataSourceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDataSourceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolver.java
+++ b/src/main/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolver.java
+++ b/src/main/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jobs/CaptureSnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/CaptureSnapshotsJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jobs/CaptureSnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/CaptureSnapshotsJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jobs/PurgeSnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/PurgeSnapshotsJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/jobs/PurgeSnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/PurgeSnapshotsJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/liquibase/ConfigUpdateException.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/ConfigUpdateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
@@ -50,7 +50,7 @@ public abstract class LiquibaseCustomTask implements CustomTaskChange, Closeable
 
     private Map<String, PreparedStatement> preparedStatements;
 
-    public LiquibaseCustomTask() {
+    protected LiquibaseCustomTask() {
         this.logger = getLogger();
         this.preparedStatements = new HashMap<>();
     }

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LoadConfigsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LoadConfigsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/metrics/MicrometerUriHackFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/metrics/MicrometerUriHackFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/metrics/MicrometerUriHackFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/metrics/MicrometerUriHackFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApi.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApi.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiClient.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiClient.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiException.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiException.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiImpl.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiImpl.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacService.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacService.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/StubRbacApi.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/StubRbacApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/rbac/StubRbacApi.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/StubRbacApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/IngressResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/OpenApiJsonResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OpenApiJsonResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/OpenApiJsonResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OpenApiJsonResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/OpenApiYamlResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OpenApiYamlResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/OpenApiYamlResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OpenApiYamlResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/VersionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/VersionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resource/VersionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/VersionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resteasy/EnumParamConverterProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/EnumParamConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resteasy/OffsetDateTimeParamConverterProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/OffsetDateTimeParamConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resteasy/OffsetDateTimeParamConverterProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/OffsetDateTimeParamConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resteasy/PageLinkCreator.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/PageLinkCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/resteasy/PageLinkCreator.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/PageLinkCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/AntiCsrfFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/AntiCsrfFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/GetVerbIncludingAntiCsrfFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/GetVerbIncludingAntiCsrfFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFailureHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFailureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFailureHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFailureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthoritiesMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthoritiesMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthoritiesMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthoritiesMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/OptInFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/OptInFilter.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RestAuthenticationEntryPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RestAuthenticationEntryPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/RhAssociatePrincipal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RhAssociatePrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/RhIdentity.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RhIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/WhitelistedAccountReportAccessService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/X509Principal.java
+++ b/src/main/java/org/candlepin/subscriptions/security/X509Principal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequired.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequired.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequired.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequired.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/spring/JobCompleteEvent.java
+++ b/src/main/java/org/candlepin/subscriptions/spring/JobCompleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/spring/JobCompleteShutdownListener.java
+++ b/src/main/java/org/candlepin/subscriptions/spring/JobCompleteShutdownListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/spring/QueueProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/spring/QueueProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountListSourceException.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountListSourceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountListSourceException.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountListSourceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/DatabaseAccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/DatabaseAccountListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/DatabaseAccountListSource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/DatabaseAccountListSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/UsageSnapshotProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollectorFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollectorFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactSetNamespace.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactSetNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactSetNamespace.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactSetNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -57,7 +57,7 @@ public abstract class BaseSnapshotRoller {
     protected  TallySnapshotRepository tallyRepo;
     protected ApplicationClock clock;
 
-    public BaseSnapshotRoller(TallySnapshotRepository tallyRepo, ApplicationClock clock) {
+    protected BaseSnapshotRoller(TallySnapshotRepository tallyRepo, ApplicationClock clock) {
         this.tallyRepo = tallyRepo;
         this.clock = clock;
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/Task.java
+++ b/src/main/java/org/candlepin/subscriptions/task/Task.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/Task.java
+++ b/src/main/java/org/candlepin/subscriptions/task/Task.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskDescriptor.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskDescriptor.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskExecutionException.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskExecutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskExecutionException.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskExecutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskManagerException.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskManagerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskManagerException.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskManagerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskQueueConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskQueueConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskType.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskType.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/TaskWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/task/TaskWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/TaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/TaskQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/TaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/TaskQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializer.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializer.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializer.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializer.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaApplicationListener.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaApplicationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaApplicationListener.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaApplicationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProcessor.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProcessor.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueue.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/DailyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/DailyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/DailyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/DailyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/LiquibaseUpdateOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/util/LiquibaseUpdateOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/MonthlyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/MonthlyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/MonthlyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/MonthlyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/QuarterlyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/QuarterlyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/QuarterlyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/QuarterlyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/SnapshotTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/SnapshotTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/SnapshotTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/SnapshotTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/WeeklyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/WeeklyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/WeeklyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/WeeklyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/YearlyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/YearlyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/util/YearlyTimeAdjuster.java
+++ b/src/main/java/org/candlepin/subscriptions/util/YearlyTimeAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/validator/VerificationMode.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/VerificationMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/validator/VerificationModeValidator.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/VerificationModeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/FixedClockConfiguration.java
+++ b/src/test/java/org/candlepin/subscriptions/FixedClockConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/FixedClockConfiguration.java
+++ b/src/test/java/org/candlepin/subscriptions/FixedClockConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/cloudigrade/CloudigradeServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/cloudigrade/CloudigradeServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/OpenApiSpecControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/OpenApiSpecControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/OpenApiSpecControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/OpenApiSpecControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/OptInControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/OptInControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/OptInControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/OptInControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/PoolIngressControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/TallyRetentionControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/TallyRetentionControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/TallyRetentionControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/TallyRetentionControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/controller/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/controller/TallySnapshotControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/model/HardwareMeasurementTypeTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HardwareMeasurementTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/model/HardwareMeasurementTypeTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HardwareMeasurementTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/model/ServiceLevelTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/ServiceLevelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/model/ServiceLevelTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/ServiceLevelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/model/UsageTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/UsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/db/model/UsageTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/UsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/CacheTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/CacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/CacheTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/CacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/FileAccountSyncListSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/FileAccountSyncListSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/FileAccountSyncListSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/FileAccountSyncListSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/PerLineFileResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/PerLineFileResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/PerLineFileResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/PerLineFileResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductIdToProductsMapSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/filter/ContentNegotiationRequestFilterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/filter/ContentNegotiationRequestFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/filter/ContentNegotiationRequestFilterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/filter/ContentNegotiationRequestFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolverTest.java
+++ b/src/test/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolverTest.java
+++ b/src/test/java/org/candlepin/subscriptions/jackson/ObjectMapperContextResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/jackson/TestPojo.java
+++ b/src/test/java/org/candlepin/subscriptions/jackson/TestPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/jackson/TestPojo.java
+++ b/src/test/java/org/candlepin/subscriptions/jackson/TestPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resteasy/PageLinkCreatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/PageLinkCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/resteasy/PageLinkCreatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/PageLinkCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockInsightsUserSecurityContextFactory.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockInsightsUserSecurityContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockInsightsUserSecurityContextFactory.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockInsightsUserSecurityContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
+++ b/src/test/java/org/candlepin/subscriptions/security/WithMockRedHatPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequiredTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequiredTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnlyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/Assertions.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/Assertions.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/TestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/TestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/NormalizedFactsTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/NormalizedFactsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/NormalizedFactsTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/NormalizedFactsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/Assertions.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/Assertions.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/TaskDescriptorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/TaskDescriptorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/TaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/TaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueueTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueueTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/ExecutorTaskQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroMessageSerializationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroMessageSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroMessageSerializationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroMessageSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTester.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTester.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTaskTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTaskTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/tasks/UpdateAccountSnapshotsTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/util/SnapshotTimeAdjusterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/SnapshotTimeAdjusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/util/SnapshotTimeAdjusterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/SnapshotTimeAdjusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/util/TestClock.java
+++ b/src/test/java/org/candlepin/subscriptions/util/TestClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/test/java/org/candlepin/subscriptions/util/TestClock.java
+++ b/src/test/java/org/candlepin/subscriptions/util/TestClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
1. Update notices to beginning in 2019 rather than 2009.
2. Update the copyright regex to allow just "2020", as this is a more accurate way to begin a new class file.

Prior we were using the header copyright range we were using from Candlepin. However, that's inaccurate, so this fixes those year ranges.