### PR TITLE
Fixup openapi spec path to be more useful

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -5,11 +5,25 @@ info:
   version: 1.0.0
 
 servers:
-  - url: http://localhost:8080/api/rhsm-subscriptions/v1
-  - url: https://ci.cloud.redhat.com/api/rhsm-subscriptions/v1
-  - url: https://qa.cloud.redhat.com/api/rhsm-subscriptions/v1
-  - url: https://stage.cloud.redhat.com/api/rhsm-subscriptions/v1
-  - url: https://cloud.redhat.com/api/rhsm-subscriptions/v1
+  - url: /{PATH_PREFIX}/{APP_NAME}/v1
+    variables:
+      PATH_PREFIX:
+        default: api
+      APP_NAME:
+        default: rhsm-subscriptions
+  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}/v1
+    variables:
+      HOSTNAME:
+        enum:
+          - ci.cloud.redhat.com
+          - qa.cloud.redhat.com
+          - stage.cloud.redhat.com
+          - cloud.redhat.com
+        default: ci.cloud.redhat.com
+      PATH_PREFIX:
+        default: api
+      APP_NAME:
+        default: rhsm-subscriptions
 
 paths:
   /version:
@@ -524,7 +538,7 @@ paths:
         - hosts
   /ingress/candlepin_pools/{org_id}:
     description: "Integration endpoint for updating an account's subscription capacity from
-      Candlepin pool data."
+      Candlepin pool data. (Internal-only API)"
     parameters:
       - name: org_id
         in: path
@@ -533,7 +547,7 @@ paths:
           type: string
         description: "The org ID of the pool data"
     post:
-      summary: "Update an account's subscription capacity from Candlepin pool data."
+      summary: "Update an account's subscription capacity from Candlepin pool data. (Internal-only API)"
       operationId: updateCapacityFromCandlepinPools
       requestBody:
         required: true


### PR DESCRIPTION
This makes it so that if you're serving on a non-standard port swagger-ui will still function.

Also went ahead and noted that the ingress APIs are not user-facing.