### PR TITLE
podman-compose: Advertise kafka on 9092

### DIFF
--- a/container-compose.yml
+++ b/container-compose.yml
@@ -19,12 +19,13 @@ services:
   kafka:
     image: docker.io/confluentinc/cp-kafka
     ports:
+      - "9092:9092"
       - "29092:29092"
     depends_on:
       - zookeeper
     environment:
       - KAFKA_LISTENERS=INTERNAL://kafka:9092,EXTERNAL://kafka:29092
-      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka:9092,EXTERNAL://localhost:29092
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://localhost:9092,EXTERNAL://localhost:29092
       - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
       - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
       - KAFKA_BROKER_ID=1


### PR DESCRIPTION
This makes it so that the default configs can reach kafka.

Might need to remove and recreate the pod (easiest via `podman-compose
down; podman-compose up -d`)