### PR TITLE
Reintroduce HYPERVISOR measurement type

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
@@ -29,6 +29,7 @@ import java.util.List;
  */
 public enum HardwareMeasurementType {
     PHYSICAL,
+    HYPERVISOR,
     VIRTUAL,
     TOTAL,
     AWS, // AWS measured by HBI data

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -177,11 +177,27 @@ public class TallySnapshot implements Serializable {
             snapshot.setPhysicalInstanceCount(physical.getInstanceCount());
         }
 
-        HardwareMeasurement hypervisor = this.hardwareMeasurements.get(HardwareMeasurementType.VIRTUAL);
+        HardwareMeasurement virtual = this.hardwareMeasurements.get(HardwareMeasurementType.VIRTUAL);
+        HardwareMeasurement hypervisor = this.hardwareMeasurements.get(HardwareMeasurementType.HYPERVISOR);
+
+        // Sum "HYPERVISOR" and "VIRTUAL" records in the short term
+        int totalVirtualCores = 0;
+        int totalVirtualSockets = 0;
+        int totalVirtualInstanceCount = 0;
+        if (virtual != null) {
+            totalVirtualCores += virtual.getCores();
+            totalVirtualSockets += virtual.getSockets();
+            totalVirtualInstanceCount += virtual.getSockets();
+        }
         if (hypervisor != null) {
-            snapshot.setHypervisorCores(hypervisor.getCores());
-            snapshot.setHypervisorSockets(hypervisor.getSockets());
-            snapshot.setHypervisorInstanceCount(hypervisor.getInstanceCount());
+            totalVirtualCores += hypervisor.getCores();
+            totalVirtualSockets += hypervisor.getSockets();
+            totalVirtualInstanceCount += hypervisor.getSockets();
+        }
+        if (hypervisor != null || virtual != null) {
+            snapshot.setHypervisorCores(totalVirtualCores);
+            snapshot.setHypervisorSockets(totalVirtualSockets);
+            snapshot.setHypervisorInstanceCount(totalVirtualInstanceCount);
         }
 
         // Tally up all the cloud providers that we support. We count/store them separately in the DB

--- a/src/main/resources/liquibase/202011090921-re-add-hypervisor-type.xml
+++ b/src/main/resources/liquibase/202011090921-re-add-hypervisor-type.xml
@@ -1,20 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet id="202010291320-1" author="awood">
-        <comment>Rename "hypervisor" measurement type to "virtual".</comment>
-        <update tableName="hardware_measurements">
-            <column name="measurement_type" value="VIRTUAL"/>
-            <where>measurement_type='HYPERVISOR'</where>
-        </update>
-    </changeSet>
-
-    <changeSet id="202010291320-2" author="awood" dbms="postgresql">
+    <changeSet id="202011090921-1" author="khowell" dbms="postgresql">
         <createProcedure>
             CREATE OR REPLACE FUNCTION copy_measurement() RETURNS trigger AS $$
             BEGIN
@@ -36,7 +28,7 @@
                         hypervisor_instance_count = NEW.instance_count,
                         hypervisor_sockets = NEW.sockets
                     WHERE id = NEW.snapshot_id;
-                ELSIF (not NEW.measurement_type = ANY('{AWS,GOOGLE,AZURE,ALIBABA}'::text[])) THEN
+                ELSIF (not NEW.measurement_type = ANY('{HYPERVISOR,AWS,GOOGLE,AZURE,ALIBABA,AWS_CLOUDIGRADE}'::text[])) THEN
                     RAISE EXCEPTION 'Unknown measurement_type %', NEW.measurement_type;
                 END IF;
 
@@ -44,6 +36,8 @@
             END;
             $$ LANGUAGE plpgsql;
         </createProcedure>
+
     </changeSet>
+
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -31,5 +31,6 @@
     <include file="liquibase/202008250927-add-cloudigrade-type.xml" />
     <include file="liquibase/202009211317-add-additional-host-fields.xml" />
     <include file="liquibase/202010080931-fix-capacity-unspecified.xml" />
+    <include file="liquibase/202011090921-re-add-hypervisor-type.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -369,6 +369,25 @@ public class TallyResourceTest {
     }
 
     @Test
+    void testShouldAddHypervisorAndVirtual() {
+        TallySnapshot snapshot = new TallySnapshot();
+        HardwareMeasurement hypervisorMeasurement = new HardwareMeasurement();
+        hypervisorMeasurement.setSockets(3);
+        hypervisorMeasurement.setInstanceCount(3);
+        HardwareMeasurement virtualMeasurement = new HardwareMeasurement();
+        virtualMeasurement.setSockets(7);
+        virtualMeasurement.setInstanceCount(7);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.HYPERVISOR, hypervisorMeasurement);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.VIRTUAL, virtualMeasurement);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
+            .asApiSnapshot();
+
+        assertEquals(10, apiSnapshot.getHypervisorInstanceCount().intValue());
+        assertEquals(10, apiSnapshot.getHypervisorSockets().intValue());
+    }
+
+    @Test
     public void testShouldThrowExceptionOnBadOffset() throws IOException {
         SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource.getTallyReport(
             "product1",


### PR DESCRIPTION
I found that we didn't include 202010291320-rename-measurement-type.xml
in changelog.xml in #208, doh!

This caused attempts to tally or retrieve tallies to fail due to
unexpected values.

However, given that we plan to start differentiating HYPERVISOR and
VIRTUAL, it no longer makes sense to just remove the value.

So instead this PR re-adds the type, and simply maps either HYPERVISOR
or VIRTUAL to the `hypervisor_sockets` or `hypervisor_cores`, etc.
values in the API for tally.

This also ensures that both HYPERVISOR and VIRTUAL are tolerated for
inserts into hardware measurements by updating the trigger

To test, use the following SQL to insert a snapshot into the DB that has
the HYPERVISOR and VIRTUAL enum values (observe that you cannot insert
VIRTUAL, until liquibase runs):

```
insert into tally_snapshots(id, product_id, account_number, granularity, owner_id, instance_count, cores, snapshot_date, sockets, physical_cores, physical_sockets, physical_instance_count, hypervisor_cores, hypervisor_sockets, hypervisor_instance_count, unit_of_measure, sla) values ( '78add7e0-74df-4908-aef6-fdc23f5f7690', 'RHEL', 'account123', 'DAILY', 'org123', 10, 10, '2020-11-09T01:01:01', 10, 0, 0, 0, 3, 3, 3, '_ANY', '_ANY');
insert into hardware_measurements(snapshot_id, measurement_type, cores, instance_count, sockets) values ('78add7e0-74df-4908-aef6-fdc23f5f7690', 'HYPERVISOR', 7, 7, 7);
insert into hardware_measurements(snapshot_id, measurement_type, cores, instance_count, sockets) values ('78add7e0-74df-4908-aef6-fdc23f5f7690', 'VIRTUAL', 3, 3, 3);
```

Call that fails without this change (but succeeds with it):

```
curl -X GET "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=DAILY&beginning=2020-11-08T17%3A32%3A28Z&ending=2020-11-10T17%3A32%3A28Z" -H  "accept: application/vnd.api+json" -H  "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
```