### PR TITLE
Do not log stack trace on warning for unknown role

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
@@ -103,7 +103,8 @@ public class CloudigradeAccountUsageCollector {
                     calculation.addCloudigrade(HardwareMeasurementType.AWS_CLOUDIGRADE, count);
                 }
                 catch (IllegalArgumentException e) {
-                    log.warn("Skipping cloudigrade usage: {}", usageCount, e);
+                    log.warn("Skipping cloudigrade usage due to: {}", e.toString());
+                    log.debug("Usage record: {}", usageCount);
                 }
             }
         });


### PR DESCRIPTION
To test, run org.candlepin.subscriptions.tally.CloudigradeAccountUsageCollectorTest in IDEA and observe the logging output.