### PR TITLE
Add flags for cloudigrade to API snapshots

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -883,6 +883,16 @@ components:
           default: 0
         has_data:
           type: boolean
+        has_cloudigrade_data:
+          description: "Indicates whether this tally report was enriched with data from Cloudigrade."
+          type: boolean
+          default: false
+        has_cloudigrade_mismatch:
+          description: "Indicates whether this tally report appears to have a mismatch in reporting
+            between Cloudigrade and other data sources. This may or may not indicate an issue with data
+            data sources."
+          type: boolean
+          default: false
     CapacityReport:
       properties:
         data:

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -207,9 +207,12 @@ public class TallySnapshot implements Serializable {
         Integer cloudSockets = 0;
         HardwareMeasurement cloudigradeMeasurement =
             this.hardwareMeasurements.get(HardwareMeasurementType.AWS_CLOUDIGRADE);
+        snapshot.setHasCloudigradeData(cloudigradeMeasurement != null);
         for (HardwareMeasurementType type : HardwareMeasurementType.getCloudProviderTypes()) {
             HardwareMeasurement measurement = this.hardwareMeasurements.get(type);
             if (cloudigradeMeasurement != null && type == HardwareMeasurementType.AWS) {
+                snapshot.setHasCloudigradeMismatch(
+                    cloudigradeMeasurement.getInstanceCount() != measurement.getInstanceCount());
                 // if cloudigrade data exists, then HBI-derived AWS data is ignored
                 continue;
             }

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -366,6 +366,46 @@ public class TallyResourceTest {
 
         assertEquals(7, apiSnapshot.getCloudInstanceCount().intValue());
         assertEquals(7, apiSnapshot.getCloudSockets().intValue());
+        assertTrue(apiSnapshot.getHasCloudigradeData());
+        assertTrue(apiSnapshot.getHasCloudigradeMismatch());
+    }
+
+    @Test
+    void testShouldNotFlagCloudigradeDataIfNotPresent() {
+        TallySnapshot snapshot = new TallySnapshot();
+        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
+        hbiMeasurement.setSockets(3);
+        hbiMeasurement.setInstanceCount(3);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, hbiMeasurement);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
+            .asApiSnapshot();
+
+        assertEquals(3, apiSnapshot.getCloudInstanceCount().intValue());
+        assertEquals(3, apiSnapshot.getCloudSockets().intValue());
+        assertFalse(apiSnapshot.getHasCloudigradeData());
+        assertFalse(apiSnapshot.getHasCloudigradeMismatch());
+    }
+
+    @Test
+    void testShouldNotFlagCloudigradeMismatchIfMatching() {
+        TallySnapshot snapshot = new TallySnapshot();
+        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
+        hbiMeasurement.setSockets(7);
+        hbiMeasurement.setInstanceCount(7);
+        HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
+        cloudigradeMeasurement.setSockets(7);
+        cloudigradeMeasurement.setInstanceCount(7);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, hbiMeasurement);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
+            .asApiSnapshot();
+
+        assertEquals(7, apiSnapshot.getCloudInstanceCount().intValue());
+        assertEquals(7, apiSnapshot.getCloudSockets().intValue());
+        assertTrue(apiSnapshot.getHasCloudigradeData());
+        assertFalse(apiSnapshot.getHasCloudigradeMismatch());
     }
 
     @Test


### PR DESCRIPTION
Two flags added:

  - `has_cloudigrade_data`: true if cloudigrade data was included in the
    snapshot, false otherwise.
  - `has_cloudigrade_mismatch`: true if there was cloudigrade data and
    the instance count differed from HBI data, false otherwise.