### PR TITLE
Add event JSON schema and DB object

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath "org.openapitools:openapi-generator-gradle-plugin:4.3.1"
+        classpath "org.jsonschema2pojo:jsonschema2pojo-gradle-plugin:1.0.2"
     }
 }
 
@@ -132,6 +133,20 @@ allprojects {
         testRuntime "org.junit.jupiter:junit-jupiter-engine"
         testRuntime "ch.qos.logback:logback-classic"
     }
+}
+
+apply plugin: 'jsonschema2pojo'
+jsonSchema2Pojo {
+    source = files("${projectDir}/schemas")
+    targetPackage = 'org.candlepin.subscriptions.json'
+    includeAdditionalProperties = false
+    includeJsr303Annotations = true
+    initializeCollections = false
+    dateTimeType = 'java.time.OffsetDateTime'
+    sourceType = 'yamlschema'
+    generateBuilders = true
+    includeGetters = true
+    includeSetters = true
 }
 
 bootJar {

--- a/schemas/event.yaml
+++ b/schemas/event.yaml
@@ -78,6 +78,10 @@ properties:
           description: UOM for the measurement. (e.g. Cores, Sockets)
           type: string
           required: true
+          enum:
+            - Cores
+            - Sockets
+            - Core-seconds
     required: false
   cloud_provider:
     description: Identifier for the cloud provider of the subject.

--- a/schemas/event.yaml
+++ b/schemas/event.yaml
@@ -19,12 +19,12 @@ properties:
     description: Account identifier for the relevant account.
     type: string
     required: true
-  subject_type:
-    description: Identifier for the type of subject. (E.g. RHEL System, OpenShift Cluster)
+  service_type:
+    description: Identifier for the type of service being measured. (E.g. RHEL System, OpenShift Cluster)
     type: string
     required: true
-  subject_id:
-    description: Primary identifier for the subject, according to the source.
+  instance_id:
+    description: Primary identifier for the instance of the service, according to the event producer.
     type: string
     required: true
   timestamp:
@@ -44,17 +44,17 @@ properties:
     existingJavaType: java.util.Optional<String>
     required: false
   inventory_id:
-    description: Host-based inventory ID for the subject.
+    description: Host-based inventory ID for the service, if applicable and known.
     type: string
     existingJavaType: java.util.Optional<String>
     required: false
   insights_id:
-    description: Red Hat Insights ID for the subject.
+    description: Red Hat Insights ID for the service, if applicable and known.
     type: string
     existingJavaType: java.util.Optional<String>
     required: false
   subscription_manager_id:
-    description: subscription-manager ID for the subject.
+    description: subscription-manager ID for the service, if applicable and known.
     type: string
     existingJavaType: java.util.Optional<String>
     required: false
@@ -65,7 +65,7 @@ properties:
       type: string
     required: false
   measurements:
-    description: Capture measurements for the subject.
+    description: Captures measurements for the service instance.
     type: array
     items:
       type: object

--- a/schemas/event.yaml
+++ b/schemas/event.yaml
@@ -1,0 +1,146 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: Event
+properties:
+  event_id:
+    description: UUID for the event, will be generated upon ingestion if not specified.
+    type: string
+    format: uuid
+    required: false
+  event_source:
+    description: Identifier for the system that captured the event.
+    type: string
+    required: true
+  event_type:
+    description: Source-specific identifier for the type of event (e.g. Snapshot, Delete). This allows
+      the source to encode a special semantic for the event.
+    type: string
+    required: false
+  account_number:
+    description: Account identifier for the relevant account.
+    type: string
+    required: true
+  subject_type:
+    description: Identifier for the type of subject. (E.g. RHEL System, OpenShift Cluster)
+    type: string
+    required: true
+  subject_id:
+    description: Primary identifier for the subject, according to the source.
+    type: string
+    required: true
+  timestamp:
+    description: Time that the event happened or the snapshot was captured.
+    type: string
+    format: date-time
+    required: true
+  expiration:
+    description: End of the range for the event (exclusive).
+    type: string
+    existingJavaType: java.util.Optional<java.time.OffsetDateTime>
+    format: date-time
+    required: false
+  display_name:
+    description: User-set name for the subject.
+    type: string
+    existingJavaType: java.util.Optional<String>
+    required: false
+  inventory_id:
+    description: Host-based inventory ID for the subject.
+    type: string
+    existingJavaType: java.util.Optional<String>
+    required: false
+  insights_id:
+    description: Red Hat Insights ID for the subject.
+    type: string
+    existingJavaType: java.util.Optional<String>
+    required: false
+  subscription_manager_id:
+    description: subscription-manager ID for the subject.
+    type: string
+    existingJavaType: java.util.Optional<String>
+    required: false
+  correlation_ids:
+    description: List of IDs to be used in debugging. Correlation IDs should ideally be unique.
+    type: array
+    items:
+      type: string
+    required: false
+  measurements:
+    description: Capture measurements for the subject.
+    type: array
+    items:
+      type: object
+      properties:
+        value:
+          description: Measurement value.
+          type: number
+          required: true
+        uom:
+          description: UOM for the measurement. (e.g. Cores, Sockets)
+          type: string
+          required: true
+    required: false
+  cloud_provider:
+    description: Identifier for the cloud provider of the subject.
+    type: string
+    enum:
+      - ''  # UNSPECIFIED
+      - Alibaba
+      - AWS
+      - Azure
+      - Google
+    required: false
+  hardware_type:
+    description: Identifier for the type of hardware of the subject.
+    type: string
+    enum:
+      - ''  # UNSPECIFIED
+      - Physical
+      - Virtual
+      - Cloud
+    required: false
+  hypervisor_uuid:
+    description: Subscription-manager ID of the hypervisor, as reported in virt-who mappings.
+    type: string
+    existingJavaType: java.util.Optional<String>
+    required: false
+  product_ids:
+    description: List of engineering product IDs detected on the subject.
+    type: array
+    items:
+      type: string
+    required: false
+  role:
+    description: The syspurpose role for the system.
+    type: string
+    enum:
+      - ''  # UNSPECIFIED
+      - Red Hat Enterprise Linux Server
+      - Red Hat Enterprise Linux Workstation
+      - Red Hat Enterprise Linux Compute Node
+    required: false
+  sla:
+    description: Service level for the subject.
+    type: string
+    enum:
+      - ''  # UNSPECIFIED
+      - Premium
+      - Standard
+      - Self-Support
+    required: false
+  usage:
+    description: Intended usage for the subject.
+    type: string
+    enum:
+      - ''  # UNSPECIFIED
+      - Production
+      - Development/Test
+      - Disaster Recovery
+    required: false
+  uom:
+    description: Preferred unit of measure for the subject (for products with multiple possible UOM).
+    type: string
+    enum:
+      - ''  # UNSPECIFIED
+      - Cores
+      - Sockets
+    required: false

--- a/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -41,6 +41,10 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
      *
      * The events returned include those at begin and up to (but not including) end.
      *
+     * NOTE: this query does not use `between` since between semantics are inclusive. e.g. `select * from
+     * events where timestamp between '2021-01-01T00:00:00Z' and '2021-01-01T01:00:00Z` would match events
+     * at midnight UTC and 1am UTC.
+     *
      * @param accountNumber account number
      * @param begin start of the time range (inclusive)
      * @param end end of the time range (exclusive)

--- a/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import org.candlepin.subscriptions.db.model.EventRecord;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+/**
+ * DB repository for Event records.
+ *
+ * @see EventRecord
+ * @see org.candlepin.subscriptions.json.Event
+ */
+public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> {
+
+    /**
+     * Fetch a stream of events for a given account for a given time range.
+     *
+     * The events returned include those at begin and up to (but not including) end.
+     *
+     * @param accountNumber account number
+     * @param begin start of the time range (inclusive)
+     * @param end end of the time range (exclusive)
+     * @return Stream of EventRecords
+     */
+    Stream<EventRecord> findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+        String accountNumber, OffsetDateTime begin, OffsetDateTime end);
+}

--- a/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -51,6 +52,7 @@ import javax.sql.DataSource;
     basePackages = "org.candlepin.subscriptions.db",
     entityManagerFactoryRef = "rhsmSubscriptionsEntityManagerFactory",
     transactionManagerRef = "rhsmSubscriptionsTransactionManager")
+@ComponentScan(basePackages = "org.candlepin.subscriptions.db")
 public class RhsmSubscriptionsDataSourceConfiguration {
 
     @Bean

--- a/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
@@ -20,31 +20,20 @@
  */
 package org.candlepin.subscriptions.db.model;
 
-import org.candlepin.subscriptions.exception.ErrorCode;
-import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.json.Event;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
 
-import javax.persistence.AttributeConverter;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.Valid;
-import javax.ws.rs.core.Response;
 
 /**
  * DB entity for an event record.
@@ -54,44 +43,27 @@ import javax.ws.rs.core.Response;
 @Entity
 @Table(name = "events")
 public class EventRecord {
-    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    static {
-        // the following allows us to distinguish between
-        // - Optional.of(null) (null value, e.g. {"foo":null}), representing a field to be cleared
-        // - null (missing field, e.g. {}), representing a field that was unaffected or unknown
-        OBJECT_MAPPER.registerModule(new Jdk8Module());
-
-        OBJECT_MAPPER.registerModule(new JavaTimeModule());
-        OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        OBJECT_MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        OBJECT_MAPPER.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
-        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    public EventRecord() {
+        /* intentionally empty */
     }
 
     /**
-     * Create a new EventRecord given Event JSON.
+     * Create a new EventRecord from a given Event.
      *
-     * Generates a new random UUID if the Event JSON does not have a UUID.
+     * Generates a new random UUID if the Event does not have a UUID.
      *
-     * @param json event in JSON format
-     * @return EventRecord, populated with a deserialized event record
-     * @throws JsonProcessingException if the jsonString cannot be processed
+     * @param event the event object
      */
-    public static EventRecord fromJson(String json) throws JsonProcessingException {
-        Event event = OBJECT_MAPPER.readValue(json, Event.class);
-        return EventRecord.fromEvent(event);
-    }
-
-    public static EventRecord fromEvent(Event event) {
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public EventRecord(Event event) {
+        Objects.requireNonNull(event, "event must not be null");
         if (event.getEventId() == null) {
             event.setEventId(UUID.randomUUID());
         }
-        EventRecord eventRecord = new EventRecord();
-        eventRecord.setId(event.getEventId());
-        eventRecord.setEvent(event);
-        eventRecord.setAccountNumber(event.getAccountNumber());
-        eventRecord.setTimestamp(event.getTimestamp());
-        return eventRecord;
+        this.id = event.getEventId();
+        this.event = event;
+        this.accountNumber = event.getAccountNumber();
+        this.timestamp = event.getTimestamp();
     }
 
     @Id
@@ -104,7 +76,7 @@ public class EventRecord {
 
     @Valid
     @Column(name = "data")
-    @Convert(converter = EventRecord.Converter.class)
+    @Convert(converter = EventRecordConverter.class)
     private Event event;
 
     public UUID getId() {
@@ -156,42 +128,4 @@ public class EventRecord {
         return Objects.hash(id, event);
     }
 
-    public String toJson() {
-        try {
-            return OBJECT_MAPPER.writeValueAsString(this);
-        }
-        catch (JsonProcessingException e) {
-            throw new SubscriptionsException(
-                ErrorCode.UNHANDLED_EXCEPTION_ERROR,
-                Response.Status.INTERNAL_SERVER_ERROR,
-                "Error emitting event JSON",
-                e
-            );
-        }
-    }
-
-    /**
-     * JPA AttributeConverter which uses Jackson to map to/from Event JSON.
-     */
-    private static class Converter implements AttributeConverter<Event, String> {
-        @Override
-        public String convertToDatabaseColumn(Event attribute) {
-            try {
-                return OBJECT_MAPPER.writeValueAsString(attribute);
-            }
-            catch (JsonProcessingException e) {
-                throw new IllegalArgumentException("Error serializing event", e);
-            }
-        }
-
-        @Override
-        public Event convertToEntityAttribute(String dbData) {
-            try {
-                return OBJECT_MAPPER.readValue(dbData, Event.class);
-            }
-            catch (JsonProcessingException e) {
-                throw new IllegalArgumentException("Error parsing event", e);
-            }
-        }
-    }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import org.candlepin.subscriptions.exception.ErrorCode;
+import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.json.Event;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.Valid;
+import javax.ws.rs.core.Response;
+
+/**
+ * DB entity for an event record.
+ *
+ * An event record consists of an ID and a JSON document with the event data.
+ */
+@Entity
+@Table(name = "events")
+public class EventRecord {
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    static {
+        // the following allows us to distinguish between
+        // - Optional.of(null) (null value, e.g. {"foo":null}), representing a field to be cleared
+        // - null (missing field, e.g. {}), representing a field that was unaffected or unknown
+        OBJECT_MAPPER.registerModule(new Jdk8Module());
+
+        OBJECT_MAPPER.registerModule(new JavaTimeModule());
+        OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        OBJECT_MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        OBJECT_MAPPER.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+
+    /**
+     * Create a new EventRecord given Event JSON.
+     *
+     * Generates a new random UUID if the Event JSON does not have a UUID.
+     *
+     * @param json event in JSON format
+     * @return EventRecord, populated with a deserialized event record
+     * @throws JsonProcessingException if the jsonString cannot be processed
+     */
+    public static EventRecord fromJson(String json) throws JsonProcessingException {
+        Event event = OBJECT_MAPPER.readValue(json, Event.class);
+        return EventRecord.fromEvent(event);
+    }
+
+    public static EventRecord fromEvent(Event event) {
+        if (event.getEventId() == null) {
+            event.setEventId(UUID.randomUUID());
+        }
+        EventRecord eventRecord = new EventRecord();
+        eventRecord.setId(event.getEventId());
+        eventRecord.setEvent(event);
+        eventRecord.setAccountNumber(event.getAccountNumber());
+        eventRecord.setTimestamp(event.getTimestamp());
+        return eventRecord;
+    }
+
+    @Id
+    private UUID id;
+
+    @Column(name = "account_number")
+    private String accountNumber;
+
+    private OffsetDateTime timestamp;
+
+    @Valid
+    @Column(name = "data")
+    @Convert(converter = EventRecord.Converter.class)
+    private Event event;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public OffsetDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(OffsetDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Event getEvent() {
+        return event;
+    }
+
+    public void setEvent(Event event) {
+        this.event = event;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EventRecord)) {
+            return false;
+        }
+        EventRecord that = (EventRecord) o;
+        return Objects.equals(id, that.id) && Objects.equals(event, that.event);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, event);
+    }
+
+    public String toJson() {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(this);
+        }
+        catch (JsonProcessingException e) {
+            throw new SubscriptionsException(
+                ErrorCode.UNHANDLED_EXCEPTION_ERROR,
+                Response.Status.INTERNAL_SERVER_ERROR,
+                "Error emitting event JSON",
+                e
+            );
+        }
+    }
+
+    /**
+     * JPA AttributeConverter which uses Jackson to map to/from Event JSON.
+     */
+    private static class Converter implements AttributeConverter<Event, String> {
+        @Override
+        public String convertToDatabaseColumn(Event attribute) {
+            try {
+                return OBJECT_MAPPER.writeValueAsString(attribute);
+            }
+            catch (JsonProcessingException e) {
+                throw new IllegalArgumentException("Error serializing event", e);
+            }
+        }
+
+        @Override
+        public Event convertToEntityAttribute(String dbData) {
+            try {
+                return OBJECT_MAPPER.readValue(dbData, Event.class);
+            }
+            catch (JsonProcessingException e) {
+                throw new IllegalArgumentException("Error parsing event", e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/EventRecordConverter.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/EventRecordConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import org.candlepin.subscriptions.json.Event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.AttributeConverter;
+
+/**
+ * JPA AttributeConverter which uses Jackson to map to/from Event JSON.
+ */
+@Component
+class EventRecordConverter implements AttributeConverter<Event, String> {
+
+    private static ObjectMapper objectMapper;
+
+    public EventRecordConverter() {
+        /* intentionally left empty */
+    }
+
+    // hack to get ObjectMapper from spring context, we should remove once we're on Spring Boot 2.1 &
+    // Hibernate 5.3 per https://stackoverflow.com/a/54686119
+    @Autowired
+    @SuppressWarnings("java:S3010")
+    EventRecordConverter(ObjectMapper mapper) {
+        EventRecordConverter.objectMapper = mapper;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(Event attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        }
+        catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Error serializing event", e);
+        }
+    }
+
+    @Override
+    public Event convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(dbData, Event.class);
+        }
+        catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Error parsing event", e);
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -24,9 +24,7 @@ import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.db.model.EventRecord;
 import org.candlepin.subscriptions.json.Event;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import org.springframework.stereotype.Controller;
+import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;
@@ -39,7 +37,7 @@ import javax.transaction.Transactional;
 /**
  * Encapsulates interaction with event store.
  */
-@Controller
+@Service
 public class EventController {
     private final EventRecordRepository repo;
 
@@ -65,13 +63,12 @@ public class EventController {
     /**
      * Validates and saves event JSON in the DB.
      *
-     * @param json JSON representation of the event
+     * @param event the event to save
      * @return the event ID
-     * @throws JsonProcessingException if the value can't be deserialized properly
      */
     @Transactional
-    public UUID saveEvent(String json) throws JsonProcessingException {
-        EventRecord eventRecord = EventRecord.fromJson(json);
+    public UUID saveEvent(Event event) {
+        EventRecord eventRecord = new EventRecord(event);
         repo.save(eventRecord);
         return eventRecord.getId();
     }

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.event;
+
+import org.candlepin.subscriptions.db.EventRecordRepository;
+import org.candlepin.subscriptions.db.model.EventRecord;
+import org.candlepin.subscriptions.json.Event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.stereotype.Controller;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+
+/**
+ * Encapsulates interaction with event store.
+ */
+@Controller
+public class EventController {
+    private final EventRecordRepository repo;
+
+    public EventController(EventRecordRepository repo) {
+        this.repo = repo;
+    }
+
+    /**
+     * Note: calling method needs to use @Transactional
+     *
+     * @param accountNumber account identifier
+     * @param begin beginning of the time range (inclusive)
+     * @param end end of the time range (exclusive)
+     * @return stream of Event
+     */
+    public Stream<Event> fetchEventsInTimeRange(String accountNumber, OffsetDateTime begin,
+        OffsetDateTime end) {
+        return repo
+            .findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+            accountNumber, begin, end).map(EventRecord::getEvent);
+    }
+
+    /**
+     * Validates and saves event JSON in the DB.
+     *
+     * @param json JSON representation of the event
+     * @return the event ID
+     * @throws JsonProcessingException if the value can't be deserialized properly
+     */
+    @Transactional
+    public UUID saveEvent(String json) throws JsonProcessingException {
+        EventRecord eventRecord = EventRecord.fromJson(json);
+        repo.save(eventRecord);
+        return eventRecord.getId();
+    }
+
+    /**
+     * Fetch a single Event by its ID.
+     *
+     * @param eventId Event id as a UUID
+     * @return Event if present, otherwise Optional.empty()
+     */
+    @Transactional
+    public Optional<Event> getEvent(UUID eventId) {
+        try {
+            return Optional.of(repo.getOne(eventId).getEvent());
+        }
+        catch (EntityNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/jmx/EventJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/EventJmxBean.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.jmx;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.event.EventController;
+import org.candlepin.subscriptions.json.Event;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jmx.JmxException;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedOperationParameter;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.transaction.Transactional;
+
+/**
+ * JMX Bean for interacting with the event store.
+ *
+ * Allows insertion of event JSON *only in dev-mode*.
+ */
+@Component
+@ManagedResource
+public class EventJmxBean {
+    private static final Logger log = LoggerFactory.getLogger(EventJmxBean.class);
+
+    private final ApplicationProperties applicationProperties;
+    private final EventController eventController;
+
+    public EventJmxBean(ApplicationProperties applicationProperties, EventController eventController) {
+        this.applicationProperties = applicationProperties;
+        this.eventController = eventController;
+    }
+
+    @Transactional
+    @ManagedOperation(description = "Fetch events (for debugging).")
+    @ManagedOperationParameter(name = "accountNumber", description = "Account number")
+    @ManagedOperationParameter(name = "begin", description = "Beginning of time range (inclusive)")
+    @ManagedOperationParameter(name = "end", description = "End of time range (exclusive)")
+    public String fetchEventsInTimeRange(String accountNumber, String begin, String end) {
+        OffsetDateTime beginValue = OffsetDateTime.parse(begin);
+        OffsetDateTime endValue = OffsetDateTime.parse(end);
+        Stream<Event> eventStream = eventController.fetchEventsInTimeRange(accountNumber, beginValue,
+            endValue);
+        return String.format("[%s]", eventStream.map(Event::toString).collect(Collectors.joining(",")));
+    }
+
+    @ManagedOperation(description = "Fetch an event")
+    @ManagedOperationParameter(name = "eventId", description = "Event UUID")
+    public String getEvent(String eventId) {
+        return eventController.getEvent(UUID.fromString(eventId)).toString();
+    }
+
+    @ManagedOperation(description = "Save an event. Supported only in dev-mode.")
+    @ManagedOperationParameter(name = "json", description = "Event JSON")
+    public String saveEvent(String json) {
+        if (!applicationProperties.isDevMode()) {
+            throw new JmxException("Unsupported outside dev-mode!");
+        }
+        try {
+            return eventController.saveEvent(json).toString();
+        }
+        catch (Exception e) {
+            log.error("Error saving event", e);
+            throw new JmxException("Error saving event. See log for details.");
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/jmx/EventJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/EventJmxBean.java
@@ -24,6 +24,8 @@ import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.json.Event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jmx.JmxException;
@@ -51,10 +53,13 @@ public class EventJmxBean {
 
     private final ApplicationProperties applicationProperties;
     private final EventController eventController;
+    private final ObjectMapper objectMapper;
 
-    public EventJmxBean(ApplicationProperties applicationProperties, EventController eventController) {
+    public EventJmxBean(ApplicationProperties applicationProperties, EventController eventController,
+        ObjectMapper objectMapper) {
         this.applicationProperties = applicationProperties;
         this.eventController = eventController;
+        this.objectMapper = objectMapper;
     }
 
     @Transactional
@@ -83,7 +88,7 @@ public class EventJmxBean {
             throw new JmxException("Unsupported outside dev-mode!");
         }
         try {
-            return eventController.saveEvent(json).toString();
+            return eventController.saveEvent(objectMapper.readValue(json, Event.class)).toString();
         }
         catch (Exception e) {
             log.error("Error saving event", e);

--- a/src/main/java/org/candlepin/subscriptions/resteasy/ObjectMapperContextResolver.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ObjectMapperContextResolver.java
@@ -20,13 +20,9 @@
  */
 package org.candlepin.subscriptions.resteasy;
 
-import org.candlepin.subscriptions.ApplicationProperties;
-
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
+
+import org.springframework.stereotype.Component;
 
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
@@ -37,21 +33,13 @@ import javax.ws.rs.ext.Provider;
  * use the configured ObjectMapper provided by this instance.
  */
 @Provider
+@Component
 public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
 
     private final ObjectMapper objectMapper;
 
-    public ObjectMapperContextResolver(ApplicationProperties applicationProperties) {
-        objectMapper = new ObjectMapper();
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        objectMapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
-        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, applicationProperties.isPrettyPrintJson());
-        objectMapper.setSerializationInclusion(Include.NON_NULL);
-        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-
-        // Tell the mapper to check the classpath for any serialization/deserialization modules
-        // such as the Java8 date/time module (JavaTimeModule).
-        objectMapper.findAndRegisterModules();
+    public ObjectMapperContextResolver(ObjectMapper mapper) {
+        this.objectMapper = mapper;
     }
 
     @Override

--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -20,15 +20,12 @@
  */
 package org.candlepin.subscriptions.resteasy;
 
-import org.candlepin.subscriptions.ApplicationProperties;
-
 import org.jboss.resteasy.springboot.ResteasyAutoConfiguration;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -43,13 +40,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @ComponentScan(basePackages = {"org.candlepin.subscriptions.exception.mapper",
     "org.candlepin.subscriptions.resteasy"})
 public class ResteasyConfiguration implements WebMvcConfigurer {
-    @Bean
-    @Primary
-    public ObjectMapperContextResolver objectMapperContextResolver(
-        ApplicationProperties applicationProperties) {
-        return new ObjectMapperContextResolver(applicationProperties);
-    }
-
     @Bean
     public static BeanFactoryPostProcessor servletInitializer() {
         return new JaxrsApplicationServletInitializer();

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -63,6 +63,7 @@ import java.util.Set;
     ProductIdMappingConfiguration.class, InventoryDataSourceConfiguration.class, JmxBeansConfiguration.class})
 @ComponentScan(basePackages = {
     "org.candlepin.subscriptions.cloudigrade",
+    "org.candlepin.subscriptions.event",
     "org.candlepin.subscriptions.inventory.db",
     "org.candlepin.subscriptions.jmx",
     "org.candlepin.subscriptions.tally"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,7 +75,7 @@ rhsm-subscriptions:
     org.candlepin.subscriptions.resteasy: ${PATH_PREFIX:api}/${APP_NAME:rhsm-subscriptions}/v1
   product-id-to-products-map-resource-location: classpath:product_id_to_products_map.yaml
   datasource:
-    url: jdbc:postgresql://${DATABASE_HOST:localhost}:${DATABASE_PORT:5432}/${DATABASE_DATABASE:rhsm-subscriptions}?reWriteBatchedInserts=true
+    url: jdbc:postgresql://${DATABASE_HOST:localhost}:${DATABASE_PORT:5432}/${DATABASE_DATABASE:rhsm-subscriptions}?reWriteBatchedInserts=true&stringtype=unspecified
     username: ${DATABASE_USERNAME:rhsm-subscriptions}
     password: ${DATABASE_PASSWORD:rhsm-subscriptions}
     driver-class-name: org.postgresql.Driver

--- a/src/main/resources/liquibase/202011130945-add-events-table.xml
+++ b/src/main/resources/liquibase/202011130945-add-events-table.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <property name="json_type" dbms="hsqldb" value="clob"/>
+    <property name="json_type" dbms="postgresql" value="jsonb"/>
+    <changeSet id="202011130945-1" author="khowell">
+        <createTable tableName="events">
+            <column name="id" type="UUID">
+                <constraints primaryKey="true" primaryKeyName="events_pk"/>
+            </column>
+            <column name="account_number" type="VARCHAR(255)"/>
+            <column name="timestamp" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="data" type="${json_type}"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="202011130945-2" author="khowell">
+        <createIndex tableName="events" indexName="events_account_timestamp_idx">
+            <column name="account_number"/>
+            <column name="timestamp"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>
+    <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -33,5 +33,6 @@
     <include file="liquibase/202010080931-fix-capacity-unspecified.xml" />
     <include file="liquibase/202011090921-re-add-hypervisor-type.xml" />
     <include file="liquibase/202012141133-enforce-display-name-not-null.xml" />
+    <include file="liquibase/202011130945-add-events-table.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -61,7 +61,7 @@ class EventRecordRepositoryTest {
         event.setEventSource("eventSource");
         event.setDisplayName(Optional.empty());
 
-        EventRecord record = EventRecord.fromEvent(event);
+        EventRecord record = new EventRecord(event);
         repository.saveAndFlush(record);
 
         EventRecord found = repository.getOne(eventId);

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.EventRecord;
+import org.candlepin.subscriptions.json.Event;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class EventRecordRepositoryTest {
+    private static final Clock CLOCK = new FixedClockConfiguration().fixedClock().getClock();
+
+    @Autowired
+    private EventRecordRepository repository;
+
+    @Test
+    void saveAndUpdate() {
+        Event event = new Event();
+        event.setAccountNumber("account123");
+        event.setTimestamp(OffsetDateTime.now(CLOCK));
+        event.setSubjectId("subjectId");
+        event.setSubjectType("RHEL System");
+        UUID eventId = UUID.randomUUID();
+        event.setEventId(eventId);
+        event.setEventSource("eventSource");
+        event.setDisplayName(Optional.empty());
+
+        EventRecord record = EventRecord.fromEvent(event);
+        repository.saveAndFlush(record);
+
+        EventRecord found = repository.getOne(eventId);
+        assertNull(found.getEvent().getInventoryId());
+        assertNotNull(found.getEvent().getDisplayName());
+        assertFalse(found.getEvent().getDisplayName().isPresent());
+        assertEquals(record, found);
+    }
+
+    @Test
+    void testFindBeginInclusive() {
+        EventRecord oldEvent = new EventRecord();
+        UUID oldId = UUID.randomUUID();
+        oldEvent.setId(oldId);
+        oldEvent.setAccountNumber("account123");
+        oldEvent.setTimestamp(OffsetDateTime.now(CLOCK).minusSeconds(1));
+
+        EventRecord currentEvent = new EventRecord();
+        UUID currentId = UUID.randomUUID();
+        currentEvent.setId(currentId);
+        currentEvent.setAccountNumber("account123");
+        currentEvent.setTimestamp(OffsetDateTime.now(CLOCK));
+
+        repository.saveAll(Arrays.asList(oldEvent, currentEvent));
+        repository.flush();
+
+        List<EventRecord> found = repository
+            .findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp("account123",
+            OffsetDateTime.now(CLOCK), OffsetDateTime.now(CLOCK).plusYears(1))
+            .collect(Collectors.toList());
+
+        assertEquals(1, found.size());
+        assertEquals(currentId, found.get(0).getId());
+    }
+
+    @Test
+    void testFindEndExclusive() {
+        EventRecord futureEvent = new EventRecord();
+        UUID futureId = UUID.randomUUID();
+        futureEvent.setId(futureId);
+        futureEvent.setAccountNumber("account123");
+        futureEvent.setTimestamp(OffsetDateTime.now(CLOCK));
+
+        EventRecord currentEvent = new EventRecord();
+        UUID currentId = UUID.randomUUID();
+        currentEvent.setId(currentId);
+        currentEvent.setAccountNumber("account123");
+        currentEvent.setTimestamp(OffsetDateTime.now(CLOCK).minusSeconds(1));
+
+        repository.saveAll(Arrays.asList(futureEvent, currentEvent));
+        repository.flush();
+
+        List<EventRecord> found = repository
+            .findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp("account123",
+            OffsetDateTime.now(CLOCK).minusYears(1), OffsetDateTime.now(CLOCK))
+            .collect(Collectors.toList());
+
+        assertEquals(1, found.size());
+        assertEquals(currentId, found.get(0).getId());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -54,8 +54,8 @@ class EventRecordRepositoryTest {
         Event event = new Event();
         event.setAccountNumber("account123");
         event.setTimestamp(OffsetDateTime.now(CLOCK));
-        event.setSubjectId("subjectId");
-        event.setSubjectType("RHEL System");
+        event.setInstanceId("instanceId");
+        event.setServiceType("RHEL System");
         UUID eventId = UUID.randomUUID();
         event.setEventId(eventId);
         event.setEventSource("eventSource");

--- a/src/test/java/org/candlepin/subscriptions/db/model/EventRecordTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/EventRecordTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.subscriptions.json.Event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.junit.jupiter.api.Test;
+
+class EventRecordTest {
+    @Test
+    void testJsonOptionalVsNull() throws JsonProcessingException {
+        String testData = "{\"display_name\":null}";
+        Event event = EventRecord.OBJECT_MAPPER.readValue(testData, Event.class);
+        assertNotNull(event.getDisplayName());
+        assertFalse(event.getDisplayName().isPresent());
+        assertNull(event.getInventoryId());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/db/model/EventRecordTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/EventRecordTest.java
@@ -25,16 +25,28 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.candlepin.subscriptions.json.Event;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@SpringBootTest
+@ActiveProfiles("test")
 class EventRecordTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
     @Test
     void testJsonOptionalVsNull() throws JsonProcessingException {
-        String testData = "{\"display_name\":null}";
-        Event event = EventRecord.OBJECT_MAPPER.readValue(testData, Event.class);
+        String testData = "{\"event_id\":\"99f6b275-6031-4967-84b6-147bd0191474\",\"display_name\":null}";
+        EventRecord eventRecord = objectMapper.readValue(testData, EventRecord.class);
+        Event event = eventRecord.getEvent();
         assertNotNull(event.getDisplayName());
         assertFalse(event.getDisplayName().isPresent());
         assertNull(event.getInventoryId());
+        assertEquals(testData, objectMapper.writeValueAsString(eventRecord.getEvent()));
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/resteasy/ObjectMapperContextResolverTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/ObjectMapperContextResolverTest.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.resteasy;
 import static org.hamcrest.MatcherAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.jackson.TestPojo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,20 +32,26 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Calendar;
 import java.util.TimeZone;
 
 
+@SpringBootTest
+@ActiveProfiles("api,test")
 @TestInstance(Lifecycle.PER_CLASS)
 class ObjectMapperContextResolverTest {
+
+    @Autowired
+    private ObjectMapperContextResolver resolver;
 
     private ObjectMapper mapper;
 
     @BeforeAll
     void setupTests() {
-        ApplicationProperties props = new ApplicationProperties();
-        ObjectMapperContextResolver resolver = new ObjectMapperContextResolver(props);
         mapper = resolver.getContext(Void.class);
     }
 


### PR DESCRIPTION
I added a gradle plugin for json schema POJO generation.

I modified our postgresql connection settings to tolerate strings in the JSONB field (other solutions were overly complex). (They get implicitly cast by postgres with `stringtype=unspecified`).

I employed two strategies in the schema:
1. When a field was an enum, '' semantically means "unset this field", while `null` or omitted means the event does not modify the field.
2. For non-enums, Optional.empty() (`null` in JSON) means "unset this field", while omitting the field will result in `null` in Java, meaning do not modify the field.

Note I preferred to use Optional on the enums as well, but couldn't find a good way to do that. In both cases, the advice to producers would be to omit the field if they don't have the info.

To test, run with `DEV_MODE=true ./gradlew bootRun`. Then navigate to http://localhost:8080/actuator/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-EventJmxBean-eventJmxBean

Try using `saveEvent` to put in an event:

```json
{"subject_id":"foobar","timestamp":"2020-12-25T00:00:00Z","account_number":"account123","event_source":"foobar","subject_type":"OpenShift Cluster"}
```

Then use `getEvent` with the event ID to fetch the event.

Try `fetchEventsInTimeRange`:

- with `accountNumber`: account123, `begin`: '2020-12-25T00:00:00Z, `end`: 2020-12-25T01:00:00Z, note that the event is returned (begin inclusive)
- with `accountNumber`: account123, `begin`: '2020-12-24T00:00:00Z, `end`: 2020-12-25T00:00:00Z, note that the event is not returned (end exclusive)