### PR TITLE
Move CapacityResource to resource package

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -18,14 +18,13 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.capacity;
+package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.db.model.Usage;
-import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.util.ApplicationClock;

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.resource;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import org.candlepin.subscriptions.capacity.CapacityResource;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
 import org.candlepin.subscriptions.db.model.ServiceLevel;


### PR DESCRIPTION
Accidentally ended up in the wrong package in #211. This caused it to be
omitted from the `api` profile.

Testing
-------
Run using `SPRING_PROFILES_ACTIVE=api RBAC_USE_STUB=true ./gradlew
bootRun`.

Try:

```
curl -v "http://localhost:8080/api/rhsm-subscriptions/v1/capacity/products/RHEL?granularity=daily&beginning=2017-07-21T17%3A32%3A28Z&ending=2017-07-21T17%3A32%3A28Z" -H  "accept: application/vnd.api+json" -H  "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
```

Without the change you get a 404. With you get a 200.