### PR TITLE
Lburnett/ent 3251 unify metadata from api output

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -183,17 +183,17 @@ paths:
           in: query
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/GranularityGenerated'
           description: "The level of granularity to return."
         - name: sla
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/ServiceLevelGenerated'
           description: "Include only snapshots matching the specified service level."
         - name: usage
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/UsageGenerated'
           description: "Include only snapshots matching the specified usage."
         - name: beginning
           in: query
@@ -261,7 +261,7 @@ paths:
                 meta:
                   count: 10
                   product: RHEL
-                  granularity: DAILY
+                  granularity: Daily
                   service_level: Premium
                   usage: Production
         '400':
@@ -302,17 +302,17 @@ paths:
           in: query
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/GranularityGenerated'
           description: "The level of granularity to return."
         - name: sla
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/ServiceLevelGenerated'
           description: "Include only capacity for the specified service level."
         - name: usage
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/UsageGenerated'
           description: "Include only capacity for the specified usage level."
         - name: beginning
           in: query
@@ -372,7 +372,7 @@ paths:
                 meta:
                   count: 10
                   product: RHEL
-                  granularity: DAILY
+                  granularity: Daily
                   service_level: Premium
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -412,12 +412,12 @@ paths:
         - name: sla
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/ServiceLevelGenerated'
           description: "Include only hosts for the specified service level."
         - name: usage
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/UsageGenerated'
           description: "Include only hosts for the specified usage level."
         - name: uom
           in: query
@@ -654,6 +654,17 @@ components:
           schema:
             $ref: "#/components/schemas/Errors"
   schemas:
+    GranularityGenerated:
+      type: string
+      enum: [ DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY ]
+    ServiceLevelGenerated:
+      type: string
+      enum: [ "", Premium, Standard, Self-Support, _ANY ]
+      x-enum-varnames: [ UNSPECIFIED, PREMIUM, STANDARD, SELF_SUPPORT, ANY ]
+    UsageGenerated:
+      type: string
+      enum: [ "", Production, Development/Test, Disaster Recovery, _ANY ]
+      x-enum-varnames: [ UNSPECIFIED, PRODUCTION, DEVELOPMENT_TEST, DISASTER_RECOVERY, ANY ]
     Uom:
       type: string
       enum:
@@ -779,18 +790,21 @@ components:
             product:
               type: string
             service_level:
+              allOf:
+                - $ref: '#/components/schemas/ServiceLevelGenerated'
               description: "Describes the service level that the report was made against. Not set if it wasn't
                 specified as a query parameter."
-              type: string
             usage:
+              allOf:
+                - $ref: '#/components/schemas/UsageGenerated'
               description: "Describes the usage that the report was made against. Not set if it wasn't
                             specified as a query parameter."
-              type: string
             granularity:
+              allOf:
+                - $ref: '#/components/schemas/GranularityGenerated'
               description: "Describes the significance of each date in the TallySnapshot list. For example if the
-                granularity is set to 'weekly', the dates in the TallySnapshot list will represent the start of a
-                seven day period."
-              type: string
+                              granularity is set to 'weekly', the dates in the TallySnapshot list will represent the start of a
+                              seven day period."
           required:
             - count
             - product
@@ -921,18 +935,21 @@ components:
             product:
               type: string
             granularity:
+              allOf:
+                - $ref: '#/components/schemas/GranularityGenerated'
               description: "Describes the significance of each date in the CapacitySnapshot list. For example if the
                 granularity is set to 'weekly', the dates in the CapacitySnapshot list will represent the start of a
                 seven day period."
-              type: string
             service_level:
+              allOf:
+                - $ref: '#/components/schemas/ServiceLevelGenerated'
               description: "Describes the service level that the report was made against. Not set if it wasn't
                 specified as a query parameter."
-              type: string
             usage:
+              allOf:
+                - $ref: '#/components/schemas/UsageGenerated'
               description: "Describes the usages that the report was made against. Not set if it wasn't
                specified as a query parameter."
-              type: string
           required:
             - count
             - product
@@ -1020,13 +1037,16 @@ components:
             product:
               type: string
             service_level:
+              allOf:
+                - $ref: '#/components/schemas/ServiceLevelGenerated'
               description: "Describes the service level that the report was made against. Not set if it wasn't
                     specified as a query parameter."
               type: string
             usage:
+              allOf:
+                - $ref: '#/components/schemas/UsageGenerated'
               description: "Describes the usages that the report was made against. Not set if it wasn't
                    specified as a query parameter."
-              type: string
             uom:
               $ref: '#/components/schemas/Uom'
           required:
@@ -1179,4 +1199,4 @@ components:
           type: string
 
 security:
-  - 3ScaleIdentity: []
+  - 3ScaleIdentity: [ ]

--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,8 @@ dependencies {
         exclude group: "org.apache.kafka"
     }
 
+    implementation 'org.apache.commons:commons-text:1.9'
+
     compile "org.springframework.boot:spring-boot-starter-actuator"
     compile "org.springframework.boot:spring-boot-starter-aop"
     compile "org.springframework.boot:spring-boot-starter-data-jpa"

--- a/src/main/java/org/candlepin/subscriptions/db/model/Granularity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Granularity.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import org.candlepin.subscriptions.utilization.api.model.GranularityGenerated;
+
 /**
  * Granularity of a given snapshot.
  *
@@ -28,9 +30,9 @@ package org.candlepin.subscriptions.db.model;
  * tallies were 2, 3, 4, 5, 6, 2, 4, the weekly tally snapshot would be 6.
  */
 public enum Granularity {
-    DAILY,
-    WEEKLY,
-    MONTHLY,
-    QUARTERLY,
-    YEARLY
+    DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY;
+
+    public static Granularity fromOpenApi(GranularityGenerated apiParam) {
+        return Granularity.valueOf(apiParam.name());
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelGenerated;
+
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -80,6 +82,10 @@ public enum ServiceLevel {
         else {
             return fromString(value);
         }
+    }
+
+    public static ServiceLevel fromOpenApi(ServiceLevelGenerated serviceLevelGenerated) {
+        return ServiceLevel.valueOf(serviceLevelGenerated.name());
     }
 
     public String getValue() {

--- a/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import org.candlepin.subscriptions.utilization.api.model.UsageGenerated;
+
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -79,6 +81,10 @@ public enum Usage {
         else {
             return fromString(value);
         }
+    }
+
+    public static Usage fromOpenApi(UsageGenerated usageGenerated) {
+        return Usage.valueOf(usageGenerated.name());
     }
 
     public String getValue() {

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -94,8 +94,13 @@ public class CapacityResource implements CapacityApi {
             sanitizedUsage = null;
         }
 
-        List<CapacitySnapshot> capacities = getCapacities(ownerId, productId, sanitizedServiceLevel,
-            sanitizedUsage, granularity, beginning, ending);
+        List<CapacitySnapshot> capacities = getCapacities(ownerId,
+            productId,
+            sanitizedServiceLevel,
+            sanitizedUsage,
+            granularity,
+            beginning,
+            ending);
 
         List<CapacitySnapshot> data;
         TallyReportLinks links;
@@ -118,7 +123,8 @@ public class CapacityResource implements CapacityApi {
         report.getMeta().setCount(report.getData().size());
 
         if (sanitizedServiceLevel != null) {
-            report.getMeta()
+            report
+                .getMeta()
                 .setServiceLevel(ServiceLevelGenerated.fromValue(sanitizedServiceLevel.getValue()));
         }
 
@@ -131,27 +137,16 @@ public class CapacityResource implements CapacityApi {
         return report;
     }
 
-    private List<CapacitySnapshot> paginate(List<CapacitySnapshot> capacities, Pageable pageable) {
-        if (pageable == null) {
-            return capacities;
-        }
-        int offset = pageable.getPageNumber() * pageable.getPageSize();
-        int lastIndex = Math.min(capacities.size(), offset + pageable.getPageSize());
-        return capacities.subList(offset, lastIndex);
-    }
-
     private List<CapacitySnapshot> getCapacities(String ownerId, String productId, ServiceLevel sla,
         Usage usage, Granularity granularity, @NotNull OffsetDateTime reportBegin,
         @NotNull OffsetDateTime reportEnd) {
 
-        List<SubscriptionCapacity> matches = repository.findByOwnerAndProductId(
-            ownerId,
+        List<SubscriptionCapacity> matches = repository.findByOwnerAndProductId(ownerId,
             productId,
             sla,
             usage,
             reportBegin,
-            reportEnd
-        );
+            reportEnd);
 
         SnapshotTimeAdjuster timeAdjuster = SnapshotTimeAdjuster.getTimeAdjuster(clock, granularity);
 
@@ -166,6 +161,15 @@ public class CapacityResource implements CapacityApi {
             next = clock.startOfDay(next.plus(offset));
         }
         return result;
+    }
+
+    private List<CapacitySnapshot> paginate(List<CapacitySnapshot> capacities, Pageable pageable) {
+        if (pageable == null) {
+            return capacities;
+        }
+        int offset = pageable.getPageNumber() * pageable.getPageSize();
+        int lastIndex = Math.min(capacities.size(), offset + pageable.getPageSize());
+        return capacities.subList(offset, lastIndex);
     }
 
     private CapacitySnapshot createCapacitySnapshot(OffsetDateTime date, List<SubscriptionCapacity> matches) {
@@ -212,6 +216,5 @@ public class CapacityResource implements CapacityApi {
     private int sanitize(Integer value) {
         return value != null ? value : 0;
     }
-
 
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -60,8 +60,9 @@ import javax.ws.rs.core.UriInfo;
 @Component
 public class HostsResource implements HostsApi {
 
-    public static final Map<HostReportSort, String> SORT_PARAM_MAPPING =
-        ImmutableMap.<HostReportSort, String>builderWithExpectedSize(5)
+    @SuppressWarnings("linelength")
+    public static final Map<HostReportSort, String> SORT_PARAM_MAPPING = ImmutableMap.<HostReportSort, String>builderWithExpectedSize(
+        5)
         .put(HostReportSort.DISPLAY_NAME, "key.host.displayName")
         .put(HostReportSort.CORES, "cores")
         .put(HostReportSort.HARDWARE_TYPE, "key.host.hardwareType")
@@ -69,12 +70,10 @@ public class HostsResource implements HostsApi {
         .put(HostReportSort.LAST_SEEN, "key.host.lastSeen")
         .put(HostReportSort.MEASUREMENT_TYPE, "measurementType")
         .build();
-
-    @Context
-    UriInfo uriInfo;
-
     private final HostRepository repository;
     private final PageLinkCreator pageLinkCreator;
+    @Context
+    UriInfo uriInfo;
 
     public HostsResource(HostRepository repository, PageLinkCreator pageLinkCreator) {
         this.repository = repository;
@@ -111,15 +110,13 @@ public class HostsResource implements HostsApi {
         ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
         Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
         Pageable page = ResourceUtils.getPageable(offset, limit, sortValue);
-        Page<TallyHostView> hosts = repository.getTallyHostViews(
-            accountNumber,
+        Page<TallyHostView> hosts = repository.getTallyHostViews(accountNumber,
             productId,
             sanitizedSla,
             sanitizedUsage,
             minCores,
             minSockets,
-            page
-        );
+            page);
 
         TallyReportLinks links;
         if (offset != null || limit != null) {
@@ -131,14 +128,12 @@ public class HostsResource implements HostsApi {
 
         return new HostReport()
             .links(links)
-            .meta(
-                new HostReportMeta()
-                    .count((int) hosts.getTotalElements())
-                    .product(productId)
-                    .serviceLevel(sla)
-                    .usage(usage)
-                    .uom(uom)
-            )
+            .meta(new HostReportMeta()
+                .count((int) hosts.getTotalElements())
+                .product(productId)
+                .serviceLevel(sla)
+                .usage(usage)
+                .uom(uom))
             .data(hosts.getContent().stream().map(TallyHostView::asApiHost).collect(Collectors.toList()));
     }
 
@@ -158,10 +153,7 @@ public class HostsResource implements HostsApi {
 
         return new HypervisorGuestReport()
             .links(links)
-            .meta(
-                new HypervisorGuestReportMeta()
-                    .count((int) guests.getTotalElements())
-            )
+            .meta(new HypervisorGuestReportMeta().count((int) guests.getTotalElements()))
             .data(guests.getContent().stream().map(Host::asApiHost).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -32,9 +32,11 @@ import org.candlepin.subscriptions.utilization.api.model.HostReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 import org.candlepin.subscriptions.utilization.api.model.HypervisorGuestReport;
 import org.candlepin.subscriptions.utilization.api.model.HypervisorGuestReportMeta;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelGenerated;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportLinks;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
+import org.candlepin.subscriptions.utilization.api.model.UsageGenerated;
 import org.candlepin.subscriptions.utilization.api.resources.HostsApi;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,6 +49,8 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 
@@ -77,10 +81,10 @@ public class HostsResource implements HostsApi {
         this.pageLinkCreator = pageLinkCreator;
     }
 
-    @Override
     @ReportingAccessRequired
-    public HostReport getHosts(String productId, Integer offset, Integer limit, String sla,
-        String usage, Uom uom, HostReportSort sort, SortDirection dir) {
+    @Override
+    public HostReport getHosts(String productId, Integer offset, @Min(1) @Max(100) Integer limit,
+        ServiceLevelGenerated sla, UsageGenerated usage, Uom uom, HostReportSort sort, SortDirection dir) {
 
         Sort.Direction dirValue = Sort.Direction.ASC;
         if (dir == SortDirection.DESC) {

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -99,8 +99,9 @@ public class ResourceUtils {
      * @return the encoded identity header.
      */
     public static String getIdentityHeader() {
-        HttpServletRequest request =
-            ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+
+        @SuppressWarnings("linelength") HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
+            .getRequestAttributes()).getRequest();
         return request.getHeader(IdentityHeaderAuthenticationFilter.RH_IDENTITY_HEADER);
     }
 
@@ -135,12 +136,10 @@ public class ResourceUtils {
         }
 
         if (offset % limit != 0) {
-            throw new SubscriptionsException(
-                ErrorCode.VALIDATION_FAILED_ERROR,
+            throw new SubscriptionsException(ErrorCode.VALIDATION_FAILED_ERROR,
                 Response.Status.BAD_REQUEST,
                 "Offset must be divisible by limit",
-                "Arbitrary offsets are not currently supported by this API"
-            );
+                "Arbitrary offsets are not currently supported by this API");
         }
         return PageRequest.of(offset / limit, limit, sort);
     }

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -26,6 +26,8 @@ import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter;
 import org.candlepin.subscriptions.security.InsightsUserPrincipal;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelGenerated;
+import org.candlepin.subscriptions.utilization.api.model.UsageGenerated;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +37,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
@@ -141,6 +145,12 @@ public class ResourceUtils {
         return PageRequest.of(offset / limit, limit, sort);
     }
 
+    public static Usage sanitizeUsage(UsageGenerated usageGenerated) {
+
+        return Objects.nonNull(usageGenerated) ? Usage.fromOpenApi(usageGenerated) : Usage.ANY;
+
+    }
+
     /**
      * Validate and reject bad usage.
      *
@@ -154,12 +164,24 @@ public class ResourceUtils {
             return Usage.ANY;
         }
         Usage sanitizedUsage = Usage.fromString(usage);
+
+
+        //TODO LB take this into consideration.  Should we not enumerate input then?
+
         // If the usage parameter is not one that we support, then throw an exception.
         // If we don't, the query would default to UNSPECIFIED, which would be confusing.
         if (StringUtils.hasLength(usage) && sanitizedUsage == Usage.UNSPECIFIED) {
             throw new BadRequestException("Invalid usage parameter specified.");
         }
         return sanitizedUsage;
+    }
+
+    public static ServiceLevel sanitizeServiceLevel(ServiceLevelGenerated serviceLevelGenerated) {
+
+        return Objects.nonNull(serviceLevelGenerated) ?
+            ServiceLevel.fromOpenApi(serviceLevelGenerated) :
+            ServiceLevel.ANY;
+
     }
 
     /**
@@ -175,6 +197,9 @@ public class ResourceUtils {
             return ServiceLevel.ANY;
         }
         ServiceLevel sanitizedSla = ServiceLevel.fromString(sla);
+
+        //TODO LB take this into consideration.  Should we not enumerate input then?
+
         // If the sla parameter is not one that we support, then throw an exception.
         // If we don't, the query would default to UNSPECIFIED, which would be confusing.
         if (StringUtils.hasLength(sla) && sanitizedSla == ServiceLevel.UNSPECIFIED) {

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -56,11 +56,12 @@ import javax.ws.rs.core.UriInfo;
 @Component
 public class TallyResource implements TallyApi {
 
-    @Context UriInfo uriInfo;
-
     private final TallySnapshotRepository repository;
     private final PageLinkCreator pageLinkCreator;
     private final ApplicationClock clock;
+
+    @Context
+    private UriInfo uriInfo;
 
     public TallyResource(TallySnapshotRepository repository, PageLinkCreator pageLinkCreator,
         ApplicationClock clock) {
@@ -69,6 +70,7 @@ public class TallyResource implements TallyApi {
         this.clock = clock;
     }
 
+    @SuppressWarnings("linelength")
     @Override
     @ReportingAccessRequired
     public TallyReport getTallyReport(String productId, @NotNull GranularityGenerated granularityGenerated,
@@ -86,8 +88,8 @@ public class TallyResource implements TallyApi {
         ServiceLevel serviceLevel = ResourceUtils.sanitizeServiceLevel(sla);
         Usage effectiveUsage = ResourceUtils.sanitizeUsage(usageGenerated);
         Granularity granularityValue = Granularity.fromOpenApi(granularityGenerated);
-        Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage = repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+
+        Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage = repository.findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             accountNumber,
             productId,
             granularityValue,
@@ -95,8 +97,7 @@ public class TallyResource implements TallyApi {
             effectiveUsage,
             beginning,
             ending,
-            pageable
-        );
+            pageable);
 
         List<TallySnapshot> snaps = snapshotPage
             .stream()
@@ -109,7 +110,9 @@ public class TallyResource implements TallyApi {
         report.getMeta().setGranularity(GranularityGenerated.fromValue(granularityValue.toString()));
         report.getMeta().setProduct(productId);
         report.getMeta().setServiceLevel(sla);
-        report.getMeta().setUsage(usageGenerated == null ? null : UsageGenerated.fromValue(effectiveUsage.getValue()));
+        report
+            .getMeta()
+            .setUsage(usageGenerated == null ? null : UsageGenerated.fromValue(effectiveUsage.getValue()));
 
         // Only set page links if we are paging (not filling).
         if (pageable != null) {

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -106,7 +106,7 @@ public class TallyResource implements TallyApi {
         TallyReport report = new TallyReport();
         report.setData(snaps);
         report.setMeta(new TallyReportMeta());
-        report.getMeta().setGranularity(granularityGenerated);
+        report.getMeta().setGranularity(GranularityGenerated.fromValue(granularityValue.toString()));
         report.getMeta().setProduct(productId);
         report.getMeta().setServiceLevel(sla);
         report.getMeta().setUsage(usageGenerated == null ? null : UsageGenerated.fromValue(effectiveUsage.getValue()));

--- a/src/main/java/org/candlepin/subscriptions/resteasy/EnumParamConverterProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/EnumParamConverterProvider.java
@@ -43,7 +43,8 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class EnumParamConverterProvider implements ParamConverterProvider {
 
-    private static final Collection<Class<?>> caseInsensitiveParams = ResteasyConfiguration.caseInsensitiveDeserialization;
+    @SuppressWarnings("linelength")
+    private static final Collection<Class<?>> CASE_INSENSITIVE_PARAMS = ResteasyConfiguration.CASE_INSENSITIVE_DESERIALIZATION;
 
     @Override
     public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
@@ -51,9 +52,9 @@ public class EnumParamConverterProvider implements ParamConverterProvider {
             return null;
         }
 
-        return caseInsensitiveParams.contains(rawType) ?
-            new CaseInsensitiveEnumParamConverter<>(rawType) :
-            new EnumParamConverter<>(rawType);
+        return CASE_INSENSITIVE_PARAMS.contains(rawType) ?
+               new CaseInsensitiveEnumParamConverter<>(rawType) :
+               new EnumParamConverter<>(rawType);
     }
 
     /**
@@ -95,8 +96,13 @@ public class EnumParamConverterProvider implements ParamConverterProvider {
         }
     }
 
+    //TODO extend EnumParamConverterProvider or something to get rid of the duplicate code
 
-    //TODO try extending EnumParamConverter to get rid of duplicate code
+    /**
+     * ParamConverterProvider to enable use of enums in query providers in a case-insensitive manner
+     *
+     * @param <T>
+     */
     static class CaseInsensitiveEnumParamConverter<T> implements ParamConverter<T> {
 
         private final Class<T> className;
@@ -106,7 +112,8 @@ public class EnumParamConverterProvider implements ParamConverterProvider {
             this.className = className;
 
             if (Objects.nonNull(className.getEnumConstants())) {
-                keyValuePairs = Arrays.stream(className.getEnumConstants())
+                keyValuePairs = Arrays
+                    .stream(className.getEnumConstants())
                     .collect(Collectors.toMap(T::toString, value -> value));
             }
         }
@@ -117,15 +124,19 @@ public class EnumParamConverterProvider implements ParamConverterProvider {
                 return null;
             }
 
-            Optional<Map.Entry<String, T>> result = keyValuePairs.entrySet().stream()
-                .filter(kv -> value.equalsIgnoreCase(kv.getKey())).findFirst();
+            Optional<Map.Entry<String, T>> result = keyValuePairs
+                .entrySet()
+                .stream()
+                .filter(kv -> value.equalsIgnoreCase(kv.getKey()))
+                .findFirst();
 
             if (result.isPresent()) {
                 return result.get().getValue();
             }
 
-            throw new IllegalArgumentException(
-                String.format("%s is not a valid value for %s", value, className));
+            throw new IllegalArgumentException(String.format("%s is not a valid value for %s",
+                value,
+                className));
         }
 
         @Override

--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ * Copyright (c) 2019 - 2020 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,16 +46,21 @@ import java.util.Collection;
  */
 @Configuration
 @Import(ResteasyAutoConfiguration.class)
-@ComponentScan(basePackages = {"org.candlepin.subscriptions.exception.mapper",
-    "org.candlepin.subscriptions.resteasy"})
+@ComponentScan(basePackages = {
+    "org.candlepin.subscriptions.exception.mapper", "org.candlepin.subscriptions.resteasy"
+})
 public class ResteasyConfiguration implements WebMvcConfigurer {
 
+    protected static final Collection<Class<?>> CASE_INSENSITIVE_DESERIALIZATION =
+        Arrays.asList(GranularityGenerated.class, ServiceLevelGenerated.class, UsageGenerated.class);
 
-    protected static final Collection<Class<?>> caseInsensitiveDeserialization = Arrays
-        .asList(GranularityGenerated.class, ServiceLevelGenerated.class, UsageGenerated.class);
+    protected static final Collection<Class<?>> TITLE_CASE_SERIALIZATION =
+        Arrays.asList(GranularityGenerated.class, ServiceLevelGenerated.class, UsageGenerated.class);
 
-    protected static final Collection<Class<?>> titleCaseSerialization = Arrays
-        .asList(GranularityGenerated.class, ServiceLevelGenerated.class, UsageGenerated.class);
+    @Bean
+    public static BeanFactoryPostProcessor servletInitializer() {
+        return new JaxrsApplicationServletInitializer();
+    }
 
     @Bean
     @Primary
@@ -68,11 +73,6 @@ public class ResteasyConfiguration implements WebMvcConfigurer {
         return new ObjectMapperContextResolver(applicationProperties, titlecaseSerializer);
     }
 
-    @Bean
-    public static BeanFactoryPostProcessor servletInitializer() {
-        return new JaxrsApplicationServletInitializer();
-    }
-
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addViewController("/api-docs").setViewName("redirect:/api-docs/index.html");
@@ -81,9 +81,7 @@ public class ResteasyConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/api-docs/openapi.*").addResourceLocations(
-            "classpath:openapi.yaml",
-            "classpath:openapi.json"
-        );
+        registry.addResourceHandler("/api-docs/openapi.*")
+            .addResourceLocations("classpath:openapi.yaml", "classpath:openapi.json");
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -21,6 +21,9 @@
 package org.candlepin.subscriptions.resteasy;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.utilization.api.model.GranularityGenerated;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelGenerated;
+import org.candlepin.subscriptions.utilization.api.model.UsageGenerated;
 
 import org.jboss.resteasy.springboot.ResteasyAutoConfiguration;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -33,6 +36,9 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 /**
  * Configuration of Resteasy.
  *
@@ -43,11 +49,23 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @ComponentScan(basePackages = {"org.candlepin.subscriptions.exception.mapper",
     "org.candlepin.subscriptions.resteasy"})
 public class ResteasyConfiguration implements WebMvcConfigurer {
+
+
+    protected static final Collection<Class<?>> caseInsensitiveDeserialization = Arrays
+        .asList(GranularityGenerated.class, ServiceLevelGenerated.class, UsageGenerated.class);
+
+    protected static final Collection<Class<?>> titleCaseSerialization = Arrays
+        .asList(GranularityGenerated.class, ServiceLevelGenerated.class, UsageGenerated.class);
+
     @Bean
     @Primary
     public ObjectMapperContextResolver objectMapperContextResolver(
-        ApplicationProperties applicationProperties) {
-        return new ObjectMapperContextResolver(applicationProperties);
+        ApplicationProperties applicationProperties, TitlecaseSerializer titlecaseSerializer) {
+
+        //TODO make list of simple modules to pass instead of burrying the titlecase serialization lists in
+        // the object mapper
+
+        return new ObjectMapperContextResolver(applicationProperties, titlecaseSerializer);
     }
 
     @Bean

--- a/src/main/java/org/candlepin/subscriptions/resteasy/TitlecaseSerializer.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/TitlecaseSerializer.java
@@ -1,0 +1,27 @@
+package org.candlepin.subscriptions.resteasy;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import org.apache.commons.text.WordUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class TitlecaseSerializer extends StdSerializer<Enum> {
+
+    public TitlecaseSerializer() {
+        this(null);
+    }
+
+    private TitlecaseSerializer(Class<Enum> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(Enum value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeString(WordUtils.capitalizeFully(value.toString()));
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/resteasy/TitlecaseSerializer.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/TitlecaseSerializer.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
 package org.candlepin.subscriptions.resteasy;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -9,8 +29,13 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+/**
+ * Custom Serializer to serialize an enum using Titlecase
+ */
 @Component
 public class TitlecaseSerializer extends StdSerializer<Enum> {
+
+    private static final long serialVersionUID = 3212553887145757195L;
 
     public TitlecaseSerializer() {
         this(null);

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -34,6 +34,9 @@ import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReport;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
+import org.candlepin.subscriptions.utilization.api.model.GranularityGenerated;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelGenerated;
+import org.candlepin.subscriptions.utilization.api.model.UsageGenerated;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +51,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 
 @SpringBootTest
@@ -91,16 +93,8 @@ class CapacityResourceTest {
                 eq(max)))
             .thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            null
-        );
+        CapacityReport report = resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, null, null, null, null);
 
         assertEquals(9, report.getData().size());
     }
@@ -120,16 +114,9 @@ class CapacityResourceTest {
                 eq(max)))
             .thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            "Premium",
-            null
-        );
+        CapacityReport report = resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, null, null,
+                ServiceLevelGenerated.PREMIUM, null);
 
         assertEquals(9, report.getData().size());
     }
@@ -149,16 +136,9 @@ class CapacityResourceTest {
             eq(max)))
             .thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            "Production"
-        );
+        CapacityReport report = resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, null, null, null,
+                UsageGenerated.PRODUCTION);
 
         assertEquals(9, report.getData().size());
     }
@@ -178,16 +158,9 @@ class CapacityResourceTest {
                 eq(max)))
             .thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            "",
-            null
-        );
+        CapacityReport report = resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, null, null,
+                ServiceLevelGenerated.UNSPECIFIED, null);
 
         assertEquals(9, report.getData().size());
     }
@@ -207,16 +180,9 @@ class CapacityResourceTest {
             eq(max)))
             .thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            ""
-        );
+        CapacityReport report = resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, null, null, null,
+                UsageGenerated.UNSPECIFIED);
 
         assertEquals(9, report.getData().size());
     }
@@ -248,16 +214,8 @@ class CapacityResourceTest {
                 eq(max)))
             .thenReturn(Arrays.asList(capacity, capacity2));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            null
-        );
+        CapacityReport report = resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, null, null, null, null);
 
         CapacitySnapshot capacitySnapshot = report.getData().get(0);
         assertEquals(12, capacitySnapshot.getHypervisorSockets().intValue());
@@ -268,33 +226,16 @@ class CapacityResourceTest {
 
     @Test
     void testShouldThrowExceptionOnBadOffset() {
-        SubscriptionsException e = assertThrows(SubscriptionsException.class, () ->
-            resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            11,
-            10,
-            null,
-            null)
-        );
+        SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, 11, 10, null, null));
         assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
     }
 
     @Test
     void testShouldThrowBadRequestOnBadSla() {
-        BadRequestException e = assertThrows(BadRequestException.class, () ->
-            resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            0,
-            10,
-            "badSla",
-            null)
-        );
+        assertThrows(IllegalArgumentException.class, () -> resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, 0, 10,
+                ServiceLevelGenerated.valueOf("badSla"), null));
     }
 
     @Test
@@ -312,16 +253,8 @@ class CapacityResourceTest {
                 eq(max)))
             .thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            1,
-            1,
-            null,
-            null
-        );
+        CapacityReport report = resource
+            .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, 1, 1, null, null);
 
         assertEquals(1, report.getData().size());
         assertEquals(OffsetDateTime.now().minusDays(3).truncatedTo(ChronoUnit.DAYS),
@@ -332,16 +265,8 @@ class CapacityResourceTest {
     @WithMockRedHatPrincipal("1111")
     public void testAccessDeniedWhenAccountIsNotWhitelisted() {
         assertThrows(AccessDeniedException.class, () -> {
-            resource.getCapacityReport(
-                "product1",
-                "daily",
-                min,
-                max,
-                null,
-                null,
-                null,
-                null
-            );
+            resource
+                .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, null, null, null, null);
         });
     }
 
@@ -349,16 +274,8 @@ class CapacityResourceTest {
     @WithMockRedHatPrincipal(value = "123456", roles = {})
     public void testAccessDeniedWhenUserIsNotAnAdmin() {
         assertThrows(AccessDeniedException.class, () -> {
-            resource.getCapacityReport(
-                "product1",
-                "daily",
-                min,
-                max,
-                null,
-                null,
-                null,
-                null
-            );
+            resource
+                .getCapacityReport("product1", GranularityGenerated.DAILY, min, max, null, null, null, null);
         });
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.resource;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.subscriptions.db.AccountListSource;
@@ -37,8 +36,11 @@ import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.RoleProvider;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
+import org.candlepin.subscriptions.utilization.api.model.GranularityGenerated;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelGenerated;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
+import org.candlepin.subscriptions.utilization.api.model.UsageGenerated;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,10 +59,8 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 
-@SuppressWarnings("linelength")
 @SpringBootTest
 @ActiveProfiles("api,test")
 @WithMockRedHatPrincipal("123456")
@@ -103,16 +103,9 @@ public class TallyResourceTest {
                 Mockito.any(Pageable.class)))
             .thenReturn(new PageImpl<>(Arrays.asList(snap)));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
-            min,
-            max,
-            10,
-            10,
-            null,
-            Usage.PRODUCTION.getValue()
-        );
+        TallyReport report = resource
+            .getTallyReport("product1", GranularityGenerated.DAILY, min, max, 10, 10, null,
+                UsageGenerated.PRODUCTION);
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
@@ -127,8 +120,8 @@ public class TallyResourceTest {
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", null,
-            Usage.PRODUCTION.getValue(), Granularity.DAILY.name(), 1);
+        assertMetadata(report.getMeta(), "product1", null, UsageGenerated.PRODUCTION,
+            GranularityGenerated.DAILY, 1);
 
     }
 
@@ -149,16 +142,8 @@ public class TallyResourceTest {
                 Mockito.any(Pageable.class)))
             .thenReturn(new PageImpl<>(Arrays.asList(snap)));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
-            min,
-            max,
-            10,
-            10,
-            ServiceLevel.PREMIUM.getValue(),
-            null
-        );
+        TallyReport report = resource.getTallyReport("product1", GranularityGenerated.DAILY, min, max, 10, 10,
+            ServiceLevelGenerated.PREMIUM, null);
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
@@ -173,8 +158,8 @@ public class TallyResourceTest {
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(), null, Granularity.DAILY.name(),
-            1);
+        assertMetadata(report.getMeta(), "product1", ServiceLevelGenerated.PREMIUM, null,
+            GranularityGenerated.DAILY, 1);
 
     }
 
@@ -194,16 +179,8 @@ public class TallyResourceTest {
                  Mockito.any(Pageable.class)))
             .thenReturn(new PageImpl<>(Arrays.asList(snap)));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
-            min,
-            max,
-            10,
-            10,
-            ServiceLevel.UNSPECIFIED.getValue(),
-            Usage.PRODUCTION.getValue()
-        );
+        TallyReport report = resource.getTallyReport("product1", GranularityGenerated.DAILY, min, max, 10, 10,
+            ServiceLevelGenerated.UNSPECIFIED, UsageGenerated.PRODUCTION);
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
@@ -218,8 +195,8 @@ public class TallyResourceTest {
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", "", Usage.PRODUCTION.getValue(), Granularity.DAILY.name(),
-            1);
+        assertMetadata(report.getMeta(), "product1", ServiceLevelGenerated.UNSPECIFIED,
+            UsageGenerated.PRODUCTION, GranularityGenerated.DAILY, 1);
     }
 
     @Test
@@ -238,16 +215,8 @@ public class TallyResourceTest {
                 Mockito.any(Pageable.class)))
             .thenReturn(new PageImpl<>(Arrays.asList(snap)));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
-            min,
-            max,
-            10,
-            10,
-            ServiceLevel.PREMIUM.getValue(),
-            Usage.UNSPECIFIED.getValue()
-        );
+        TallyReport report = resource.getTallyReport("product1", GranularityGenerated.DAILY, min, max, 10, 10,
+            ServiceLevelGenerated.PREMIUM, UsageGenerated.UNSPECIFIED);
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
@@ -262,8 +231,8 @@ public class TallyResourceTest {
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(), "", Granularity.DAILY.name(),
-            1);
+        assertMetadata(report.getMeta(), "product1", ServiceLevelGenerated.PREMIUM,
+            UsageGenerated.UNSPECIFIED, GranularityGenerated.DAILY, 1);
     }
 
     @Test
@@ -281,16 +250,9 @@ public class TallyResourceTest {
                  Mockito.eq(max),
                  Mockito.any(Pageable.class)))
             .thenReturn(new PageImpl<>(Arrays.asList(snap)));
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
-            min,
-            max,
-            10,
-            10,
-            ServiceLevel.PREMIUM.getValue(),
-            Usage.PRODUCTION.getValue()
-        );
+
+        TallyReport report = resource.getTallyReport("product1", GranularityGenerated.DAILY, min, max, 10, 10,
+            ServiceLevelGenerated.PREMIUM, UsageGenerated.PRODUCTION);
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
@@ -305,8 +267,8 @@ public class TallyResourceTest {
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(),
-            Usage.PRODUCTION.getValue(), Granularity.DAILY.name(), 1);
+        assertMetadata(report.getMeta(), "product1", ServiceLevelGenerated.PREMIUM, UsageGenerated.PRODUCTION,
+            GranularityGenerated.DAILY, 1);
     }
 
     @Test
@@ -324,16 +286,9 @@ public class TallyResourceTest {
             Mockito.eq(max),
             Mockito.any(Pageable.class)))
             .thenReturn(new PageImpl<>(Arrays.asList(snap)));
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            10,
-            10,
-            ServiceLevel.PREMIUM.getValue(),
-            Usage.PRODUCTION.getValue()
-        );
+
+        TallyReport report = resource.getTallyReport("product1", GranularityGenerated.DAILY, min, max, 10, 10,
+            ServiceLevelGenerated.PREMIUM, UsageGenerated.PRODUCTION);
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
@@ -449,16 +404,9 @@ public class TallyResourceTest {
 
     @Test
     public void testShouldThrowExceptionOnBadOffset() throws IOException {
-        SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource.getTallyReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            11,
-            10,
-            ServiceLevel.PREMIUM.getValue(),
-            Usage.PRODUCTION.getValue()
-        ));
+        SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource
+            .getTallyReport("product1", GranularityGenerated.DAILY, min, max, 11, 10,
+                ServiceLevelGenerated.PREMIUM, UsageGenerated.PRODUCTION));
         assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
     }
 
@@ -476,16 +424,8 @@ public class TallyResourceTest {
                  Mockito.eq(null)))
             .thenReturn(new PageImpl<>(Collections.emptyList()));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            null
-        );
+        TallyReport report = resource
+            .getTallyReport("product1", GranularityGenerated.DAILY, min, max, null, null, null, null);
 
         // Since nothing was returned from the DB, there should be one generated snapshot for each day
         // in the range.
@@ -495,8 +435,7 @@ public class TallyResourceTest {
 
     @Test
     void testEmptySnapshotFilledWithAllZeroes() {
-        org.candlepin.subscriptions.utilization.api.model.TallySnapshot snapshot =
-            new org.candlepin.subscriptions.utilization.api.model.TallySnapshot();
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot snapshot = new org.candlepin.subscriptions.utilization.api.model.TallySnapshot();
 
         assertEquals(0, snapshot.getInstanceCount().intValue());
         assertEquals(0, snapshot.getCores().intValue());
@@ -511,17 +450,9 @@ public class TallyResourceTest {
 
     @Test
     public void ensureBadRequestExceptionIsThrownWhenAnInvalidSlaParameterIsSpecified() {
-        assertThrows(BadRequestException.class, () -> {
-            resource.getTallyReport(
-                "product1",
-                "daily",
-                min,
-                max,
-                null,
-                null,
-                "foo_sla",
-                null
-            );
+        assertThrows(IllegalArgumentException.class, () -> {
+            resource.getTallyReport("product1", GranularityGenerated.DAILY, min, max, null, null,
+                ServiceLevelGenerated.valueOf("foo_sla"), null);
         });
     }
 
@@ -540,16 +471,8 @@ public class TallyResourceTest {
                  Mockito.eq(null)))
             .thenReturn(new PageImpl<>(Collections.emptyList()));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            null
-        );
+        TallyReport report = resource
+            .getTallyReport("product1", GranularityGenerated.DAILY, min, max, null, null, null, null);
         assertNotNull(report);
     }
 
@@ -557,16 +480,7 @@ public class TallyResourceTest {
     @WithMockRedHatPrincipal("1111")
     public void testAccessDeniedWhenAccountIsNotWhitelisted() {
         assertThrows(AccessDeniedException.class, () -> {
-            resource.getTallyReport(
-                "product1",
-                "daily",
-                min,
-                max,
-                null,
-                null,
-                null,
-                null
-            );
+            resource.getTallyReport("product1", GranularityGenerated.DAILY, min, max, null, null, null, null);
         });
     }
 
@@ -574,26 +488,17 @@ public class TallyResourceTest {
     @WithMockRedHatPrincipal(value = "123456", roles = {})
     public void testAccessDeniedWhenUserIsNotAnAdmin() {
         assertThrows(AccessDeniedException.class, () -> {
-            resource.getTallyReport(
-                "product1",
-                "daily",
-                min,
-                max,
-                null,
-                null,
-                null,
-                null
-            );
+            resource.getTallyReport("product1", GranularityGenerated.DAILY, min, max, null, null, null, null);
         });
     }
 
-    private void assertMetadata(TallyReportMeta meta, String expectedProd, String expectedSla,
-        String expectedUsage, String expectedGranularity, Integer expectedCount) {
-        assertEquals(expectedProd, meta.getProduct());
+    private void assertMetadata(TallyReportMeta meta, String expectedProduct,
+        ServiceLevelGenerated expectedSla, UsageGenerated expectedUsage,
+        GranularityGenerated expectedGranularity, Integer expectedCount) {
+        assertEquals(expectedProduct, meta.getProduct());
         assertEquals(expectedSla, meta.getServiceLevel());
         assertEquals(expectedUsage, meta.getUsage());
-        assertEquals(expectedGranularity, meta.getGranularity());
         assertEquals(expectedCount, meta.getCount());
-
+        assertEquals(expectedGranularity, meta.getGranularity());
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/resteasy/ObjectMapperContextResolverTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/ObjectMapperContextResolverTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import java.util.Calendar;
 import java.util.TimeZone;
 
-
 @TestInstance(Lifecycle.PER_CLASS)
 class ObjectMapperContextResolverTest {
 
@@ -46,7 +45,8 @@ class ObjectMapperContextResolverTest {
     @BeforeAll
     void setupTests() {
         ApplicationProperties props = new ApplicationProperties();
-        ObjectMapperContextResolver resolver = new ObjectMapperContextResolver(props);
+        TitlecaseSerializer titlecaseSerializer = new TitlecaseSerializer();
+        ObjectMapperContextResolver resolver = new ObjectMapperContextResolver(props, titlecaseSerializer);
         mapper = resolver.getContext(Void.class);
     }
 
@@ -127,7 +127,7 @@ class ObjectMapperContextResolverTest {
         assertIncludesCollection(data, "valueList", "[]");
     }
 
-    private void assertContainsProperty(String data, String key, String value)  throws Exception {
+    private void assertContainsProperty(String data, String key, String value) throws Exception {
         String toFind = String.format("\"%s\":\"%s\"", key, value);
         assertThat(data, Matchers.containsString(toFind));
     }


### PR DESCRIPTION
This PR takes care of MOST of the ask of [ENT-2607](https://issues.redhat.com/browse/ENT-2607), to unify the canonical values of Granularity, Service Level, and Usage metadata.  I haven't finished Product Id yet. [ENT-2512](https://issues.redhat.com/browse/ENT-2512) goes along with this card as well.  The ask of [ENT-2512](https://issues.redhat.com/browse/ENT-2512) is to enumerate the same items.

I'd like to get feedback of what I have so far, and I'll probably put out a non-draft PR that includes the product id enumeration as well.

The "highlights" of the changes are as follows:

- Updated the api-spec.yaml file to define the enums mentioned above as schemas, and reference them in the appropriate places through the spec file
- Updated Resteasy configurations to use custom serializer/deserializer for the newly defined enums.  The deserializer ensures that the incoming query params continue to support case insensitive.  The serializer is enforcing title case when the new enums are returned in a response.
  - Added `org.apache.commons:commons-text` dependency to the project for titlecase support to prevent reinventing the wheel.  Let me know if it's preferable to implement that logic manually instead.


Something I'm not too thrilled about and is an area for improvement  (taking suggestions!) is that I've got the serializer and deserializer configured in two different manners.  For the serializer, I was able to extend StdSerializer<T> and register it as a module in the ObjectMapperContextResolver class.  When I tried to extend StdDeserializer<T> the same way, the deserialize method didn't execute as expected.  Then I found the `EnumParamConverterProvider` class, and added logic there to support the case insensitivity.  I've got some TODO flags in there to consolidate some of the code, but I'm open to a completely different approach.  An idea I had after the fact was to try to extend JsonDeserializer, but not sure how that would work out since I don't want to force every enum in a project to use a case-insensitive deserializer.  Anyway, I don't have much experience with jax-rs so I'm very much open to other ideas you guys may have.


![image](https://user-images.githubusercontent.com/19955562/100673362-4e990f80-3331-11eb-88a9-81f8d21b88a3.png)

