### PR TITLE
Update openapi specification to create schemas for enums to mirror th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 bin
 .vscode
 .editorconfig
+
+.run/

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -161,7 +161,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/ProductId'
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -183,17 +183,17 @@ paths:
           in: query
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/GranularityType'
           description: "The level of granularity to return."
         - name: sla
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/ServiceLevelType'
           description: "Include only snapshots matching the specified service level."
         - name: usage
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/UsageType'
           description: "Include only snapshots matching the specified usage."
         - name: beginning
           in: query
@@ -261,7 +261,7 @@ paths:
                 meta:
                   count: 10
                   product: RHEL
-                  granularity: DAILY
+                  granularity: Daily
                   service_level: Premium
                   usage: Production
         '400':
@@ -281,7 +281,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/ProductId'
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -302,17 +302,17 @@ paths:
           in: query
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/GranularityType'
           description: "The level of granularity to return."
         - name: sla
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/ServiceLevelType'
           description: "Include only capacity for the specified service level."
         - name: usage
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/UsageType'
           description: "Include only capacity for the specified usage level."
         - name: beginning
           in: query
@@ -372,7 +372,7 @@ paths:
                 meta:
                   count: 10
                   product: RHEL
-                  granularity: DAILY
+                  granularity: Daily
                   service_level: Premium
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -391,7 +391,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/ProductId'
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -412,12 +412,12 @@ paths:
         - name: sla
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/ServiceLevelType'
           description: "Include only hosts for the specified service level."
         - name: usage
           in: query
           schema:
-            type: string
+            $ref: '#/components/schemas/UsageType'
           description: "Include only hosts for the specified usage level."
         - name: uom
           in: query
@@ -654,6 +654,31 @@ components:
           schema:
             $ref: "#/components/schemas/Errors"
   schemas:
+    # Schemas ending in "Type" are intentionally named to prevent naming conflicts with db model classes
+    GranularityType:
+      type: string
+      enum: [ Daily, Weekly, Monthly, Quarterly, Yearly ]
+    ServiceLevelType:
+      type: string
+      enum: [ "", Premium, Standard, Self-Support, _ANY ]
+    UsageType:
+      type: string
+      enum: [ "", Production, Development/Test, Disaster Recovery, _ANY ]
+    ProductId:
+      type: string
+      enum:
+        - OpenShift Container Platform
+        - RHEL
+        - RHEL Compute Node
+        - RHEL Desktop
+        - RHEL for ARM
+        - RHEL for IBM Power
+        - RHEL for IBM z
+        - RHEL for x86
+        - RHEL Server
+        - RHEL Workstation
+        - Satellite 6
+        - Satellite 6 Capsule
     Uom:
       type: string
       enum:
@@ -777,20 +802,20 @@ components:
             count:
               type: integer
             product:
-              type: string
+              $ref: '#/components/schemas/ProductId'
             service_level:
+              $ref: '#/components/schemas/ServiceLevelType'
               description: "Describes the service level that the report was made against. Not set if it wasn't
                 specified as a query parameter."
-              type: string
             usage:
+              $ref: '#/components/schemas/UsageType'
               description: "Describes the usage that the report was made against. Not set if it wasn't
                             specified as a query parameter."
-              type: string
             granularity:
+              $ref: '#/components/schemas/GranularityType'
               description: "Describes the significance of each date in the TallySnapshot list. For example if the
-                granularity is set to 'weekly', the dates in the TallySnapshot list will represent the start of a
-                seven day period."
-              type: string
+                              granularity is set to 'weekly', the dates in the TallySnapshot list will represent the start of a
+                              seven day period."
           required:
             - count
             - product
@@ -919,20 +944,20 @@ components:
             count:
               type: integer
             product:
-              type: string
+              $ref: '#/components/schemas/ProductId'
             granularity:
+              $ref: '#/components/schemas/GranularityType'
               description: "Describes the significance of each date in the CapacitySnapshot list. For example if the
                 granularity is set to 'weekly', the dates in the CapacitySnapshot list will represent the start of a
                 seven day period."
-              type: string
             service_level:
+              $ref: '#/components/schemas/ServiceLevelType'
               description: "Describes the service level that the report was made against. Not set if it wasn't
                 specified as a query parameter."
-              type: string
             usage:
+              $ref: '#/components/schemas/UsageType'
               description: "Describes the usages that the report was made against. Not set if it wasn't
                specified as a query parameter."
-              type: string
           required:
             - count
             - product
@@ -1018,15 +1043,16 @@ components:
             count:
               type: integer
             product:
-              type: string
+              $ref: '#/components/schemas/ProductId'
             service_level:
+              $ref: '#/components/schemas/ServiceLevelType'
               description: "Describes the service level that the report was made against. Not set if it wasn't
                     specified as a query parameter."
               type: string
             usage:
+              $ref: '#/components/schemas/UsageType'
               description: "Describes the usages that the report was made against. Not set if it wasn't
                    specified as a query parameter."
-              type: string
             uom:
               $ref: '#/components/schemas/Uom'
           required:

--- a/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
@@ -178,13 +178,13 @@ public class CandlepinPoolCapacityMapper {
 
         if (sla.isPresent()) {
             ServiceLevel slaValue = ServiceLevel.fromString(sla.get());
-            if (slaValue == ServiceLevel.UNSPECIFIED) {
+            if (slaValue == ServiceLevel.EMPTY) {
                 log.warn("Product {} has unsupported service level {}", pool.getProductId(), sla.get());
             }
             return slaValue;
         }
 
-        return ServiceLevel.UNSPECIFIED;
+        return ServiceLevel.EMPTY;
     }
 
     private Usage getUsage(CandlepinPool pool) {
@@ -194,13 +194,13 @@ public class CandlepinPoolCapacityMapper {
 
         if (usage.isPresent()) {
             Usage usageValue = Usage.fromString(usage.get());
-            if (usageValue == Usage.UNSPECIFIED) {
+            if (usageValue == Usage.EMPTY) {
                 log.warn("Product {} has unsupported usage {}", pool.getProductId(), usage.get());
             }
             return usageValue;
         }
 
-        return Usage.UNSPECIFIED;
+        return Usage.EMPTY;
     }
 
     private List<String> extractProductIds(Collection<CandlepinProvidedProduct> providedProducts) {

--- a/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepositoryImpl.java
+++ b/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepositoryImpl.java
@@ -66,11 +66,11 @@ public class CustomizedSubscriptionCapacityRepositoryImpl
         predicates.add(cb.equal(capacity.get("key").get("ownerId"), ownerId));
         predicates.add(cb.equal(capacity.get("key").get("productId"), productId));
 
-        if (serviceLevel != null && serviceLevel != ServiceLevel.ANY) {
+        if (serviceLevel != null && serviceLevel != ServiceLevel._ANY) {
             predicates.add(cb.equal(capacity.get("serviceLevel"), serviceLevel));
         }
 
-        if (usage != null && usage != Usage.ANY) {
+        if (usage != null && usage != Usage._ANY) {
             predicates.add(cb.equal(capacity.get("usage"), usage));
         }
 

--- a/src/main/java/org/candlepin/subscriptions/db/model/Granularity.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Granularity.java
@@ -20,6 +20,10 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import org.candlepin.subscriptions.utilization.api.model.GranularityType;
+
+import java.util.Map;
+
 /**
  * Granularity of a given snapshot.
  *
@@ -27,10 +31,33 @@ package org.candlepin.subscriptions.db.model;
  * represents the maximum tally totals across all days in that week. For example, given a week where daily
  * tallies were 2, 3, 4, 5, 6, 2, 4, the weekly tally snapshot would be 6.
  */
-public enum Granularity {
-    DAILY,
-    WEEKLY,
-    MONTHLY,
-    QUARTERLY,
-    YEARLY
+public enum Granularity implements StringValueEnum<GranularityType> {
+    DAILY("Daily", GranularityType.DAILY),
+    WEEKLY("Weekly", GranularityType.WEEKLY),
+    MONTHLY("Monthly", GranularityType.MONTHLY),
+    QUARTERLY("Quarterly", GranularityType.QUARTERLY),
+    YEARLY("Yearly", GranularityType.YEARLY);
+
+    private static final Map<String, Granularity> VALUE_ENUM_MAP = StringValueEnum.initializeImmutableMap(
+        Granularity.class);
+
+    private final String value;
+    private final GranularityType openApiEnum;
+
+    Granularity(String value, GranularityType openApiEnum) {
+        this.value = value;
+        this.openApiEnum = openApiEnum;
+    }
+
+    public static Granularity fromString(String value) {
+        return StringValueEnum.getValueOf(Granularity.class, VALUE_ENUM_MAP, value, null);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public GranularityType asOpenApiEnum() {
+        return openApiEnum;
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/StringValueEnum.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/StringValueEnum.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.db.model;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Interface to reduce duplication of common methods for some enums
+ *
+ * @param <T>
+ */
+public interface StringValueEnum<T> {
+
+    static <T> T getValueOf(Class<T> className, Map<String, T> valueEnumMap, String value, T defaultEnum) {
+        String key = Objects.nonNull(value) ? value.toLowerCase() : null;
+
+        T match = valueEnumMap.get(key);
+
+        if (Objects.nonNull(match)) {
+            return match;
+        }
+        else if (Objects.nonNull(defaultEnum)) {
+            return defaultEnum;
+        }
+        else {
+            throw new IllegalArgumentException(
+                String.format("%s is not a valid value for %s", value, className));
+        }
+
+    }
+
+    /**
+     * Maps lowercase string values of an enum's .getValue() to the enum itself
+     *
+     * @param enumClass Given enum class to create map for
+     * @param <T>       Subclass of StringValueEnum
+     *
+     * @return Map where keys are lowercase string value of the given enumClass's value
+     */
+    static <T extends StringValueEnum<?>> Map<String, T> initializeImmutableMap(Class<T> enumClass) {
+        return Arrays.stream(enumClass.getEnumConstants()).collect(
+            Collectors.toMap(t -> t.getValue().toLowerCase(), value -> value));
+    }
+
+    String getValue();
+
+    T asOpenApiEnum();
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -66,10 +66,10 @@ public class TallySnapshot implements Serializable {
     private String accountNumber;
 
     @Column(name = "sla")
-    private ServiceLevel serviceLevel = ServiceLevel.ANY;
+    private ServiceLevel serviceLevel = ServiceLevel._ANY;
 
     @Column(name = "usage")
-    private Usage usage = Usage.ANY;
+    private Usage usage = Usage._ANY;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "granularity")

--- a/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.db.model;
 
-import com.google.common.collect.ImmutableMap;
+import org.candlepin.subscriptions.utilization.api.model.UsageType;
 
 import java.util.Map;
 
@@ -32,57 +32,42 @@ import javax.persistence.Converter;
  *
  * Usage represents the class of usage for a given system or subscription.
  */
-public enum Usage {
-    UNSPECIFIED(""),
-    PRODUCTION("Production"),
-    DEVELOPMENT_TEST("Development/Test"),
-    DISASTER_RECOVERY("Disaster Recovery"),
-    ANY("_ANY");
+public enum Usage implements StringValueEnum<UsageType> {
+    EMPTY("", UsageType.EMPTY),
+    PRODUCTION("Production", UsageType.PRODUCTION),
+    DEVELOPMENT_TEST("Development/Test", UsageType.DEVELOPMENT_TEST),
+    DISASTER_RECOVERY("Disaster Recovery", UsageType.DISASTER_RECOVERY),
+    _ANY("_ANY", UsageType._ANY); //NOSONAR
+
+    private static final Map<String, Usage> VALUE_ENUM_MAP = StringValueEnum.initializeImmutableMap(
+        Usage.class);
 
     private final String value;
+    private final UsageType openApiEnum;
 
-    private static final Map<String, Usage> VALUE_ENUM_MAP = ImmutableMap.of(
-        PRODUCTION.value.toUpperCase(), PRODUCTION,
-        DEVELOPMENT_TEST.value.toUpperCase(), DEVELOPMENT_TEST,
-        DISASTER_RECOVERY.value.toUpperCase(), DISASTER_RECOVERY
-    );
-
-    Usage(String value) {
+    Usage(String value, UsageType openApiEnum) {
         this.value = value;
+        this.openApiEnum = openApiEnum;
     }
 
     /**
-     * Parse the usage from its string representation (excluding special value _ANY)
-     *
-     * NOTE: this method will not return the special value ANY, and gives UNSPECIFIED for any invalid value.
+     * Parse the usage from its string representation
      *
      * @param value String representation of the Usage, as seen in a host record
-     * @return the Usage enum; UNSPECIFIED if unparseable.
+     *
+     * @return the Usage enum
      */
     public static Usage fromString(String value) {
-        String key = value == null ? "" : value.toUpperCase();
-        return VALUE_ENUM_MAP.getOrDefault(key, UNSPECIFIED);
-    }
-
-    /**
-     * Parse the usage from its string representation.
-     *
-     * NOTE: this method will return UNSPECIFIED for any invalid value.
-     *
-     * @param value String representation of the Usage, as seen in the DB
-     * @return the Usage enum; UNSPECIFIED if unparseable.
-     */
-    public static Usage fromDbString(String value) {
-        if ("_ANY".equals(value)) {
-            return Usage.ANY;
-        }
-        else {
-            return fromString(value);
-        }
+        return StringValueEnum.getValueOf(Usage.class, VALUE_ENUM_MAP, value, EMPTY);
     }
 
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public UsageType asOpenApiEnum() {
+        return openApiEnum;
     }
 
     /**
@@ -90,6 +75,7 @@ public enum Usage {
      */
     @Converter(autoApply = true)
     public static class EnumConverter implements AttributeConverter<Usage, String> {
+
         @Override
         public String convertToDatabaseColumn(Usage attribute) {
             if (attribute == null) {
@@ -100,7 +86,8 @@ public enum Usage {
 
         @Override
         public Usage convertToEntityAttribute(String dbData) {
-            return Usage.fromDbString(dbData);
+            return Usage.fromString(dbData);
         }
     }
+
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -26,19 +26,21 @@ import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFilter;
 import org.candlepin.subscriptions.security.InsightsUserPrincipal;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
+import org.candlepin.subscriptions.utilization.api.model.UsageType;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.Objects;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 
 /**
@@ -142,44 +144,24 @@ public class ResourceUtils {
     }
 
     /**
-     * Validate and reject bad usage.
+     * Uses Usage.ANY for a null value, otherwise returns db model equivalent of UsageType
+     * generated enum
      *
-     * throws a BadRequestException if the usage value is bad.
-     *
-     * @param usage string form of usage
+     * @param usageType openapi generated equivalent enum for UsageType
      * @return Usage enum
      */
-    public static Usage sanitizeUsage(String usage) {
-        if (usage == null) {
-            return Usage.ANY;
-        }
-        Usage sanitizedUsage = Usage.fromString(usage);
-        // If the usage parameter is not one that we support, then throw an exception.
-        // If we don't, the query would default to UNSPECIFIED, which would be confusing.
-        if (StringUtils.hasLength(usage) && sanitizedUsage == Usage.UNSPECIFIED) {
-            throw new BadRequestException("Invalid usage parameter specified.");
-        }
-        return sanitizedUsage;
+    public static Usage sanitizeUsage(UsageType usageType) {
+        return Objects.isNull(usageType) ? Usage._ANY : Usage.fromString(usageType.toString());
     }
 
     /**
-     * Validate and reject bad sla.
-     *
-     * throws a BadRequestException if the sla value is bad.
+     * Uses ServiceLevel.ANY for a null value, otherwise returns db model equivalent of ServiceLevelType
+     * generated enum
      *
      * @param sla string form of sla
      * @return ServiceLevel enum
      */
-    public static ServiceLevel sanitizeServiceLevel(String sla) {
-        if (sla == null) {
-            return ServiceLevel.ANY;
-        }
-        ServiceLevel sanitizedSla = ServiceLevel.fromString(sla);
-        // If the sla parameter is not one that we support, then throw an exception.
-        // If we don't, the query would default to UNSPECIFIED, which would be confusing.
-        if (StringUtils.hasLength(sla) && sanitizedSla == ServiceLevel.UNSPECIFIED) {
-            throw new BadRequestException("Invalid sla parameter specified.");
-        }
-        return sanitizedSla;
+    public static ServiceLevel sanitizeServiceLevel(ServiceLevelType sla) {
+        return Objects.isNull(sla) ? ServiceLevel._ANY : ServiceLevel.fromString(sla.toString());
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
@@ -113,11 +113,11 @@ public class CloudigradeAccountUsageCollector {
     private UsageCalculation.Key extractKey(UsageCount usageCount, Map<String, String> archToProductMap,
         Map<String, List<String>> roleToProductsMap) {
         String productId = extractProductId(usageCount, archToProductMap, roleToProductsMap);
-        ServiceLevel sla = ServiceLevel.fromDbString(usageCount.getSla());
-        Usage usage = Usage.fromDbString(usageCount.getUsage());
+        ServiceLevel sla = ServiceLevel.fromString(usageCount.getSla());
+        Usage usage = Usage.fromString(usageCount.getUsage());
         // FIXME cloudigrade does report usage yet, workaround below
         if (usageCount.getUsage() == null) {
-            usage = Usage.ANY;
+            usage = Usage._ANY;
         }
         return new UsageCalculation.Key(productId, sla, usage);
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -127,8 +127,8 @@ public class InventoryAccountUsageCollector {
                     hypervisorGuestCounts.put(host.getHypervisorUuid(), ++guests);
                 }
 
-                ServiceLevel[] slas = new ServiceLevel[]{facts.getSla(), ServiceLevel.ANY};
-                Usage[] usages = new Usage[]{facts.getUsage(), Usage.ANY};
+                ServiceLevel[] slas = new ServiceLevel[]{facts.getSla(), ServiceLevel._ANY };
+                Usage[] usages = new Usage[]{facts.getUsage(), Usage._ANY };
 
                 // Calculate for each UsageKey
                 products.forEach(product -> {

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -252,7 +252,7 @@ public class FactNormalizer {
 
     private Usage extractRhsmUsage(InventoryHostFacts hostFacts) {
         Usage effectiveUsage = Usage.fromString(hostFacts.getSyspurposeUsage());
-        if (hostFacts.getSyspurposeUsage() != null && effectiveUsage == Usage.UNSPECIFIED &&
+        if (hostFacts.getSyspurposeUsage() != null && effectiveUsage == Usage.EMPTY &&
             log.isDebugEnabled()) {
 
             log.debug(
@@ -267,7 +267,7 @@ public class FactNormalizer {
 
     private ServiceLevel extractRhsmSla(InventoryHostFacts hostFacts) {
         ServiceLevel effectiveSla = ServiceLevel.fromString(hostFacts.getSyspurposeSla());
-        if (hostFacts.getSyspurposeSla() != null && effectiveSla == ServiceLevel.UNSPECIFIED &&
+        if (hostFacts.getSyspurposeSla() != null && effectiveSla == ServiceLevel.EMPTY &&
             log.isDebugEnabled()) {
 
             log.debug(

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -41,8 +41,8 @@ public class NormalizedFacts {
     public static final String OWNER_KEY = "owner";
 
     private Set<String> products;
-    private ServiceLevel sla = ServiceLevel.UNSPECIFIED;
-    private Usage usage = Usage.UNSPECIFIED;
+    private ServiceLevel sla = ServiceLevel.EMPTY;
+    private Usage usage = Usage.EMPTY;
     private Integer cores;
     private Integer sockets;
     private String owner;

--- a/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapperTest.java
@@ -130,8 +130,8 @@ class CandlepinPoolCapacityMapperTest {
         expectedRhelCapacity.setBeginDate(LONG_AGO);
         expectedRhelCapacity.setEndDate(NOWISH);
         expectedRhelCapacity.setSubscriptionId("subId");
-        expectedRhelCapacity.setServiceLevel(ServiceLevel.UNSPECIFIED);
-        expectedRhelCapacity.setUsage(Usage.UNSPECIFIED);
+        expectedRhelCapacity.setServiceLevel(ServiceLevel.EMPTY);
+        expectedRhelCapacity.setUsage(Usage.EMPTY);
         expectedRhelCapacity.setOwnerId("ownerId");
 
         SubscriptionCapacity expectedServerCapacity = new SubscriptionCapacity();
@@ -143,8 +143,8 @@ class CandlepinPoolCapacityMapperTest {
         expectedServerCapacity.setEndDate(NOWISH);
         expectedServerCapacity.setSubscriptionId("subId");
         expectedServerCapacity.setOwnerId("ownerId");
-        expectedServerCapacity.setServiceLevel(ServiceLevel.UNSPECIFIED);
-        expectedServerCapacity.setUsage(Usage.UNSPECIFIED);
+        expectedServerCapacity.setServiceLevel(ServiceLevel.EMPTY);
+        expectedServerCapacity.setUsage(Usage.EMPTY);
 
         assertThat(capacities, Matchers.containsInAnyOrder(
             expectedRhelCapacity,

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -70,8 +70,8 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.ANY,
+            ServiceLevel._ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
@@ -99,8 +99,8 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.ANY,
+            ServiceLevel._ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
@@ -128,8 +128,8 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.ANY,
+            ServiceLevel._ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
@@ -157,8 +157,8 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.ANY,
+            ServiceLevel._ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
@@ -186,8 +186,8 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.ANY,
+            ServiceLevel._ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(0, found.size());
@@ -203,8 +203,8 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.ANY,
+            ServiceLevel._ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(0, found.size());
@@ -220,8 +220,8 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.ANY,
+            ServiceLevel._ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
@@ -237,7 +237,7 @@ class SubscriptionCapacityRepositoryTest {
             "ownerId",
             "product",
             ServiceLevel.STANDARD,
-            Usage.ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(0, found.size());
@@ -252,7 +252,7 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
+            ServiceLevel._ANY,
             Usage.DEVELOPMENT_TEST,
             NOWISH,
             FAR_FUTURE);
@@ -269,7 +269,7 @@ class SubscriptionCapacityRepositoryTest {
             "ownerId",
             "product",
             ServiceLevel.PREMIUM,
-            Usage.ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
 
@@ -284,7 +284,7 @@ class SubscriptionCapacityRepositoryTest {
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
+            ServiceLevel._ANY,
             Usage.PRODUCTION,
             NOWISH,
             FAR_FUTURE);
@@ -301,7 +301,7 @@ class SubscriptionCapacityRepositoryTest {
         standard.setSubscriptionId("standard");
         standard.setServiceLevel(ServiceLevel.STANDARD);
         unset.setSubscriptionId("unset");
-        unset.setServiceLevel(ServiceLevel.UNSPECIFIED);
+        unset.setServiceLevel(ServiceLevel.EMPTY);
         repository.saveAll(Arrays.asList(premium, standard, unset));
         repository.flush();
 
@@ -325,19 +325,19 @@ class SubscriptionCapacityRepositoryTest {
         standard.setSubscriptionId("standard");
         standard.setServiceLevel(ServiceLevel.STANDARD);
         unset.setSubscriptionId("unset");
-        unset.setServiceLevel(ServiceLevel.UNSPECIFIED);
+        unset.setServiceLevel(ServiceLevel.EMPTY);
         repository.saveAll(Arrays.asList(premium, standard, unset));
         repository.flush();
 
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.UNSPECIFIED,
+            ServiceLevel.EMPTY,
             Usage.PRODUCTION,
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
-        assertEquals(ServiceLevel.UNSPECIFIED, found.get(0).getServiceLevel());
+        assertEquals(ServiceLevel.EMPTY, found.get(0).getServiceLevel());
     }
 
     @Test
@@ -350,14 +350,14 @@ class SubscriptionCapacityRepositoryTest {
         standard.setSubscriptionId("standard");
         standard.setServiceLevel(ServiceLevel.STANDARD);
         unset.setSubscriptionId("unset");
-        unset.setServiceLevel(ServiceLevel.UNSPECIFIED);
+        unset.setServiceLevel(ServiceLevel.EMPTY);
         repository.saveAll(Arrays.asList(premium, standard, unset));
         repository.flush();
 
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
+            ServiceLevel._ANY,
             Usage.PRODUCTION,
             NOWISH,
             FAR_FUTURE);
@@ -374,14 +374,14 @@ class SubscriptionCapacityRepositoryTest {
         dr.setSubscriptionId("dr");
         dr.setUsage(Usage.DISASTER_RECOVERY);
         unset.setSubscriptionId("unset");
-        unset.setUsage(Usage.UNSPECIFIED);
+        unset.setUsage(Usage.EMPTY);
         repository.saveAll(Arrays.asList(production, dr, unset));
         repository.flush();
 
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
+            ServiceLevel._ANY,
             null,
             NOWISH,
             FAR_FUTURE);
@@ -398,19 +398,19 @@ class SubscriptionCapacityRepositoryTest {
         dr.setSubscriptionId("dr");
         dr.setUsage(Usage.DISASTER_RECOVERY);
         unset.setSubscriptionId("unset");
-        unset.setUsage(Usage.UNSPECIFIED);
+        unset.setUsage(Usage.EMPTY);
         repository.saveAll(Arrays.asList(production, dr, unset));
         repository.flush();
 
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.UNSPECIFIED,
+            ServiceLevel._ANY,
+            Usage.EMPTY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(1, found.size());
-        assertEquals(Usage.UNSPECIFIED, found.get(0).getUsage());
+        assertEquals(Usage.EMPTY, found.get(0).getUsage());
     }
 
     @Test
@@ -423,15 +423,15 @@ class SubscriptionCapacityRepositoryTest {
         dr.setSubscriptionId("dr");
         dr.setUsage(Usage.DISASTER_RECOVERY);
         unset.setSubscriptionId("unset");
-        unset.setUsage(Usage.UNSPECIFIED);
+        unset.setUsage(Usage.EMPTY);
         repository.saveAll(Arrays.asList(production, dr, unset));
         repository.flush();
 
         List<SubscriptionCapacity> found = repository.findByOwnerAndProductId(
             "ownerId",
             "product",
-            ServiceLevel.ANY,
-            Usage.ANY,
+            ServiceLevel._ANY,
+            Usage._ANY,
             NOWISH,
             FAR_FUTURE);
         assertEquals(3, found.size());

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -103,8 +103,8 @@ public class TallySnapshotRepositoryTest {
     @SuppressWarnings("linelength")
     @Test
     public void testFindByEmptyServiceLevelAndUsage() {
-        TallySnapshot t1 = createUnpersisted("A1", "P1", Granularity.DAILY, ServiceLevel.UNSPECIFIED,
-            Usage.UNSPECIFIED, 1111, 111, 11, NOWISH);
+        TallySnapshot t1 = createUnpersisted("A1", "P1", Granularity.DAILY, ServiceLevel.EMPTY,
+            Usage.EMPTY, 1111, 111, 11, NOWISH);
 
         repository.saveAll(Arrays.asList(t1));
         repository.flush();
@@ -114,8 +114,8 @@ public class TallySnapshotRepositoryTest {
             "A1",
             "P1",
             Granularity.DAILY,
-            ServiceLevel.UNSPECIFIED,
-            Usage.UNSPECIFIED,
+            ServiceLevel.EMPTY,
+            Usage.EMPTY,
             LONG_AGO,
             FAR_FUTURE,
             PageRequest.of(0, 10))

--- a/src/test/java/org/candlepin/subscriptions/db/model/GranularityTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/GranularityTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.subscriptions.db.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.subscriptions.utilization.api.model.GranularityType;
+
+import com.google.common.collect.Sets;
+
+import org.junit.jupiter.api.Test;
+
+import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class GranularityTest {
+
+    public static final String DAILY_MIXEDCASE = "DaIlY";
+    public static final String BAD_VALUE = "bicentenially";
+
+    @Test
+    void testFromStringBadValue() {
+        assertThrows(IllegalArgumentException.class, () -> Granularity.fromString(BAD_VALUE));
+    }
+
+    @Test
+    void testFromStringEmpty() {
+        assertThrows(IllegalArgumentException.class, () -> Granularity.fromString(StringUtils.EMPTY));
+    }
+
+    @Test
+    void testFromStringNull() {
+        assertThrows(IllegalArgumentException.class, () -> Granularity.fromString(null));
+    }
+
+    @Test
+    void testFromStringUpperCase() {
+        assertEquals(Granularity.DAILY, Granularity.fromString(DAILY_MIXEDCASE.toUpperCase()));
+    }
+
+    @Test
+    void testFromStringLowerCase() {
+        assertEquals(Granularity.DAILY, Granularity.fromString(DAILY_MIXEDCASE.toLowerCase()));
+    }
+
+    @Test
+    void testFromStringMixedCase() {
+        assertEquals(Granularity.DAILY, Granularity.fromString(DAILY_MIXEDCASE));
+    }
+
+    @Test
+    void testAsOpenApiEnumValuesMatch() {
+        Set<GranularityType> expected = Sets.newHashSet(GranularityType.class.getEnumConstants());
+        Set<GranularityType> actual = Sets.newHashSet(Granularity.class.getEnumConstants()).stream().map(
+            Granularity::asOpenApiEnum).collect(Collectors.toSet());
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/db/model/ServiceLevelTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/ServiceLevelTest.java
@@ -22,9 +22,22 @@ package org.candlepin.subscriptions.db.model;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
+
+import com.google.common.collect.Sets;
+
 import org.junit.jupiter.api.Test;
 
+import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
 class ServiceLevelTest {
+
+    public static final String PREMIUM_MIXED_CASE = "PreMIUm";
+    public static final String BAD_VALUE = "platinum";
+
     @Test
     void testEachValueSurvivesStringConversion() {
         ServiceLevel.EnumConverter converter = new ServiceLevel.EnumConverter();
@@ -32,5 +45,45 @@ class ServiceLevelTest {
             assertEquals(converter.convertToDatabaseColumn(sla), sla.getValue());
             assertEquals(converter.convertToEntityAttribute(sla.getValue()), sla);
         }
+    }
+
+    @Test
+    void testFromStringEmptyString() {
+        assertEquals(ServiceLevel.EMPTY, ServiceLevel.fromString(StringUtils.EMPTY));
+    }
+
+    @Test
+    void testFromStringInvalidValueDefaultUnspecified() {
+        assertEquals(ServiceLevel.EMPTY, ServiceLevel.fromString(BAD_VALUE));
+    }
+
+    @Test
+    void testFromStringNullDefaultUnspecified() {
+        assertEquals(ServiceLevel.EMPTY, ServiceLevel.fromString(null));
+    }
+
+    @Test
+    void testFromStringUpperCase() {
+        assertEquals(ServiceLevel.PREMIUM, ServiceLevel.fromString(PREMIUM_MIXED_CASE.toUpperCase()));
+    }
+
+    @Test
+    void testFromStringLowerCase() {
+
+        assertEquals(ServiceLevel.PREMIUM, ServiceLevel.fromString(PREMIUM_MIXED_CASE.toLowerCase()));
+    }
+
+    @Test
+    void testFromStringMixedCase() {
+        assertEquals(ServiceLevel.PREMIUM, ServiceLevel.fromString(PREMIUM_MIXED_CASE));
+    }
+
+    @Test
+    void testAsOpenApiEnumValuesMatch() {
+        Set<ServiceLevelType> expected = Sets.newHashSet(ServiceLevelType.class.getEnumConstants());
+        Set<ServiceLevelType> actual = Sets.newHashSet(ServiceLevel.class.getEnumConstants()).stream()
+            .map(ServiceLevel::asOpenApiEnum).collect(Collectors.toSet());
+
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/model/UsageTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/UsageTest.java
@@ -22,9 +22,22 @@ package org.candlepin.subscriptions.db.model;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.candlepin.subscriptions.utilization.api.model.UsageType;
+
+import com.google.common.collect.Sets;
+
 import org.junit.jupiter.api.Test;
 
+import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
 class UsageTest {
+
+    public static final String DEVELOPMENT_TEST_MIXED_CASE = "DevelOPment/TeSt";
+    public static final String BAD_VALUE = "overused";
+
     @Test
     void testEachValueSurvivesStringConversion() {
         Usage.EnumConverter converter = new Usage.EnumConverter();
@@ -33,4 +46,44 @@ class UsageTest {
             assertEquals(converter.convertToEntityAttribute(usage.getValue()), usage);
         }
     }
+
+    @Test
+    void testFromStringInvalidValueDefaultUnspecified() {
+        assertEquals(Usage.EMPTY, Usage.fromString(BAD_VALUE));
+    }
+
+    @Test
+    void testFromStringNullDefaultUnspecified() {
+        assertEquals(Usage.EMPTY, Usage.fromString(null));
+    }
+
+    @Test
+    void testFromStringEmptyString() {
+        assertEquals(Usage.EMPTY, Usage.fromString(StringUtils.EMPTY));
+    }
+
+    @Test
+    void testFromStringUpperCase() {
+        assertEquals(Usage.DEVELOPMENT_TEST, Usage.fromString(DEVELOPMENT_TEST_MIXED_CASE.toUpperCase()));
+    }
+
+    @Test
+    void testFromStringLowerCase() {
+        assertEquals(Usage.DEVELOPMENT_TEST, Usage.fromString(DEVELOPMENT_TEST_MIXED_CASE.toLowerCase()));
+    }
+
+    @Test
+    void testFromStringMixedCase() {
+        assertEquals(Usage.DEVELOPMENT_TEST, Usage.fromString(DEVELOPMENT_TEST_MIXED_CASE));
+    }
+
+    @Test
+    void testAsOpenApiEnumValuesMatch() {
+        Set<UsageType> expected = Sets.newHashSet(UsageType.class.getEnumConstants());
+        Set<UsageType> actual = Sets.newHashSet(Usage.class.getEnumConstants()).stream().map(
+            Usage::asOpenApiEnum).collect(Collectors.toSet());
+
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -34,6 +34,10 @@ import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReport;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
+import org.candlepin.subscriptions.utilization.api.model.GranularityType;
+import org.candlepin.subscriptions.utilization.api.model.ProductId;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
+import org.candlepin.subscriptions.utilization.api.model.UsageType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +52,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 
 @SpringBootTest
@@ -82,25 +85,16 @@ class CapacityResourceTest {
         capacity.setBeginDate(min);
         capacity.setEndDate(max);
 
-        when(repository.findByOwnerAndProductId(
-                eq("owner123456"),
-                eq("product1"),
-                eq(ServiceLevel.ANY),
-                eq(Usage.ANY),
-                eq(min),
-                eq(max)))
-            .thenReturn(Collections.singletonList(capacity));
+        when(repository.findByOwnerAndProductId(eq("owner123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
+            eq(min),
+            eq(max)
+        )).thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            null
-        );
+        CapacityReport report = resource
+            .getCapacityReport(ProductId.RHEL, GranularityType.DAILY, min, max, null, null, null, null);
 
         assertEquals(9, report.getData().size());
     }
@@ -111,23 +105,21 @@ class CapacityResourceTest {
         capacity.setBeginDate(min);
         capacity.setEndDate(max);
 
-        when(repository.findByOwnerAndProductId(
-                eq("owner123456"),
-                eq("product1"),
-                eq(ServiceLevel.PREMIUM),
-                eq(Usage.ANY),
-                eq(min),
-                eq(max)))
-            .thenReturn(Collections.singletonList(capacity));
+        when(repository.findByOwnerAndProductId(eq("owner123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel.PREMIUM),
+            eq(Usage._ANY),
+            eq(min),
+            eq(max)
+        )).thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
+        CapacityReport report = resource.getCapacityReport(ProductId.RHEL,
+            GranularityType.DAILY,
             min,
             max,
             null,
             null,
-            "Premium",
+            ServiceLevelType.PREMIUM,
             null
         );
 
@@ -140,24 +132,22 @@ class CapacityResourceTest {
         capacity.setBeginDate(min);
         capacity.setEndDate(max);
 
-        when(repository.findByOwnerAndProductId(
-            eq("owner123456"),
-            eq("product1"),
-            eq(ServiceLevel.ANY),
+        when(repository.findByOwnerAndProductId(eq("owner123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
             eq(Usage.PRODUCTION),
             eq(min),
-            eq(max)))
-            .thenReturn(Collections.singletonList(capacity));
+            eq(max)
+        )).thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
+        CapacityReport report = resource.getCapacityReport(ProductId.RHEL,
+            GranularityType.DAILY,
             min,
             max,
             null,
             null,
             null,
-            "Production"
+            UsageType.PRODUCTION
         );
 
         assertEquals(9, report.getData().size());
@@ -169,23 +159,21 @@ class CapacityResourceTest {
         capacity.setBeginDate(min);
         capacity.setEndDate(max);
 
-        when(repository.findByOwnerAndProductId(
-                eq("owner123456"),
-                eq("product1"),
-                eq(ServiceLevel.ANY),
-                eq(Usage.ANY),
-                eq(min),
-                eq(max)))
-            .thenReturn(Collections.singletonList(capacity));
+        when(repository.findByOwnerAndProductId(eq("owner123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
+            eq(min),
+            eq(max)
+        )).thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
+        CapacityReport report = resource.getCapacityReport(ProductId.RHEL,
+            GranularityType.DAILY,
             min,
             max,
             null,
             null,
-            "",
+            ServiceLevelType.EMPTY,
             null
         );
 
@@ -198,24 +186,22 @@ class CapacityResourceTest {
         capacity.setBeginDate(min);
         capacity.setEndDate(max);
 
-        when(repository.findByOwnerAndProductId(
-            eq("owner123456"),
-            eq("product1"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        when(repository.findByOwnerAndProductId(eq("owner123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(min),
-            eq(max)))
-            .thenReturn(Collections.singletonList(capacity));
+            eq(max)
+        )).thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
+        CapacityReport report = resource.getCapacityReport(ProductId.RHEL,
+            GranularityType.DAILY,
             min,
             max,
             null,
             null,
             null,
-            ""
+            UsageType.EMPTY
         );
 
         assertEquals(9, report.getData().size());
@@ -239,25 +225,16 @@ class CapacityResourceTest {
         capacity2.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
         capacity2.setEndDate(max);
 
-        when(repository.findByOwnerAndProductId(
-                eq("owner123456"),
-                eq("product1"),
-                eq(null),
-                eq(null),
-                eq(min),
-                eq(max)))
-            .thenReturn(Arrays.asList(capacity, capacity2));
+        when(repository.findByOwnerAndProductId(eq("owner123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(null),
+            eq(null),
+            eq(min),
+            eq(max)
+        )).thenReturn(Arrays.asList(capacity, capacity2));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            null
-        );
+        CapacityReport report = resource
+            .getCapacityReport(ProductId.RHEL, GranularityType.DAILY, min, max, null, null, null, null);
 
         CapacitySnapshot capacitySnapshot = report.getData().get(0);
         assertEquals(12, capacitySnapshot.getHypervisorSockets().intValue());
@@ -268,33 +245,11 @@ class CapacityResourceTest {
 
     @Test
     void testShouldThrowExceptionOnBadOffset() {
-        SubscriptionsException e = assertThrows(SubscriptionsException.class, () ->
-            resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            11,
-            10,
-            null,
-            null)
-        );
+        SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> {
+            resource
+                .getCapacityReport(ProductId.RHEL, GranularityType.DAILY, min, max, 11, 10, null, null);
+        });
         assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
-    }
-
-    @Test
-    void testShouldThrowBadRequestOnBadSla() {
-        BadRequestException e = assertThrows(BadRequestException.class, () ->
-            resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            0,
-            10,
-            "badSla",
-            null)
-        );
     }
 
     @Test
@@ -303,38 +258,29 @@ class CapacityResourceTest {
         capacity.setBeginDate(min);
         capacity.setEndDate(max);
 
-        when(repository.findByOwnerAndProductId(
-                eq("owner123456"),
-                eq("product1"),
-                eq(ServiceLevel.ANY),
-                eq(Usage.ANY),
-                eq(min),
-                eq(max)))
-            .thenReturn(Collections.singletonList(capacity));
+        when(repository.findByOwnerAndProductId(eq("owner123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
+            eq(min),
+            eq(max)
+        )).thenReturn(Collections.singletonList(capacity));
 
-        CapacityReport report = resource.getCapacityReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            1,
-            1,
-            null,
-            null
-        );
+        CapacityReport report = resource
+            .getCapacityReport(ProductId.RHEL, GranularityType.DAILY, min, max, 1, 1, null, null);
 
         assertEquals(1, report.getData().size());
         assertEquals(OffsetDateTime.now().minusDays(3).truncatedTo(ChronoUnit.DAYS),
-            report.getData().get(0).getDate());
+            report.getData().get(0).getDate()
+        );
     }
 
     @Test
     @WithMockRedHatPrincipal("1111")
     public void testAccessDeniedWhenAccountIsNotWhitelisted() {
         assertThrows(AccessDeniedException.class, () -> {
-            resource.getCapacityReport(
-                "product1",
-                "daily",
+            resource.getCapacityReport(ProductId.RHEL,
+                GranularityType.DAILY,
                 min,
                 max,
                 null,
@@ -349,9 +295,8 @@ class CapacityResourceTest {
     @WithMockRedHatPrincipal(value = "123456", roles = {})
     public void testAccessDeniedWhenUserIsNotAnAdmin() {
         assertThrows(AccessDeniedException.class, () -> {
-            resource.getCapacityReport(
-                "product1",
-                "daily",
+            resource.getCapacityReport(ProductId.RHEL,
+                GranularityType.DAILY,
                 min,
                 max,
                 null,

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -31,6 +31,7 @@ import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
+import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
 
@@ -51,122 +52,142 @@ import java.util.Collections;
 @WithMockRedHatPrincipal("123456")
 class HostsResourceTest {
 
+    static final Sort.Order IMPLICIT_ORDER = new Sort.Order(Sort.Direction.ASC, "id");
     @MockBean
     HostRepository repository;
-
     @MockBean
     PageLinkCreator pageLinkCreator;
-
     @MockBean
     AccountListSource accountListSource;
-
     @Autowired
     HostsResource resource;
-
-    static final Sort.Order IMPLICIT_ORDER = new Sort.Order(Sort.Direction.ASC, "id");
 
     @BeforeEach
     public void setup() throws AccountListSourceException {
         PageImpl<TallyHostView> mockPage = new PageImpl<>(Collections.emptyList());
-        when(repository.getTallyHostViews(any(), any(), any(), any(), anyInt(), anyInt(), any()))
-            .thenReturn(mockPage);
+        when(repository.getTallyHostViews(any(), any(), any(), any(), anyInt(), anyInt(), any())).thenReturn(
+            mockPage);
         when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
     }
 
     @Test
+    @SuppressWarnings("indentation")
     void testShouldMapDisplayNameAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.DISPLAY_NAME, SortDirection.ASC);
+        resource.getHosts(ProductId.RHEL,
+            0,
+            1,
+            null,
+            null,
+            null,
+            HostReportSort.DISPLAY_NAME,
+            SortDirection.ASC
+        );
 
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1,
-            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
-            IMPLICIT_ORDER)))
+            eq(PageRequest.of(0, 1, Sort.by(
+                Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
+                IMPLICIT_ORDER
+            )))
         );
     }
 
     @Test
     void testShouldMapCoresAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.CORES, SortDirection.ASC);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, HostReportSort.CORES, SortDirection.ASC);
 
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES));
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
+
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1,
-            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)),
-            IMPLICIT_ORDER)))
+            eq(pageRequest)
         );
     }
 
     @Test
     void testShouldMapSocketsAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.SOCKETS, SortDirection.ASC);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, HostReportSort.SOCKETS, SortDirection.ASC);
 
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS));
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
+
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1,
-            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)),
-            IMPLICIT_ORDER)))
+            eq(pageRequest)
         );
     }
 
     @Test
     void testShouldMapLastSeenAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.LAST_SEEN, SortDirection.ASC);
+        resource.getHosts(ProductId.RHEL,
+            0,
+            1,
+            null,
+            null,
+            null,
+            HostReportSort.LAST_SEEN,
+            SortDirection.ASC
+        );
 
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN));
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
+
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1,
-            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)),
-            IMPLICIT_ORDER)))
+            eq(pageRequest)
         );
     }
 
     @Test
     void testShouldMapHardwareTypeAppropriately() {
-        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.HARDWARE_TYPE, SortDirection.ASC);
+        resource.getHosts(ProductId.RHEL,
+            0,
+            1,
+            null,
+            null,
+            null,
+            HostReportSort.HARDWARE_TYPE,
+            SortDirection.ASC
+        );
 
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE));
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
+
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1,
-            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)),
-            IMPLICIT_ORDER)))
+            eq(pageRequest)
         );
     }
 
     @Test
     void testShouldDefaultToImplicitOrder() {
-        resource.getHosts("RHEL", 0, 1, null, null, null, null, null);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null, null);
 
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
@@ -175,29 +196,28 @@ class HostsResourceTest {
 
     @Test
     void testShouldDefaultToAscending() {
-        resource.getHosts("RHEL", 0, 1, null, null, null, HostReportSort.DISPLAY_NAME, null);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, HostReportSort.DISPLAY_NAME, null);
 
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME));
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
+
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(0),
             eq(0),
-            eq(PageRequest.of(0, 1,
-            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
-            IMPLICIT_ORDER)))
+            eq(pageRequest)
         );
     }
 
     @Test
     void testShouldUseMinCoresWhenUomIsCores() {
-        resource.getHosts("RHEL", 0, 1, null, null, Uom.CORES, null, null);
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.CORES, null, null);
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(1),
             eq(0),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
@@ -206,12 +226,11 @@ class HostsResourceTest {
 
     @Test
     void testShouldUseMinSocketsWhenUomIsSockets() {
-        resource.getHosts("RHEL", 0, 1, null, null, Uom.SOCKETS, null, null);
-        verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq("RHEL"),
-            eq(ServiceLevel.ANY),
-            eq(Usage.ANY),
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.SOCKETS, null, null);
+        verify(repository, only()).getTallyHostViews(eq("account123456"),
+            eq(ProductId.RHEL.toString()),
+            eq(ServiceLevel._ANY),
+            eq(Usage._ANY),
             eq(0),
             eq(1),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.resource;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.subscriptions.db.AccountListSource;
@@ -37,8 +36,12 @@ import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.RoleProvider;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
+import org.candlepin.subscriptions.utilization.api.model.GranularityType;
+import org.candlepin.subscriptions.utilization.api.model.ProductId;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
+import org.candlepin.subscriptions.utilization.api.model.UsageType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,7 +60,6 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 
 @SuppressWarnings("linelength")
@@ -66,20 +68,18 @@ import javax.ws.rs.core.Response;
 @WithMockRedHatPrincipal("123456")
 public class TallyResourceTest {
 
-    @MockBean
-    TallySnapshotRepository repository;
-
-    @MockBean
-    PageLinkCreator pageLinkCreator;
-
-    @MockBean
-    AccountListSource accountListSource;
-
-    @Autowired
-    TallyResource resource;
-
+    public static final ProductId RHEL_PRODUCT_ID = ProductId.RHEL;
+    public static final String INVALID_PRODUCT_ID_VALUE = "bad_product";
     private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
     private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
+    @MockBean
+    TallySnapshotRepository repository;
+    @MockBean
+    PageLinkCreator pageLinkCreator;
+    @MockBean
+    AccountListSource accountListSource;
+    @Autowired
+    TallyResource resource;
 
     @BeforeEach
     public void setupTests() throws AccountListSourceException {
@@ -94,42 +94,57 @@ public class TallyResourceTest {
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
                 Mockito.eq("account123456"),
-                Mockito.eq("product1"),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
-                Mockito.eq(ServiceLevel.ANY),
+                Mockito.eq(ServiceLevel._ANY),
                 Mockito.eq(Usage.PRODUCTION),
                 Mockito.eq(min),
                 Mockito.eq(max),
-                Mockito.any(Pageable.class)))
-            .thenReturn(new PageImpl<>(Arrays.asList(snap)));
+                Mockito.any(Pageable.class)
+            )).thenReturn(new PageImpl<>(Arrays.asList(snap)));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
+        TallyReport report = resource.getTallyReport(RHEL_PRODUCT_ID,
+            GranularityType.DAILY,
             min,
             max,
             10,
             10,
             null,
-            Usage.PRODUCTION.getValue()
+            UsageType.PRODUCTION
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
         Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
-            Mockito.eq("product1"),
+            Mockito.eq(RHEL_PRODUCT_ID.toString()),
             Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.ANY),
+            Mockito.eq(ServiceLevel._ANY),
             Mockito.eq(Usage.PRODUCTION),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", null,
-            Usage.PRODUCTION.getValue(), Granularity.DAILY.name(), 1);
+        assertMetadata(report.getMeta(),
+            RHEL_PRODUCT_ID,
+            null,
+            UsageType.PRODUCTION,
+            GranularityType.DAILY,
+            1
+        );
 
+    }
+
+    private void assertMetadata(TallyReportMeta meta, ProductId expectedProduct,
+        ServiceLevelType expectedSla, UsageType expectedUsage,
+        GranularityType expectedGranularity, Integer expectedCount) {
+
+        assertEquals(expectedProduct, meta.getProduct());
+        assertEquals(expectedSla, meta.getServiceLevel());
+        assertEquals(expectedUsage, meta.getUsage());
+        assertEquals(expectedCount, meta.getCount());
+        assertEquals(expectedGranularity, meta.getGranularity());
     }
 
     @Test
@@ -137,26 +152,24 @@ public class TallyResourceTest {
 
         TallySnapshot snap = new TallySnapshot();
 
-        Mockito.when(repository
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-                Mockito.eq("account123456"),
-                Mockito.eq("product1"),
-                Mockito.eq(Granularity.DAILY),
-                Mockito.eq(ServiceLevel.PREMIUM),
-                Mockito.eq(Usage.ANY),
-                Mockito.eq(min),
-                Mockito.eq(max),
-                Mockito.any(Pageable.class)))
-            .thenReturn(new PageImpl<>(Arrays.asList(snap)));
+        Mockito.when(repository.findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+            Mockito.eq("account123456"),
+            Mockito.eq(RHEL_PRODUCT_ID.toString()),
+            Mockito.eq(Granularity.DAILY),
+            Mockito.eq(ServiceLevel.PREMIUM),
+            Mockito.eq(Usage._ANY),
+            Mockito.eq(min),
+            Mockito.eq(max),
+            Mockito.any(Pageable.class)
+        )).thenReturn(new PageImpl<>(Arrays.asList(snap)));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
+        TallyReport report = resource.getTallyReport(RHEL_PRODUCT_ID,
+            GranularityType.DAILY,
             min,
             max,
             10,
             10,
-            ServiceLevel.PREMIUM.getValue(),
+            ServiceLevelType.PREMIUM,
             null
         );
         assertEquals(1, report.getData().size());
@@ -164,62 +177,73 @@ public class TallyResourceTest {
         Pageable expectedPageable = PageRequest.of(1, 10);
         Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
-            Mockito.eq("product1"),
+            Mockito.eq(RHEL_PRODUCT_ID.toString()),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.PREMIUM),
-            Mockito.eq(Usage.ANY),
+            Mockito.eq(Usage._ANY),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(), null, Granularity.DAILY.name(),
-            1);
+        assertMetadata(report.getMeta(),
+            RHEL_PRODUCT_ID,
+            ServiceLevelType.PREMIUM,
+            null,
+            GranularityType.DAILY,
+            1
+        );
 
     }
 
     @Test
+    @SuppressWarnings({ "linelength", "indentation" })
     public void testUnsetSlaQueryParameter() {
         TallySnapshot snap = new TallySnapshot();
 
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-                 Mockito.eq("account123456"),
-                 Mockito.eq("product1"),
-                 Mockito.eq(Granularity.DAILY),
-                 Mockito.eq(ServiceLevel.UNSPECIFIED),
-                 Mockito.eq(Usage.PRODUCTION),
-                 Mockito.eq(min),
-                 Mockito.eq(max),
-                 Mockito.any(Pageable.class)))
-            .thenReturn(new PageImpl<>(Arrays.asList(snap)));
+                Mockito.eq("account123456"),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(Granularity.DAILY),
+                Mockito.eq(ServiceLevel.EMPTY),
+                Mockito.eq(Usage.PRODUCTION),
+                Mockito.eq(min),
+                Mockito.eq(max),
+                Mockito.any(Pageable.class)
+            )).thenReturn(new PageImpl<>(Arrays.asList(snap)));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
+        TallyReport report = resource.getTallyReport(RHEL_PRODUCT_ID,
+            GranularityType.DAILY,
             min,
             max,
             10,
             10,
-            ServiceLevel.UNSPECIFIED.getValue(),
-            Usage.PRODUCTION.getValue()
+            ServiceLevelType.EMPTY,
+            UsageType.PRODUCTION
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
-        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-            Mockito.eq("account123456"),
-            Mockito.eq("product1"),
-            Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.UNSPECIFIED),
-            Mockito.eq(Usage.PRODUCTION),
-            Mockito.eq(min),
-            Mockito.eq(max),
-            Mockito.eq(expectedPageable)
-        );
+        Mockito.verify(repository)
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                Mockito.eq("account123456"),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(Granularity.DAILY),
+                Mockito.eq(ServiceLevel.EMPTY),
+                Mockito.eq(Usage.PRODUCTION),
+                Mockito.eq(min),
+                Mockito.eq(max),
+                Mockito.eq(expectedPageable)
+            );
 
-        assertMetadata(report.getMeta(), "product1", "", Usage.PRODUCTION.getValue(), Granularity.DAILY.name(),
-            1);
+        assertMetadata(report.getMeta(),
+            RHEL_PRODUCT_ID,
+            ServiceLevelType.EMPTY,
+            UsageType.PRODUCTION,
+            GranularityType.DAILY,
+            1
+        );
     }
 
     @Test
@@ -229,41 +253,45 @@ public class TallyResourceTest {
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
                 Mockito.eq("account123456"),
-                Mockito.eq("product1"),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
-                Mockito.eq(Usage.UNSPECIFIED),
+                Mockito.eq(Usage.EMPTY),
                 Mockito.eq(min),
                 Mockito.eq(max),
-                Mockito.any(Pageable.class)))
-            .thenReturn(new PageImpl<>(Arrays.asList(snap)));
+                Mockito.any(Pageable.class)
+            )).thenReturn(new PageImpl<>(Arrays.asList(snap)));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
+        TallyReport report = resource.getTallyReport(RHEL_PRODUCT_ID,
+            GranularityType.DAILY,
             min,
             max,
             10,
             10,
-            ServiceLevel.PREMIUM.getValue(),
-            Usage.UNSPECIFIED.getValue()
+            ServiceLevelType.PREMIUM,
+            UsageType.EMPTY
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
         Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
-            Mockito.eq("product1"),
+            Mockito.eq(RHEL_PRODUCT_ID.toString()),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.PREMIUM),
-            Mockito.eq(Usage.UNSPECIFIED),
+            Mockito.eq(Usage.EMPTY),
             Mockito.eq(min),
             Mockito.eq(max),
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(), "", Granularity.DAILY.name(),
-            1);
+        assertMetadata(report.getMeta(),
+            RHEL_PRODUCT_ID,
+            ServiceLevelType.PREMIUM,
+            UsageType.EMPTY,
+            GranularityType.DAILY,
+            1
+        );
     }
 
     @Test
@@ -272,31 +300,31 @@ public class TallyResourceTest {
 
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-                 Mockito.eq("account123456"),
-                 Mockito.eq("product1"),
-                 Mockito.eq(Granularity.DAILY),
-                 Mockito.eq(ServiceLevel.PREMIUM),
-                 Mockito.eq(Usage.PRODUCTION),
-                 Mockito.eq(min),
-                 Mockito.eq(max),
-                 Mockito.any(Pageable.class)))
-            .thenReturn(new PageImpl<>(Arrays.asList(snap)));
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            Granularity.DAILY.name(),
+                Mockito.eq("account123456"),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(Granularity.DAILY),
+                Mockito.eq(ServiceLevel.PREMIUM),
+                Mockito.eq(Usage.PRODUCTION),
+                Mockito.eq(min),
+                Mockito.eq(max),
+                Mockito.any(Pageable.class)
+            )).thenReturn(new PageImpl<>(Arrays.asList(snap)));
+
+        TallyReport report = resource.getTallyReport(RHEL_PRODUCT_ID,
+            GranularityType.DAILY,
             min,
             max,
             10,
             10,
-            ServiceLevel.PREMIUM.getValue(),
-            Usage.PRODUCTION.getValue()
+            ServiceLevelType.PREMIUM,
+            UsageType.PRODUCTION
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
         Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
-            Mockito.eq("product1"),
+            Mockito.eq(RHEL_PRODUCT_ID.toString()),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.PREMIUM),
             Mockito.eq(Usage.PRODUCTION),
@@ -305,8 +333,13 @@ public class TallyResourceTest {
             Mockito.eq(expectedPageable)
         );
 
-        assertMetadata(report.getMeta(), "product1", ServiceLevel.PREMIUM.getValue(),
-            Usage.PRODUCTION.getValue(), Granularity.DAILY.name(), 1);
+        assertMetadata(report.getMeta(),
+            RHEL_PRODUCT_ID,
+            ServiceLevelType.PREMIUM,
+            UsageType.PRODUCTION,
+            GranularityType.DAILY,
+            1
+        );
     }
 
     @Test
@@ -315,38 +348,38 @@ public class TallyResourceTest {
 
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-            Mockito.eq("account123456"),
-            Mockito.eq("product1"),
-            Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.PREMIUM),
-            Mockito.eq(Usage.PRODUCTION),
-            Mockito.eq(min),
-            Mockito.eq(max),
-            Mockito.any(Pageable.class)))
-            .thenReturn(new PageImpl<>(Arrays.asList(snap)));
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            "daily",
+                Mockito.eq("account123456"),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(Granularity.DAILY),
+                Mockito.eq(ServiceLevel.PREMIUM),
+                Mockito.eq(Usage.PRODUCTION),
+                Mockito.eq(min),
+                Mockito.eq(max),
+                Mockito.any(Pageable.class)
+            )).thenReturn(new PageImpl<>(Arrays.asList(snap)));
+
+        TallyReport report = resource.getTallyReport(RHEL_PRODUCT_ID,
+            GranularityType.DAILY,
             min,
             max,
             10,
             10,
-            ServiceLevel.PREMIUM.getValue(),
-            Usage.PRODUCTION.getValue()
+            ServiceLevelType.PREMIUM,
+            UsageType.PRODUCTION
         );
         assertEquals(1, report.getData().size());
 
         Pageable expectedPageable = PageRequest.of(1, 10);
-        Mockito.verify(repository)
-            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+        Mockito.verify(repository).findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
             Mockito.eq("account123456"),
-            Mockito.eq("product1"),
+            Mockito.eq(RHEL_PRODUCT_ID.toString()),
             Mockito.eq(Granularity.DAILY),
             Mockito.eq(ServiceLevel.PREMIUM),
             Mockito.eq(Usage.PRODUCTION),
             Mockito.eq(min),
             Mockito.eq(max),
-            Mockito.eq(expectedPageable));
+            Mockito.eq(expectedPageable)
+        );
     }
 
     @Test
@@ -450,14 +483,14 @@ public class TallyResourceTest {
     @Test
     public void testShouldThrowExceptionOnBadOffset() throws IOException {
         SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource.getTallyReport(
-            "product1",
-            "daily",
+            RHEL_PRODUCT_ID,
+            GranularityType.DAILY,
             min,
             max,
             11,
             10,
-            ServiceLevel.PREMIUM.getValue(),
-            Usage.PRODUCTION.getValue()
+            ServiceLevelType.PREMIUM,
+            UsageType.PRODUCTION
         ));
         assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
     }
@@ -466,26 +499,18 @@ public class TallyResourceTest {
     public void reportDataShouldGetFilledWhenPagingParametersAreNotPassed() {
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-                 Mockito.eq("account123456"),
-                 Mockito.eq("product1"),
-                 Mockito.eq(Granularity.DAILY),
-                 Mockito.eq(ServiceLevel.ANY),
-                 Mockito.eq(Usage.ANY),
-                 Mockito.eq(min),
-                 Mockito.eq(max),
-                 Mockito.eq(null)))
-            .thenReturn(new PageImpl<>(Collections.emptyList()));
+                Mockito.eq("account123456"),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(Granularity.DAILY),
+                Mockito.eq(ServiceLevel._ANY),
+                Mockito.eq(Usage._ANY),
+                Mockito.eq(min),
+                Mockito.eq(max),
+                Mockito.eq(null)
+            )).thenReturn(new PageImpl<>(Collections.emptyList()));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            null
-        );
+        TallyReport report = resource
+            .getTallyReport(RHEL_PRODUCT_ID, GranularityType.DAILY, min, max, null, null, null, null);
 
         // Since nothing was returned from the DB, there should be one generated snapshot for each day
         // in the range.
@@ -495,8 +520,7 @@ public class TallyResourceTest {
 
     @Test
     void testEmptySnapshotFilledWithAllZeroes() {
-        org.candlepin.subscriptions.utilization.api.model.TallySnapshot snapshot =
-            new org.candlepin.subscriptions.utilization.api.model.TallySnapshot();
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot snapshot = new org.candlepin.subscriptions.utilization.api.model.TallySnapshot();
 
         assertEquals(0, snapshot.getInstanceCount().intValue());
         assertEquals(0, snapshot.getCores().intValue());
@@ -510,46 +534,22 @@ public class TallyResourceTest {
     }
 
     @Test
-    public void ensureBadRequestExceptionIsThrownWhenAnInvalidSlaParameterIsSpecified() {
-        assertThrows(BadRequestException.class, () -> {
-            resource.getTallyReport(
-                "product1",
-                "daily",
-                min,
-                max,
-                null,
-                null,
-                "foo_sla",
-                null
-            );
-        });
-    }
-
-    @Test
-    @WithMockRedHatPrincipal(value = "123456", roles = {"ROLE_" + RoleProvider.SWATCH_ADMIN_ROLE})
+    @WithMockRedHatPrincipal(value = "123456", roles = { "ROLE_" + RoleProvider.SWATCH_ADMIN_ROLE })
     public void canReportWithOnlyReportingRole() {
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-                 Mockito.eq("account123456"),
-                 Mockito.eq("product1"),
-                 Mockito.eq(Granularity.DAILY),
-                 Mockito.eq(ServiceLevel.ANY),
-                 Mockito.eq(Usage.ANY),
-                 Mockito.eq(min),
-                 Mockito.eq(max),
-                 Mockito.eq(null)))
-            .thenReturn(new PageImpl<>(Collections.emptyList()));
+                Mockito.eq("account123456"),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(Granularity.DAILY),
+                Mockito.eq(ServiceLevel._ANY),
+                Mockito.eq(Usage._ANY),
+                Mockito.eq(min),
+                Mockito.eq(max),
+                Mockito.eq(null)
+            )).thenReturn(new PageImpl<>(Collections.emptyList()));
 
-        TallyReport report = resource.getTallyReport(
-            "product1",
-            "daily",
-            min,
-            max,
-            null,
-            null,
-            null,
-            null
-        );
+        TallyReport report = resource
+            .getTallyReport(RHEL_PRODUCT_ID, GranularityType.DAILY, min, max, null, null, null, null);
         assertNotNull(report);
     }
 
@@ -557,9 +557,8 @@ public class TallyResourceTest {
     @WithMockRedHatPrincipal("1111")
     public void testAccessDeniedWhenAccountIsNotWhitelisted() {
         assertThrows(AccessDeniedException.class, () -> {
-            resource.getTallyReport(
-                "product1",
-                "daily",
+            resource.getTallyReport(RHEL_PRODUCT_ID,
+                GranularityType.DAILY,
                 min,
                 max,
                 null,
@@ -574,9 +573,8 @@ public class TallyResourceTest {
     @WithMockRedHatPrincipal(value = "123456", roles = {})
     public void testAccessDeniedWhenUserIsNotAnAdmin() {
         assertThrows(AccessDeniedException.class, () -> {
-            resource.getTallyReport(
-                "product1",
-                "daily",
+            resource.getTallyReport(RHEL_PRODUCT_ID,
+                GranularityType.DAILY,
                 min,
                 max,
                 null,
@@ -585,15 +583,5 @@ public class TallyResourceTest {
                 null
             );
         });
-    }
-
-    private void assertMetadata(TallyReportMeta meta, String expectedProd, String expectedSla,
-        String expectedUsage, String expectedGranularity, Integer expectedCount) {
-        assertEquals(expectedProd, meta.getProduct());
-        assertEquals(expectedSla, meta.getServiceLevel());
-        assertEquals(expectedUsage, meta.getUsage());
-        assertEquals(expectedGranularity, meta.getGranularity());
-        assertEquals(expectedCount, meta.getCount());
-
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
@@ -71,6 +71,6 @@ public class AccountUsageCalculationTest {
     }
 
     private UsageCalculation.Key createUsageKey(String productId) {
-        return new UsageCalculation.Key(productId, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
+        return new UsageCalculation.Key(productId, ServiceLevel.EMPTY, Usage.EMPTY);
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
@@ -96,8 +96,9 @@ class CloudigradeAccountUsageCollectorTest {
         AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
         collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage),
             Collections.singletonList(ACCOUNT));
-        assertEquals(1, accountUsage.getCalculation(new UsageCalculation.Key("RHEL", ServiceLevel.ANY,
-            Usage.ANY)).getTotals(HardwareMeasurementType.AWS_CLOUDIGRADE).getInstances());
+        assertEquals(1, accountUsage.getCalculation(new UsageCalculation.Key("RHEL", ServiceLevel._ANY,
+            Usage._ANY
+        )).getTotals(HardwareMeasurementType.AWS_CLOUDIGRADE).getInstances());
     }
 
     @Test
@@ -140,8 +141,9 @@ class CloudigradeAccountUsageCollectorTest {
         AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
         collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage),
             Collections.singletonList(ACCOUNT));
-        assertEquals(1, accountUsage.getCalculation(new UsageCalculation.Key("RHEL", ServiceLevel.ANY,
-            Usage.ANY)).getTotals(HardwareMeasurementType.AWS_CLOUDIGRADE).getInstances());
+        assertEquals(1, accountUsage.getCalculation(new UsageCalculation.Key("RHEL", ServiceLevel._ANY,
+            Usage._ANY
+        )).getTotals(HardwareMeasurementType.AWS_CLOUDIGRADE).getInstances());
     }
 
     @Test
@@ -162,8 +164,9 @@ class CloudigradeAccountUsageCollectorTest {
         AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
         collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage),
             Collections.singletonList(ACCOUNT));
-        assertEquals(1, accountUsage.getCalculation(new UsageCalculation.Key("RHEL Server", ServiceLevel.ANY,
-            Usage.ANY)).getTotals(HardwareMeasurementType.AWS_CLOUDIGRADE).getInstances());
+        assertEquals(1, accountUsage.getCalculation(new UsageCalculation.Key("RHEL Server", ServiceLevel._ANY,
+            Usage._ANY
+        )).getTotals(HardwareMeasurementType.AWS_CLOUDIGRADE).getInstances());
     }
 
     @Test
@@ -187,6 +190,7 @@ class CloudigradeAccountUsageCollectorTest {
         assertEquals(0, accountUsage.getKeys().size());
     }
 
+    @SuppressWarnings("linelength")
     @Test
     void testEnrichUsageMatchesByArch() throws ApiException, IOException {
         UsageCount usageCount = new UsageCount()
@@ -205,8 +209,9 @@ class CloudigradeAccountUsageCollectorTest {
         AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
         collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage),
             Collections.singletonList(ACCOUNT));
-        assertEquals(1, accountUsage.getCalculation(new UsageCalculation.Key("RHEL for x86", ServiceLevel.ANY,
-            Usage.ANY)).getTotals(HardwareMeasurementType.AWS_CLOUDIGRADE).getInstances());
+        assertEquals(1, accountUsage.getCalculation(new UsageCalculation.Key("RHEL for x86", ServiceLevel._ANY,
+            Usage._ANY
+        )).getTotals(HardwareMeasurementType.AWS_CLOUDIGRADE).getInstances());
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -251,7 +251,7 @@ public class InventoryAccountUsageCollectorTest {
         AccountUsageCalculation a1Calc = calcs.get("A1");
         assertEquals(1, a1Calc.getProducts().size());
         checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", 16, 16, 2);
-        checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.ANY, 16, 16, 2);
+        checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel._ANY, 16, 16, 2);
         checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.STANDARD, 6, 6, 1);
         checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.PREMIUM, 10, 10, 1);
     }
@@ -261,11 +261,11 @@ public class InventoryAccountUsageCollectorTest {
         List<String> targetAccounts = Collections.singletonList("A1");
 
         InventoryHostFacts host1 = createRhsmHost("A1", "O1",
-            TEST_PRODUCT_ID.toString(), ServiceLevel.UNSPECIFIED, Usage.DEVELOPMENT_TEST, 6, 6, "",
+            TEST_PRODUCT_ID.toString(), ServiceLevel.EMPTY, Usage.DEVELOPMENT_TEST, 6, 6, "",
             OffsetDateTime.now());
 
         InventoryHostFacts host2 = createRhsmHost("A1", "O1",
-            TEST_PRODUCT_ID.toString(), ServiceLevel.UNSPECIFIED, Usage.PRODUCTION, 10, 10, "",
+            TEST_PRODUCT_ID.toString(), ServiceLevel.EMPTY, Usage.PRODUCTION, 10, 10, "",
             OffsetDateTime.now());
 
         mockReportedHypervisors(targetAccounts, new HashMap<>());
@@ -279,10 +279,10 @@ public class InventoryAccountUsageCollectorTest {
         AccountUsageCalculation a1Calc = calcs.get("A1");
         assertEquals(1, a1Calc.getProducts().size());
         checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", 16, 16, 2);
-        checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.UNSPECIFIED, Usage.ANY, 16, 16, 2);
-        checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.UNSPECIFIED, Usage.DEVELOPMENT_TEST,
+        checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.EMPTY, Usage._ANY, 16, 16, 2);
+        checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.EMPTY, Usage.DEVELOPMENT_TEST,
             6, 6, 1);
-        checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.UNSPECIFIED, Usage.PRODUCTION,
+        checkTotalsCalculation(a1Calc, "A1", "O1", "RHEL", ServiceLevel.EMPTY, Usage.PRODUCTION,
             10, 10, 1);
     }
 
@@ -505,13 +505,13 @@ public class InventoryAccountUsageCollectorTest {
 
     private void checkTotalsCalculation(AccountUsageCalculation calc, String account, String owner,
         String product, int cores, int sockets, int instances) {
-        checkTotalsCalculation(calc, account, owner, product, ServiceLevel.ANY, cores, sockets, instances);
+        checkTotalsCalculation(calc, account, owner, product, ServiceLevel._ANY, cores, sockets, instances);
     }
 
     private void checkTotalsCalculation(AccountUsageCalculation calc, String account, String owner,
         String product, ServiceLevel serviceLevel, int cores, int sockets, int instances) {
 
-        checkTotalsCalculation(calc, account, owner, product, serviceLevel, Usage.ANY, cores, sockets,
+        checkTotalsCalculation(calc, account, owner, product, serviceLevel, Usage._ANY, cores, sockets,
             instances);
     }
 
@@ -551,11 +551,11 @@ public class InventoryAccountUsageCollectorTest {
     }
 
     private UsageCalculation.Key createUsageKey(String product) {
-        return createUsageKey(product, ServiceLevel.ANY);
+        return createUsageKey(product, ServiceLevel._ANY);
     }
 
     private UsageCalculation.Key createUsageKey(String product, ServiceLevel sla) {
-        return new UsageCalculation.Key(product, sla, Usage.ANY);
+        return new UsageCalculation.Key(product, sla, Usage._ANY);
     }
 
     private UsageCalculation.Key createUsageKey(String product, ServiceLevel sla, Usage usage) {

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -77,7 +77,7 @@ public class InventoryHostFactTestHelper {
 
     public static InventoryHostFacts createRhsmHost(String account, String orgId, String products,
         Integer cores, Integer sockets, String syspurposeRole, OffsetDateTime syncTimeStamp) {
-        return createRhsmHost(account, orgId, products, ServiceLevel.UNSPECIFIED, cores, sockets,
+        return createRhsmHost(account, orgId, products, ServiceLevel.EMPTY, cores, sockets,
             syspurposeRole, syncTimeStamp);
     }
 
@@ -85,7 +85,7 @@ public class InventoryHostFactTestHelper {
         ServiceLevel sla, Integer cores, Integer sockets, String syspurposeRole,
         OffsetDateTime syncTimeStamp) {
 
-        return createRhsmHost(account, orgId, products, sla, Usage.UNSPECIFIED, cores, sockets,
+        return createRhsmHost(account, orgId, products, sla, Usage.EMPTY, cores, sockets,
             syspurposeRole, syncTimeStamp);
     }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
@@ -21,9 +21,7 @@
 package org.candlepin.subscriptions.tally;
 
 import static org.candlepin.subscriptions.tally.collector.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -65,7 +63,7 @@ public class UsageCalculationTest {
     }
 
     private UsageCalculation.Key createUsageKey(String product) {
-        return new UsageCalculation.Key(product, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
+        return new UsageCalculation.Key(product, ServiceLevel.EMPTY, Usage.EMPTY);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -106,7 +106,7 @@ public class DefaultProductUsageCollectorTest {
     }
 
     private UsageCalculation.Key createUsageKey() {
-        return new UsageCalculation.Key("NON_RHEL", ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
+        return new UsageCalculation.Key("NON_RHEL", ServiceLevel.EMPTY, Usage.EMPTY);
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -22,9 +22,7 @@ package org.candlepin.subscriptions.tally.collector;
 
 import static org.candlepin.subscriptions.tally.collector.Assertions.*;
 import static org.candlepin.subscriptions.tally.collector.TestHelper.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.HostTallyBucket;
@@ -127,7 +125,7 @@ public class RHELProductUsageCollectorTest {
     }
 
     private UsageCalculation.Key createUsageKey() {
-        return new UsageCalculation.Key("RHEL", ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
+        return new UsageCalculation.Key("RHEL", ServiceLevel.EMPTY, Usage.EMPTY);
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
@@ -20,9 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
@@ -71,7 +69,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> currentSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED,
+                TEST_PRODUCT, granularity, ServiceLevel.EMPTY, Usage.EMPTY,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
@@ -87,7 +85,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> currentSnaps = repository
              .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                 TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED,
+                 TEST_PRODUCT, granularity, ServiceLevel.EMPTY, Usage.EMPTY,
                  startOfGranularPeriod, endOfGranularPeriod,
                  PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
@@ -102,7 +100,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> updatedSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED,
+                TEST_PRODUCT, granularity, ServiceLevel.EMPTY, Usage.EMPTY,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedSnaps.size());
@@ -136,7 +134,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> currentSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate("A1",
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED,  Usage.UNSPECIFIED,
+                TEST_PRODUCT, granularity, ServiceLevel.EMPTY,  Usage.EMPTY,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, currentSnaps.size());
@@ -150,7 +148,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> updatedSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(account,
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED,  Usage.UNSPECIFIED,
+                TEST_PRODUCT, granularity, ServiceLevel.EMPTY,  Usage.EMPTY,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(1, updatedSnaps.size());
@@ -172,14 +170,14 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
         List<TallySnapshot> currentSnaps = repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate("A1",
-                TEST_PRODUCT, granularity, ServiceLevel.UNSPECIFIED,  Usage.UNSPECIFIED,
+                TEST_PRODUCT, granularity, ServiceLevel.EMPTY,  Usage.EMPTY,
                 startOfGranularPeriod, endOfGranularPeriod,
                 PageRequest.of(0, 100)).stream().collect(Collectors.toList());
         assertEquals(0, currentSnaps.size());
     }
 
     private UsageCalculation.Key createUsageKey(String product) {
-        return new UsageCalculation.Key(product, ServiceLevel.UNSPECIFIED, Usage.UNSPECIFIED);
+        return new UsageCalculation.Key(product, ServiceLevel.EMPTY, Usage.EMPTY);
     }
 
     private AccountUsageCalculation createTestData() {


### PR DESCRIPTION
TL;DR

* update the open-api spec yaml file to define Granularity, Usage, ServiceLevel, and ProductId as enums
* update the resource classes accordingly
* enhance the EnumParamConverterProvider class to convert query params in a casing-agnostic manner
* create an interface for the db model enums to implement to give us a unified means of converting generated <-> db model enums
* unit tests!
* format things a million times because checkstyle still hates my formatter


Room for Improvements:

* miscellaneous inline comments on this PR
* There's no db.model for ProductId, but there doesn't look like there's a need for it.  Should we add it anyway for consistency with the other api enums?  My vote is no. 