### PR TITLE
lburnett/filter hosts by display name [ENT-3195]

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -424,6 +424,13 @@ paths:
           schema:
             $ref: '#/components/schemas/Uom'
           description: "Filter hosts to those that contribute to a specific unit of measure"
+        - name: display_name_contains
+          description: Include only hosts containing the specified display name. Passing an empty string behaves the same way as passing null
+          schema:
+            type: string
+            #Default to empty string to prevent complex jpql statement later
+            default: ''
+          in: query
         - name: sort
           in: query
           schema:

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ allprojects {
             dependencySet(group: "org.junit.jupiter", version: "$junit_version") {
                 entry "junit-jupiter-api"
                 entry "junit-jupiter-engine"
+                entry "junit-jupiter-params"
             }
             dependencySet(group: "org.mockito", version: "$mockito_version") {
                 entry "mockito-core"
@@ -123,6 +124,7 @@ allprojects {
 
         // We use JUnit 5 which the spring-boot-starter-test doesn't provide
         testCompile "org.junit.jupiter:junit-jupiter-api"
+        testCompile "org.junit.jupiter:junit-jupiter-params"
         testCompile "org.mockito:mockito-core"
         testCompile "org.mockito:mockito-junit-jupiter"
         testCompile "org.hamcrest:hamcrest"

--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -47,36 +47,40 @@ public interface HostRepository extends JpaRepository<Host, UUID> {
      * A TallyHostView is a Host representation detailing what 'bucket' was applied
      * to the current daily snapshots.
      *
-     * @param accountNumber The account number of the hosts to query (required).
-     * @param productId The bucket product ID to filter Host by (pass null to ignore).
-     * @param sla The bucket service level to filter Hosts by (pass null to ignore).
-     * @param usage The bucket usage to filter Hosts by (pass null to ignore).
-     * @param minCores Filter to Hosts with at least this number of cores.
-     * @param minSockets Filter to Hosts with at least this number of sockets.
-     * @param pageable the current paging info for this query.
+     * @param accountNumber        The account number of the hosts to query (required).
+     * @param productId            The bucket product ID to filter Host by (pass null to ignore).
+     * @param sla                  The bucket service level to filter Hosts by (pass null to ignore).
+     * @param usage                The bucket usage to filter Hosts by (pass null to ignore).
+     * @param displayNameSubstring Case-insensitive string to filter Hosts' display name by (pass null or empty string to ignore)
+     * @param minCores             Filter to Hosts with at least this number of cores.
+     * @param minSockets           Filter to Hosts with at least this number of sockets.
+     * @param pageable             the current paging info for this query.
      * @return a page of Host entities matching the criteria.
      */
     @Query(
         value = "select b from HostTallyBucket b join fetch b.key.host h where " +
-                "h.accountNumber = :account and " +
-                "b.key.productId = :product and " +
-                "b.key.sla = :sla and b.key.usage = :usage and " +
-                "b.cores >= :minCores and b.sockets >= :minSockets",
+            "h.accountNumber = :account and " +
+            "b.key.productId = :product and " +
+            "b.key.sla = :sla and b.key.usage = :usage and " +
+            // Have to do the null check first, otherwise the lower in the LIKE clause has issues with datatypes
+            "(:displayNameSubstring IS NULL or (lower(b.key.host.displayName) LIKE lower(concat('%', :displayNameSubstring,'%')))) and " +
+            "b.cores >= :minCores and b.sockets >= :minSockets",
         // Because we are using a 'fetch join' to avoid having to lazy load each bucket host,
         // we need to specify how the Page should gets its count when the 'limit' parameter
         // is used.
         countQuery = "select count(b) from HostTallyBucket b join b.key.host h where " +
-                     "h.accountNumber = :account and " +
-                     "b.key.productId = :product and " +
-                     "b.key.sla = :sla and b.key.usage = :usage and " +
-                     "b.cores >= :minCores and b.sockets >= :minSockets"
-
+            "h.accountNumber = :account and " +
+            "b.key.productId = :product and " +
+            "b.key.sla = :sla and b.key.usage = :usage and " +
+            "(:displayNameSubstring IS NULL or (lower(b.key.host.displayName) LIKE lower(concat('%', :displayNameSubstring,'%')))) and " +
+            "b.cores >= :minCores and b.sockets >= :minSockets"
     )
-    Page<TallyHostView> getTallyHostViews(
+    Page<TallyHostView> getTallyHostViews(//NOSONAR (exceeds allowed 7 params)
         @Param("account") String accountNumber,
         @Param("product") String productId,
         @Param("sla") ServiceLevel sla,
         @Param("usage") Usage usage,
+        @Param("displayNameSubstring") String displayNameSubstring,
         @Param("minCores") int minCores,
         @Param("minSockets") int minSockets,
         Pageable pageable

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -39,6 +39,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 
 /**
  * Represents a reported Host from inventory. This entity stores normalized facts for a
@@ -52,16 +53,19 @@ public class Host implements Serializable {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
-    @Column(name = "inventory_id")
+    @NotNull
+    @Column(name = "inventory_id", nullable = false)
     private String inventoryId;
 
     @Column(name = "insights_id")
     private String insightsId;
 
-    @Column(name = "display_name")
+    @NotNull
+    @Column(name = "display_name", nullable = false)
     private String displayName;
 
-    @Column(name = "account_number")
+    @NotNull
+    @Column(name = "account_number", nullable = false)
     private String accountNumber;
 
     @Column(name = "org_id")

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -84,7 +84,8 @@ public class HostsResource implements HostsApi {
     @ReportingAccessRequired
     @Override
     public HostReport getHosts(ProductId productId, Integer offset, @Min(1) @Max(100) Integer limit,
-        ServiceLevelType sla, UsageType usage, Uom uom, HostReportSort sort, SortDirection dir) {
+        ServiceLevelType sla, UsageType usage, Uom uom, String displayNameContains, HostReportSort sort,
+        SortDirection dir) {
 
         Sort.Direction dirValue = Sort.Direction.ASC;
         if (dir == SortDirection.DESC) {
@@ -115,6 +116,7 @@ public class HostsResource implements HostsApi {
             productId.toString(),
             sanitizedSla,
             sanitizedUsage,
+            displayNameContains,
             minCores,
             minSockets,
             page);

--- a/src/main/resources/liquibase/202012141133-enforce-display-name-not-null.xml
+++ b/src/main/resources/liquibase/202012141133-enforce-display-name-not-null.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202012141133" author="lburnett">
+        <comment>
+            Add not null constraint to hosts.display_name and set existing null values to empty
+            string
+        </comment>
+        <addNotNullConstraint tableName="hosts" columnName="display_name" defaultNullValue=""/>
+    </changeSet>
+</databaseChangeLog>
+    <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -32,5 +32,6 @@
     <include file="liquibase/202009211317-add-additional-host-fields.xml" />
     <include file="liquibase/202010080931-fix-capacity-unspecified.xml" />
     <include file="liquibase/202011090921-re-add-hypervisor-type.xml" />
+    <include file="liquibase/202012141133-enforce-display-name-not-null.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -65,129 +65,119 @@ class HostsResourceTest {
     @BeforeEach
     public void setup() throws AccountListSourceException {
         PageImpl<TallyHostView> mockPage = new PageImpl<>(Collections.emptyList());
-        when(repository.getTallyHostViews(any(), any(), any(), any(), anyInt(), anyInt(), any())).thenReturn(
-            mockPage);
+        when(repository.getTallyHostViews(any(), any(), any(), any(), any(), anyInt(), anyInt(), any()))
+            .thenReturn(mockPage);
         when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
     }
 
     @Test
     @SuppressWarnings("indentation")
     void testShouldMapDisplayNameAppropriately() {
-        resource.getHosts(ProductId.RHEL,
-            0,
-            1,
-            null,
-            null,
-            null,
-            HostReportSort.DISPLAY_NAME,
-            SortDirection.ASC
-        );
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            HostReportSort.DISPLAY_NAME, SortDirection.ASC);
 
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1, Sort.by(
                 Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
-                IMPLICIT_ORDER
-            )))
+                IMPLICIT_ORDER)))
         );
     }
 
     @Test
     void testShouldMapCoresAppropriately() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, HostReportSort.CORES, SortDirection.ASC);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            HostReportSort.CORES, SortDirection.ASC);
 
-        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES));
-        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
-
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(0),
             eq(0),
-            eq(pageRequest)
+            eq(
+            PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)),
+            IMPLICIT_ORDER)))
         );
     }
 
     @Test
     void testShouldMapSocketsAppropriately() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, HostReportSort.SOCKETS, SortDirection.ASC);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            HostReportSort.SOCKETS, SortDirection.ASC);
 
-        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS));
-        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
-
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(0),
             eq(0),
-            eq(pageRequest)
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)),
+            IMPLICIT_ORDER)))
         );
     }
 
     @Test
     void testShouldMapLastSeenAppropriately() {
-        resource.getHosts(ProductId.RHEL,
-            0,
-            1,
-            null,
-            null,
-            null,
-            HostReportSort.LAST_SEEN,
-            SortDirection.ASC
-        );
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            HostReportSort.LAST_SEEN, SortDirection.ASC);
 
-        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN));
-        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
-
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(0),
             eq(0),
-            eq(pageRequest)
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)),
+            IMPLICIT_ORDER)))
         );
     }
 
     @Test
     void testShouldMapHardwareTypeAppropriately() {
-        resource.getHosts(ProductId.RHEL,
-            0,
-            1,
-            null,
-            null,
-            null,
-            HostReportSort.HARDWARE_TYPE,
-            SortDirection.ASC
-        );
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            HostReportSort.HARDWARE_TYPE, SortDirection.ASC);
 
-        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE));
-        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
-
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(0),
             eq(0),
-            eq(pageRequest)
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)),
+            IMPLICIT_ORDER)))
         );
     }
 
     @Test
     void testShouldDefaultToImplicitOrder() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null, null);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null, null,
+            SortDirection.ASC);
 
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
@@ -196,28 +186,33 @@ class HostsResourceTest {
 
     @Test
     void testShouldDefaultToAscending() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, HostReportSort.DISPLAY_NAME, null);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            HostReportSort.DISPLAY_NAME, null);
 
-        Sort.Order asc = Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME));
-        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(asc, IMPLICIT_ORDER));
-
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(0),
             eq(0),
-            eq(pageRequest)
+            eq(PageRequest.of(0, 1,
+            Sort.by(Sort.Order.asc(HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
+            IMPLICIT_ORDER)))
         );
     }
 
     @Test
     void testShouldUseMinCoresWhenUomIsCores() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.CORES, null, null);
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.CORES, null, null,
+            null);
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(1),
             eq(0),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
@@ -226,11 +221,14 @@ class HostsResourceTest {
 
     @Test
     void testShouldUseMinSocketsWhenUomIsSockets() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.SOCKETS, null, null);
-        verify(repository, only()).getTallyHostViews(eq("account123456"),
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.SOCKETS, null, null,
+            null);
+        verify(repository, only()).getTallyHostViews(
+            eq("account123456"),
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
+            eq(null),
             eq(0),
             eq(1),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))


### PR DESCRIPTION
Add support for `display_name_contains` as an optional query param for GET `/hosts/products/{product_id}`.

Expanded the jpql `@Query` in HostRepository.  A potential item for future improvement would be to update the related `@Entity` classes and their relationships, and refactor use spring data's `Specification` api to dynamically build the WHERE expressions and not have to explicitly concern ourselves with the optional query params coming into the endpoint being null/empty/converting to "_ANY", etc.