### PR TITLE
Omit invalid hypervisors when querying reported hypervisors during data collection for a tally

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
@@ -45,14 +45,14 @@ public class InventoryDatabaseOperations {
     public void processHostFacts(Collection<String> accounts, int culledOffsetDays,
         Consumer<InventoryHostFacts> consumer) {
         try (Stream<InventoryHostFacts> hostFactStream = repo.getFacts(accounts, culledOffsetDays)) {
-            hostFactStream.forEach(consumer::accept);
+            hostFactStream.forEach(consumer);
         }
     }
 
     @Transactional(value = "inventoryTransactionManager", readOnly = true)
     public void reportedHypervisors(Collection<String> accounts, Consumer<Object[]> consumer) {
         try (Stream<Object[]> stream = repo.getReportedHypervisors(accounts)) {
-            stream.forEach(consumer::accept);
+            stream.forEach(consumer);
         }
     }
 }


### PR DESCRIPTION
Updated the InventoryRepository's reportedHypervisors native query to include the number of sockets from its system profile facts, and then not include them in the results, essentially treating it as an unknown hypervisor.

Below is both the new & old versions of the query formatted for readability.  Comparing the number_of_sockets from the jsonb column in the WHERE clause increased the execution time by >2000%, which is why I opted to use a subquery in the FROM clause.

### New Version
```sql
select hyp_id,
       hyp_subman_id
from (
         select distinct h.facts -> 'rhsm' ->> 'VM_HOST_UUID'                             as hyp_id,
                         h_.canonical_facts ->> 'subscription_manager_id'                 as hyp_subman_id,
                         jsonb_extract_path(h_.system_profile_facts, 'number_of_sockets') as sockets
         from hosts h
                  left outer join hosts h_ on h.facts -> 'rhsm' ->> 'VM_HOST_UUID' =
                                              h_.canonical_facts ->> 'subscription_manager_id'
         where h.facts -> 'rhsm' -> 'VM_HOST_UUID' is not null
           and h.account IN (:accounts)
         union
             all
         select distinct h.facts -> 'satellite' ->> 'virtual_host_uuid'                   as hyp_id,
                         h_.canonical_facts ->> 'subscription_manager_id'                 as hyp_subman_id,
                         jsonb_extract_path(h_.system_profile_facts, 'number_of_sockets') as sockets
         from hosts h
                  left outer join hosts h_ on h.facts -> 'satellite' ->> 'virtual_host_uuid' =
                                              h_.canonical_facts ->> 'subscription_manager_id'
         where h.facts -> 'satellite' -> 'virtual_host_uuid' is not null
           and h.account IN (:accounts)
     ) as wrapper
where sockets <> '0'
```
### develop Version
```sql
select distinct h.facts -> 'rhsm' ->> 'VM_HOST_UUID'             as hyp_id,
                h_.canonical_facts ->> 'subscription_manager_id' as hyp_subman_id
from hosts h
         left outer join hosts h_ on h.facts -> 'rhsm' ->> 'VM_HOST_UUID' =
                                     h_.canonical_facts ->> 'subscription_manager_id'
where h.facts -> 'rhsm' -> 'VM_HOST_UUID' is not null
  and h.account IN (:accounts)
union
    all
select distinct h.facts -> 'satellite' ->> 'virtual_host_uuid'   as hyp_id,
                h_.canonical_facts ->> 'subscription_manager_id' as hyp_subman_id
from hosts h
         left outer join hosts h_ on h.facts -> 'satellite' ->> 'virtual_host_uuid' =
                                     h_.canonical_facts ->> 'subscription_manager_id'
where h.facts -> 'satellite' -> 'virtual_host_uuid' is not null
  and h.account IN (:accounts)
```
### helper/test script
Here's the helper script that I'm using to grab which hypervisors are invalid and are being omitted from the results, so I can cross check them with the rhsm-subscription hosts table and see what socket/core count their hosts end up with.
```sql
select
    *
from
    (
        select
            hyp_id,
            hyp_subman_id
        from
            (
                select
                    distinct h.facts -> 'rhsm' ->> 'VM_HOST_UUID' as hyp_id,
                    h_.canonical_facts ->> 'subscription_manager_id' as hyp_subman_id,
                    jsonb_extract_path(h_.system_profile_facts, 'number_of_sockets') as sockets
                from
                    hosts h
                    left outer join hosts h_ on h.facts -> 'rhsm' ->> 'VM_HOST_UUID' = h_.canonical_facts ->> 'subscription_manager_id'
                where
                    h.facts -> 'rhsm' -> 'VM_HOST_UUID' is not null
                    and h.account IN (:accounts)
                union
                all
                select
                    distinct h.facts -> 'satellite' ->> 'virtual_host_uuid' as hyp_id,
                    h_.canonical_facts ->> 'subscription_manager_id' as hyp_subman_id,
                    jsonb_extract_path(h_.system_profile_facts, 'number_of_sockets') as sockets
                from
                    hosts h
                    left outer join hosts h_ on h.facts -> 'satellite' ->> 'virtual_host_uuid' = h_.canonical_facts ->> 'subscription_manager_id'
                where
                    h.facts -> 'satellite' -> 'virtual_host_uuid' is not null
                    and h.account IN (:accounts)
            ) as wrapper
        where sockets <> '0'
    ) as socketsTbl
    FULL OUTER JOIN (
        select
            distinct h.facts -> 'rhsm' ->> 'VM_HOST_UUID' as hyp_id,
            h_.canonical_facts ->> 'subscription_manager_id' as hyp_subman_id
        from
            hosts h
            left outer join hosts h_ on h.facts -> 'rhsm' ->> 'VM_HOST_UUID' = h_.canonical_facts ->> 'subscription_manager_id'
        where
            h.facts -> 'rhsm' -> 'VM_HOST_UUID' is not null
          and h.account IN (:accounts)
        union
        all
        select
            distinct h.facts -> 'satellite' ->> 'virtual_host_uuid' as hyp_id,
            h_.canonical_facts ->> 'subscription_manager_id' as hyp_subman_id
        from
            hosts h
            left outer join hosts h_ on h.facts -> 'satellite' ->> 'virtual_host_uuid' = h_.canonical_facts ->> 'subscription_manager_id'
        where
            h.facts -> 'satellite' -> 'virtual_host_uuid' is not null
          and h.account IN (:accounts)
    ) as develop ON socketsTbl.hyp_id = develop.hyp_id
WHERE
    socketsTbl.hyp_id is null
    or develop.hyp_id is null
```