### PR TITLE
Add Satellite primary product to find all satellite server & capsule instances.

### DIFF
--- a/src/main/resources/product_id_to_products_map.yaml
+++ b/src/main/resources/product_id_to_products_map.yaml
@@ -46,7 +46,9 @@
   - RHEL for x86
 
 250:  # Red Hat Satellite
-  - Satellite 6
+  - Satellite
+  - Satellite Server
 
 269:  # Red Hat Satellite Capsule
-  - Satellite 6 Capsule
+  - Satellite
+  - Satellite Capsule


### PR DESCRIPTION
Also remove the version number from Satellite product name.

This basically follows the pattern from RHEL to have one product to roll up everything as well as sub products for different versions. 