### PR TITLE
Add Marketplace API client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,7 @@ dependencies {
     compile project(":cloudigrade-client")
     compile project(":rbac-client")
     compile project(":subscription-client")
+    compile project(":marketplace-client")
     compile project(":kafka-schema")
 
     // This starter pulls in Spring Boot versions that we don't want.  The actual classes that we need are
@@ -429,8 +430,23 @@ project(":subscription-client") {
     }
 }
 
+project(":marketplace-client") {
+    apply plugin: "org.openapi.generator"
+
+    ext {
+        api_spec_path = "${projectDir}/marketplace-api-spec.yaml"
+        config_file = "${projectDir}/marketplace-client-config.json"
+    }
+
+    dependencies {
+        compileOnly "org.springframework:spring-web"
+        compileOnly "javax.servlet:javax.servlet-api"
+    }
+}
+
 configure(subprojects.findAll { it.name in ["cloudigrade-client", 'rbac-client', 'rhsm-client',
-                                            'insights-inventory-client', 'subscription-client']}) {
+                                            'insights-inventory-client', 'subscription-client',
+                                            'marketplace-client']}) {
     apply plugin: "org.openapi.generator"
     apply plugin: "checkstyle"
 

--- a/marketplace-client/marketplace-api-spec.yaml
+++ b/marketplace-client/marketplace-api-spec.yaml
@@ -1,0 +1,161 @@
+# This is a file maintained by the rhsm-subscription project that describes
+# a portion of the Marketplace API.
+openapi: 3.0.2
+info:
+  title: marketplace-api
+  description: Third-party specification for Marketplace API, see https://marketplace.redhat.com/en-us/documentation/api-reference
+  version: 1.0.0
+
+paths:
+  /api-security/om-auth/cloud/token:
+    post:
+      operationId: getAccessToken
+      tags:
+        - marketplace
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/AuthRequest"
+      responses:
+        '200':
+          description: The operation completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+  /metering/api/v1/metrics:
+    post:
+      operationId: submitUsageEvents
+      tags:
+        - marketplace
+      security:
+        - accessToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UsageRequest"
+      responses:
+        '200':
+          description: The operation completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusResponse"
+  /metering/api/v1/metrics/{batchId}:
+    parameters:
+      - name: batchId
+        required: true
+        in: path
+        schema:
+          type: string
+    get:
+      operationId: getUsageBatchStatus
+      tags:
+        - marketplace
+      security:
+        - accessToken: []
+      responses:
+        '200':
+          description: Batch status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusResponse"
+
+
+components:
+  schemas:
+    AuthRequest:
+      properties:
+        grant_type:
+          $ref: "#/components/schemas/AuthGrantType"
+        apikey:
+          type: string
+    AuthGrantType:
+      type: string
+      enum: [ "urn:ibm:params:oauth:grant-type:apikey" ]
+    AuthResponse:
+      required:
+        - access_token
+        - expiration
+      properties:
+        access_token:
+          type: string
+        expiration:
+          type: integer
+          format: int64
+    UsageRequest:
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/UsageEvent"
+    UsageEvent:
+      required:
+        - start
+        - end
+        - resourceType
+        - subscriptionId
+        - eventId
+        - additionalAttributes
+        - measuredUsage
+      properties:
+        start:
+          description: Start time of the usage in millseconds since Unix epoch.
+          type: integer
+          format: int64
+        end:
+          description: End time of the usage in millseconds since Unix epoch.
+          type: integer
+          format: int64
+        resourceType:
+          type: string
+        subscriptionId:
+          type: string
+        eventId:
+          description: Event ID for Marketplace API.
+          type: string
+        additionalAttributes:
+          type: object
+        measuredUsage:
+          type: array
+          items:
+            $ref: "#/components/schemas/UsageMeasurement"
+    UsageMeasurement:
+      required:
+        - chargeId
+        - value
+      properties:
+        chargeId:
+          type: string
+        value:
+          type: number
+          format: double
+    StatusResponse:
+      properties:
+        status:
+          type: string
+        message:
+          type: string
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchStatus"
+    BatchStatus:
+      properties:
+        status:
+          type: string
+        batchId:
+          type: string
+
+  securitySchemes:
+    accessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/marketplace-client/marketplace-api-spec.yaml
+++ b/marketplace-client/marketplace-api-spec.yaml
@@ -17,7 +17,12 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/AuthRequest"
+              type: object
+              properties:
+                grant_type:
+                  type: string
+                apikey:
+                  type: string
       responses:
         '200':
           description: The operation completed successfully
@@ -69,12 +74,6 @@ paths:
 
 components:
   schemas:
-    AuthRequest:
-      properties:
-        grant_type:
-          $ref: "#/components/schemas/AuthGrantType"
-        apikey:
-          type: string
     AuthGrantType:
       type: string
       enum: [ "urn:ibm:params:oauth:grant-type:apikey" ]

--- a/marketplace-client/marketplace-client-config.json
+++ b/marketplace-client/marketplace-client-config.json
@@ -1,0 +1,8 @@
+{
+  "modelPackage": "org.candlepin.subscriptions.marketplace.api.model",
+  "apiPackage": "org.candlepin.subscriptions.marketplace.api.resources",
+  "invokerPackage": "org.candlepin.subscriptions.marketplace",
+  "groupId": "org.candlepin",
+  "artifactId": "marketplace-client",
+  "java8": true
+}

--- a/marketplace-client/marketplace-client-config.json
+++ b/marketplace-client/marketplace-client-config.json
@@ -3,6 +3,5 @@
   "apiPackage": "org.candlepin.subscriptions.marketplace.api.resources",
   "invokerPackage": "org.candlepin.subscriptions.marketplace",
   "groupId": "org.candlepin",
-  "artifactId": "marketplace-client",
-  "java8": true
+  "artifactId": "marketplace-client"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'rhsm-subscriptions'
-include ':api', ':insights-inventory-client', ':rhsm-client', ':cloudigrade-client', 'kafka-schema', ':rbac-client', ':subscription-client'
+include ':api', ':insights-inventory-client', ':rhsm-client', ':cloudigrade-client', 'kafka-schema', ':rbac-client', ':subscription-client', ':marketplace-client'

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions;
 import org.candlepin.subscriptions.capacity.CapacityIngressConfiguration;
 import org.candlepin.subscriptions.conduit.ConduitConfiguration;
 import org.candlepin.subscriptions.conduit.job.OrgSyncConfiguration;
+import org.candlepin.subscriptions.marketplace.MarketplaceWorkerConfiguration;
 import org.candlepin.subscriptions.resource.ApiConfiguration;
 import org.candlepin.subscriptions.retention.PurgeSnapshotsConfiguration;
 import org.candlepin.subscriptions.security.SecurityConfig;
@@ -61,7 +62,8 @@ import javax.validation.Validator;
     ApiConfiguration.class, ConduitConfiguration.class, CapacityIngressConfiguration.class,
     CaptureSnapshotsConfiguration.class, PurgeSnapshotsConfiguration.class,
     LiquibaseUpdateOnlyConfiguration.class, TallyWorkerConfiguration.class, OrgSyncConfiguration.class,
-    DevModeConfiguration.class, SecurityConfig.class, HawtioConfiguration.class
+    MarketplaceWorkerConfiguration.class, DevModeConfiguration.class, SecurityConfig.class,
+    HawtioConfiguration.class
 })
 public class ApplicationConfiguration implements WebMvcConfigurer {
     @Bean

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceApiFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceApiFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import org.candlepin.subscriptions.http.HttpClient;
+import org.candlepin.subscriptions.marketplace.api.resources.MarketplaceApi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * Factory that produces marketplace API clients.
+ */
+@Component
+public class MarketplaceApiFactory implements FactoryBean<MarketplaceApi> {
+
+    private static Logger log = LoggerFactory.getLogger(MarketplaceApiFactory.class);
+
+    private final MarketplaceProperties serviceProperties;
+
+    public MarketplaceApiFactory(MarketplaceProperties serviceProperties) {
+        this.serviceProperties = serviceProperties;
+    }
+
+    @Override
+    public MarketplaceApi getObject() throws Exception {
+        ApiClient apiClient = new ApiClient();
+        apiClient.setHttpClient(HttpClient.buildHttpClient(serviceProperties, apiClient.getJSON(),
+            apiClient.isDebugging()));
+        if (serviceProperties.getUrl() != null) {
+            log.info("Marketplace service URL: {}", serviceProperties.getUrl());
+            apiClient.setBasePath(serviceProperties.getUrl());
+        }
+        else {
+            log.warn("Marketplace service URL not set...");
+        }
+
+        return new MarketplaceApi(apiClient);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return MarketplaceApi.class;
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceApiFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceApiFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
+import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
+import org.candlepin.subscriptions.resource.ResourceUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jmx.JmxException;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Exposes admin functions for Marketplace integration.
+ */
+@Component
+@ManagedResource
+public class MarketplaceJmxBean {
+    private static final Logger log = LoggerFactory.getLogger(MarketplaceJmxBean.class);
+
+    private final ApplicationProperties properties;
+    private final MarketplaceService marketplaceService;
+    private final ObjectMapper mapper;
+
+    MarketplaceJmxBean(ApplicationProperties properties, MarketplaceService marketplaceService,
+        ObjectMapper mapper) {
+
+        this.properties = properties;
+        this.marketplaceService = marketplaceService;
+        this.mapper = mapper;
+    }
+
+    @ManagedOperation(description = "Force a refresh of the access token")
+    public void refreshAccessToken() throws ApiException {
+        Object principal = ResourceUtils.getPrincipal();
+        log.info("Marketplace access token forcibly refreshed by {}", principal);
+        marketplaceService.forceRefreshAccessToken();
+    }
+
+    @ManagedOperation(description = "Submit usage event JSON (dev-mode only)")
+    public String submitUsageEvent(String payloadJson) throws JsonProcessingException, ApiException {
+        if (!properties.isDevMode()) {
+            throw new JmxException("Unsupported outside dev-mode");
+        }
+        UsageEvent usageEvent = mapper.readValue(payloadJson, UsageEvent.class);
+        UsageRequest usageRequest = new UsageRequest().addDataItem(usageEvent);
+        return marketplaceService.submitUsageEvents(usageRequest).toString();
+    }
+
+    @ManagedOperation(description = "Fetch a usage event status")
+    public String getUsageEventStatus(String batchId) throws ApiException {
+        return marketplaceService.getUsageBatchStatus(batchId).toString();
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import org.candlepin.subscriptions.http.HttpClientProperties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Properties for the Marketplace integration.
+ */
+@Component
+@ConfigurationProperties(prefix = "rhsm-subscriptions.marketplace")
+public class MarketplaceProperties extends HttpClientProperties {
+
+    /**
+     * Marketplace API key (from https://marketplace.redhat.com/en-us/account/service-ids)
+     */
+    private String apiKey;
+
+    /**
+     * Amount of time prior to token expiration to request a new token anyways.
+     */
+    private Duration tokenRefreshPeriod = Duration.ofMinutes(1);
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public Duration getTokenRefreshPeriod() {
+        return tokenRefreshPeriod;
+    }
+
+    public void setTokenRefreshPeriod(Duration tokenRefreshPeriod) {
+        this.tokenRefreshPeriod = tokenRefreshPeriod;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import org.candlepin.subscriptions.marketplace.api.model.AuthGrantType;
+import org.candlepin.subscriptions.marketplace.api.model.AuthResponse;
+import org.candlepin.subscriptions.marketplace.api.model.StatusResponse;
+import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
+import org.candlepin.subscriptions.marketplace.api.resources.MarketplaceApi;
+import org.candlepin.subscriptions.marketplace.auth.HttpBearerAuth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Encapsulates auth-related aspects of interacting with the Marketplace API.
+ */
+@Component
+public class MarketplaceService {
+
+    private final MarketplaceApi api;
+    private final String apiKey;
+    private final long tokenRefreshPeriodMs;
+    private String accessToken;
+    private long tokenRefreshCutoff;
+
+    @Autowired
+    public MarketplaceService(MarketplaceProperties properties, MarketplaceApi api) {
+        this.api = api;
+        this.apiKey = properties.getApiKey();
+        this.tokenRefreshPeriodMs = properties.getTokenRefreshPeriod().toMillis() / 1000;
+        this.accessToken = null;
+        this.tokenRefreshCutoff = 0L;
+    }
+
+    public synchronized void forceRefreshAccessToken() throws ApiException {
+        this.tokenRefreshCutoff = 0L;
+        ensureAccessToken();
+    }
+
+    public synchronized void ensureAccessToken() throws ApiException {
+        if (OffsetDateTime.now().toEpochSecond() > tokenRefreshCutoff) {
+            AuthResponse response =
+                api.getAccessToken(AuthGrantType.URN_IBM_PARAMS_OAUTH_GRANT_TYPE_APIKEY, apiKey);
+
+            accessToken = response.getAccessToken();
+            tokenRefreshCutoff = response.getExpiration() - (tokenRefreshPeriodMs);
+            HttpBearerAuth auth = (HttpBearerAuth) api.getApiClient().getAuthentication("accessToken");
+            auth.setBearerToken(accessToken);
+        }
+    }
+
+    public StatusResponse submitUsageEvents(UsageRequest usageRequest) throws ApiException {
+        ensureAccessToken();
+        return api.submitUsageEvents(usageRequest);
+    }
+
+    public StatusResponse getUsageBatchStatus(String batchId) throws ApiException {
+        ensureAccessToken();
+        return api.getUsageBatchStatus(batchId);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
@@ -61,7 +61,7 @@ public class MarketplaceService {
     public synchronized void ensureAccessToken() throws ApiException {
         if (OffsetDateTime.now().toEpochSecond() > tokenRefreshCutoff) {
             AuthResponse response =
-                api.getAccessToken(AuthGrantType.URN_IBM_PARAMS_OAUTH_GRANT_TYPE_APIKEY, apiKey);
+                api.getAccessToken(AuthGrantType.URN_IBM_PARAMS_OAUTH_GRANT_TYPE_APIKEY.getValue(), apiKey);
 
             accessToken = response.getAccessToken();
             tokenRefreshCutoff = response.getExpiration() - (tokenRefreshPeriodMs);

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Configuration for the Marketplace integration worker.
+ */
+@Profile("marketplace")
+@ComponentScan(basePackages = "org.candlepin.subscriptions.marketplace")
+public class MarketplaceWorkerConfiguration {
+    /* intentionally empty */
+}

--- a/src/main/resources/application-marketplace.yaml
+++ b/src/main/resources/application-marketplace.yaml
@@ -1,0 +1,5 @@
+rhsm-subscriptions:
+  marketplace:
+    api-key: ${MARKETPLACE_API_KEY}
+    url: ${MARKETPLACE_URL}
+    token-refresh-period: ${MARKETPLACE_TOKEN_REFRESH_PERIOD:1m}


### PR DESCRIPTION
The overall workflow is as follows:

1. A Marketplace offering is defined.
2. The charge ID(s) from the defined offering are provided for Subscription Watch configuration
   (comes from https://sandbox.marketplace.redhat.com/en-us/commerce/edition-charge-editor).
   Because this charge ID is consistent, we should eventually create a config value for it.
   (this field is out of the scope of this change).
3. A user subscribes via the Marketplace UI.
4. A notification is sent to RH backend systems.
5. (Details TBD) Subscription Watch retrieves one or more subscription IDs to be used for integration with the Marketplace API.
6. Subscription Watch emits usage events to the Marketplace API.

The Marketplace UI can be used to verify charges: https://sandbox.marketplace.redhat.com/en-us/account/pending-charges

Needs:
  - `MARKETPLACE_URL` - e.g. `https://sandbox.marketplace.redhat.com`
  - `MARKETPLACE_API_KEY` - from https://sandbox.marketplace.redhat.com/en-us/account/service-ids, reach out to me for a secret for testing or create your own
  - `subscriptionId` - from the subscription notification (email or webhook), reach out to me to, I will provide for testing
  - `eventId` - generated, I came up locally via `uuidgen | sed 's/\-//g' | dd if=/dev/stdin of=/dev/stdout bs=24 count=1 2>/dev/null`

Additionally, `MARKETPLACE_TOKEN_REFRESH_PERIOD` controls the tolerance for the age of the temporary token used to make API calls (it defaults to 1 minute).

NOTE: according to the Marketplace team, `eventId` should actually be a GUID, and there is work planned to fix it. Currently it is a 24-char ID...

Run as:
```
DEV_MODE=true MARKETPLACE_API_KEY=$MARKETPLACE_API_KEY MARKETPLACE_URL=https://sandbox.marketplace.redhat.com SPRING_PROFILES_ACTIVE=marketplace
```

Open up https://sandbox.marketplace.redhat.com/en-us/account/pending-charges and note the current value for pending charges.

Use http://localhost:8080/actuator/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.marketplace-MarketplaceJmxBean-marketplaceJmxBean with operation
`submitUsageEvent`, give payloadJson as follows, replacing all values in the JSON of FIXME as appropriate (refer to notes above about the source of values).

```json
{
  "start": 1608218158000,
  "end": 1608218158000,
  "resourceType": "SAAS",
  "subscriptionId": "FIXME",
  "eventId": "FIXME",
  "additionalAttributes": {},
  "measuredUsage": [
    {
      "chargeId": "redhat.com:openshiftdedicated:cpu_hour",
      "value": 154
    }
  ]
}
```

Take the resulting response and note the batch ID. Verify the batch is completed via the `getUsageEventStatus` JMX operation.

Verify the resulting charge difference in https://sandbox.marketplace.redhat.com/en-us/account/pending-charges