### PR TITLE
Default displayNameContains to empty string to appease database libraries.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -36,6 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collection;
 import java.util.UUID;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Provides access to Host database entities.
  */
@@ -80,7 +82,7 @@ public interface HostRepository extends JpaRepository<Host, UUID> {
         @Param("product") String productId,
         @Param("sla") ServiceLevel sla,
         @Param("usage") Usage usage,
-        @Param("displayNameSubstring") String displayNameSubstring,
+        @NotNull @Param("displayNameSubstring") String displayNameSubstring,
         @Param("minCores") int minCores,
         @Param("minSockets") int minSockets,
         Pageable pageable

--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -63,7 +63,7 @@ public interface HostRepository extends JpaRepository<Host, UUID> {
             "b.key.productId = :product and " +
             "b.key.sla = :sla and b.key.usage = :usage and " +
             // Have to do the null check first, otherwise the lower in the LIKE clause has issues with datatypes
-            "(:displayNameSubstring IS NULL or (lower(b.key.host.displayName) LIKE lower(concat('%', :displayNameSubstring,'%')))) and " +
+            "((lower(b.key.host.displayName) LIKE lower(concat('%', :displayNameSubstring,'%')))) and " +
             "b.cores >= :minCores and b.sockets >= :minSockets",
         // Because we are using a 'fetch join' to avoid having to lazy load each bucket host,
         // we need to specify how the Page should gets its count when the 'limit' parameter
@@ -72,7 +72,7 @@ public interface HostRepository extends JpaRepository<Host, UUID> {
             "h.accountNumber = :account and " +
             "b.key.productId = :product and " +
             "b.key.sla = :sla and b.key.usage = :usage and " +
-            "(:displayNameSubstring IS NULL or (lower(b.key.host.displayName) LIKE lower(concat('%', :displayNameSubstring,'%')))) and " +
+            "((lower(b.key.host.displayName) LIKE lower(concat('%', :displayNameSubstring,'%')))) and " +
             "b.cores >= :minCores and b.sockets >= :minSockets"
     )
     Page<TallyHostView> getTallyHostViews(//NOSONAR (exceeds allowed 7 params)

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -48,6 +48,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.validation.constraints.Max;
@@ -111,12 +112,16 @@ public class HostsResource implements HostsApi {
         String accountNumber = ResourceUtils.getAccountNumber();
         ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
         Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
+        String sanitizedDisplayNameSubstring = Objects.nonNull(displayNameContains) ?
+            displayNameContains :
+            "";
         Pageable page = ResourceUtils.getPageable(offset, limit, sortValue);
-        Page<TallyHostView> hosts = repository.getTallyHostViews(accountNumber,
+        Page<TallyHostView> hosts = repository.getTallyHostViews(
+            accountNumber,
             productId.toString(),
             sanitizedSla,
             sanitizedUsage,
-            displayNameContains,
+            sanitizedDisplayNameSubstring,
             minCores,
             minSockets,
             page);

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -65,11 +65,13 @@ class HostRepositoryTest {
     private final String RHEL = "RHEL";
     private final String COOL_PROD = "COOL_PROD";
     private static final String DEFAULT_DISPLAY_NAME = "REDHAT_PWNS";
+    private static final String SANITIZED_MISSING_DISPLAY_NAME = "";
 
     @Autowired
     private HostRepository repo;
 
     private Map<String, Host> existingHostsByInventoryId;
+
 
     @Transactional
     @BeforeAll
@@ -146,7 +148,7 @@ class HostRepositoryTest {
         repo.saveAndFlush(host);
 
         Page<TallyHostView> hosts = repo.getTallyHostViews(expAccount, RHEL, ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
         assertEquals(1, found.size());
 
@@ -222,7 +224,7 @@ class HostRepositoryTest {
     @Test
     void testFindHostsWhenAccountIsDifferent() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account1", RHEL, ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -233,7 +235,7 @@ class HostRepositoryTest {
     @Test
     void testFindHostsWhenProductIsDifferent() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", COOL_PROD, ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -244,7 +246,7 @@ class HostRepositoryTest {
     @Test
     void testFindHostsWhenSLAIsDifferent() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", RHEL, ServiceLevel.SELF_SUPPORT,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -255,7 +257,7 @@ class HostRepositoryTest {
     @Test
     void testFindHostsWhenUsageIsDifferent() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", RHEL, ServiceLevel.SELF_SUPPORT,
-            Usage.DISASTER_RECOVERY, null, 0, 0, PageRequest.of(0, 10));
+            Usage.DISASTER_RECOVERY, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -310,7 +312,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByIdForImplicitSort() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC, "id"));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC, "id"));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());
@@ -321,7 +323,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByDisplayName() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -333,7 +335,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByMeasurementType() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account3", RHEL, ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -345,7 +347,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByCores() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest
             .of(0, 10, Sort.Direction.ASC, HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.CORES)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -357,7 +359,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortBySockets() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest
             .of(0, 10, Sort.Direction.ASC, HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -369,7 +371,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByLastSeen() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -381,7 +383,7 @@ class HostRepositoryTest {
     @Test
     void testCanSortByHardwareType() {
         Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC,
             HostsResource.SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
@@ -438,7 +440,7 @@ class HostRepositoryTest {
         repo.flush();
 
         Page<TallyHostView> results = repo.getTallyHostViews("my_acct", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10));
         Map<String, TallyHostView> hosts = results.getContent().stream()
             .collect(Collectors.toMap(TallyHostView::getHardwareMeasurementType, Function.identity()));
         assertEquals(2, hosts.size());
@@ -476,7 +478,7 @@ class HostRepositoryTest {
         repo.flush();
 
         Page<TallyHostView> results = repo.getTallyHostViews("my_acct", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 0, PageRequest.of(0, 10));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10));
         Map<String, TallyHostView> hosts = results.getContent().stream()
             .collect(Collectors.toMap(TallyHostView::getHardwareMeasurementType, Function.identity()));
         assertEquals(1, hosts.size());
@@ -512,7 +514,7 @@ class HostRepositoryTest {
         repo.flush();
 
         Page<TallyHostView> results = repo.getTallyHostViews("my_acct", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 0, 1, PageRequest.of(0, 10));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 1, PageRequest.of(0, 10));
         Map<String, TallyHostView> hosts = results.getContent().stream()
             .collect(Collectors.toMap(TallyHostView::getHardwareMeasurementType, Function.identity()));
         assertEquals(1, hosts.size());
@@ -547,7 +549,7 @@ class HostRepositoryTest {
         repo.flush();
 
         Page<TallyHostView> results = repo.getTallyHostViews("my_acct", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, null, 1, 0, PageRequest.of(0, 10));
+            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 1, 0, PageRequest.of(0, 10));
         Map<String, TallyHostView> hosts = results.getContent().stream()
             .collect(Collectors.toMap(TallyHostView::getHardwareMeasurementType, Function.identity()));
         assertEquals(1, hosts.size());

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -311,8 +311,14 @@ class HostRepositoryTest {
     @Transactional
     @Test
     void testCanSortByIdForImplicitSort() {
-        Page<TallyHostView> hosts = repo.getTallyHostViews("account2", "RHEL", ServiceLevel.PREMIUM,
-            Usage.PRODUCTION, SANITIZED_MISSING_DISPLAY_NAME, 0, 0, PageRequest.of(0, 10, Sort.Direction.ASC, "id"));
+        Page<TallyHostView> hosts = repo.getTallyHostViews("account2",
+            "RHEL",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            0,
+            PageRequest.of(0, 10, Sort.Direction.ASC, "id"));
         List<TallyHostView> found = hosts.stream().collect(Collectors.toList());
 
         assertEquals(1, found.size());

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 class HostsResourceTest {
 
     static final Sort.Order IMPLICIT_ORDER = new Sort.Order(Sort.Direction.ASC, "id");
+    private static final String SANITIZED_MISSING_DISPLAY_NAME = "";
     @MockBean
     HostRepository repository;
     @MockBean
@@ -81,7 +82,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1, Sort.by(
@@ -100,7 +101,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(0),
             eq(0),
             eq(
@@ -120,7 +121,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1,
@@ -139,7 +140,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1,
@@ -158,7 +159,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1,
@@ -177,7 +178,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
@@ -194,7 +195,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(0),
             eq(0),
             eq(PageRequest.of(0, 1,
@@ -212,7 +213,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(1),
             eq(0),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
@@ -228,7 +229,7 @@ class HostsResourceTest {
             eq(ProductId.RHEL.toString()),
             eq(ServiceLevel._ANY),
             eq(Usage._ANY),
-            eq(null),
+            eq(SANITIZED_MISSING_DISPLAY_NAME),
             eq(0),
             eq(1),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))


### PR DESCRIPTION
Quick fix to sanitize a null input and set it to an empty string.