### PR TITLE
Add initContainer for liquibase updates

### DIFF
--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -73,6 +73,48 @@ objects:
           prometheus.io/port: '8080'
           prometheus.io/scrape: 'true'
       spec:
+        initContainers:
+          - image: ${IMAGE}:${IMAGE_TAG}
+            name: liquibase
+            env:
+              - name: SPRING_PROFILES_ACTIVE
+                value: liquibase-only
+              - name: JAVA_MAX_MEM_RATIO
+                value: '85'
+              - name: GC_MAX_METASPACE_SIZE
+                value: '256'
+              - name: DATABASE_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db
+                    key: db.host
+              - name: DATABASE_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db
+                    key: db.port
+              - name: DATABASE_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db
+                    key: db.user
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db
+                    key: db.password
+              - name: DATABASE_DATABASE
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db
+                    key: db.name
+            resources:
+              requests:
+                cpu: ${CPU_REQUEST}
+                memory: ${MEMORY_REQUEST}
+              limits:
+                cpu: ${CPU_LIMIT}
+                memory: ${MEMORY_LIMIT}
         containers:
           - image: ${IMAGE}:${IMAGE_TAG}
             name: rhsm-conduit
@@ -82,8 +124,8 @@ objects:
                 value: 'true'
               - name: HAWTIO_BASE_PATH
                 value: ${HAWTIO_BASE_PATH}
-              - name: JAVA_OPTIONS
-                value: -Dspring.profiles.active=rhsm-conduit,kafka-queue
+              - name: SPRING_PROFILES_ACTIVE
+                value: rhsm-conduit,kafka-queue
               - name: LOG_FILE
                 value: /logs/server.log
               - name: JAVA_MAX_MEM_RATIO
@@ -250,8 +292,8 @@ objects:
               - image: ${IMAGE}:${IMAGE_TAG}
                 name: rhsm-conduit-cron-sync
                 env:
-                - name: JAVA_OPTIONS
-                  value: -Dspring.profiles.active=orgsync
+                - name: SPRING_PROFILES_ACTIVE
+                  value: orgsync
                 - name: JAVA_MAX_MEM_RATIO
                   value: '85'
                 - name: GC_MAX_METASPACE_SIZE

--- a/templates/rhsm-subscriptions-api.yml
+++ b/templates/rhsm-subscriptions-api.yml
@@ -88,14 +88,56 @@ objects:
             prometheus.io/port: '8080'
             prometheus.io/scrape: 'true'
         spec:
+          initContainers:
+            - image: ${IMAGE}:${IMAGE_TAG}
+              name: liquibase
+              env:
+                - name: SPRING_PROFILES_ACTIVE
+                  value: liquibase-only
+                - name: JAVA_MAX_MEM_RATIO
+                  value: '85'
+                - name: GC_MAX_METASPACE_SIZE
+                  value: '256'
+                - name: DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.host
+                - name: DATABASE_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.port
+                - name: DATABASE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.user
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.password
+                - name: DATABASE_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.name
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
           containers:
             - image: ${IMAGE}:${IMAGE_TAG}
               name: rhsm-subscriptions-api
               env:
                 - name: LOG_FILE
                   value: /logs/server.log
-                - name: JAVA_OPTIONS
-                  value: -Dspring.profiles.active=api
+                - name: SPRING_PROFILES_ACTIVE
+                  value: api
                 - name: JAVA_MAX_MEM_RATIO
                   value: '85'
                 - name: GC_MAX_METASPACE_SIZE

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -63,6 +63,48 @@ objects:
             prometheus.io/port: '8080'
             prometheus.io/scrape: 'true'
         spec:
+          initContainers:
+            - image: ${IMAGE}:${IMAGE_TAG}
+              name: liquibase
+              env:
+                - name: SPRING_PROFILES_ACTIVE
+                  value: liquibase-only
+                - name: JAVA_MAX_MEM_RATIO
+                  value: '85'
+                - name: GC_MAX_METASPACE_SIZE
+                  value: '256'
+                - name: DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.host
+                - name: DATABASE_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.port
+                - name: DATABASE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.user
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.password
+                - name: DATABASE_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.name
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
           containers:
             - image: ${IMAGE}:${IMAGE_TAG}
               name: rhsm-subscriptions-capacity-ingress
@@ -70,7 +112,9 @@ objects:
                 - name: LOG_FILE
                   value: /logs/server.log
                 - name: JAVA_OPTIONS
-                  value: -Dspring.config.additional-location=file:/config/ssl.properties -Dspring.profiles.active=capacity-ingress
+                  value: -Dspring.config.additional-location=file:/config/ssl.properties
+                - name: SPRING_PROFILES_ACTIVE
+                  value: capacity-ingress
                 - name: JAVA_MAX_MEM_RATIO
                   value: '85'
                 - name: GC_MAX_METASPACE_SIZE

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -55,8 +55,8 @@ objects:
                 - image: ${IMAGE}:${IMAGE_TAG}
                   name: rhsm-subscriptions-cron-tally
                   env:
-                    - name: JAVA_OPTIONS
-                      value: -Dspring.profiles.active=capture-snapshots,kafka-queue
+                    - name: SPRING_PROFILES_ACTIVE
+                      value: capture-snapshots,kafka-queue
                     - name: JAVA_MAX_MEM_RATIO
                       value: '85'
                     - name: GC_MAX_METASPACE_SIZE
@@ -140,8 +140,8 @@ objects:
                 - image: ${IMAGE}:${IMAGE_TAG}
                   name: rhsm-subscriptions-cron-purge
                   env:
-                    - name: JAVA_OPTIONS
-                      value: -Dspring.profiles.active=purge-snapshots,kafka-queue
+                    - name: SPRING_PROFILES_ACTIVE
+                      value: purge-snapshots,kafka-queue
                     - name: JAVA_MAX_MEM_RATIO
                       value: '85'
                     - name: GC_MAX_METASPACE_SIZE

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -75,6 +75,48 @@ objects:
             prometheus.io/port: '8080'
             prometheus.io/scrape: 'true'
         spec:
+          initContainers:
+            - image: ${IMAGE}:${IMAGE_TAG}
+              name: liquibase
+              env:
+                - name: SPRING_PROFILES_ACTIVE
+                  value: liquibase-only
+                - name: JAVA_MAX_MEM_RATIO
+                  value: '85'
+                - name: GC_MAX_METASPACE_SIZE
+                  value: '256'
+                - name: DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.host
+                - name: DATABASE_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.port
+                - name: DATABASE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.user
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.password
+                - name: DATABASE_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.name
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
           containers:
             - image: ${IMAGE}:${IMAGE_TAG}
               name: rhsm-subscriptions-worker
@@ -86,8 +128,8 @@ objects:
                   value: ${HAWTIO_BASE_PATH}
                 - name: LOG_FILE
                   value: /logs/server.log
-                - name: JAVA_OPTIONS
-                  value: -Dspring.profiles.active=worker
+                - name: SPRING_PROFILES_ACTIVE
+                  value: worker
                 - name: JAVA_MAX_MEM_RATIO
                   value: '85'
                 - name: GC_MAX_METASPACE_SIZE


### PR DESCRIPTION
Also went ahead and pivoted to SPRING_PROFILES_ACTIVE rather than the Java property for consistency.

With this change, liquibase updates always run first to completion before the pod starts (meaning timeouts of liquibase changes should not be an issue).

Note that with this change, to view logs of the liquibase run, will need to use syntax like:

```
oc logs -f rhsm-subscriptions-api-61-4sd9r -c liquibase
```

To test, you can use our deploy job to deploy to the CI environment: https://rhsm-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/swatch-deploy-ci/build?delay=0sec (picking this branch).