### PR TITLE
Force compose to use conventional ports

### DIFF
--- a/container-compose.yml
+++ b/container-compose.yml
@@ -8,11 +8,11 @@ services:
     volumes:
       - ./init_dbs.sh:/docker-entrypoint-initdb.d/init_dbs.sh:z
     ports:
-      - "5432"
+      - "5432:5432"
   zookeeper:
     image: docker.io/confluentinc/cp-zookeeper
     ports:
-      - "32181"
+      - "32181:32181"
     environment:
       - ZOOKEEPER_CLIENT_PORT=32181
       - ZOOKEEPER_SERVER_ID=1


### PR DESCRIPTION
I only noticed b/c `podman-compose down` followed by `podman-compose up` broke my dev setup.

So, the difference between `5432` and `5432:5432`:

 - `5432` instructs podman to pick an arbitrary port to map to a container's port `5432`
 - `5432:5432` instructs podman to map the host's port `5432` to a container's port `5432`

podman v2.2.0+ ensures that the arbitrary port is random.

See containers/podman#7947