### PR TITLE
Hide Spring Boot local config files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,13 @@
 
 **/prometheumultiprocess
 
+# Spring Boot reads local configuration out of a directory named config.
+# However, Gradle also looks for project configurations (most notably
+# Checkstyle configuration) in the config directory.  This section hides
+# everything under the config directory except what Gradle is going to use.
+config/
+!config/checkstyle
+
 #VS Code
 .project
 .settings


### PR DESCRIPTION
Spring Boot reads local configuration out of a directory named config.  However, Gradle also looks for project configurations (most notably Checkstyle configuration) in the config directory.  This commit hides everything under the config directory except what Gradle is going to use.