### PR TITLE
Set ACCOUNT_BATCH_SIZE globally, filter larger messages

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -79,6 +79,12 @@ public class TallySnapshotController {
 
     @Timed("rhsm-subscriptions.snapshots.collection")
     public void produceSnapshotsForAccounts(List<String> accounts) {
+        if (accounts.size() > props.getAccountBatchSize()) {
+            log.info("Skipping message w/ {} accounts: count is greater than configured batch size: {}",
+                accounts.size(),
+                props.getAccountBatchSize());
+            return;
+        }
         log.info("Producing snapshots for {} accounts.", accounts.size());
         // Account list could be large. Only print them when debugging.
         if (log.isDebugEnabled()) {

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -10,7 +10,6 @@ rhsm-subscriptions:
   role-to-products-map-resource-location: classpath:role_to_products_map.yaml
   arch-to-product-map-resource-location: classpath:arch_to_product_map.yaml
   account-list-resource-location: ${ACCOUNT_LIST_RESOURCE_LOCATION:}
-  account-batch-size: ${ACCOUNT_BATCH_SIZE:1}
 
   cloudigrade-enabled: ${CLOUDIGRADE_ENABLED:false}
   cloudigrade-max-attempts: ${CLOUDIGRADE_MAX_ATTEMPTS:2}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -83,6 +83,7 @@ rhsm-subscriptions:
   jobs:
     capture-snapshot-schedule: ${CAPTURE_SNAPSHOT_SCHEDULE:0 0/5 * * * ?}
     purge-snapshot-schedule: ${PURGE_SNAPSHOT_SCHEDULE:0 0/5 * * * ?}
+  account-batch-size: ${ACCOUNT_BATCH_SIZE:1}
   tasks:
     topic: ${KAFKA_TOPIC:platform.rhsm-subscriptions.tasks}
     kafka-group-id: ${KAFKA_GROUP_ID:rhsm-subscriptions-task-processor}

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -37,6 +37,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.io.IOException;
+import java.util.Collections;
 
 @SpringBootTest
 @ActiveProfiles("worker,test")
@@ -91,5 +92,12 @@ class TallySnapshotControllerTest {
         props.setCloudigradeEnabled(false);
         controller.produceSnapshotsForAccount(ACCOUNT);
         verifyZeroInteractions(cloudigradeCollector);
+    }
+
+    @Test
+    void testBatchesLargerThanConfigIgnored() {
+        controller.produceSnapshotsForAccounts(Collections.nCopies(props.getAccountBatchSize() + 1, "foo"));
+        verifyZeroInteractions(cloudigradeCollector);
+        verifyZeroInteractions(inventoryCollector);
     }
 }


### PR DESCRIPTION
To test, try:

```
SPRING_PROFILES_ACTIVE=capture-snapshots,kafka-queue ACCOUNT_BATCH_SIZE=40 ./gradlew bootRun
```

followed by:

```
SPRING_PROFILES_ACTIVE=worker,kafka-queue ACCOUNT_BATCH_SIZE=1 ./gradlew bootRun
```

and observe the log messages about ignored messages, beginning with
"Skipping message"

This test also illustrates that the ACCOUNT_BATCH_SIZE is set properly
for both worker and capture-snapshots profiles.