### PR TITLE
Make InventoryAccountCollector remove only stale data

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -2,6 +2,7 @@
 import argparse
 import uuid
 import os
+import json
 import subprocess
 import sys
 
@@ -12,34 +13,62 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
                   subscription_manager_id=None, cores=None, sockets=None, is_guest=None, hypervisor_uuid=None,
                   hardware_type=None, measurement_type=None, num_of_guests=None, last_seen=None, product=None,
                   sla=None, usage=None, is_unmapped_guest=None, is_hypervisor=None, cloud_provider=None,
-                  skip_buckets=False):
+                  skip_buckets=False, is_hbi=False):
     host_id = uuid.uuid4()
     inventory_id=inventory_id or uuid.uuid4()
     insights_id=insights_id or uuid.uuid4()
     if not is_guest:
         hypervisor_uuid = None
-    host_fields = {
-        'id': host_id,
-        'inventory_id': inventory_id,
-        'insights_id': insights_id,
-        'account_number': account_number or 'account123',
-        'org_id': org_id or 'org123',
-        'display_name': display_name or insights_id,
-        'subscription_manager_id': subscription_manager_id or uuid.uuid4(),
-        'cores': cores,
-        'sockets': sockets,
-        'is_guest': is_guest or False,
-        'hypervisor_uuid': hypervisor_uuid or None,
-        'hardware_type': hardware_type or 'PHYSICAL',
-        'num_of_guests': num_of_guests,
-        'last_seen': last_seen or '1993-03-26',
-        'is_unmapped_guest': is_unmapped_guest or False,
-        'is_hypervisor': is_hypervisor or False,
-        'cloud_provider': cloud_provider or None
-    }
+    if is_hbi:
+        host_fields = {
+            'id': inventory_id,
+            'account': account_number or 'account123',
+            'display_name': display_name or insights_id,
+            'created_on': last_seen or '1993-03-26',
+            'modified_on': last_seen or '1993-03-26',
+            'facts': json.dumps({
+                'rhsm': {
+                    'orgId': f'org_{account_number or "account123"}',
+                    'VM_HOST_UUID': str(hypervisor_uuid) if hypervisor_uuid else None,
+                    'IS_VIRTUAL': is_guest,
+                },
+            }),
+            'canonical_facts': json.dumps({
+                'subscription_manager_id': subscription_manager_id,
+                'insights_id': str(insights_id),
+            }),
+            'system_profile_facts': json.dumps({
+                'installed_products': [{'id': '72'}],
+                'infrastructure_type': hardware_type or 'PHYSICAL',
+                'cores_per_socket': cores // sockets,
+                'number_of_sockets': sockets,
+            }),
+            'stale_timestamp': '2030-01-01',
+            'reporter': 'rhsm-conduit',
+        }
+    else:
+        host_fields = {
+            'id': host_id,
+            'inventory_id': inventory_id,
+            'insights_id': insights_id,
+            'account_number': account_number or 'account123',
+            'org_id': org_id or 'org123',
+            'display_name': display_name or insights_id,
+            'subscription_manager_id': subscription_manager_id or uuid.uuid4(),
+            'cores': cores,
+            'sockets': sockets,
+            'is_guest': is_guest or False,
+            'hypervisor_uuid': hypervisor_uuid or None,
+            'hardware_type': hardware_type or 'PHYSICAL',
+            'num_of_guests': num_of_guests,
+            'last_seen': last_seen or '1993-03-26',
+            'is_unmapped_guest': is_unmapped_guest or False,
+            'is_hypervisor': is_hypervisor or False,
+            'cloud_provider': cloud_provider or None
+        }
 
     _generate_insert('hosts', **host_fields)
-    if not skip_buckets:
+    if not is_hbi and not skip_buckets:
         _generate_buckets(host_id, product, sla, usage, cores=cores, sockets=sockets, measurement_type=measurement_type)
     return host_fields
 
@@ -47,6 +76,8 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
 def db_repr(value):
     if value is None:
         return 'null'
+    if type(value) is uuid.UUID:
+        return f"'{str(value)}'"
     return repr(value)
 
 
@@ -83,13 +114,13 @@ parser.add_argument('--db-host',
                     default='localhost',
                     help='Database host')
 parser.add_argument('--db-user',
-                    default='rhsm-subscriptions',
+                    default=None,
                     help='Database user')
 parser.add_argument('--db-password',
-                    default='',
+                    default=None,
                     help='Database password')
 parser.add_argument('--db-name',
-                    default='rhsm-subscriptions',
+                    default=None,
                     help='Database name')
 parser.add_argument('--num-physical',
                     type=int,
@@ -108,6 +139,8 @@ parser.add_argument('--unmapped-guests',
                     help='Are the guests to be created unmapped?')
 parser.add_argument('--account',
                     help='Set the account for the inserted records')
+parser.add_argument('--num-accounts', type=int, default=1,
+                    help='treat "--account" as a prefix and generate a number of accounts')
 parser.add_argument('--hypervisor-id',
                     help='Set the hypervisor id for any hypervisors or guests inserted')
 parser.add_argument('--product',
@@ -121,49 +154,82 @@ parser.add_argument('--cores', default=4,
 parser.add_argument('--sockets', default=1,
                     help='Set the sockets for the inserted hosts')
 parser.add_argument('--output-sql', action='store_true')
+parser.add_argument('--hbi', action='store_true', dest='is_hbi',
+                    help='Mock HBI data rather than tally data')
+parser.add_argument('--opt-in', action='store_true',
+                    help='Opt in this account')
+parser.add_argument('--clear', action='store_true',
+                    help='Mock HBI data rather than tally data')
 
 args = parser.parse_args()
+if args.is_hbi:
+    default_db = default_user = default_password = 'insights'
+else:
+    default_db = default_user = default_password = 'rhsm-subscriptions'
 os.environ['PGHOST'] = args.db_host
-os.environ['PGDATABASE'] = args.db_name
-os.environ['PGUSER'] = args.db_user
-os.environ['PGPASSWORD'] = args.db_password
+os.environ['PGDATABASE'] = args.db_name or default_db
+os.environ['PGUSER'] = args.db_user or default_user
+os.environ['PGPASSWORD'] = args.db_password or default_password
 
 psql = None
 if not args.output_sql:
     psql = subprocess.Popen('psql', stdin=subprocess.PIPE, shell=True, text=True)
     output = psql.stdin
 
-product = args.product or "RHEL"
+output.write('begin;')
+if args.clear:
+    if not args.is_hbi:
+        output.write('delete from host_tally_buckets;')
+    output.write('delete from hosts;')
 
-for i in range(args.num_physical):
-    generate_host(account_number=args.account, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
-                  product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets)
-
-hypervisor = None
-for i in range(args.num_hypervisors):
-    hypervisor = generate_host(account_number=args.account, hardware_type='PHYSICAL', measurement_type='VIRTUAL', product=args.product,
-                               sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True)
-    # create a physical entry for the host as well.
-    generate_host(account_number=args.account, hardware_type='PHYSICAL', measurement_type='PHYSICAL', product=args.product,
-                  sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True)
-
-create_unmapped = args.unmapped_guests
-for i in range(args.num_guests):
-    if args.hypervisor_id:
-        hypervisor_uuid = args.hypervisor_id
-    elif hypervisor is not None:
-        hypervisor_uuid = hypervisor['subscription_manager_id']
-        # If we are associating the guests with a created hypervisor host, don't allow it to be unmapped
-        # since it was considered as reported.
-        create_unmapped = False
+for i in range(args.num_accounts):
+    if args.num_accounts > 1:
+        account = f'{args.account}{i}'
     else:
-        hypervisor_uuid = None
+        account = args.account
+    if args.opt_in:
+        _generate_insert('account_config',
+            account_number=account,
+            sync_enabled=True,
+            reporting_enabled=True,
+            opt_in_type='API',
+            created='2021-01-01',
+            updated='2021-01-01'
+        )
 
-    skip_buckets = "RHEL" in product.upper()
-    generate_host(account_number=args.account, hardware_type='VIRTUALIZED', is_guest=True,
-                  product=args.product, sla=args.sla, usage=args.usage, hypervisor_uuid=hypervisor_uuid,
-                  cores=args.cores, sockets=args.sockets, is_unmapped_guest=create_unmapped,
-                  skip_buckets=skip_buckets)
+    product = args.product or "RHEL"
+
+    for i in range(args.num_physical):
+        generate_host(account_number=account, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
+                    product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hbi=args.is_hbi)
+
+    hypervisor = None
+    for i in range(args.num_hypervisors):
+        hypervisor = generate_host(account_number=account, hardware_type='PHYSICAL', measurement_type='VIRTUAL', product=args.product,
+                                sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True)
+        # create a physical entry for the host as well.
+        generate_host(account_number=account, hardware_type='PHYSICAL', measurement_type='PHYSICAL', product=args.product,
+                    sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True, is_hbi=args.is_hbi)
+
+    create_unmapped = args.unmapped_guests
+    for i in range(args.num_guests):
+        if args.hypervisor_id:
+            hypervisor_uuid = args.hypervisor_id
+        elif hypervisor is not None:
+            hypervisor_uuid = hypervisor['subscription_manager_id']
+            # If we are associating the guests with a created hypervisor host, don't allow it to be unmapped
+            # since it was considered as reported.
+            create_unmapped = False
+        else:
+            hypervisor_uuid = None
+
+        skip_buckets = "RHEL" in product.upper()
+        generate_host(account_number=account, hardware_type='VIRTUALIZED', is_guest=True,
+                    product=args.product, sla=args.sla, usage=args.usage, hypervisor_uuid=hypervisor_uuid,
+                    cores=args.cores, sockets=args.sockets, is_unmapped_guest=create_unmapped,
+                    skip_buckets=skip_buckets, is_hbi=args.is_hbi)
+
+output.write('commit;')
 
 if psql:
     psql.stdin.close()

--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -28,12 +28,10 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 import javax.validation.constraints.NotNull;
@@ -99,9 +97,5 @@ public interface HostRepository extends JpaRepository<Host, UUID> {
         Pageable pageable
     );
 
-    @Transactional
-    @Modifying
-    @Query("delete from Host where account_number in (:accounts)")
-    int deleteByAccountNumberIn(@Param("accounts") Collection<String> accounts);
-
+    List<Host> findByAccountNumber(String accountNumber);
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -361,7 +361,9 @@ public class Host implements Serializable {
 
     public void addBucket(HostTallyBucket bucket) {
         bucket.getKey().setHost(this);
-        getBuckets().add(bucket);
+        if (!getBuckets().contains(bucket)) {
+            getBuckets().add(bucket);
+        }
     }
 
     public void removeBucket(HostTallyBucket bucket) {

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -26,12 +26,12 @@ import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 import java.io.Serializable;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.persistence.CascadeType;
@@ -131,7 +131,7 @@ public class Host implements Serializable {
         orphanRemoval = true,
         fetch = FetchType.EAGER
     )
-    private List<HostTallyBucket> buckets = new ArrayList<>();
+    private Set<HostTallyBucket> buckets = new HashSet<>();
 
     @Column(name = "is_unmapped_guest")
     private boolean isUnmappedGuest;
@@ -338,15 +338,11 @@ public class Host implements Serializable {
         this.lastSeen = lastSeen;
     }
 
-    public List<HostTallyBucket> getBuckets() {
-        if (this.buckets == null) {
-            this.buckets = new ArrayList<>();
-        }
-
+    public Set<HostTallyBucket> getBuckets() {
         return buckets;
     }
 
-    public void setBuckets(List<HostTallyBucket> buckets) {
+    public void setBuckets(Set<HostTallyBucket> buckets) {
         this.buckets = buckets;
     }
 
@@ -361,9 +357,7 @@ public class Host implements Serializable {
 
     public void addBucket(HostTallyBucket bucket) {
         bucket.getKey().setHost(this);
-        if (!getBuckets().contains(bucket)) {
-            getBuckets().add(bucket);
-        }
+        getBuckets().add(bucket);
     }
 
     public void removeBucket(HostTallyBucket bucket) {

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -27,6 +27,7 @@ import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.inventory.db.InventoryDatabaseOperations;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollector;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollectorFactory;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
@@ -45,10 +46,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Collects the max values from all accounts in the inventory.
@@ -79,11 +82,9 @@ public class InventoryAccountUsageCollector {
     public Map<String, AccountUsageCalculation> collect(Collection<String> products,
         Collection<String> accounts) {
 
-        // Delete all of the host records for the specified accounts before starting the
-        // calculation. Applicable hosts will be recreated as usage is calculated.
-        log.info("Deleting existing Hosts: {}", accounts);
-        int deleted = hostRepository.deleteByAccountNumberIn(accounts);
-        log.info("Deleted {} existing Host records.", deleted);
+        List<Host> existing = getAccountHosts(accounts);
+        Map<String, Host> inventoryHostMap =
+            existing.stream().collect(Collectors.toMap(Host::getInventoryId, Function.identity()));
 
         Map<String, String> hypMapping = new HashMap<>();
         Map<String, Set<UsageCalculation.Key>> hypervisorUsageKeys = new HashMap<>();
@@ -120,7 +121,8 @@ public class InventoryAccountUsageCollector {
                     accountCalc.setOwner(owner);
                 }
 
-                Host host = new Host(hostFacts, facts);
+                Host host = getOrCreateHost(inventoryHostMap, hostFacts, facts);
+
                 if (facts.isHypervisor()) {
                     Map<String, NormalizedFacts> idToHypervisorMap = accountHypervisorFacts
                         .computeIfAbsent(account, a -> new HashMap<>());
@@ -191,6 +193,9 @@ public class InventoryAccountUsageCollector {
             });
         });
 
+        log.info("Removing {} stale host records (HBI records no longer present).", inventoryHostMap.size());
+        hostRepository.deleteAll(inventoryHostMap.values());
+
         if (hypervisorHosts.size() > 0) {
             log.info("Persisting {} hypervisor hosts.", hypervisorHosts.size());
             hostRepository.saveAll(hypervisorHosts.values());
@@ -202,4 +207,28 @@ public class InventoryAccountUsageCollector {
 
         return calcsByAccount;
     }
+
+    private List<Host> getAccountHosts(Collection<String> accounts) {
+        return accounts.stream()
+            .map(hostRepository::findByAccountNumber)
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+    }
+
+    private Host getOrCreateHost(Map<String, Host> inventoryHostMap, InventoryHostFacts hostFacts,
+        NormalizedFacts facts) {
+
+        Host existingHost = inventoryHostMap.remove(hostFacts.getInventoryId().toString());
+        Host host;
+        if (existingHost == null) {
+            host = new Host(hostFacts, facts);
+        }
+        else {
+            host = existingHost;
+            host.getBuckets().clear(); // ensure we recalculate to remove any stale buckets
+            host.populateFieldsFromHbi(hostFacts, facts);
+        }
+        return host;
+    }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -399,28 +399,6 @@ class HostRepositoryTest {
 
     @Transactional
     @Test
-    void testDeleteByAccount() {
-        Host host1 = createHost("h1", "A1");
-        host1.setDisplayName(DEFAULT_DISPLAY_NAME);
-        Host h1 = repo.saveAndFlush(host1);
-
-        Host host2 = createHost("h2", "A2");
-        host2.setDisplayName(DEFAULT_DISPLAY_NAME);
-        Host h2 = repo.saveAndFlush(host2);
-
-        Host host3 = createHost("h3", "A3");
-        host3.setDisplayName(DEFAULT_DISPLAY_NAME);
-        Host h3 = repo.saveAndFlush(host3);
-
-        assertTrue(repo.findById(h1.getId()).isPresent());
-        assertTrue(repo.findById(h2.getId()).isPresent());
-        assertTrue(repo.findById(h3.getId()).isPresent());
-
-        assertEquals(2, repo.deleteByAccountNumberIn(Arrays.asList("A1", "A2")));
-    }
-
-    @Transactional
-    @Test
     void testGetHostViews() {
         Host host1 = new Host("INV1", "HOST1", "my_acct", "my_org", "sub_id");
         host1.setSockets(1);

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -207,7 +207,12 @@ class HostRepositoryTest {
         toUpdate.setSockets(4);
         toUpdate.setCores(8);
         toUpdate.setDisplayName(DEFAULT_DISPLAY_NAME);
-        toUpdate.removeBucket(host.getBuckets().get(0));
+
+        HostTallyBucket rhelBucket = host.getBuckets().stream()
+            .filter(h -> h.getKey().getProductId().equals("RHEL")).findFirst().orElse(null);
+        HostTallyBucket satelliteBucket = host.getBuckets().stream()
+            .filter(h -> h.getKey().getProductId().equals("Satellite")).findFirst().orElse(null);
+        toUpdate.removeBucket(rhelBucket);
         repo.saveAndFlush(toUpdate);
 
         Optional<Host> updateResult = repo.findById(toUpdate.getId());
@@ -217,7 +222,7 @@ class HostRepositoryTest {
         assertEquals(4, updated.getSockets().intValue());
         assertEquals(8, updated.getCores().intValue());
         assertEquals(1, updated.getBuckets().size());
-        assertTrue(updated.getBuckets().contains(host.getBuckets().get(0)));
+        assertTrue(updated.getBuckets().contains(satelliteBucket));
     }
 
     @Transactional


### PR DESCRIPTION
There were a couple optimizations to be had to make this performant:

 - Made the HostTallyBuckets work properly with the `equals/hashCode` methods
 - Gather all stale host records and remove them at the end

I also had to clear the buckets list to be recalculated each time (though you can see that Hibernate does not issue extraneous DML).

I made a couple of changes to the `insert-mock-hosts` script to make testing easier (see below).

Testing
-------
First, for each, clear out some data in rhsm-subscriptions:

```sql
truncate tally_snapshots cascade;
truncate hosts cascade;
truncate account_config;
```

Then, use the `insert-mock-hosts` script to set up one of the test cases below:

A few large accounts (10 accounts with 100,000 hosts each in HBI):

```
bin/insert-mock-hosts --hbi --clear
bin/insert-mock-hosts --hbi --num-physical 100000 --account acct_ --num-accounts 10 --clear
bin/insert-mock-hosts --opt-in --account acct_ --num-accounts 10
```

Lots of small accounts (10,000 accounts with 10 hosts each in HBI):

```
bin/insert-mock-hosts --hbi --clear
bin/insert-mock-hosts --hbi --num-physical 10 --account acct_ --num-accounts 10000 --clear
bin/insert-mock-hosts --opt-in --account acct_ --num-accounts 10000
```

To run the test, start the service via `./gradlew bootRun`. Then, once started up, make note of the time, use `TallyJmxBean.tallyConfiguredAccounts()` via http://localhost:8080/actuator/hawtio.

Make note of the final timestamp.

It's worth repeating the test, as subseqent tallies have no DML to do.

If desired you can simulate the last_seen being updated by running sql against the insights DB:

```sql
update hosts set modified_on='2102-01-01';
```

In my testing, I saw the timings get about twice as fast for the large accounts, and about twice as fast for the second; even better is the subsequent runs (with no new buckets) were about 3 times faster (or more).

You can also see the SQL if curious by setting the following properties in `config/application.properties` (please disable for timings):

```
logging.level.org.hibernate.SQL=DEBUG
logging.level.org.hibernate.type=TRACE
spring.jpa.properties.hibernate.format_sql=true
```