### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
Part of ENT-3387.  I'm submitting this PR for group discussion around using Dependabot.

Dependabot automatically submits PR requests to update libraries.  Personally, I would prefer a less automated system that provides a dashboard of dependencies with a list of which ones are out of date and which ones have open CVEs.  I do see some utility in using Dependabot even if it's a little different from my ideal.

See the [documentation](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates) for all the available configuration options.

Sidenote: Github [does not currently support Gradle](https://github.com/isaacs/github/issues/1620) in its Dependency Graph section (underneath the Insights tab).