### PR TITLE
ENT-3424: Up max http header size to 48000

### DIFF
--- a/templates/rhsm-subscriptions-api.yml
+++ b/templates/rhsm-subscriptions-api.yml
@@ -9,6 +9,8 @@ metadata:
   name: rhsm-subscriptions-api
 
 parameters:
+  - name: SERVER_MAX_HTTP_HEADER_SIZE
+    value: '48000'
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL
@@ -134,6 +136,8 @@ objects:
             - image: ${IMAGE}:${IMAGE_TAG}
               name: rhsm-subscriptions-api
               env:
+                - name: SERVER_MAX_HTTP_HEADER_SIZE
+                  value: ${SERVER_MAX_HTTP_HEADER_SIZE}
                 - name: LOG_FILE
                   value: /logs/server.log
                 - name: SPRING_PROFILES_ACTIVE

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -11,6 +11,8 @@ metadata:
 parameters:
   - name: HAWTIO_BASE_PATH
     value: /app/rhsm-subscriptions/actuator/hawtio
+  - name: SERVER_MAX_HTTP_HEADER_SIZE
+    value: '48000'
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL
@@ -124,6 +126,8 @@ objects:
                 # turn off built-in jolokia, so that the spring boot jolokia actuator will work
                 - name: AB_JOLOKIA_OFF
                   value: 'true'
+                - name: SERVER_MAX_HTTP_HEADER_SIZE
+                  value: ${SERVER_MAX_HTTP_HEADER_SIZE}
                 - name: HAWTIO_BASE_PATH
                   value: ${HAWTIO_BASE_PATH}
                 - name: LOG_FILE


### PR DESCRIPTION
Also add a template param for this, so we can adjust without a code update.