### PR TITLE
RHCLOUD-12116: add owner_id to rhsm-conduit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -361,7 +361,7 @@ project(":insights-inventory-client") {
     }
 
     task downloadSystemProfileSpec(type: Download) {
-        src 'https://raw.githubusercontent.com/RedHatInsights/insights-host-inventory/075f8e4433ecfb2e227e02108096847242e14e19/swagger/system_profile.spec.yaml'
+        src 'https://raw.githubusercontent.com/RedHatInsights/insights-host-inventory/d479778d9ae72fea9a493429ea44142364648ec5/swagger/system_profile.spec.yaml'
         dest buildDir
         overwrite false
     }

--- a/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -137,6 +137,7 @@ public abstract class InventoryService {
         }
         systemProfile.setSystemMemoryBytes(facts.getSystemMemoryBytes());
         systemProfile.setNumberOfSockets(facts.getCpuSockets());
+        systemProfile.setOwnerId(facts.getSubscriptionManagerId());
         return systemProfile;
     }
 

--- a/src/test/java/org/candlepin/subscriptions/conduit/inventory/DefaultInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/conduit/inventory/DefaultInventoryServiceTest.java
@@ -114,7 +114,8 @@ class DefaultInventoryServiceTest {
             .coresPerSocket(2)
             .infrastructureType("virtual")
             .systemMemoryBytes(1024L)
-            .numberOfSockets(4);
+            .numberOfSockets(4)
+            .ownerId("108152b1-6b41-4e1b-b908-922c943e7950");
 
         CreateHostIn expectedHostEntry = new CreateHostIn()
             .account("1234-account")


### PR DESCRIPTION
I had to bump the systemprofile schema used. Note I didn't bump to latest as there is a problematic definition - NestedObject - which openapi-generator throws exceptions about.