### PR TITLE
ENT-3518: various rhsm-conduit fixes

### DIFF
--- a/src/main/resources/application-orgsync.yaml
+++ b/src/main/resources/application-orgsync.yaml
@@ -1,0 +1,8 @@
+rhsm-conduit:
+  org-sync:
+    # The cron schedule is only used in development mode.  In a production deployment, a version of the
+    # application with the "orgsync" profile is deployed and run as a one-shot job.  The scheduling
+    # is handled by OpenShift's cron capabilities.
+    schedule: ${ORG_SYNC_SCHEDULE:0 */2 * * * ?}
+  tasks:
+    topic: ${CONDUIT_KAFKA_TOPIC:platform.rhsm-conduit.tasks}

--- a/src/main/resources/application-rhsm-conduit.yaml
+++ b/src/main/resources/application-rhsm-conduit.yaml
@@ -1,9 +1,4 @@
 rhsm-conduit:
-  org-sync:
-    # The cron schedule is only used in development mode.  In a production deployment, a version of the
-    # application with the "orgsync" profile is deployed and run as a one-shot job.  The scheduling
-    # is handled by OpenShift's cron capabilities.
-    schedule: ${ORG_SYNC_SCHEDULE:0 */2 * * * ?}
   rhsm:
     use-stub: ${RHSM_USE_STUB:false}
     url: ${RHSM_URL:http://localhost:9090}
@@ -11,6 +6,8 @@ rhsm-conduit:
     keystore-password: ${RHSM_KEYSTORE_PASSWORD:changeit}
     request-batch-size: ${RHSM_BATCH_SIZE:1000}
     max-connections: ${RHSM_MAX_CONNECTIONS:100}
+    truststore-file: ${RHSM_TRUSTSTORE:}
+    truststore-password: ${RHSM_TRUSTSTORE_PASSWORD:changeit}
   inventory-service:
     use-stub: ${INVENTORY_USE_STUB:true}
     api-key: ${INVENTORY_API_KEY:changeit}

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -180,6 +180,13 @@ objects:
                     key: keystore_password
               - name: RHSM_KEYSTORE
                 value: /pinhead/keystore.jks
+              - name: RHSM_TRUSTSTORE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: tls
+                    key: keystore_password
+              - name: RHSM_TRUSTSTORE
+                value: /pinhead/truststore.jks
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -293,7 +300,7 @@ objects:
                 name: rhsm-conduit-cron-sync
                 env:
                 - name: SPRING_PROFILES_ACTIVE
-                  value: orgsync
+                  value: orgsync,kafka-queue
                 - name: JAVA_MAX_MEM_RATIO
                   value: '85'
                 - name: GC_MAX_METASPACE_SIZE


### PR DESCRIPTION
- Specify the topic in orgsync profile properties
- Move the schedule to orgsync profile properties
- Add truststore config to rhsm-conduit profile properties
- Add truststore config to OpenShift template
- Add kafka-queue profile to the cronjob

These are little details that were missed in #199.

To verify, see rhsm-ci environment (I deployed this branch there), specifically see logs from the rhsm-conduit pod and cron-sync pod.

If needed, you can redeploy via https://rhsm-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/swatch-deploy-ci/

Also if needed you can use `oc edit CronJob/rhsm-conduit-cron-sync` to schedule the job for earlier :-)