### PR TITLE
Update to spring boot 2.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,19 +29,14 @@ plugins {
 ext {
     swagger_annotations_version = "1.5.21"
     swagger_ui_version = "3.20.8"
-    prometheus_version = "1.1.2"
     resteasy_version = "3.6.2.Final"
-    spring_boot_version = "2.2.9.RELEASE"
+    spring_boot_version = "2.4.2"
     spring_data_releasetrain = "Moore-RELEASE"
     postgres_jdbc_driver_version = "42.2.5"
-    junit_version = "5.3.2"
-    mockito_version = "2.23.4"
-    hamcrest_version = "2.2"
     jboss_jaxrs_api_version = "1.0.2.Final"
     resteasy_spring_boot_starter_version = "3.0.0.Final"
     logstash_logback_encoder_version = "5.3"
     aws_sdk_version = "1.11.32"
-    snakeyaml_version = "1.25"
     kafka_avro_serializer_version = "5.2.1"
     avro_version = "1.8.2"
 }
@@ -61,29 +56,17 @@ allprojects {
         dependencies{
             dependency "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:$jboss_jaxrs_api_version"
             dependency "io.swagger:swagger-annotations:$swagger_annotations_version"
-            dependency "io.micrometer:micrometer-registry-prometheus:$prometheus_version"
             dependency "org.webjars:swagger-ui:$swagger_ui_version"
             dependency "net.logstash.logback:logstash-logback-encoder:$logstash_logback_encoder_version"
-            dependency "org.hamcrest:hamcrest:$hamcrest_version"
             dependency "org.postgresql:postgresql:$postgres_jdbc_driver_version"
             dependency "org.jboss.resteasy:resteasy-spring-boot-starter:$resteasy_spring_boot_starter_version"
             dependency "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender:1.11"
             dependency "com.amazonaws:aws-java-sdk-logs:$aws_sdk_version"
             dependency "com.amazonaws:aws-java-sdk-ec2:$aws_sdk_version"
-            dependency "org.yaml:snakeyaml:$snakeyaml_version"
             dependencySet(group: "org.jboss.resteasy", version: "$resteasy_version") {
                 entry "resteasy-client"
                 entry "resteasy-multipart-provider"
                 entry "resteasy-validator-provider-11"
-            }
-            dependencySet(group: "org.junit.jupiter", version: "$junit_version") {
-                entry "junit-jupiter-api"
-                entry "junit-jupiter-engine"
-                entry "junit-jupiter-params"
-            }
-            dependencySet(group: "org.mockito", version: "$mockito_version") {
-                entry "mockito-core"
-                entry "mockito-junit-jupiter"
             }
             dependency "io.confluent:kafka-avro-serializer:$kafka_avro_serializer_version"
             dependency "org.apache.avro:avro:$avro_version"
@@ -227,6 +210,7 @@ dependencies {
     compile "org.yaml:snakeyaml"
     compile "org.postgresql:postgresql"
     compile "io.hawt:hawtio-springboot"
+    compile "org.hibernate.validator:hibernate-validator"
 
     testCompile "org.springframework.security:spring-security-test"
     testCompile "org.springframework.kafka:spring-kafka-test"

--- a/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
+++ b/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
@@ -36,7 +36,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
@@ -71,16 +71,16 @@ public class KafkaConfigurator {
 
         consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         // Prevent the client from continuously replaying a message that fails to deserialize.
-        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
 
         // Configure the error handling delegate deserializer classes based on whether the
         // schema registry is being bypassed.
         if (bypassRegistry) {
-            consumerConfig.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS, AvroDeserializer.class);
+            consumerConfig.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, AvroDeserializer.class);
             consumerConfig.put(AvroDeserializer.TARGET_TYPE_CLASS, TaskMessage.class);
         }
         else {
-            consumerConfig.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS,
+            consumerConfig.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS,
                 KafkaAvroDeserializer.class);
             consumerConfig.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true);
         }

--- a/src/test/java/org/candlepin/subscriptions/capacity/PoolIngressControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/PoolIngressControllerTest.java
@@ -45,7 +45,7 @@ import java.util.Collections;
 import java.util.List;
 
 @SpringBootTest
-@ActiveProfiles("capacity-ingress,test")
+@ActiveProfiles({"capacity-ingress", "test"})
 class PoolIngressControllerTest {
 
     @Autowired

--- a/src/test/java/org/candlepin/subscriptions/cloudigrade/CloudigradeServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/cloudigrade/CloudigradeServiceTest.java
@@ -40,7 +40,7 @@ import java.time.LocalDate;
 import java.util.Base64;
 
 @SpringBootTest
-@ActiveProfiles("worker,test")
+@ActiveProfiles({"worker", "test"})
 class CloudigradeServiceTest {
     @MockBean
     ConcurrentApi concurrentApi;

--- a/src/test/java/org/candlepin/subscriptions/conduit/HbiObjectMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/conduit/HbiObjectMapperTest.java
@@ -41,7 +41,7 @@ import java.util.TimeZone;
 
 @SpringBootTest
 @TestInstance(Lifecycle.PER_CLASS)
-@ActiveProfiles("rhsm-conduit,test")
+@ActiveProfiles({"rhsm-conduit", "test"})
 class HbiObjectMapperTest {
 
     @Autowired

--- a/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -58,7 +58,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @SpringBootTest
-@ActiveProfiles("rhsm-conduit,test")
+@ActiveProfiles({"rhsm-conduit", "test"})
 class InventoryControllerTest {
     @MockBean
     InventoryService inventoryService;

--- a/src/test/java/org/candlepin/subscriptions/conduit/inventory/client/ApiClientTest.java
+++ b/src/test/java/org/candlepin/subscriptions/conduit/inventory/client/ApiClientTest.java
@@ -32,7 +32,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("rhsm-conduit,test,test-api-client")
+@ActiveProfiles({"rhsm-conduit", "test", "test-api-client"})
 class ApiClientTest {
     @Autowired
     private HostsApi hostsApi;

--- a/src/test/java/org/candlepin/subscriptions/conduit/rhsm/RhsmServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/conduit/rhsm/RhsmServiceTest.java
@@ -43,7 +43,7 @@ import java.util.Collections;
 import javax.validation.ConstraintViolationException;
 
 @SpringBootTest
-@ActiveProfiles("rhsm-conduit,test")
+@ActiveProfiles({"rhsm-conduit", "test"})
 class RhsmServiceTest {
     @Autowired
     @Qualifier("rhsmRetryTemplate")

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -58,7 +58,7 @@ import javax.ws.rs.core.Response;
 
 @SpringBootTest
 @WithMockRedHatPrincipal("123456")
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 class CapacityResourceTest {
 
     private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -48,7 +48,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.Collections;
 
 @SpringBootTest
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @WithMockRedHatPrincipal("123456")
 class HostsResourceTest {
 

--- a/src/test/java/org/candlepin/subscriptions/resource/OpenApiSpecControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/OpenApiSpecControllerTest.java
@@ -28,7 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 class OpenApiSpecControllerTest {
     @Autowired
     OpenApiSpecController controller;

--- a/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
@@ -46,7 +46,7 @@ import javax.ws.rs.BadRequestException;
 
 
 @SpringBootTest
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @WithMockRedHatPrincipal("123456")
 public class OptInResourceTest {
 

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -64,7 +64,7 @@ import javax.ws.rs.core.Response;
 
 @SuppressWarnings("linelength")
 @SpringBootTest
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @WithMockRedHatPrincipal("123456")
 public class TallyResourceTest {
 

--- a/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
@@ -34,7 +34,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 public class VersionResourceTest {
     @MockBean BuildProperties buildProperties;
 

--- a/src/test/java/org/candlepin/subscriptions/resteasy/ObjectMapperContextResolverTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/ObjectMapperContextResolverTest.java
@@ -41,7 +41,7 @@ import java.util.TimeZone;
 
 
 @SpringBootTest
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
 class ObjectMapperContextResolverTest {
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionServiceTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.Collections;
 
 @SpringBootTest
-@ActiveProfiles("worker,test")
+@ActiveProfiles({"worker", "test"})
 class SubscriptionServiceTest {
     private static final String CRITERIA =
         "criteria;web_customer_id=123;statusList=active;statusList=temporary";

--- a/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
@@ -47,7 +47,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @SpringBootTest
-@ActiveProfiles("worker,test")
+@ActiveProfiles({"worker", "test"})
 class CloudigradeAccountUsageCollectorTest {
     public static final String ACCOUNT = "foo123";
 

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -61,7 +61,7 @@ import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 
 @SpringBootTest
-@ActiveProfiles("worker,test")
+@ActiveProfiles({"worker", "test"})
 @Import(MockProductAndRoleConfiguration.class)
 public class InventoryAccountUsageCollectorTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 import java.util.Collections;
 
 @SpringBootTest
-@ActiveProfiles("worker,test")
+@ActiveProfiles({"worker", "test"})
 class TallySnapshotControllerTest {
 
     public static final String ACCOUNT = "foo123";

--- a/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
@@ -42,7 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @SpringBootTest
-@ActiveProfiles("worker,test")
+@ActiveProfiles({"worker", "test"})
 class CaptureSnapshotsTaskManagerTest {
 
     @MockBean

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 @SpringBootTest
 // The transactional annotation will rollback the transaction at the end of every test.
 @Transactional
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
 public class DailySnapshotRollerTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
@@ -46,7 +46,7 @@ import java.time.Duration;
 @SpringBootTest
 // The transactional annotation will rollback the transaction at the end of every test.
 @Transactional
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
 class HourlySnapshotRollerTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 @SpringBootTest
 // The transactional annotation will rollback the transaction at the end of every test.
 @Transactional
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
 public class MonthlySnapshotRollerTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 @SpringBootTest
 // The transactional annotation will rollback the transaction at the end of every test.
 @Transactional
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
 public class QuarterlySnapshotRollerTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 @SpringBootTest
 // The transactional annotation will rollback the transaction at the end of every test.
 @Transactional
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
 public class WeeklySnapshotRollerTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 @SpringBootTest
 // The transactional annotation will rollback the transaction at the end of every test.
 @Transactional
-@ActiveProfiles("api,test")
+@ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
 public class YearlySnapshotRollerTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/tasks/TallyTaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/tasks/TallyTaskFactoryTest.java
@@ -37,7 +37,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 
 @SpringBootTest
-@ActiveProfiles("worker,test")
+@ActiveProfiles({"worker", "test"})
 class TallyTaskFactoryTest {
 
     @Autowired

--- a/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
@@ -33,7 +33,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 
 @SpringBootTest
-@ActiveProfiles("worker,test")
+@ActiveProfiles({"worker", "test"})
 public class TaskWorkerTest {
 
     @MockBean

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -54,7 +54,7 @@ import java.util.Map;
 
 @SpringBootTest
 @DirtiesContext
-@ActiveProfiles("worker,test,test-kafka,test-kafka-schema")
+@ActiveProfiles({"worker", "test", "test-kafka", "test-kafka-schema"})
 @EmbeddedKafka(partitions = 1, topics = {"${rhsm-subscriptions.tasks.topic}"})
 public class KafkaTaskQueueSchemaRegistryTest extends KafkaTaskQueueTester {
 
@@ -94,15 +94,15 @@ public class KafkaTaskQueueSchemaRegistryTest extends KafkaTaskQueueTester {
             // properly configured. Once verified, we can manually instantiate the deserializer
             // with the mock schema registry.
             Map<String, Object> factoryConfig = factory.getConfigurationProperties();
-            assertEquals(ErrorHandlingDeserializer2.class,
+            assertEquals(ErrorHandlingDeserializer.class,
                 factoryConfig.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
             assertEquals(KafkaAvroDeserializer.class,
-                factoryConfig.get(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS));
+                factoryConfig.get(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS));
             assertThat(factoryConfig,
                 Matchers.hasKey(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG));
 
             KafkaAvroDeserializer delegate = new KafkaAvroDeserializer(registryClient, factoryConfig);
-            ErrorHandlingDeserializer2 errorDeserializer = new ErrorHandlingDeserializer2(delegate);
+            ErrorHandlingDeserializer errorDeserializer = new ErrorHandlingDeserializer(delegate);
             return new DefaultKafkaConsumerFactory<>(factoryConfig, new StringDeserializer(),
                 errorDeserializer);
         }

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @DirtiesContext
-@ActiveProfiles("worker,test,kafka-test")
+@ActiveProfiles({"worker", "test", "kafka-test"})
 @EmbeddedKafka(partitions = 1, topics = {"${rhsm-subscriptions.tasks.topic}"})
 class KafkaTaskQueueTest extends KafkaTaskQueueTester {
 


### PR DESCRIPTION
I had to replace org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2 with org.springframework.kafka.support.serializer.ErrorHandlingDeserializer (apparently these have the same semantics as Javadocs suggest for a while ErrorHandlingDeserializer2 just subclassed the other).

I removed some unneeded dependency version overrides, namely:
  - hamcrest
  - junit
  - micrometer-registry-prometheus
  - mockito
  - snakeyaml

In doing so the spring dep bom updated them for us :-)

I had to separate profiles used in `@ActiveProfiles` annotations (e.g. `{"api", "test"}` instead of `"api,test"`. Apparently older spring boot tolerated either.

Closes #266