### PR TITLE
Ent 1573

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/conduit/ConduitConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/conduit/ConduitConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
+import org.springframework.retry.annotation.EnableRetry;
 
 /**
  * Configuration for the "rhsm-conduit" profile.
@@ -43,6 +44,7 @@ import org.springframework.context.annotation.Profile;
  * production and consumption of tasks from the rhsm-conduit task queue.
  */
 @Configuration
+@EnableRetry
 @Profile("rhsm-conduit")
 @EnableConfigurationProperties(OrgSyncProperties.class)
 @Import({

--- a/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceRetryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceRetryTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019 - 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.conduit.inventory.kafka;
+
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doThrow;
+
+import org.candlepin.subscriptions.conduit.inventory.ConduitFacts;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.KafkaException;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+@SpringBootTest
+@ContextConfiguration(
+    classes = KafkaEnabledInventoryServiceRetryTest.SpringConfiguration.class,
+    loader = AnnotationConfigContextLoader.class)
+class KafkaEnabledInventoryServiceRetryTest {
+
+    @Autowired
+    List<ConduitFacts> expectedFacts;
+
+    @Autowired
+    KafkaEnabledInventoryService kafkaEnabledInventoryService;
+
+    @Test
+    void retrySendHostUpdate() throws RuntimeException {
+        kafkaEnabledInventoryService.sendHostUpdate(expectedFacts);
+
+        verify(kafkaEnabledInventoryService, times(3)).sendHostUpdate(expectedFacts);
+    }
+
+    @EnableRetry
+    static class SpringConfiguration {
+        @Bean
+        List<ConduitFacts> getConduitFacts() {
+            ConduitFacts conduitFacts = new ConduitFacts();
+            conduitFacts.setAccountNumber("my_account");
+
+            return Arrays.asList(conduitFacts);
+        }
+
+        @Bean
+        KafkaEnabledInventoryService sendHostUpdate(List<ConduitFacts> conduitFacts)
+            throws RuntimeException {
+
+            KafkaEnabledInventoryService kafkaEnabledInventoryService =
+                mock(KafkaEnabledInventoryService.class);
+
+            doThrow(new KafkaException("Failed first execution"))
+                .doThrow(new KafkaException("Failed second execution"))
+                .doNothing()
+                .when(kafkaEnabledInventoryService).sendHostUpdate(conduitFacts);
+
+            return kafkaEnabledInventoryService;
+        }
+    }
+}


### PR DESCRIPTION
This change adds Spring Restart to the Kafka enabled inventory service, for the method which sends host updates.  If there are intermittent Kafka interruptions, this method now retries at most four times to retry, waiting between 100 and 400 milliseconds.  

Testing procedure #1:

    1.  Start Kafka: podman-compose up -d
    2.  Start the RHSM-Subscriptions API
    3.  Stop Kafka: podman-compose down
    4.  Submit an event to the API to run Kafka
    5.  The API should show three failures and retries in succession, followed by a final failure.  

Testing procedure #2:

    1.  Start Kafka: podman-compose up -d
    2.  Start the RHSM-Subscriptions API
    3.  Submit an event to the API to run Kafka
    4.  Stop Kafka: podman-compose down
    5.  Watch the console for one or two failures
    6.  Before the third failure, start Kafka: podman-compose up -d
    7.  Watch the console for a success after the two failures.  
