### PR TITLE
Perform OpenShift metrics gathering via two PromQL queries

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/OpenshiftMetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/OpenshiftMetricProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Red Hat, Inc.
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,21 +20,18 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 /**
- * Properties related to all metrics that are to be gathered from the prometheus service.
+ * An extension of the MetricProperties class specific to OpenShift metrics gathering.
  */
-@ConfigurationProperties(prefix = "rhsm-subscriptions.metering.prometheus.metric")
-public class PrometheusMetricsPropeties {
+public class OpenshiftMetricProperties extends MetricProperties {
 
-    private OpenshiftMetricProperties openshift = new OpenshiftMetricProperties();
+    private String subscriptionLabelPromQL;
 
-    public OpenshiftMetricProperties getOpenshift() {
-        return openshift;
+    public String getSubscriptionLabelPromQL() {
+        return subscriptionLabelPromQL;
     }
 
-    public void setOpenshift(OpenshiftMetricProperties openshift) {
-        this.openshift = openshift;
+    public void setSubscriptionLabelPromQL(String subscriptionLabelPromQL) {
+        this.subscriptionLabelPromQL = subscriptionLabelPromQL;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -35,14 +35,17 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import io.micrometer.core.annotation.Timed;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 
 /**
@@ -79,62 +82,21 @@ public class PrometheusMeteringController {
         MetricProperties openshiftProperties = metricProperties.getOpenshift();
         openshiftRetry.execute(context -> {
             try {
-                log.info("Collecting OpenShift metrics");
+                // Reset the start/end dates to ensure they span a complete hour.
+                // NOTE: If the prometheus query step changes, we will need to adjust this.
+                OffsetDateTime queryStart = clock.startOfHour(start);
+                OffsetDateTime queryEnd = clock.endOfHour(end);
 
-                QueryResult metricData = prometheusService.runRangeQuery(
-                    // Substitute the account number into the query. The query is expected to
-                    // contain %s for replacement.
-                    String.format(openshiftProperties.getMetricPromQL(), account),
-                    // Reset the start/end dates to ensure they span a complete hour.
-                    // NOTE: If the prometheus query step changes, we will need to adjust this.
-                    clock.startOfHour(start),
-                    clock.endOfHour(end),
-                    openshiftProperties.getStep(),
-                    openshiftProperties.getQueryTimeout()
-                );
-
-                if (StatusType.ERROR.equals(metricData.getStatus())) {
-                    throw new MeteringException(
-                        String.format("Unable to fetch OpenShift metrics: %s", metricData.getError())
-                    );
+                log.info("Collecting labels for OpenShift metrics...");
+                Map<LabelSetKey, Map<String, String>> labels = getSubscriptionLabels(account, queryStart,
+                    queryEnd);
+                if (labels.isEmpty()) {
+                    log.info("No subscription labels found. No events will be generated.");
                 }
 
-                // Given the possibility of a very large number of events, we will batch persist them
-                // to provide the ability to tweak them.
-                List<Event> events = new LinkedList<>();
-                int eventCount = 0;
-                for (QueryResultDataResult r : metricData.getData().getResult()) {
-                    Map<String, String> labels = r.getMetric();
-                    String clusterId = labels.get("_id");
-                    String sla = labels.get("support");
-                    String usage = labels.get("usage");
-
-                    // For the openshift metrics, we expect our results to be a 'matrix'
-                    // vector [(instant_time,value), ...] so we only look at the result's getValues()
-                    // data.
-                    for (List<BigDecimal> measurement : r.getValues()) {
-                        BigDecimal time = measurement.get(0);
-                        BigDecimal value = measurement.get(1);
-
-                        Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId,
-                            sla, usage, clock.dateFromUnix(time), value.doubleValue());
-                        events.add(event);
-                        eventCount++;
-
-                        if (events.size() >= openshiftProperties.getEventBatchSize()) {
-                            log.info("Saving {} events", events.size());
-                            eventController.saveAll(events);
-                            events.clear();
-                        }
-                    }
-                }
-
-                // Flush the remainder
-                if (!events.isEmpty()) {
-                    log.debug("Saving remaining events: {}", events.size());
-                    eventController.saveAll(events);
-                }
-                log.info("Created {} Events for OpenShift metrics.", eventCount);
+                log.info("Collecting OpenShift metrics and generating events");
+                int eventCount = generateEventsFromMetrics(labels, account, queryStart, queryEnd);
+                log.info("Created {} OpenShift metric events for account {}.", eventCount, account);
                 return null;
             }
             catch (Exception e) {
@@ -145,4 +107,148 @@ public class PrometheusMeteringController {
         });
     }
 
+    private Map<LabelSetKey, Map<String, String>> getSubscriptionLabels(String account,
+        OffsetDateTime start, OffsetDateTime end) {
+        OpenshiftMetricProperties openshiftProperties = metricProperties.getOpenshift();
+        Map<LabelSetKey, Map<String, String>> labelData = new HashMap<>();
+
+        QueryResult labelMetrics = prometheusService.runRangeQuery(
+            String.format(openshiftProperties.getSubscriptionLabelPromQL(), account),
+            start,
+            end,
+            openshiftProperties.getStep(),
+            openshiftProperties.getQueryTimeout()
+        );
+
+        if (StatusType.ERROR.equals(labelMetrics.getStatus())) {
+            throw new MeteringException(
+                String.format("Unable to fetch openshift metrics: %s", labelMetrics.getError())
+            );
+        }
+
+        labelMetrics.getData().getResult().forEach(r -> {
+            // Just need the label values from here.
+            Map<String, String> labels = r.getMetric();
+            String clusterId = labels.getOrDefault("_id", "");
+
+            r.getValues().forEach(measurement -> {
+                BigDecimal time = measurement.get(0);
+                labelData.put(new LabelSetKey(clusterId, time), labels);
+            });
+        });
+
+        return labelData;
+    }
+
+    private int generateEventsFromMetrics(Map<LabelSetKey, Map<String, String>> labelSets,
+        String account, OffsetDateTime start, OffsetDateTime end) {
+        OpenshiftMetricProperties openshiftProperties = metricProperties.getOpenshift();
+        log.info("Collecting metrics!");
+        QueryResult metricData = prometheusService.runRangeQuery(
+            // Substitute the account number into the query. The query is expected to
+            // contain %s for replacement.
+            String.format(openshiftProperties.getMetricPromQL(), account),
+            start,
+            end,
+            openshiftProperties.getStep(),
+            openshiftProperties.getQueryTimeout()
+        );
+
+        if (StatusType.ERROR.equals(metricData.getStatus())) {
+            throw new MeteringException(
+                String.format("Unable to fetch openshift metrics: %s", metricData.getError())
+            );
+        }
+
+        List<Event> events = new LinkedList<>();
+        int totalEvents = 0;
+        for (QueryResultDataResult r : metricData.getData().getResult()) {
+            Map<String, String> metricLabels = r.getMetric();
+            String clusterId = metricLabels.getOrDefault("_id", "");
+            if (!StringUtils.hasText(clusterId)) {
+                // Can't map this metric without a cluster ID. Not likely to happen but we
+                // will log just in case.
+                log.warn("Skipping metric due to missing cluster ID.");
+                continue;
+            }
+
+            for (List<BigDecimal> measurement : r.getValues()) {
+                BigDecimal time = measurement.get(0);
+                BigDecimal value = measurement.get(1);
+                if (time == null || value == null) {
+                    // Not likely to happen, but will log just in case.
+                    log.warn("Skipping metric since time/value pair was invalid: {}/{}", time, value);
+                    continue;
+                }
+
+                Map<String, String> clusterLabels = labelSets.get(new LabelSetKey(clusterId, time));
+                if (clusterLabels == null) {
+                    // This could potentially happen if the metric existed but the
+                    // Labels weren't reported yet.
+                    log.warn("Found OpenShift metric but could not associate cluster {} " +
+                        "with any labels. Time: {} Value: {}", clusterId, time, value);
+                    continue;
+                }
+
+                Event event = MeteringEventFactory.openShiftClusterCores(
+                    clusterLabels.get("ebs_account"),
+                    clusterLabels.get("_id"),
+                    clusterLabels.get("support"),
+                    clusterLabels.get("usage"),
+                    clock.dateFromUnix(time),
+                    value.doubleValue()
+                );
+                events.add(event);
+                totalEvents++;
+
+                if (events.size() >= openshiftProperties.getEventBatchSize()) {
+                    log.info("Saving {} events", events.size());
+                    eventController.saveAll(events);
+                    events.clear();
+                }
+            }
+        }
+
+        // Flush the remainder
+        if (!events.isEmpty()) {
+            log.info("Saving events: {}", events.size());
+            eventController.saveAll(events);
+        }
+        return totalEvents;
+    }
+
+    private class LabelSetKey {
+        private String clusterId;
+        private BigDecimal date;
+
+        public LabelSetKey(String clusterId, BigDecimal date) {
+            this.clusterId = clusterId;
+            this.date = date;
+        }
+
+        public String getClusterId() {
+            return clusterId;
+        }
+
+        public BigDecimal getDate() {
+            return date;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            LabelSetKey that = (LabelSetKey) o;
+            return Objects.equals(clusterId, that.clusterId) && Objects.equals(date, that.date);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(clusterId, date);
+        }
+    }
 }

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -7,10 +7,8 @@ rhsm-subscriptions:
     prometheus:
       metric:
         openshift:
-          metricPromQL: >-
-            max(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) without(environment, region)*on(_id)
-            group_right(prometheus) group(subscription_labels{ebs_account='%s', support=~'Premium|Standard|Self-Support|None'})
-            by (_id,ebs_account, support, usage)
+          metricPromQL: group(subscription_labels{ebs_account='%s',support=~'Premium|Standard|Self-Support|None'})by(_id,ebs_account)*on(_id) group_right(ebs_account) cluster:usage:workload:capacity_physical_cpu_cores:min:5m
+          subscriptionLabelPromQL: group(cluster:usage:workload:capacity_physical_cpu_cores:min:5m) by (_id)*on(_id) group_right (ebs_acount) subscription_labels{ebs_account='%s',support=~'Premium|Standard|Self-Support|None'}
       client:
         token: ${PROM_AUTH_TOKEN:}
         url: ${PROM_URL:https://localhost/api/v1}

--- a/src/test/java/org/candlepin/subscriptions/metering/OpenShiftMetricsHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/OpenShiftMetricsHelper.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering;
+
+import org.candlepin.subscriptions.prometheus.model.QueryResult;
+import org.candlepin.subscriptions.prometheus.model.QueryResultData;
+import org.candlepin.subscriptions.prometheus.model.QueryResultDataResult;
+import org.candlepin.subscriptions.prometheus.model.ResultType;
+import org.candlepin.subscriptions.prometheus.model.StatusType;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * A utility class to help with creating prometheus API response data.
+ */
+public class OpenShiftMetricsHelper {
+
+    private OpenShiftMetricsHelper() {
+
+    }
+
+    public static QueryResult buildSubscriptionLabelsQueryResult(String account, String clusterId,
+        String serviceLevel, String usage, List<List<BigDecimal>> timeValueTuples) {
+        QueryResultDataResult dataResult = buildLabelDataResult(account, clusterId, serviceLevel,
+            usage, timeValueTuples);
+
+        return new QueryResult()
+            .status(StatusType.SUCCESS)
+            .data(
+               new QueryResultData()
+                   .resultType(ResultType.MATRIX)
+                   .addResultItem(dataResult)
+            );
+    }
+
+    public static QueryResult buildCoresMetricQueryResult(String account, String clusterId,
+        List<List<BigDecimal>> timeValueTuples) {
+        QueryResultDataResult dataResult = new QueryResultDataResult()
+            .putMetricItem("_id", clusterId)
+            .putMetricItem("ebs_account", account);
+
+        // NOTE: A tuple is [unix_time,value]
+        timeValueTuples.forEach(tuple -> dataResult.addValuesItem(tuple));
+
+        return new QueryResult()
+        .status(StatusType.SUCCESS)
+        .data(
+           new QueryResultData()
+               .resultType(ResultType.MATRIX)
+               .addResultItem(dataResult)
+        );
+    }
+
+    public static QueryResultDataResult buildLabelDataResult(String account, String clusterId,
+        String serviceLevel, String usage, List<List<BigDecimal>> timeValueTuples) {
+        QueryResultDataResult dataResult = new QueryResultDataResult()
+            .putMetricItem("_id", clusterId)
+            .putMetricItem("ebs_account", account)
+            .putMetricItem("support", serviceLevel)
+            .putMetricItem("usage", usage);
+
+        // NOTE: A tuple is [unix_time,value]
+        timeValueTuples.forEach(tuple -> dataResult.addValuesItem(tuple));
+        return dataResult;
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -20,6 +20,9 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus;
 
+import static org.candlepin.subscriptions.metering.OpenShiftMetricsHelper.buildCoresMetricQueryResult;
+import static org.candlepin.subscriptions.metering.OpenShiftMetricsHelper.buildLabelDataResult;
+import static org.candlepin.subscriptions.metering.OpenShiftMetricsHelper.buildSubscriptionLabelsQueryResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,9 +36,6 @@ import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.metering.MeteringEventFactory;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
-import org.candlepin.subscriptions.prometheus.model.QueryResultData;
-import org.candlepin.subscriptions.prometheus.model.QueryResultDataResult;
-import org.candlepin.subscriptions.prometheus.model.ResultType;
 import org.candlepin.subscriptions.prometheus.model.StatusType;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
@@ -77,29 +77,43 @@ class PrometheusMeteringControllerTest {
 
     @Test
     void testRetryWhenOpenshiftServiceReturnsError() throws Exception {
+        String expectedLabelQuery = String.format(props.getOpenshift().getSubscriptionLabelPromQL(),
+            expectedAccount);
+        String expectedMetricQuery = String.format(props.getOpenshift().getMetricPromQL(), expectedAccount);
+
         QueryResult errorResponse = new QueryResult();
         errorResponse.setStatus(StatusType.ERROR);
         errorResponse.setError("FORCED!!");
 
-        QueryResult good = buildOpenShiftClusterQueryResult(expectedAccount, expectedClusterId, expectedSla,
-            expectedUsage, List.of(List.of(new BigDecimal(12312.345), new BigDecimal(24))));
+        QueryResult metrics = buildCoresMetricQueryResult(expectedAccount, expectedClusterId,
+            List.of(List.of(new BigDecimal(12312.345), new BigDecimal(24))));
+        QueryResult labels = buildSubscriptionLabelsQueryResult(expectedAccount, expectedClusterId,
+            expectedSla, expectedUsage, List.of(List.of(new BigDecimal(22222.22), new BigDecimal(1))));
 
-        when(service.runRangeQuery(anyString(), any(), any(), any(), any()))
-            .thenReturn(errorResponse, errorResponse, good);
+        when(service.runRangeQuery(eq(expectedLabelQuery), any(), any(), any(), any()))
+            .thenReturn(errorResponse, errorResponse, labels);
+        when(service.runRangeQuery(eq(expectedMetricQuery), any(), any(), any(), any()))
+            .thenReturn(metrics);
 
         OffsetDateTime start = OffsetDateTime.now();
         OffsetDateTime end = start.plusDays(1);
 
-        controller.collectOpenshiftMetrics("account", start, end);
-        verify(service, times(3)).runRangeQuery(anyString(), any(), any(), any(), any());
+        controller.collectOpenshiftMetrics(expectedAccount, start, end);
+
+        // Query for labels will fail twice due to errorResponse, and will pass on the 3rd retry.
+        verify(service, times(3)).runRangeQuery(eq(expectedLabelQuery), any(), any(), any(), any());
+        // Query for metrics should only run once since the above failures prevent the query from happening.
+        verify(service, times(1)).runRangeQuery(eq(expectedMetricQuery), any(), any(), any(), any());
     }
 
     @Test
     void datesAdjustedWhenReportingOpenShiftMetrics() throws Exception {
         OffsetDateTime start = clock.now().withSecond(30).withMinute(22);
         OffsetDateTime end = start.plusHours(4);
-        QueryResult data = buildOpenShiftClusterQueryResult(expectedAccount, expectedClusterId, expectedSla,
-            expectedUsage, List.of(List.of(new BigDecimal(12312.345), new BigDecimal(24))));
+
+        QueryResult data = buildSubscriptionLabelsQueryResult(expectedAccount, expectedClusterId,
+            expectedSla, expectedUsage, List.of(List.of(new BigDecimal(22222.22), new BigDecimal(1))));
+
         when(service.runRangeQuery(anyString(), any(), any(), any(), any())).thenReturn(data);
 
         controller.collectOpenshiftMetrics(expectedAccount, start, end);
@@ -118,11 +132,19 @@ class PrometheusMeteringControllerTest {
         BigDecimal time2 = BigDecimal.valueOf(222222.222);
         BigDecimal val2 = BigDecimal.valueOf(120L);
 
-        QueryResult data = buildOpenShiftClusterQueryResult(expectedAccount, expectedClusterId, expectedSla,
-            expectedUsage, List.of(List.of(time1, val1), List.of(time2, val2)));
+        QueryResult labels = buildSubscriptionLabelsQueryResult(expectedAccount, expectedClusterId,
+            expectedSla, expectedUsage, List.of(List.of(time1, new BigDecimal(1)),
+                List.of(time2, new BigDecimal(1))));
+
+        QueryResult metrics = buildCoresMetricQueryResult(expectedAccount, expectedClusterId,
+            List.of(List.of(time1, val1), List.of(time2, val2)));
+
         when(service.runRangeQuery(
             eq(String.format(props.getOpenshift().getMetricPromQL(), expectedAccount)),
-            any(), any(), any(), any())).thenReturn(data);
+            any(), any(), any(), any())).thenReturn(metrics);
+        when(service.runRangeQuery(
+            eq(String.format(props.getOpenshift().getSubscriptionLabelPromQL(), expectedAccount)),
+            any(), any(), any(), any())).thenReturn(labels);
 
         OffsetDateTime start = clock.startOfCurrentHour();
         OffsetDateTime end = clock.endOfHour(start.plusDays(1));
@@ -152,38 +174,104 @@ class PrometheusMeteringControllerTest {
         // Create enough events to persist 2 times the batch size events, plus 2 to trigger
         // an extra flush at the end.
         List<List<BigDecimal>> recordedMetrics = new LinkedList<>();
+        List<List<BigDecimal>> recordedLabelMetrics = new LinkedList<>();
         for (int i = 0; i < props.getOpenshift().getEventBatchSize() * 2 + 2; i++) {
-            recordedMetrics.add(List.of(new BigDecimal(111111.111), new BigDecimal(12)));
+            BigDecimal time = new BigDecimal(clock.now().toEpochSecond());
+            recordedMetrics.add(List.of(time, new BigDecimal(12)));
+            recordedLabelMetrics.add(List.of(time, new BigDecimal(1)));
         }
         assertEquals(12, recordedMetrics.size());
+        assertEquals(12, recordedLabelMetrics.size());
 
-        QueryResult data = buildOpenShiftClusterQueryResult("my-account", "my-cluster", expectedSla,
-            expectedUsage, recordedMetrics);
-        when(service.runRangeQuery(eq(String.format(props.getOpenshift().getMetricPromQL(),
-            expectedAccount)), any(), any(), any(), any())).thenReturn(data);
+        QueryResult labels = buildSubscriptionLabelsQueryResult(expectedAccount, expectedClusterId,
+            expectedSla, expectedUsage, recordedLabelMetrics);
+
+        QueryResult metrics = buildCoresMetricQueryResult(expectedAccount, expectedClusterId,
+            recordedMetrics);
+
+        when(service.runRangeQuery(
+            eq(String.format(props.getOpenshift().getMetricPromQL(), expectedAccount)),
+            any(), any(), any(), any())).thenReturn(metrics);
+        when(service.runRangeQuery(
+            eq(String.format(props.getOpenshift().getSubscriptionLabelPromQL(), expectedAccount)),
+            any(), any(), any(), any())).thenReturn(labels);
 
         controller.collectOpenshiftMetrics(expectedAccount, start, end);
 
         verify(eventController, times(3)).saveAll(any());
     }
 
-    private QueryResult buildOpenShiftClusterQueryResult(String account, String clusterId, String sla,
-        String usage, List<List<BigDecimal>> timeValueTuples) {
-        QueryResultDataResult dataResult = new QueryResultDataResult()
-            .putMetricItem("_id", clusterId)
-            .putMetricItem("support", sla)
-            .putMetricItem("usage", usage)
-            .putMetricItem("ebs_account", account);
+    // This test demonstrates that if the support label changes for a cluster, it will be reflected in
+    // the events that are produced.
+    @Test
+    void testSlaChangeForCluster() throws Exception {
+        BigDecimal time1 = BigDecimal.valueOf(clock.now().toEpochSecond());
+        BigDecimal time2 = BigDecimal.valueOf(clock.now().plusMinutes(5).toEpochSecond());
 
-        // NOTE: A tuple is [unix_time,value]
-        timeValueTuples.forEach(tuple -> dataResult.addValuesItem(tuple));
+        QueryResult labels = buildSubscriptionLabelsQueryResult(expectedAccount, expectedClusterId,
+            "Premium", expectedUsage, List.of(List.of(time1, new BigDecimal(1))));
+        labels.getData().addResultItem(buildLabelDataResult(expectedAccount, expectedClusterId,
+            "Standard", expectedUsage, List.of(List.of(time2, new BigDecimal(1)))));
 
-        return new QueryResult()
-        .status(StatusType.SUCCESS)
-        .data(
-            new QueryResultData()
-            .resultType(ResultType.MATRIX)
-            .addResultItem(dataResult)
-        );
+        BigDecimal expectedVal1 = new BigDecimal(12);
+        BigDecimal expectedVal2 = new BigDecimal(16);
+        QueryResult metrics = buildCoresMetricQueryResult(expectedAccount, expectedClusterId,
+            List.of(List.of(time1, expectedVal1), List.of(time2, expectedVal2)));
+
+        when(service.runRangeQuery(
+            eq(String.format(props.getOpenshift().getMetricPromQL(), expectedAccount)),
+            any(), any(), any(), any())).thenReturn(metrics);
+        when(service.runRangeQuery(
+            eq(String.format(props.getOpenshift().getSubscriptionLabelPromQL(), expectedAccount)),
+            any(), any(), any(), any())).thenReturn(labels);
+
+        Event event1 = MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId,
+            "Premium", expectedUsage, clock.dateFromUnix(time1), expectedVal1.doubleValue());
+        Event event2 = MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId,
+            "Standard", expectedUsage, clock.dateFromUnix(time2), expectedVal2.doubleValue());
+        List<Event> expectedEvents = List.of(event1, event2);
+
+        OffsetDateTime start = clock.startOfCurrentHour();
+        OffsetDateTime end = clock.endOfHour(start.plusDays(1));
+        controller.collectOpenshiftMetrics(expectedAccount, start, end);
+
+        verify(eventController).saveAll(expectedEvents);
     }
+
+    /*
+        A cores metric timestamp has to align with a subscription label metric timestamp in order
+        for an event to be created for a cluster. This could potentially occur if the labels for
+        the cluster has not yet been reported.
+     */
+    @Test
+    void whenMetricAndLabelDatesDoNoLineUpAnEventIsNotCreatedForMetric() throws Exception {
+        BigDecimal time1 = BigDecimal.valueOf(clock.now().toEpochSecond());
+        BigDecimal time2 = BigDecimal.valueOf(clock.now().plusMinutes(5).toEpochSecond());
+
+        QueryResult labels = buildSubscriptionLabelsQueryResult(expectedAccount, expectedClusterId,
+            "Premium", expectedUsage, List.of(List.of(time1, new BigDecimal(1))));
+
+        BigDecimal expectedVal1 = new BigDecimal(12);
+        BigDecimal expectedVal2 = new BigDecimal(16);
+        QueryResult metrics = buildCoresMetricQueryResult(expectedAccount, expectedClusterId,
+            List.of(List.of(time1, expectedVal1), List.of(time2, expectedVal2)));
+
+        when(service.runRangeQuery(
+            eq(String.format(props.getOpenshift().getMetricPromQL(), expectedAccount)),
+            any(), any(), any(), any())).thenReturn(metrics);
+        when(service.runRangeQuery(
+            eq(String.format(props.getOpenshift().getSubscriptionLabelPromQL(), expectedAccount)),
+            any(), any(), any(), any())).thenReturn(labels);
+
+        Event event = MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId,
+            "Premium", expectedUsage, clock.dateFromUnix(time1), expectedVal1.doubleValue());
+        List<Event> expectedEvents = List.of(event);
+
+        OffsetDateTime start = clock.startOfCurrentHour();
+        OffsetDateTime end = clock.endOfHour(start.plusDays(1));
+        controller.collectOpenshiftMetrics(expectedAccount, start, end);
+
+        verify(eventController).saveAll(expectedEvents);
+    }
+
 }


### PR DESCRIPTION
First pull the subscription_lables metrics that contain our metadata,
from prometheus and key the label sets by cluster_id and timestamp.

Next the OpenShift cluster cores metrics are pulled by account and an
Event object is created/persisted if a label set was found matching
the cluster ID and timestamp of the metric value.

Note:
  While this approach isn't optimal, it was done in order to get around
  a join issue caused by the original query when labels such as 'support'
  changes for a cluster.


**Testing**
Testing should be exactly the same as the instructions in #246 .

In fact, we should be seeing the same results from both branches, which would actually be a good test.