### PR TITLE
ENT-3263: prometheus latency setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,11 @@ allprojects {
     dependencies {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
+        compileOnly "org.projectlombok:lombok"
+        annotationProcessor "org.projectlombok:lombok"
+        testCompileOnly "org.projectlombok:lombok"
+        testAnnotationProcessor "org.projectlombok:lombok"
+
         testCompile "org.springframework.boot:spring-boot-starter-test"
         testCompile "org.springframework:spring-test"
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -186,7 +186,7 @@
     <module name="ImportOrder">
       <!-- Static imports should go at the top of the import list -->
       <property name="option" value="top"/>
-      <property name="groups" value="/^org\.candlepin/,com,org,net,ch,io,liquibase,java,javax"/>
+      <property name="groups" value="/^org\.candlepin/,com,org,net,ch,io,liquibase,lombok,java,javax"/>
       <property name="separated" value="true"/>
     </module>
 

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -25,6 +25,9 @@ import org.candlepin.subscriptions.security.AntiCsrfFilter;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.time.Duration;
 
 /**
@@ -178,6 +181,13 @@ public class ApplicationProperties {
      * Kafka topic for sending tally summaries.
      */
     private String tallySummaryTopic = "platform.rhsm-subscriptions.tally";
+
+    /**
+     * Determine the "window" to look at metrics
+     */
+    @Getter
+    @Setter
+    private Duration prometheusLatencyDuration = Duration.ofHours(4L);
 
     public String getVersion() {
         return version;

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountRepository;
 import org.candlepin.subscriptions.db.model.Account;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -37,9 +38,11 @@ import org.candlepin.subscriptions.metering.MeteringEventFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashSet;
@@ -64,6 +67,7 @@ public class MetricUsageCollector {
     private final AccountRepository accountRepository;
     private final EventController eventController;
     private final ProductConfig productConfig;
+    private final ApplicationProperties applicationProperties;
 
     /**
      * Encapsulates all per-product information we anticipate putting into configuration used by this
@@ -100,17 +104,39 @@ public class MetricUsageCollector {
         }
     }
 
+    @Autowired
     public MetricUsageCollector(AccountRepository accountRepository,
-        EventController eventController) {
+        EventController eventController, ApplicationProperties applicationProperties) {
 
         this.accountRepository = accountRepository;
         this.eventController = eventController;
         this.productConfig = new ProductConfig();
+        this.applicationProperties = applicationProperties;
+
+    }
+
+    protected OffsetDateTime adjustTimeForLatency(OffsetDateTime dateTime, Duration adjustmentAmount) {
+
+        return dateTime.toZonedDateTime().minus(adjustmentAmount).toOffsetDateTime();
+
     }
 
     @Transactional
     public AccountUsageCalculation collect(String accountNumber, OffsetDateTime startDateTime,
         OffsetDateTime endDateTime) {
+
+        Duration latencyAdjustment = applicationProperties.getPrometheusLatencyDuration();
+
+        OffsetDateTime modifiedStartDateTime = startDateTime.toZonedDateTime().minus(
+            latencyAdjustment).toOffsetDateTime();
+        OffsetDateTime modifiedEndDateTime = endDateTime.toZonedDateTime().minus(
+            latencyAdjustment).toOffsetDateTime();
+
+        log.info(
+            "Adjusting timeframe of query to account for prometheus latency.  " +
+            "startDateTime: {} -> {}, endDateTime: {} -> {}",
+            startDateTime, modifiedStartDateTime, endDateTime, modifiedEndDateTime
+        );
 
         Account account = accountRepository.findById(accountNumber).orElseThrow(() ->
             new SubscriptionsException(ErrorCode.OPT_IN_REQUIRED, Response.Status.BAD_REQUEST,
@@ -121,8 +147,9 @@ public class MetricUsageCollector {
             .filter(host -> productConfig.getServiceType().equals(host.getInstanceType()))
             .collect(Collectors.toMap(Host::getInstanceId, Function.identity()));
         Stream<Event> eventStream = eventController.fetchEventsInTimeRange(accountNumber,
-            startDateTime,
-            endDateTime).filter(event -> event.getServiceType().equals(productConfig.getServiceType()));
+            modifiedStartDateTime,
+            modifiedEndDateTime)
+            .filter(event -> event.getServiceType().equals(productConfig.getServiceType()));
 
         eventStream.forEach(event -> {
             String instanceId = event.getInstanceId();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -98,4 +98,4 @@ rhsm-subscriptions:
       tasks:
         topic: ${OPENSHIFT_METERING_TASK_TOPIC:platform.rhsm-subscriptions.openshift-metering-tasks}
         kafka-group-id: ${OPENSHIFT_METERING_TASK_GROUP_ID:openshift-metering-task-processor}
-
+  prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:4h}


### PR DESCRIPTION
Subtract duration from start & end times during MetricUsageCollector.collect to account for prometheus latency.

Depends on #293.