### PR TITLE
ENT-3542 & ENT-3263: Produce hourly tally for all configured accounts and implement prometheus latency setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,11 @@ allprojects {
     dependencies {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
+        compileOnly "org.projectlombok:lombok"
+        annotationProcessor "org.projectlombok:lombok"
+        testCompileOnly "org.projectlombok:lombok"
+        testAnnotationProcessor "org.projectlombok:lombok"
+
         testCompile "org.springframework.boot:spring-boot-starter-test"
         testCompile "org.springframework:spring-test"
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -186,7 +186,7 @@
     <module name="ImportOrder">
       <!-- Static imports should go at the top of the import list -->
       <property name="option" value="top"/>
-      <property name="groups" value="/^org\.candlepin/,com,org,net,ch,io,liquibase,java,javax"/>
+      <property name="groups" value="/^org\.candlepin/,com,org,net,ch,io,liquibase,lombok,java,javax"/>
       <property name="separated" value="true"/>
     </module>
 

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -25,6 +25,9 @@ import org.candlepin.subscriptions.security.AntiCsrfFilter;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.time.Duration;
 
 /**
@@ -178,6 +181,13 @@ public class ApplicationProperties {
      * Kafka topic for sending tally summaries.
      */
     private String tallySummaryTopic = "platform.rhsm-subscriptions.tally";
+
+    /**
+     * Determine the "window" to look at metrics
+     */
+    @Getter
+    @Setter
+    private Duration prometheusLatencyDuration = Duration.ofHours(4L);
 
     public String getVersion() {
         return version;

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -38,6 +38,9 @@ import java.time.Duration;
  *
  * @see ApplicationConfiguration
  */
+
+@Getter
+@Setter
 @ConfigurationProperties(prefix = "rhsm-subscriptions")
 public class ApplicationProperties {
     private String version;
@@ -183,233 +186,14 @@ public class ApplicationProperties {
     private String tallySummaryTopic = "platform.rhsm-subscriptions.tally";
 
     /**
-     * Determine the "window" to look at metrics
+     * Offsets the range to look at metrics to account for delay in prometheus having metrics available
      */
-    @Getter
-    @Setter
     private Duration prometheusLatencyDuration = Duration.ofHours(4L);
 
-    public String getVersion() {
-        return version;
-    }
+    /**
+     * Amount of time from current timestamp to start looking for metrics during a tally,
+     * indepedent of the prometheus latency duration
+     */
+    private Duration metricLookupRangeDuration = Duration.ofHours(24L);
 
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public boolean isPrettyPrintJson() {
-        return prettyPrintJson;
-    }
-
-    public void setPrettyPrintJson(boolean prettyPrintJson) {
-        this.prettyPrintJson = prettyPrintJson;
-    }
-
-    public String getProductIdToProductsMapResourceLocation() {
-        return productIdToProductsMapResourceLocation;
-    }
-
-    public void setProductIdToProductsMapResourceLocation(String productIdToProductsMapResourceLocation) {
-        this.productIdToProductsMapResourceLocation = productIdToProductsMapResourceLocation;
-    }
-
-    public String getRoleToProductsMapResourceLocation() {
-        return roleToProductsMapResourceLocation;
-    }
-
-    public void setRoleToProductsMapResourceLocation(String roleToProductsMapResourceLocation) {
-        this.roleToProductsMapResourceLocation = roleToProductsMapResourceLocation;
-    }
-
-    public String getAccountListResourceLocation() {
-        return accountListResourceLocation;
-    }
-
-    public void setAccountListResourceLocation(String accountListResourceLocation) {
-        this.accountListResourceLocation = accountListResourceLocation;
-    }
-
-    public int getHostLastSyncThresholdHours() {
-        return hostLastSyncThresholdHours;
-    }
-
-    public void setHostLastSyncThresholdHours(int hostLastSyncThresholdHours) {
-        this.hostLastSyncThresholdHours = hostLastSyncThresholdHours;
-    }
-
-    public int getAccountBatchSize() {
-        return this.accountBatchSize;
-    }
-
-    public void setAccountBatchSize(int accountBatchSize) {
-        this.accountBatchSize = accountBatchSize;
-    }
-
-    public boolean isDevMode() {
-        return devMode;
-    }
-
-    public void setDevMode(boolean devMode) {
-        this.devMode = devMode;
-    }
-
-    public String getProductWhitelistResourceLocation() {
-        return productWhitelistResourceLocation;
-    }
-
-    public void setProductWhitelistResourceLocation(String productWhitelistResourceLocation) {
-        this.productWhitelistResourceLocation = productWhitelistResourceLocation;
-    }
-
-    public String getReportingAccountWhitelistResourceLocation() {
-        return reportingAccountWhitelistResourceLocation;
-    }
-
-    public void setReportingAccountWhitelistResourceLocation(String location) {
-        this.reportingAccountWhitelistResourceLocation = location;
-    }
-
-    public Duration getAccountListCacheTtl() {
-        return accountListCacheTtl;
-    }
-
-    public void setAccountListCacheTtl(Duration accountListCacheTtl) {
-        this.accountListCacheTtl = accountListCacheTtl;
-    }
-
-    public Duration getProductIdToProductsMapCacheTtl() {
-        return productIdToProductsMapCacheTtl;
-    }
-
-    public void setProductIdToProductsMapCacheTtl(Duration productIdToProductsMapCacheTtl) {
-        this.productIdToProductsMapCacheTtl = productIdToProductsMapCacheTtl;
-    }
-
-    public Duration getProductWhiteListCacheTtl() {
-        return productWhiteListCacheTtl;
-    }
-
-    public void setProductWhiteListCacheTtl(Duration productWhiteListCacheTtl) {
-        this.productWhiteListCacheTtl = productWhiteListCacheTtl;
-    }
-
-    public Duration getRoleToProductsMapCacheTtl() {
-        return roleToProductsMapCacheTtl;
-    }
-
-    public void setRoleToProductsMapCacheTtl(Duration roleToProductsMapCacheTtl) {
-        this.roleToProductsMapCacheTtl = roleToProductsMapCacheTtl;
-    }
-
-    public Duration getReportingAccountWhitelistCacheTtl() {
-        return reportingAccountWhitelistCacheTtl;
-    }
-
-    public void setReportingAccountWhitelistCacheTtl(Duration reportingAccountWhitelistCacheTtl) {
-        this.reportingAccountWhitelistCacheTtl = reportingAccountWhitelistCacheTtl;
-    }
-
-    public int getCullingOffsetDays() {
-        return cullingOffsetDays;
-    }
-
-    public void setCullingOffsetDays(int cullingOffsetDays) {
-        this.cullingOffsetDays = cullingOffsetDays;
-    }
-
-    public String getAntiCsrfDomainSuffix() {
-        return antiCsrfDomainSuffix;
-    }
-
-    public void setAntiCsrfDomainSuffix(String antiCsrfDomainSuffix) {
-        this.antiCsrfDomainSuffix = antiCsrfDomainSuffix;
-    }
-
-    public int getAntiCsrfPort() {
-        return antiCsrfPort;
-    }
-
-    public void setAntiCsrfPort(int antiCsrfPort) {
-        this.antiCsrfPort = antiCsrfPort;
-    }
-
-    public String getRbacApplicationName() {
-        return rbacApplicationName;
-    }
-
-    public void setRbacApplicationName(String rbacApplicationName) {
-        this.rbacApplicationName = rbacApplicationName;
-    }
-
-    public String getHawtioBasePath() {
-        return hawtioBasePath;
-    }
-
-    public void setHawtioBasePath(String hawtioBasePath) {
-        this.hawtioBasePath = hawtioBasePath;
-    }
-
-    public boolean isCloudigradeEnabled() {
-        return cloudigradeEnabled;
-    }
-
-    public void setCloudigradeEnabled(boolean cloudigradeEnabled) {
-        this.cloudigradeEnabled = cloudigradeEnabled;
-    }
-
-    public String getArchToProductMapResourceLocation() {
-        return archToProductMapResourceLocation;
-    }
-
-    public void setArchToProductMapResourceLocation(String archToProductMapResourceLocation) {
-        this.archToProductMapResourceLocation = archToProductMapResourceLocation;
-    }
-
-    public Duration getArchToProductMapCacheTtl() {
-        return archToProductMapCacheTtl;
-    }
-
-    public void setArchToProductMapCacheTtl(Duration archToProductMapCacheTtl) {
-        this.archToProductMapCacheTtl = archToProductMapCacheTtl;
-    }
-
-    public int getCloudigradeMaxAttempts() {
-        return cloudigradeMaxAttempts;
-    }
-
-    public void setCloudigradeMaxAttempts(int cloudigradeMaxAttempts) {
-        this.cloudigradeMaxAttempts = cloudigradeMaxAttempts;
-    }
-
-    public JobProperties getJobs() {
-        return jobs;
-    }
-
-    public void setJobs(JobProperties jobs) {
-        this.jobs = jobs;
-    }
-
-    public String getProductProfileRegistryResourceLocation() {
-        return productProfileRegistryResourceLocation;
-    }
-
-    public void setProductProfileRegistryResourceLocation(String productProfileRegistryResourceLocation) {
-        this.productProfileRegistryResourceLocation = productProfileRegistryResourceLocation;
-    }
-
-    public Duration getProductProfileListCacheTtl() {
-        return productProfileListCacheTtl;
-    }
-
-    public void setProductProfileListCacheTtl(Duration productProfileListCacheTtl) {
-        this.productProfileListCacheTtl = productProfileListCacheTtl;
-    }
-
-    public String getTallySummaryTopic() {
-        return tallySummaryTopic;
-    }
-
-    public void setTallySummaryTopic(String tallySummaryTopic) {
-        this.tallySummaryTopic = tallySummaryTopic;
-    }
 }

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -87,4 +87,11 @@ public class TallyJmxBean {
         tasks.tallyAccountByHourly(accountNumber, startDateTime, endDateTime);
 
     }
+
+    @ManagedOperation(description = "Trigger hourly tally for all configured accounts")
+    public void tallyAllAccountsByHourly() {
+        log.info("Hourly tally for all accounts triggered over JMX by {}", ResourceUtils.getPrincipal());
+
+        tasks.updateHourlySnapshotsForAllAccounts();
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountRepository;
 import org.candlepin.subscriptions.db.model.Account;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -37,9 +38,11 @@ import org.candlepin.subscriptions.metering.MeteringEventFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashSet;
@@ -64,6 +67,7 @@ public class MetricUsageCollector {
     private final AccountRepository accountRepository;
     private final EventController eventController;
     private final ProductConfig productConfig;
+    private final ApplicationProperties applicationProperties;
 
     /**
      * Encapsulates all per-product information we anticipate putting into configuration used by this
@@ -100,17 +104,39 @@ public class MetricUsageCollector {
         }
     }
 
+    @Autowired
     public MetricUsageCollector(AccountRepository accountRepository,
-        EventController eventController) {
+        EventController eventController, ApplicationProperties applicationProperties) {
 
         this.accountRepository = accountRepository;
         this.eventController = eventController;
         this.productConfig = new ProductConfig();
+        this.applicationProperties = applicationProperties;
+
+    }
+
+    protected OffsetDateTime adjustTimeForLatency(OffsetDateTime dateTime, Duration adjustmentAmount) {
+
+        return dateTime.toZonedDateTime().minus(adjustmentAmount).toOffsetDateTime();
+
     }
 
     @Transactional
     public AccountUsageCalculation collect(String accountNumber, OffsetDateTime startDateTime,
         OffsetDateTime endDateTime) {
+
+        Duration latencyAdjustment = applicationProperties.getPrometheusLatencyDuration();
+
+        OffsetDateTime modifiedStartDateTime = startDateTime.toZonedDateTime().minus(
+            latencyAdjustment).toOffsetDateTime();
+        OffsetDateTime modifiedEndDateTime = endDateTime.toZonedDateTime().minus(
+            latencyAdjustment).toOffsetDateTime();
+
+        log.info(
+            "Adjusting timeframe of query to account for prometheus latency.  " +
+            "startDateTime: {} -> {}, endDateTime: {} -> {}",
+            startDateTime, modifiedStartDateTime, endDateTime, modifiedEndDateTime
+        );
 
         Account account = accountRepository.findById(accountNumber).orElseThrow(() ->
             new SubscriptionsException(ErrorCode.OPT_IN_REQUIRED, Response.Status.BAD_REQUEST,
@@ -121,8 +147,9 @@ public class MetricUsageCollector {
             .filter(host -> productConfig.getServiceType().equals(host.getInstanceType()))
             .collect(Collectors.toMap(Host::getInstanceId, Function.identity()));
         Stream<Event> eventStream = eventController.fetchEventsInTimeRange(accountNumber,
-            startDateTime,
-            endDateTime).filter(event -> event.getServiceType().equals(productConfig.getServiceType()));
+            modifiedStartDateTime,
+            modifiedEndDateTime)
+            .filter(event -> event.getServiceType().equals(productConfig.getServiceType()));
 
         eventStream.forEach(event -> {
             String instanceId = event.getInstanceId();

--- a/src/main/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsJob.java
@@ -44,6 +44,7 @@ public class CaptureSnapshotsJob implements Runnable {
     public void run() {
         try {
             tasks.updateSnapshotsForAllAccounts();
+            tasks.updateHourlySnapshotsForAllAccounts();
         }
         catch (Exception e) {
             throw new JobFailureException("Failed to run CaptureSnapshotsJob.", e);

--- a/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
@@ -51,8 +51,13 @@ public class CaptureMetricsSnapshotTask implements Task {
 
     @Override
     public void execute() {
+        if (startDateTime.isAfter(endDateTime)) {
+            throw new IllegalArgumentException(
+                "Cannot produce hourly snapshot for account {}.  Invalid date range provided.");
+        }
         log.info("Producing hourly snapshot for account {} in timeframe {}-{}", accountNumber, startDateTime,
             endDateTime);
+
         snapshotController.produceHourlySnapshotsForAccount(accountNumber, startDateTime, endDateTime);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -99,3 +99,4 @@ rhsm-subscriptions:
         topic: ${OPENSHIFT_METERING_TASK_TOPIC:platform.rhsm-subscriptions.openshift-metering-tasks}
         kafka-group-id: ${OPENSHIFT_METERING_TASK_GROUP_ID:openshift-metering-task-processor}
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:4h}
+  metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:24h}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -98,4 +98,4 @@ rhsm-subscriptions:
       tasks:
         topic: ${OPENSHIFT_METERING_TASK_TOPIC:platform.rhsm-subscriptions.openshift-metering-tasks}
         kafka-group-id: ${OPENSHIFT_METERING_TASK_GROUP_ID:openshift-metering-task-processor}
-
+  prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:4h}

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.tally;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountRepository;
 import org.candlepin.subscriptions.db.model.Account;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -40,12 +39,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashSet;
@@ -64,12 +61,9 @@ class MetricUsageCollectorTest {
     @Mock
     EventController eventController;
 
-    @Mock
-    ApplicationProperties applicationProperties;
-
     @BeforeEach
     void setup() {
-        metricUsageCollector = new MetricUsageCollector(accountRepo, eventController, applicationProperties);
+        metricUsageCollector = new MetricUsageCollector(accountRepo, eventController);
     }
 
     @Test
@@ -267,22 +261,5 @@ class MetricUsageCollectorTest {
         assertEquals(Double.valueOf(42.0),
             accountUsageCalculation.getCalculation(usageCalculationKey).getTotals(
             HardwareMeasurementType.PHYSICAL).getMeasurement(Measurement.Uom.CORES));
-    }
-
-    @ParameterizedTest(name = "testAdjustTimeForLatency[{index}] {arguments}")
-    @CsvSource({
-        "2021-02-01T00:00:00Z, PT0H, 2021-02-01T00:00:00Z",
-        "2021-02-01T00:00:00Z, PT1H, 2021-01-31T23:00:00Z",
-        "2021-02-01T00:00:00Z, PT25H, 2021-01-30T23:00:00Z",
-        "2021-02-01T00:00:00Z, PT-1H, 2021-02-01T01:00:00Z",
-        "2021-02-01T00:00:00Z, PT1M, 2021-01-31T23:59:00Z",
-        "2021-02-01T00:00:00Z, P1D, 2021-01-31T00:00:00Z"
-    })
-    void testAdjustTimeForLatency(OffsetDateTime originalDateTime, Duration latencyDuration,
-        OffsetDateTime adjustedDateTime) {
-
-        OffsetDateTime actual = metricUsageCollector.adjustTimeForLatency(originalDateTime, latencyDuration);
-
-        assertEquals(adjustedDateTime, actual);
     }
 }


### PR DESCRIPTION
Produce hourly tally for all configured accounts

Add metric-lookup-range-duration configuration to be used when scheduling hourly snapshot job
Queue up an hourly tally for all configured accounts and expose operation via the TallyJmxBean
Also produce hourly snapshots during the CaptureSnapshotsJob

**Note: Refactoring to minimize some duplicate code in CaptureSnapshotsJob is getting kicked down the road because of timelines, that work is captured in a new card in the backlog ENT-3561**
