### PR TITLE
Fix bean issue with default profiles

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
@@ -71,7 +71,7 @@ public class PrometheusServiceConfiguration {
     }
 
     @Bean
-    EventController eventController(EventRecordRepository repo) {
+    EventController prometheusEventController(EventRecordRepository repo) {
         return new EventController(repo);
     }
 


### PR DESCRIPTION
Duplicate bean name was causing a startup issue when running with default profiles.

## Testing
Deploy as follows:

```bash
./gradlew clean bootRun
```

Before this patch, the application will not start and complains about eventController bean.

Application should start after this patch is applied.