### PR TITLE
Filter out hosts with null inventory IDs when collecting from inventory

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -82,8 +82,9 @@ public class InventoryAccountUsageCollector {
         Collection<String> accounts) {
 
         List<Host> existing = getAccountHosts(accounts);
-        Map<String, Host> inventoryHostMap =
-            existing.stream().collect(Collectors.toMap(Host::getInventoryId, Function.identity()));
+        Map<String, Host> inventoryHostMap = existing.stream()
+            .filter(host -> host.getInventoryId() != null)
+            .collect(Collectors.toMap(Host::getInventoryId, Function.identity()));
 
         Map<String, String> hypMapping = new HashMap<>();
         Map<String, Set<UsageCalculation.Key>> hypervisorUsageKeys = new HashMap<>();


### PR DESCRIPTION
Now that we are storing host records from more than just HBI,
inventory ID may be null. Filter is so that we do not get
duplicate keys during the stream mapping.