### PR TITLE
ENT-3517: add core hours hosts apis

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -431,6 +431,24 @@ paths:
             #Default to empty string to prevent complex jpql statement later
             default: ''
           in: query
+        - name: beginning
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the start of the report period. Dates should be provided in ISO 8601
+            format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z.
+            Only applicable for OpenShift-dedicated-metrics and OpenShift-metrics products"
+        - name: ending
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the end of the report period. Dates should be provided in ISO 8601
+            format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z.
+            Only applicable for OpenShift-dedicated-metrics and OpenShift-metrics products"
         - name: sort
           in: query
           schema:
@@ -688,6 +706,7 @@ components:
         - Satellite Capsule
         - Satellite Server
         - OpenShift-metrics
+        - OpenShift-dedicated-metrics
     Uom:
       type: string
       enum:
@@ -1128,6 +1147,9 @@ components:
           type: integer
           format: int32
           minimum: 0
+        core_hours:
+          type: number
+          format: double
         hardware_type:
           description: What the type of the host is (e.g. hypervisor, physical, etc.).
           type: string

--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,7 @@ release {
 
 dependencies {
     // Generates configuration metadata that IntelliJ can use
+    annotationProcessor('org.hibernate:hibernate-jpamodelgen')
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     // For the LiveReload feature of spring boot as long as IntelliJ is set to build/make automatically on
     // code changes

--- a/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -21,13 +21,22 @@
 package org.candlepin.subscriptions.db;
 
 import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostBucketKey_;
+import org.candlepin.subscriptions.db.model.HostTallyBucket_;
+import org.candlepin.subscriptions.db.model.Host_;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyHostView;
 import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,7 +49,7 @@ import javax.validation.constraints.NotNull;
  * Provides access to Host database entities.
  */
 @SuppressWarnings({"linelength", "indentation"})
-public interface HostRepository extends JpaRepository<Host, UUID> {
+public interface HostRepository extends JpaRepository<Host, UUID>, JpaSpecificationExecutor<Host> {
 
     /**
      * Find all Hosts by bucket criteria and return a page of TallyHostView objects.
@@ -86,6 +95,51 @@ public interface HostRepository extends JpaRepository<Host, UUID> {
         @Param("minSockets") int minSockets,
         Pageable pageable
     );
+
+    @Override
+    @EntityGraph(attributePaths = {"buckets"})
+    Page<Host> findAll(Specification<Host> specification, Pageable pageable);
+
+    /**
+     * Find all Hosts by bucket criteria and return a page of TallyHostView objects.
+     * A TallyHostView is a Host representation detailing what 'bucket' was applied
+     * to the current daily snapshots.
+     *
+     * @param accountNumber        The account number of the hosts to query (required).
+     * @param productId            The bucket product ID to filter Host by (pass null to ignore).
+     * @param sla                  The bucket service level to filter Hosts by (pass null to ignore).
+     * @param usage                The bucket usage to filter Hosts by (pass null to ignore).
+     * @param displayNameSubstring Case-insensitive string to filter Hosts' display name by (pass null or empty string to ignore)
+     * @param minCores             Filter to Hosts with at least this number of cores.
+     * @param minSockets           Filter to Hosts with at least this number of sockets.
+     * @param month                Filter to Hosts with with monthly instance totals in provided month
+     * @param pageable             the current paging info for this query.
+     * @return a page of Host entities matching the criteria.
+     */
+    @SuppressWarnings("java:S107")
+    default Page<Host> findAllBy(@Param("account") String accountNumber, @Param("product") String productId,
+        @Param("sla") ServiceLevel sla, @Param("usage") Usage usage,
+        @NotNull @Param("displayNameSubstring") String displayNameSubstring, @Param("minCores") int minCores,
+        @Param("minSockets") int minSockets, String month, Pageable pageable) {
+
+        HostSpecification searchCriteria = new HostSpecification();
+
+        searchCriteria.add(new SearchCriteria(Host_.ACCOUNT_NUMBER, accountNumber, SearchOperation.EQUAL));
+        searchCriteria.add(new SearchCriteria(HostBucketKey_.PRODUCT_ID, productId, SearchOperation.EQUAL));
+        searchCriteria.add(new SearchCriteria(HostBucketKey_.SLA, sla, SearchOperation.EQUAL));
+        searchCriteria.add(new SearchCriteria(HostBucketKey_.USAGE, usage, SearchOperation.EQUAL));
+        searchCriteria.add(new SearchCriteria(Host_.DISPLAY_NAME, displayNameSubstring, SearchOperation.CONTAINS));
+        searchCriteria.add(new SearchCriteria(HostTallyBucket_.CORES, minCores,
+            SearchOperation.GREATER_THAN_EQUAL));
+        searchCriteria.add(new SearchCriteria(HostTallyBucket_.SOCKETS, minSockets,
+            SearchOperation.GREATER_THAN_EQUAL));
+        searchCriteria.add(new SearchCriteria(InstanceMonthlyTotalKey_.MONTH,
+            new InstanceMonthlyTotalKey(month, Measurement.Uom.CORES), SearchOperation.EQUAL));
+
+        return findAll(searchCriteria, pageable);
+
+    }
+
 
     @Query(
         "select distinct h from Host h where " +

--- a/src/main/java/org/candlepin/subscriptions/db/HostSpecification.java
+++ b/src/main/java/org/candlepin/subscriptions/db/HostSpecification.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostBucketKey_;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.HostTallyBucket_;
+import org.candlepin.subscriptions.db.model.Host_;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.MapJoin;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+/**
+ * Util class for dynamically building Specification<Host>
+ */
+public class HostSpecification implements Specification<Host> {
+
+    private final transient List<SearchCriteria> list;
+
+    public HostSpecification() {
+        this.list = new ArrayList<>();
+    }
+
+    public void add(SearchCriteria criteria) {
+        list.add(criteria);
+    }
+
+    @Override
+    @SuppressWarnings("java:S3776")
+    public Predicate toPredicate(Root<Host> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+
+        Join<Host, HostTallyBucket> bucketListJoin = root.join(Host_.buckets, JoinType.INNER);
+        MapJoin<Host, InstanceMonthlyTotalKey, Double> instanceMonthlyTotalRoot = root
+            .joinMap(Host_.MONTHLY_TOTALS);
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        Map<String, Path<?>> rootPaths = Map
+            .of(
+            HostBucketKey_.PRODUCT_ID, bucketListJoin.get(HostTallyBucket_.KEY),
+            HostBucketKey_.SLA, bucketListJoin.get(HostTallyBucket_.KEY),
+            HostBucketKey_.USAGE, bucketListJoin.get(HostTallyBucket_.KEY),
+            HostTallyBucket_.CORES, bucketListJoin,
+            HostTallyBucket_.SOCKETS, bucketListJoin,
+            HostTallyBucket_.MEASUREMENT_TYPE, bucketListJoin,
+            InstanceMonthlyTotalKey_.MONTH, instanceMonthlyTotalRoot
+        );
+
+        for (SearchCriteria criteria : list) {
+            Path<?> path = rootPaths.getOrDefault(criteria.getKey(), root);
+            if (criteria.getOperation().equals(SearchOperation.GREATER_THAN)) {
+                predicates
+                    .add(builder.greaterThan(path.get(criteria.getKey()), criteria.getValue().toString()));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.LESS_THAN)) {
+                predicates.add(builder.lessThan(path.get(criteria.getKey()), criteria.getValue().toString()));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_EQUAL)) {
+                predicates.add(builder
+                    .greaterThanOrEqualTo(path.get(criteria.getKey()), criteria.getValue().toString()));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.LESS_THAN_EQUAL)) {
+                predicates.add(
+                    builder.lessThanOrEqualTo(path.get(criteria.getKey()), criteria.getValue().toString()));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.NOT_EQUAL)) {
+                predicates.add(builder.notEqual(path.get(criteria.getKey()), criteria.getValue()));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.EQUAL)) {
+                var key = Objects.equals(instanceMonthlyTotalRoot, path) ?
+                    instanceMonthlyTotalRoot.key() :
+                    path.get(criteria.getKey());
+
+                predicates.add(builder.equal(key, criteria.getValue()));
+
+            }
+            else if (criteria.getOperation().equals(SearchOperation.CONTAINS)) {
+                predicates.add(builder.like(builder.lower(path.get(criteria.getKey())),
+                    "%" + criteria.getValue().toString().toLowerCase() + "%"));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.MATCH_END)) {
+                predicates.add(builder.like(builder.lower(path.get(criteria.getKey())),
+                    criteria.getValue().toString().toLowerCase() + "%"));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.MATCH_START)) {
+                predicates.add(builder.like(builder.lower(path.get(criteria.getKey())),
+                    "%" + criteria.getValue().toString().toLowerCase()));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.IN)) {
+                predicates.add(builder.in(path.get(criteria.getKey())).value(criteria.getValue()));
+            }
+            else if (criteria.getOperation().equals(SearchOperation.NOT_IN)) {
+                predicates.add(builder.not(path.get(criteria.getKey())).in(criteria.getValue()));
+            }
+        }
+
+        return builder.and(predicates.toArray(new Predicate[0]));
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/db/SearchCriteria.java
+++ b/src/main/java/org/candlepin/subscriptions/db/SearchCriteria.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Representation of a single constraint
+ */
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchCriteria {
+
+    @NotNull
+    private String key;
+
+    @NotNull
+    private Object value;
+
+    @NotNull
+    private SearchOperation operation;
+}

--- a/src/main/java/org/candlepin/subscriptions/db/SearchOperation.java
+++ b/src/main/java/org/candlepin/subscriptions/db/SearchOperation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+/**
+ * Operations for programatically building queries via specifications
+ */
+public enum SearchOperation {
+    GREATER_THAN,
+    LESS_THAN,
+    GREATER_THAN_EQUAL,
+    LESS_THAN_EQUAL,
+    NOT_EQUAL,
+    EQUAL,
+    CONTAINS,
+    MATCH_START,
+    MATCH_END,
+    IN,
+    NOT_IN
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostBucketKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostBucketKey.java
@@ -20,6 +20,11 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
@@ -31,6 +36,10 @@ import javax.persistence.Embeddable;
  * An embeddable composite key for a host bucket.
  */
 @Embeddable
+@ToString
+@NoArgsConstructor
+@Getter
+@Setter
 public class HostBucketKey implements Serializable {
     @Column(name = "host_id")
     private UUID hostId;
@@ -45,47 +54,12 @@ public class HostBucketKey implements Serializable {
     @Column(name = "as_hypervisor")
     private Boolean asHypervisor;
 
-    public HostBucketKey() {
-    }
-
     public HostBucketKey(Host host, String productId, ServiceLevel sla, Usage usage, Boolean asHypervisor) {
         this.hostId = host == null ? null : host.getId();
         this.productId = productId;
         this.sla = sla;
         this.usage = usage;
         this.asHypervisor = asHypervisor;
-    }
-
-    public UUID getHostId() {
-        return hostId;
-    }
-
-    public void setHostId(UUID hostId) {
-        this.hostId = hostId;
-    }
-
-    public String getProductId() {
-        return productId;
-    }
-
-    public void setProductId(String productId) {
-        this.productId = productId;
-    }
-
-    public ServiceLevel getSla() {
-        return sla;
-    }
-
-    public void setSla(ServiceLevel sla) {
-        this.sla = sla;
-    }
-
-    public Usage getUsage() {
-        return usage;
-    }
-
-    public void setUsage(Usage usage) {
-        this.usage = usage;
     }
 
     public Boolean getAsHypervisor() {

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -20,6 +20,11 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -37,6 +42,10 @@ import javax.persistence.Table;
 /**
  * Represents a bucket that this host contributes to.
  */
+@ToString
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "host_tally_buckets")
 public class HostTallyBucket implements Serializable {
@@ -51,12 +60,10 @@ public class HostTallyBucket implements Serializable {
     @Column(name = "measurement_type")
     private HardwareMeasurementType measurementType;
 
+    @ToString.Exclude
     @MapsId("hostId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Host host;
-
-    public HostTallyBucket() {
-    }
 
     @SuppressWarnings("java:S107")
     public HostTallyBucket(Host host, String productId, ServiceLevel sla, Usage usage, Boolean asHypervisor,
@@ -66,42 +73,6 @@ public class HostTallyBucket implements Serializable {
         this.cores = cores;
         this.sockets = sockets;
         this.measurementType = type;
-    }
-
-    public HostBucketKey getKey() {
-        return key;
-    }
-
-    public void setKey(HostBucketKey key) {
-        this.key = key;
-    }
-
-    public int getCores() {
-        return cores;
-    }
-
-    public void setCores(int cores) {
-        this.cores = cores;
-    }
-
-    public int getSockets() {
-        return sockets;
-    }
-
-    public void setSockets(int sockets) {
-        this.sockets = sockets;
-    }
-
-    public HardwareMeasurementType getMeasurementType() {
-        return measurementType;
-    }
-
-    public void setMeasurementType(HardwareMeasurementType measurementType) {
-        this.measurementType = measurementType;
-    }
-
-    public Host getHost() {
-        return host;
     }
 
     public void setHost(Host host) {

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallyHostView.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallyHostView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -79,9 +79,11 @@ public class TallySnapshot implements Serializable {
     @Column(name = "account_number")
     private String accountNumber;
 
+    @Builder.Default
     @Column(name = "sla")
     private ServiceLevel serviceLevel = ServiceLevel._ANY;
 
+    @Builder.Default
     @Column(name = "usage")
     private Usage usage = Usage._ANY;
 

--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -61,7 +61,7 @@ public class MeteringEventFactory {
      * @return a populated Event instance.
      */
     public static Event openShiftClusterCores(String accountNumber, String clusterId, String serviceLevel,
-        String usage, OffsetDateTime measuredTime, Double measuredValue) {
+        String usage, OffsetDateTime measuredTime, OffsetDateTime expired, Double measuredValue) {
         return new Event()
             .withEventSource(OPENSHIFT_CLUSTER_EVENT_SOURCE)
             .withEventType(OPENSHIFT_CLUSTER_EVENT_TYPE)
@@ -69,6 +69,7 @@ public class MeteringEventFactory {
             .withAccountNumber(accountNumber)
             .withInstanceId(clusterId)
             .withTimestamp(measuredTime)
+            .withExpiration(Optional.of(expired))
             .withDisplayName(Optional.of(clusterId))
             .withSla(getSla(serviceLevel, accountNumber, clusterId))
             .withUsage(getUsage(usage, accountNumber, clusterId))

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -116,8 +116,15 @@ public class PrometheusMeteringController {
                         BigDecimal time = measurement.get(0);
                         BigDecimal value = measurement.get(1);
 
+                        OffsetDateTime eventTermDate = clock.dateFromUnix(time);
+                        // Need to subtract the step because we are averaging and the metric value
+                        // actually represents the end of the measured period. The start of the event
+                        // should be at the beginning.
+                        OffsetDateTime eventDate =
+                            eventTermDate.minusSeconds(metricProperties.getOpenshift().getStep());
+
                         Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId,
-                            sla, usage, clock.dateFromUnix(time), value.doubleValue());
+                            sla, usage, eventDate, eventTermDate, value.doubleValue());
                         events.add(event);
                         eventCount++;
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
@@ -22,18 +22,16 @@ package org.candlepin.subscriptions.metering.service.prometheus;
 
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
-import org.candlepin.subscriptions.metering.MeteringException;
 import org.candlepin.subscriptions.prometheus.ApiException;
 import org.candlepin.subscriptions.prometheus.api.ApiProvider;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
 
+import com.google.common.net.UrlEscapers;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.time.OffsetDateTime;
 
 /**
@@ -58,11 +56,7 @@ public class PrometheusService {
             // NOTE: While the ApiClient **should** in theory already encode the query,
             //       it does not handle the curly braces correctly causing issues
             //       when the request is made.
-            //
-            //       Also, the Prometheus APIs do not seem to like whitespace, even when encoded.
-            String accountQuery = StringUtils.trimAllWhitespace(promQuery);
-            log.debug("RAW Query: {}", accountQuery);
-            String query = URLEncoder.encode(accountQuery, "UTF-8");
+            String query = UrlEscapers.urlFragmentEscaper().escape(promQuery);
             log.debug("Running prometheus query: Start: {} End: {} Step: {}, Query: {}",
                 start.toEpochSecond(), end.toEpochSecond(), step, query);
             return apiProvider.queryRangeApi().queryRange(query, start.toEpochSecond(),
@@ -77,10 +71,6 @@ public class PrometheusService {
                 new ApiException(String.format("Prometheus API response code: %s", apie.getCode()))
             );
         }
-        catch (UnsupportedEncodingException e) {
-            throw new MeteringException("Unsupported encoding for specified PromQL.", e);
-        }
-
     }
 
 }

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -12,9 +12,9 @@ rhsm-subscriptions:
           backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}
           backOffMultiplier: ${OPENSHIFT_BACK_OFF_MULTIPLIER:1.5}
           metricPromQL: >-
-            max(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) without(environment, region)*on(_id)
-            group_right(prometheus) group(subscription_labels{ebs_account='%s', support=~'Premium|Standard|Self-Support|None'})
-            by (_id,ebs_account, support, usage)
+            max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / 13.0) by (_id)
+            * on(_id) group_right
+            min_over_time(subscription_labels{ebs_account="%s", support=~"Premium|Standard|Self-Support|None"}[1h])
       client:
         token: ${PROM_AUTH_TOKEN:}
         url: ${PROM_URL:https://localhost/api/v1}

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -41,13 +41,15 @@ class MeteringEventFactoryTest {
         String clusterId = "my-cluster";
         String sla = "Premium";
         String usage = "Production";
-        OffsetDateTime measuredTime = OffsetDateTime.now();
+        OffsetDateTime expiry = OffsetDateTime.now();
+        OffsetDateTime measuredTime = expiry.minusHours(1);
         Double measuredValue = 23.0;
 
-        Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId, sla, usage, measuredTime,
-            measuredValue);
+        Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId, sla, usage,
+            measuredTime, expiry, measuredValue);
         assertEquals(account, event.getAccountNumber());
         assertEquals(measuredTime, event.getTimestamp());
+        assertEquals(expiry, event.getExpiration().get());
         assertEquals(clusterId, event.getInstanceId());
         assertEquals(Optional.of(clusterId), event.getDisplayName());
         assertEquals(Sla.PREMIUM, event.getSla());
@@ -64,35 +66,35 @@ class MeteringEventFactoryTest {
     @Test
     void testOpenShiftClusterCoresHandlesNullServiceLevel() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", null,
-            "Production", OffsetDateTime.now(), 12.5);
+            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresSlaSetToEmptyForSlaValueNone() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "None",
-            "Production", OffsetDateTime.now(), 12.5);
+            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertEquals(Sla.__EMPTY__, event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresInvalidSlaWillNotBeSetOnEvent() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "UNKNOWN_SLA",
-            "Production", OffsetDateTime.now(), 12.5);
+            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresInvalidUsageSetsNullValue() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "Premium",
-            "UNKNOWN_USAGE", OffsetDateTime.now(), 12.5);
+            "UNKNOWN_USAGE", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getUsage());
     }
 
     @Test
     void testOpenShiftClusterCoresHandlesNullUsage() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "Premium",
-            null, OffsetDateTime.now(), 12.5);
+            null, OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getUsage());
     }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -129,9 +129,11 @@ class PrometheusMeteringControllerTest {
 
         List<Event> expectedEvents = List.of(
             MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId, expectedSla,
-                expectedUsage, clock.dateFromUnix(time1), val1.doubleValue()),
+                expectedUsage, clock.dateFromUnix(time1).minusSeconds(props.getOpenshift().getStep()),
+                clock.dateFromUnix(time1), val1.doubleValue()),
             MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId, expectedSla,
-                expectedUsage, clock.dateFromUnix(time2), val2.doubleValue())
+                expectedUsage, clock.dateFromUnix(time2).minusSeconds(props.getOpenshift().getStep()),
+                clock.dateFromUnix(time2), val2.doubleValue())
         );
 
         controller.collectOpenshiftMetrics(expectedAccount, start, end);

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
@@ -29,14 +29,14 @@ import org.candlepin.subscriptions.prometheus.model.QueryResult;
 import org.candlepin.subscriptions.prometheus.resources.QueryApi;
 import org.candlepin.subscriptions.prometheus.resources.QueryRangeApi;
 
+import com.google.common.net.UrlEscapers;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.util.StringUtils;
 
-import java.net.URLEncoder;
 import java.time.OffsetDateTime;
 
 
@@ -57,7 +57,7 @@ class PrometheusServiceTest {
     void testGetOpenshiftMetrics() throws Exception {
 
         String expectedQuery =
-            URLEncoder.encode(StringUtils.trimAllWhitespace(props.getOpenshift().getMetricPromQL()), "UTF-8");
+            UrlEscapers.urlFragmentEscaper().escape(props.getOpenshift().getMetricPromQL());
         QueryResult expectedResult = new QueryResult();
 
         OffsetDateTime end = OffsetDateTime.now();

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -35,8 +35,11 @@ import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -45,6 +48,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.OffsetDateTime;
 import java.util.Collections;
 
 @SpringBootTest
@@ -54,6 +58,8 @@ class HostsResourceTest {
 
     static final Sort.Order IMPLICIT_ORDER = new Sort.Order(Sort.Direction.ASC, "id");
     private static final String SANITIZED_MISSING_DISPLAY_NAME = "";
+    private static final OffsetDateTime NULL_BEGINNING_ENDING_PARAM = null;
+
     @MockBean
     HostRepository repository;
     @MockBean
@@ -75,6 +81,7 @@ class HostsResourceTest {
     @SuppressWarnings("indentation")
     void testShouldMapDisplayNameAppropriately() {
         resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
             HostReportSort.DISPLAY_NAME, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
@@ -94,6 +101,7 @@ class HostsResourceTest {
     @Test
     void testShouldMapCoresAppropriately() {
         resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
             HostReportSort.CORES, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
@@ -114,6 +122,7 @@ class HostsResourceTest {
     @Test
     void testShouldMapSocketsAppropriately() {
         resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
             HostReportSort.SOCKETS, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
@@ -133,6 +142,7 @@ class HostsResourceTest {
     @Test
     void testShouldMapLastSeenAppropriately() {
         resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
             HostReportSort.LAST_SEEN, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
@@ -152,6 +162,7 @@ class HostsResourceTest {
     @Test
     void testShouldMapHardwareTypeAppropriately() {
         resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
             HostReportSort.HARDWARE_TYPE, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
@@ -170,7 +181,8 @@ class HostsResourceTest {
 
     @Test
     void testShouldDefaultToImplicitOrder() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null, null,
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM, null,
             SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
@@ -188,6 +200,7 @@ class HostsResourceTest {
     @Test
     void testShouldDefaultToAscending() {
         resource.getHosts(ProductId.RHEL, 0, 1, null, null, null, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
             HostReportSort.DISPLAY_NAME, null);
 
         verify(repository, only()).getTallyHostViews(
@@ -206,8 +219,9 @@ class HostsResourceTest {
 
     @Test
     void testShouldUseMinCoresWhenUomIsCores() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.CORES, null, null,
-            null);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.CORES, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
+            null, null);
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq(ProductId.RHEL.toString()),
@@ -222,8 +236,10 @@ class HostsResourceTest {
 
     @Test
     void testShouldUseMinSocketsWhenUomIsSockets() {
-        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.SOCKETS, null, null,
-            null);
+        resource.getHosts(ProductId.RHEL, 0, 1, null, null, Uom.SOCKETS, null,
+            NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
+            null, null);
+
         verify(repository, only()).getTallyHostViews(
             eq("account123456"),
             eq(ProductId.RHEL.toString()),
@@ -234,5 +250,24 @@ class HostsResourceTest {
             eq(1),
             eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
         );
+    }
+
+    @ParameterizedTest(name = "testInvalidBeginningAndEndingDates[{index}] {arguments}")
+    @CsvSource({
+        "2000-01-01T00:00:00Z, 1999-01-01T00:00:00Z",
+        "2021-02-01T00:00:00Z, 2021-03-01T00:00:00Z"
+    })
+    void testInvalidBeginningAndEndingDates(OffsetDateTime beginning, OffsetDateTime ending) {
+        Assertions.assertThrows(IllegalArgumentException.class,
+            () -> resource.validateBeginningAndEndingDates(beginning, ending));
+    }
+
+    @ParameterizedTest(name = "testValidBeginningAndEndingDates[{index}] {arguments}")
+    @CsvSource({
+        "2000-01-01T00:00:00Z, 2000-01-01T00:00:00Z",
+        "2000-01-01T00:00:00Z, 2000-01-31T00:00:00Z"
+    })
+    void testValidBeginningAndEndingDates(OffsetDateTime beginning, OffsetDateTime ending) {
+        Assertions.assertDoesNotThrow(() -> resource.validateBeginningAndEndingDates(beginning, ending));
     }
 }


### PR DESCRIPTION
Update host APIs for monthly core-hours

* Quick & dirty implementation for including month core-hours in the payload of GET /hosts.
* Added optional `beginning` and `ending` query parameters to the API.  These are ignored if the product_id isn't `OpenShift-dedicated-metrics` or `OpenShift-metrics`.
* When the product_id is one of these, validation is in place to make sure that `ending` doesn't come before `beginning`, and that `beginning` and `ending` are of the same month. There's a very strong assumption here that the UI is always going to pass the first timestamp of a month and the last timestamp of the same month.
* Also as a part of this PR, I introduced using JPA Specifications/Criteria to the `HostRepository` class.  This will be helpful/reused when we come back to do the hypervisor work, as well as refactoring to to use the Measurments.Uom/Value pattern in lieu of the now deprecated cores/sockets fields in the `Host` entity.  In the interest of time, I took the shortcut and introduced the `HostRepository.findAll(Specification, Pageable)` and `Host.asTallyHostViewApiHost` methods, and invoke those instead when the product_id is one of the designated types.

Testing - Prep Some Data
-------
1. Clear some data and then ensure opted in:

```sql
truncate table events;
truncate table tally_snapshots cascade;
truncate table hosts cascade;
insert into account_config(account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated) VALUES ('account123', true, true, 'DB', now(), now());
```

2. Insert some events:

```sql
insert into events(id, account_number, timestamp, data) values ('033a45b7-e8c4-440a-b0bb-76c3f3f67d85','account123', '2021-01-01T00:00Z', '{"account_number":"account123","timestamp":"2021-01-01T00:00:00Z","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d85","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}]}');
insert into events(id, account_number, timestamp, data) values ('a66ac2a1-17c0-4bc3-bc29-0430953d626c','account123', '2021-01-01T02:00Z', '{"account_number":"account123","timestamp":"2021-01-01T02:00:00Z","event_id":"a66ac2a1-17c0-4bc3-bc29-0430953d626c","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":2.0}]}');
insert into events(id, account_number, timestamp, data) values ('fad48795-ae0a-4674-b864-822ddfb799d0','account123', '2021-01-01T03:00Z', '{"account_number":"account123","timestamp":"2021-01-01T03:00:00Z","event_id":"fad48795-ae0a-4674-b864-822ddfb799d0","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}]}');
```

3. Invoke the hourly tally for the account:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-01-01T00:00:00Z","2021-01-01T23:59:59.999Z"]}'
```

4. Verify the host records contains 10 cores:

```sql
select * from instance_monthly_totals;
```

5. Insert a new event in the middle:

```sql
insert into events(id, account_number, timestamp, data) values ('c8e49ded-cd75-4016-8be7-3f795ff65645','account123', '2021-01-01T00:00Z', '{"account_number":"account123","timestamp":"2021-01-01T01:00:00Z","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d85","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":20.0}]}');
```

6. Retrigger the range containing only the new event

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-01-01T00:00:00Z","2021-01-01T02:00:00Z"]}'
```

7. Observe that the new monthly total contains 30 cores:

```sql
select * from instance_monthly_totals;
```

Testing - Call Hosts API
-------
1. Call the API with the OpenShift-metrics product and a valid beginning/ending date range
```bash
curl -X GET --location "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-metrics?beginning=2021-01-01T00:00:00.000Z&ending=2021-01-31T23:59:59.999Z" \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo"
```

2. Observe the response is populated correctly with `core_hours`
```json
{"data":[{"display_name":"4e8534b5-42b5-4f00-9969-29046e2b1986","sockets":0,"cores":4,"core_hours":30.0,"hardware_type":"PHYSICAL","measurement_type":"PHYSICAL","last_seen":"2020-12-31T22:00:00-05:00","is_unmapped_guest":false,"is_hypervisor":false}],"meta":{"count":1,"product":"OpenShift-metrics"}}
```