### PR TITLE
Add product profile for OpenShift metrics

### DIFF
--- a/src/main/resources/product_profile_registry.yaml
+++ b/src/main/resources/product_profile_registry.yaml
@@ -85,4 +85,16 @@ finestGranularity: DAILY
 burstable: false
 syspurposeRoles: []
 architectureProductMap: {}
-
+---
+name: OpenShift-metrics
+finestGranularity: HOURLY
+burstable: false
+productIds: []
+syspurposeRoles:
+  - name: ocp
+    products:
+      - OpenShift-metrics
+  - name: osd
+    products:
+      - OpenShift-dedicated-metrics
+architectureProductMap: {}


### PR DESCRIPTION
This is necessary to get the snapshot rollers to produce at HOURLY granularity.

Note I chose the names of the roles based on what is in the `subscription_labels` `product` label, which will allow us to populate `role` via product without transformation.