### PR TITLE
ENT-3586: OpenShiftMeteringJob now accounts for prometheus latency

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftJobProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftJobProfile.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.metering.profile;
 
+import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.jobs.JobProperties;
 import org.candlepin.subscriptions.metering.job.OpenShiftMeteringJob;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
@@ -55,8 +56,8 @@ public class OpenShiftJobProfile {
 
     @Bean
     OpenShiftMeteringJob openshiftMeteringJob(PrometheusMetricsTaskManager tasks, ApplicationClock clock,
-        PrometheusMetricsProperties metricProperties) {
-        return new OpenShiftMeteringJob(tasks, clock, metricProperties);
+        PrometheusMetricsProperties metricProperties, ApplicationProperties appProps) {
+        return new OpenShiftMeteringJob(tasks, clock, metricProperties, appProps);
     }
 
     @Bean


### PR DESCRIPTION
When the job is run, the range used for metrics gathering is now calculated
using the rhsm-subscriptions.prometheusLatencyDuration config property.

**TESTING**
```bash
PROMETHEUS_LATENCY_DURATION=4h RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_METRIC_OPENSHIFT_STEP=3600 RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_METRIC_OPENSHIFT_RANGE_IN_MINUTES=60 PROM_AUTH_TOKEN="$(echo $PROM_TOKEN)" PROM_URL="https://telemeter-lts.datahub.redhat.com/api/v1" ./gradlew clean bootRun --args="--spring.profiles.active=openshift-metering-job"
```

Check that the log message printed by the job shows the expected range.