### PR TITLE
ENT-3516: Add core_hours to Tally API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -687,6 +687,7 @@ components:
         - Satellite
         - Satellite Capsule
         - Satellite Server
+        - OpenShift-metrics
     Uom:
       type: string
       enum:
@@ -852,6 +853,11 @@ components:
         cores:
           type: integer
           format: int32
+          minimum: 0
+          default: 0
+        core_hours:
+          type: number
+          format: double
           minimum: 0
           default: 0
         sockets:

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.db.model;
 
 import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.json.Measurement.Uom;
 
 import java.io.Serializable;
 import java.time.OffsetDateTime;
@@ -271,6 +272,9 @@ public class TallySnapshot implements Serializable {
         snapshot.setCloudInstanceCount(cloudInstances);
         snapshot.setCloudCores(cloudCores);
         snapshot.setCloudSockets(cloudSockets);
+
+        snapshot.setCoreHours(tallyMeasurements.get(
+            new TallyMeasurementKey(HardwareMeasurementType.TOTAL, Uom.CORES)));
 
         snapshot.setHasData(id != null);
         return snapshot;

--- a/src/test/java/org/candlepin/subscriptions/db/model/TallySnapshotTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/TallySnapshotTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.subscriptions.json.Measurement.Uom;
+
+import org.junit.jupiter.api.Test;
+
+class TallySnapshotTest {
+
+    @Test
+    void testShouldIgnoreHbiAwsWhenCloudigradeAwsPresent() {
+        TallySnapshot snapshot = new TallySnapshot();
+        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
+        hbiMeasurement.setSockets(3);
+        hbiMeasurement.setInstanceCount(3);
+        HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
+        cloudigradeMeasurement.setSockets(7);
+        cloudigradeMeasurement.setInstanceCount(7);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, hbiMeasurement);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
+            .asApiSnapshot();
+
+        assertEquals(7, apiSnapshot.getCloudInstanceCount().intValue());
+        assertEquals(7, apiSnapshot.getCloudSockets().intValue());
+        assertTrue(apiSnapshot.getHasCloudigradeData());
+        assertTrue(apiSnapshot.getHasCloudigradeMismatch());
+    }
+
+    @Test
+    void testShouldNotFlagCloudigradeDataIfNotPresent() {
+        TallySnapshot snapshot = new TallySnapshot();
+        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
+        hbiMeasurement.setSockets(3);
+        hbiMeasurement.setInstanceCount(3);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, hbiMeasurement);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
+            .asApiSnapshot();
+
+        assertEquals(3, apiSnapshot.getCloudInstanceCount().intValue());
+        assertEquals(3, apiSnapshot.getCloudSockets().intValue());
+        assertFalse(apiSnapshot.getHasCloudigradeData());
+        assertFalse(apiSnapshot.getHasCloudigradeMismatch());
+    }
+
+    @Test
+    void testShouldNotFlagCloudigradeMismatchIfMatching() {
+        TallySnapshot snapshot = new TallySnapshot();
+        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
+        hbiMeasurement.setSockets(7);
+        hbiMeasurement.setInstanceCount(7);
+        HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
+        cloudigradeMeasurement.setSockets(7);
+        cloudigradeMeasurement.setInstanceCount(7);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, hbiMeasurement);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
+            .asApiSnapshot();
+
+        assertEquals(7, apiSnapshot.getCloudInstanceCount().intValue());
+        assertEquals(7, apiSnapshot.getCloudSockets().intValue());
+        assertTrue(apiSnapshot.getHasCloudigradeData());
+        assertFalse(apiSnapshot.getHasCloudigradeMismatch());
+    }
+
+    @Test
+    void testShouldTolerateAccountWithOnlyCloudigrade() {
+        TallySnapshot snapshot = new TallySnapshot();
+        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
+        hbiMeasurement.setSockets(7);
+        hbiMeasurement.setInstanceCount(7);
+        HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
+        cloudigradeMeasurement.setSockets(7);
+        cloudigradeMeasurement.setInstanceCount(7);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot =
+            snapshot.asApiSnapshot();
+
+        assertEquals(7, apiSnapshot.getCloudInstanceCount().intValue());
+        assertEquals(7, apiSnapshot.getCloudSockets().intValue());
+        assertTrue(apiSnapshot.getHasCloudigradeData());
+        assertFalse(apiSnapshot.getHasCloudigradeMismatch());
+    }
+
+    @Test
+    void testShouldAddHypervisorAndVirtual() {
+        TallySnapshot snapshot = new TallySnapshot();
+        HardwareMeasurement hypervisorMeasurement = new HardwareMeasurement();
+        hypervisorMeasurement.setSockets(30);
+        hypervisorMeasurement.setInstanceCount(3);
+        HardwareMeasurement virtualMeasurement = new HardwareMeasurement();
+        virtualMeasurement.setSockets(70);
+        virtualMeasurement.setInstanceCount(7);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.HYPERVISOR, hypervisorMeasurement);
+        snapshot.setHardwareMeasurement(HardwareMeasurementType.VIRTUAL, virtualMeasurement);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot =
+            snapshot.asApiSnapshot();
+
+        assertEquals(10, apiSnapshot.getHypervisorInstanceCount().intValue());
+        assertEquals(100, apiSnapshot.getHypervisorSockets().intValue());
+    }
+
+    @Test
+    void shouldAddCoreHoursWhenCreatingApiSnapshot() {
+        Double expCoreHours = 22.2;
+        TallySnapshot snapshot = new TallySnapshot();
+        snapshot.setMeasurement(HardwareMeasurementType.TOTAL, Uom.CORES, expCoreHours);
+
+        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot =
+            snapshot.asApiSnapshot();
+        assertEquals(expCoreHours, apiSnapshot.getCoreHours());
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -26,8 +26,6 @@ import static org.mockito.Mockito.*;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
-import org.candlepin.subscriptions.db.model.HardwareMeasurement;
-import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.db.model.Usage;
@@ -383,104 +381,6 @@ public class TallyResourceTest {
     }
 
     @Test
-    void testShouldIgnoreHbiAwsWhenCloudigradeAwsPresent() {
-        TallySnapshot snapshot = new TallySnapshot();
-        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
-        hbiMeasurement.setSockets(3);
-        hbiMeasurement.setInstanceCount(3);
-        HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
-        cloudigradeMeasurement.setSockets(7);
-        cloudigradeMeasurement.setInstanceCount(7);
-        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, hbiMeasurement);
-        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
-
-        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
-            .asApiSnapshot();
-
-        assertEquals(7, apiSnapshot.getCloudInstanceCount().intValue());
-        assertEquals(7, apiSnapshot.getCloudSockets().intValue());
-        assertTrue(apiSnapshot.getHasCloudigradeData());
-        assertTrue(apiSnapshot.getHasCloudigradeMismatch());
-    }
-
-    @Test
-    void testShouldNotFlagCloudigradeDataIfNotPresent() {
-        TallySnapshot snapshot = new TallySnapshot();
-        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
-        hbiMeasurement.setSockets(3);
-        hbiMeasurement.setInstanceCount(3);
-        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, hbiMeasurement);
-
-        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
-            .asApiSnapshot();
-
-        assertEquals(3, apiSnapshot.getCloudInstanceCount().intValue());
-        assertEquals(3, apiSnapshot.getCloudSockets().intValue());
-        assertFalse(apiSnapshot.getHasCloudigradeData());
-        assertFalse(apiSnapshot.getHasCloudigradeMismatch());
-    }
-
-    @Test
-    void testShouldNotFlagCloudigradeMismatchIfMatching() {
-        TallySnapshot snapshot = new TallySnapshot();
-        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
-        hbiMeasurement.setSockets(7);
-        hbiMeasurement.setInstanceCount(7);
-        HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
-        cloudigradeMeasurement.setSockets(7);
-        cloudigradeMeasurement.setInstanceCount(7);
-        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, hbiMeasurement);
-        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
-
-        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
-            .asApiSnapshot();
-
-        assertEquals(7, apiSnapshot.getCloudInstanceCount().intValue());
-        assertEquals(7, apiSnapshot.getCloudSockets().intValue());
-        assertTrue(apiSnapshot.getHasCloudigradeData());
-        assertFalse(apiSnapshot.getHasCloudigradeMismatch());
-    }
-
-    @Test
-    void testShouldTolerateAccountWithOnlyCloudigrade() {
-        TallySnapshot snapshot = new TallySnapshot();
-        HardwareMeasurement hbiMeasurement = new HardwareMeasurement();
-        hbiMeasurement.setSockets(7);
-        hbiMeasurement.setInstanceCount(7);
-        HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
-        cloudigradeMeasurement.setSockets(7);
-        cloudigradeMeasurement.setInstanceCount(7);
-        snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
-
-        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
-            .asApiSnapshot();
-
-        assertEquals(7, apiSnapshot.getCloudInstanceCount().intValue());
-        assertEquals(7, apiSnapshot.getCloudSockets().intValue());
-        assertTrue(apiSnapshot.getHasCloudigradeData());
-        assertFalse(apiSnapshot.getHasCloudigradeMismatch());
-    }
-
-    @Test
-    void testShouldAddHypervisorAndVirtual() {
-        TallySnapshot snapshot = new TallySnapshot();
-        HardwareMeasurement hypervisorMeasurement = new HardwareMeasurement();
-        hypervisorMeasurement.setSockets(30);
-        hypervisorMeasurement.setInstanceCount(3);
-        HardwareMeasurement virtualMeasurement = new HardwareMeasurement();
-        virtualMeasurement.setSockets(70);
-        virtualMeasurement.setInstanceCount(7);
-        snapshot.setHardwareMeasurement(HardwareMeasurementType.HYPERVISOR, hypervisorMeasurement);
-        snapshot.setHardwareMeasurement(HardwareMeasurementType.VIRTUAL, virtualMeasurement);
-
-        org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot = snapshot
-            .asApiSnapshot();
-
-        assertEquals(10, apiSnapshot.getHypervisorInstanceCount().intValue());
-        assertEquals(100, apiSnapshot.getHypervisorSockets().intValue());
-    }
-
-    @Test
     public void testShouldThrowExceptionOnBadOffset() throws IOException {
         SubscriptionsException e = assertThrows(SubscriptionsException.class, () -> resource.getTallyReport(
             RHEL_PRODUCT_ID,
@@ -531,6 +431,7 @@ public class TallyResourceTest {
         assertEquals(0, snapshot.getCloudInstanceCount().intValue());
         assertEquals(0, snapshot.getCloudCores().intValue());
         assertEquals(0, snapshot.getCloudSockets().intValue());
+        assertEquals(0.0, snapshot.getCoreHours());
     }
 
     @Test


### PR DESCRIPTION
TASK: https://issues.redhat.com/browse/ENT-3516

Also moved some TallySnapshot model tests out
of the resource test and into its own test class.

## Testing

**NOTE:** I noticed in the results that the snapshot report filler is not properly setting the snapshot dates on 'dummy' snapshot records. I will create a new card to get this regression addressed.

To test, insert some events into the DB with this SQL:
Run the app:

```bash
$ DEV_MODE=true ./gradlew clean bootRun
```

Insert the following records:
```sql
insert into events(id, account_number, timestamp, data) values ('033a45b7-e8c4-440a-b0bb-76c3f3f67d85','account123', '2021-01-01T00:00Z', '{"account_number":"account123","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d85","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}]}');
insert into events(id, account_number, timestamp, data) values ('a66ac2a1-17c0-4bc3-bc29-0430953d626c','account123', '2021-01-01T01:00Z', '{"account_number":"account123","event_id":"a66ac2a1-17c0-4bc3-bc29-0430953d626c","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":2.0}]}');
insert into events(id, account_number, timestamp, data) values ('fad48795-ae0a-4674-b864-822ddfb799d0','account123', '2021-01-01T02:00Z', '{"account_number":"account123","event_id":"fad48795-ae0a-4674-b864-822ddfb799d0","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}]}');
```

Generate hourly snapshots:

http://localhost:8080/actuator/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-TallyJmxBean-tallyJmxBean
method: tallyAccountByHourly(String, String, String), account: account123, startDateTime: 2021-01-01T00:00:00Z, endDateTime: 2021-01-01T12:00:00Z

Ensure that you have opted in ( account: account123  org: 123456) and hit the tally API:
```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics?granularity=hourly&beginning=2021-01-01T00:00:00.000Z&ending=2021-01-01T02:00:00Z" | python -mjson.tool

{
    "data": [
        {
            "date": "2020-12-31T20:00:00-04:00",
            "instance_count": 0,
            "cores": 0,
            "core_hours": 4.0,
            "sockets": 0,
            "physical_instance_count": 0,
            "physical_cores": 0,
            "physical_sockets": 0,
            "hypervisor_instance_count": 0,
            "hypervisor_cores": 0,
            "hypervisor_sockets": 0,
            "cloud_instance_count": 0,
            "cloud_cores": 0,
            "cloud_sockets": 0,
            "has_data": true,
            "has_cloudigrade_data": false,
            "has_cloudigrade_mismatch": false
        },
        {
            "date": "2020-12-31T21:00:00-04:00",
            "instance_count": 0,
            "cores": 0,
            "core_hours": 2.0,
            "sockets": 0,
            "physical_instance_count": 0,
            "physical_cores": 0,
            "physical_sockets": 0,
            "hypervisor_instance_count": 0,
            "hypervisor_cores": 0,
            "hypervisor_sockets": 0,
            "cloud_instance_count": 0,
            "cloud_cores": 0,
            "cloud_sockets": 0,
            "has_data": true,
            "has_cloudigrade_data": false,
            "has_cloudigrade_mismatch": false
        },
        {
            "date": "2020-12-31T22:00:00-04:00",
            "instance_count": 0,
            "cores": 0,
            "core_hours": 4.0,
            "sockets": 0,
            "physical_instance_count": 0,
            "physical_cores": 0,
            "physical_sockets": 0,
            "hypervisor_instance_count": 0,
            "hypervisor_cores": 0,
            "hypervisor_sockets": 0,
            "cloud_instance_count": 0,
            "cloud_cores": 0,
            "cloud_sockets": 0,
            "has_data": true,
            "has_cloudigrade_data": false,
            "has_cloudigrade_mismatch": false
        }
    ],
    "meta": {
        "count": 3,
        "product": "OpenShift-metrics",
        "granularity": "Hourly"
    }
}

```