### PR TITLE
Bug Fix: Properly set hypervisor instance counts in snapshot API model

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -231,12 +231,12 @@ public class TallySnapshot implements Serializable {
         if (virtual != null) {
             totalVirtualCores += virtual.getCores();
             totalVirtualSockets += virtual.getSockets();
-            totalVirtualInstanceCount += virtual.getSockets();
+            totalVirtualInstanceCount += virtual.getInstanceCount();
         }
         if (hypervisor != null) {
             totalVirtualCores += hypervisor.getCores();
             totalVirtualSockets += hypervisor.getSockets();
-            totalVirtualInstanceCount += hypervisor.getSockets();
+            totalVirtualInstanceCount += hypervisor.getInstanceCount();
         }
         if (hypervisor != null || virtual != null) {
             snapshot.setHypervisorCores(totalVirtualCores);

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -465,10 +465,10 @@ public class TallyResourceTest {
     void testShouldAddHypervisorAndVirtual() {
         TallySnapshot snapshot = new TallySnapshot();
         HardwareMeasurement hypervisorMeasurement = new HardwareMeasurement();
-        hypervisorMeasurement.setSockets(3);
+        hypervisorMeasurement.setSockets(30);
         hypervisorMeasurement.setInstanceCount(3);
         HardwareMeasurement virtualMeasurement = new HardwareMeasurement();
-        virtualMeasurement.setSockets(7);
+        virtualMeasurement.setSockets(70);
         virtualMeasurement.setInstanceCount(7);
         snapshot.setHardwareMeasurement(HardwareMeasurementType.HYPERVISOR, hypervisorMeasurement);
         snapshot.setHardwareMeasurement(HardwareMeasurementType.VIRTUAL, virtualMeasurement);
@@ -477,7 +477,7 @@ public class TallyResourceTest {
             .asApiSnapshot();
 
         assertEquals(10, apiSnapshot.getHypervisorInstanceCount().intValue());
-        assertEquals(10, apiSnapshot.getHypervisorSockets().intValue());
+        assertEquals(100, apiSnapshot.getHypervisorSockets().intValue());
     }
 
     @Test


### PR DESCRIPTION
Found this issue while reading through some code. Fixed the issue and strengthened the unit test.