### PR TITLE
Retain a year's worth of daily snapshots

### DIFF
--- a/src/main/resources/application-purge-snapshots.yaml
+++ b/src/main/resources/application-purge-snapshots.yaml
@@ -1,8 +1,18 @@
 rhsm-subscriptions:
   tally-retention-policy:
+    # 70 days worth
     hourly: ${TALLY_RETENTION_HOURLY:1680}
-    daily: ${TALLY_RETENTION_DAILY:37}
+
+    # A year and change
+    daily: ${TALLY_RETENTION_DAILY:370}
+
+    # Roughly 3 months worth
     weekly: ${TALLY_RETENTION_WEEKLY:12}
+
+    # A year's worth
     monthly: ${TALLY_RETENTION_MONTHLY:12}
+
+    # Four year's worth
     quarterly: ${TALLY_RETENTION_QUARTERLY:16}
+
     yearly: ${TALLY_RETENTION_YEARLY:5}


### PR DESCRIPTION
Because of leap year, we would have needed to do at least 366, but I
like round numbers so I went with 370.  A little buffer might be helpful
anyway.