### PR TITLE
ENT-3587: Properly create/update events when processing OpenShift metrics

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
  * @see EventRecord
  * @see org.candlepin.subscriptions.json.Event
  */
+@SuppressWarnings({"linelength", "indentation"})
 public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> {
 
     /**
@@ -52,4 +53,23 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
      */
     Stream<EventRecord> findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
         String accountNumber, OffsetDateTime begin, OffsetDateTime end);
+
+    /**
+     * Fetch a stream of events for a given account, event type and event source for a given time range.
+     *
+     * The events returned include those at begin and up to (but not including) end.
+     *
+     * NOTE: this query does not use `between` since between semantics are inclusive. e.g. `select * from
+     * events where timestamp between '2021-01-01T00:00:00Z' and '2021-01-01T01:00:00Z` would match events
+     * at midnight UTC and 1am UTC.
+     *
+     * @param accountNumber account number
+     * @param eventSource event source
+     * @param eventType event type
+     * @param begin start of the time range (inclusive)
+     * @param end end of the time range (exclusive)
+     * @return Stream of EventRecords
+     */
+    Stream<EventRecord> findByAccountNumberAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+        String accountNumber, String eventSource, String eventType, OffsetDateTime begin, OffsetDateTime end);
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/EventKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/EventKey.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import org.candlepin.subscriptions.json.Event;
+
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+/**
+ * Defines the unique constraints for an EventRecord. This object is primarily used for creating
+ * lookup tables while processing Events pulled from the DB.
+ */
+@Getter
+public class EventKey {
+
+    private String accountNumber;
+    private String eventType;
+    private String eventSource;
+    private String instanceId;
+    private OffsetDateTime timestamp;
+
+    public EventKey(String accountNumber, String eventSource, String eventType, String instanceId,
+        OffsetDateTime timestamp) {
+        Objects.requireNonNull(accountNumber, "EventKey requires a non null 'accountNumber'.");
+        this.accountNumber = accountNumber;
+
+        Objects.requireNonNull(eventType, "EventKey requires a non null 'eventType'.");
+        this.eventType = eventType;
+
+        Objects.requireNonNull(eventSource, "EventKey requires a non null 'eventSource'.");
+        this.eventSource = eventSource;
+
+        Objects.requireNonNull(instanceId, "EventKey requires a non null 'instanceId'.");
+        this.instanceId = instanceId;
+
+        Objects.requireNonNull(timestamp, "EventKey requires a non null 'timestamp'.");
+        this.timestamp = timestamp;
+    }
+
+    public static EventKey fromEvent(Event event) {
+        return new EventKey(event.getAccountNumber(), event.getEventSource(), event.getEventType(),
+            event.getInstanceId(), event.getTimestamp());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EventKey eventKey = (EventKey) o;
+        return Objects.equals(accountNumber, eventKey.accountNumber) &&
+            Objects.equals(eventType, eventKey.eventType) &&
+            Objects.equals(eventSource, eventKey.eventSource) &&
+            Objects.equals(instanceId, eventKey.instanceId) &&
+            Objects.equals(timestamp, eventKey.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountNumber, eventType, eventSource, instanceId, timestamp);
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
@@ -63,6 +63,9 @@ public class EventRecord {
         this.id = event.getEventId();
         this.event = event;
         this.accountNumber = event.getAccountNumber();
+        this.eventType = event.getEventType();
+        this.eventSource = event.getEventSource();
+        this.instanceId = event.getInstanceId();
         this.timestamp = event.getTimestamp();
     }
 
@@ -71,6 +74,15 @@ public class EventRecord {
 
     @Column(name = "account_number")
     private String accountNumber;
+
+    @Column(name = "event_type")
+    private String eventType;
+
+    @Column(name = "event_source")
+    private String eventSource;
+
+    @Column(name = "instance_id")
+    private String instanceId;
 
     private OffsetDateTime timestamp;
 
@@ -95,6 +107,22 @@ public class EventRecord {
         this.accountNumber = accountNumber;
     }
 
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getEventSource() {
+        return eventSource;
+    }
+
+    public void setEventSource(String eventSource) {
+        this.eventSource = eventSource;
+    }
+
     public OffsetDateTime getTimestamp() {
         return timestamp;
     }
@@ -116,16 +144,19 @@ public class EventRecord {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof EventRecord)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
         EventRecord that = (EventRecord) o;
-        return Objects.equals(id, that.id) && Objects.equals(event, that.event);
+        return Objects.equals(accountNumber, that.accountNumber) &&
+            Objects.equals(eventType, that.eventType) &&
+            Objects.equals(eventSource, that.eventSource) &&
+            Objects.equals(instanceId, that.instanceId) &&
+            Objects.equals(timestamp, that.timestamp);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, event);
+        return Objects.hash(accountNumber, eventType, eventSource, instanceId, timestamp);
     }
-
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -62,7 +62,17 @@ public class MeteringEventFactory {
      */
     public static Event openShiftClusterCores(String accountNumber, String clusterId, String serviceLevel,
         String usage, OffsetDateTime measuredTime, OffsetDateTime expired, Double measuredValue) {
-        return new Event()
+        Event event = new Event();
+        updateOpenShiftClusterCores(event, accountNumber, clusterId, serviceLevel, usage,
+            measuredTime, expired, measuredValue);
+        return event;
+    }
+
+    @SuppressWarnings("java:S107")
+    public static void updateOpenShiftClusterCores(Event toUpdate, String accountNumber, String clusterId,
+        String serviceLevel, String usage, OffsetDateTime measuredTime, OffsetDateTime expired,
+        Double measuredValue) {
+        toUpdate
             .withEventSource(OPENSHIFT_CLUSTER_EVENT_SOURCE)
             .withEventType(OPENSHIFT_CLUSTER_EVENT_TYPE)
             .withServiceType(OPENSHIFT_CLUSTER_SERVICE_TYPE)

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
@@ -70,11 +70,6 @@ public class MetricProperties {
      */
     private double backOffMultiplier = 2;
 
-    /**
-     * Batch size to use while persisting events.
-     */
-    private int eventBatchSize = 1000;
-
     public String getMetricPromQL() {
         return metricPromQL;
     }
@@ -137,14 +132,6 @@ public class MetricProperties {
 
     public void setBackOffMultiplier(double backOffMultiplier) {
         this.backOffMultiplier = backOffMultiplier;
-    }
-
-    public int getEventBatchSize() {
-        return eventBatchSize;
-    }
-
-    public void setEventBatchSize(int eventBatchSize) {
-        this.eventBatchSize = eventBatchSize;
     }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus;
 
+import org.candlepin.subscriptions.db.model.EventKey;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.metering.MeteringEventFactory;
@@ -40,7 +41,8 @@ import io.micrometer.core.annotation.Timed;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
-import java.util.LinkedList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -77,6 +79,10 @@ public class PrometheusMeteringController {
     @Transactional
     public void collectOpenshiftMetrics(String account, OffsetDateTime start, OffsetDateTime end) {
         MetricProperties openshiftProperties = metricProperties.getOpenshift();
+        // Reset the start/end dates to ensure they span a complete hour.
+        // NOTE: If the prometheus query step changes, we will need to adjust this.
+        OffsetDateTime startDate = clock.startOfHour(start);
+        OffsetDateTime endDate = clock.endOfHour(end);
         openshiftRetry.execute(context -> {
             try {
                 log.info("Collecting OpenShift metrics");
@@ -85,10 +91,8 @@ public class PrometheusMeteringController {
                     // Substitute the account number into the query. The query is expected to
                     // contain %s for replacement.
                     String.format(openshiftProperties.getMetricPromQL(), account),
-                    // Reset the start/end dates to ensure they span a complete hour.
-                    // NOTE: If the prometheus query step changes, we will need to adjust this.
-                    clock.startOfHour(start),
-                    clock.endOfHour(end),
+                    startDate,
+                    endDate,
                     openshiftProperties.getStep(),
                     openshiftProperties.getQueryTimeout()
                 );
@@ -99,10 +103,16 @@ public class PrometheusMeteringController {
                     );
                 }
 
-                // Given the possibility of a very large number of events, we will batch persist them
-                // to provide the ability to tweak them.
-                List<Event> events = new LinkedList<>();
-                int eventCount = 0;
+                Map<EventKey, Event> existing = eventController.mapEventsInTimeRange(
+                    account,
+                    MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_SOURCE,
+                    MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_TYPE,
+                    startDate,
+                    endDate
+                );
+                log.debug("Found {} existing events.", existing.size());
+
+                Map<EventKey, Event> events = new HashMap<>();
                 for (QueryResultDataResult r : metricData.getData().getResult()) {
                     Map<String, String> labels = r.getMetric();
                     String clusterId = labels.get("_id");
@@ -123,25 +133,17 @@ public class PrometheusMeteringController {
                         OffsetDateTime eventDate =
                             eventTermDate.minusSeconds(metricProperties.getOpenshift().getStep());
 
-                        Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId,
-                            sla, usage, eventDate, eventTermDate, value.doubleValue());
-                        events.add(event);
-                        eventCount++;
-
-                        if (events.size() >= openshiftProperties.getEventBatchSize()) {
-                            log.info("Saving {} events", events.size());
-                            eventController.saveAll(events);
-                            events.clear();
-                        }
+                        Event event = createOrUpdateEvent(existing, account, clusterId, sla, usage,
+                            eventDate, eventTermDate, value);
+                        events.put(EventKey.fromEvent(event), event);
                     }
                 }
 
-                // Flush the remainder
-                if (!events.isEmpty()) {
-                    log.debug("Saving remaining events: {}", events.size());
-                    eventController.saveAll(events);
-                }
-                log.info("Created {} Events for OpenShift metrics.", eventCount);
+                eventController.saveAll(events.values());
+                log.info("Persisted {} events for OpenShift metrics.", events.size());
+
+                // Delete any stale events found during the period.
+                deleteStaleEvents(existing.values());
                 return null;
             }
             catch (Exception e) {
@@ -152,4 +154,30 @@ public class PrometheusMeteringController {
         });
     }
 
+    @SuppressWarnings("java:S107")
+    private Event createOrUpdateEvent(Map<EventKey, Event> existing, String account, String instanceId,
+        String sla, String usage, OffsetDateTime measuredDate, OffsetDateTime expired, BigDecimal value) {
+        EventKey lookupKey = new EventKey(
+            account,
+            MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_SOURCE,
+            MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_TYPE,
+            instanceId,
+            measuredDate
+        );
+
+        Event event = existing.remove(lookupKey);
+        if (event == null) {
+            event = new Event();
+        }
+        MeteringEventFactory.updateOpenShiftClusterCores(event, account, instanceId, sla, usage,
+            measuredDate, expired, value.doubleValue());
+        return event;
+    }
+
+    private void deleteStaleEvents(Collection<Event> toDelete) {
+        if (!toDelete.isEmpty()) {
+            log.info("Deleting {} stale OpenShift metric events.", toDelete.size());
+            eventController.deleteEvents(toDelete);
+        }
+    }
 }

--- a/src/main/resources/liquibase/202102251446-add-constraints-indexes-fields-to-events.xml
+++ b/src/main/resources/liquibase/202102251446-add-constraints-indexes-fields-to-events.xml
@@ -1,0 +1,32 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="202102251446-1" author="awood">
+        <comment>
+            These columns will store data extracted from the JSON in the data column. With
+            Postgresql, we could apply the unique constraint and indexes below using JSON operator
+            expressions but that does not work in HSQLDB.
+        </comment>
+        <addColumn tableName="events">
+            <column name="event_type" type="VARCHAR(60)"/>
+            <column name="event_source" type="VARCHAR(60)"/>
+            <column name="instance_id" type="VARCHAR(60)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="202102251446-2" author="awood">
+        <comment>Prevent duplicate event records from being created</comment>
+        <addUniqueConstraint tableName="events"
+            columnNames="event_type, event_source, instance_id, account_number, timestamp"/>
+    </changeSet>
+
+    <changeSet id="202102251446-3" author="awood">
+        <createIndex tableName="events" indexName="events_event_type_idx">
+            <column name="account_number"/>
+            <column name="event_type"/>
+            <column name="timestamp"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -42,5 +42,6 @@
     <include file="liquibase/202101291558-modify-hosts-for-non-hbi-sources.xml" />
     <include file="liquibase/202102260917-add-instance-monthly-totals.xml" />
     <include file="liquibase/202103031601-modify-hosts-instance-id-not-null.xml" />
+    <include file="liquibase/202102251446-add-constraints-indexes-fields-to-events.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/model/EventKeyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/EventKeyTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.json.Event;
+import org.candlepin.subscriptions.util.ApplicationClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+class EventKeyTest {
+
+    private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+
+    @Test
+    void testLookup() {
+        Event e1 = eventForInstanceId("instance1");
+        Event e2 = eventForInstanceId("instance2");
+        Event e3 = eventForInstanceId("instance3");
+
+        Map<EventKey, Event> eventMap = Stream.of(e1, e2, e3)
+            .collect(Collectors.toMap(EventKey::fromEvent, Function.identity()));
+
+        assertEquals(e1, eventMap.get(keyForInstanceId("instance1")));
+        assertEquals(e2, eventMap.get(keyForInstanceId("instance2")));
+        assertEquals(e3, eventMap.get(keyForInstanceId("instance3")));
+    }
+
+    @Test
+    void testEquality() {
+        EventKey ek1 = new EventKey("account", "source", "type", "instance", clock.now());
+        EventKey ek2 = new EventKey("account", "source", "type", "instance", clock.now());
+        EventKey ek3 = new EventKey("account3", "source3", "type3", "instance3", clock.now().minusDays(1));
+
+        assertEquals(ek1, ek2);
+        assertNotEquals(ek1, ek3);
+    }
+
+    private EventKey keyForInstanceId(String instanceId) {
+        return new EventKey("account", "source", "type", instanceId, clock.now());
+    }
+
+    private Event eventForInstanceId(String instanceId) {
+        return new Event()
+            .withAccountNumber("account")
+            .withEventType("type")
+            .withEventSource("source")
+            .withInstanceId(instanceId)
+            .withTimestamp(clock.now());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -21,14 +21,17 @@
 package org.candlepin.subscriptions.metering.service.prometheus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.EventKey;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.metering.MeteringEventFactory;
@@ -40,6 +43,7 @@ import org.candlepin.subscriptions.prometheus.model.StatusType;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -47,8 +51,10 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
-import java.util.LinkedList;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 @SpringBootTest
@@ -136,37 +142,97 @@ class PrometheusMeteringControllerTest {
                 clock.dateFromUnix(time2), val2.doubleValue())
         );
 
+        ArgumentCaptor<Collection> saveCaptor = ArgumentCaptor.forClass(Collection.class);
+        doNothing().when(eventController).saveAll(saveCaptor.capture());
+
         controller.collectOpenshiftMetrics(expectedAccount, start, end);
 
         verify(service).runRangeQuery(
             String.format(props.getOpenshift().getMetricPromQL(), expectedAccount),
             start, end, props.getOpenshift().getStep(),
             props.getOpenshift().getQueryTimeout());
-        verify(eventController).saveAll(expectedEvents);
+        verify(eventController).saveAll(any());
+
+        // Attempted to verify the eventController.saveAll(events) but
+        // couldn't find a way to get mockito to match on the collection
+        // of HashMap.Value. Using a capture works just as well, but is a less convenient.
+        assertEquals(expectedEvents.size(), saveCaptor.getValue().size());
+        assertTrue(saveCaptor.getValue().containsAll(expectedEvents));
     }
 
     @Test
-    void verifyOpenShiftEventsAreBatchedWhileBeingPersisted() throws Exception {
-        OffsetDateTime end = clock.now();
-        OffsetDateTime start = end.minusDays(2);
+    void verifyExistingEventsAreUpdatedWhenReportedByPrometheusAndDeletedIfStale() {
+        BigDecimal time1 = BigDecimal.valueOf(123456.234);
+        BigDecimal val1 = BigDecimal.valueOf(100L);
+        BigDecimal time2 = BigDecimal.valueOf(222222.222);
+        BigDecimal val2 = BigDecimal.valueOf(120L);
 
-        props.getOpenshift().setEventBatchSize(5);
-        // Create enough events to persist 2 times the batch size events, plus 2 to trigger
-        // an extra flush at the end.
-        List<List<BigDecimal>> recordedMetrics = new LinkedList<>();
-        for (int i = 0; i < props.getOpenshift().getEventBatchSize() * 2 + 2; i++) {
-            recordedMetrics.add(List.of(new BigDecimal(111111.111), new BigDecimal(12)));
-        }
-        assertEquals(12, recordedMetrics.size());
+        QueryResult data = buildOpenShiftClusterQueryResult(expectedAccount, expectedClusterId, expectedSla,
+            expectedUsage, List.of(List.of(time1, val1), List.of(time2, val2)));
+        when(service.runRangeQuery(
+            eq(String.format(props.getOpenshift().getMetricPromQL(), expectedAccount)),
+            any(), any(), any(), any())).thenReturn(data);
 
-        QueryResult data = buildOpenShiftClusterQueryResult("my-account", "my-cluster", expectedSla,
-            expectedUsage, recordedMetrics);
-        when(service.runRangeQuery(eq(String.format(props.getOpenshift().getMetricPromQL(),
-            expectedAccount)), any(), any(), any(), any())).thenReturn(data);
+        OffsetDateTime start = clock.startOfCurrentHour();
+        OffsetDateTime end = clock.endOfHour(start.plusDays(1));
+
+        Event updatedEvent = MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId,
+            expectedSla, expectedUsage,
+            clock.dateFromUnix(time1).minusSeconds(props.getOpenshift().getStep()),
+            clock.dateFromUnix(time1),
+            val1.doubleValue());
+
+        List<Event> expectedEvents = List.of(updatedEvent,
+            MeteringEventFactory.openShiftClusterCores(expectedAccount,
+            expectedClusterId, expectedSla, expectedUsage,
+            clock.dateFromUnix(time2).minusSeconds(props.getOpenshift().getStep()),
+            clock.dateFromUnix(time2), val2.doubleValue()));
+
+        Event purgedEvent = MeteringEventFactory.openShiftClusterCores(expectedAccount,
+            "CLUSTER_NO_LONGER_EXISTS", expectedSla, expectedUsage,
+            clock.dateFromUnix(time1).minusSeconds(props.getOpenshift().getStep()),
+            clock.dateFromUnix(time1), val1.doubleValue());
+
+        List<Event> existingEvents = List.of(
+            // This event will get updated by the incoming data from prometheus.
+            MeteringEventFactory.openShiftClusterCores(expectedAccount,
+            expectedClusterId, expectedSla, expectedUsage, updatedEvent.getTimestamp(),
+            updatedEvent.getExpiration().get(), 144.4),
+            // This event should get purged because prometheus did not report this cluster.
+            purgedEvent
+        );
+        when(eventController.mapEventsInTimeRange(expectedAccount,
+            MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_SOURCE,
+            MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_TYPE,
+            start,
+            end
+        ))
+            .thenReturn(existingEvents.stream().collect(Collectors.toMap(
+            EventKey::fromEvent, Function.identity())));
+
+        ArgumentCaptor<Collection> saveCaptor = ArgumentCaptor.forClass(Collection.class);
+        doNothing().when(eventController).saveAll(saveCaptor.capture());
+
+        ArgumentCaptor<Collection> purgeCaptor = ArgumentCaptor.forClass(Collection.class);
+        doNothing().when(eventController).deleteEvents(purgeCaptor.capture());
 
         controller.collectOpenshiftMetrics(expectedAccount, start, end);
 
-        verify(eventController, times(3)).saveAll(any());
+        verify(service).runRangeQuery(
+            String.format(props.getOpenshift().getMetricPromQL(), expectedAccount),
+            start, end, props.getOpenshift().getStep(),
+            props.getOpenshift().getQueryTimeout());
+        verify(eventController).saveAll(any());
+        verify(eventController).deleteEvents(any());
+
+        // Attempted to verify the eventController calls below, but
+        // couldn't find a way to get mockito to match on collection of HashMap.Value.
+        // Using a capture works just as well, but is a less convenient.
+        assertEquals(expectedEvents.size(), saveCaptor.getValue().size());
+        assertTrue(saveCaptor.getValue().containsAll(expectedEvents));
+
+        assertEquals(1, purgeCaptor.getValue().size());
+        assertTrue(purgeCaptor.getValue().contains(purgedEvent));
     }
 
     private QueryResult buildOpenShiftClusterQueryResult(String account, String clusterId, String sla,


### PR DESCRIPTION
When metric data is being processed, update existing events and
delete any that are stale from a previous run. If the metering
process is re-run then event data should be in sync afterwards.

Prior to this change, duplicate events would be created as if
the metering process was run twice.

https://issues.redhat.com/browse/ENT-3587

**NOTE:** I've merged the required database changes from #318 into this branch so they can be merged together.

**TESTING**

1) See https://docs.engineering.redhat.com/display/ENT/Prometheus+Metrics for getting an auth token for thanos. I like to export it into a variable so my startup command remains the same.
```bash
export PROM_TOKEN=<YOUR_TOKEN_FROM_ABOVE>
```

2) After getting your token, deploy the app. Using  a step of 300 will create way more events for the period than our normal 1h step when the collection runs. We will make sure they get purged later.
```bash
$ DEV_MODE=true RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_METRIC_OPENSHIFT_STEP=300 RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_METRIC_OPENSHIFT_RANGE_IN_MINUTES=480 PROM_AUTH_TOKEN="$(echo $PROM_TOKEN)" PROM_URL="https://telemeter-lts.datahub.redhat.com/api/v1" ./gradlew clean bootRun --args="--spring.profiles.active=openshift-metering-worker"
```
3) Hit the JMX endpoint to start collection for the account.
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMeteringForAccount(java.lang.String)","arguments":["1460290"]}'
```

4) Watch the logs to see that events were added, and check the count in the DB.
```bash
psql -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from events;"
 count 
-------
   440

```

5) Stop the application and re-launch as follows ensuring that your database isn't wiped out. This time we use a 1h step to reduce the number of metrics pulled from prometheus.
```bash
$ DEV_MODE=true RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_METRIC_OPENSHIFT_STEP=3600 RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_METRIC_OPENSHIFT_RANGE_IN_MINUTES=480 PROM_AUTH_TOKEN="$(echo $PROM_TOKEN)" PROM_URL="https://telemeter-lts.datahub.redhat.com/api/v1" ./gradlew clean bootRun --args="--spring.profiles.active=openshift-metering-worker"
```

6) Hit the JMX endpoint again
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMeteringForAccount(java.lang.String)","arguments":["1460290"]}'
```
NOTE:
```bash
2021-03-01 14:43:24,120 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Fetching metrics from prometheus: 2021-03-01T10:00Z -> 2021-03-01T18:59:59.999999999Z [Step: 3600]
2021-03-01 14:43:26,391 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Persisted 41 events for OpenShift metrics.
2021-03-01 14:43:26,391 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Deleting 399 stale OpenShift metric events.
2021-03-01 14:43:26,515 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.task.OpenShiftMetricsTask] - Openshift metrics task complete.
```

7) Watch the logs to see that events were added/purged, and check the count in the DB to make sure that it reflects the deletions/updates.
```bash
psql -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from events;"

 count 
-------
    41
(1 row)
```