### PR TITLE
ENT-3576: Add monthlyTotals measurements to Host

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -24,9 +24,13 @@ import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -56,6 +60,8 @@ import javax.validation.constraints.NotNull;
  * Represents a reported Host from inventory. This entity stores normalized facts for a
  * Host returned from HBI.
  */
+@Setter
+@Getter
 @Entity
 @Table(name = "hosts")
 public class Host implements Serializable {
@@ -108,6 +114,14 @@ public class Host implements Serializable {
     @MapKeyColumn(name = "uom")
     @Column(name = "value")
     private Map<Measurement.Uom, Double> measurements = new EnumMap<>(Measurement.Uom.class);
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "instance_monthly_totals",
+        joinColumns = @JoinColumn(name = "instance_id")
+    )
+    @Column(name = "value")
+    private Map<InstanceMonthlyTotalKey, Double> monthlyTotals = new HashMap<>();
 
     @Column(name = "is_guest")
     private boolean guest;
@@ -198,62 +212,6 @@ public class Host implements Serializable {
         this.hardwareType = normalizedFacts.getHardwareType();
     }
 
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public String getInventoryId() {
-        return inventoryId;
-    }
-
-    public void setInventoryId(String inventoryId) {
-        this.inventoryId = inventoryId;
-    }
-
-    public String getInsightsId() {
-        return insightsId;
-    }
-
-    public void setInsightsId(String insightsId) {
-        this.insightsId = insightsId;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getAccountNumber() {
-        return accountNumber;
-    }
-
-    public void setAccountNumber(String accountNumber) {
-        this.accountNumber = accountNumber;
-    }
-
-    public String getOrgId() {
-        return orgId;
-    }
-
-    public void setOrgId(String orgId) {
-        this.orgId = orgId;
-    }
-
-    public String getSubscriptionManagerId() {
-        return subscriptionManagerId;
-    }
-
-    public void setSubscriptionManagerId(String subscriptionManagerId) {
-        this.subscriptionManagerId = subscriptionManagerId;
-    }
-
     /**
      * @deprecated use getMeasurement(Measurement.Uom.CORES) instead
      *
@@ -292,68 +250,12 @@ public class Host implements Serializable {
         this.sockets = sockets;
     }
 
-    public Map<Measurement.Uom, Double> getMeasurements() {
-        return measurements;
-    }
-
-    public void setMeasurements(Map<Measurement.Uom, Double> measurements) {
-        this.measurements = measurements;
-    }
-
     public Double getMeasurement(Measurement.Uom uom) {
         return measurements.get(uom);
     }
 
     public void setMeasurement(Measurement.Uom uom, Double value) {
         measurements.put(uom, value);
-    }
-
-    public Boolean getGuest() {
-        return guest;
-    }
-
-    public void setGuest(Boolean guest) {
-        this.guest = guest;
-    }
-
-    public String getHypervisorUuid() {
-        return hypervisorUuid;
-    }
-
-    public void setHypervisorUuid(String hypervisorUuid) {
-        this.hypervisorUuid = hypervisorUuid;
-    }
-
-    public HostHardwareType getHardwareType() {
-        return hardwareType;
-    }
-
-    public void setHardwareType(HostHardwareType hardwareType) {
-        this.hardwareType = hardwareType;
-    }
-
-    public Integer getNumOfGuests() {
-        return numOfGuests;
-    }
-
-    public void setNumOfGuests(Integer numOfGuests) {
-        this.numOfGuests = numOfGuests;
-    }
-
-    public OffsetDateTime getLastSeen() {
-        return lastSeen;
-    }
-
-    public void setLastSeen(OffsetDateTime lastSeen) {
-        this.lastSeen = lastSeen;
-    }
-
-    public Set<HostTallyBucket> getBuckets() {
-        return buckets;
-    }
-
-    public void setBuckets(Set<HostTallyBucket> buckets) {
-        this.buckets = buckets;
     }
 
     public HostTallyBucket addBucket(String productId, ServiceLevel sla, Usage usage, Boolean asHypervisor,
@@ -374,44 +276,39 @@ public class Host implements Serializable {
         getBuckets().remove(bucket);
     }
 
-    public boolean isUnmappedGuest() {
-        return isUnmappedGuest;
+    public Double getMonthlyTotal(String monthId, Measurement.Uom uom) {
+        var key = new InstanceMonthlyTotalKey(monthId, uom);
+        return monthlyTotals.get(key);
     }
 
-    public void setUnmappedGuest(boolean unmappedGuest) {
-        isUnmappedGuest = unmappedGuest;
+    public Double getMonthlyTotal(OffsetDateTime reference, Measurement.Uom uom) {
+        var key = new InstanceMonthlyTotalKey(reference, uom);
+        return monthlyTotals.get(key);
     }
 
-    public boolean isHypervisor() {
-        return isHypervisor;
+    public void addToMonthlyTotal(String monthId, Measurement.Uom uom, Double value) {
+        var key = new InstanceMonthlyTotalKey(monthId, uom);
+        Double currentValue = monthlyTotals.getOrDefault(key, 0.0);
+        monthlyTotals.put(key, currentValue + value);
     }
 
-    public void setHypervisor(boolean hypervisor) {
-        isHypervisor = hypervisor;
+    public void addToMonthlyTotal(OffsetDateTime timestamp, Measurement.Uom uom, Double value) {
+        var key = new InstanceMonthlyTotalKey(timestamp, uom);
+        Double currentValue = monthlyTotals.getOrDefault(key, 0.0);
+        monthlyTotals.put(key, currentValue + value);
     }
 
-    public String getCloudProvider() {
-        return cloudProvider;
+    public void clearMonthlyTotals(OffsetDateTime startDateTime, OffsetDateTime endDateTime) {
+        for (OffsetDateTime offset = startDateTime; !offset.isAfter(endDateTime); offset =
+            offset.plusMonths(1)) {
+            clearMonthlyTotal(offset);
+        }
     }
 
-    public void setCloudProvider(String cloudProvider) {
-        this.cloudProvider = cloudProvider;
-    }
-
-    public String getInstanceType() {
-        return instanceType;
-    }
-
-    public void setInstanceType(String type) {
-        this.instanceType = type;
-    }
-
-    public String getInstanceId() {
-        return instanceId;
-    }
-
-    public void setInstanceId(String instanceId) {
-        this.instanceId = instanceId;
+    public void clearMonthlyTotal(OffsetDateTime timestamp) {
+        String monthIdentifier = InstanceMonthlyTotalKey.formatMonthId(timestamp);
+        Set<InstanceMonthlyTotalKey> keys = monthlyTotals.keySet();
+        keys.removeIf(key -> Objects.equals(key.getMonth(), monthIdentifier));
     }
 
     public org.candlepin.subscriptions.utilization.api.model.Host asApiHost() {

--- a/src/main/java/org/candlepin/subscriptions/db/model/InstanceMonthlyTotalKey.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/InstanceMonthlyTotalKey.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import org.candlepin.subscriptions.json.Measurement;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+/**
+ * Key for instance monthly totals
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class InstanceMonthlyTotalKey implements Serializable {
+    private static final DateTimeFormatter MONTH_ID_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM");
+
+    /**
+     * month in YYYY-MM format
+     */
+    private String month;
+
+    @Enumerated(EnumType.STRING)
+    private Measurement.Uom uom;
+
+    public static String formatMonthId(OffsetDateTime reference) {
+        return reference.format(MONTH_ID_FORMATTER);
+    }
+
+    public InstanceMonthlyTotalKey(OffsetDateTime reference, Measurement.Uom uom) {
+        this.month = formatMonthId(reference);
+        this.uom = uom;
+    }
+}

--- a/src/main/resources/liquibase/202102260917-add-instance-monthly-totals.xml
+++ b/src/main/resources/liquibase/202102260917-add-instance-monthly-totals.xml
@@ -1,0 +1,27 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="202102260917-1" author="khowell">
+        <comment>Add table to track per-month cumulative total measurements</comment>
+        <createTable tableName="instance_monthly_totals">
+            <column name="instance_id" type="uuid">
+                <constraints referencedTableName="hosts" referencedColumnNames="id"
+                    nullable="false" foreignKeyName="instance_monthly_totals_host_id_fk"
+                    deleteCascade="true"/>
+            </column>
+            <column name="month" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uom" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="double precision">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="instance_monthly_totals" columnNames="instance_id,month,uom"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -40,5 +40,6 @@
     <include file="liquibase/202102031030-update-subscription-pkey.xml" />
     <include file="liquibase/202101260823-add-measurements-tables.xml" />
     <include file="liquibase/202101291558-modify-hosts-for-non-hbi-sources.xml" />
+    <include file="liquibase/202102260917-add-instance-monthly-totals.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.db.model;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,7 @@ class HostTest {
         assertNull(host.getOrgId());
         assertNull(host.getDisplayName());
         assertNull(host.getSubscriptionManagerId());
-        assertFalse(host.getGuest());
+        assertFalse(host.isGuest());
         assertNull(host.getHypervisorUuid());
         assertEquals(0, host.getMeasurements().size());
         assertFalse(host.isHypervisor());
@@ -70,13 +71,23 @@ class HostTest {
         assertEquals(host.getOrgId(), inventoryHostFacts.getOrgId());
         assertEquals(host.getDisplayName(), inventoryHostFacts.getDisplayName());
         assertEquals(host.getSubscriptionManagerId(), inventoryHostFacts.getSubscriptionManagerId());
-        assertTrue(host.getGuest());
+        assertTrue(host.isGuest());
         assertEquals(host.getHypervisorUuid(), normalizedFacts.getHypervisorUuid());
         assertEquals(2, host.getMeasurements().size());
         assertTrue(host.isHypervisor());
         assertEquals(host.getCloudProvider(), normalizedFacts.getCloudProviderType().name());
         assertEquals(host.getLastSeen(), inventoryHostFacts.getModifiedOn());
         assertEquals(host.getHardwareType(), normalizedFacts.getHardwareType());
+    }
+
+    @Test
+    void testRemoveRangeRemovesMultipleMonths() {
+        Host host = new Host();
+        host.addToMonthlyTotal("2021-01", Measurement.Uom.CORES, 1.0);
+        host.addToMonthlyTotal("2021-02", Measurement.Uom.CORES, 2.0);
+        host.clearMonthlyTotals(OffsetDateTime.parse("2021-01-01T00:00:00Z"),
+            OffsetDateTime.parse("2021-02-01T00:00:00Z"));
+        assertTrue(host.getMonthlyTotals().isEmpty());
     }
 
     private InventoryHostFacts getInventoryHostFactsFull() {


### PR DESCRIPTION
The way these are captured are generally, as an event is processed, the measurements are added to the monthly totals.

In the case that any host record appears to be newer than the time range being processed, we assume that the monthly totals need to be recalculated in full, and the date range of events is expanded to cover whole months.

Testing
-------
1. Clear some data and then ensure opted in:

```sql
truncate table events;
truncate table tally_snapshots cascade;
truncate table hosts cascade;
insert into account_config(account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated) VALUES ('account123', true, true, 'DB', now(), now());
```

2. Insert some events:

```sql
insert into events(id, account_number, timestamp, data) values ('033a45b7-e8c4-440a-b0bb-76c3f3f67d85','account123', '2021-01-01T00:00Z', '{"account_number":"account123","timestamp":"2021-01-01T00:00:00Z","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d85","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}]}');
insert into events(id, account_number, timestamp, data) values ('a66ac2a1-17c0-4bc3-bc29-0430953d626c','account123', '2021-01-01T02:00Z', '{"account_number":"account123","timestamp":"2021-01-01T02:00:00Z","event_id":"a66ac2a1-17c0-4bc3-bc29-0430953d626c","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":2.0}]}');
insert into events(id, account_number, timestamp, data) values ('fad48795-ae0a-4674-b864-822ddfb799d0','account123', '2021-01-01T03:00Z', '{"account_number":"account123","timestamp":"2021-01-01T03:00:00Z","event_id":"fad48795-ae0a-4674-b864-822ddfb799d0","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}]}');
```

3. Invoke the hourly tally for the account:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-01-01T00:00:00Z","2021-01-01T23:59:59.999Z"]}'
```

4. Verify the host records contains 10 cores:

```sql
select * from instance_monthly_totals;
```

5. Insert a new event in the middle:

```sql
insert into events(id, account_number, timestamp, data) values ('c8e49ded-cd75-4016-8be7-3f795ff65645','account123', '2021-01-01T00:00Z', '{"account_number":"account123","timestamp":"2021-01-01T01:00:00Z","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d85","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":20.0}]}');
```

6. Retrigger the range containing only the new event

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-01-01T00:00:00Z","2021-01-01T02:00:00Z"]}'
```

7. Observe that the new monthly total contains 30 cores:

```sql
select * from instance_monthly_totals;
```