### PR TITLE
ENT-3595: Properly set stub snapshot dates for filled Hourly report

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.subscriptions.tally.filler;
 
-import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.SnapshotTimeAdjuster;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -43,11 +42,9 @@ import java.util.Optional;
 public class ReportFiller {
     private static final Logger log = LoggerFactory.getLogger(ReportFiller.class);
 
-    private final ApplicationClock clock;
     private final SnapshotTimeAdjuster timeAdjuster;
 
-    public ReportFiller(ApplicationClock clock, SnapshotTimeAdjuster timeAdjuster) {
-        this.clock = clock;
+    public ReportFiller(SnapshotTimeAdjuster timeAdjuster) {
         this.timeAdjuster = timeAdjuster;
     }
 
@@ -147,7 +144,7 @@ public class ReportFiller {
         List<TallySnapshot> result = new ArrayList<>();
         OffsetDateTime next = timeAdjuster.adjustToPeriodStart(OffsetDateTime.from(start));
         while (next.isBefore(end) || next.isEqual(end)) {
-            result.add(createDefaultSnapshot(clock.startOfDay(next)));
+            result.add(createDefaultSnapshot(next));
             next = timeAdjuster.adjustToPeriodStart(next.plus(offset));
         }
         return result;

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
@@ -42,7 +42,7 @@ public class ReportFillerFactory {
      */
     public static ReportFiller getInstance(ApplicationClock clock, Granularity granularity) {
         SnapshotTimeAdjuster timeAdjuster = SnapshotTimeAdjuster.getTimeAdjuster(clock, granularity);
-        return new ReportFiller(clock, timeAdjuster);
+        return new ReportFiller(timeAdjuster);
     }
 
 

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/HourlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/HourlyReportFillerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+class HourlyReportFillerTest {
+
+    private ApplicationClock clock;
+    private ReportFiller filler;
+
+    public HourlyReportFillerTest() {
+        clock = new FixedClockConfiguration().fixedClock();
+        filler = ReportFillerFactory.getInstance(clock, Granularity.HOURLY);
+    }
+
+    @Test
+    void noExistingSnapsShouldfillWithDailyGranularity() {
+        OffsetDateTime start = clock.now();
+        OffsetDateTime end = start.plusHours(3);
+
+        TallyReport report = new TallyReport();
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), clock.startOfHour(start), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), clock.startOfHour(start.plusHours(1)), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), 0, 0, 0, false);
+    }
+
+    @Test
+    void shouldFillGapsBasedOnExistingSnapshotsForDailyGranularity() {
+        OffsetDateTime start = clock.now();
+        OffsetDateTime snap1Date = start.plusHours(2);
+        OffsetDateTime end = start.plusHours(4);
+
+        TallySnapshot snap1 = new TallySnapshot().date(snap1Date).cores(2).instanceCount(1)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().date(end).cores(6).instanceCount(3)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(5, filled.size());
+        OffsetDateTime reportStart = clock.startOfHour(start);
+        assertSnapshot(filled.get(0), reportStart, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), reportStart.plusHours(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
+            snap1.getInstanceCount(), true);
+        assertSnapshot(filled.get(3), reportStart.plusHours(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(4), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
+            snap2.getInstanceCount(), true);
+    }
+
+    @Test
+    void testSnapshotsIgnoredWhenNoDatesSet() {
+        OffsetDateTime start = clock.startOfToday();
+        OffsetDateTime end = start.plusHours(3);
+
+        TallySnapshot snap1 = new TallySnapshot().cores(12).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().cores(25).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), start, 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusHours(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusHours(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), start.plusHours(3), 0, 0, 0, false);
+    }
+
+    @Test
+    void testNoRedundantSnapshotsEmittedAscending() {
+        OffsetDateTime start = clock.now();
+        OffsetDateTime snap1Date = start.plusHours(1);
+        OffsetDateTime snap2Date = start.plusHours(1).plusMinutes(2);
+        OffsetDateTime end = start.plusHours(3);
+
+        TallySnapshot snap1 = new TallySnapshot().date(snap1Date).cores(2).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().date(snap2Date).cores(5).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), clock.startOfHour(start), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
+            snap2.getInstanceCount(), true);
+        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), 0, 0, 0, false);
+    }
+
+    @Test
+    void testNoRedundantSnapshotsEmittedDescending() {
+        OffsetDateTime start = clock.now();
+        OffsetDateTime snap1Date = start.plusHours(1);
+        OffsetDateTime snap2Date = start.plusHours(1).plusMinutes(2);
+        OffsetDateTime end = start.plusHours(3);
+
+        TallySnapshot snap1 = new TallySnapshot().date(snap1Date).cores(2).sockets(3).instanceCount(4)
+            .hasData(true);
+        TallySnapshot snap2 = new TallySnapshot().date(snap2Date).cores(5).sockets(6).instanceCount(7)
+            .hasData(true);
+        List<TallySnapshot> snaps = Arrays.asList(snap2, snap1);
+
+        TallyReport report = new TallyReport().data(snaps);
+        filler.fillGaps(report, start, end);
+
+        List<TallySnapshot> filled = report.getData();
+        assertEquals(4, filled.size());
+        assertSnapshot(filled.get(0), clock.startOfHour(start), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
+            snap2.getInstanceCount(), true);
+        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), 0, 0, 0, false);
+    }
+
+}


### PR DESCRIPTION
Previously, when a tally report was run at an HOURLY granularity, all 'stub' snapshots that filled a report's time range all started at midnight. This fix ensures that the dates are properly adjusted when filling reports.


**HOW TO TEST**
Launch the app.
```bash
$ DEV_MODE=true ./gradlew clean bootRun
```
Pick an account and generate a valid header value for curl requests.
```bash
echo -n '{"identity":{"account_number":"6274079", "internal":{"org_id":"2144245"}}}' | base64 -w 0
```

Opt in with the account you used above.
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["6274079","2144245",true,true,true]}'
```

Curl the API for any date range using the HOURLY granularity. **Ensure to use the header generated above.**
```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjYyNzQwNzkiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMjE0NDI0NSJ9fX0=" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics?granularity=hourly&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T04:59:59.999Z" | python -mjson.tool

{
    "data": [
        {
            "date": "2019-06-19T00:00:00Z",
            "instance_count": 0,
            "cores": 0,
            "core_hours": 0.0,
            "sockets": 0,
            "physical_instance_count": 0,
            "physical_cores": 0,
            "physical_sockets": 0,
            "hypervisor_instance_count": 0,
            "hypervisor_cores": 0,
            "hypervisor_sockets": 0,
            "cloud_instance_count": 0,
            "cloud_cores": 0,
            "cloud_sockets": 0,
            "has_data": false,
            "has_cloudigrade_data": false,
            "has_cloudigrade_mismatch": false
        },
        {
            "date": "2019-06-19T01:00:00Z",
            ...
        {
            "date": "2019-06-19T02:00:00Z",
            ...
        },
        {
            "date": "2019-06-19T03:00:00Z",
            ...
        },
        {
            "date": "2019-06-19T04:00:00Z",
            ...
        }
    ],
    "meta": {
        "count": 5,
        "product": "OpenShift-metrics",
        "granularity": "Hourly"
    }
```

Note that the dates are all descending per hour.