### PR TITLE
ENT-3592: fix DataIntegrityViolation.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -106,6 +106,7 @@ public class HostTallyBucket implements Serializable {
 
     public void setHost(Host host) {
         this.host = host;
+        this.key.setHostId(host.getId());
     }
 
     @Override

--- a/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -106,7 +106,7 @@ public class HostTallyBucket implements Serializable {
 
     public void setHost(Host host) {
         this.host = host;
-        this.key.setHostId(host.getId());
+        this.key.setHostId(host == null ? null : host.getId());
     }
 
     @Override

--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTallyBucketTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTallyBucketTest.java
@@ -28,7 +28,7 @@ import org.mockito.Mockito;
 
 import java.util.UUID;
 
-public class HostTallyBucketTest {
+class HostTallyBucketTest {
 
     // This is necessary to avoid duplicate keys with null hostId.
     @Test

--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTallyBucketTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTallyBucketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,8 +30,9 @@ import java.util.UUID;
 
 public class HostTallyBucketTest {
 
+    // This is necessary to avoid duplicate keys with null hostId.
     @Test
-    void setHostId() {
+    void testBucketSetHostAlsoSetsBucketKeyHostId() {
         Host host = Mockito.mock(Host.class);
         HostTallyBucket hostTallyBucket = new HostTallyBucket(host, "product123", ServiceLevel.PREMIUM,
             Usage.PRODUCTION, false, 4, 4, HardwareMeasurementType.PHYSICAL);
@@ -41,5 +42,16 @@ public class HostTallyBucketTest {
         hostTallyBucket.setHost(host);
 
         assertEquals(host.getId(), hostTallyBucket.getKey().getHostId());
+    }
+
+     // Set bucket key host ID to null when the host is null.
+    @Test
+    void testBucketSetNullHostAlsoSetsBucketKeyHostId() {
+        HostTallyBucket hostTallyBucket = new HostTallyBucket(null, "product123", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, false, 4, 4, HardwareMeasurementType.PHYSICAL);
+
+        hostTallyBucket.setHost(null);
+
+        assertNull(hostTallyBucket.getKey().getHostId());
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTallyBucketTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTallyBucketTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+
+public class HostTallyBucketTest {
+
+    @Test
+    void setHostId() {
+        Host host = Mockito.mock(Host.class);
+        HostTallyBucket hostTallyBucket = new HostTallyBucket(host, "product123", ServiceLevel.PREMIUM,
+            Usage.PRODUCTION, false, 4, 4, HardwareMeasurementType.PHYSICAL);
+
+        when(host.getId()).thenReturn(UUID.randomUUID());
+
+        hostTallyBucket.setHost(host);
+
+        assertEquals(host.getId(), hostTallyBucket.getKey().getHostId());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -177,14 +177,14 @@ class MetricUsageCollectorTest {
         Set<HostTallyBucket> expected = new HashSet<>();
         Set.of(Usage._ANY, Usage.PRODUCTION).forEach(usage ->
             Set.of(ServiceLevel._ANY, ServiceLevel.PREMIUM).forEach(sla -> {
-                HostTallyBucket bucket = new HostTallyBucket();
-                bucket.setHost(instance);
                 HostBucketKey key = new HostBucketKey();
                 key.setProductId(MetricUsageCollector.ProductConfig.OPENSHIFT_PRODUCT_ID);
                 key.setSla(sla);
                 key.setUsage(usage);
                 key.setAsHypervisor(false);
+                HostTallyBucket bucket = new HostTallyBucket();
                 bucket.setKey(key);
+                bucket.setHost(instance);
                 expected.add(bucket);
             })
         );


### PR DESCRIPTION
Added a line to HostTallyBucket.setHost() which sets the hostID
of the HostBucketKey.