### PR TITLE
ENT-3599: Make instance_id not null; populate from inventory_id when appropriate

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -49,6 +49,7 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
     else:
         host_fields = {
             'id': host_id,
+            'instance_id': inventory_id,
             'inventory_id': inventory_id,
             'insights_id': insights_id,
             'account_number': account_number or 'account123',

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -169,6 +169,7 @@ public class Host implements Serializable {
     public Host(String inventoryId, String insightsId, String accountNumber, String orgId, String subManId) {
         this.instanceType = "HBI_HOST";
         this.inventoryId = inventoryId;
+        this.instanceId = inventoryId;
         this.insightsId = insightsId;
         this.accountNumber = accountNumber;
         this.orgId = orgId;
@@ -185,6 +186,7 @@ public class Host implements Serializable {
 
         if (inventoryHostFacts.getInventoryId() != null) {
             this.inventoryId = inventoryHostFacts.getInventoryId().toString();
+            this.instanceId = inventoryHostFacts.getInventoryId().toString();
         }
 
         this.insightsId = inventoryHostFacts.getInsightsId();

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -70,6 +70,9 @@ public class Host implements Serializable {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
+    /**
+     * The canonical natural identifier for this instance.
+     */
     @Column(name = "instance_id")
     private String instanceId;
 
@@ -186,6 +189,8 @@ public class Host implements Serializable {
 
         if (inventoryHostFacts.getInventoryId() != null) {
             this.inventoryId = inventoryHostFacts.getInventoryId().toString();
+            // We assume that the instance ID for any given HBI host record is the inventory ID; compare to
+            // an OpenShift Cluster from Prometheus data, where we use the cluster ID.
             this.instanceId = inventoryHostFacts.getInventoryId().toString();
         }
 

--- a/src/main/resources/liquibase/202103031601-modify-hosts-instance-id-not-null.xml
+++ b/src/main/resources/liquibase/202103031601-modify-hosts-instance-id-not-null.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="202103031601-1" author="khowell">
+        <update tableName="hosts">
+            <column name="instance_id" valueComputed="inventory_id"/>
+            <where>instance_type = 'HBI_HOST'</where>
+        </update>
+    </changeSet>
+
+    <changeSet id="202103031601-2" author="khowell">
+        <addNotNullConstraint tableName="hosts" columnName="instance_id"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -41,5 +41,6 @@
     <include file="liquibase/202101260823-add-measurements-tables.xml" />
     <include file="liquibase/202101291558-modify-hosts-for-non-hbi-sources.xml" />
     <include file="liquibase/202102260917-add-instance-monthly-totals.xml" />
+    <include file="liquibase/202103031601-modify-hosts-instance-id-not-null.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/AccountRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountRepositoryTest.java
@@ -30,6 +30,8 @@ import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.db.model.config.AccountConfig;
 import org.candlepin.subscriptions.db.model.config.OptInType;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -43,6 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -79,6 +82,19 @@ class AccountRepositoryTest {
 
         hostRepo.flush();
         accountConfigRepo.flush();
+    }
+
+    @Test
+    void testHbiHostCanBeLoaded() {
+        NormalizedFacts normalizedFacts = new NormalizedFacts();
+        InventoryHostFacts inventoryHostFacts = new InventoryHostFacts();
+        inventoryHostFacts.setInventoryId(UUID.randomUUID());
+        inventoryHostFacts.setDisplayName("foo");
+        inventoryHostFacts.setAccount("account123");
+        Host host = new Host(inventoryHostFacts, normalizedFacts);
+        hostRepo.save(host);
+
+        assertTrue(repo.findById("account123").isPresent());
     }
 
     @Test


### PR DESCRIPTION
Prior to this change, Account failed to load when existing records with null instance_id are present, with an error: `org.hibernate.HibernateException: null index column for collection`

There are a few changes related:

1) Update existing data by setting the value of `instance_id` to inventory_id for existing records (those with `instance_type='HBI_HOST'`).
2) Add a not null constraint to prevent future bad data.
3) Adjust Host so that when populating from inventory records, `instance_id` is populated.

Testing
-------
On `develop`, (*not* this branch), insert some mock hosts:

```
bin/insert-mock-hosts --num-physical 4
```

Insert some events:

```sql
insert into events(id, account_number, timestamp, data) values ('033a45b7-e8c4-440a-b0bb-76c3f3f67d85','account123', '2021-01-01T00:00Z', '{"account_number":"account123","timestamp":"2021-01-01T00:00:00Z","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d85","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}]}');
insert into events(id, account_number, timestamp, data) values ('a66ac2a1-17c0-4bc3-bc29-0430953d626c','account123', '2021-01-01T02:00Z', '{"account_number":"account123","timestamp":"2021-01-01T01:00:00Z","event_id":"a66ac2a1-17c0-4bc3-bc29-0430953d626c","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":2.0}]}');
insert into events(id, account_number, timestamp, data) values ('fad48795-ae0a-4674-b864-822ddfb799d0','account123', '2021-01-01T03:00Z', '{"account_number":"account123","timestamp":"2021-01-01T02:00:00Z","event_id":"fad48795-ae0a-4674-b864-822ddfb799d0","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}]}');
```

Run the service:

```
./gradlew bootRun
```

Trigger an hourly tally:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-01-01T00:00:00Z","2021-01-01T23:59:59.999Z"]}'
```

Observe:

```
[ERROR] [org.candlepin.subscriptions.tally.TallySnapshotController] - Could not collect existing usage snapshots for account account123
org.springframework.orm.jpa.JpaSystemException: null index column for collection: org.candlepin.subscriptions.db.model.Account.serviceInstances; nested exception is org.hibernate.HibernateException: null index column for collection: org.candlepin.subscriptions.db.model.Account.serviceInstances
```

Now, checkout this branch, and restart the service. Without clearing data, re-run the hourly tally, and observe that it completes without error.