### PR TITLE
MON-1507: Update promql query for OpenShift

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -61,7 +61,7 @@ public class MeteringEventFactory {
      * @return a populated Event instance.
      */
     public static Event openShiftClusterCores(String accountNumber, String clusterId, String serviceLevel,
-        String usage, OffsetDateTime measuredTime, Double measuredValue) {
+        String usage, OffsetDateTime measuredTime, OffsetDateTime expired, Double measuredValue) {
         return new Event()
             .withEventSource(OPENSHIFT_CLUSTER_EVENT_SOURCE)
             .withEventType(OPENSHIFT_CLUSTER_EVENT_TYPE)
@@ -69,6 +69,7 @@ public class MeteringEventFactory {
             .withAccountNumber(accountNumber)
             .withInstanceId(clusterId)
             .withTimestamp(measuredTime)
+            .withExpiration(Optional.of(expired))
             .withDisplayName(Optional.of(clusterId))
             .withSla(getSla(serviceLevel, accountNumber, clusterId))
             .withUsage(getUsage(usage, accountNumber, clusterId))

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -116,8 +116,15 @@ public class PrometheusMeteringController {
                         BigDecimal time = measurement.get(0);
                         BigDecimal value = measurement.get(1);
 
+                        OffsetDateTime eventTermDate = clock.dateFromUnix(time);
+                        // Need to subtract the step because we are averaging and the metric value
+                        // actually represents the end of the measured period. The start of the event
+                        // should be at the beginning.
+                        OffsetDateTime eventDate =
+                            eventTermDate.minusSeconds(metricProperties.getOpenshift().getStep());
+
                         Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId,
-                            sla, usage, clock.dateFromUnix(time), value.doubleValue());
+                            sla, usage, eventDate, eventTermDate, value.doubleValue());
                         events.add(event);
                         eventCount++;
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
@@ -22,18 +22,16 @@ package org.candlepin.subscriptions.metering.service.prometheus;
 
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
-import org.candlepin.subscriptions.metering.MeteringException;
 import org.candlepin.subscriptions.prometheus.ApiException;
 import org.candlepin.subscriptions.prometheus.api.ApiProvider;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
 
+import com.google.common.net.UrlEscapers;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.time.OffsetDateTime;
 
 /**
@@ -58,11 +56,7 @@ public class PrometheusService {
             // NOTE: While the ApiClient **should** in theory already encode the query,
             //       it does not handle the curly braces correctly causing issues
             //       when the request is made.
-            //
-            //       Also, the Prometheus APIs do not seem to like whitespace, even when encoded.
-            String accountQuery = StringUtils.trimAllWhitespace(promQuery);
-            log.debug("RAW Query: {}", accountQuery);
-            String query = URLEncoder.encode(accountQuery, "UTF-8");
+            String query = UrlEscapers.urlFragmentEscaper().escape(promQuery);
             log.debug("Running prometheus query: Start: {} End: {} Step: {}, Query: {}",
                 start.toEpochSecond(), end.toEpochSecond(), step, query);
             return apiProvider.queryRangeApi().queryRange(query, start.toEpochSecond(),
@@ -77,10 +71,6 @@ public class PrometheusService {
                 new ApiException(String.format("Prometheus API response code: %s", apie.getCode()))
             );
         }
-        catch (UnsupportedEncodingException e) {
-            throw new MeteringException("Unsupported encoding for specified PromQL.", e);
-        }
-
     }
 
 }

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -12,9 +12,9 @@ rhsm-subscriptions:
           backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}
           backOffMultiplier: ${OPENSHIFT_BACK_OFF_MULTIPLIER:1.5}
           metricPromQL: >-
-            max(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) without(environment, region)*on(_id)
-            group_right(prometheus) group(subscription_labels{ebs_account='%s', support=~'Premium|Standard|Self-Support|None'})
-            by (_id,ebs_account, support, usage)
+            max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / 13.0) by (_id)
+            * on(_id) group_right
+            min_over_time(subscription_labels{ebs_account="%s", support=~"Premium|Standard|Self-Support|None"}[1h])
       client:
         token: ${PROM_AUTH_TOKEN:}
         url: ${PROM_URL:https://localhost/api/v1}

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -41,13 +41,15 @@ class MeteringEventFactoryTest {
         String clusterId = "my-cluster";
         String sla = "Premium";
         String usage = "Production";
-        OffsetDateTime measuredTime = OffsetDateTime.now();
+        OffsetDateTime expiry = OffsetDateTime.now();
+        OffsetDateTime measuredTime = expiry.minusHours(1);
         Double measuredValue = 23.0;
 
-        Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId, sla, usage, measuredTime,
-            measuredValue);
+        Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId, sla, usage,
+            measuredTime, expiry, measuredValue);
         assertEquals(account, event.getAccountNumber());
         assertEquals(measuredTime, event.getTimestamp());
+        assertEquals(expiry, event.getExpiration().get());
         assertEquals(clusterId, event.getInstanceId());
         assertEquals(Optional.of(clusterId), event.getDisplayName());
         assertEquals(Sla.PREMIUM, event.getSla());
@@ -64,35 +66,35 @@ class MeteringEventFactoryTest {
     @Test
     void testOpenShiftClusterCoresHandlesNullServiceLevel() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", null,
-            "Production", OffsetDateTime.now(), 12.5);
+            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresSlaSetToEmptyForSlaValueNone() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "None",
-            "Production", OffsetDateTime.now(), 12.5);
+            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertEquals(Sla.__EMPTY__, event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresInvalidSlaWillNotBeSetOnEvent() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "UNKNOWN_SLA",
-            "Production", OffsetDateTime.now(), 12.5);
+            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresInvalidUsageSetsNullValue() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "Premium",
-            "UNKNOWN_USAGE", OffsetDateTime.now(), 12.5);
+            "UNKNOWN_USAGE", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getUsage());
     }
 
     @Test
     void testOpenShiftClusterCoresHandlesNullUsage() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "Premium",
-            null, OffsetDateTime.now(), 12.5);
+            null, OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getUsage());
     }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -129,9 +129,11 @@ class PrometheusMeteringControllerTest {
 
         List<Event> expectedEvents = List.of(
             MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId, expectedSla,
-                expectedUsage, clock.dateFromUnix(time1), val1.doubleValue()),
+                expectedUsage, clock.dateFromUnix(time1).minusSeconds(props.getOpenshift().getStep()),
+                clock.dateFromUnix(time1), val1.doubleValue()),
             MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId, expectedSla,
-                expectedUsage, clock.dateFromUnix(time2), val2.doubleValue())
+                expectedUsage, clock.dateFromUnix(time2).minusSeconds(props.getOpenshift().getStep()),
+                clock.dateFromUnix(time2), val2.doubleValue())
         );
 
         controller.collectOpenshiftMetrics(expectedAccount, start, end);

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
@@ -29,14 +29,14 @@ import org.candlepin.subscriptions.prometheus.model.QueryResult;
 import org.candlepin.subscriptions.prometheus.resources.QueryApi;
 import org.candlepin.subscriptions.prometheus.resources.QueryRangeApi;
 
+import com.google.common.net.UrlEscapers;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.util.StringUtils;
 
-import java.net.URLEncoder;
 import java.time.OffsetDateTime;
 
 
@@ -57,7 +57,7 @@ class PrometheusServiceTest {
     void testGetOpenshiftMetrics() throws Exception {
 
         String expectedQuery =
-            URLEncoder.encode(StringUtils.trimAllWhitespace(props.getOpenshift().getMetricPromQL()), "UTF-8");
+            UrlEscapers.urlFragmentEscaper().escape(props.getOpenshift().getMetricPromQL());
         QueryResult expectedResult = new QueryResult();
 
         OffsetDateTime end = OffsetDateTime.now();


### PR DESCRIPTION
This PR addresses a few things:
* Updated the PromQL query to closer represent the core hours metrics.
* Addresses some query encoding issues that were uncovered when the query was updated.
* Because we are taking the average over an hour, we need to set the event
date to the start of the hour that the query is averaging over. For
example, the query might return a metric at time of 3pm, but the value
is actually the average b/w 2pm and 3pm. We set the event timestamp to
the start 2pm and have it expire at 3pm. We adjust this by the configured
step of the query.

**HOW TO TEST**
The steps on #322 is a good way to test this.