### PR TITLE
Use Optional.ofNullable instead of Optional.of in hosts API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -132,8 +132,8 @@ public class HostsResource implements HostsApi {
         if (isSpecial) {
 
             OffsetDateTime now = OffsetDateTime.now();
-            OffsetDateTime start = Optional.of(beginning).orElse(now);
-            OffsetDateTime end = Optional.of(ending).orElse(now);
+            OffsetDateTime start = Optional.ofNullable(beginning).orElse(now);
+            OffsetDateTime end = Optional.ofNullable(ending).orElse(now);
 
             validateBeginningAndEndingDates(start, end);
 


### PR DESCRIPTION
I made a bad suggestion in #309, and thought I had tested it :-/. Doh!