### PR TITLE
ENT-3622: Emit a TallySummary event for each TallySnapshot

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -91,11 +91,12 @@ public class SnapshotSummaryProducer {
 
     public void produceTallySummaryMessages(Map<String, List<TallySnapshot>> newAndUpdatedSnapshots) {
         AtomicInteger totalTallies = new AtomicInteger();
-        newAndUpdatedSnapshots.entrySet().stream()
-            .map(entry -> createTallySummary(entry.getKey(), entry.getValue())).forEach(tallySummary -> {
-                tallySummaryKafkaTemplate.send(tallySummaryTopic, tallySummary);
+        newAndUpdatedSnapshots.forEach((account, snapshots) -> snapshots.stream()
+            .map(snapshot -> createTallySummary(account, List.of(snapshot)))
+            .forEach(summary -> {
+                tallySummaryKafkaTemplate.send(tallySummaryTopic, summary);
                 totalTallies.getAndIncrement();
-            });
+            }));
 
         log.info("Produced {} TallySummary messages", totalTallies);
     }


### PR DESCRIPTION
For verification, I recommend invoking the hourly tally as described in https://issues.redhat.com/browse/ENT-3622, and observing it doesn't cause issues. Note I've deployed to CI environment (rhsm-subscriptions-worker-155-sxstk); deploy job can be used to redeploy to CI for verification if desired.