### PR TITLE
ENT-3619: Handle duplicate snapshots and hosts

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -84,7 +84,7 @@ public class InventoryAccountUsageCollector {
         List<Host> existing = getAccountHosts(accounts);
         Map<String, Host> inventoryHostMap = existing.stream()
             .filter(host -> host.getInventoryId() != null)
-            .collect(Collectors.toMap(Host::getInventoryId, Function.identity()));
+            .collect(Collectors.toMap(Host::getInventoryId, Function.identity(), this::handleDuplicateHost));
 
         Map<String, String> hypMapping = new HashMap<>();
         Map<String, Set<UsageCalculation.Key>> hypervisorUsageKeys = new HashMap<>();
@@ -196,6 +196,12 @@ public class InventoryAccountUsageCollector {
         }
 
         return calcsByAccount;
+    }
+
+    private Host handleDuplicateHost(Host host1, Host host2) {
+        log.warn("Removing duplicate host record w/ inventory ID: {}", host2.getInventoryId());
+        hostRepository.delete(host2);
+        return host1;
     }
 
     private void collectHypervisorGuestData(Map<String, Set<UsageCalculation.Key>> hypervisorUsageKeys,

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -87,4 +87,12 @@ public class DailySnapshotRollerTest {
         tester.performDoesNotPersistEmptySnapshots(Granularity.DAILY, clock.startOfToday(),
             clock.endOfToday());
     }
+
+    @Test
+    @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
+    void testHandlesDuplicates() {
+        tester.performRemovesDuplicates(Granularity.DAILY, clock.startOfToday(),
+            clock.endOfToday());
+    }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
@@ -108,4 +108,10 @@ class HourlySnapshotRollerTest {
         tester.performDoesNotPersistEmptySnapshots(HOURLY, clock.startOfCurrentHour(),
             clock.endOfCurrentHour());
     }
+
+    @Test
+    @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
+    void testHandlesDuplicates() {
+        tester.performRemovesDuplicates(HOURLY, clock.startOfCurrentHour(), clock.endOfCurrentHour());
+    }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -81,4 +81,11 @@ public class MonthlySnapshotRollerTest {
             clock.endOfCurrentMonth(), true);
     }
 
+    @Test
+    @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
+    void testHandlesDuplicates() {
+        tester.performRemovesDuplicates(Granularity.MONTHLY, clock.startOfCurrentMonth(),
+            clock.endOfCurrentMonth());
+    }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -79,4 +79,11 @@ public class QuarterlySnapshotRollerTest {
             clock.endOfCurrentQuarter(), true);
     }
 
+    @Test
+    @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
+    void testHandlesDuplicates() {
+        tester.performRemovesDuplicates(Granularity.QUARTERLY, clock.startOfCurrentQuarter(),
+            clock.endOfCurrentQuarter());
+    }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -79,4 +79,11 @@ public class WeeklySnapshotRollerTest {
             clock.startOfCurrentWeek(), clock.endOfCurrentWeek(), true);
     }
 
+    @Test
+    @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
+    void testHandlesDuplicates() {
+        tester.performRemovesDuplicates(Granularity.WEEKLY, clock.startOfCurrentWeek(),
+            clock.endOfCurrentWeek());
+    }
+
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -78,4 +78,12 @@ public class YearlySnapshotRollerTest {
         this.tester.performUpdateWithLesserValueTest(Granularity.YEARLY, clock.startOfCurrentYear(),
             clock.endOfCurrentYear(), true);
     }
+
+    @Test
+    @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
+    void testHandlesDuplicates() {
+        tester.performRemovesDuplicates(Granularity.YEARLY, clock.startOfCurrentYear(),
+            clock.endOfCurrentYear());
+    }
+
 }


### PR DESCRIPTION
This handles two cases that shouldn't happen, but have shown problems
during testing:

1. When more than one host record exists for a single inventory ID.
2. When more than one snapshot exists for a given granularity and usage key and timeframe.

Testing:

insert some problematic data:

```
bin/insert-mock-hosts --num-physical=4 --clear
```

```
echo "update hosts set inventory_id='$(uuidgen)' where 1=1;" | psql -h localhost rhsm-subscriptions -U rhsm-subscriptions
echo "insert into tally_snapshots(id, product_id, account_number, granularity, snapshot_date, sla, usage) values ('$(uuidgen)', 'RHEL', 'account123', 'DAILY', now(), '', '');" | psql -h localhost rhsm-subscriptions -U rhsm-subscriptions
echo "insert into tally_snapshots(id, product_id, account_number, granularity, snapshot_date, sla, usage) values ('$(uuidgen)', 'RHEL', 'account123', 'DAILY', now(), '', '');" | psql -h localhost rhsm-subscriptions -U rhsm-subscriptions
```

Run a tally operation:

```
curl 'http://localhost:8080/actuator/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccount(java.lang.String)","arguments":["account123"]}'
```

Observe warnings for the removed inconsistent data such as:

```
[WARN ] [org.candlepin.subscriptions.tally.InventoryAccountUsageCollector] - Removing duplicate host record w/ inventory ID: 749628b1-899b-4332-822f-9361b0b53eeb
[WARN ] [org.candlepin.subscriptions.tally.roller.BaseSnapshotRoller] - Removing duplicate TallySnapshot w/ granularity: DAILY, key: Key{productId='RHEL', sla=EMPTY, usage=EMPTY}
```