### PR TITLE
Fix epoch conversion to use relevant zone offset.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -25,7 +25,7 @@ import org.candlepin.subscriptions.db.model.Granularity;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.DayOfWeek;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -178,9 +178,12 @@ public class ApplicationClock {
     }
 
     public OffsetDateTime dateFromUnix(BigDecimal time) {
+        return dateFromUnix(time.longValue());
+    }
+
+    public OffsetDateTime dateFromUnix(Long time) {
         ZoneId zone = this.clock.getZone();
-        ZonedDateTime zonedDateTime = LocalDateTime.ofEpochSecond(time.longValue(), 0,
-            OffsetDateTime.now(zone).getOffset()).atZone(zone);
+        ZonedDateTime zonedDateTime = Instant.ofEpochSecond(time).atZone(zone);
         return zonedDateTime.toOffsetDateTime();
     }
 

--- a/src/test/java/org/candlepin/subscriptions/FixedClockConfiguration.java
+++ b/src/test/java/org/candlepin/subscriptions/FixedClockConfiguration.java
@@ -28,19 +28,52 @@ import org.springframework.context.annotation.Primary;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @TestConfiguration
 public class FixedClockConfiguration {
+    // A zoneless time
+    public static final LocalDateTime SPRING_TIME = LocalDateTime.of(2019, 5, 24, 12, 35, 0, 0);
+    public static final ZonedDateTime SPRING_TIME_UTC = SPRING_TIME.atZone(ZoneId.of("UTC"));
+    public static final ZonedDateTime SPRING_TIME_EDT = SPRING_TIME.atZone(ZoneId.of("America/New_York"));
+
+    // date --utc -d '2019-5-24T12:35:00 UTC' +%s
+    public static final long SPRING_EPOCH_UTC = 1558701300L;
+    // date --utc -d '2019-5-24T12:35:00 EDT' +%s
+    public static final long SPRING_EPOCH_EDT = 1558715700L;
+
+    public static final LocalDateTime WINTER_TIME = LocalDateTime.of(2019, 1, 3, 14, 15, 0, 0);
+    public static final ZonedDateTime WINTER_TIME_UTC = WINTER_TIME.atZone(ZoneId.of("UTC"));
+    public static final ZonedDateTime WINTER_TIME_EST = WINTER_TIME.atZone(ZoneId.of("America/New_York"));
+
+    // date --utc -d '2019-1-3T14:15:00 UTC' +%s
+    public static final Long WINTER_EPOCH_UTC = 1546524900L;
+    //date --utc -d '2019-1-3T14:15:00 EST' +%s
+    public static final Long WINTER_EPOCH_EST = 1546542900L;
 
     @Bean
     @Primary
     public ApplicationClock fixedClock() {
-        return new ApplicationClock(Clock.fixed(
-            Instant.from(OffsetDateTime.of(2019, 5, 24, 12, 35, 0, 0, ZoneOffset.UTC)),
-            ZoneId.of("UTC"))
+        return new ApplicationClock(Clock.fixed(Instant.from(SPRING_TIME_UTC), ZoneId.of("UTC")));
+    }
+
+    @Bean(name = "ZuluWinterClock")
+    public ApplicationClock utcWinterClock() {
+        return new ApplicationClock(Clock.fixed(Instant.from(WINTER_TIME_UTC), ZoneId.of("UTC")));
+    }
+
+    @Bean(name = "EDTSpringClock")
+    public ApplicationClock edtSpringClock() {
+        return new ApplicationClock(
+            Clock.fixed(Instant.from(SPRING_TIME_EDT), ZoneId.of("America/New_York")));
+    }
+
+    @Bean(name = "ESTWinterClock")
+    public ApplicationClock estWinterClock() {
+        return new ApplicationClock(
+            Clock.fixed(Instant.from(WINTER_TIME_EST), ZoneId.of("America/New_York"))
         );
     }
 


### PR DESCRIPTION
The code was originally written:

    LocalDateTime.ofEpochSecond(time.longValue(), 0,
        OffsetDateTime.now(zone).getOffset()).atZone(zone);

This old code takes the offset of the current timezone at the instant
the code is run.  The issue is that time zone offsets change.  Instead
the instant of time needs to be converted according to the time zone
rules that were applicable during that specific instant:

    Instant.ofEpochSecond(time).atZone(zone);

The most common change is daylight saving time, but political decisions
can also result in changes.  For example, in 2011 Samoa switched its
time zone offset. Originally, Samoa had its primary economic interaction
with the United States, but had slowly shifted to be more engaged with
Australia, so the government decided to change the timezone offset to
reflect this.  The offset went from UTC-11 to UTC+13 and Samoa skipped
the entire day of 30 December 2011 in the process.

---
# Testing
The unit tests pass and cover the basic cases of a zone's offset shifting around.  To see the original bug, just replace the 

```java
ZonedDateTime zonedDateTime = Instant.ofEpochSecond(time).atZone(zone);
```

line in ApplicationClock's `dateFromUnix` with

```java
ZonedDateTime zonedDateTime = LocalDateTime.ofEpochSecond(time, 0,
        OffsetDateTime.now(zone).getOffset()).atZone(zone);
```

If you do that in the next few days, the

```java
assertEquals(OffsetDateTime.from(SPRING_TIME_EDT), standardClock.dateFromUnix(SPRING_EPOCH_EDT));
```

assertion will fail with 

```
expected: <2019-05-24T12:35-04:00> but was: <2019-05-24T11:35-04:00>
Expected :2019-05-24T12:35-04:00
Actual   :2019-05-24T11:35-04:00
```

Once we enter DST on 14 March 2021, this assertion will pass, but the one testing the WINTER_EPOCH will fail :smiley: 