### PR TITLE
ENT-3570: Adjust config for event pipeline

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -165,4 +165,12 @@ public class ApplicationProperties {
      */
     private Duration metricLookupRangeDuration = Duration.ofHours(24L);
 
+    /**
+     * Latency offset: how far back to set the hourly tally window.
+     *
+     * The offset is subtracted from the beginning and ending times of the latency window, to delay the entire
+     * processing window.  This ensures more metering tasks finish and report their totals before tallying
+     * begins.
+     */
+    private Duration hourlyTallyOffset = Duration.ofMinutes(60L);
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
@@ -20,9 +20,14 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Properties related to a metric that is to be gathered from the prometheus service.
  */
+@Getter
+@Setter
 public class MetricProperties {
 
     /**
@@ -69,69 +74,4 @@ public class MetricProperties {
      * The multiplier to use to generate the next backoff interval when retrying metrics gathering.
      */
     private double backOffMultiplier = 2;
-
-    public String getMetricPromQL() {
-        return metricPromQL;
-    }
-
-    public void setMetricPromQL(String metricPromQL) {
-        this.metricPromQL = metricPromQL;
-    }
-
-    public int getStep() {
-        return step;
-    }
-
-    public void setStep(int step) {
-        this.step = step;
-    }
-
-    public int getRangeInMinutes() {
-        return rangeInMinutes;
-    }
-
-    public void setRangeInMinutes(int rangeInMinutes) {
-        this.rangeInMinutes = rangeInMinutes;
-    }
-
-    public int getQueryTimeout() {
-        return queryTimeout;
-    }
-
-    public void setQueryTimeout(int queryTimeout) {
-        this.queryTimeout = queryTimeout;
-    }
-
-    public int getMaxAttempts() {
-        return maxAttempts;
-    }
-
-    public void setMaxAttempts(int maxAttempts) {
-        this.maxAttempts = maxAttempts;
-    }
-
-    public long getBackOffMaxInterval() {
-        return backOffMaxInterval;
-    }
-
-    public void setBackOffMaxInterval(long backOffMaxInterval) {
-        this.backOffMaxInterval = backOffMaxInterval;
-    }
-
-    public long getBackOffInitialInterval() {
-        return backOffInitialInterval;
-    }
-
-    public void setBackOffInitialInterval(long backOffInitialInterval) {
-        this.backOffInitialInterval = backOffInitialInterval;
-    }
-
-    public double getBackOffMultiplier() {
-        return backOffMultiplier;
-    }
-
-    public void setBackOffMultiplier(double backOffMultiplier) {
-        this.backOffMultiplier = backOffMultiplier;
-    }
-
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -99,4 +99,5 @@ rhsm-subscriptions:
         topic: ${OPENSHIFT_METERING_TASK_TOPIC:platform.rhsm-subscriptions.openshift-metering-tasks}
         kafka-group-id: ${OPENSHIFT_METERING_TASK_GROUP_ID:openshift-metering-task-processor}
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:4h}
+  hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:24h}

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -37,6 +37,8 @@ parameters:
     value: 500m
   - name: CPU_LIMIT
     value: 1900m
+  - name: HOURLY_TALLY_OFFSET
+    value: 60m
 
 objects:
   - apiVersion: batch/v1beta1
@@ -73,6 +75,8 @@ objects:
                       value: ${KAFKA_BOOTSTRAP_HOST}
                     - name: OPENSHIFT_METERING_RANGE
                       value: ${OPENSHIFT_METERING_RANGE}
+                    - name: HOURLY_TALLY_OFFSET
+                      value: ${HOURLY_TALLY_OFFSET}
                     - name: DATABASE_HOST
                       valueFrom:
                         secretKeyRef:


### PR DESCRIPTION
ENT-3570: Adjust config for event pipeline.  

This change delays the latency window by an hour, with the goal of making sure all metering tasks are finished before the tally starts.  