### PR TITLE
ENT-3618: Properly map swatch product IDs for OpenShift based on the 'product' label from Prometheus metrics.

### DIFF
--- a/schemas/event.yaml
+++ b/schemas/event.yaml
@@ -121,6 +121,8 @@ properties:
       - Red Hat Enterprise Linux Server
       - Red Hat Enterprise Linux Workstation
       - Red Hat Enterprise Linux Compute Node
+      - ocp
+      - osd
     required: false
   sla:
     description: Service level for the subject.

--- a/src/main/java/org/candlepin/subscriptions/files/SubscriptionWatchProduct.java
+++ b/src/main/java/org/candlepin/subscriptions/files/SubscriptionWatchProduct.java
@@ -28,6 +28,15 @@ public class SubscriptionWatchProduct {
     private String engProductId;
     private Set<String> swatchProductIds;
 
+    public SubscriptionWatchProduct() {
+        // Required for YAML
+    }
+
+    public SubscriptionWatchProduct(String engProductId, Set<String> swatchProductIds) {
+        this.engProductId = engProductId;
+        this.swatchProductIds = swatchProductIds;
+    }
+
     public String getEngProductId() {
         return engProductId;
     }

--- a/src/main/java/org/candlepin/subscriptions/files/SyspurposeRole.java
+++ b/src/main/java/org/candlepin/subscriptions/files/SyspurposeRole.java
@@ -28,6 +28,15 @@ public class SyspurposeRole {
     private String name;
     private Set<String> swatchProductIds;
 
+    public SyspurposeRole() {
+        // required for YAML
+    }
+
+    public SyspurposeRole(String name, Set<String> swatchProductIds) {
+        this.name = name;
+        this.swatchProductIds = swatchProductIds;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -118,6 +118,10 @@ public class PrometheusMeteringController {
                     String clusterId = labels.get("_id");
                     String sla = labels.get("support");
                     String usage = labels.get("usage");
+                    // NOTE: Role comes from the product label despite its name. The values set here
+                    //       are NOT engineering or swatch product IDs. They map to the roles in the
+                    //       product profile. For openshift, the values will be 'ocp' or 'osd'.
+                    String role = labels.get("product");
 
                     // For the openshift metrics, we expect our results to be a 'matrix'
                     // vector [(instant_time,value), ...] so we only look at the result's getValues()
@@ -133,7 +137,7 @@ public class PrometheusMeteringController {
                         OffsetDateTime eventDate =
                             eventTermDate.minusSeconds(metricProperties.getOpenshift().getStep());
 
-                        Event event = createOrUpdateEvent(existing, account, clusterId, sla, usage,
+                        Event event = createOrUpdateEvent(existing, account, clusterId, sla, usage, role,
                             eventDate, eventTermDate, value);
                         events.put(EventKey.fromEvent(event), event);
                     }
@@ -156,7 +160,8 @@ public class PrometheusMeteringController {
 
     @SuppressWarnings("java:S107")
     private Event createOrUpdateEvent(Map<EventKey, Event> existing, String account, String instanceId,
-        String sla, String usage, OffsetDateTime measuredDate, OffsetDateTime expired, BigDecimal value) {
+        String sla, String usage, String role, OffsetDateTime measuredDate, OffsetDateTime expired,
+        BigDecimal value) {
         EventKey lookupKey = new EventKey(
             account,
             MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_SOURCE,
@@ -169,7 +174,7 @@ public class PrometheusMeteringController {
         if (event == null) {
             event = new Event();
         }
-        MeteringEventFactory.updateOpenShiftClusterCores(event, account, instanceId, sla, usage,
+        MeteringEventFactory.updateOpenShiftClusterCores(event, account, instanceId, sla, usage, role,
             measuredDate, expired, value.doubleValue());
         return event;
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -258,12 +258,12 @@ public class MetricUsageCollector {
         Set<String> productIds = new HashSet<>();
         Stream.of(event.getRole())
             .filter(Objects::nonNull)
-            .map(role -> productProfile.mapSwatchProductsByRole().getOrDefault(role.value(),
+            .map(role -> productProfile.getSwatchProductsByRoles().getOrDefault(role.value(),
                 Collections.emptySet()))
             .forEach(productIds::addAll);
 
         Optional.ofNullable(event.getProductIds()).orElse(Collections.emptyList()).stream()
-            .map(productProfile.mapSwatchProductsByEngProducts()::get)
+            .map(productProfile.getSwatchProductsByEngProducts()::get)
             .filter(Objects::nonNull)
             .forEach(productIds::addAll);
 

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -32,21 +32,18 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.files.ProductProfile;
 import org.candlepin.subscriptions.json.Event;
-import org.candlepin.subscriptions.metering.MeteringEventFactory;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -58,59 +55,20 @@ import javax.ws.rs.core.Response;
 /**
  * Collects instances and tallies based on hourly metrics.
  */
-@Component
 public class MetricUsageCollector {
     private static final Logger log = LoggerFactory.getLogger(MetricUsageCollector.class);
 
     private final AccountRepository accountRepository;
     private final EventController eventController;
     private final ApplicationClock clock;
-    private final ProductConfig productConfig;
+    private final ProductProfile productProfile;
 
-    /**
-     * Encapsulates all per-product information we anticipate putting into configuration used by this
-     * collector.
-     */
-    public static class ProductConfig {
-        public static final String OPENSHIFT_PRODUCT_ID = "OpenShift-metrics";
-        public static final String SERVICE_TYPE = MeteringEventFactory.OPENSHIFT_CLUSTER_SERVICE_TYPE;
-        private static final ServiceLevel DEFAULT_SLA = ServiceLevel.PREMIUM;
-        private static final Usage DEFAULT_USAGE = Usage.PRODUCTION;
-
-        public String getServiceType() {
-            return SERVICE_TYPE;
-        }
-
-        public String getProductId() {
-            return OPENSHIFT_PRODUCT_ID;
-        }
-
-        public Usage getDefaultUsage() {
-            return DEFAULT_USAGE;
-        }
-
-        public ServiceLevel getDefaultSla() {
-            return DEFAULT_SLA;
-        }
-
-        public Map<Event.Role, List<String>> getRoleProductIdMapping() {
-            return Collections.emptyMap();
-        }
-
-        public Map<String, List<String>> getEngineeringProductIdToSwatchProductMapping() {
-            return Collections.emptyMap();
-        }
-    }
-
-    @Autowired
-    public MetricUsageCollector(AccountRepository accountRepository, EventController eventController,
-        ApplicationClock clock) {
-
+    public MetricUsageCollector(ProductProfile productProfile, AccountRepository accountRepository,
+        EventController eventController, ApplicationClock clock) {
         this.accountRepository = accountRepository;
         this.eventController = eventController;
         this.clock = clock;
-        this.productConfig = new ProductConfig();
-
+        this.productProfile = productProfile;
     }
 
     @Transactional
@@ -125,7 +83,7 @@ public class MetricUsageCollector {
         Map<String, Host> serviceInstances = new HashMap<>();
         OffsetDateTime newestInstanceTimestamp = OffsetDateTime.MIN;
         for (Host host : account.getServiceInstances().values()) {
-            if (productConfig.getServiceType().equals(host.getInstanceType())) {
+            if (productProfile.getServiceType().equals(host.getInstanceType())) {
                 serviceInstances.put(host.getInstanceId(), host);
                 newestInstanceTimestamp = newestInstanceTimestamp.isAfter(host.getLastSeen()) ?
                     newestInstanceTimestamp : host.getLastSeen();
@@ -154,7 +112,7 @@ public class MetricUsageCollector {
         Stream<Event> eventStream = eventController.fetchEventsInTimeRange(accountNumber,
             effectiveStartDateTime,
             effectiveEndDateTime)
-            .filter(event -> event.getServiceType().equals(productConfig.getServiceType()));
+            .filter(event -> event.getServiceType().equals(productProfile.getServiceType()));
 
         eventStream.forEach(event -> {
             String instanceId = event.getInstanceId();
@@ -278,11 +236,11 @@ public class MetricUsageCollector {
         ServiceLevel effectiveSla = Optional.ofNullable(event.getSla())
             .map(Event.Sla::toString)
             .map(ServiceLevel::fromString)
-            .orElse(productConfig.getDefaultSla());
+            .orElse(productProfile.getDefaultSla());
         Usage effectiveUsage = Optional.ofNullable(event.getUsage())
             .map(Event.Usage::toString)
             .map(Usage::fromString)
-            .orElse(productConfig.getDefaultUsage());
+            .orElse(productProfile.getDefaultUsage());
         Set<String> productIds = getProductIds(event);
 
         for (String productId : productIds) {
@@ -298,15 +256,17 @@ public class MetricUsageCollector {
 
     private Set<String> getProductIds(Event event) {
         Set<String> productIds = new HashSet<>();
-        productIds.add(productConfig.getProductId()); // this product ID always applies
         Stream.of(event.getRole())
             .filter(Objects::nonNull)
-            .map(role -> productConfig.getRoleProductIdMapping().getOrDefault(role, Collections.emptyList()))
+            .map(role -> productProfile.mapSwatchProductsByRole().getOrDefault(role.value(),
+                Collections.emptySet()))
             .forEach(productIds::addAll);
+
         Optional.ofNullable(event.getProductIds()).orElse(Collections.emptyList()).stream()
-            .map(productConfig.getEngineeringProductIdToSwatchProductMapping()::get)
+            .map(productProfile.mapSwatchProductsByEngProducts()::get)
             .filter(Objects::nonNull)
             .forEach(productIds::addAll);
+
         return productIds;
     }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -66,7 +66,7 @@ public class TallySnapshotController {
         MaxSeenSnapshotStrategy maxSeenSnapshotStrategy,
         @Qualifier("collectorRetryTemplate") RetryTemplate retryTemplate,
         @Qualifier("cloudigradeRetryTemplate") RetryTemplate cloudigradeRetryTemplate,
-        MetricUsageCollector metricUsageCollector,
+        @Qualifier("OpenShiftMetricsUsageCollector") MetricUsageCollector metricUsageCollector,
         CombiningRollupSnapshotStrategy combiningRollupSnapshotStrategy) {
 
         this.props = props;

--- a/src/main/resources/product_profile_registry.yaml
+++ b/src/main/resources/product_profile_registry.yaml
@@ -95,6 +95,9 @@ syspurposeRoles:
   - name: osd
     swatchProductIds:
       - OpenShift-dedicated-metrics
+serviceType: OpenShift Cluster
 finestGranularity: HOURLY
+defaultSla: PREMIUM
+defaultUsage: PRODUCTION
 burstable: false
 architectureSwatchProductIdMap: {}

--- a/src/main/resources/product_profile_registry.yaml
+++ b/src/main/resources/product_profile_registry.yaml
@@ -83,11 +83,18 @@ burstable: false
 syspurposeRoles: []
 architectureSwatchProductIdMap: {}
 ---
-name: OpenShift-metrics
+name: OpenShiftContainerPlatform
 products:
   - engProductId: 290 # Red Hat OpenShift Container Platform
     swatchProductIds:
       - OpenShift Container Platform
+finestGranularity: DAILY
+burstable: false
+syspurposeRoles: []
+architectureSwatchProductIdMap: {}
+---
+name: OpenShiftMetrics
+products: []
 syspurposeRoles:
   - name: ocp
     swatchProductIds:

--- a/src/test/java/org/candlepin/subscriptions/files/ProductProfileRegistrySourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductProfileRegistrySourceTest.java
@@ -43,7 +43,8 @@ class ProductProfileRegistrySourceTest {
             "RHELProducts",
             "SatelliteProducts",
             "OpenShiftHourlyProducts",
-            "OtherProducts"
+            "OtherProducts",
+            "OpenShiftMetrics"
         ));
         assertEquals(expected, registry.listProfiles());
     }

--- a/src/test/java/org/candlepin/subscriptions/files/ProductProfileRegistryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductProfileRegistryTest.java
@@ -32,8 +32,10 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 class ProductProfileRegistryTest {
 
@@ -116,7 +118,7 @@ class ProductProfileRegistryTest {
 
     @Test
     void testListProfiles() {
-        Set<String> expected = Set.of("p1", "p2", "p3");
+        Set<String> expected = Set.of("p1", "p2", "p3", "p4");
         Set<String> actual = registry.listProfiles();
         assertEquals(expected, actual);
     }
@@ -124,7 +126,7 @@ class ProductProfileRegistryTest {
     @Test
     void testGetAllProductProfiles() {
         Set<ProductProfile> profiles = registry.getAllProductProfiles();
-        assertEquals(3, profiles.size());
+        assertEquals(4, profiles.size());
         assertEquals(Set.of(HOURLY, DAILY),
             profiles.stream().map(ProductProfile::getFinestGranularity).collect(Collectors.toSet()));
     }
@@ -184,5 +186,14 @@ class ProductProfileRegistryTest {
     void mapsSwatchProductIdToProfileByRole() {
         ProductProfile actual = registry.findProfileForSwatchProductId(OPENSHIFT_METRICS);
         assertEquals("p4", actual.getName());
+    }
+
+    @Test
+    void mapsProfileByName() {
+        Stream.of("p1", "p2", "p3", "p4").forEach(n -> {
+            Optional<ProductProfile> profile = registry.getProfileByName(n);
+            assertTrue(profile.isPresent(), "Profile not found with name: " + n);
+            assertEquals(n, profile.get().getName());
+        });
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/files/ProductProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductProfileTest.java
@@ -55,7 +55,8 @@ class ProductProfileTest {
             new SyspurposeRole("ROLE_1", swatchProds1),
             new SyspurposeRole("ROLE_2", swatchProds2)
         ));
-        Map<String, Set<String>> mapping = p.mapSwatchProductsByRole();
+
+        Map<String, Set<String>> mapping = p.getSwatchProductsByRoles();
         assertTrue(mapping.containsKey("ROLE_1"));
         assertThat(mapping.get("ROLE_1"), Matchers.containsInAnyOrder(swatchProds1.toArray()));
         assertTrue(mapping.containsKey("ROLE_2"));
@@ -63,10 +64,12 @@ class ProductProfileTest {
     }
 
     @Test
-    void mapSwatchProductsByRoleHandlesNull() {
-        ProductProfile p = new ProductProfile("test", Collections.emptySet(), Granularity.DAILY);
-        Map<String, Set<String>> mapping = p.mapSwatchProductsByRole();
-        assertTrue(mapping.isEmpty());
+    void mapSwatchProductsByRoleHandlesEmptySet() {
+        ProductProfile profile1 = new ProductProfile("test", Collections.emptySet(), Granularity.DAILY);
+        assertTrue(profile1.getSwatchProductsByRoles().isEmpty());
+
+        ProductProfile profile2 = new ProductProfile();
+        assertTrue(profile2.getSwatchProductsByRoles().isEmpty());
     }
 
     @Test
@@ -79,20 +82,31 @@ class ProductProfileTest {
             new SubscriptionWatchProduct("PROD_2", swatchProds2)
         );
 
-        ProductProfile p = new ProductProfile("test", products, Granularity.DAILY);
-
-        Map<String, Set<String>> mapping = p.mapSwatchProductsByEngProducts();
+        ProductProfile profile1 = new ProductProfile("test", products, Granularity.DAILY);
+        Map<String, Set<String>> mapping = profile1.getSwatchProductsByEngProducts();
         assertTrue(mapping.containsKey("PROD_1"));
         assertThat(mapping.get("PROD_1"), Matchers.containsInAnyOrder(swatchProds1.toArray()));
         assertTrue(mapping.containsKey("PROD_2"));
         assertThat(mapping.get("PROD_2"), Matchers.containsInAnyOrder(swatchProds2.toArray()));
+
+        ProductProfile profile2 = new ProductProfile();
+        profile2.setProducts(products);
+        Map<String, Set<String>> mapping2 = profile2.getSwatchProductsByEngProducts();
+        assertTrue(mapping2.containsKey("PROD_1"));
+        assertThat(mapping2.get("PROD_1"), Matchers.containsInAnyOrder(swatchProds1.toArray()));
+        assertTrue(mapping2.containsKey("PROD_2"));
+        assertThat(mapping2.get("PROD_2"), Matchers.containsInAnyOrder(swatchProds2.toArray()));
+
+        assertEquals(mapping, mapping2);
     }
 
     @Test
-    void mapSwatchProductsByEngProductsHandlesNull() {
-        ProductProfile p = new ProductProfile("test", Collections.emptySet(), Granularity.DAILY);
-        Map<String, Set<String>> mapping = p.mapSwatchProductsByEngProducts();
-        assertTrue(mapping.isEmpty());
+    void mapSwatchProductsByEngProductsHandlesEmptySet() {
+        ProductProfile profile1 = new ProductProfile("test", Collections.emptySet(), Granularity.DAILY);
+        assertTrue(profile1.getSwatchProductsByEngProducts().isEmpty());
+
+        ProductProfile profile2 = new ProductProfile();
+        assertTrue(profile2.getSwatchProductsByEngProducts().isEmpty());
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/files/ProductProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductProfileTest.java
@@ -20,13 +20,17 @@
  */
 package org.candlepin.subscriptions.files;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.db.model.Granularity;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 class ProductProfileTest {
     @Test
@@ -40,6 +44,55 @@ class ProductProfileTest {
         assertTrue(p.supportsGranularity(Granularity.MONTHLY));
         assertTrue(p.supportsGranularity(Granularity.QUARTERLY));
         assertTrue(p.supportsGranularity(Granularity.YEARLY));
+    }
+
+    @Test
+    void mapSwatchProductsByRoleTest() {
+        ProductProfile p = new ProductProfile("test", Collections.emptySet(), Granularity.DAILY);
+        Set<String> swatchProds1 = Set.of("SW_PROD_1", "SW_PROD_2");
+        Set<String> swatchProds2 = Set.of("SW_PROD_1");
+        p.setSyspurposeRoles(Set.of(
+            new SyspurposeRole("ROLE_1", swatchProds1),
+            new SyspurposeRole("ROLE_2", swatchProds2)
+        ));
+        Map<String, Set<String>> mapping = p.mapSwatchProductsByRole();
+        assertTrue(mapping.containsKey("ROLE_1"));
+        assertThat(mapping.get("ROLE_1"), Matchers.containsInAnyOrder(swatchProds1.toArray()));
+        assertTrue(mapping.containsKey("ROLE_2"));
+        assertThat(mapping.get("ROLE_2"), Matchers.containsInAnyOrder(swatchProds2.toArray()));
+    }
+
+    @Test
+    void mapSwatchProductsByRoleHandlesNull() {
+        ProductProfile p = new ProductProfile("test", Collections.emptySet(), Granularity.DAILY);
+        Map<String, Set<String>> mapping = p.mapSwatchProductsByRole();
+        assertTrue(mapping.isEmpty());
+    }
+
+    @Test
+    void mapSwatchProductsByEngProducts() {
+        Set<String> swatchProds1 = Set.of("SW_PROD_1", "SW_PROD_2");
+        Set<String> swatchProds2 = Set.of("SW_PROD_1");
+
+        Set<SubscriptionWatchProduct> products = Set.of(
+            new SubscriptionWatchProduct("PROD_1", swatchProds1),
+            new SubscriptionWatchProduct("PROD_2", swatchProds2)
+        );
+
+        ProductProfile p = new ProductProfile("test", products, Granularity.DAILY);
+
+        Map<String, Set<String>> mapping = p.mapSwatchProductsByEngProducts();
+        assertTrue(mapping.containsKey("PROD_1"));
+        assertThat(mapping.get("PROD_1"), Matchers.containsInAnyOrder(swatchProds1.toArray()));
+        assertTrue(mapping.containsKey("PROD_2"));
+        assertThat(mapping.get("PROD_2"), Matchers.containsInAnyOrder(swatchProds2.toArray()));
+    }
+
+    @Test
+    void mapSwatchProductsByEngProductsHandlesNull() {
+        ProductProfile p = new ProductProfile("test", Collections.emptySet(), Granularity.DAILY);
+        Map<String, Set<String>> mapping = p.mapSwatchProductsByEngProducts();
+        assertTrue(mapping.isEmpty());
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -41,12 +41,13 @@ class MeteringEventFactoryTest {
         String clusterId = "my-cluster";
         String sla = "Premium";
         String usage = "Production";
+        String role = "ocp";
         OffsetDateTime expiry = OffsetDateTime.now();
         OffsetDateTime measuredTime = expiry.minusHours(1);
         Double measuredValue = 23.0;
 
         Event event = MeteringEventFactory.openShiftClusterCores(account, clusterId, sla, usage,
-            measuredTime, expiry, measuredValue);
+            role, measuredTime, expiry, measuredValue);
         assertEquals(account, event.getAccountNumber());
         assertEquals(measuredTime, event.getTimestamp());
         assertEquals(expiry, event.getExpiration().get());
@@ -66,36 +67,50 @@ class MeteringEventFactoryTest {
     @Test
     void testOpenShiftClusterCoresHandlesNullServiceLevel() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", null,
-            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
+            "Production", "ocp", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresSlaSetToEmptyForSlaValueNone() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "None",
-            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
+            "Production", "ocp", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertEquals(Sla.__EMPTY__, event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresInvalidSlaWillNotBeSetOnEvent() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "UNKNOWN_SLA",
-            "Production", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
+            "Production", "ocp", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getSla());
     }
 
     @Test
     void testOpenShiftClusterCoresInvalidUsageSetsNullValue() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "Premium",
-            "UNKNOWN_USAGE", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
+            "UNKNOWN_USAGE", "ocp", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getUsage());
     }
 
     @Test
     void testOpenShiftClusterCoresHandlesNullUsage() throws Exception {
         Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "Premium",
-            null, OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
+            null, "ocp", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
         assertNull(event.getUsage());
+    }
+
+    @Test
+    void testOpenShiftClusterCoresInvalidRoleSetsNullValue() {
+        Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "Premium",
+            "Production", "UNKNOWN_ROLE", OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
+        assertNull(event.getRole());
+    }
+
+    @Test
+    void testOpenShiftClusterCoresHandlesNullRole() {
+        Event event = MeteringEventFactory.openShiftClusterCores("my-account", "cluster-id", "Premium",
+            "Production", null, OffsetDateTime.now(), OffsetDateTime.now(), 12.5);
+        assertNull(event.getRole());
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -80,6 +80,7 @@ class PrometheusMeteringControllerTest {
     private final String expectedClusterId = "C1";
     private final String expectedSla = "Premium";
     private final String expectedUsage = "Production";
+    private final String expectedRole = "ocm";
 
     @Test
     void testRetryWhenOpenshiftServiceReturnsError() throws Exception {
@@ -135,10 +136,12 @@ class PrometheusMeteringControllerTest {
 
         List<Event> expectedEvents = List.of(
             MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId, expectedSla,
-                expectedUsage, clock.dateFromUnix(time1).minusSeconds(props.getOpenshift().getStep()),
+                expectedUsage, expectedRole,
+                clock.dateFromUnix(time1).minusSeconds(props.getOpenshift().getStep()),
                 clock.dateFromUnix(time1), val1.doubleValue()),
             MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId, expectedSla,
-                expectedUsage, clock.dateFromUnix(time2).minusSeconds(props.getOpenshift().getStep()),
+                expectedUsage, expectedRole,
+                clock.dateFromUnix(time2).minusSeconds(props.getOpenshift().getStep()),
                 clock.dateFromUnix(time2), val2.doubleValue())
         );
 
@@ -177,26 +180,26 @@ class PrometheusMeteringControllerTest {
         OffsetDateTime end = clock.endOfHour(start.plusDays(1));
 
         Event updatedEvent = MeteringEventFactory.openShiftClusterCores(expectedAccount, expectedClusterId,
-            expectedSla, expectedUsage,
+            expectedSla, expectedUsage, expectedRole,
             clock.dateFromUnix(time1).minusSeconds(props.getOpenshift().getStep()),
             clock.dateFromUnix(time1),
             val1.doubleValue());
 
         List<Event> expectedEvents = List.of(updatedEvent,
             MeteringEventFactory.openShiftClusterCores(expectedAccount,
-            expectedClusterId, expectedSla, expectedUsage,
+            expectedClusterId, expectedSla, expectedUsage, expectedRole,
             clock.dateFromUnix(time2).minusSeconds(props.getOpenshift().getStep()),
             clock.dateFromUnix(time2), val2.doubleValue()));
 
         Event purgedEvent = MeteringEventFactory.openShiftClusterCores(expectedAccount,
-            "CLUSTER_NO_LONGER_EXISTS", expectedSla, expectedUsage,
+            "CLUSTER_NO_LONGER_EXISTS", expectedSla, expectedUsage, expectedRole,
             clock.dateFromUnix(time1).minusSeconds(props.getOpenshift().getStep()),
             clock.dateFromUnix(time1), val1.doubleValue());
 
         List<Event> existingEvents = List.of(
             // This event will get updated by the incoming data from prometheus.
             MeteringEventFactory.openShiftClusterCores(expectedAccount,
-            expectedClusterId, expectedSla, expectedUsage, updatedEvent.getTimestamp(),
+            expectedClusterId, expectedSla, expectedUsage, expectedRole, updatedEvent.getTimestamp(),
             updatedEvent.getExpiration().get(), 144.4),
             // This event should get purged because prometheus did not report this cluster.
             purgedEvent

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -53,6 +54,7 @@ class TallySnapshotControllerTest {
     CloudigradeAccountUsageCollector cloudigradeCollector;
 
     @MockBean
+    @Qualifier("OpenShiftMetricsUsageCollector")
     MetricUsageCollector metricUsageCollector;
 
     @MockBean

--- a/src/test/resources/test_product_profile_registry.yaml
+++ b/src/test/resources/test_product_profile_registry.yaml
@@ -93,3 +93,19 @@ products:
 finestGranularity: DAILY
 syspurposeRoles: []
 architectureSwatchProductIdMap: {}
+---
+name: OpenShiftMetrics
+products: []
+syspurposeRoles:
+  - name: ocp
+    swatchProductIds:
+      - OpenShift-metrics
+  - name: osd
+    swatchProductIds:
+      - OpenShift-dedicated-metrics
+serviceType: OpenShift Cluster
+finestGranularity: HOURLY
+defaultSla: PREMIUM
+defaultUsage: PRODUCTION
+burstable: false
+architectureSwatchProductIdMap: {}


### PR DESCRIPTION
The PR addresses 3 issues that came out of the reported bug in ENT-3618. Details can be found [here](https://issues.redhat.com/browse/ENT-3618?focusedCommentId=15901338&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15901338)

As they were all related, I've included the fixes in the same PR but 3 commits.

In summary, this PR fixes:
1) No more ProductId not found warning message for OpenShift metering products.
2) Snapshots produced from OpenShift metric events should now properly update the swatch product IDs for osd and ocp metrics.

**HOW TO TEST**
Get your token [here](https://docs.engineering.redhat.com/display/ENT/Prometheus+Metrics) and export to $PROM_TOKEN.

Run the app as follows:
```bash
$ DEV_MODE=true PROM_AUTH_TOKEN="$(echo $PROM_TOKEN)" PROM_URL="https://telemeter-lts.datahub.redhat.com/api/v1" ./gradlew clean bootRun
```

Opt-In with these 2 accounts so that you can run the tallies for each.
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d  '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["6341237","123456",true,true,true]}'

$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["540155","654321",true,true,true]}'
```

Pull the metrics from Prometheus for each account.
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMeteringForAccount(java.lang.String)","arguments":["6341237"]}'

$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMeteringForAccount(java.lang.String)","arguments":["540155"]}'
```

Tally the snapshots for each account.
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6341237","2021-03-10T00:00:00Z","2021-03-10T23:59:59.999Z"]}'

$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["540155","2021-03-10T00:00:00Z","2021-03-10T23:59:59.999Z"]}'
```

Verify the snapshots the product ID being used for each account.
Account 6341237 should only have product osd product: OpenShift-dedicated-metrics
Account 540155 should only have  ocp product: OpenShift-metrics
```sql
select id, account_number, snapshot_date, product_id, sla, usage, granularity from tally_snapshots s where account_number in ('6341237', '540155') order by account_number;
```