### PR TITLE
ENT-3633 - (bug) Hourly snapshots being produced for non-openshift products

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ ext {
     kafka_avro_serializer_version = "6.1.0"
     avro_version = "1.10.1"
     webjars_locator_version = "0.40"
+    generatedMetamodels = "build/generated/sources/annotationProcessor/java/main/org/candlepin/subscriptions"
 }
 
 allprojects {
@@ -101,6 +102,7 @@ allprojects {
         annotationProcessor "org.projectlombok:lombok"
         testCompileOnly "org.projectlombok:lombok"
         testAnnotationProcessor "org.projectlombok:lombok"
+        annotationProcessor('org.hibernate:hibernate-jpamodelgen')
 
         testCompile "org.springframework.boot:spring-boot-starter-test"
         testCompile "org.springframework:spring-test"
@@ -250,6 +252,14 @@ tasks.register('dependencyJson') {
             dependents: artifactInstances.collect { it.dependent },
         ]
     }.sort { "${it.group}:${it.name}:${it.version}" })
+}
+
+sourceSets {
+    main.java.srcDir generatedMetamodels
+}
+
+compileJava {
+    options.annotationProcessorGeneratedSourcesDirectory = file(generatedMetamodels)
 }
 
 compileJava.dependsOn(processResources)

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -151,15 +151,21 @@ public abstract class BaseSnapshotRoller {
             }
 
             for (UsageCalculation.Key usageKey : accountCalc.getKeys()) {
-                TallySnapshot snap = accountSnapsByUsageKey.get(usageKey);
-                UsageCalculation productCalc = accountCalc.getCalculation(usageKey);
-                if (snap == null && productCalc.hasMeasurements()) {
-                    snap = createSnapshotFromProductUsageCalculation(accountCalc.getAccount(),
-                        accountCalc.getOwner(), productCalc, targetGranularity);
-                    snaps.add(snap);
-                }
-                else if (snap != null && updateMaxValues(snap, productCalc)) {
-                    snaps.add(snap);
+                boolean isGranularitySupported = productProfileRegistry
+                    .findProfileForSwatchProductId(usageKey.getProductId())
+                    .supportsGranularity(targetGranularity);
+
+                if (isGranularitySupported) {
+                    TallySnapshot snap = accountSnapsByUsageKey.get(usageKey);
+                    UsageCalculation productCalc = accountCalc.getCalculation(usageKey);
+                    if (snap == null && productCalc.hasMeasurements()) {
+                        snap = createSnapshotFromProductUsageCalculation(accountCalc.getAccount(),
+                            accountCalc.getOwner(), productCalc, targetGranularity);
+                        snaps.add(snap);
+                    }
+                    else if (snap != null && updateMaxValues(snap, productCalc)) {
+                        snaps.add(snap);
+                    }
                 }
             }
         }

--- a/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
@@ -55,7 +55,9 @@ public class CaptureMetricsSnapshotTask implements Task {
             throw new IllegalArgumentException(
                 "Cannot produce hourly snapshot for account {}.  Invalid date range provided.");
         }
-        log.info("Producing hourly snapshot for account {} in timeframe {}-{}", accountNumber, startDateTime,
+        log.info("Producing hourly snapshot for account {} between startDateTime {} and endDateTime {}",
+            accountNumber,
+            startDateTime,
             endDateTime);
 
         snapshotController.produceHourlySnapshotsForAccount(accountNumber, startDateTime, endDateTime);


### PR DESCRIPTION
On the develop branch, if you follow the instructions below for seeding data, then running some tallies, RHEL Hourly snapshots were being produced...this first query and table of results below is an example.  I don't have instructions included for putting test data into the insights database for the HBI portion of this.....but you'll need that in order to get RHEL snapshots.

```sql
SELECT DISTINCT product_id,
    --account_number,
    granularity
FROM tally_snapshots
WHERE sla = '_ANY'
    AND usage = '_ANY'
     AND granularity = 'HOURLY'
    --AND account_number = 'account123'
GROUP BY product_id,
    --account_number,
    granularity
ORDER BY --account_number,
    granularity ASC;
```

```

+---------------------------+-----------+
|product_id                 |granularity|
+---------------------------+-----------+
|OpenShift-dedicated-metrics|HOURLY     |
|OpenShift-metrics          |HOURLY     |
|RHEL                       |HOURLY     |
|RHEL Desktop               |HOURLY     |
|RHEL for x86               |HOURLY     |
|RHEL Server                |HOURLY     |
+---------------------------+-----------+

```


# Test instructions
---
## Clear data & insert test event data
```sql
TRUNCATE tally_snapshots CASCADE;
TRUNCATE hosts CASCADE;
TRUNCATE events CASCADE;

INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('1edc517a-d049-4361-9804-e4111ce061ae', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Development/Test", "event_id": "1edc517a-d049-4361-9804-e4111ce061ae", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "display_name": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'c6123fbb-84d0-47a7-b069-ff9048caf7c7');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('9fd69ad7-9294-4d8d-a5f4-c5ca45bdb2ec', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Standard", "usage": "Development/Test", "event_id": "9fd69ad7-9294-4d8d-a5f4-c5ca45bdb2ec", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "display_name": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', '0e94471b-f9bb-4b30-8d6e-8ad6c3539392');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('91ef5257-6f44-4ad5-812e-ae070483e4a7', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Production", "event_id": "91ef5257-6f44-4ad5-812e-ae070483e4a7", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "display_name": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'bdeffe2b-08c6-40ef-b2cf-e3c458a0273a');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('a35a0f56-d46b-4c36-ad4b-e6e889e13c9f', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Production", "event_id": "a35a0f56-d46b-4c36-ad4b-e6e889e13c9f", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "display_name": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'bdeffe2b-08c6-40ef-b2cf-e3c458a0273a');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('0b021762-59e6-41ae-bbe6-e4ba1deaf3a1', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Standard", "usage": "Development/Test", "event_id": "0b021762-59e6-41ae-bbe6-e4ba1deaf3a1", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "display_name": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', '0e94471b-f9bb-4b30-8d6e-8ad6c3539392');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('e223e90d-f567-4a4f-b05f-7ad9e67fe5c5', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Development/Test", "event_id": "e223e90d-f567-4a4f-b05f-7ad9e67fe5c5", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "display_name": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'c6123fbb-84d0-47a7-b069-ff9048caf7c7');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('922855da-29da-438f-b8c5-d2f3df7f62fd', 'account123', '2021-03-10 19:00:00.000000', '{"role":"osd","sla": "Premium", "usage": "Development/Test", "event_id": "922855da-29da-438f-b8c5-d2f3df7f62fd", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "f418a78c-2099-4932-9ff2-135dabd09077", "display_name": "f418a78c-2099-4932-9ff2-135dabd09077", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'f418a78c-2099-4932-9ff2-135dabd09077');
```

## kick off hourly tally
```sh
curl -X POST \
  'http://localhost:8080/actuator/hawtio/jolokia/' \
  -H 'Content-Type: application/json; charset=utf-8' \
  -d '{
  "type": "exec",
  "mbean": "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
  "operation": "tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)",
  "arguments": [
    "account123",
    "2021-03-09T00:00:00Z",
    "2021-03-10T23:59:00Z"
  ]
}'
```

## observe that hourly snapshots are produced for the account
```sql
SELECT DISTINCT
    product_id,
    --account_number,
    granularity
  FROM tally_snapshots
 WHERE
       sla = '_ANY'
   AND usage = '_ANY'
   --AND granularity = 'HOURLY'
 GROUP BY
     product_id,
     --account_number,
     granularity
 ORDER BY
     --account_number,
     granularity ASC,
     product_id;
```
```
+---------------------------+-----------+
|product_id                 |granularity|
+---------------------------+-----------+
|OpenShift-dedicated-metrics|DAILY      |
|OpenShift-metrics          |DAILY      |
|OpenShift-dedicated-metrics|HOURLY     |
|OpenShift-metrics          |HOURLY     |
+---------------------------+-----------+
```


## kick off "regular" tally for all configured accounts

```sh
curl -X POST \
  'http://localhost:8080/actuator/hawtio/jolokia/' \
  -H 'Content-Type: application/json; charset=utf-8' \
  -d '{
  "type": "exec",
  "mbean": "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
  "operation": "tallyConfiguredAccounts()"
}'
```

## observe that there are no longer any RHEL/Hourly snapshots being produced
```sql
SELECT DISTINCT product_id,
    --account_number,
    granularity
FROM tally_snapshots
WHERE sla = '_ANY'
    AND usage = '_ANY'
     --AND granularity = 'HOURLY'
    --AND account_number = 'account123'
GROUP BY product_id,
    --account_number,
    granularity
ORDER BY --account_number,
    granularity ASC;
```
```
+---------------------------+-----------+
|product_id                 |granularity|
+---------------------------+-----------+
|OpenShift-dedicated-metrics|DAILY      |
|OpenShift-metrics          |DAILY      |
|RHEL                       |DAILY      |
|RHEL Desktop               |DAILY      |
|RHEL for x86               |DAILY      |
|RHEL Server                |DAILY      |
|OpenShift-dedicated-metrics|HOURLY     |
|OpenShift-metrics          |HOURLY     |
|RHEL                       |MONTHLY    |
|RHEL Desktop               |MONTHLY    |
|RHEL for x86               |MONTHLY    |
|RHEL Server                |MONTHLY    |
|RHEL                       |QUARTERLY  |
|RHEL Desktop               |QUARTERLY  |
|RHEL for x86               |QUARTERLY  |
|RHEL Server                |QUARTERLY  |
|RHEL                       |WEEKLY     |
|RHEL Desktop               |WEEKLY     |
|RHEL for x86               |WEEKLY     |
|RHEL Server                |WEEKLY     |
|RHEL                       |YEARLY     |
|RHEL Desktop               |YEARLY     |
|RHEL for x86               |YEARLY     |
|RHEL Server                |YEARLY     |
+---------------------------+-----------+

```