### PR TITLE
ENT-3265: Add MarketplaceProducer

### DIFF
--- a/marketplace-client/marketplace-api-spec.yaml
+++ b/marketplace-client/marketplace-api-spec.yaml
@@ -99,7 +99,6 @@ components:
       required:
         - start
         - end
-        - resourceType
         - subscriptionId
         - eventId
         - additionalAttributes
@@ -113,8 +112,6 @@ components:
           description: End time of the usage in millseconds since Unix epoch.
           type: integer
           format: int64
-        resourceType:
-          type: string
         subscriptionId:
           type: string
         eventId:
@@ -128,10 +125,10 @@ components:
             $ref: "#/components/schemas/UsageMeasurement"
     UsageMeasurement:
       required:
-        - chargeId
+        - metricId
         - value
       properties:
-        chargeId:
+        metricId:
           type: string
         value:
           type: number

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
@@ -41,6 +41,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ManagedResource
+// must log, then throw because the exception is passed to client and not logged.
+@SuppressWarnings("java:S2139")
 public class MarketplaceJmxBean {
     private static final Logger log = LoggerFactory.getLogger(MarketplaceJmxBean.class);
 

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
@@ -45,13 +45,15 @@ public class MarketplaceJmxBean {
 
     private final ApplicationProperties properties;
     private final MarketplaceService marketplaceService;
+    private final MarketplaceProducer marketplaceProducer;
     private final ObjectMapper mapper;
 
     MarketplaceJmxBean(ApplicationProperties properties, MarketplaceService marketplaceService,
-        ObjectMapper mapper) {
+        MarketplaceProducer marketplaceProducer, ObjectMapper mapper) {
 
         this.properties = properties;
         this.marketplaceService = marketplaceService;
+        this.marketplaceProducer = marketplaceProducer;
         this.mapper = mapper;
     }
 
@@ -69,7 +71,7 @@ public class MarketplaceJmxBean {
         }
         UsageEvent usageEvent = mapper.readValue(payloadJson, UsageEvent.class);
         UsageRequest usageRequest = new UsageRequest().addDataItem(usageEvent);
-        return marketplaceService.submitUsageEvents(usageRequest).toString();
+        return marketplaceProducer.submitUsageRequest(usageRequest).toString();
     }
 
     @ManagedOperation(description = "Fetch a usage event status")

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
@@ -57,13 +57,12 @@ public class MarketplaceProducer {
         this.retryTemplate = retryTemplate;
     }
 
-    @Timed("rhsm-subscriptions.marketplace.usage")
+    @Timed("rhsm-subscriptions.marketplace.usage.submission")
     public StatusResponse submitUsageRequest(UsageRequest usageRequest) {
         // NOTE: https://issues.redhat.com/browse/ENT-3609 will address failures
         return retryTemplate.execute(context -> tryRequest(usageRequest));
     }
 
-    @Timed("rhsm-subscriptions.marketplace.usage.request")
     private StatusResponse tryRequest(UsageRequest usageRequest) {
         try {
             StatusResponse status = marketplaceService.submitUsageEvents(usageRequest);

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
@@ -69,11 +69,10 @@ public class MarketplaceProducer {
             StatusResponse status = marketplaceService.submitUsageEvents(usageRequest);
             log.debug("Marketplace response: {}", status);
             if (status.getData() != null) {
-                status.getData().forEach(batchStatus -> {
+                status.getData().forEach(batchStatus ->
                     log.info("Marketplace Batch: {} for Tally Snapshot IDs: {}", batchStatus.getBatchId(),
-                        usageRequest.getData().stream()
-                        .map(UsageEvent::getEventId).collect(Collectors.joining(",")));
-                });
+                    usageRequest.getData().stream()
+                    .map(UsageEvent::getEventId).collect(Collectors.joining(","))));
             }
             return status;
         }

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import org.candlepin.subscriptions.marketplace.api.model.StatusResponse;
+import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Service;
+
+import io.micrometer.core.annotation.Timed;
+
+/**
+ * Component that is responsible for emitting usage info to Marketplace, including handling retries.
+ */
+@Service
+public class MarketplaceProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(MarketplaceProducer.class);
+
+    private final MarketplaceService marketplaceService;
+    private final RetryTemplate retryTemplate;
+
+    @Autowired
+    MarketplaceProducer(MarketplaceService marketplaceService,
+        @Qualifier("marketplaceRetryTemplate") RetryTemplate retryTemplate) {
+        this.marketplaceService = marketplaceService;
+        this.retryTemplate = retryTemplate;
+    }
+
+    @Timed("rhsm-subscriptions.marketplace.usage")
+    public StatusResponse submitUsageRequest(UsageRequest usageRequest) throws ApiException {
+        // NOTE: https://issues.redhat.com/browse/ENT-3609 will address failures
+        return retryTemplate.execute(context -> tryRequest(usageRequest));
+    }
+
+    @Timed("rhsm-subscriptions.marketplace.usage.request")
+    private StatusResponse tryRequest(UsageRequest usageRequest) throws ApiException {
+        StatusResponse status = marketplaceService.submitUsageEvents(usageRequest);
+        log.debug("Marketplace response: {}", status);
+        return status;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
@@ -25,11 +25,16 @@ import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.time.Duration;
 
 /**
  * Properties for the Marketplace integration.
  */
+@Getter
+@Setter
 @Component
 @ConfigurationProperties(prefix = "rhsm-subscriptions.marketplace")
 public class MarketplaceProperties extends HttpClientProperties {
@@ -44,19 +49,23 @@ public class MarketplaceProperties extends HttpClientProperties {
      */
     private Duration tokenRefreshPeriod = Duration.ofMinutes(1);
 
-    public String getApiKey() {
-        return apiKey;
-    }
+    /**
+     * How many attempts before giving up.
+     */
+    private Integer maxAttempts;
 
-    public void setApiKey(String apiKey) {
-        this.apiKey = apiKey;
-    }
+    /**
+     * Retry backoff interval.
+     */
+    private Duration backOffInitialInterval;
 
-    public Duration getTokenRefreshPeriod() {
-        return tokenRefreshPeriod;
-    }
+    /**
+     * Retry backoff interval.
+     */
+    private Duration backOffMaxInterval;
 
-    public void setTokenRefreshPeriod(Duration tokenRefreshPeriod) {
-        this.tokenRefreshPeriod = tokenRefreshPeriod;
-    }
+    /**
+     * Retry exponential backoff multiplier.
+     */
+    private Double backOffMultiplier;
 }

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
@@ -30,6 +30,8 @@ import org.candlepin.subscriptions.marketplace.auth.HttpBearerAuth;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import io.micrometer.core.annotation.Timed;
+
 import java.time.OffsetDateTime;
 
 /**
@@ -70,6 +72,7 @@ public class MarketplaceService {
         }
     }
 
+    @Timed("rhsm-subscriptions.marketplace.usage.request")
     public StatusResponse submitUsageEvents(UsageRequest usageRequest) throws ApiException {
         ensureAccessToken();
         return api.submitUsageEvents(usageRequest);

--- a/src/main/resources/application-marketplace.yaml
+++ b/src/main/resources/application-marketplace.yaml
@@ -3,3 +3,8 @@ rhsm-subscriptions:
     api-key: ${MARKETPLACE_API_KEY}
     url: ${MARKETPLACE_URL}
     token-refresh-period: ${MARKETPLACE_TOKEN_REFRESH_PERIOD:1m}
+    # 9 retries -> 1s + 2s + 4s + 8s + 16s + 32s + 64s + 64s + 64s = 255s (~5 minutes)
+    max-attempts: ${MARKETPLACE_MAX_ATTEMPTS:10}
+    back-off-max-interval: ${MARKETPLACE_BACK_OFF_MAX_INTERVAL:64s}
+    back-off-initial-interval: ${MARKETPLACE_BACK_OFF_INITIAL_INTERVAL:1s}
+    back-off-multiplier: ${MARKETPLACE_BACK_OFF_MULTIPLIER:2}

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceProducerTest.java
@@ -44,8 +44,9 @@ class MarketplaceProducerTest {
 
         when(marketplaceService.submitUsageEvents(any())).thenThrow(SubscriptionsException.class);
 
+        var usageRequest = new UsageRequest();
         assertThrows(SubscriptionsException.class, () ->
-            marketplaceProducer.submitUsageRequest(new UsageRequest())
+            marketplaceProducer.submitUsageRequest(usageRequest)
         );
 
         verify(marketplaceService, times(2)).submitUsageEvents(any());

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceProducerTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
 
 import org.junit.jupiter.api.Test;
@@ -41,9 +42,9 @@ class MarketplaceProducerTest {
         MarketplaceService marketplaceService = mock(MarketplaceService.class);
         MarketplaceProducer marketplaceProducer = new MarketplaceProducer(marketplaceService, retryTemplate);
 
-        when(marketplaceService.submitUsageEvents(any())).thenThrow(ApiException.class);
+        when(marketplaceService.submitUsageEvents(any())).thenThrow(SubscriptionsException.class);
 
-        assertThrows(ApiException.class, () ->
+        assertThrows(SubscriptionsException.class, () ->
             marketplaceProducer.submitUsageRequest(new UsageRequest())
         );
 


### PR DESCRIPTION
This also makes necessary updates to Marketplace API client.

The MarketplaceProducer component doesn't do much, it really just wraps up usage reporting with a retry.

I added some custom metrics so we can see at a glance how this component is performing (via `@Timed` annotations).

Testing
-------

Much of this is repeated from #235...

First, get a marketplace API key and export it as an env var for convenience:

```
export MARKETPLACE_API_KEY=$KEYGOESHERE
```

Then run the service.

```
DEV_MODE=true MARKETPLACE_URL=https://sandbox.marketplace.redhat.com SPRING_PROFILES_ACTIVE=marketplace ./gradlew bootRun
```

Then, emit a usage event manually via
http://localhost:8080/actuator/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.marketplace-MarketplaceJmxBean-marketplaceJmxBean

Replace FIXME below for all fields as follows:

- `start` and `end`: generate current timestamp in ms via `echo "$(date +%s)000"`
- `subscriptionId`: Current value for testing here (internal doc): https://docs.engineering.redhat.com/display/ENT/Marketplace+Notes
- `eventId`: generate via `uuidgen`

```json
{
  "start": FIXME,
  "end": FIXME,
  "subscriptionId": FIXME,
  "eventId": FIXME,
  "additionalAttributes": {},
  "measuredUsage": [
    {
      "metricId": "redhat.com:openshiftdedicated:cpu_hour",
      "value": 154
    }
  ]
}
```

View the resulting charge changes at https://sandbox.marketplace.redhat.com/en-us/account/pending-charges if desired.

Check out the new prometheus metrics:

```
curl http://localhost:8080/actuator/prometheus | grep marketplace
```

Experience the retry functionality by running against a non-existent endpoint:

```
MARKETPLACE_MAX_ATTEMPTS=2 DEV_MODE=true MARKETPLACE_URL=http://localhost:8080/does-not-exist SPRING_PROFILES_ACTIVE=marketplace ./gradlew bootRun
```

Check out the new prometheus metrics:

```
curl http://localhost:8080/actuator/prometheus | grep marketplace
```

