### PR TITLE
ENT-3639: Fix constraint violation adding metric Events

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -56,7 +56,11 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-
+//
+// NOTE: We should really turn these into integration tests when
+//       we have time. All of the mocking here is getting hard
+//       to follow.
+//
 @SpringBootTest
 @ActiveProfiles({"openshift-metering-worker", "test"})
 class PrometheusMeteringControllerTest {
@@ -73,6 +77,8 @@ class PrometheusMeteringControllerTest {
     @Autowired
     private PrometheusMeteringController controller;
 
+    @Autowired
+    private PrometheusMetricsProperties promProps;
 
     private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
 
@@ -204,8 +210,8 @@ class PrometheusMeteringControllerTest {
         when(eventController.mapEventsInTimeRange(expectedAccount,
             MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_SOURCE,
             MeteringEventFactory.OPENSHIFT_CLUSTER_EVENT_TYPE,
-            start,
-            end
+            start.minusSeconds(promProps.getOpenshift().getStep()),
+            end.minusSeconds(promProps.getOpenshift().getStep())
         ))
             .thenReturn(existingEvents.stream().collect(Collectors.toMap(
             EventKey::fromEvent, Function.identity())));


### PR DESCRIPTION
There were a couple issues with dates that needed to
be addressed. An extra hour was getting added to the
metric lookup dates when the end date was at the top
of an hour.

Also, when looking up existing dates, we need to account for
the start date shift when metrics are transformed into
Events. Because of this, we were trying to create new
Events, when we should have been updating the existing ones.

**TESTING**
Deploy the app and hit the JMX endpoint twice for a single account.

```bash
$ DEV_MODE=true PROM_URL="http://localhost:8082/api/v1" ./gradlew clean bootRun

$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMeteringForAccount(java.lang.String)","arguments":["540155"]}'

$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMeteringForAccount(java.lang.String)","arguments":["540155"]}'
```