### PR TITLE
Fix issues in MetricUsageCollector

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/BootApplication.java
+++ b/src/main/java/org/candlepin/subscriptions/BootApplication.java
@@ -27,6 +27,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 
+import java.time.ZoneOffset;
+import java.util.TimeZone;
+
 /** Bootstrapper for Spring Boot. */
 @SpringBootConfiguration
 @EnableAspectJAutoProxy
@@ -36,6 +39,13 @@ import org.springframework.context.annotation.Import;
 @SuppressWarnings("checkstyle:hideutilityclassconstructor")
 public class BootApplication {
     public static void main(String[] args) {
+        /*
+        Force the JVM to operate in UTC, see org.candlepin.subscriptions.util.ApplicationClock
+
+        Hibernate will return OffsetDateTime in the system timezone, while we coerce dates into UTC in
+        ApplicationClock! Setting it here means the whole application deals exclusively with UTC.
+         */
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
         SpringApplication app = new SpringApplication(BootApplication.class);
         app.run(args);
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
@@ -88,6 +88,11 @@ public class CombiningRollupSnapshotStrategy {
         OffsetDateTime endDateTime, Map<OffsetDateTime, AccountUsageCalculation> accountCalcs,
         DoubleBinaryOperator reductionFunction) {
 
+        if (accountCalcs.isEmpty()) {
+            // nothing to do here, return early to avoid a null swatch product ID lookup
+            return;
+        }
+
         String swatchProductId = getSwatchProductId(accountCalcs);
         Set<String> swatchProductIds = getSwatchProductIds(accountCalcs);
 

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
 
@@ -124,7 +125,7 @@ public class TallySnapshotController {
                 context -> metricUsageCollector.collect(accountNumber, startDateTime, endDateTime));
             combiningRollupSnapshotStrategy
                 .produceSnapshotsFromCalculations(accountNumber, startDateTime, endDateTime,
-                accountCalcs, Double::sum);
+                accountCalcs, Granularity.HOURLY, Double::sum);
         }
         catch (Exception e) {
             log.error("Could not collect existing usage snapshots for account {}", accountNumber, e);

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -35,7 +35,6 @@ import io.micrometer.core.annotation.Timed;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -120,24 +119,16 @@ public class TallySnapshotController {
     public void produceHourlySnapshotsForAccount(String accountNumber, OffsetDateTime startDateTime,
         OffsetDateTime endDateTime) {
 
-        Map<OffsetDateTime, AccountUsageCalculation> accountCalcs = new HashMap<>();
         try {
-            for (OffsetDateTime offset = startDateTime; offset.isBefore(endDateTime); offset =
-                offset.plusHours(1)) {
-                OffsetDateTime finalOffset = offset;
-                accountCalcs.put(offset, retryTemplate
-                    .execute(context -> metricUsageCollector.collect(accountNumber, finalOffset,
-                    finalOffset.plusHours(1))));
-            }
+            Map<OffsetDateTime, AccountUsageCalculation> accountCalcs = retryTemplate.execute(
+                context -> metricUsageCollector.collect(accountNumber, startDateTime, endDateTime));
+            combiningRollupSnapshotStrategy
+                .produceSnapshotsFromCalculations(accountNumber, startDateTime, endDateTime,
+                accountCalcs, Double::sum);
         }
         catch (Exception e) {
             log.error("Could not collect existing usage snapshots for account {}", accountNumber, e);
-            return;
         }
-
-        combiningRollupSnapshotStrategy
-            .produceSnapshotsFromCalculations(accountNumber, startDateTime, endDateTime,
-            accountCalcs, Double::sum);
     }
 
     private void attemptCloudigradeEnrichment(List<String> accounts,

--- a/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
@@ -82,7 +82,7 @@ class CombiningRollupSnapshotStrategyTest {
             OffsetDateTime.parse("2021-02-25T11:00:00Z"),
             OffsetDateTime.parse("2021-02-25T14:00:00Z"),
             Map.of(OffsetDateTime.parse("2021-02-25T12:00:00Z"), noonUsage,
-            OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Double::sum);
+            OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Granularity.HOURLY, Double::sum);
 
         TallySnapshot noonSnapshot = createTallySnapshot(Granularity.HOURLY, "2021-02-25T12:00:00Z", 4.0);
         TallySnapshot afternoonSnapshot = createTallySnapshot(Granularity.HOURLY, "2021-02-25T13:00:00Z",
@@ -116,7 +116,8 @@ class CombiningRollupSnapshotStrategyTest {
         combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations("account123",
             hourlyTimestamp1,
             hourlyTimestamp2,
-            Map.of(hourlyTimestamp1, day1Usage, hourlyTimestamp2, day2Usage), Double::sum);
+            Map.of(hourlyTimestamp1, day1Usage, hourlyTimestamp2, day2Usage), Granularity.HOURLY,
+            Double::sum);
 
         TallySnapshot day1HourlySnapshot = createTallySnapshot(Granularity.HOURLY, hourlyTimestamp1, 4.0);
         TallySnapshot day2HourlySnapshot = createTallySnapshot(Granularity.HOURLY, hourlyTimestamp2, 3.0);
@@ -159,7 +160,7 @@ class CombiningRollupSnapshotStrategyTest {
             OffsetDateTime.parse("2021-02-25T11:00:00Z"),
             OffsetDateTime.parse("2021-02-25T14:00:00Z"),
             Map.of(OffsetDateTime.parse("2021-02-25T12:00:00Z"), noonUsage,
-            OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Double::sum);
+            OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Granularity.HOURLY, Double::sum);
 
         TallySnapshot afternoonSnapshot = createTallySnapshot(Granularity.HOURLY, "2021-02-25T13:00:00Z",
             3.0);
@@ -194,7 +195,7 @@ class CombiningRollupSnapshotStrategyTest {
             OffsetDateTime.parse("2021-02-25T11:00:00Z"),
             OffsetDateTime.parse("2021-02-25T14:00:00Z"),
             Map.of(OffsetDateTime.parse("2021-02-25T12:00:00Z"), noonUsage,
-            OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Double::sum);
+            OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Granularity.HOURLY, Double::sum);
 
         TallySnapshot noonSnapshot = createTallySnapshot(Granularity.HOURLY, "2021-02-25T12:00:00Z", 4.0);
         TallySnapshot afternoonSnapshot = createTallySnapshot(Granularity.HOURLY, "2021-02-25T13:00:00Z",
@@ -216,16 +217,6 @@ class CombiningRollupSnapshotStrategyTest {
         usage.getProducts().add(OPEN_SHIFT_HOURLY);
 
         return usage;
-    }
-
-    @Test
-    void testLookupFinestGranularity() {
-
-        Granularity expected = Granularity.HOURLY;
-        Granularity actual = combiningRollupSnapshotStrategy.lookupFinestGranularity(OPEN_SHIFT_HOURLY);
-
-        assertEquals(expected, actual);
-
     }
 
     private TallySnapshot createTallySnapshot(Granularity granularity, String snapshotDate, double value) {

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -103,10 +103,9 @@ class MetricUsageCollectorTest {
             .withMeasurements(Collections.singletonList(measurement));
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
 
-        metricUsageCollector.collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+        metricUsageCollector.collectHour(account, OffsetDateTime.MIN);
         Host instance = account.getServiceInstances().get(event.getInstanceId());
         assertNotNull(instance);
     }
@@ -123,10 +122,9 @@ class MetricUsageCollectorTest {
             .withMeasurements(Collections.singletonList(measurement));
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         assertNotNull(accountUsageCalculation);
         UsageCalculation.Key usageCalculationKey =
             new UsageCalculation.Key(RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION);
@@ -148,10 +146,9 @@ class MetricUsageCollectorTest {
             .withInstanceId(UUID.randomUUID().toString());
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         assertNotNull(accountUsageCalculation);
     }
 
@@ -167,10 +164,9 @@ class MetricUsageCollectorTest {
             .withInstanceId(UUID.randomUUID().toString());
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         assertNotNull(accountUsageCalculation);
     }
 
@@ -187,10 +183,9 @@ class MetricUsageCollectorTest {
             .withSla(Event.Sla.PREMIUM);
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         Host instance = account.getServiceInstances().get(event.getInstanceId());
         assertNotNull(instance);
         Set<HostTallyBucket> expected = new HashSet<>();
@@ -223,10 +218,9 @@ class MetricUsageCollectorTest {
             .withSla(Event.Sla.PREMIUM);
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         assertNotNull(accountUsageCalculation);
         UsageCalculation.Key usageCalculationKey = new UsageCalculation.Key(RHEL, ServiceLevel._ANY,
             Usage.PRODUCTION);
@@ -249,10 +243,9 @@ class MetricUsageCollectorTest {
             .withUsage(Event.Usage.PRODUCTION);
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         assertNotNull(accountUsageCalculation);
         UsageCalculation.Key usageCalculationKey = new UsageCalculation.Key(RHEL, ServiceLevel.PREMIUM,
             Usage._ANY);
@@ -275,11 +268,10 @@ class MetricUsageCollectorTest {
 
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
 
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         assertNotNull(accountUsageCalculation);
 
         UsageCalculation.Key serverKey = new UsageCalculation.Key(RHEL_SERVER_SWATCH_PRODUCT_ID,
@@ -308,11 +300,10 @@ class MetricUsageCollectorTest {
 
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event));
 
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         assertNotNull(accountUsageCalculation);
 
         UsageCalculation.Key engIdKey = new UsageCalculation.Key(RHEL, ServiceLevel.PREMIUM, Usage._ANY);
@@ -342,10 +333,9 @@ class MetricUsageCollectorTest {
             .withUsage(Event.Usage.PRODUCTION);
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event, event));
         AccountUsageCalculation accountUsageCalculation = metricUsageCollector
-            .collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+            .collectHour(account, OffsetDateTime.MIN);
         assertNotNull(accountUsageCalculation);
         UsageCalculation.Key usageCalculationKey =
             new UsageCalculation.Key(RHEL,
@@ -368,10 +358,9 @@ class MetricUsageCollectorTest {
             .withUsage(Event.Usage.PRODUCTION);
         Account account = new Account();
         account.setAccountNumber("account123");
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
         when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event, event));
 
-        metricUsageCollector.collect("account123", OffsetDateTime.MIN, OffsetDateTime.MAX);
+        metricUsageCollector.collectHour(account, OffsetDateTime.MIN);
         Host instance = account.getServiceInstances().values().stream().findFirst().orElseThrow();
         assertEquals(Double.valueOf(84.0), instance.getMonthlyTotal("2021-02", Measurement.Uom.CORES));
     }
@@ -396,41 +385,13 @@ class MetricUsageCollectorTest {
         existing.setLastSeen(OffsetDateTime.parse("2021-02-25T00:00:01Z"));
         account.getServiceInstances().put(instanceId, existing);
         when(accountRepo.findById(any())).thenReturn(Optional.of(account));
-        when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event, event));
+        when(eventController.fetchEventsInTimeRange(any(), any(), any()))
+            .thenAnswer(m -> Stream.of(event, event));
 
-        metricUsageCollector.collect("account123", OffsetDateTime.parse("2021-01-01T00:00:00Z"),
-            OffsetDateTime.parse("2021-03-01T00:00:00Z"));
+        metricUsageCollector.collect("account123", OffsetDateTime.parse("2021-02-25T00:00:00Z"),
+            OffsetDateTime.parse("2021-02-25T01:00:00Z"));
         Host instance = account.getServiceInstances().values().stream().findFirst().orElseThrow();
         assertEquals(Double.valueOf(84.0), instance.getMonthlyTotal("2021-02", Measurement.Uom.CORES));
-    }
-
-    @Test
-    void testRecalculationQueriesEventsForAllAffectedMonths() {
-        Measurement measurement = new Measurement().withUom(Measurement.Uom.CORES).withValue(42.0);
-        String instanceId = UUID.randomUUID().toString();
-        Event event = new Event()
-            .withEventId(UUID.randomUUID())
-            .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
-            .withServiceType(SERVICE_TYPE)
-            .withInstanceId(instanceId)
-            .withMeasurements(Collections.singletonList(measurement))
-            .withUsage(Event.Usage.PRODUCTION);
-        Account account = new Account();
-        account.setAccountNumber("account123");
-        Host existing = new Host();
-        existing.addToMonthlyTotal("2021-02", Measurement.Uom.CORES, 10.0);
-        existing.setInstanceId(instanceId);
-        existing.setInstanceType(SERVICE_TYPE);
-        existing.setLastSeen(OffsetDateTime.parse("2021-02-25T00:00:01Z"));
-        account.getServiceInstances().put(instanceId, existing);
-        when(accountRepo.findById(any())).thenReturn(Optional.of(account));
-        when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event, event));
-
-        metricUsageCollector.collect("account123", OffsetDateTime.parse("2021-01-29T00:00:00Z"),
-            OffsetDateTime.parse("2021-02-01T00:00:00Z"));
-        verify(eventController).fetchEventsInTimeRange("account123",
-            OffsetDateTime.parse("2021-01-01T00:00:00Z"),
-            OffsetDateTime.parse("2021-02-28T23:59:59.999999999Z"));
     }
 
     @Test
@@ -461,10 +422,11 @@ class MetricUsageCollectorTest {
         account.getServiceInstances().put(staleInstance.getInstanceId(), staleInstance);
 
         when(accountRepo.findById(any())).thenReturn(Optional.of(account));
-        when(eventController.fetchEventsInTimeRange(any(), any(), any())).thenReturn(Stream.of(event, event));
+        when(eventController.fetchEventsInTimeRange(any(), any(), any()))
+            .thenAnswer(m -> Stream.of(event, event));
 
-        metricUsageCollector.collect("account123", OffsetDateTime.parse("2021-01-01T00:00:00Z"),
-            OffsetDateTime.parse("2021-03-01T00:00:00Z"));
+        metricUsageCollector.collect("account123", OffsetDateTime.parse("2021-02-25T00:00:00Z"),
+            OffsetDateTime.parse("2021-02-25T01:00:00Z"));
         assertEquals(Double.valueOf(84.0), activeInstance.getMonthlyTotal("2021-02", Measurement.Uom.CORES));
         assertNull(staleInstance.getMonthlyTotal("2021-02", Measurement.Uom.CORES));
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -38,7 +38,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.io.IOException;
-import java.time.OffsetDateTime;
 import java.util.Collections;
 
 @SpringBootTest
@@ -107,17 +106,4 @@ class TallySnapshotControllerTest {
         verifyZeroInteractions(inventoryCollector);
     }
 
-    @Test
-    void testUsageMetricControllerDoes24Hours() {
-        OffsetDateTime begin = OffsetDateTime.parse("2007-12-03T00:00:00Z");
-        OffsetDateTime end = OffsetDateTime.parse("2007-12-03T23:59:59.999Z");
-
-        AccountUsageCalculation foo = new AccountUsageCalculation("foo");
-        foo.getProducts().add("OpenShift Hourly");
-
-        when(metricUsageCollector.collect(eq("foo"), any(), any()))
-            .thenReturn(foo);
-        controller.produceHourlySnapshotsForAccount("foo", begin, end);
-        verify(metricUsageCollector, times(24)).collect(eq("foo"), any(), any());
-    }
 }


### PR DESCRIPTION
1. Force the JVM to operate in UTC, otherwise there are subtle bugs when running on a non-UTC system, because ApplicationClock forces UTC, and Hibernate returns values in the system timezone.
2. Rework MetricUsageCollector to partition hours up-front, and deal with clearing monthly totals as needed up-front.
3. Rework MetricUsageCollector to handle stale hosts by maintaining a running lookup of active instances and tallying from the lookup rather than from latest account state.
4. Ensure CombiningRollupSnapshotStrategy fetches existing snapshots for all product IDs being tallied.
5. Fix a redunant loop over products in CombiningRollupSnapshotStrategy.
6. Filter out running calculations not having any usage.

Testing
-------

1. Insert some events into the DB:

```sql
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('1edc517a-d049-4361-9804-e4111ce061ae', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Development/Test", "event_id": "1edc517a-d049-4361-9804-e4111ce061ae", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "display_name": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'c6123fbb-84d0-47a7-b069-ff9048caf7c7');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('9fd69ad7-9294-4d8d-a5f4-c5ca45bdb2ec', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Standard", "usage": "Development/Test", "event_id": "9fd69ad7-9294-4d8d-a5f4-c5ca45bdb2ec", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "display_name": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', '0e94471b-f9bb-4b30-8d6e-8ad6c3539392');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('91ef5257-6f44-4ad5-812e-ae070483e4a7', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Production", "event_id": "91ef5257-6f44-4ad5-812e-ae070483e4a7", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "display_name": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'bdeffe2b-08c6-40ef-b2cf-e3c458a0273a');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('a35a0f56-d46b-4c36-ad4b-e6e889e13c9f', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Production", "event_id": "a35a0f56-d46b-4c36-ad4b-e6e889e13c9f", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "display_name": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'bdeffe2b-08c6-40ef-b2cf-e3c458a0273a');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('0b021762-59e6-41ae-bbe6-e4ba1deaf3a1', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Standard", "usage": "Development/Test", "event_id": "0b021762-59e6-41ae-bbe6-e4ba1deaf3a1", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "display_name": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', '0e94471b-f9bb-4b30-8d6e-8ad6c3539392');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('e223e90d-f567-4a4f-b05f-7ad9e67fe5c5', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Development/Test", "event_id": "e223e90d-f567-4a4f-b05f-7ad9e67fe5c5", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "display_name": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'c6123fbb-84d0-47a7-b069-ff9048caf7c7');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('922855da-29da-438f-b8c5-d2f3df7f62fd', 'account123', '2021-03-10 19:00:00.000000', '{"role":"osd","sla": "Premium", "usage": "Development/Test", "event_id": "922855da-29da-438f-b8c5-d2f3df7f62fd", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "f418a78c-2099-4932-9ff2-135dabd09077", "display_name": "f418a78c-2099-4932-9ff2-135dabd09077", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'f418a78c-2099-4932-9ff2-135dabd09077');
```

2. Tally:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-03-10T00:00:00Z","2021-03-10T23:59:59.999Z"]}'
```

3. Look in the DB to see resulting data:

```sql
select s.account_number, s.snapshot_date, s.product_id, m.* from tally_snapshots s, tally_measurements m
where s.id=m.snapshot_id and account_number = 'account123' and s.granularity='HOURLY' and s.usage='_ANY' and s
    .sla='_ANY' and m.measurement_type='TOTAL' order by s.account_number, s.product_id, s.snapshot_date;

select * from hosts join instance_measurements im on hosts.id = im.instance_id join instance_monthly_totals
    imt on hosts.id = imt.instance_id;
```

4. Re-tally:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-03-10T00:00:00Z","2021-03-10T23:59:59.999Z"]}'
```

5. Look in the DB again:

```sql
select s.account_number, s.snapshot_date, s.product_id, m.* from tally_snapshots s, tally_measurements m
where s.id=m.snapshot_id and account_number = 'account123' and s.granularity='HOURLY' and s.usage='_ANY' and s
    .sla='_ANY' and m.measurement_type='TOTAL' order by s.account_number, s.product_id, s.snapshot_date;

select * from hosts join instance_measurements im on hosts.id = im.instance_id join instance_monthly_totals
    imt on hosts.id = imt.instance_id;
```

Co-Authored-By: Michael Stead <mstead@redhat.com>
Co-Authored-By: Lindsey Burnett <lburnett@redhat.com>

Fixes:
- https://issues.redhat.com/browse/ENT-3640