### PR TITLE
ENT-3266: Add MarketplaceWorker and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ We have a number of profiles. Each profile activates a subset of components in t
 - `capture-snapshots`: Run the tally job and exit
 - `kafka-queue`: Run with a kafka queue (instead of the default in-memory queue)
 - `rhsm-conduit`: Run the worker for syncing systems between Hosted Candlepin and HBI
+- `marketplace`: Run the worker responsible for processing tally summaries and emitting usage to Marketplace.
 
 These can be specified most easily via the `SPRING_PROFILES_ACTIVE` environment variable. For example:
 

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
@@ -68,4 +68,9 @@ public class MarketplaceProperties extends HttpClientProperties {
      * Retry exponential backoff multiplier.
      */
     private Double backOffMultiplier;
+
+    /**
+     * Have the stub mapper emit empty usage requests (vs. full one) to be removed by ENT-3264
+     */
+    private boolean mapperStubEmpty;
 }

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorker.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
+import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import io.micrometer.core.annotation.Timed;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Worker that maps tally summaries and submits them to Marketplace.
+ */
+@Service
+public class MarketplaceWorker {
+
+    private static final Logger log = LoggerFactory.getLogger(MarketplaceWorker.class);
+
+    /**
+     * placeholder class, to be removed w/ https://issues.redhat.com/browse/ENT-3265
+     */
+    @Service
+    static class MarketplaceProducer {
+        void submitUsageRequest(UsageRequest request) {
+            log.info("submitUsageRequest called w/ request: {}", request);
+        }
+    }
+
+    /**
+     * placeholder class, to be removed w/ https://issues.redhat.com/browse/ENT-3264
+     */
+    @Service
+    static class MarketplacePayloadMapper {
+        UsageRequest mapTallySummary(TallySummary summary) {
+            log.info("mapTallySummary called w/ summary: {}", summary);
+            return new UsageRequest().data(List.of(new UsageEvent()));
+        }
+    }
+
+    @Getter
+    @Setter
+    private String topic;
+
+    private final MarketplaceProducer producer;
+    private final MarketplacePayloadMapper payloadMapper;
+
+    public MarketplaceWorker(ApplicationProperties properties, MarketplaceProducer producer,
+        MarketplacePayloadMapper payloadMapper) {
+        topic = properties.getTallySummaryTopic();
+        this.producer = producer;
+        this.payloadMapper = payloadMapper;
+    }
+
+    @Timed("rhsm-subscriptions.marketplace.tally-summary")
+    @KafkaListener(id = "marketplace-worker", topics = "#{__listener.topic}",
+        containerFactory = "kafkaTallySummaryListenerContainerFactory")
+    public void receive(TallySummary tallySummary) {
+        Optional.ofNullable(payloadMapper.mapTallySummary(tallySummary))
+            .filter(s -> !s.getData().isEmpty())
+            .ifPresent(producer::submitUsageRequest);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorker.java
@@ -27,6 +27,7 @@ import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
@@ -35,6 +36,7 @@ import io.micrometer.core.annotation.Timed;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,23 +49,26 @@ public class MarketplaceWorker {
     private static final Logger log = LoggerFactory.getLogger(MarketplaceWorker.class);
 
     /**
-     * placeholder class, to be removed w/ https://issues.redhat.com/browse/ENT-3265
-     */
-    @Service
-    static class MarketplaceProducer {
-        void submitUsageRequest(UsageRequest request) {
-            log.info("submitUsageRequest called w/ request: {}", request);
-        }
-    }
-
-    /**
      * placeholder class, to be removed w/ https://issues.redhat.com/browse/ENT-3264
      */
     @Service
     static class MarketplacePayloadMapper {
+        private final MarketplaceProperties properties;
+
+        @Autowired
+        MarketplacePayloadMapper(MarketplaceProperties properties) {
+            this.properties = properties;
+        }
+
         UsageRequest mapTallySummary(TallySummary summary) {
             log.info("mapTallySummary called w/ summary: {}", summary);
-            return new UsageRequest().data(List.of(new UsageEvent()));
+            if (properties.isMapperStubEmpty()) {
+                return new UsageRequest().data(Collections.emptyList());
+            }
+            else {
+                // NOTE: this payload will fail marketplace validation
+                return new UsageRequest().data(List.of(new UsageEvent()));
+            }
         }
     }
 

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
@@ -23,18 +23,17 @@ package org.candlepin.subscriptions.marketplace;
 import org.candlepin.subscriptions.json.TallySummary;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
-
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Profile;
-import org.springframework.retry.support.RetryTemplate;
-import org.springframework.retry.support.RetryTemplateBuilder;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.retry.support.RetryTemplateBuilder;
 
 /**
  * Configuration for the Marketplace integration worker.

--- a/src/main/resources/application-marketplace.yaml
+++ b/src/main/resources/application-marketplace.yaml
@@ -8,3 +8,5 @@ rhsm-subscriptions:
     back-off-max-interval: ${MARKETPLACE_BACK_OFF_MAX_INTERVAL:64s}
     back-off-initial-interval: ${MARKETPLACE_BACK_OFF_INITIAL_INTERVAL:1s}
     back-off-multiplier: ${MARKETPLACE_BACK_OFF_MULTIPLIER:2}
+    # temporary; remove once https://issues.redhat.com/browse/ENT-3264 is implemented
+    mapper-stub-empty: ${MARKETPLACE_MAPPER_STUB_EMPTY:true}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,7 @@ spring:
       - rhsm-conduit
       - worker
       - openshift-metering-worker
+      - marketplace
       - kafka-queue
   liquibase:
     change-log: classpath:/liquibase/changelog.xml

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import static org.mockito.Mockito.*;
+
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.marketplace.MarketplaceWorker.MarketplacePayloadMapper;
+import org.candlepin.subscriptions.marketplace.MarketplaceWorker.MarketplaceProducer;
+import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
+import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class MarketplaceWorkerTest {
+
+    @Test
+    void testWorkerCallsProduceForNonEmptyPayload() {
+        ApplicationProperties properties = new ApplicationProperties();
+        MarketplaceProducer producer = mock(MarketplaceProducer.class);
+        MarketplacePayloadMapper payloadMapper = mock(MarketplacePayloadMapper.class);
+        var worker = new MarketplaceWorker(properties, producer, payloadMapper);
+
+        UsageRequest usageRequest = new UsageRequest().data(List.of(new UsageEvent()));
+        when(payloadMapper.mapTallySummary(any())).thenReturn(usageRequest);
+
+        worker.receive(new TallySummary());
+
+        verify(producer, times(1)).submitUsageRequest(usageRequest);
+    }
+
+    @Test
+    void testWorkerSkipsEmptyPayloads() {
+        ApplicationProperties properties = new ApplicationProperties();
+        MarketplaceProducer producer = mock(MarketplaceProducer.class);
+        MarketplacePayloadMapper payloadMapper = mock(MarketplacePayloadMapper.class);
+        var worker = new MarketplaceWorker(properties, producer, payloadMapper);
+
+        UsageRequest usageRequest = new UsageRequest().data(Collections.emptyList());
+        when(payloadMapper.mapTallySummary(any())).thenReturn(usageRequest);
+
+        worker.receive(new TallySummary());
+
+        verify(producer, times(0)).submitUsageRequest(any());
+    }
+
+    @Test
+    void testWorkerSkipsNullPayloads() {
+        ApplicationProperties properties = new ApplicationProperties();
+        MarketplaceProducer producer = mock(MarketplaceProducer.class);
+        MarketplacePayloadMapper payloadMapper = mock(MarketplacePayloadMapper.class);
+        var worker = new MarketplaceWorker(properties, producer, payloadMapper);
+
+        when(payloadMapper.mapTallySummary(any())).thenReturn(null);
+
+        worker.receive(new TallySummary());
+
+        verify(producer, times(0)).submitUsageRequest(any());
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.*;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.marketplace.MarketplaceWorker.MarketplacePayloadMapper;
-import org.candlepin.subscriptions.marketplace.MarketplaceWorker.MarketplaceProducer;
 import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
 import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
 

--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -59,7 +59,8 @@ parameters:
     value: 1s
   - name: MARKETPLACE_BACK_OFF_MULTIPLIER
     value: '2'
-
+  - name: MARKETPLACE_DUMMY_ID
+    value: DUMMY
 
 objects:
   - apiVersion: apps.openshift.io/v1
@@ -198,6 +199,8 @@ objects:
                   value: ${MARKETPLACE_BACK_OFF_INITIAL_INTERVAL}
                 - name: MARKETPLACE_BACK_OFF_MULTIPLIER
                   value: ${MARKETPLACE_BACK_OFF_MULTIPLIER}
+                - name: MARKETPLACE_DUMMY_ID
+                  value: ${MARKETPLACE_DUMMY_ID}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:

--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -51,6 +51,15 @@ parameters:
     value: 100m
   - name: MARKETPLACE_TOKEN_REFRESH_PERIOD
     value: 1m
+  - name: MARKETPLACE_MAX_ATTEMPTS
+    value: '10'
+  - name: MARKETPLACE_BACK_OFF_MAX_INTERVAL
+    value: 64s
+  - name: MARKETPLACE_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: MARKETPLACE_BACK_OFF_MULTIPLIER
+    value: '2'
+
 
 objects:
   - apiVersion: apps.openshift.io/v1
@@ -181,6 +190,14 @@ objects:
                       key: url
                 - name: MARKETPLACE_TOKEN_REFRESH_PERIOD
                   value: ${MARKETPLACE_TOKEN_REFRESH_PERIOD}
+                - name: MARKETPLACE_MAX_ATTEMPTS
+                  value: ${MARKETPLACE_MAX_ATTEMPTS}
+                - name: MARKETPLACE_BACK_OFF_MAX_INTERVAL
+                  value: ${MARKETPLACE_BACK_OFF_MAX_INTERVAL}
+                - name: MARKETPLACE_BACK_OFF_INITIAL_INTERVAL
+                  value: ${MARKETPLACE_BACK_OFF_INITIAL_INTERVAL}
+                - name: MARKETPLACE_BACK_OFF_MULTIPLIER
+                  value: ${MARKETPLACE_BACK_OFF_MULTIPLIER}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:

--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -1,0 +1,259 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  app: rhsm-subscriptions
+  template: marketplace-worker
+metadata:
+  annotations:
+    description: Components that handle submitting usage info to Marketplace.
+  name: marketplace-worker
+
+parameters:
+  - name: HAWTIO_BASE_PATH
+    value: /app/rhsm-subscriptions/actuator/hawtio
+  - name: SERVER_MAX_HTTP_HEADER_SIZE
+    value: '48000'
+  - name: LOGGING_LEVEL_ROOT
+    value: WARN
+  - name: LOGGING_LEVEL
+    value: INFO
+  - name: KAFKA_BOOTSTRAP_HOST
+    required: true
+  - name: KAFKA_MESSAGE_THREADS
+    value: '24'
+  - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
+    value: '3600000'
+  - name: REPLICAS
+    value: '1'
+  - name: IMAGE
+    value: quay.io/cloudservices/rhsm-subscriptions
+  - name: IMAGE_TAG
+    value: latest
+  - name: IMAGE_PULL_SECRET
+    value: quay-cloudservices-pull
+  - name: MEMORY_REQUEST
+    value: 1000Mi
+  - name: MEMORY_LIMIT
+    value: 1700Mi
+  - name: CPU_REQUEST
+    value: 450m
+  - name: CPU_LIMIT
+    value: 1800m
+  - name: SPLUNK_FORWARDER_IMAGE
+    value: quay.io/cloudservices/rhsm-splunk-forwarder:8f72cfb
+  - name: SPLUNK_FORWARDER_MEMORY_REQUEST
+    value: 128Mi
+  - name: SPLUNK_FORWARDER_MEMORY_LIMIT
+    value: 150Mi
+  - name: SPLUNK_FORWARDER_CPU_REQUEST
+    value: 50m
+  - name: SPLUNK_FORWARDER_CPU_LIMIT
+    value: 100m
+  - name: MARKETPLACE_TOKEN_REFRESH_PERIOD
+    value: 1m
+
+objects:
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      name: marketplace-worker
+    spec:
+      replicas: ${{REPLICAS}}
+      selector:
+        deploymentconfig: marketplace-worker
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            deploymentconfig: marketplace-worker
+            prometheus: rhsm
+          annotations:
+            prometheus.io/path: /actuator/prometheus
+            prometheus.io/port: '8080'
+            prometheus.io/scrape: 'true'
+        spec:
+          initContainers:
+            - image: ${IMAGE}:${IMAGE_TAG}
+              name: liquibase
+              env:
+                - name: SPRING_PROFILES_ACTIVE
+                  value: liquibase-only
+                - name: JAVA_MAX_MEM_RATIO
+                  value: '85'
+                - name: GC_MAX_METASPACE_SIZE
+                  value: '256'
+                - name: DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.host
+                - name: DATABASE_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.port
+                - name: DATABASE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.user
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.password
+                - name: DATABASE_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.name
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+          containers:
+            - image: ${IMAGE}:${IMAGE_TAG}
+              name: marketplace-worker
+              env:
+                # turn off built-in jolokia, so that the spring boot jolokia actuator will work
+                - name: AB_JOLOKIA_OFF
+                  value: 'true'
+                - name: SERVER_MAX_HTTP_HEADER_SIZE
+                  value: ${SERVER_MAX_HTTP_HEADER_SIZE}
+                - name: HAWTIO_BASE_PATH
+                  value: ${HAWTIO_BASE_PATH}
+                - name: LOG_FILE
+                  value: /logs/server.log
+                - name: SPRING_PROFILES_ACTIVE
+                  value: marketplace,kafka-queue
+                - name: JAVA_MAX_MEM_RATIO
+                  value: '85'
+                - name: GC_MAX_METASPACE_SIZE
+                  value: '256'
+                - name: LOGGING_LEVEL_ROOT
+                  value: ${LOGGING_LEVEL_ROOT}
+                - name: LOGGING_LEVEL_ORG_CANDLEPIN
+                  value: ${LOGGING_LEVEL}
+                - name: KAFKA_BOOTSTRAP_HOST
+                  value: ${KAFKA_BOOTSTRAP_HOST}
+                - name: KAFKA_MESSAGE_THREADS
+                  value: ${KAFKA_MESSAGE_THREADS}
+                - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
+                  value: ${KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS}
+                - name: DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.host
+                - name: DATABASE_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.port
+                - name: DATABASE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.user
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.password
+                - name: DATABASE_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.name
+                - name: MARKETPLACE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: marketplace
+                      key: key
+                - name: MARKETPLACE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: marketplace
+                      key: url
+                - name: MARKETPLACE_TOKEN_REFRESH_PERIOD
+                  value: ${MARKETPLACE_TOKEN_REFRESH_PERIOD}
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /actuator/health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 90
+                periodSeconds: 20
+                successThreshold: 1
+                timeoutSeconds: 3
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+              volumeMounts:
+                - name: logs
+                  mountPath: /logs
+              workingDir: /
+            - name: splunk
+              env:
+                - name: SPLUNKMETA_namespace
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+              image: ${SPLUNK_FORWARDER_IMAGE}
+              resources:
+                requests:
+                  cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                  memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                limits:
+                  cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                  memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /var/log/app
+                  name: logs
+                  readOnly: true
+                - mountPath: /tls/splunk.pem
+                  name: splunk
+                  subPath: splunk.pem
+          volumes:
+            - name: splunk
+              secret:
+                secretName: splunk
+            - name: logs
+              emptyDir: {}
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 75
+          imagePullSecrets:
+            - name: ${IMAGE_PULL_SECRET}
+            - name: quay-cloudservices-pull
+      triggers:
+        - type: ConfigChange
+
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: marketplace-worker-monitoring
+      labels:
+        prometheus: rhsm
+    spec:
+      ports:
+        - port: 8080
+          name: "8080"
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        deploymentconfig: marketplace-worker


### PR DESCRIPTION
Note that the payload mapper is currently stubbed out. Temporarily, `MARKETPLACE_MAPPER_STUB_EMPTY` (default true) controls whether the payload emitted is empty or not.

Testing
-------

Run via 
```
MARKETPLACE_MAPPER_STUB_EMPTY=false MARKETPLACE_MAX_ATTEMPTS=1 DEV_MODE=true MARKETPLACE_URL=http://localhost:8088/does-not-exist ./gradlew bootRun
```

Insert some events:

```sql
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('1edc517a-d049-4361-9804-e4111ce061ae', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Development/Test", "event_id": "1edc517a-d049-4361-9804-e4111ce061ae", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "display_name": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'c6123fbb-84d0-47a7-b069-ff9048caf7c7');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('9fd69ad7-9294-4d8d-a5f4-c5ca45bdb2ec', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Standard", "usage": "Development/Test", "event_id": "9fd69ad7-9294-4d8d-a5f4-c5ca45bdb2ec", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "display_name": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', '0e94471b-f9bb-4b30-8d6e-8ad6c3539392');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('91ef5257-6f44-4ad5-812e-ae070483e4a7', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Production", "event_id": "91ef5257-6f44-4ad5-812e-ae070483e4a7", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "display_name": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'bdeffe2b-08c6-40ef-b2cf-e3c458a0273a');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('a35a0f56-d46b-4c36-ad4b-e6e889e13c9f', 'account123', '2021-03-10 19:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Production", "event_id": "a35a0f56-d46b-4c36-ad4b-e6e889e13c9f", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "display_name": "bdeffe2b-08c6-40ef-b2cf-e3c458a0273a", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'bdeffe2b-08c6-40ef-b2cf-e3c458a0273a');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('0b021762-59e6-41ae-bbe6-e4ba1deaf3a1', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Standard", "usage": "Development/Test", "event_id": "0b021762-59e6-41ae-bbe6-e4ba1deaf3a1", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "display_name": "0e94471b-f9bb-4b30-8d6e-8ad6c3539392", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', '0e94471b-f9bb-4b30-8d6e-8ad6c3539392');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('e223e90d-f567-4a4f-b05f-7ad9e67fe5c5', 'account123', '2021-03-10 20:00:00.000000', '{"role":"ocp","sla": "Premium", "usage": "Development/Test", "event_id": "e223e90d-f567-4a4f-b05f-7ad9e67fe5c5", "timestamp": "2021-03-10T20:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T21:00:00Z", "instance_id": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "display_name": "c6123fbb-84d0-47a7-b069-ff9048caf7c7", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'c6123fbb-84d0-47a7-b069-ff9048caf7c7');
INSERT INTO events (id, account_number, timestamp, data, event_type, event_source, instance_id) VALUES ('922855da-29da-438f-b8c5-d2f3df7f62fd', 'account123', '2021-03-10 19:00:00.000000', '{"role":"osd","sla": "Premium", "usage": "Development/Test", "event_id": "922855da-29da-438f-b8c5-d2f3df7f62fd", "timestamp": "2021-03-10T19:00:00Z", "event_type": "snapshot", "expiration": "2021-03-10T20:00:00Z", "instance_id": "f418a78c-2099-4932-9ff2-135dabd09077", "display_name": "f418a78c-2099-4932-9ff2-135dabd09077", "event_source": "prometheus-openshift", "measurements": [{"uom": "Cores", "value": 12.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot', 'prometheus-openshift', 'f418a78c-2099-4932-9ff2-135dabd09077');
```

Trigger tally:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-03-10T00:00:00Z","2021-03-10T23:59:59.999Z"]}'
```

Verify via log activity:

```
2021-03-17 20:40:58,685 [thread=marketplace-worker-0-C-1] [INFO ] [org.candlepin.subscriptions.marketplace.MarketplaceWorker] - mapTallySummary called w/ summary: org.candlepin.subscriptions.json.TallySummary@786d6ad9[accountNumber=account123,tallySnapshots=[org.candlepin.subscriptions.json.TallySnapshot@3f06f070[id=a260e99d-b617-4dd9-9194-64717629b001,snapshotDate=2021-03-10T00:00Z,productId=OpenShift-metrics,sla=Premium,usage=<null>,granularity=Daily,tallyMeasurements=[org.candlepin.subscriptions.json.TallyMeasurement@640060bb[hardwareMeasurementType=PHYSICAL,uom=Cores,value=48.0], org.candlepin.subscriptions.json.TallyMeasurement@42f5afe2[hardwareMeasurementType=TOTAL,uom=Cores,value=48.0]]]]]
2021-03-17 20:40:58,686 [thread=marketplace-worker-0-C-1] [ERROR] [org.springframework.kafka.listener.SeekToCurrentErrorHandler] - Backoff FixedBackOff{interval=0, currentAttempts=10, maxAttempts=9} exhausted for ConsumerRecord(topic = platform.rhsm-subscriptions.tally, partition = 0, leaderEpoch = 0, offset = 246264, CreateTime = 1616013657687, serialized key size = -1, serialized value size = 361, headers = RecordHeaders(headers = [], isReadOnly = false), key = null, value = org.candlepin.subscriptions.json.TallySummary@786d6ad9[accountNumber=account123,tallySnapshots=[org.candlepin.subscriptions.json.TallySnapshot@3f06f070[id=a260e99d-b617-4dd9-9194-64717629b001,snapshotDate=2021-03-10T00:00Z,productId=OpenShift-metrics,sla=Premium,usage=<null>,granularity=Daily,tallyMeasurements=[org.candlepin.subscriptions.json.TallyMeasurement@640060bb[hardwareMeasurementType=PHYSICAL,uom=Cores,value=48.0], org.candlepin.subscriptions.json.TallyMeasurement@42f5afe2[hardwareMeasurementType=TOTAL,uom=Cores,value=48.0]]]]])
org.springframework.kafka.listener.ListenerExecutionFailedException: Listener method 'public void org.candlepin.subscriptions.marketplace.MarketplaceWorker.receive(org.candlepin.subscriptions.json.TallySummary)' threw exception; nested exception is javax.ws.rs.ProcessingException: RESTEASY004655: Unable to invoke request; nested exception is javax.ws.rs.ProcessingException: RESTEASY004655: Unable to invoke request
```

This shows that when the stubbed mapper emits a non-empty payload, the producer attempts to send it to the configured marketplace URL

You can also try with `MARKETPLACE_MAPPER_STUB_EMPTY=true` (or omitted) to see that when the mapper emits an empty payload, no interaction with Marketplace happens.

Testing on CI
-------------

First, ensure the version has been built by using the CI deploy job
against this branch.

Then:

```
oc process \
    -p KAFKA_BOOTSTRAP_HOST=KAFKA_BOOTSTRAP_HOST=platform-mq-ci-kafka-bootstrap.platform-mq-ci.svc.cluster.local \
    -p IMAGE=docker-registry.default.svc:5000/rhsm-ci/rhsm-subscriptions \
    -p IMAGE_TAG=$(git show --format=%h --no-patch --abbrev=7) \
    -p IMAGE_PULL_SECRET=default-dockercfg-bd4dv \
    -f templates/marketplace-worker.yml | oc -n rhsm-ci apply -f -
```

Then retrigger some tallies if needed, and verify as above, Note that *no* interaction with Marketplace API should happen, since the mapper is not yet implemented, and the stubbed mapper is configured to emit empty payloads.