### PR TITLE
ENT-3628 inventory_id is marked as required in openapi spec for host …

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1121,7 +1121,6 @@ components:
             - count
     Host:
       required:
-        - inventory_id
         - display_name
         - hardware_type
         - last_seen


### PR DESCRIPTION
Remove remove inventory_id from the required fields list in rhsm-subscriptions-api-spec.yaml.  

Consulted with Nikhil about this, and once this change has been reviewed, he will help test it.  The alternative would be setting up the test environment on my development PC, which turns out be a lot of work.  