### PR TITLE
ENT-3635: Get OpenShift metering accounts from Prometheus

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -21,12 +21,14 @@
 package org.candlepin.subscriptions.db;
 
 import org.candlepin.subscriptions.db.model.config.AccountConfig;
+import org.candlepin.subscriptions.db.model.config.OptInType;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -46,4 +48,17 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
         "where c.optInType='API' and c.created between :startOfWeek and :endOfWeek")
     int getCountOfOptInsForDateRange(OffsetDateTime startOfWeek, OffsetDateTime endOfWeek);
 
+    default Optional<AccountConfig> createOrUpdateAccountConfig(String account, OffsetDateTime current,
+        OptInType optInType, boolean enableSync, boolean enableReporting) {
+        Optional<AccountConfig> found = findById(account);
+        AccountConfig accountConfig = found.orElse(new AccountConfig(account));
+        if (!found.isPresent()) {
+            accountConfig.setOptInType(optInType);
+            accountConfig.setCreated(current);
+        }
+        accountConfig.setSyncEnabled(enableSync);
+        accountConfig.setReportingEnabled(enableReporting);
+        accountConfig.setUpdated(current);
+        return Optional.of(save(accountConfig));
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
@@ -20,11 +20,14 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.db.model.config.OrgConfig;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -35,4 +38,16 @@ public interface OrgConfigRepository extends JpaRepository<OrgConfig, String> {
     @Query("select distinct c.orgId from OrgConfig c where c.syncEnabled = TRUE")
     Stream<String> findSyncEnabledOrgs();
 
+    default Optional<OrgConfig> createOrUpdateOrgConfig(String orgId, OffsetDateTime current,
+        OptInType optInType, boolean enableSync) {
+        Optional<OrgConfig> found = findById(orgId);
+        OrgConfig orgConfig = found.orElse(new OrgConfig(orgId));
+        if (!found.isPresent()) {
+            orgConfig.setOptInType(optInType);
+            orgConfig.setCreated(current);
+        }
+        orgConfig.setSyncEnabled(enableSync);
+        orgConfig.setUpdated(current);
+        return Optional.of(save(orgConfig));
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
@@ -41,5 +41,10 @@ public enum OptInType {
     /**
      * Configured by an admin via the API.
      */
-    API
+    API,
+
+    /**
+     * Configured via prometheus detection.
+     */
+    PROMETHEUS
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.metering.profile;
 
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
@@ -76,8 +77,9 @@ public class OpenShiftWorkerProfile {
     @Bean
     PrometheusMeteringController getController(ApplicationClock clock, PrometheusMetricsProperties mProps,
         PrometheusService service, EventController eventController,
-        @Qualifier("openshiftMetricRetryTemplate") RetryTemplate openshiftRetryTemplate) {
+        @Qualifier("openshiftMetricRetryTemplate") RetryTemplate openshiftRetryTemplate,
+        AccountConfigRepository accountConfigRepo) {
         return new PrometheusMeteringController(clock, mProps, service, eventController,
-            openshiftRetryTemplate);
+            openshiftRetryTemplate, accountConfigRepo);
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
@@ -36,6 +36,11 @@ public class MetricProperties {
     private String metricPromQL;
 
     /**
+     * The PromQL to run when gathering a list of accounts to enable for this metric.
+     */
+    private String enabledAccountPromQL;
+
+    /**
      * How long to wait for results from the query.
      */
     private int queryTimeout = 10000;

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSource.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering.service.prometheus;
+
+import org.candlepin.subscriptions.prometheus.model.QueryResult;
+
+import org.springframework.util.StringUtils;
+
+import java.time.OffsetDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Provides account lists from Prometheus metrics.
+ */
+public class PrometheusAccountSource {
+
+    private PrometheusService service;
+    private PrometheusMetricsProperties prometheusProps;
+
+    public PrometheusAccountSource(PrometheusService service, PrometheusMetricsProperties prometheusProps) {
+        this.service = service;
+        this.prometheusProps = prometheusProps;
+    }
+
+    public Set<String> getOpenShiftMarketplaceAccounts(OffsetDateTime time) {
+        MetricProperties openshift = this.prometheusProps.getOpenshift();
+        QueryResult result = service.runQuery(openshift.getEnabledAccountPromQL(),
+            time, openshift.getQueryTimeout());
+
+        return result.getData().getResult().stream()
+            .map(r -> r.getMetric().getOrDefault("ebs_account", ""))
+            .filter(StringUtils::hasText)
+            .collect(Collectors.toSet());
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/metering/task/OpenShiftTasksConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/OpenShiftTasksConfiguration.java
@@ -20,8 +20,10 @@
  */
 package org.candlepin.subscriptions.metering.task;
 
-import org.candlepin.subscriptions.db.AccountListSource;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMeteringTaskFactory;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.task.TaskFactory;
@@ -47,6 +49,12 @@ import org.springframework.context.annotation.Profile;
  */
 public class OpenShiftTasksConfiguration {
 
+    @Bean
+    PrometheusAccountSource accountSource(PrometheusService service,
+        PrometheusMetricsProperties metricProperties) {
+        return new PrometheusAccountSource(service, metricProperties);
+    }
+
     // Qualify this bean so that a new instance is created in the case that another
     // queue is configured for another topic.
     @Bean
@@ -59,8 +67,8 @@ public class OpenShiftTasksConfiguration {
     @Bean
     public PrometheusMetricsTaskManager metricsTaskManager(TaskQueue queue,
         @Qualifier("openshiftTaskQueueProperties") TaskQueueProperties queueProps,
-        AccountListSource accounts) {
-        return new PrometheusMetricsTaskManager(queue, queueProps, accounts);
+        PrometheusAccountSource accountSource) {
+        return new PrometheusMetricsTaskManager(queue, queueProps, accountSource);
     }
 
     // The following beans are defined for the worker profile only allowing

--- a/src/main/java/org/candlepin/subscriptions/security/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInController.java
@@ -66,8 +66,10 @@ public class OptInController {
         OffsetDateTime now = clock.now();
 
         Optional<AccountConfig> accountData =
-            createOrUpdateAccountConfig(accountNumber, now, optInType, enableTallySync, enableTallyReporting);
-        Optional<OrgConfig> orgData = createOrUpdateOrgConfig(orgId, now, optInType, enableConduitSync);
+            accountConfigRepository.createOrUpdateAccountConfig(accountNumber, now, optInType,
+            enableTallySync, enableTallyReporting);
+        Optional<OrgConfig> orgData = orgConfigRepository.createOrUpdateOrgConfig(orgId, now, optInType,
+            enableConduitSync);
         return buildDto(
             buildMeta(accountNumber, orgId),
             buildOptInAccountDTO(accountData),
@@ -94,33 +96,6 @@ public class OptInController {
             buildOptInAccountDTO(accountConfigRepository.findById(accountNumber)),
             buildOptInOrgDTO(orgConfigRepository.findById(orgId))
         );
-    }
-
-    private Optional<AccountConfig> createOrUpdateAccountConfig(String account, OffsetDateTime current,
-        OptInType optInType, boolean enableSync, boolean enableReporting) {
-        Optional<AccountConfig> found = accountConfigRepository.findById(account);
-        AccountConfig accountConfig = found.orElse(new AccountConfig(account));
-        if (!found.isPresent()) {
-            accountConfig.setOptInType(optInType);
-            accountConfig.setCreated(current);
-        }
-        accountConfig.setSyncEnabled(enableSync);
-        accountConfig.setReportingEnabled(enableReporting);
-        accountConfig.setUpdated(current);
-        return Optional.of(accountConfigRepository.save(accountConfig));
-    }
-
-    private Optional<OrgConfig> createOrUpdateOrgConfig(String orgId, OffsetDateTime current,
-        OptInType optInType, boolean enableSync) {
-        Optional<OrgConfig> found = orgConfigRepository.findById(orgId);
-        OrgConfig orgConfig = found.orElse(new OrgConfig(orgId));
-        if (!found.isPresent()) {
-            orgConfig.setOptInType(optInType);
-            orgConfig.setCreated(current);
-        }
-        orgConfig.setSyncEnabled(enableSync);
-        orgConfig.setUpdated(current);
-        return Optional.of(orgConfigRepository.save(orgConfig));
     }
 
     private OptInConfig buildDto(OptInConfigMeta meta, OptInConfigDataAccount accountData,

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -15,6 +15,3 @@ rhsm-subscriptions:
             max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / 13.0) by (_id)
             * on(_id) group_right
             min_over_time(subscription_labels{ebs_account="%s", support=~"Premium|Standard|Self-Support|None"}[1h])
-      client:
-        token: ${PROM_AUTH_TOKEN:}
-        url: ${PROM_URL:https://localhost/api/v1}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -94,6 +94,15 @@ rhsm-subscriptions:
   # Base path override for reverse proxy support
   hawtio-base-path: ${HAWTIO_BASE_PATH:}
   metering:
+    prometheus:
+      client:
+        token: ${PROM_AUTH_TOKEN:}
+        url: ${PROM_URL:https://localhost/api/v1}
+      metric:
+        openshift:
+          enabledAccountPromQL: >-
+            group(min_over_time(subscription_labels{ebs_account != '', billing_model='marketplace'}[1h]))
+            by (ebs_account)
     openshift:
       tasks:
         topic: ${OPENSHIFT_METERING_TASK_TOPIC:platform.rhsm-subscriptions.openshift-metering-tasks}

--- a/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
@@ -28,7 +28,10 @@ import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.db.model.config.OrgConfig;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -39,7 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
+@TestInstance(Lifecycle.PER_CLASS)
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
@@ -48,6 +51,11 @@ public class OrgConfigRepositoryTest {
     @Autowired
     private OrgConfigRepository repository;
     private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+
+    @BeforeAll
+    void cleanUpDatabase() {
+        repository.deleteAll();
+    }
 
     @Test
     public void saveAndUpdate() {
@@ -87,7 +95,7 @@ public class OrgConfigRepositoryTest {
         repository.delete(toDelete);
         repository.flush();
 
-        assertEquals(0, repository.count());
+        assertTrue(repository.findById(config.getOrgId()).isEmpty());
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering.service.prometheus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.subscriptions.prometheus.model.QueryResult;
+import org.candlepin.subscriptions.prometheus.model.QueryResultData;
+import org.candlepin.subscriptions.prometheus.model.QueryResultDataResult;
+import org.candlepin.subscriptions.prometheus.model.ResultType;
+import org.candlepin.subscriptions.prometheus.model.StatusType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+
+@ExtendWith(MockitoExtension.class)
+class PrometheusAccountSourceTest {
+
+    final String TEST_QUERY = "TEST_QUERY";
+
+    @Mock
+    PrometheusService service;
+
+    PrometheusAccountSource accountSource;
+    PrometheusMetricsProperties promProps;
+
+    @BeforeEach
+    void setupTest() {
+        MetricProperties osProps = new MetricProperties();
+        osProps.setEnabledAccountPromQL(TEST_QUERY);
+
+        promProps = new PrometheusMetricsProperties();
+        promProps.setOpenshift(osProps);
+        accountSource = new PrometheusAccountSource(service, promProps);
+    }
+
+    @Test
+    void usesPromQLFromConfig() {
+        OffsetDateTime expectedDate = OffsetDateTime.now();
+        when(service.runQuery(TEST_QUERY, expectedDate, promProps.getOpenshift().getQueryTimeout()))
+            .thenReturn(buildAccountQueryResult(List.of("A1")));
+
+        accountSource.getOpenShiftMarketplaceAccounts(expectedDate);
+        verify(service).runQuery(promProps.getOpenshift().getEnabledAccountPromQL(), expectedDate,
+            promProps.getOpenshift().getQueryTimeout());
+    }
+
+    @Test
+    void filtersOutNullAndEmptyAccounts() {
+        String expectedAccount = "ACCOUNT_1";
+        OffsetDateTime expectedDate = OffsetDateTime.now();
+
+        // Note List.of(...) does not accept null
+        List<String> accountList = new LinkedList<>();
+        accountList.add(null);
+        accountList.add("");
+        accountList.add(expectedAccount);
+
+        when(service.runQuery(TEST_QUERY, expectedDate, promProps.getOpenshift().getQueryTimeout()))
+            .thenReturn(buildAccountQueryResult(accountList));
+
+        Set<String> accounts = accountSource.getOpenShiftMarketplaceAccounts(expectedDate);
+        assertEquals(1, accounts.size());
+        assertTrue(accounts.contains(expectedAccount));
+    }
+
+    @Test
+    void getAllAccounts() {
+        List<String> expectedAccounts = List.of("A1", "A2");
+        OffsetDateTime expectedDate = OffsetDateTime.now();
+
+        when(service.runQuery(TEST_QUERY, expectedDate, promProps.getOpenshift().getQueryTimeout()))
+            .thenReturn(buildAccountQueryResult(expectedAccounts));
+
+        Set<String> accounts = accountSource.getOpenShiftMarketplaceAccounts(expectedDate);
+        assertEquals(2, accounts.size());
+        assertTrue(accounts.containsAll(expectedAccounts));
+    }
+
+    private QueryResult buildAccountQueryResult(List<String> accounts) {
+        QueryResultData resultData = new QueryResultData().resultType(ResultType.MATRIX);
+        accounts.forEach(account -> {
+            resultData.addResultItem(new QueryResultDataResult().putMetricItem("ebs_account", account));
+        });
+        return new QueryResult()
+            .status(StatusType.SUCCESS)
+            .data(resultData);
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
@@ -50,11 +50,14 @@ class PrometheusServiceTest {
     @MockBean
     private QueryRangeApi rangeApi;
 
+    @MockBean
+    private PrometheusAccountSource accountSource;
+
     @Autowired
     private PrometheusMetricsProperties props;
 
     @Test
-    void testGetOpenshiftMetrics() throws Exception {
+    void testRangeQueryApi() throws Exception {
 
         String expectedQuery =
             UrlEscapers.urlFragmentEscaper().escape(props.getOpenshift().getMetricPromQL());
@@ -72,6 +75,22 @@ class PrometheusServiceTest {
 
         QueryResult result = service.runRangeQuery(props.getOpenshift().getMetricPromQL(),
             start, end, 3600, 1);
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    void testQueryApi() throws Exception {
+        String expectedQuery =
+            UrlEscapers.urlFragmentEscaper().escape(props.getOpenshift().getMetricPromQL());
+        QueryResult expectedResult = new QueryResult();
+
+        OffsetDateTime time = OffsetDateTime.now();
+        when(queryApi.query(expectedQuery, time, 1)).thenReturn(expectedResult);
+
+        ApiProvider provider = new StubApiProvider(queryApi, rangeApi);
+        PrometheusService service = new PrometheusService(provider);
+
+        QueryResult result = service.runQuery(props.getOpenshift().getMetricPromQL(), time, 1);
         assertEquals(expectedResult, result);
     }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -20,11 +20,12 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus.task;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import org.candlepin.subscriptions.db.AccountListSource;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource;
 import org.candlepin.subscriptions.task.TaskDescriptor;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.TaskType;
@@ -37,7 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
-import java.util.Arrays;
+import java.util.Set;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -49,10 +50,10 @@ class PrometheusMetricsTaskManagerTest {
     private TaskQueue queue;
 
     @Mock
-    private AccountListSource accountSource;
+    private TaskQueueProperties queueProperties;
 
     @Mock
-    private TaskQueueProperties queueProperties;
+    private PrometheusAccountSource accountSource;
 
     private PrometheusMetricsTaskManager manager;
 
@@ -83,7 +84,7 @@ class PrometheusMetricsTaskManagerTest {
         OffsetDateTime end = OffsetDateTime.now();
         OffsetDateTime start = end.minusDays(1);
 
-        when(accountSource.syncableAccounts()).thenReturn(Arrays.asList("a1", "a2").stream());
+        when(accountSource.getOpenShiftMarketplaceAccounts(any())).thenReturn(Set.of("a1", "a2"));
         TaskDescriptor account1Task =
             TaskDescriptor.builder(TaskType.OPENSHIFT_METRICS_COLLECTION, TASK_TOPIC)
             .setSingleValuedArg("account", "a1")


### PR DESCRIPTION
## Details
[ENT-3635](https://issues.redhat.com/browse/ENT-3635)

When OpenShift metrics collection is triggered for all accounts
(via the job or jmx), the account list is pulled from Prometheus using the
subscription_labels metric, matching on the billing_model="marketplace"
label, and will be included in the list of accounts that has
OpenShift metering enabled.

When an OpenShift metering task is executed for an account, we first
make sure that it is opted in, and then gather the meterics.

## Testing
Currently there doesn't seem to be any accounts in subscription_labels that have a _billing_model_ label set to _marketplace_. As such, you will have to modify the PromQL so that it will actually match some of them.

First you'll need to set up access to a Prometheus server. See https://docs.engineering.redhat.com/display/ENT/Prometheus+Metrics for getting an auth token for thanos. I like to export it into a variable so my startup command remains the same.

Deploy the application as follows. We override the PromQL here so that we pull back accounts with billing_model  of standard.
```bash
DEV_MODE=true RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_METRIC_OPENSHIFT_ENABLED_ACCOUNT_PROM_Q_L="group(min_over_time(subscription_labels{ebs_account != '', billing_model='standard'}[1h])) by (ebs_account)" PROM_URL="http://localhost:8082/api/v1" ./gradlew clean bootRun --args="--spring.profiles.active=openshift-metering-worker"
```

Test pulling the metrics for ALL matching accounts. 
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMetering()","arguments":[]}'
```

The logs should show something like the following as the accounts are getting processed.
```
--- SNIP ---
2021-03-17 14:21:46,931 [thread=pool-6-thread-11] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Ensuring marketplace account 5481602 has been set up for syncing/reporting.
2021-03-17 14:21:46,932 [thread=pool-6-thread-19] [INFO ] [org.candlepin.subscriptions.metering.task.OpenShiftMetricsTask] - Running Openshift metrics update for account: 6459587
2021-03-17 14:21:46,935 [thread=pool-6-thread-11] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Collecting OpenShift metrics
2021-03-17 14:21:46,936 [thread=pool-6-thread-11] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Fetching metrics from prometheus: 2021-03-17T13:00Z -> 2021-03-17T13:59:59.999999999Z [Step: 3600]
2021-03-17 14:21:46,964 [thread=pool-6-thread-13] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Persisted 2 events for OpenShift metrics.
2021-03-17 14:21:46,977 [thread=pool-6-thread-13] [INFO ] [org.candlepin.subscriptions.metering.task.OpenShiftMetricsTask] - Openshift metrics task complete.
--- SNIP ---
```

Also try, running an update for a single account. In this case, the query is not performed as we specified the account, but the account is still opted in during metrics gathering.
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMeteringForAccount(java.lang.String)","arguments":["6661312"]}'
```
```
--- SNIP ---
2021-03-17 14:29:46,448 [thread=http-nio-8080-exec-1] [INFO ] [org.candlepin.subscriptions.metering.jmx.OpenShiftJmxBean] - Openshift metering for 6661312 triggered via JMX by anonymousUser
2021-03-17 14:29:46,452 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.task.OpenShiftMetricsTask] - Running Openshift metrics update for account: 6661312
2021-03-17 14:29:46,463 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Ensuring marketplace account 6661312 has been set up for syncing/reporting.
2021-03-17 14:29:46,525 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Collecting OpenShift metrics
2021-03-17 14:29:46,525 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Fetching metrics from prometheus: 2021-03-17T13:00Z -> 2021-03-17T13:59:59.999999999Z [Step: 3600]
2021-03-17 14:29:48,377 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Persisted 3 events for OpenShift metrics.
2021-03-17 14:29:48,411 [thread=pool-6-thread-1] [INFO ] [org.candlepin.subscriptions.metering.task.OpenShiftMetricsTask] - Openshift metrics task complete.

--- SNIP ---
```