### PR TITLE
ENT-3264: Marketplace Payload Mapper

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/files/ProductProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductProfile.java
@@ -28,17 +28,23 @@ import org.candlepin.subscriptions.db.model.Usage;
 
 import org.springframework.util.StringUtils;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * Represents information telling capacity and tally how to handle certain products
  */
+@ToString
+@EqualsAndHashCode
 public class ProductProfile {
     private static final ProductProfile DEFAULT_PROFILE = new ProductProfile("DEFAULT",
         Collections.emptySet(), DAILY);
@@ -61,6 +67,11 @@ public class ProductProfile {
     private Map<String, Set<String>> swatchProductsByRoles;
     private Map<String, Set<String>> swatchProductsByEngProducts;
 
+
+    // TODO there's a card dedicated to putting this value in the product registry yaml (ENT-3610)
+    @Getter
+    @Setter
+    private String metricId = "redhat.com:openshiftdedicated:cpu_hour";
 
     public ProductProfile() {
         // Default used for YAML deserialization
@@ -190,42 +201,4 @@ public class ProductProfile {
         return this.swatchProductsByEngProducts;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ProductProfile that = (ProductProfile) o;
-        return burstable == that.burstable && Objects.equals(name, that.name) &&
-            Objects.equals(products, that.products) && finestGranularity == that.finestGranularity &&
-            Objects.equals(serviceType, that.serviceType) &&
-            defaultSla == that.defaultSla &&
-            defaultUsage == that.defaultUsage &&
-            Objects.equals(prometheusMetricName, that.prometheusMetricName) &&
-            Objects.equals(prometheusCounterName, that.prometheusCounterName) &&
-            Objects.equals(architectureSwatchProductIdMap, that.architectureSwatchProductIdMap) &&
-            Objects.equals(swatchProductsByRoles, that.swatchProductsByRoles) &&
-            Objects.equals(swatchProductsByEngProducts, that.swatchProductsByEngProducts);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-            name,
-            products,
-            finestGranularity,
-            serviceType,
-            defaultSla,
-            defaultUsage,
-            burstable,
-            prometheusMetricName,
-            prometheusCounterName,
-            architectureSwatchProductIdMap,
-            swatchProductsByRoles,
-            swatchProductsByEngProducts
-        );
-    }
 }

--- a/src/main/java/org/candlepin/subscriptions/files/ProductProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductProfile.java
@@ -68,7 +68,7 @@ public class ProductProfile {
     private Map<String, Set<String>> swatchProductsByEngProducts;
 
 
-    // TODO there's a card dedicated to putting this value in the product registry yaml (ENT-3610)
+    // there's a card dedicated to putting this value in the product registry yaml (ENT-3610)
     @Getter
     @Setter
     private String metricId = "redhat.com:openshiftdedicated:cpu_hour";

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapper.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.files.ProductProfileRegistry;
+import org.candlepin.subscriptions.json.TallySnapshot;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
+import org.candlepin.subscriptions.marketplace.api.model.UsageMeasurement;
+import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
+import org.candlepin.subscriptions.tally.UsageCalculation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Maps TallySummary to payload contents to be sent to RHM apis
+ */
+@Service
+public class MarketplacePayloadMapper {
+    private static final Logger log = LoggerFactory.getLogger(MarketplacePayloadMapper.class);
+
+    private final ProductProfileRegistry profileRegistry;
+
+    @Autowired
+    public MarketplacePayloadMapper(ProductProfileRegistry profileRegistry) {
+        this.profileRegistry = profileRegistry;
+    }
+
+    /**
+     * Create UsageRequest pojo to send to Marketplace
+     *
+     * @param tallySummary TallySummary
+     * @return UsageRequest
+     */
+    public UsageRequest createUsageRequest(TallySummary tallySummary) {
+
+        UsageRequest usageRequest = new UsageRequest();
+
+        var usageEvents = produceUsageEvents(tallySummary);
+        usageEvents.forEach(usageRequest::addDataItem);
+
+        return usageRequest;
+    }
+
+    /**
+     * We only want to send snapshot information for OpenShift-metrics, OpenShift-dedicated-metrics product
+     * ids.  To prevent duplicate data, we don't want to send snapshots with the Usage or ServiceLevel of
+     * "_ANY".  We only want to report on hourly metrics, so the Granularity should be HOURLY.
+     *
+     * @param snapshot tally snapshot
+     * @return eligibility status
+     */
+    protected boolean isSnapshotPAYGEligible(TallySnapshot snapshot) {
+        String productId = snapshot.getProductId();
+        var applicableProducts = List.of("OpenShift-metrics", "OpenShift-dedicated-metrics");
+        boolean isApplicableProduct = applicableProducts.contains(productId);
+
+        boolean isHourlyGranularity = Objects
+            .equals(TallySnapshot.Granularity.HOURLY, snapshot.getGranularity());
+        boolean isSpecificUsage = !Objects.equals(snapshot.getUsage(), TallySnapshot.Usage.ANY);
+        boolean isSpecificServiceLevel = !Objects.equals(snapshot.getSla(), TallySnapshot.Sla.ANY);
+
+        boolean isSnapshotPAYGEligible =
+            isHourlyGranularity && isApplicableProduct && isSpecificUsage && isSpecificServiceLevel;
+
+        if (!isSnapshotPAYGEligible) {
+            log.debug("Snapshot not eligible for sending to RHM {}", snapshot);
+        }
+        return isSnapshotPAYGEligible;
+    }
+
+    /**
+     * UsageRequest objects are made up of a list of UsageEvents.
+     *
+     * @param tallySummary TallySummary
+     * @return List<UsageEvent>
+     */
+    protected List<UsageEvent> produceUsageEvents(TallySummary tallySummary) {
+        return tallySummary.getTallySnapshots().stream().filter(this::isSnapshotPAYGEligible)
+            .map(snapshot -> {
+                String productId = snapshot.getProductId();
+                OffsetDateTime snapshotDate = snapshot.getSnapshotDate();
+                String eventId = snapshot.getId().toString();
+
+                // call MarketplaceIdProvider.findSubscriptionId once available
+                UsageCalculation.Key usageKey = new UsageCalculation.Key(productId,
+                    ServiceLevel.fromString(snapshot.getSla().toString()),
+                    Usage.fromString(snapshot.getUsage().toString()));
+
+
+                /*
+                This will need to be updated if we expand the criteria defined in the
+                isSnapshotPAYGEligible method to allow for Granularities other than HOURLY
+                 */
+                OffsetDateTime startDate = snapshotDate.minus(Duration.of(1, ChronoUnit.HOURS));
+
+                long start = startDate.toEpochSecond();
+                long end = snapshotDate.toEpochSecond();
+
+                var subscriptionId = findSubscriptionId(tallySummary.getAccountNumber(), usageKey,
+                    startDate, snapshotDate).orElseThrow();
+
+                var usageMeasurements = produceUsageMeasurements(snapshot, productId);
+
+                UsageEvent event = new UsageEvent();
+                event.setMeasuredUsage(usageMeasurements);
+                event.setEnd(end);
+                event.setStart(start);
+                event.setSubscriptionId(subscriptionId);
+                event.setEventId(eventId);
+
+                return event;
+            }).collect(Collectors.toList());
+    }
+
+    /**
+     * UsageEvents include a list of usage measurements.  This data includes unit of measure (UOM), the
+     * value for the uom, and the metricId (RHM terminology) which is a configuration value of the product
+     * the uom is for.
+     *
+     * @param snapshot TallySnapshot
+     * @param productId swatch product id
+     * @return List<UsageMeasurement>
+     */
+    protected List<UsageMeasurement> produceUsageMeasurements(TallySnapshot snapshot, String productId) {
+        var productProfile = profileRegistry.findProfileForSwatchProductId(productId);
+
+        List<UsageMeasurement> usageMeasurements = new ArrayList<>();
+
+        //Filter out any HardwareMeasurementType.TOTAL measurments to prevent duplicates
+        snapshot.getTallyMeasurements().stream().filter(measurement -> !Objects
+            .equals(HardwareMeasurementType.TOTAL.toString(), measurement.getHardwareMeasurementType()))
+            .forEach(measurement -> {
+                UsageMeasurement usageMeasurement = new UsageMeasurement();
+                usageMeasurement.setValue(measurement.getValue());
+                usageMeasurement.setMetricId(productProfile.getMetricId());
+                usageMeasurements.add(usageMeasurement);
+            });
+        return usageMeasurements;
+    }
+
+    private Optional<String> findSubscriptionId(String accountNumber, UsageCalculation.Key usageKey,
+        OffsetDateTime rangeStart, OffsetDateTime rangeEnd) {
+
+        log.debug("looking up subscription id for {}, {}, range {} to {}", accountNumber, usageKey,
+            rangeStart, rangeEnd);
+
+        return Optional.of("bananas" + UUID.randomUUID().toString());
+
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapper.java
@@ -54,10 +54,13 @@ public class MarketplacePayloadMapper {
     private static final Logger log = LoggerFactory.getLogger(MarketplacePayloadMapper.class);
 
     private final ProductProfileRegistry profileRegistry;
+    private final MarketplaceProperties marketplaceProperties;
 
     @Autowired
-    public MarketplacePayloadMapper(ProductProfileRegistry profileRegistry) {
+    public MarketplacePayloadMapper(ProductProfileRegistry profileRegistry,
+        MarketplaceProperties marketplaceProperties) {
         this.profileRegistry = profileRegistry;
+        this.marketplaceProperties = marketplaceProperties;
     }
 
     /**
@@ -88,7 +91,8 @@ public class MarketplacePayloadMapper {
      */
     protected boolean isSnapshotPAYGEligible(TallySnapshot snapshot) {
         String productId = snapshot.getProductId();
-        var applicableProducts = List.of("OpenShift-metrics", "OpenShift-dedicated-metrics");
+
+        var applicableProducts = marketplaceProperties.getEligibleSwatchProductIds();
         boolean isApplicableProduct = applicableProducts.contains(productId);
 
         boolean isHourlyGranularity = Objects

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapper.java
@@ -91,14 +91,14 @@ public class MarketplacePayloadMapper {
         var applicableProducts = List.of("OpenShift-metrics", "OpenShift-dedicated-metrics");
         boolean isApplicableProduct = applicableProducts.contains(productId);
 
-        boolean isHourlyGranularity = Objects.nonNull(snapshot.getGranularity()) &&
-            Objects.equals(TallySnapshot.Granularity.HOURLY, snapshot.getGranularity());
+        boolean isHourlyGranularity = Objects
+            .equals(TallySnapshot.Granularity.HOURLY, snapshot.getGranularity());
 
-        boolean isSpecificUsage = Objects.nonNull(snapshot.getUsage()) &&
-            !Objects.equals(snapshot.getUsage(), TallySnapshot.Usage.ANY);
+        boolean isSpecificUsage = !List.of(TallySnapshot.Usage.ANY, TallySnapshot.Usage.__EMPTY__)
+            .contains(snapshot.getUsage());
 
-        boolean isSpecificServiceLevel =
-            Objects.nonNull(snapshot.getSla()) && !Objects.equals(snapshot.getSla(), TallySnapshot.Sla.ANY);
+        boolean isSpecificServiceLevel = !List.of(TallySnapshot.Sla.ANY, TallySnapshot.Sla.__EMPTY__)
+            .contains(snapshot.getSla());
 
         boolean isSnapshotPAYGEligible =
             isHourlyGranularity && isApplicableProduct && isSpecificUsage && isSpecificServiceLevel;

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
@@ -29,6 +29,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Properties for the Marketplace integration.
@@ -73,4 +75,7 @@ public class MarketplaceProperties extends HttpClientProperties {
      * Have the stub mapper emit empty usage requests (vs. full one) to be removed by ENT-3264
      */
     private boolean mapperStubEmpty;
+
+    private List<String> eligibleSwatchProductIds = new ArrayList<>();
+
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -71,12 +71,16 @@ public class SnapshotSummaryProducer {
         var sla = org.candlepin.subscriptions.json.TallySnapshot.Sla
             .fromValue(tallySnapshot.getServiceLevel().getValue());
 
+        var usage = org.candlepin.subscriptions.json.TallySnapshot.Usage
+            .fromValue(tallySnapshot.getUsage().getValue());
+
         return new org.candlepin.subscriptions.json.TallySnapshot()
             .withGranularity(granularity)
             .withId(tallySnapshot.getId())
             .withProductId(tallySnapshot.getProductId())
             .withSnapshotDate(tallySnapshot.getSnapshotDate())
             .withSla(sla)
+            .withUsage(usage)
             .withTallyMeasurements(mapMeasurements(tallySnapshot.getTallyMeasurements()));
     }
 

--- a/src/main/resources/application-marketplace.yaml
+++ b/src/main/resources/application-marketplace.yaml
@@ -10,3 +10,6 @@ rhsm-subscriptions:
     back-off-multiplier: ${MARKETPLACE_BACK_OFF_MULTIPLIER:2}
     # temporary; remove once https://issues.redhat.com/browse/ENT-3264 is implemented
     mapper-stub-empty: ${MARKETPLACE_MAPPER_STUB_EMPTY:true}
+    eligible-swatch-product-ids:
+      - OpenShift-metrics
+      - OpenShift-dedicated-metrics

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.context.annotation.Profile;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.subscriptions.files.ProductProfile;
+import org.candlepin.subscriptions.files.ProductProfileRegistry;
+import org.candlepin.subscriptions.json.TallyMeasurement;
+import org.candlepin.subscriptions.json.TallySnapshot;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
+import org.candlepin.subscriptions.marketplace.api.model.UsageMeasurement;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+class MarketplacePayloadMapperTest {
+
+    @Mock
+    ProductProfileRegistry profileRegistry;
+    @InjectMocks
+    MarketplacePayloadMapper marketplacePayloadMapper;
+
+    @BeforeEach
+    void init() {
+
+        ProductProfile productProfile = new ProductProfile();
+        productProfile.setMetricId("redhat.com:openshiftdedicated:cpu_hour");
+        MockitoAnnotations.openMocks(this);
+
+        when(profileRegistry.findProfileForSwatchProductId(anyString())).thenReturn(productProfile);
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateHardwareMeasurementPermutations")
+    void testProduceUsageMeasurements(
+        List<TallyMeasurement> tallyMeasurements, List<UsageMeasurement> expected) {
+
+        String productId = "OpenShift-metrics";
+
+        var snapshot = new TallySnapshot()
+            .withId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
+            .withProductId(productId)
+            .withSnapshotDate(OffsetDateTime.now())
+            .withUsage(TallySnapshot.Usage.PRODUCTION)
+            .withTallyMeasurements(tallyMeasurements)
+            .withSla(TallySnapshot.Sla.PREMIUM)
+            .withGranularity(TallySnapshot.Granularity.HOURLY);
+
+        var actual = marketplacePayloadMapper
+            .produceUsageMeasurements(snapshot, productId);
+
+        assertEquals(expected, actual);
+    }
+
+    @SuppressWarnings("linelength")
+    static Stream<Arguments> generateHardwareMeasurementPermutations() {
+        double value = 36.0;
+
+        TallyMeasurement physicalCoreMeasurement = new TallyMeasurement()
+            .withHardwareMeasurementType("PHYSICAL").withUom(TallyMeasurement.Uom.CORES).withValue(value);
+        TallyMeasurement totalCoreMeasurment = new TallyMeasurement().withHardwareMeasurementType("TOTAL")
+            .withUom(TallyMeasurement.Uom.CORES).withValue(value);
+        TallyMeasurement virtualCoreMeasurment = new TallyMeasurement().withHardwareMeasurementType("VIRTUAL")
+            .withUom(TallyMeasurement.Uom.CORES).withValue(value);
+
+        UsageMeasurement usageMeasurement = new UsageMeasurement().value(value)
+            .metricId("redhat.com:openshiftdedicated:cpu_hour");
+
+        Arguments physical = Arguments.of(List.of(physicalCoreMeasurement), List.of(usageMeasurement));
+        Arguments virtual = Arguments.of(List.of(virtualCoreMeasurment), List.of(usageMeasurement));
+        Arguments physicalTotal = Arguments.of(List.of(physicalCoreMeasurement, totalCoreMeasurment), List.of(usageMeasurement));
+        Arguments virtualTotal = Arguments.of(List.of(virtualCoreMeasurment, totalCoreMeasurment), List.of(usageMeasurement));
+        Arguments physicalVirtual = Arguments.of(List.of(physicalCoreMeasurement, virtualCoreMeasurment), List.of(usageMeasurement, usageMeasurement));
+        Arguments physicalVirtualTotal = Arguments.of(List.of(physicalCoreMeasurement, virtualCoreMeasurment, totalCoreMeasurment), List.of(usageMeasurement, usageMeasurement));
+
+        return Stream
+            .of(physical, virtual, physicalTotal, virtualTotal, physicalVirtual, physicalVirtualTotal);
+    }
+
+    @ParameterizedTest(name = "testIsSnapshotPAYGEligible [{index}]")
+    @MethodSource("generateIsSnapshotPaygEligibleData")
+    void testIsSnapshotPAYGEligible(TallySnapshot snapshot, boolean isEligible) {
+
+        boolean actual = marketplacePayloadMapper.isSnapshotPAYGEligible(snapshot);
+        assertEquals(isEligible, actual);
+    }
+
+    static Stream<Arguments> generateIsSnapshotPaygEligibleData() {
+
+        Arguments eligbileOpenShiftMetrics = Arguments
+            .of(new TallySnapshot().withProductId("OpenShift-metrics")
+            .withUsage(TallySnapshot.Usage.PRODUCTION).withSla(TallySnapshot.Sla.PREMIUM)
+            .withGranularity(TallySnapshot.Granularity.HOURLY), true);
+
+        Arguments notEligibleBecauseSla = Arguments.of(new TallySnapshot().withProductId("OpenShift-metrics")
+            .withUsage(TallySnapshot.Usage.PRODUCTION).withSla(TallySnapshot.Sla.ANY)
+            .withGranularity(TallySnapshot.Granularity.HOURLY), false);
+
+        Arguments notEligibleBecauseGranularity = Arguments
+            .of(new TallySnapshot().withProductId("OpenShift-metrics")
+            .withUsage(TallySnapshot.Usage.PRODUCTION).withSla(TallySnapshot.Sla.PREMIUM)
+            .withGranularity(TallySnapshot.Granularity.DAILY), false);
+
+        Arguments notElgibleBecauseUsage = Arguments
+            .of(new TallySnapshot().withProductId("OpenShift-metrics").withUsage(TallySnapshot.Usage.ANY)
+            .withSla(TallySnapshot.Sla.PREMIUM).withGranularity(TallySnapshot.Granularity.HOURLY), false);
+
+        Arguments eligbileOpenShiftDedicatedMetrics = Arguments
+            .of(new TallySnapshot().withProductId("OpenShift-dedicated-metrics")
+            .withUsage(TallySnapshot.Usage.PRODUCTION).withSla(TallySnapshot.Sla.PREMIUM)
+            .withGranularity(TallySnapshot.Granularity.HOURLY), true);
+
+        Arguments notEligibleBecauseProductId = Arguments
+            .of(new TallySnapshot().withProductId("RHEL").withUsage(TallySnapshot.Usage.PRODUCTION)
+            .withSla(TallySnapshot.Sla.PREMIUM).withGranularity(TallySnapshot.Granularity.HOURLY), false);
+
+        return Stream
+            .of(eligbileOpenShiftMetrics, eligbileOpenShiftDedicatedMetrics, notEligibleBecauseProductId,
+                notEligibleBecauseSla, notEligibleBecauseGranularity, notElgibleBecauseUsage);
+    }
+
+    @Test
+    void testProduceUsageEvents() {
+        TallyMeasurement physicalCoreMeasurement = new TallyMeasurement()
+            .withHardwareMeasurementType("PHYSICAL").withUom(TallyMeasurement.Uom.CORES).withValue(36.0);
+
+        var snapshotDateLong = 1616100754L;
+
+        OffsetDateTime snapshotDate = OffsetDateTime
+            .ofInstant(Instant.ofEpochMilli(snapshotDateLong), ZoneId.of("UTC"));
+        var snapshot = new TallySnapshot()
+            .withId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
+            .withProductId("OpenShift-metrics")
+            .withSnapshotDate(snapshotDate)
+            .withUsage(TallySnapshot.Usage.PRODUCTION)
+            .withTallyMeasurements(List.of(physicalCoreMeasurement))
+            .withSla(TallySnapshot.Sla.PREMIUM)
+            .withGranularity(TallySnapshot.Granularity.HOURLY);
+
+        var summary = new TallySummary().withTallySnapshots(List.of(snapshot)).withAccountNumber("test123");
+
+        var expected = List
+            .of(new UsageEvent().start(1612500L).end(1616100L).eventId("c204074d-626f-4272-aa05-b6d69d6de16a")
+            .measuredUsage(List.of(
+            new UsageMeasurement().value(36.0).metricId("redhat.com:openshiftdedicated:cpu_hour"))));
+
+        List<UsageEvent> actual = marketplacePayloadMapper.produceUsageEvents(summary);
+
+        assertEquals(1, actual.size());
+        assertEquals(expected.get(0).getEventId(), actual.get(0).getEventId());
+        assertEquals(expected.get(0).getMeasuredUsage(), actual.get(0).getMeasuredUsage());
+        assertEquals(expected.get(0).getStart(), actual.get(0).getStart());
+        assertEquals(expected.get(0).getEnd(), actual.get(0).getEnd());
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
@@ -30,6 +30,7 @@ import org.candlepin.subscriptions.json.TallySnapshot;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
 import org.candlepin.subscriptions.marketplace.api.model.UsageMeasurement;
+import org.candlepin.subscriptions.utilization.api.model.ProductId;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.context.annotation.Profile;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -51,6 +53,8 @@ class MarketplacePayloadMapperTest {
 
     @Mock
     ProductProfileRegistry profileRegistry;
+    @Mock
+    MarketplaceProperties marketplaceProperties;
     @InjectMocks
     MarketplacePayloadMapper marketplacePayloadMapper;
 
@@ -62,6 +66,8 @@ class MarketplacePayloadMapperTest {
         MockitoAnnotations.openMocks(this);
 
         when(profileRegistry.findProfileForSwatchProductId(anyString())).thenReturn(productProfile);
+        when(marketplaceProperties.getEligibleSwatchProductIds()).thenReturn(List.of(
+            ProductId.OPENSHIFT_METRICS.toString(), ProductId.OPENSHIFT_DEDICATED_METRICS.toString()));
     }
 
     @ParameterizedTest

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.*;
 
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.json.TallySummary;
-import org.candlepin.subscriptions.marketplace.MarketplaceWorker.MarketplacePayloadMapper;
 import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
 import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
 
@@ -46,7 +45,7 @@ class MarketplaceWorkerTest {
         var worker = new MarketplaceWorker(properties, producer, payloadMapper);
 
         UsageRequest usageRequest = new UsageRequest().data(List.of(new UsageEvent()));
-        when(payloadMapper.mapTallySummary(any())).thenReturn(usageRequest);
+        when(payloadMapper.createUsageRequest(any())).thenReturn(usageRequest);
 
         worker.receive(new TallySummary());
 
@@ -61,7 +60,7 @@ class MarketplaceWorkerTest {
         var worker = new MarketplaceWorker(properties, producer, payloadMapper);
 
         UsageRequest usageRequest = new UsageRequest().data(Collections.emptyList());
-        when(payloadMapper.mapTallySummary(any())).thenReturn(usageRequest);
+        when(payloadMapper.createUsageRequest(any())).thenReturn(usageRequest);
 
         worker.receive(new TallySummary());
 
@@ -75,7 +74,7 @@ class MarketplaceWorkerTest {
         MarketplacePayloadMapper payloadMapper = mock(MarketplacePayloadMapper.class);
         var worker = new MarketplaceWorker(properties, producer, payloadMapper);
 
-        when(payloadMapper.mapTallySummary(any())).thenReturn(null);
+        when(payloadMapper.createUsageRequest(any())).thenReturn(null);
 
         worker.receive(new TallySummary());
 


### PR DESCRIPTION
# Prereq
* Run with `marketplace` profile enabled
* Use debug log level

# Test option 1
* Invoke the `submitTallySummary` JMX endpoint with this payload
(org.candlepin.subscriptons.marketplace -> MarketplaceJmxBean -> Operations -> submitTallySummary(String))

```javascript
{
    "account_number": "account123",
    "tally_snapshots": [
        {
            "id": "c204074d-626f-4272-aa05-b6d69d6de16a",
            "snapshot_date": 1615406400,
            "product_id": "OpenShift-metrics",
            "usage": "Production",
            "sla": "Premium",
            "granularity": "Hourly",
            "tally_measurements": [
                {
                    "hardware_measurement_type": "TOTAL",
                    "uom": "Cores",
                    "value": 36
                },
                {
                    "hardware_measurement_type": "PHYSICAL",
                    "uom": "Cores",
                    "value": 36
                }
            ]
        }
    ]
}
```

# Test option 2
ORRRRR

If you have TallySummary messages in a kafka topic, the MarketplaceWorker will pick them up now.

# Results
You should see a debug log statement with the UsageEvent payload
```
2021-03-19 16:09:03,168 [thread=marketplace-worker-0-C-1] [DEBUG ] [org.candlepin.subscriptions.marketplace.MarketplacePayloadMapper] - UsageRequest class UsageRequest {
    data: [class UsageEvent {
        start: 1615402800
        end: 1615406400
        subscriptionId: bananas2c017c5f-f1b1-4f3b-8e30-b2137f9eaffe
        eventId: 8779f11c-481c-4cee-86f8-0fee0ab19bee
        additionalAttributes: null
        measuredUsage: [class UsageMeasurement {
            metricId: redhat.com:openshiftdedicated:cpu_hour
            value: 12.0
        }]
    }]
}

```
# Expected errors

An ugly stacktrace about `RESTEASY003720: path param MARKETPLACE_URL` is expected, unless you have it set in `application-marketplace.yml` or have the environment variable set.

```
2021-03-19 18:13:43,334 [thread=marketplace-worker-0-C-1] [ERROR] [org.springframework.kafka.listener.SeekToCurrentErrorHandler] - Backoff FixedBackOff{interval=0, currentAttempts=10, maxAttempts=9} exhausted for ConsumerRecord(topic = platform.rhsm-subscriptions.tally, partition = 0, leaderEpoch = 0, offset = 1664466, CreateTime = 1616177622873, serialized key size = -1, serialized value size = 390, headers = RecordHeaders(headers = [], isReadOnly = false), key = null, value = org.candlepin.subscriptions.json.TallySummary@4b5d643a[accountNumber=account123,tallySnapshots=[org.candlepin.subscriptions.json.TallySnapshot@76bee3f7[id=5571d83a-31e0-4f57-ad13-4c61b6d488b3,snapshotDate=2021-03-10T19:00Z,productId=OpenShift-metrics,sla=Standard,usage=Development/Test,granularity=Hourly,tallyMeasurements=[org.candlepin.subscriptions.json.TallyMeasurement@41c5b4a8[hardwareMeasurementType=PHYSICAL,uom=Cores,value=12.0], org.candlepin.subscriptions.json.TallyMeasurement@15b004c[hardwareMeasurementType=TOTAL,uom=Cores,value=12.0]]]]])
org.springframework.kafka.listener.ListenerExecutionFailedException: Listener method 'public void org.candlepin.subscriptions.marketplace.MarketplaceWorker.receive(org.candlepin.subscriptions.json.TallySummary)' threw exception; nested exception is java.lang.IllegalArgumentException: RESTEASY003720: path param MARKETPLACE_URL has not been provided by the parameter map; nested exception is java.lang.IllegalArgumentException: RESTEASY003720: path param MARKETPLACE_URL has not been provided by the parameter map

```

