### PR TITLE
ENT-3627: Fix Daily Metric Tally Increases

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -72,13 +72,12 @@ public class TallyJmxBean {
     @ManagedOperationParameter(
         name = "startDateTime", description =
         "Beginning of the range of time the tally should include. " +
-        "Expected to be in ISO 8601 format (e.g. 2017-08-01T17:32:28Z)."
+        "Should be top of the hour and expected to be in ISO 8601 format (e.g. 2020-08-02T14:00Z)."
     )
-
     @ManagedOperationParameter(
         name = "endDateTime", description =
         "Ending of the range of time the tally should include. " +
-        "Expected to be in ISO 8601 format (e.g. 2017-08-01T17:32:28Z)."
+        "Should be top of the hour and expected to be in ISO 8601 format (e.g. 2020-08-02T14:00Z)."
     )
     public void tallyAccountByHourly(String accountNumber, String startDateTime, String endDateTime) {
         log.info("Hourly tally between {} and {} for account {} triggered over JMX by {}",

--- a/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -224,4 +224,9 @@ public class ApplicationClock {
                 throw new IllegalArgumentException(String.format(BAD_GRANULARITY_MESSAGE, granularity));
         }
     }
+
+    public boolean isHourlyRange(OffsetDateTime startDateTime, OffsetDateTime endDateTime) {
+        return startDateTime.isEqual(startOfHour(startDateTime)) &&
+            endDateTime.isEqual(startOfHour(endDateTime));
+    }
 }

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -216,6 +216,15 @@ class ApplicationClockTest {
         assertDate(2019, 5, 24, 12, 59, 59, 999_999_999, clock.endOfCurrentHour());
     }
 
+    @Test
+    void testIsHourlyRange() {
+        OffsetDateTime start = clock.startOfCurrentHour();
+        OffsetDateTime end = start.plusHours(1);
+        assertTrue(clock.isHourlyRange(start, end));
+        assertFalse(clock.isHourlyRange(start.minusMinutes(1), end));
+        assertFalse(clock.isHourlyRange(start, end.minusMinutes(1)));
+    }
+
     private void assertDate(int year, int month, int day, int hour, int minute, int seconds, int nanos,
         OffsetDateTime date) {
         assertEquals(year, date.getYear());


### PR DESCRIPTION
Daily snapshot values increase when the date changes. Properly set the
dates when updating instance measurements.

## Testing

```bash
# Start with a clean deployment.
$ podman-compose down; podman-compose up -d

# Deploy the application connected to a Telemeter instance (PROM_URL)
$ DEV_MODE=true  PROM_URL="http://localhost:8082/api/v1" ./gradlew clean bootRun

# Opt-in account: 6661312
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["6661312","123456",true,true,true]}'

# Gather metrics for an account: 6661312
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performCustomOpenshiftMeteringForAccount(java.lang.String, java.lang.String, java.lang.Integer)","arguments":["6661312", "2021-03-19T16:00:00Z", 5760]}'

# No real report data
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjY2NjEzMTIiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics?granularity=daily&beginning=2021-03-16T00:00:00.000Z&ending=2021-03-17T23:59:59.999Z" | python -mjson.tool

# Run the hourly tally and verify you get an IllegalArguementException due to dates.
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6661312", "2021-03-16T14:50:03.711582Z", "2021-03-17T14:50:03.711582Z"]}'

# Run a valid tally
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6661312", "2021-03-16T14:00Z", "2021-03-17T15:00Z"]}'

# Check the core_hours numbers again and you should have real values.
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjY2NjEzMTIiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics?granularity=daily&beginning=2021-03-16T00:00:00.000Z&ending=2021-03-17T23:59:59.999Z" | python -mjson.tool

# Run the tally again, and because it detected a re-tally, it will process from the start of the month, picking up any that were out of range on the first attempt.
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6661312", "2021-03-16T14:00Z", "2021-03-17T15:00Z"]}'

# Get a daily report and notice the numbers go up. This is correct because of new data.
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjY2NjEzMTIiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics?granularity=daily&beginning=2021-03-16T00:00:00.000Z&ending=2021-03-17T23:59:59.999Z" | python -mjson.tool

# Do another tally shifting the start date ahead to miss some hours. End result should be same as the report above, and not increase.
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6661312", "2021-03-16T20:00Z", "2021-03-17T15:00Z"]}'
```