### PR TITLE
Revert spring-data-jpa to 2.4.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ allprojects {
             dependency "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:$jboss_jaxrs_api_version"
             dependency "io.swagger:swagger-annotations:$swagger_annotations_version"
             dependency "org.webjars:swagger-ui:$swagger_ui_version"
+            // NOTE(khowell): please remove this override when https://issues.redhat.com/browse/ENT-3686 is addressed
+            dependency "org.springframework.data:spring-data-jpa:2.4.5"
             dependency "org.webjars:webjars-locator:$webjars_locator_version"
             dependency "org.jboss.resteasy:resteasy-spring-boot-starter:$resteasy_spring_boot_starter_version"
             dependencySet(group: "org.jboss.resteasy", version: "$resteasy_version") {


### PR DESCRIPTION
Behavior around sorting changed and broke our unit tests.