### PR TITLE
Use fully qualified names for parameterized tests

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.db;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.ParameterizedTest.*;
 
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.Host;
@@ -473,7 +474,7 @@ class HostRepositoryTest {
     }
 
     @Transactional
-    @ParameterizedTest
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     @MethodSource("org.candlepin.subscriptions.db.HostRepositoryTest#instanceSortParams")
     void canSortByInstanceBasedSortMethods(String sort) {
         Pageable page = PageRequest.of(0, 1, Sort.by(sort));
@@ -486,7 +487,7 @@ class HostRepositoryTest {
     }
 
     @Transactional
-    @ParameterizedTest
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     @MethodSource("org.candlepin.subscriptions.db.HostRepositoryTest#tallyViewSortParams")
     void canSortByHostBasedSortMethods(String sort) {
         Pageable page = PageRequest.of(0, 1, Sort.by(sort));
@@ -595,7 +596,7 @@ class HostRepositoryTest {
     }
 
     @Transactional
-    @ParameterizedTest
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     @CsvSource({
         "'',3",
         "banana,1",

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import static org.junit.jupiter.params.ParameterizedTest.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.subscriptions.db.AccountListSource;
@@ -252,7 +253,7 @@ class HostsResourceTest {
         );
     }
 
-    @ParameterizedTest(name = "testInvalidBeginningAndEndingDates[{index}] {arguments}")
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     @CsvSource({
         "2000-01-01T00:00:00Z, 1999-01-01T00:00:00Z",
         "2021-02-01T00:00:00Z, 2021-03-01T00:00:00Z"
@@ -262,7 +263,7 @@ class HostsResourceTest {
             () -> resource.validateBeginningAndEndingDates(beginning, ending));
     }
 
-    @ParameterizedTest(name = "testValidBeginningAndEndingDates[{index}] {arguments}")
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     @CsvSource({
         "2000-01-01T00:00:00Z, 2000-01-01T00:00:00Z",
         "2000-01-01T00:00:00Z, 2000-01-31T00:00:00Z"

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.ParameterizedTest.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.subscriptions.db.AccountRepository;
@@ -134,7 +135,7 @@ class MetricUsageCollectorTest {
             HardwareMeasurementType.PHYSICAL).getMeasurement(Measurement.Uom.CORES));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     @EnumSource(Event.HardwareType.class)
     void testCollectHandlesAllHardwareTypes(Event.HardwareType hardwareType) {
         Event event = new Event()
@@ -152,7 +153,7 @@ class MetricUsageCollectorTest {
         assertNotNull(accountUsageCalculation);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     @EnumSource(Event.CloudProvider.class)
     void testCollectHandlesAllCloudProviders(Event.CloudProvider cloudProvider) {
         Event event = new Event()

--- a/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally.job;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.ParameterizedTest.*;
 import static org.mockito.BDDMockito.*;
 
 import org.candlepin.subscriptions.ApplicationProperties;
@@ -195,7 +196,7 @@ class CaptureSnapshotsTaskManagerTest {
         return dateTime.toZonedDateTime().minus(adjustmentAmount).toOffsetDateTime();
     }
 
-    @ParameterizedTest(name = "testAdjustTimeForLatency[{index}] {arguments}")
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     @CsvSource({
         "2021-02-01T00:00:00Z, PT0H, 2021-02-01T00:00:00Z",
         "2021-02-01T00:00:00Z, PT1H, 2021-01-31T23:00:00Z",


### PR DESCRIPTION
The default test name for a parameterized test is just the index number
and the arguments which does not actually tell you which specific test
method is being run.  The reasoning behind this is that test runners are
expected to print the test method name and then underneath in a
tree-like fashion, print the individual instances of that test.  Our
test runner doesn't follow this behavior making it difficult to tell
what method generated a particular parameterized test.  This patch
corrects the issue by mandating a more verbose name.