### PR TITLE
ENT-3695: Improve logging around hourly tally via JMX

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
@@ -86,6 +86,8 @@ public class CombiningRollupSnapshotStrategy {
 
         if (accountCalcs.isEmpty()) {
             // nothing to do here, return early
+            log.info("No account calculations available. No snapshots will be produced for account: {}",
+                accountNumber);
             return;
         }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -120,6 +120,8 @@ public class TallySnapshotController {
     @Timed("rhsm-subscriptions.snapshots.single.hourly")
     public void produceHourlySnapshotsForAccount(String accountNumber, OffsetDateTime startDateTime,
         OffsetDateTime endDateTime) {
+        log.info("Producing hourly snapshot for account {} between startDateTime {} and endDateTime {}",
+            accountNumber, startDateTime, endDateTime);
         try {
             var accountCalcs = retryTemplate.execute(
                 context -> metricUsageCollector.collect(accountNumber, startDateTime, endDateTime));
@@ -131,6 +133,7 @@ public class TallySnapshotController {
             combiningRollupSnapshotStrategy
                 .produceSnapshotsFromCalculations(accountNumber, startDateTime, endDateTime,
                 applicableUsageCalculations, Granularity.HOURLY, Double::sum);
+            log.info("Finished producing hourly snapshots for account: {}", accountNumber);
         }
         catch (Exception e) {
             log.error("Could not collect metrics and/or produce snapshots for account {}", accountNumber, e);

--- a/src/main/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManager.java
@@ -124,15 +124,17 @@ public class CaptureSnapshotsTaskManager {
 
     public void tallyAccountByHourly(String accountNumber, String startDateTime, String endDateTime) {
 
-        log.info("Queuing hourly snapshot production for accountNumber {} between {} and {}",
-            accountNumber, startDateTime, endDateTime);
-
         if (!applicationClock.isHourlyRange(
             OffsetDateTime.parse(startDateTime), OffsetDateTime.parse(endDateTime))) {
+            log.error("Hourly snapshot production for accountNumber {} will not be queued. " +
+                "Invalid start/end times specified.", accountNumber);
             throw new IllegalArgumentException(String.format(
-                "Date range must start at top of the hour and end at the bottom of the hour: [%s -> %s]",
+                "Start/End times must be at the top of the hour: [%s -> %s]",
                 startDateTime, endDateTime));
         }
+
+        log.info("Queuing hourly snapshot production for accountNumber {} between {} and {}",
+            accountNumber, startDateTime, endDateTime);
 
         queue.enqueue(TaskDescriptor.builder(TaskType.UPDATE_HOURLY_SNAPSHOTS, taskQueueProperties.getTopic())
             .setSingleValuedArg("accountNumber", accountNumber)

--- a/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
@@ -23,17 +23,12 @@ package org.candlepin.subscriptions.tally.tasks;
 import org.candlepin.subscriptions.tally.TallySnapshotController;
 import org.candlepin.subscriptions.task.Task;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.OffsetDateTime;
 
 /**
  * Captures hourly metrics between a given timeframe for a given account
  */
 public class CaptureMetricsSnapshotTask implements Task {
-
-    private static final Logger log = LoggerFactory.getLogger(CaptureMetricsSnapshotTask.class);
 
     private final String accountNumber;
     private final TallySnapshotController snapshotController;
@@ -55,11 +50,6 @@ public class CaptureMetricsSnapshotTask implements Task {
             throw new IllegalArgumentException(
                 "Cannot produce hourly snapshot for account {}.  Invalid date range provided.");
         }
-        log.info("Producing hourly snapshot for account {} between startDateTime {} and endDateTime {}",
-            accountNumber,
-            startDateTime,
-            endDateTime);
-
         snapshotController.produceHourlySnapshotsForAccount(accountNumber, startDateTime, endDateTime);
     }
 }


### PR DESCRIPTION
When start/end time validation fails when running hourly
tally via JMX, the logs can lead you to believe that the
task was queued and never got picked up.

This patch improves logging when validation fails and also
strengthens overall logging around the hourly tally. 