### PR TITLE
Tweak cronjob for queuing metrics gathering

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -105,8 +105,8 @@ rhsm-subscriptions:
       metric:
         openshift:
           enabledAccountPromQL: >-
-            group(min_over_time(subscription_labels{ebs_account != '', billing_model='marketplace'}[1h]))
-            by (ebs_account)
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(subscription_labels{ebs_account != '', billing_model='marketplace'}[1h]))
+            by (ebs_account)}
     openshift:
       tasks:
         topic: ${OPENSHIFT_METERING_TASK_TOPIC:platform.rhsm-subscriptions.openshift-metering-tasks}

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -49,6 +49,9 @@ parameters:
     value: 128Mi
   - name: TOKEN_REFRESHER_MEMORY_LIMIT
     value: 150Mi
+  # TODO: this should be removed once OCM has non-standard billing_model clusters
+  - name: OPENSHIFT_ENABLED_ACCOUNT_PROMQL
+    value: "group(min_over_time(subscription_labels{ebs_account != '', billing_model='standard'}[1h])) by (ebs_account)"
 
 objects:
   - apiVersion: batch/v1beta1
@@ -134,6 +137,9 @@ objects:
                           key: db.password
                     - name: PROM_URL
                       value: http://localhost:8082
+                    # TODO remove once non-standard billing_model lands in OCM
+                    - name: OPENSHIFT_ENABLED_ACCOUNT_PROMQL
+                      value: ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL}
                   resources:
                     requests:
                       cpu: ${CPU_REQUEST}

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -39,6 +39,16 @@ parameters:
     value: 1900m
   - name: HOURLY_TALLY_OFFSET
     value: 60m
+  - name: TOKEN_REFRESHER_IMAGE
+    value: quay.io/observatorium/token-refresher:master-2021-02-05-5da9663
+  - name: TOKEN_REFRESHER_CPU_REQUEST
+    value: 50m
+  - name: TOKEN_REFRESHER_CPU_LIMIT
+    value: 100m
+  - name: TOKEN_REFRESHER_MEMORY_REQUEST
+    value: 128Mi
+  - name: TOKEN_REFRESHER_MEMORY_LIMIT
+    value: 150Mi
 
 objects:
   - apiVersion: batch/v1beta1
@@ -122,6 +132,8 @@ objects:
                         secretKeyRef:
                           name: host-inventory-db-readonly
                           key: db.password
+                    - name: PROM_URL
+                      value: http://localhost:8082
                   resources:
                     requests:
                       cpu: ${CPU_REQUEST}
@@ -130,6 +142,43 @@ objects:
                       cpu: ${CPU_LIMIT}
                       memory: ${MEMORY_LIMIT}
 
+                - name: token-refresher
+                  image: ${TOKEN_REFRESHER_IMAGE}
+                  args:
+                    - '--oidc.audience=observatorium-telemeter'
+                    - '--oidc.client-id=$(CLIENT_ID)'
+                    - '--oidc.client-secret=$(CLIENT_SECRET)'
+                    - '--oidc.issuer-url=$(ISSUER_URL)'
+                    - '--url=$(URL)'
+                    - '--web.listen=:8082'
+                  env:
+                    - name: CLIENT_ID
+                      valueFrom:
+                        secretKeyRef:
+                          name: token-refresher
+                          key: CLIENT_ID
+                    - name: CLIENT_SECRET
+                      valueFrom:
+                        secretKeyRef:
+                          name: token-refresher
+                          key: CLIENT_SECRET
+                    - name: ISSUER_URL
+                      valueFrom:
+                        secretKeyRef:
+                          name: token-refresher
+                          key: ISSUER_URL
+                    - name: URL
+                      valueFrom:
+                        secretKeyRef:
+                          name: token-refresher
+                          key: URL
+                  resources:
+                    requests:
+                      cpu: ${TOKEN_REFRESHER_CPU_REQUEST}
+                      memory: ${TOKEN_REFRESHER_MEMORY_REQUEST}
+                    limits:
+                      cpu: ${TOKEN_REFRESHER_CPU_LIMIT}
+                      memory: ${TOKEN_REFRESHER_MEMORY_LIMIT}
   - apiVersion: batch/v1beta1
     kind: CronJob
     metadata:


### PR DESCRIPTION
1. Apply token-refresher sidecar to metrics cronjob
    
Follow-on to #349.
    
To test, run the CI deploy job against this branch (only the scheduler needs to be deployed), and then tweak the metrics cronjob schedule to the near-future (hint: `oc edit CronJob/openshift-metrics-cron`).

Then verify via logs that the tasks were queued up as expected.

2. Add `OPENSHIFT_ENABLED_ACCOUNT_PROMQL` to make account promql easier to use; override to use `standard` billing_model for now.