### PR TITLE
ENT-3341, ENT-3744: Implement MarketplaceSubscriptionIdCollector

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -28,6 +28,7 @@ import org.candlepin.subscriptions.metering.MeteringConfiguration;
 import org.candlepin.subscriptions.resource.ApiConfiguration;
 import org.candlepin.subscriptions.retention.PurgeSnapshotsConfiguration;
 import org.candlepin.subscriptions.security.SecurityConfig;
+import org.candlepin.subscriptions.subscription.SubscriptionServiceConfiguration;
 import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -64,7 +65,7 @@ import javax.validation.Validator;
     CaptureSnapshotsConfiguration.class, PurgeSnapshotsConfiguration.class,
     LiquibaseUpdateOnlyConfiguration.class, TallyWorkerConfiguration.class, OrgSyncConfiguration.class,
     MarketplaceWorkerConfiguration.class, DevModeConfiguration.class, SecurityConfig.class,
-    HawtioConfiguration.class, MeteringConfiguration.class
+    HawtioConfiguration.class, MeteringConfiguration.class, SubscriptionServiceConfiguration.class
 })
 public class ApplicationConfiguration implements WebMvcConfigurer {
     @Bean

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions;
 
 import org.candlepin.subscriptions.jobs.JobProperties;
 import org.candlepin.subscriptions.security.AntiCsrfFilter;
+import org.candlepin.subscriptions.subscription.SubscriptionServiceProperties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -173,4 +174,10 @@ public class ApplicationProperties {
      * begins.
      */
     private Duration hourlyTallyOffset = Duration.ofMinutes(60L);
+
+    /**
+     * Additional properties related to the Subscription Service
+     */
+    private SubscriptionServiceProperties subscription = new SubscriptionServiceProperties();
+
 }

--- a/src/main/java/org/candlepin/subscriptions/conduit/rhsm/RhsmClientConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/conduit/rhsm/RhsmClientConfiguration.java
@@ -64,7 +64,7 @@ public class RhsmClientConfiguration {
     }
 
     @Bean(name = "rhsmRetryTemplate")
-    public RetryTemplate retryTemplate() {
+    public RetryTemplate rhsmRetryTemplate() {
         SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
         retryPolicy.setMaxAttempts(4);
 

--- a/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -27,6 +27,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -53,10 +54,12 @@ public interface SubscriptionRepository extends JpaRepository<Subscription,
     Optional<Subscription> findActiveSubscription(@Param("subscriptionId") String subscriptionId);
 
     @Query("SELECT s FROM Subscription s WHERE s.accountNumber = :accountNumber AND " +
-        "s.sku = ALL (SELECT DISTINCT o.sku FROM Offering o WHERE " +
-        ":#{#key.usage} = o.usage AND " +
+        "s.sku = ALL (SELECT DISTINCT o.sku FROM Offering o WHERE " + ":#{#key.usage} = o.usage AND " +
         ":#{#key.sla} = o.serviceLevel AND " +
-        "o.role IN :#{#roles})")
-    List<Subscription> findSubscriptionByAccountAndUsageKey(@Param("accountNumber") String accountNumber,
-        @Param("key") UsageCalculation.Key usageKey, @Param("roles") Set<String> roles);
+        "o.role IN :#{#roles}) AND s.startDate <= :rangeStart AND s.endDate >= :rangeEnd AND " +
+        "s.marketplaceSubscriptionId IS NOT NULL AND s.marketplaceSubscriptionId <> ''")
+    List<Subscription> findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
+        @Param("accountNumber") String accountNumber, @Param("key") UsageCalculation.Key usageKey,
+        @Param("roles") Set<String> roles, @Param("rangeStart") OffsetDateTime rangeStart,
+        @Param("rangeEnd") OffsetDateTime rangeEnd);
 }

--- a/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -74,7 +74,12 @@ public enum ErrorCode {
      * This typically means that an HTTP client error has occurred (HTTP 4XX)
      * when the request was made.
      */
-    INVENTORY_SERVICE_REQUEST_ERROR(2002, "Inventory API Error");
+    INVENTORY_SERVICE_REQUEST_ERROR(2002, "Inventory API Error"),
+
+    // Metering Errors
+    SUBSCRIPTION_SERVICE_REQUEST_ERROR(3000, "Subscription Service Error"),
+
+    SUBSCRIPTION_SERVICE_MARKETPLACE_ID_LOOKUP_ERROR(3001, "Could not find marketplace subscription id");
 
     private final String CODE_PREFIX = "SUBSCRIPTIONS";
 

--- a/src/main/java/org/candlepin/subscriptions/http/HttpClient.java
+++ b/src/main/java/org/candlepin/subscriptions/http/HttpClient.java
@@ -26,6 +26,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.factory.ApacheHttpClient4EngineFactory;
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.springframework.util.StringUtils;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -33,6 +34,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.Objects;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -66,7 +68,8 @@ public class HttpClient {
         apacheBuilder.setMaxConnPerRoute(serviceProperties.getMaxConnections());
         apacheBuilder.setMaxConnTotal(serviceProperties.getMaxConnections());
         // if the keystore path is not null, add certificate authentication
-        if (serviceProperties.getKeystore() != null) {
+        if (Objects.nonNull(serviceProperties.getKeystore()) &&
+            StringUtils.hasText(serviceProperties.getKeystore().getPath())) {
             apacheBuilder.setSSLContext(getSslContextFromKeystore(serviceProperties));
         }
         org.apache.http.client.HttpClient httpClient = apacheBuilder.build();

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
@@ -47,12 +47,6 @@ public class MarketplaceProperties extends HttpClientProperties {
     private String apiKey;
 
     /**
-     * TEMPORARY setting for returning a dummy subscription ID. Remove once
-     * MarketplaceSubscriptionCollector is fully implemented.
-     */
-    private String dummyId = "DUMMY";
-
-    /**
      * Amount of time prior to token expiration to request a new token anyways.
      */
     private Duration tokenRefreshPeriod = Duration.ofMinutes(1);

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
@@ -22,7 +22,7 @@ package org.candlepin.subscriptions.marketplace;
 
 import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.json.TallySummary;
-import org.candlepin.subscriptions.subscription.SubscriptionConfiguration;
+import org.candlepin.subscriptions.subscription.SubscriptionServiceConfiguration;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -43,7 +43,7 @@ import org.springframework.retry.support.RetryTemplateBuilder;
  */
 @Profile("marketplace")
 @ComponentScan(basePackages = "org.candlepin.subscriptions.marketplace")
-@Import({SubscriptionConfiguration.class, ProductMappingConfiguration.class})
+@Import({ SubscriptionServiceConfiguration.class, ProductMappingConfiguration.class})
 public class MarketplaceWorkerConfiguration {
     @Bean
     @Qualifier("marketplaceRetryTemplate")

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
@@ -53,7 +53,7 @@ public class PrometheusService {
         throws ExternalServiceException {
         log.info("Fetching metrics from prometheus: {} -> {} [Step: {}]", start, end, step);
         try {
-            String query = sanatizeQuery(promQL);
+            String query = sanitizeQuery(promQL);
             log.debug("Running prometheus range query: Start: {} End: {} Step: {}, Query: {}",
                 start.toEpochSecond(), end.toEpochSecond(), step, query);
             return apiProvider.queryRangeApi().queryRange(query, start.toEpochSecond(),
@@ -74,7 +74,7 @@ public class PrometheusService {
         throws ExternalServiceException {
         log.info("Fetching metrics from prometheus: {}", time);
         try {
-            String query = sanatizeQuery(promQL);
+            String query = sanitizeQuery(promQL);
             log.debug("Running prometheus query: Time: {}, Query: {}", time.toEpochSecond(), query);
             return apiProvider.queryApi().query(query, time, timeout);
         }
@@ -89,7 +89,7 @@ public class PrometheusService {
         }
     }
 
-    private String sanatizeQuery(String promQL) {
+    private String sanitizeQuery(String promQL) {
         // NOTE: While the ApiClient **should** in theory already encode the query,
         //       it does not handle the curly braces correctly causing issues
         //       when the request is made.

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription;
+
+import org.candlepin.subscriptions.http.HttpClientProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Duration;
+
+/**
+ * Additional properties related to the Subscription Service
+ */
+@Getter
+@Setter
+@ToString
+public class SubscriptionServiceProperties extends HttpClientProperties {
+
+    /**
+     * Number of times we should try requesting info from the Subscription Service if something fails.
+     */
+    private int maxRetryAttempts = 4;
+
+    /** Page size for subscription queries */
+    private int pageSize = 500;
+
+    /**
+     * The initial sleep interval between retries when retrying fetching info from the Subscription Service
+     */
+    private Duration backOffInitialInterval = Duration.ofSeconds(1L);
+}

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -65,7 +65,7 @@ public class SubscriptionSyncController {
 
                 newSub.setStartDate(OffsetDateTime.now());
                 if (subscription.getEffectiveEndDate() != null) {
-                    newSub.setEndDate(clock.dateFromUnix(subscription.getEffectiveEndDate()));
+                    newSub.setEndDate(clock.dateFromMilliseconds(subscription.getEffectiveEndDate()));
                 }
 
                 newSub.setMarketplaceSubscriptionId(SubscriptionDtoUtil.extractMarketplaceId(subscription));
@@ -87,10 +87,10 @@ public class SubscriptionSyncController {
             newSub.setSku(SubscriptionDtoUtil.extractSku(subscription));
             newSub.setQuantity(subscription.getQuantity());
             if (subscription.getEffectiveStartDate() != null) {
-                newSub.setStartDate(clock.dateFromUnix(subscription.getEffectiveStartDate()));
+                newSub.setStartDate(clock.dateFromMilliseconds(subscription.getEffectiveStartDate()));
             }
             if (subscription.getEffectiveEndDate() != null) {
-                newSub.setEndDate(clock.dateFromUnix(subscription.getEffectiveEndDate()));
+                newSub.setEndDate(clock.dateFromMilliseconds(subscription.getEffectiveEndDate()));
             }
             subscriptionRepository.save(newSub);
         }
@@ -104,7 +104,7 @@ public class SubscriptionSyncController {
     protected void updateSubscription(Subscription dto,
         org.candlepin.subscriptions.db.model.Subscription entity) {
         if (dto.getEffectiveEndDate() != null) {
-            entity.setEndDate(clock.dateFromUnix(dto.getEffectiveEndDate()));
+            entity.setEndDate(clock.dateFromMilliseconds(dto.getEffectiveEndDate()));
         }
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -30,7 +30,6 @@ import org.candlepin.subscriptions.files.ProductProfileRegistry;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.candlepin.subscriptions.inventory.db.InventoryDataSourceConfiguration;
 import org.candlepin.subscriptions.jmx.JmxBeansConfiguration;
-import org.candlepin.subscriptions.subscription.SubscriptionConfiguration;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.queue.TaskConsumer;
@@ -63,8 +62,8 @@ import java.util.Set;
 @EnableRetry
 @Configuration
 @Profile("worker")
-@Import({TallyTaskQueueConfiguration.class, TaskConsumerConfiguration.class, SubscriptionConfiguration.class,
-    ProductMappingConfiguration.class, InventoryDataSourceConfiguration.class, JmxBeansConfiguration.class})
+@Import({ TallyTaskQueueConfiguration.class, TaskConsumerConfiguration.class,
+    ProductMappingConfiguration.class, InventoryDataSourceConfiguration.class, JmxBeansConfiguration.class })
 @ComponentScan(basePackages = {
     "org.candlepin.subscriptions.cloudigrade",
     "org.candlepin.subscriptions.event",
@@ -150,7 +149,7 @@ public class TallyWorkerConfiguration {
     public MetricUsageCollector openShiftMetricsUsageCollector(ProductProfileRegistry registry,
         AccountRepository accountRepo, EventController eventController, ApplicationClock clock) {
         Optional<ProductProfile> profile = registry.getProfileByName("OpenShiftMetrics");
-        if (!profile.isPresent()) {
+        if (profile.isEmpty()) {
             throw new IllegalStateException("Could not find product profile for OpenShiftMetrics!");
         }
         return new MetricUsageCollector(profile.get(), accountRepo, eventController, clock);

--- a/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -187,6 +187,12 @@ public class ApplicationClock {
         return zonedDateTime.toOffsetDateTime();
     }
 
+    public OffsetDateTime dateFromMilliseconds(Long time) {
+        ZoneId zoneId = this.clock.getZone();
+        ZonedDateTime zonedDateTime = Instant.ofEpochMilli(time).atZone(zoneId);
+        return zonedDateTime.toOffsetDateTime();
+    }
+
     public OffsetDateTime calculateStartOfRange(OffsetDateTime toAdjust, Granularity granularity) {
         switch (granularity) {
             case HOURLY:

--- a/src/main/resources/application-marketplace.yaml
+++ b/src/main/resources/application-marketplace.yaml
@@ -11,6 +11,5 @@ rhsm-subscriptions:
     eligible-swatch-product-ids:
       - OpenShift-metrics
       - OpenShift-dedicated-metrics
-    dummyId: ${MARKETPLACE_DUMMY_ID:DUMMY}
     verify-batches: ${MARKETPLACE_VERIFY_BATCHES:true}
     manual-marketplace-submission-enabled: ${MARKETPLACE_MANUAL_SUBMISSION_ENABLED:false}

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -18,9 +18,3 @@ rhsm-subscriptions:
   cloudigrade:
     url: http://${CLOUDIGRADE_HOST:localhost}:${CLOUDIGRADE_PORT:8080}/api/cloudigrade/v2
     maxConnections: ${CLOUDIGRADE_MAX_CONNECTIONS:100}
-  subscription:
-    useStub: ${STUB_SUBSCRIPTION:true}
-    url: http://${SUBSCRIPTION_HOST:localhost}:${SUBSCRIPTION_PORT:8080}/svcrest/subscription/v5
-    keystore: file:${SUBSCRIPTION_KEYSTORE:}
-    keystorePassword: changeit
-    maxConnections: ${SUBSCRIPTION_MAX_CONNECTIONS:100}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -114,3 +114,12 @@ rhsm-subscriptions:
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:4h}
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:24h}
+  subscription:
+    useStub: ${SUBSCRIPTION_USE_STUB:false}
+    url: ${SUBSCRIPTION_URL:https://subscription.qa.api.redhat.com/svcrest/subscription/v5}
+    keystore: file:${SUBSCRIPTION_KEYSTORE:}
+    keystorePassword: ${SUBSCRIPTION_KEYSTORE_PASSWORD:changeit}
+    maxConnections: ${SUBSCRIPTION_MAX_CONNECTIONS:100}
+    backOffInitialInterval: ${SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL:1s}
+    maxRetryAttempts: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS:4}
+    pageSize: ${SUBSCRIPTION_PAGE_SIZE:500}

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -86,7 +86,9 @@ class SubscriptionRepositoryTest {
 
         UsageCalculation.Key key = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage.PRODUCTION);
         Set<String> roles = Set.of("ocp");
-        var resultList = subscriptionRepo.findSubscriptionByAccountAndUsageKey("1000", key, roles);
+        var resultList = subscriptionRepo
+            .findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId("1000",
+            key, roles, NOW, NOW);
         assertEquals(1, resultList.size());
 
         var result = resultList.get(0);
@@ -107,7 +109,9 @@ class SubscriptionRepositoryTest {
 
         UsageCalculation.Key key = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage.PRODUCTION);
         Set<String> roles = Set.of("ocp");
-        var result = subscriptionRepo.findSubscriptionByAccountAndUsageKey("1000", key, roles);
+        var result = subscriptionRepo
+            .findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId("1000",
+            key, roles, NOW, NOW);
         assertEquals(0, result.size());
     }
 
@@ -124,6 +128,7 @@ class SubscriptionRepositoryTest {
 
     private Subscription createSubscription(String orgId, String accountNumber, String sku, String subId) {
         Subscription subscription = new Subscription();
+        subscription.setMarketplaceSubscriptionId("bananas");
         subscription.setSubscriptionId(subId);
         subscription.setOwnerId(orgId);
         subscription.setAccountNumber(accountNumber);

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionCollectorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.ParameterizedTest.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.subscriptions.subscription.SubscriptionService;
+import org.candlepin.subscriptions.subscription.api.model.ExternalReference;
+import org.candlepin.subscriptions.subscription.api.model.Subscription;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@ActiveProfiles("test")
+class MarketplaceSubscriptionCollectorTest {
+
+    private static final Subscription SUB_WITH_IBMMARKETPLACE = new Subscription().externalReferences(
+        Map.of("ibmmarketplace", new ExternalReference().subscriptionID("GGJe4KCgzUBf73YC5rjJvDkM")
+        .accountID("account-ID-04072021-1841")));
+
+    @Mock
+    SubscriptionService subscriptionService;
+    @InjectMocks
+    MarketplaceSubscriptionCollector marketplaceSubscriptionCollector;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testRequestSubscriptions() {
+
+        when(subscriptionService.getSubscriptionsByAccountNumber(anyString()))
+            .thenReturn(List.of(SUB_WITH_IBMMARKETPLACE));
+
+        assertEquals(List.of(SUB_WITH_IBMMARKETPLACE),
+            marketplaceSubscriptionCollector.requestSubscriptions("account123"));
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
+    @MethodSource("generateMockSubscriptionPayloads")
+    void testFilterNonApplicableSubscriptions(List<Subscription> input, List<Subscription> expected) {
+
+        assertEquals(expected, marketplaceSubscriptionCollector.filterNonApplicableSubscriptions(input));
+
+    }
+
+    static Stream<Arguments> generateMockSubscriptionPayloads() {
+        //1) getExternalReferences null
+        var subscription = new Subscription().externalReferences(null);
+        Arguments nullExternalReference = Arguments.of(List.of(subscription), Collections.emptyList());
+
+        //2) External getExternalReferences empty
+        var subscription1 = new Subscription().externalReferences(Collections.emptyMap());
+        Arguments emptyExternalReferences = Arguments.of(List.of(subscription1), Collections.emptyList());
+
+        //3) getExternalReferences doesn't contain "ibmmarketplace"
+        var subscription2 = new Subscription().externalReferences(Map.of("bananas", new ExternalReference()));
+
+        Arguments nonIbmMarketplaceExternalReferences = Arguments
+            .of(List.of(subscription2), Collections.emptyList());
+
+        //4) contain only "ibmmarketplace"
+        var subscription3 = SUB_WITH_IBMMARKETPLACE;
+
+        Arguments ibmMarketplaceExternalReferences = Arguments
+            .of(List.of(subscription3), List.of(subscription3));
+
+        //5) contains "ibmmarketplace" plus another
+
+        var subscription4 = new Subscription().externalReferences(Map.of("ibmmarketplace",
+            new ExternalReference().subscriptionID("GGJe4KCgzUBf73YC5rjJvDkM")
+            .accountID("account-ID-04072021-1841"), "bananas", new ExternalReference()));
+
+        Arguments ibmMarketplacePlusNonIbmMarketplaceExternalReferences = Arguments
+            .of(List.of(subscription4), List.of(subscription4));
+
+        return Stream.of(nullExternalReference, emptyExternalReferences, nonIbmMarketplaceExternalReferences,
+            ibmMarketplaceExternalReferences, ibmMarketplacePlusNonIbmMarketplaceExternalReferences);
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionIdProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionIdProviderTest.java
@@ -108,7 +108,9 @@ class MarketplaceSubscriptionIdProviderTest {
         roleMap.put(String.valueOf(1), ocpRoles);
 
         when(mockProfile.getRolesBySwatchProduct()).thenReturn(roleMap);
-        when(repo.findSubscriptionByAccountAndUsageKey("1000", key, ocpRoles)).thenReturn(result);
+        when(repo.findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
+            eq("1000"), eq(key), eq(ocpRoles), any(OffsetDateTime.class), any(OffsetDateTime.class)))
+            .thenReturn(new ArrayList<>()).thenReturn(result);
 
         Optional<String> actual = idProvider.findSubscriptionId("1000", key, rangeStart, rangeEnd);
         assertEquals("xyz", actual.get());
@@ -128,12 +130,13 @@ class MarketplaceSubscriptionIdProviderTest {
         roleMap.put(String.valueOf(1), ocpRoles);
 
         when(mockProfile.getRolesBySwatchProduct()).thenReturn(roleMap);
-        when(repo.findSubscriptionByAccountAndUsageKey("1000", key, ocpRoles))
-            .thenReturn(new ArrayList<>())
-            .thenReturn(result);
+        when(repo.findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
+            eq("1000"), eq(key), eq(ocpRoles), any(OffsetDateTime.class), any(OffsetDateTime.class)))
+            .thenReturn(new ArrayList<>()).thenReturn(result);
 
         Optional<String> actual = idProvider.findSubscriptionId("1000", key, rangeStart, rangeEnd);
         assertEquals("abc", actual.get());
-        verify(collector).fetchSubscription("1000", key);
+
+        verify(collector).requestSubscriptions("1000");
     }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -12,7 +12,8 @@ rhsm-subscriptions:
     driver-class-name: org.hsqldb.jdbc.JDBCDriver
     platform: hsqldb
   account-batch-size: 2
-
+  subscription:
+    use-stub: true
 logging:
   level:
     org:

--- a/subscription-client/subscription-api-spec.yaml
+++ b/subscription-client/subscription-api-spec.yaml
@@ -28,7 +28,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Subscription"
-  /search/criteria;oracle_account_number={accountNumber};statusList=active;statusList=temporary/options;products=ALL;firstResultIndex={index};maxResults={pageSize}:
+  /search/criteria;oracle_account_number={accountNumber}/options;products=ALL;showExternalReferences=true;firstResultIndex={index};maxResults={pageSize}:
     description: "Search subscriptions on owner, index, and pageSize"
     parameters:
       - name: accountNumber

--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -59,8 +59,6 @@ parameters:
     value: 1s
   - name: MARKETPLACE_BACK_OFF_MULTIPLIER
     value: '2'
-  - name: MARKETPLACE_DUMMY_ID
-    value: DUMMY
   - name: MARKETPLACE_VERIFY_BATCHES
     value: 'true'
   - name: MARKETPLACE_MANUAL_SUBMISSION_ENABLED
@@ -69,6 +67,16 @@ parameters:
     value: '30000'
   - name: DATABASE_MAX_POOL_SIZE
     value: '25'
+  - name: SUBSCRIPTION_URL
+    value: https://subscription.qa.api.redhat.com/svcrest/subscription/v5
+  - name: SUBSCRIPTION_MAX_CONNECTIONS
+    value: '100'
+  - name: SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL
+    value: 1s
+  - name: SUBSCRIPTION_MAX_RETRY_ATTEMPTS
+    value: '4'
+  - name: SUBSCRIPTION_PAGE_SIZE
+    value: '500'
 
 objects:
   - apiVersion: apps.openshift.io/v1
@@ -211,12 +219,27 @@ objects:
                   value: ${MARKETPLACE_BACK_OFF_INITIAL_INTERVAL}
                 - name: MARKETPLACE_BACK_OFF_MULTIPLIER
                   value: ${MARKETPLACE_BACK_OFF_MULTIPLIER}
-                - name: MARKETPLACE_DUMMY_ID
-                  value: ${MARKETPLACE_DUMMY_ID}
                 - name: MARKETPLACE_VERIFY_BATCHES
                   value: ${MARKETPLACE_VERIFY_BATCHES}
                 - name: MARKETPLACE_MANUAL_SUBMISSION_ENABLED
                   value: ${MARKETPLACE_MANUAL_SUBMISSION_ENABLED}
+                - name: SUBSCRIPTION_KEYSTORE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: tls
+                      key: keystore_password
+                - name: SUBSCRIPTION_KEYSTORE
+                  value: /pinhead/keystore.jks
+                - name: SUBSCRIPTION_URL
+                  value: ${SUBSCRIPTION_URL}
+                - name: SUBSCRIPTION_MAX_CONNECTIONS
+                  value: ${SUBSCRIPTION_MAX_CONNECTIONS}
+                - name: SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL
+                  value: ${SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL}
+                - name: SUBSCRIPTION_MAX_RETRY_ATTEMPTS
+                  value: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS}
+                - name: SUBSCRIPTION_PAGE_SIZE
+                  value: ${SUBSCRIPTION_PAGE_SIZE}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:
@@ -238,6 +261,8 @@ objects:
                 - containerPort: 8080
                   protocol: TCP
               volumeMounts:
+                - name: pinhead
+                  mountPath: /pinhead
                 - name: logs
                   mountPath: /logs
               workingDir: /
@@ -266,6 +291,9 @@ objects:
                   name: splunk
                   subPath: splunk.pem
           volumes:
+            - name: pinhead
+              secret:
+                secretName: pinhead
             - name: splunk
               secret:
                 secretName: splunk


### PR DESCRIPTION
# Testing
* Make sure there are offerings in the offering table that matches our SKUs of interest.  See JIRA ticket comments for insert statements for testing
* Find an account to use that has subscriptions (https://webadmin.corp.qa.redhat.com/subscription-admin).  See JIRA ticket comments for account numbers I used
* Get OCP or OSD events into your table for the associated account number
* Make sure the account_config table has your account opted in
* Kick off an hourly tally for a time frame that encompasses the events in your event table

Assuming that your subscriptions table was empty to start with, after this logic executes you will see an entry in the rhsm-subscription.subscription table that matches a subscription fetched from the subscription service
```bash
curl --cert-type P12 --cert nonprod-insights.jks:"$(cat jks_pass)" 'https://subscription.qa.api.redhat.com/svcrest/subscription/v5/search/criteria;oracle_account_number=account123/options;products=ALL;showExternalReferences=true'
```

If you were to execute this again, without clearing your subscription table, the logic shouldn't execute a GET request to the subscription service this time around, because that data is in the swatch database now.


# app properties tips

```yaml
# these settings currently reside in the application-worker.yaml file
rhsm-subscriptions:
  subscription:
    useStub: false
    url: https://subscription.qa.api.redhat.com/svcrest/subscription/v5
    keystore: nonprod-insights.jks
    keystorePassword:
# turns on logging for HTTP events to help verify when the subscription service is/isn't getting called
logging:
  level:
    org:
      apache:
        http: DEBUG
```