### PR TITLE
Import ProductMappingConfiguration in MarketplaceWorkerConfiguration

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.marketplace;
 
+import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.json.TallySummary;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
@@ -39,6 +41,7 @@ import org.springframework.retry.support.RetryTemplateBuilder;
  * Configuration for the Marketplace integration worker.
  */
 @Profile("marketplace")
+@Import(ProductMappingConfiguration.class)
 @ComponentScan(basePackages = "org.candlepin.subscriptions.marketplace")
 public class MarketplaceWorkerConfiguration {
     @Bean


### PR DESCRIPTION
To test, deploy as CI does:

```
SPRING_PROFILES_ACTIVE=marketplace,kafka-queue ./gradlew bootRun
```

On `develop`, you'll get:

```
org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.candlepin.subscriptions.files.ProductProfileRegistry' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
```

With this change, the app starts up successfully.