### PR TITLE
Map times on the snapshot as milliseconds since epoch

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapper.java
@@ -145,8 +145,8 @@ public class MarketplacePayloadMapper {
              */
             OffsetDateTime startDate = snapshotDate.minus(Duration.of(1, ChronoUnit.HOURS));
 
-            long start = startDate.toEpochSecond();
-            long end = snapshotDate.toEpochSecond();
+            long start = startDate.toInstant().toEpochMilli();
+            long end = snapshotDate.toInstant().toEpochMilli();
 
             var subscriptionIdOpt = idProvider.findSubscriptionId(
                 tallySummary.getAccountNumber(), usageKey, startDate, snapshotDate);

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
@@ -189,7 +189,8 @@ class MarketplacePayloadMapperTest {
         var summary = new TallySummary().withTallySnapshots(List.of(snapshot)).withAccountNumber("test123");
 
         var expected = List
-            .of(new UsageEvent().start(1612500L).end(1616100L).eventId("c204074d-626f-4272-aa05-b6d69d6de16a")
+            .of(new UsageEvent().start(1612500754L).end(1616100754L)
+            .eventId("c204074d-626f-4272-aa05-b6d69d6de16a")
             .measuredUsage(List.of(
             new UsageMeasurement().value(36.0).metricId("redhat.com:openshiftdedicated:cpu_hour"))));
 


### PR DESCRIPTION
Otherwise, we end up sending usage from a long, long time ago...