### PR TITLE
ENT-3609: Add verification and metrics for marketplace batches

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.marketplace;
 
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.marketplace.api.model.BatchStatus;
 import org.candlepin.subscriptions.marketplace.api.model.StatusResponse;
 import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
 import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
@@ -34,7 +35,14 @@ import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
@@ -46,27 +54,93 @@ import javax.ws.rs.core.Response;
 public class MarketplaceProducer {
 
     private static final Logger log = LoggerFactory.getLogger(MarketplaceProducer.class);
+    private static final String[] SUCCESSFUL_SUBMISSION_STATUSES = new String[]{"accepted", "inprogress"};
 
     private final MarketplaceService marketplaceService;
     private final RetryTemplate retryTemplate;
+    private final Counter acceptedCounter;
+    private final Counter unverifiedCounter;
+    private final Counter rejectedCounter;
+    private final MarketplaceProperties properties;
 
     @Autowired
     MarketplaceProducer(MarketplaceService marketplaceService,
-        @Qualifier("marketplaceRetryTemplate") RetryTemplate retryTemplate) {
+        @Qualifier("marketplaceRetryTemplate") RetryTemplate retryTemplate, MeterRegistry meterRegistry,
+        MarketplaceProperties properties) {
         this.marketplaceService = marketplaceService;
         this.retryTemplate = retryTemplate;
+        this.acceptedCounter = meterRegistry.counter("rhsm-subscriptions.marketplace.batch.accepted");
+        this.unverifiedCounter = meterRegistry.counter("rhsm-subscriptions.marketplace.batch.unverified");
+        this.rejectedCounter = meterRegistry.counter("rhsm-subscriptions.marketplace.batch.rejected");
+        this.properties = properties;
     }
 
     @Timed("rhsm-subscriptions.marketplace.usage.submission")
     public StatusResponse submitUsageRequest(UsageRequest usageRequest) {
-        // NOTE: https://issues.redhat.com/browse/ENT-3609 will address failures
-        return retryTemplate.execute(context -> tryRequest(usageRequest));
+        try {
+            StatusResponse status = retryTemplate.execute(context -> tryRequest(usageRequest));
+            Set<String> batchIds = Optional.ofNullable(status.getData()).orElse(Collections.emptyList())
+                .stream()
+                .map(BatchStatus::getBatchId)
+                .collect(Collectors.toSet());
+            if (properties.isVerifyBatches()) {
+                verifyBatchIds(batchIds);
+            }
+            return status;
+        }
+        catch (Exception e) {
+            rejectedCounter.increment();
+            throw e;
+        }
+    }
+
+    private void verifyBatchIds(Set<String> batchIds) {
+        batchIds.forEach(batchId -> {
+            try {
+                retryTemplate.execute(context -> verifyBatchId(batchId));
+            }
+            catch (Exception e) {
+                log.error("Error verifying batchId {}", batchId, e);
+                unverifiedCounter.increment();
+            }
+        });
+    }
+
+    private String verifyBatchId(String batchId) {
+        try {
+            StatusResponse response = marketplaceService.getUsageBatchStatus(batchId);
+            String status = Objects.requireNonNull(response.getStatus());
+            if ("inprogress".equals(status)) {
+                // throw an exception so that retry logic re-checks the batch
+                throw new MarketplaceUsageSubmissionException(response.getMessage(), status);
+            }
+            else if (!"accepted".equals(status)) {
+                log.error("Marketplace rejected batch {} with status {} and message {}", batchId, status,
+                    response.getMessage());
+                rejectedCounter.increment();
+            }
+            else {
+                acceptedCounter.increment();
+            }
+            return status;
+        }
+        catch (ApiException e) {
+            throw new SubscriptionsException(
+                ErrorCode.REQUEST_PROCESSING_ERROR,
+                Response.Status.fromStatusCode(e.getCode()),
+                "Exception checking usage batch in Marketplace",
+                e
+            );
+        }
     }
 
     private StatusResponse tryRequest(UsageRequest usageRequest) {
         try {
             StatusResponse status = marketplaceService.submitUsageEvents(usageRequest);
             log.debug("Marketplace response: {}", status);
+            if (!Arrays.asList(SUCCESSFUL_SUBMISSION_STATUSES).contains(status.getStatus())) {
+                throw new MarketplaceUsageSubmissionException(status.getStatus(), status.getMessage());
+            }
             if (status.getData() != null) {
                 status.getData().forEach(batchStatus ->
                     log.info("Marketplace Batch: {} for Tally Snapshot IDs: {}", batchStatus.getBatchId(),

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
@@ -78,9 +78,9 @@ public class MarketplaceProperties extends HttpClientProperties {
     private Double backOffMultiplier;
 
     /**
-     * Have the stub mapper emit empty usage requests (vs. full one) to be removed by ENT-3264
+     * Verify that batches were accepted by Marketplace.
      */
-    private boolean mapperStubEmpty;
+    private boolean verifyBatches = true;
 
     private List<String> eligibleSwatchProductIds = new ArrayList<>();
 

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceService.java
@@ -78,6 +78,7 @@ public class MarketplaceService {
         return api.submitUsageEvents(usageRequest);
     }
 
+    @Timed("rhsm-subscriptions.marketplace.usage.batch-check")
     public StatusResponse getUsageBatchStatus(String batchId) throws ApiException {
         ensureAccessToken();
         return api.getUsageBatchStatus(batchId);

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceUsageSubmissionException.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceUsageSubmissionException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.marketplace;
+
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Exception for any issue submitting usage to Marketplace.
+ */
+@Getter
+@ToString
+public class MarketplaceUsageSubmissionException extends RuntimeException {
+    private final String status;
+
+    public MarketplaceUsageSubmissionException(String message, String status) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/resources/application-marketplace.yaml
+++ b/src/main/resources/application-marketplace.yaml
@@ -8,9 +8,8 @@ rhsm-subscriptions:
     back-off-max-interval: ${MARKETPLACE_BACK_OFF_MAX_INTERVAL:64s}
     back-off-initial-interval: ${MARKETPLACE_BACK_OFF_INITIAL_INTERVAL:1s}
     back-off-multiplier: ${MARKETPLACE_BACK_OFF_MULTIPLIER:2}
-    # temporary; remove once https://issues.redhat.com/browse/ENT-3264 is implemented
-    mapper-stub-empty: ${MARKETPLACE_MAPPER_STUB_EMPTY:true}
     eligible-swatch-product-ids:
       - OpenShift-metrics
       - OpenShift-dedicated-metrics
     dummyId: ${MARKETPLACE_DUMMY_ID:DUMMY}
+    verify-batches: ${MARKETPLACE_VERIFY_BATCHES:true}

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceProducerTest.java
@@ -25,11 +25,16 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.marketplace.api.model.BatchStatus;
+import org.candlepin.subscriptions.marketplace.api.model.StatusResponse;
 import org.candlepin.subscriptions.marketplace.api.model.UsageRequest;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.retry.support.RetryTemplateBuilder;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 class MarketplaceProducerTest {
 
@@ -40,7 +45,10 @@ class MarketplaceProducerTest {
             .noBackoff()
             .build();
         MarketplaceService marketplaceService = mock(MarketplaceService.class);
-        MarketplaceProducer marketplaceProducer = new MarketplaceProducer(marketplaceService, retryTemplate);
+        MeterRegistry registry = new SimpleMeterRegistry();
+        MarketplaceProducer marketplaceProducer = new MarketplaceProducer(marketplaceService, retryTemplate,
+            registry, new MarketplaceProperties());
+        var rejectedCounter = registry.counter("rhsm-subscriptions.marketplace.batch.rejected");
 
         when(marketplaceService.submitUsageEvents(any())).thenThrow(SubscriptionsException.class);
 
@@ -50,5 +58,79 @@ class MarketplaceProducerTest {
         );
 
         verify(marketplaceService, times(2)).submitUsageEvents(any());
+        assertEquals(1.0, rejectedCounter.count());
+    }
+
+    @Test
+    void testMarketplaceProducerRecordsSuccessfulBatch() throws ApiException {
+        RetryTemplate retryTemplate = new RetryTemplateBuilder()
+            .maxAttempts(2)
+            .noBackoff()
+            .build();
+        MarketplaceService marketplaceService = mock(MarketplaceService.class);
+        MeterRegistry registry = new SimpleMeterRegistry();
+        MarketplaceProducer marketplaceProducer = new MarketplaceProducer(marketplaceService, retryTemplate,
+            registry, new MarketplaceProperties());
+        var acceptedCounter = registry.counter("rhsm-subscriptions.marketplace.batch.accepted");
+
+        when(marketplaceService.submitUsageEvents(any()))
+            .thenReturn(new StatusResponse().status("inprogress").addDataItem(new BatchStatus().batchId(
+            "foo")));
+        when(marketplaceService.getUsageBatchStatus("foo")).thenReturn(new StatusResponse().status(
+            "accepted"));
+
+        var usageRequest = new UsageRequest();
+        marketplaceProducer.submitUsageRequest(usageRequest);
+
+        assertEquals(1.0, acceptedCounter.count());
+    }
+
+    @Test
+    void testMarketplaceProducerRecordsUnverifiedBatch() throws ApiException {
+        RetryTemplate retryTemplate = new RetryTemplateBuilder()
+            .maxAttempts(2)
+            .noBackoff()
+            .build();
+        MarketplaceService marketplaceService = mock(MarketplaceService.class);
+        MeterRegistry registry = new SimpleMeterRegistry();
+        MarketplaceProducer marketplaceProducer = new MarketplaceProducer(marketplaceService, retryTemplate,
+            registry, new MarketplaceProperties());
+        var unverifiedCounter = registry.counter("rhsm-subscriptions.marketplace.batch.unverified");
+
+        when(marketplaceService.submitUsageEvents(any()))
+            .thenReturn(new StatusResponse().status("inprogress").addDataItem(new BatchStatus().batchId(
+            "foo")));
+        when(marketplaceService.getUsageBatchStatus("foo")).thenReturn(new StatusResponse().status(
+            "inprogress"));
+
+        var usageRequest = new UsageRequest();
+        marketplaceProducer.submitUsageRequest(usageRequest);
+
+        verify(marketplaceService, times(2)).getUsageBatchStatus("foo");
+        assertEquals(1.0, unverifiedCounter.count());
+    }
+
+    @Test
+    void testMarketplaceProducerRecordsRejectedBatch() throws ApiException {
+        RetryTemplate retryTemplate = new RetryTemplateBuilder()
+            .maxAttempts(2)
+            .noBackoff()
+            .build();
+        MarketplaceService marketplaceService = mock(MarketplaceService.class);
+        MeterRegistry registry = new SimpleMeterRegistry();
+        MarketplaceProducer marketplaceProducer = new MarketplaceProducer(marketplaceService, retryTemplate,
+            registry, new MarketplaceProperties());
+        var rejectedCounter = registry.counter("rhsm-subscriptions.marketplace.batch.rejected");
+
+        when(marketplaceService.submitUsageEvents(any()))
+            .thenReturn(new StatusResponse().status("inprogress").addDataItem(new BatchStatus().batchId(
+            "foo")));
+        when(marketplaceService.getUsageBatchStatus("foo")).thenReturn(new StatusResponse().status(
+            "failed"));
+
+        var usageRequest = new UsageRequest();
+        marketplaceProducer.submitUsageRequest(usageRequest);
+
+        assertEquals(1.0, rejectedCounter.count());
     }
 }

--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -61,6 +61,8 @@ parameters:
     value: '2'
   - name: MARKETPLACE_DUMMY_ID
     value: DUMMY
+  - name: MARKETPLACE_VERIFY_BATCHES
+    value: 'true'
   - name: DATABASE_CONNECTION_TIMEOUT_MS
     value: '30000'
   - name: DATABASE_MAX_POOL_SIZE
@@ -209,6 +211,8 @@ objects:
                   value: ${MARKETPLACE_BACK_OFF_MULTIPLIER}
                 - name: MARKETPLACE_DUMMY_ID
                   value: ${MARKETPLACE_DUMMY_ID}
+                - name: MARKETPLACE_VERIFY_BATCHES
+                  value: ${MARKETPLACE_VERIFY_BATCHES}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:


### PR DESCRIPTION
[ENT-3609: Address marketplace API call failures](https://issues.redhat.com/browse/ENT-3609)

The strategy is to log and move on whenever there is an issue, as well as to capture metrics.

Three metrics were added:
- `rhsm_subscriptions_marketplace_batch_rejected_total`
- `rhsm_subscriptions_marketplace_batch_unverified_total`
- `rhsm_subscriptions_marketplace_batch_accepted_total`

(Prometheus names above; see MarketplaceProducer for micrometer names)

I replaced the mapper stubbed boolean that was stale with a boolean to toggle batch verification (in case we want to turn it off for some reason).

Testing
-------

Unit testing covers all scenarios, it's hard to test locally, here's an example of testing failure scenario though:

```
MARKETPLACE_MAX_ATTEMPTS=1 MARKETPLACE_URL=http://localhost:8999 ./gradlew bootRun
```

then manually emit to "marketplace" an event:

```
curl -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.marketplace:name=marketplaceJmxBean,type=MarketplaceJmxBean","operation":"submitTallySummary(java.lang.String)","arguments":["{}"]}' http://localhost:8080/actuator/jolokia
```

Now verify the counter shows 1.0:

```
curl http://localhost:8080/actuator/prometheus | grep -e '^rhsm_subscriptions_marketplace_batch_rejected_total'
```