### PR TITLE
ENT-3707: Tweak marketplace error handling for failed requests

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBean.java
@@ -79,7 +79,7 @@ public class MarketplaceJmxBean {
     @ManagedOperationParameter(name = "tallySummaryJson", description = "String representation of Tally " +
         "Summary json. Don't forget to escape quotation marks if you're trying to invoke this endpoint via " +
         "curl command")
-    public String submitTallySummary(String tallySummaryJson)
+    public void submitTallySummary(String tallySummaryJson)
         throws JsonProcessingException, RhsmJmxException {
         if (!properties.isDevMode() && !mktProperties.isManualMarketplaceSubmissionEnabled()) {
             throw new JmxException("This feature is not currently enabled.");
@@ -91,7 +91,7 @@ public class MarketplaceJmxBean {
         log.info("usageRequest to be sent: {}", usageRequest);
 
         try {
-            return marketplaceProducer.submitUsageRequest(usageRequest).toString();
+            marketplaceProducer.submitUsageRequest(usageRequest);
         }
         catch (Exception e) {
             log.error("Error submitting usage info via JMX", e);

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceJmxBeanTest.java
@@ -20,13 +20,9 @@
  */
 package org.candlepin.subscriptions.marketplace;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.marketplace.api.model.StatusResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -47,9 +43,6 @@ class MarketplaceJmxBeanTest {
 
     @Test
     void testSubmitTallySummaryEnablement() throws Exception {
-
-        when(producer.submitUsageRequest(any())).thenReturn(new StatusResponse());
-
         ApplicationProperties appProps = new ApplicationProperties();
         MarketplaceProperties mktProps = new MarketplaceProperties();
         MarketplaceJmxBean bean = new MarketplaceJmxBean(appProps, mktProps, service, producer, objMapper,

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceProducerTest.java
@@ -53,9 +53,8 @@ class MarketplaceProducerTest {
         when(marketplaceService.submitUsageEvents(any())).thenThrow(SubscriptionsException.class);
 
         var usageRequest = new UsageRequest();
-        assertThrows(SubscriptionsException.class, () ->
-            marketplaceProducer.submitUsageRequest(usageRequest)
-        );
+
+        marketplaceProducer.submitUsageRequest(usageRequest);
 
         verify(marketplaceService, times(2)).submitUsageEvents(any());
         assertEquals(1.0, rejectedCounter.count());


### PR DESCRIPTION
Rather than continually fail a marketplace initial request, log and move on. This essentially applies the behavior described in #373 more consistently.

There are essentially three failure modes:

1. Initial marketplace call fails, retries will happen until exhausted, then the snapshot ID and error will be logged, counted as rejected.
2. Initial call succeeds, but batch is rejected, the error will be logged, the error and batchId will be logged for investigation, counted as rejected.
3. Initial call succeeds, but the batch is not confirmed within a reasonable time; the batch ID will be logged for investigation, counted as "unverified".

The first one is addressed by this change. The other two were already handled.

Testing
-------

```
DEV_MODE=true MARKETPLACE_MAX_ATTEMPTS=1 MARKETPLACE_URL=http://localhost:8999 ./gradlew bootRun
```

Then:

```
curl -H 'Content-Type: application/json' http://localhost:8080/actuator/jolokia -d '{"type":"exec","mbean":"org.candlepin.subscriptions.marketplace:name=marketplaceJmxBean,type=MarketplaceJmxBean","operation":"submitTallySummary(java.lang.String)","arguments":["{\"account_number\":\"account123\",\"tally_snapshots\": [{\"id\": \"c204074d-626f-4272-aa05-b6d69d6de16a\",\"snapshot_date\": 1615406400,\"product_id\": \"OpenShift-metrics\",\"usage\": \"Production\",\"sla\": \"Premium\",\"granularity\": \"Hourly\",\"tally_measurements\": [{\"hardware_measurement_type\": \"TOTAL\",\"uom\": \"Cores\",\"value\": 36},{\"hardware_measurement_type\": \"PHYSICAL\",\"uom\": \"Cores\",\"value\": 36}]}] }"]}'
```

Observe that when the producer fails to submit usage, rather than throw an exception, it logs the error:

```
2021-03-29 18:52:11,175 [thread=http-nio-8080-exec-9] [ERROR] [org.candlepin.subscriptions.marketplace.MarketplaceProducer] - Error submitting usage for snapshot IDs: c204074d-626f-4272-aa05-b6d69d6de16a
```

Stacktrace follows.