### PR TITLE
ENT-3636: Filter openshift clusters by billing_model label

### DIFF
--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -14,4 +14,4 @@ rhsm-subscriptions:
           metricPromQL: >-
             max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / 13.0) by (_id)
             * on(_id) group_right
-            min_over_time(subscription_labels{ebs_account="%s", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(subscription_labels{ebs_account="%s", billing_model="${OPENSHIFT_BILLING_MODEL_FILTER:marketplace}", support=~"Premium|Standard|Self-Support|None"}[1h])

--- a/templates/metrics-worker.yml
+++ b/templates/metrics-worker.yml
@@ -71,6 +71,8 @@ parameters:
     value: '30000'
   - name: DATABASE_MAX_POOL_SIZE
     value: '25'
+  - name: OPENSHIFT_BILLING_MODEL_FILTER
+    value: 'marketplace'
 
 objects:
   - apiVersion: v1
@@ -221,6 +223,8 @@ objects:
                   value: ${CLOUDIGRADE_PORT}
                 - name: PROM_URL
                   value: ${PROM_URL}
+                - name: OPENSHIFT_BILLING_MODEL_FILTER
+                  value: ${OPENSHIFT_BILLING_MODEL_FILTER}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:


### PR DESCRIPTION
* Updated the PromQL to filter by billing_model="marketplace"
* Added support to allow overriding the billing_model filter.

CARD: [ENT-3636](https://issues.redhat.com/browse/ENT-3636)

### Requires merging of
https://gitlab.cee.redhat.com/rhsm/swatch-deploy-ci/-/merge_requests/5

### Testing

1. Turn debugging on and launch the app.
```bash
$ DEV_MODE=true PROM_URL="http://localhost:8082/api/v1" ./gradlew clean bootRun
```
2. Gather metrics from prometheus
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performCustomOpenshiftMeteringForAccount(java.lang.String, java.lang.String, java.lang.Integer)","arguments":["6661312", null, 18000]}'
```

3. Note that the query that was executed was logged and shows _**billing_model=%22marketplace%22**_
```
2021-03-30 15:53:50,288 [thread=openshift-metering-task-processor-0-C-1] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Running prometheus range query: Start: 1616036400 End: 1617116399 Step: 3600, Query: max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m%5B1h:5m%5D)%20/%2013.0)%20by%20(_id)%20*%20on(_id)%20group_right%20min_over_time(subscription_labels%7Bebs_account=%226661312%22,%20billing_model=%22marketplace%22,%20support=~%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D)
```

4. Re-launch the app overriding the filter.
```bash
$ OPENSHIFT_BILLING_MODEL_FILTER=standard DEV_MODE=true PROM_URL="http://localhost:8082/api/v1" ./gradlew clean bootRun
```

5. Gather metrics from prometheus
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performCustomOpenshiftMeteringForAccount(java.lang.String, java.lang.String, java.lang.Integer)","arguments":["6661312", null, 18000]}'
```

6. Note that the query that was executed was logged and shows _**billing_model=%22standard%22**_
```
2021-03-30 15:53:50,288 [thread=openshift-metering-task-processor-0-C-1] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Running prometheus range query: Start: 1616036400 End: 1617116399 Step: 3600, Query: max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m%5B1h:5m%5D)%20/%2013.0)%20by%20(_id)%20*%20on(_id)%20group_right%20min_over_time(subscription_labels%7Bebs_account=%226661312%22,%20billing_model=%22standard%22,%20support=~%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D)
```

