### PR TITLE
Use same metricId for OCP (temporarily)

### DIFF
--- a/src/main/resources/product_profile_registry.yaml
+++ b/src/main/resources/product_profile_registry.yaml
@@ -117,3 +117,5 @@ marketplaceMetrics:
     uom: Cores
     swatchProductIds:
       - OpenShift-dedicated-metrics
+      # NOTE(khowell): remove when https://issues.redhat.com/browse/ENT-3737 is implemented
+      - OpenShift-metrics


### PR DESCRIPTION
To unblock dev-instance of marketplace-worker