### PR TITLE
ENT-3689 Awood/batch size limit

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -49,7 +49,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
-import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import io.micrometer.core.aop.TimedAspect;
@@ -98,15 +97,17 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
         return new ApplicationClock();
     }
 
-    /**
-     * Tell Spring AOP to run methods in classes marked @Validated through the JSR-303 Validation
-     * implementation.  Validations that fail will throw an ConstraintViolationException.
-     * @return post-processor used by Spring AOP
+    /* Do not declare a MethodValidationPostProcessor!
+     *
+     * The Spring Core documents instruct the user to create a MethodValidationPostProcessor in order to
+     * enable method validation.  However, Spring Boot takes care of creating that bean that itself:
+     * "The method validation feature supported by Bean Validation 1.1 is automatically enabled as long as a
+     * JSR-303 implementation (such as Hibernate validator) is on the classpath" (from
+     * https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-validation).
+     *
+     * Creating our own MethodValidationPostProcessor causes ConstraintValidator implementations to *not*
+     * receive injection from the Spring IoC container.
      */
-    @Bean
-    public MethodValidationPostProcessor methodValidationPostProcessor() {
-        return new MethodValidationPostProcessor();
-    }
 
     @Bean
     public Validator validator() {

--- a/src/main/java/org/candlepin/subscriptions/conduit/inventory/ConduitFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/conduit/inventory/ConduitFacts.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.conduit.inventory;
 
 import org.candlepin.subscriptions.utilization.api.model.ConsumerInventory;
-import org.candlepin.subscriptions.validator.ip.IpAddress;
+import org.candlepin.subscriptions.validator.IpAddress;
 
 import org.hibernate.validator.constraints.Length;
 

--- a/src/main/java/org/candlepin/subscriptions/jmx/JmxProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/JmxProperties.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.jmx;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Properties related to JMX beans. The intent is for each JMX bean to have its own static inner class
+ * containing its relevant configuration.
+ */
+@Getter
+@Component
+@ConfigurationProperties(prefix = "rhsm-subscriptions.jmx")
+public class JmxProperties {
+    private final TallyBean tallyBean = new TallyBean();
+
+    /**
+     * Inner class for properties specifically associated with {@link TallyJmxBean}
+     */
+    @Getter
+    @Setter
+    public static class TallyBean {
+        /**
+         * Since the two parameters sent to {@link TallyJmxBean#tallyAccountByHourly(String, String, String)}
+         * are actually ISO 8601 timestamps we are using a Duration rather than a Period since Duration
+         * captures time and not just dates.  However, the default ChronoUnit we're using is days since
+         * that's what the range is meant to be on the order of.  If the value is specified in hours (which
+         * Spring will allow: e.g. 2160h) the behavior will be strict: e.g. Daylight Saving Time will not
+         * affect it.
+         *
+         * From the docs: "Durations and periods differ in their treatment of daylight savings time when added
+         * to ZonedDateTime. A Duration will add an exact number of seconds, thus a duration of one day is
+         * always exactly 24 hours. By contrast, a Period will add a conceptual day, trying to maintain the
+         * local time."
+         */
+        @DurationUnit(ChronoUnit.DAYS)
+        private Duration hourlyTallyDurationLimitDays = Duration.ofDays(90);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.jmx;
 
 import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
+import org.candlepin.subscriptions.validator.ParameterDuration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,11 +30,15 @@ import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedOperationParameter;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Exposes the ability to trigger a tally for an account from JMX.
  */
 @Component
+@Validated
 @ManagedResource
 public class TallyJmxBean {
 
@@ -55,7 +60,6 @@ public class TallyJmxBean {
         log.info("Tally for account {} triggered over JMX by {}", accountNumber, principal);
         tasks.updateAccountSnapshots(accountNumber);
     }
-
 
     @ManagedOperation(description = "Trigger tally for all configured accounts")
     public void tallyConfiguredAccounts() {
@@ -79,12 +83,12 @@ public class TallyJmxBean {
         "Ending of the range of time the tally should include. " +
         "Should be top of the hour and expected to be in ISO 8601 format (e.g. 2020-08-02T14:00Z)."
     )
-    public void tallyAccountByHourly(String accountNumber, String startDateTime, String endDateTime) {
+    @ParameterDuration("@jmxProperties.tallyBean.hourlyTallyDurationLimitDays")
+    public void tallyAccountByHourly(String accountNumber, @NotNull String startDateTime,
+        @NotNull String endDateTime) {
         log.info("Hourly tally between {} and {} for account {} triggered over JMX by {}",
             startDateTime, endDateTime, accountNumber, ResourceUtils.getPrincipal());
-
         tasks.tallyAccountByHourly(accountNumber, startDateTime, endDateTime);
-
     }
 
     @ManagedOperation(description = "Trigger hourly tally for all configured accounts")

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -132,11 +132,6 @@ public class TallyWorkerConfiguration {
     }
 
     @Bean
-    TallyTaskFactory taskFactory() {
-        return new TallyTaskFactory();
-    }
-
-    @Bean
     @Qualifier("tallyTaskConsumer")
     public TaskConsumer taskProcessor(
         @Qualifier("tallyTaskQueueProperties") TaskQueueProperties taskQueueProperties,

--- a/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
@@ -22,21 +22,26 @@ package org.candlepin.subscriptions.tally.tasks;
 
 import org.candlepin.subscriptions.tally.TallySnapshotController;
 import org.candlepin.subscriptions.task.Task;
+import org.candlepin.subscriptions.validator.ParameterDuration;
+
+import org.springframework.validation.annotation.Validated;
 
 import java.time.OffsetDateTime;
 
 /**
  * Captures hourly metrics between a given timeframe for a given account
  */
+@Validated
 public class CaptureMetricsSnapshotTask implements Task {
 
     private final String accountNumber;
     private final TallySnapshotController snapshotController;
-    private final OffsetDateTime startDateTime;
-    private final OffsetDateTime endDateTime;
+    private final String startDateTime;
+    private final String endDateTime;
 
+    @ParameterDuration("@jmxProperties.tallyBean.hourlyTallyDurationLimitDays")
     public CaptureMetricsSnapshotTask(TallySnapshotController snapshotController, String accountNumber,
-        OffsetDateTime startDateTime, OffsetDateTime endDateTime) {
+        String startDateTime, String endDateTime) {
         this.snapshotController = snapshotController;
         this.accountNumber = accountNumber;
         this.startDateTime = startDateTime;
@@ -46,10 +51,8 @@ public class CaptureMetricsSnapshotTask implements Task {
 
     @Override
     public void execute() {
-        if (startDateTime.isAfter(endDateTime)) {
-            throw new IllegalArgumentException(
-                "Cannot produce hourly snapshot for account {}.  Invalid date range provided.");
-        }
-        snapshotController.produceHourlySnapshotsForAccount(accountNumber, startDateTime, endDateTime);
+        OffsetDateTime startDate = OffsetDateTime.parse(startDateTime);
+        OffsetDateTime endDate = OffsetDateTime.parse(endDateTime);
+        snapshotController.produceHourlySnapshotsForAccount(accountNumber, startDate, endDate);
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/validator/IpAddress.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/IpAddress.java
@@ -18,14 +18,14 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.validator.ip;
+package org.candlepin.subscriptions.validator;
 
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import org.candlepin.subscriptions.validator.ip.IpAddress.List;
+import org.candlepin.subscriptions.validator.IpAddress.List;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Repeatable;

--- a/src/main/java/org/candlepin/subscriptions/validator/IpAddressValidator.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/IpAddressValidator.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.validator.ip;
+package org.candlepin.subscriptions.validator;
 
 import com.google.common.net.InetAddresses;
 

--- a/src/main/java/org/candlepin/subscriptions/validator/Iso8601.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/Iso8601.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import org.candlepin.subscriptions.validator.Iso8601.List;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * JSR-380 validation for ensuring that a value is in a particular ISO 8601 format.
+ */
+@Target({ FIELD, PARAMETER, ANNOTATION_TYPE, TYPE_USE })
+@Retention(RUNTIME)
+@Repeatable(List.class)
+@Documented
+@Constraint(validatedBy = { Iso8601Validator.class })
+public @interface Iso8601 {
+    String message() default "The string \"${validatedValue}\" must be in ISO 8601 format similar to " +
+        "{example}.";
+    Class<?>[] groups() default { };
+    Class<? extends Payload>[] payload() default { };
+
+    Iso8601Format value() default Iso8601Format.ISO_DATE_TIME;
+
+    /**
+     * Inner annotation to support annotating type arguments of parameterized types.
+     */
+    @Target({ FIELD, TYPE_USE })
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+        Iso8601[] value();
+    }
+
+}

--- a/src/main/java/org/candlepin/subscriptions/validator/Iso8601Format.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/Iso8601Format.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Enumeration for use with the Iso8061 validator annotation.  Values correspond to DateTimeFormatter
+ * instances.
+ *
+ * Please note that some of these formats overlap with others.  For example,
+ * "2011-12-03T10:15:30+01:00" is both a valid ISO_DATE_TIME and a valid ISO_OFFSET_DATE_TIME.  See
+ * {@link DateTimeFormatter} for all the details.
+ */
+public enum Iso8601Format {
+    ISO_DATE(DateTimeFormatter.ISO_DATE, "2011-12-03+01:00 or 2011-12-03"),
+    ISO_LOCAL_DATE(DateTimeFormatter.ISO_LOCAL_DATE, "2011-12-03"),
+    ISO_OFFSET_DATE(DateTimeFormatter.ISO_OFFSET_DATE, "2011-12-03+01:00"),
+
+    ISO_TIME(DateTimeFormatter.ISO_TIME, "10:15:30+01:00 or 10:15:30"),
+    ISO_LOCAL_TIME(DateTimeFormatter.ISO_LOCAL_TIME, "10:15:30"),
+    ISO_OFFSET_TIME(DateTimeFormatter.ISO_OFFSET_TIME, "10:15:30+01:00"),
+
+    ISO_DATE_TIME(DateTimeFormatter.ISO_DATE_TIME,
+        "2011-12-03T10:15:30, 2011-12-03T10:15:30+01:00 or 2011-12-03T10:15:30+01:00[Europe/Paris]"),
+    ISO_LOCAL_DATE_TIME(DateTimeFormatter.ISO_LOCAL_DATE_TIME, "2011-12-03T10:15:30"),
+    ISO_OFFSET_DATE_TIME(DateTimeFormatter.ISO_OFFSET_DATE_TIME, "2011-12-03T10:15:30+01:00"),
+    ISO_ZONED_DATE_TIME(DateTimeFormatter.ISO_ZONED_DATE_TIME, "2011-12-03T10:15:30+01:00[Europe/Paris]"),
+
+    ISO_INSTANT(DateTimeFormatter.ISO_INSTANT, "2011-12-03T10:15:30Z");
+
+    DateTimeFormatter formatter;
+
+    /**
+     * The predefined ISO 8601 formatters are not actually constructed using a String based pattern.  Even
+     * if they were, there's no way to get the pattern back once the formatter is constructed.
+     * See <a href="https://stackoverflow.com/a/28949605/6124862">this StackOverflow answer</a>.
+     * As a result, we need to provide at least some information to the user to show them what the right
+     * format looks like.  Rather than reverse engineer the string patterns for the formats (which I would
+     * probably get wrong and would not necessarily be meaningful to the user), we will just provide
+     * examples of what is in the correct format.
+     */
+    String example;
+
+    Iso8601Format(DateTimeFormatter formatter, String example) {
+        this.formatter = formatter;
+        this.example = example;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/validator/Iso8601Validator.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/Iso8601Validator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * A ConstraintValidator to ensure Strings are in ISO 8601 format.
+ */
+public class Iso8601Validator implements ConstraintValidator<Iso8601, String> {
+
+    private Iso8601Format format;
+
+    @Override
+    public void initialize(Iso8601 constraintAnnotation) {
+        this.format = constraintAnnotation.value();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // Note that the Jakarta Bean Validation specification recommends to consider null values as being
+        // valid. If null is not a valid value for an element, it should be annotated with @NotNull explicitly
+        if (value == null) {
+            return true;
+        }
+
+        DateTimeFormatter formatter = format.formatter;
+
+        try {
+            formatter.parse(value);
+            return true;
+        }
+        catch (DateTimeParseException e) {
+            HibernateConstraintValidatorContext hibernateContext = context.unwrap(
+                HibernateConstraintValidatorContext.class
+            );
+            hibernateContext.addMessageParameter("example", format.example);
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/validator/ParameterDuration.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/ParameterDuration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Cross-parameter constraint to verify that two String fields are a) ISO 8601 timestamps and b) the
+ * difference between those two times is less than a given Duration.
+ */
+@Target({ METHOD, CONSTRUCTOR, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = { ParameterDurationValidator.class })
+public @interface ParameterDuration {
+    String message() default "The start time, {begin}, can not be more than {duration} hours from the end" +
+        " time, {end}";
+    Class<?>[] groups() default { };
+    Class<? extends Payload>[] payload() default { };
+    String value();
+    Iso8601Format format() default Iso8601Format.ISO_OFFSET_DATE_TIME;
+}

--- a/src/main/java/org/candlepin/subscriptions/validator/ParameterDurationValidator.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/ParameterDurationValidator.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalQuery;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+/**
+ * Validator implementation that verifies the difference between two ISO 8601 strings does not exceed a
+ * given Duration. The validator operates on the last 2 string parameters of a method and assumes that the
+ * begin parameter precedes the end parameter.
+ */
+@SupportedValidationTarget(ValidationTarget.PARAMETERS)
+public class ParameterDurationValidator
+    implements ConstraintValidator<ParameterDuration, Object[]>, BeanFactoryAware {
+
+    private BeanFactory beanFactory;
+    private Duration maxDuration;
+    private Iso8601Format format;
+
+    /**
+     * Initialize this instance.  See
+     * {@link ParameterDurationValidator#findDuration(String, String, Iso8601Format)} for a discussion on why
+     * certain formats are not supported.
+     * @param constraintAnnotation the annotation instance
+     */
+    @Override
+    public void initialize(ParameterDuration constraintAnnotation) {
+        format = constraintAnnotation.format();
+
+        switch (format) {
+            case ISO_DATE:
+            case ISO_TIME:
+            case ISO_DATE_TIME:
+            case ISO_OFFSET_DATE:
+                throw new IllegalArgumentException(format.name() + " is not a supported ISO 8601 format for" +
+                    " this validator");
+            default:
+                break;
+        }
+
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        if (beanFactory != null) {
+            context.setBeanResolver(new BeanFactoryResolver(beanFactory));
+        }
+        Expression expression = parser.parseExpression(constraintAnnotation.value());
+        maxDuration = expression.getValue(context, Duration.class);
+    }
+
+    @Override
+    public boolean isValid(Object[] value, ConstraintValidatorContext context) {
+        if (value.length < 2) {
+            throw new IllegalArgumentException("At least 2 arguments are required");
+        }
+        String beginText = (String) value[value.length - 2];
+        String endText = (String) value[value.length - 1];
+
+        // leave null-checking to @NotNull on individual parameters
+        if (beginText == null || endText == null) {
+            return true;
+        }
+
+        HibernateConstraintValidatorContext hibernateContext = context.unwrap(
+            HibernateConstraintValidatorContext.class
+        );
+        hibernateContext
+            .addMessageParameter("begin", beginText)
+            .addMessageParameter("end", endText)
+            .addMessageParameter("duration", maxDuration.toHours());
+
+        Duration actual;
+        try {
+            actual = findDuration(beginText, endText, format);
+        }
+        catch (DateTimeParseException e) {
+            // If I were a better person, this message would indicate exactly which string failed to meet
+            // format requirements. We could do that by refactoring findDuration to return a Temporal,
+            // validate each Temporal before finding the Duration, and add a ConstraintViolation for each
+            // string that doesn't parse.  That design would make this method a lot longer and require a
+            // more knowledge of the validation API than what I have.  Nevertheless, it's worth considering
+            // as an improvement if the error messaging becomes a pain point.
+            hibernateContext
+                .addMessageParameter("example", format.example)
+                .buildConstraintViolationWithTemplate("The start time, {begin}, and end time, {end}, must" +
+                    " conform to a format like {example}")
+                .addConstraintViolation()
+                .disableDefaultConstraintViolation();
+            return false;
+        }
+
+        if (actual.isNegative()) {
+            hibernateContext
+                .buildConstraintViolationWithTemplate("The start time, {begin}, can not occur after the " +
+                    "ending time, {end}")
+                .addConstraintViolation()
+                .disableDefaultConstraintViolation();
+            return false;
+        }
+
+        return maxDuration.compareTo(actual) >= 0;
+    }
+
+    /**
+     * Take two parameters, parse them according to the formatter given by an {@link Iso8601Format}
+     * parameter and return the duration between them.
+     *
+     * Not all {@link Iso8601Format}'s are supported.  Specifically, formats like ISO_OFFSET_DATE,
+     * ISO_DATE, ISO_TIME, and ISO_DATE_TIME.  In the case of ISO_TIME, ISO_DATE, and ISO_DATE_TIME those
+     * formats have optional components that make comparison difficult.  For example, "10:15-01:00" and
+     * "12:45" are both valid ISO_TIME formats, but comparing the two is meaningless since one has an
+     * offset and the other does not.  ISO_OFFSET_DATE is a rather odd format in that it is not actually
+     * part of the ISO 8601 standard!  It is also problematic for comparisons so it is not supported here.
+     *
+     * A note on using date only format: the duration between those two dates will be calculated from
+     * midnight on each day.  This will not take into account any changes around Daylight Saving Time.
+     *
+     * @param beginText a String parseable by the DateTimeFormatter given with the format parameter
+     * @param endText a String parseable by the DateTimeFormatter given with the format parameter
+     * @param format a value of Iso8601Format with an associated DateTimeFormatter
+     * @throws DateTimeParseException if the beginText or endText cannot be parsed by the method
+     * @return the Duration between beginText and endText
+     */
+    protected static Duration findDuration(String beginText, String endText, Iso8601Format format) {
+        DateTimeFormatter formatter = format.formatter;
+        TemporalQuery<Temporal> query;
+        switch (format) {
+            case ISO_LOCAL_DATE_TIME:
+                query = LocalDateTime::from;
+                break;
+            case ISO_OFFSET_DATE_TIME:
+                query = OffsetDateTime::from;
+                break;
+            case ISO_ZONED_DATE_TIME:
+                query = ZonedDateTime::from;
+                break;
+            case ISO_INSTANT:
+                query = Instant::from;
+                break;
+            case ISO_LOCAL_TIME:
+                query = LocalTime::from;
+                break;
+            case ISO_OFFSET_TIME:
+                query = OffsetTime::from;
+                break;
+            case ISO_LOCAL_DATE:
+                query = LocalDateTime::from;
+                formatter = new DateTimeFormatterBuilder()
+                    // date and offset
+                    .append(DateTimeFormatter.ISO_LOCAL_DATE)
+                    // default values for hour and minute
+                    .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                    .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                    .toFormatter();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported ISO 8601 format: " + format);
+        }
+
+        Temporal begin = formatter.parse(beginText, query);
+        Temporal end = formatter.parse(endText, query);
+        return Duration.between(begin, end);
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = beanFactory;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/validator/ValidatorConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/validator/ValidatorConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/** Configuration for validators */
+@Configuration
+@ComponentScan(basePackages = {
+    "org.candlepin.subscriptions.validator"
+})
+public class ValidatorConfiguration {
+    // No op
+}

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -1,4 +1,7 @@
 rhsm-subscriptions:
+  jmx:
+    tallyBean:
+      hourlyTallyDurationLimitDays: 90d
   inventory-service:
     datasource:
       url: jdbc:postgresql://${INVENTORY_DATABASE_HOST:localhost}/${INVENTORY_DATABASE_DATABASE:insights}

--- a/src/test/java/org/candlepin/subscriptions/validator/IpAddressValidatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/validator/IpAddressValidatorTest.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.validator.ip;
+package org.candlepin.subscriptions.validator;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/org/candlepin/subscriptions/validator/Iso8601ValidatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/validator/Iso8601ValidatorTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import static org.candlepin.subscriptions.validator.Iso8601Format.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.internal.util.annotation.AnnotationDescriptor.Builder;
+import org.hibernate.validator.internal.util.annotation.AnnotationFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.Set;
+
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintViolation;
+
+@ExtendWith(MockitoExtension.class)
+class Iso8601ValidatorTest {
+    public static final String SAMPLE_LOCAL_DATE = "2011-12-03";
+    public static final String SAMPLE_OFFSET_DATE = "2011-12-03+01:00";
+
+    public static final String SAMPLE_LOCAL_TIME = "10:15:30";
+    public static final String SAMPLE_OFFSET_TIME = "10:15:30+01:00";
+
+    public static final String SAMPLE_LOCAL_DATE_TIME = "2011-12-03T10:15:30";
+    public static final String SAMPLE_OFFSET_DATE_TIME = "2011-12-03T10:15:30+01:00";
+    public static final String SAMPLE_ZONED_DATE_TIME = "2011-12-03T10:15:30+01:00[Europe/Paris]";
+
+    public static final String SAMPLE_INSTANT = "2011-12-03T10:15:30Z";
+
+    private static class ValidThing {
+        @Iso8601(ISO_LOCAL_TIME)
+        private String time;
+
+        public String getTime() {
+            return time;
+        }
+
+        public void setTime(String time) {
+            this.time = time;
+        }
+    }
+
+    @Mock
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    private void setUp() {
+        lenient().when(context.unwrap(HibernateConstraintValidatorContext.class))
+            .thenReturn(mock(HibernateConstraintValidatorContext.class));
+    }
+
+    /*
+     * Please note that some of these formats overlap with others.  For example,
+     * "2011-12-03T10:15:30+01:00" is both a valid ISO_DATE_TIME and a valid ISO_OFFSET_DATE_TIME. The
+     * tests are constructed with this in mind.
+     */
+    @Test
+    void testIsoDate() {
+        Iso8601Validator validator = buildValidator(ISO_DATE);
+        assertTrue(validator.isValid(SAMPLE_LOCAL_DATE, context));
+        assertTrue(validator.isValid(SAMPLE_OFFSET_DATE, context));
+        assertFalse(validator.isValid(SAMPLE_LOCAL_TIME, context));
+    }
+
+    @Test
+    void testIsoLocalDate() {
+        Iso8601Validator validator = buildValidator(ISO_LOCAL_DATE);
+        assertTrue(validator.isValid(SAMPLE_LOCAL_DATE, context));
+        assertFalse(validator.isValid(SAMPLE_OFFSET_DATE, context));
+    }
+
+    @Test
+    void testIsoOffsetDate() {
+        Iso8601Validator validator = buildValidator(ISO_OFFSET_DATE);
+        assertTrue(validator.isValid(SAMPLE_OFFSET_DATE, context));
+        assertFalse(validator.isValid(SAMPLE_LOCAL_DATE, context));
+    }
+
+    @Test
+    void testIsoTime() {
+        Iso8601Validator validator = buildValidator(ISO_TIME);
+        assertTrue(validator.isValid(SAMPLE_LOCAL_TIME, context));
+        assertTrue(validator.isValid(SAMPLE_OFFSET_TIME, context));
+        assertFalse(validator.isValid(SAMPLE_INSTANT, context));
+    }
+
+    @Test
+    void testIsoLocalTime() {
+        Iso8601Validator validator = buildValidator(ISO_LOCAL_TIME);
+        assertTrue(validator.isValid(SAMPLE_LOCAL_TIME, context));
+        assertFalse(validator.isValid(SAMPLE_OFFSET_TIME, context));
+    }
+
+    @Test
+    void testIsoOffsetTime() {
+        Iso8601Validator validator = buildValidator(ISO_OFFSET_TIME);
+        assertTrue(validator.isValid(SAMPLE_OFFSET_TIME, context));
+        assertFalse(validator.isValid(SAMPLE_LOCAL_TIME, context));
+    }
+
+    @Test
+    void testIsoDateTime() {
+        Iso8601Validator validator = buildValidator(ISO_DATE_TIME);
+        assertTrue(validator.isValid(SAMPLE_LOCAL_DATE_TIME, context));
+        assertTrue(validator.isValid(SAMPLE_OFFSET_DATE_TIME, context));
+        assertTrue(validator.isValid(SAMPLE_ZONED_DATE_TIME, context));
+        assertFalse(validator.isValid(SAMPLE_LOCAL_TIME, context));
+    }
+
+    @Test
+    void testIsoLocalDateTime() {
+        Iso8601Validator validator = buildValidator(ISO_LOCAL_DATE_TIME);
+        assertTrue(validator.isValid(SAMPLE_LOCAL_DATE_TIME, context));
+        assertFalse(validator.isValid(SAMPLE_OFFSET_DATE_TIME, context));
+    }
+
+    @Test
+    void testIsoOffsetDateTime() {
+        Iso8601Validator validator = buildValidator(ISO_OFFSET_DATE_TIME);
+        assertTrue(validator.isValid(SAMPLE_OFFSET_DATE_TIME, context));
+        assertFalse(validator.isValid(SAMPLE_LOCAL_DATE_TIME, context));
+    }
+
+    @Test
+    void testIsoZonedDateTime() {
+        Iso8601Validator validator = buildValidator(ISO_ZONED_DATE_TIME);
+        assertTrue(validator.isValid(SAMPLE_ZONED_DATE_TIME, context));
+        assertFalse(validator.isValid(SAMPLE_LOCAL_DATE_TIME, context));
+    }
+
+    @Test
+    void testIsoInstant() {
+        Iso8601Validator validator = buildValidator(ISO_INSTANT);
+        assertTrue(validator.isValid(SAMPLE_INSTANT, context));
+        assertFalse(validator.isValid(SAMPLE_LOCAL_DATE_TIME, context));
+    }
+
+    @Test
+    void testValidatesNull() {
+        // Note that the Jakarta Bean Validation specification recommends to consider null values as being
+        // valid. If null is not a valid value for an element, it should be annotated with @NotNull explicitly
+        Iso8601Validator validator = buildValidator(ISO_INSTANT);
+        assertTrue(validator.isValid(null, context));
+    }
+
+    @Test
+    void testSimpleValidation() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        ValidThing thing = new ValidThing();
+        thing.setTime("12:30");
+
+        Set<ConstraintViolation<ValidThing>> result = validator.validate(thing);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void testBuildsCorrectErrorMessage() {
+        String time = "ZZZ";
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        ValidThing thing = new ValidThing();
+        thing.setTime(time);
+
+        Set<ConstraintViolation<ValidThing>> constraintViolations = validator.validate(thing);
+        assertEquals(1, constraintViolations.size());
+        var violation = constraintViolations.stream().findFirst().get();
+        String expected = String.format(
+            "The string \"%s\" must be in ISO 8601 format similar to %s.", time, ISO_LOCAL_TIME.example);
+        assertEquals(expected, violation.getMessage());
+    }
+
+    private Iso8601Validator buildValidator(Iso8601Format format) {
+        Builder<Iso8601> builder = new Builder<>(Iso8601.class);
+        builder.setAttribute("value", format);
+        Iso8601Validator validator = new Iso8601Validator();
+        validator.initialize(AnnotationFactory.create(builder.build()));
+        return validator;
+    }
+
+}

--- a/src/test/java/org/candlepin/subscriptions/validator/ParameterDurationValidatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/validator/ParameterDurationValidatorTest.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.*;
+
+import org.hibernate.validator.internal.util.annotation.AnnotationDescriptor.Builder;
+import org.hibernate.validator.internal.util.annotation.AnnotationFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.expression.spel.SpelEvaluationException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.ValidationException;
+
+@SpringBootTest
+@ActiveProfiles({"worker", "test"})
+class ParameterDurationValidatorTest {
+    public static final int VALID_HOURS = 24;
+    public static final String BEGIN_DATE_TIME = "2011-12-03T10:15Z";
+    public static final String END_DATE_TIME = "2011-12-03T12:45Z";
+
+    @Autowired BeanFactory beanFactory;
+    @Autowired ValidatedThing validatedThing;
+
+    @TestConfiguration
+    static class ParameterDurationValidatorTestConfig {
+        @Bean
+        Duration testDuration() {
+            return Duration.ofHours(VALID_HOURS);
+        }
+
+        @Bean
+        String badBean() {
+            return "This is a bean not suitable for use as a duration";
+        }
+
+        @Bean
+        ValidatedThing validatedThing() {
+            return new ValidatedThing();
+        }
+    }
+
+    @Validated
+    static class ValidatedThing {
+        @ParameterDuration("@testDuration")
+        public boolean myMethod(String begin, String end) {
+            return true;
+        }
+
+        @ParameterDuration("@testDuration")
+        public boolean badMethodSignature(String begin) {
+            return true;
+        }
+
+        @ParameterDuration("@badBean")
+        public boolean badBean(String begin, String end) {
+            return true;
+        }
+
+        @ParameterDuration("@noBean")
+        public boolean noBean(String begin, String end) {
+            return true;
+        }
+
+        @ParameterDuration(value = "@testDuration", format = Iso8601Format.ISO_INSTANT)
+        public boolean myInstantMethod(String begin, String end) {
+            return true;
+        }
+
+        @ParameterDuration(value = "@testDuration", format = Iso8601Format.ISO_LOCAL_DATE)
+        public boolean myLocalDateMethod(String begin, String end) {
+            return true;
+        }
+
+        @ParameterDuration(value = "@testDuration", format = Iso8601Format.ISO_LOCAL_TIME)
+        public boolean myLocalTimeMethod(String begin, String end) {
+            return true;
+        }
+
+        @ParameterDuration(value = "@testDuration", format = Iso8601Format.ISO_DATE_TIME)
+        public boolean unsupportedIsoFormat(String begin, String end) {
+            return true;
+        }
+    }
+
+    @Test
+    void testValidatesLocalDateTimeDuration() {
+        assertTrue(validatedThing.myMethod(BEGIN_DATE_TIME, END_DATE_TIME));
+    }
+
+    @Test
+    void testDoesNotValidateTooLongLocalDateTimeDuration() {
+        String begin = BEGIN_DATE_TIME;
+        String longEnd = "2019-01-07T10:15Z";
+        var ex = assertThrows(ConstraintViolationException.class, () ->
+            validatedThing.myMethod(begin, longEnd)
+        );
+        Set<ConstraintViolation<?>> constraintViolations = ex.getConstraintViolations();
+        assertEquals(1, constraintViolations.size());
+        var violation = constraintViolations.stream().findFirst().get();
+        String expected = String.format(
+            "The start time, %s, can not be more than %s hours from the end time, %s",
+            begin, VALID_HOURS, longEnd);
+        assertEquals(expected, violation.getMessage());
+    }
+
+    @Test
+    void testDoesNotInitializeWithUnsupportedIsoFormat() {
+        var ex = assertThrows(ValidationException.class, () ->
+            validatedThing.unsupportedIsoFormat(BEGIN_DATE_TIME, END_DATE_TIME));
+        var cause = ex.getCause();
+        assertThat(cause, instanceOf(IllegalArgumentException.class));
+        assertEquals("ISO_DATE_TIME is not a supported ISO 8601 format for this validator",
+            cause.getMessage());
+    }
+
+    @Test
+    void validatesBadFormat() {
+        String badBegin = "2011-12-03TZ";
+        String badEnd = "2011-12-02TZ";
+        String example = Iso8601Format.ISO_OFFSET_DATE_TIME.example;
+        var ex = assertThrows(ConstraintViolationException.class, () -> {
+                validatedThing.myMethod(badBegin, badEnd);
+            }
+        );
+        Set<ConstraintViolation<?>> constraintViolations = ex.getConstraintViolations();
+        assertEquals(1, constraintViolations.size());
+        var violation = constraintViolations.stream().findFirst().get();
+        String expected = String.format(
+            "The start time, %s, and end time, %s, must conform to a format like %s",
+            badBegin, badEnd, example);
+        assertEquals(expected, violation.getMessage());
+    }
+
+    @Test
+    void testValidatesBeginBeforeEnd() {
+        String negativeEnd = "2011-12-02T21:45Z";
+        var ex = assertThrows(ConstraintViolationException.class, () -> {
+            validatedThing.myMethod(BEGIN_DATE_TIME, negativeEnd);
+            }
+        );
+        Set<ConstraintViolation<?>> constraintViolations = ex.getConstraintViolations();
+        assertEquals(1, constraintViolations.size());
+        var violation = constraintViolations.stream().findFirst().get();
+        String expected = String.format("The start time, %s, can not occur after the ending time, %s",
+            BEGIN_DATE_TIME, negativeEnd);
+        assertEquals(expected, violation.getMessage());
+    }
+
+    @Test
+    void testValidatesInstantDuration() {
+        assertTrue(validatedThing.myInstantMethod("2011-12-03T10:15:30.000Z", "2011-12-03T12:45:30.000Z"));
+        assertTrue(validatedThing.myInstantMethod("2011-12-03T10:15:30Z", "2011-12-03T12:45:30Z"));
+    }
+
+    @Test
+    void testValidatesTimeOnly() {
+        assertTrue(validatedThing.myLocalTimeMethod("10:15", "12:45"));
+    }
+
+    @Test
+    void testValidatesDatesOnly() {
+        assertTrue(validatedThing.myLocalDateMethod("2011-12-03", "2011-12-04"));
+    }
+
+    @Test
+    void testDoesNotWorryAboutNull() {
+        assertTrue(validatedThing.myMethod(null, BEGIN_DATE_TIME));
+    }
+
+    @Test
+    void testRequiresTwoParameters() {
+        var ex = assertThrows(ValidationException.class, () ->
+            validatedThing.badMethodSignature(BEGIN_DATE_TIME));
+        var cause = ex.getCause();
+        assertThat(cause, instanceOf(IllegalArgumentException.class));
+        assertEquals("At least 2 arguments are required", cause.getMessage());
+    }
+
+    @Test
+    void testBadBean() {
+        var ex = assertThrows(ValidationException.class, () ->
+            validatedThing.badBean(BEGIN_DATE_TIME, END_DATE_TIME));
+        var cause = ex.getCause();
+        assertThat(cause, instanceOf(SpelEvaluationException.class));
+    }
+
+    @Test
+    void testNoBean() {
+        var ex = assertThrows(ValidationException.class, () ->
+            validatedThing.noBean(BEGIN_DATE_TIME, END_DATE_TIME));
+        var cause = ex.getCause();
+        assertThat(cause, instanceOf(SpelEvaluationException.class));
+    }
+
+    /* These are primarily to illustrate another way of doing the validator testing if you do not need to
+     * provide a ConstraintValidationContext.  Creating a dummy ConstraintValidationContext is not trivial,
+     * so most of the tests that would dereference the context call the Validator indirectly by invoking a
+     * method it's been applied to.  The ConstraintValidationContext could be mocked for cases that don't
+     * use it, but for testing that the proper error messages are constructed we really don't want to use a
+     * mock for that.
+     *
+     * I'm leaving these methods here as examples for others in the future as it took some doing to figure
+     * out how to properly create the annotation instance to pass to the validator's initialize method.
+     */
+    private ParameterDurationValidator buildValidator(String spelExpression) {
+        Builder<ParameterDuration> builder = new Builder<>(ParameterDuration.class);
+        builder.setAttribute("value", spelExpression);
+        return buildValidator(builder);
+    }
+
+    private ParameterDurationValidator buildValidator(String spelExpression, Iso8601Format format) {
+        Builder<ParameterDuration> builder = new Builder<>(ParameterDuration.class);
+        builder.setAttribute("value", spelExpression);
+        builder.setAttribute("format", format);
+        return buildValidator(builder);
+    }
+
+    private ParameterDurationValidator buildValidator(Builder<ParameterDuration> builder) {
+        ParameterDurationValidator validator = new ParameterDurationValidator();
+        validator.setBeanFactory(beanFactory);
+        validator.initialize(AnnotationFactory.create(builder.build()));
+        return validator;
+    }
+
+    @Test
+    void testIsoLocalDateTimeDuration() {
+        Duration actual = ParameterDurationValidator.findDuration(
+            "2011-12-03T10:15:30",
+            "2011-12-03T12:15:30",
+            Iso8601Format.ISO_LOCAL_DATE_TIME
+        );
+        Duration expected = Duration.ofHours(2);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testIsoOffsetDateTimeDuration() {
+        Duration actual = ParameterDurationValidator.findDuration(
+            "2011-12-03T10:00-01:00", // UTC 11:00
+            "2011-12-03T20:00+03:00", // UTC 17:00
+            Iso8601Format.ISO_OFFSET_DATE_TIME
+        );
+        Duration expected = Duration.ofHours(6);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testIsoZonedDateTimeDuration() {
+        Duration actual = ParameterDurationValidator.findDuration(
+            "2011-12-03T10:15:30+01:00[Europe/Paris]", // UTC 09:15:30
+            "2011-12-03T12:15:30Z",
+            Iso8601Format.ISO_ZONED_DATE_TIME
+        );
+        Duration expected = Duration.ofHours(3);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testIsoInstantDuration() {
+        Duration actual = ParameterDurationValidator.findDuration(
+            "2011-12-03T10:15:30Z",
+            "2011-12-03T12:15:30Z",
+            Iso8601Format.ISO_INSTANT
+        );
+        Duration expected = Duration.ofHours(2);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testIsoLocalTimeDuration() {
+        Duration actual = ParameterDurationValidator.findDuration(
+            "10:15",
+            "12:45",
+            Iso8601Format.ISO_LOCAL_TIME
+        );
+        Duration expected = Duration.ofMinutes(150);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testIsoOffsetTimeDuration() {
+        Duration actual = ParameterDurationValidator.findDuration(
+            "10:00-04:00", // UTC 14:00
+            "20:00+03:00", // UTC 17:00
+            Iso8601Format.ISO_OFFSET_TIME
+        );
+        Duration expected = Duration.ofHours(3);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testIsoLocalDateDuration() {
+        Duration actual = ParameterDurationValidator.findDuration(
+            "2011-12-03",
+            "2011-12-10",
+            Iso8601Format.ISO_LOCAL_DATE
+        );
+        Duration expected = Duration.ofHours(7 * 24);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
# Testing

1. Start the app with a useful value for the duration limit.  You can specify hours like "8h" if you want.
```
$ ./gradlew bootRun --args="--rhsm-subscriptions.jmx.tallyBean.hourlyTallyDurationLimitDays=1"
```
2. Submit a request outside the valid range.
```
$ curl -v 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["1234","2020-08-02T14:00Z","2020-08-09T15:00Z"]}'
```
3. You will receive a ConstraintViolationException as a result with a helpful error message
4. The response will be a 500 error, but that's a function of Jolokia.  We already have a mapper in place for our REST endpoints that converts ConstraintViolationExceptions to 400 Bad Request responses.
5. Try again with a valid date range.
6. Your job will be accepted.

We can easily apply these validations to other JMX beans and REST endpoints.