### PR TITLE
ENT-3667: lookup orgId when performing auto-opt-in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,7 @@ dependencies {
     compile project(":subscription-client")
     compile project(":marketplace-client")
     compile project(":prometheus-client")
+    compile project(":user-client")
     compile project(":kafka-schema")
 
     // This starter pulls in Spring Boot versions that we don't want.  The actual classes that we need are
@@ -445,9 +446,18 @@ project(":prometheus-client") {
     }
 }
 
+project(":user-client") {
+    apply plugin: "org.openapi.generator"
+
+    ext {
+        api_spec_path = "${projectDir}/user-api-spec.yaml"
+        config_file = "${projectDir}/user-client-config.json"
+    }
+}
+
 configure(subprojects.findAll { it.name in ["cloudigrade-client", 'rbac-client', 'rhsm-client',
                                             'insights-inventory-client', 'subscription-client',
-                                            'marketplace-client', 'prometheus-client']}) {
+                                            'marketplace-client', 'prometheus-client', 'user-client']}) {
     apply plugin: "org.openapi.generator"
     apply plugin: "checkstyle"
 

--- a/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/X509ApiClientFactoryConfiguration.java
+++ b/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/X509ApiClientFactoryConfiguration.java
@@ -22,6 +22,7 @@
 package org.candlepin.subscriptions.conduit.rhsm.client;
 
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -110,7 +111,7 @@ public class X509ApiClientFactoryConfiguration {
     }
 
     public boolean usesDefaultTruststore() {
-        return getTruststoreFile() == null;
+        return !StringUtils.hasText(getTruststoreFile());
     }
 
     public String toString() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'rhsm-subscriptions'
-include ':api', ':insights-inventory-client', ':rhsm-client', ':cloudigrade-client', 'kafka-schema', ':rbac-client', ':subscription-client', ':marketplace-client', ':prometheus-client'
+include ':api', ':insights-inventory-client', ':rhsm-client', ':cloudigrade-client', 'kafka-schema',
+        ':rbac-client', ':subscription-client', ':marketplace-client', ':prometheus-client',
+        ':user-client'
 

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -31,6 +31,7 @@ import org.candlepin.subscriptions.security.SecurityConfig;
 import org.candlepin.subscriptions.subscription.SubscriptionServiceConfiguration;
 import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsConfiguration;
+import org.candlepin.subscriptions.user.UserServiceClientConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.HawtioConfiguration;
 import org.candlepin.subscriptions.util.LiquibaseUpdateOnlyConfiguration;
@@ -65,7 +66,8 @@ import javax.validation.Validator;
     CaptureSnapshotsConfiguration.class, PurgeSnapshotsConfiguration.class,
     LiquibaseUpdateOnlyConfiguration.class, TallyWorkerConfiguration.class, OrgSyncConfiguration.class,
     MarketplaceWorkerConfiguration.class, DevModeConfiguration.class, SecurityConfig.class,
-    HawtioConfiguration.class, MeteringConfiguration.class, SubscriptionServiceConfiguration.class
+    HawtioConfiguration.class, MeteringConfiguration.class, SubscriptionServiceConfiguration.class,
+    UserServiceClientConfiguration.class
 })
 public class ApplicationConfiguration implements WebMvcConfigurer {
     @Bean

--- a/src/main/java/org/candlepin/subscriptions/jmx/JmxBeansConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/JmxBeansConfiguration.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.jmx;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
 import org.candlepin.subscriptions.security.OptInController;
+import org.candlepin.subscriptions.user.AccountService;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -40,7 +41,7 @@ public class JmxBeansConfiguration {
     @Bean
     @ConditionalOnMissingBean(OptInController.class)
     OptInController optInController(ApplicationClock clock, AccountConfigRepository accountConfigRepo,
-        OrgConfigRepository orgConfigRepo) {
-        return new OptInController(clock, accountConfigRepo, orgConfigRepo);
+        OrgConfigRepository orgConfigRepo, AccountService accountService) {
+        return new OptInController(clock, accountConfigRepo, orgConfigRepo, accountService);
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
@@ -65,6 +65,18 @@ public class OptInJmxBean {
         return controller.getOptInConfig(accountNumber, orgId).toString();
     }
 
+    @ManagedOperation(description = "Fetch an opt in configuration (given only the account number)")
+    @ManagedOperationParameter(name = "accountNumber", description = "Red Hat Account Number")
+    public String getOptInConfigForAccountNumber(String accountNumber) {
+        return controller.getOptInConfigForAccountNumber(accountNumber).toString();
+    }
+
+    @ManagedOperation(description = "Fetch an opt in configuration (given only the org ID)")
+    @ManagedOperationParameter(name = "orgId", description = "Red Hat Org ID")
+    public String getOptInConfigForOrgId(String orgId) {
+        return controller.getOptInConfigForOrgId(orgId).toString();
+    }
+
     @ManagedOperation(description = "Delete opt in configuration")
     @ManagedOperationParameter(name = "accountNumber", description = "Red Hat Account Number")
     @ManagedOperationParameter(name = "orgId", description = "Red Hat Org ID")
@@ -90,6 +102,22 @@ public class OptInJmxBean {
 
         String text = "Completed opt in for account %s and org %s:\n%s";
         return String.format(text, accountNumber, orgId, config.toString());
+    }
+
+    @ManagedOperation(description = "Ensure opt-in exists for account number only.")
+    public String ensureOptinForAccountNumber(String accountNumber, boolean enableTallySync,
+        boolean enableTallyReporting, boolean enableConduitSync) {
+        controller.optInByAccountNumber(accountNumber, OptInType.JMX, enableTallySync, enableTallyReporting,
+            enableConduitSync);
+        return String.format("Completed opt in for account %s", accountNumber);
+    }
+
+    @ManagedOperation(description = "Ensure opt-in exists for org ID only.")
+    public String ensureOptInForOrgId(String orgId, boolean enableTallySync,
+        boolean enableTallyReporting, boolean enableConduitSync) {
+        controller.optInByOrgId(orgId, OptInType.JMX, enableTallySync, enableTallyReporting,
+            enableConduitSync);
+        return String.format("Completed opt in for orgId %s", orgId);
     }
 
     @ManagedAttribute(description = "Count of how many orgs opted-in in the previous week.")

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -20,13 +20,13 @@
  */
 package org.candlepin.subscriptions.metering.profile;
 
-import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService;
 import org.candlepin.subscriptions.metering.service.prometheus.config.PrometheusServiceConfiguration;
 import org.candlepin.subscriptions.metering.task.OpenShiftTasksConfiguration;
+import org.candlepin.subscriptions.security.OptInController;
 import org.candlepin.subscriptions.task.queue.TaskConsumerConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 
@@ -78,8 +78,8 @@ public class OpenShiftWorkerProfile {
     PrometheusMeteringController getController(ApplicationClock clock, PrometheusMetricsProperties mProps,
         PrometheusService service, EventController eventController,
         @Qualifier("openshiftMetricRetryTemplate") RetryTemplate openshiftRetryTemplate,
-        AccountConfigRepository accountConfigRepo) {
+        OptInController optInController) {
         return new PrometheusMeteringController(clock, mProps, service, eventController,
-            openshiftRetryTemplate, accountConfigRepo);
+            openshiftRetryTemplate, optInController);
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -90,10 +90,10 @@ public class PrometheusMeteringController {
         // at the top of an hour. Otherwise we would get an extra hour added onto the date
         // when we moved it to the end of the hour.
         OffsetDateTime endDate = clock.endOfHour(end.minusMinutes(1));
+        log.debug("Ensuring marketplace account {} has been set up for syncing/reporting.", account);
+        ensureOptIn(account);
         openshiftRetry.execute(context -> {
             try {
-                log.debug("Ensuring marketplace account {} has been set up for syncing/reporting.", account);
-                ensureOptIn(account);
 
                 log.info("Collecting OpenShift metrics");
                 QueryResult metricData = prometheusService.runRangeQuery(

--- a/src/main/java/org/candlepin/subscriptions/user/AccountApiFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/user/AccountApiFactory.java
@@ -26,14 +26,16 @@ import org.candlepin.subscriptions.user.api.resources.AccountApi;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+
+import javax.annotation.Nonnull;
 
 /**
  * Factory bean for AccountApi.
  */
-public class AccountApiFactory implements FactoryBean<AccountApi> {
+public class AccountApiFactory extends AbstractFactoryBean<AccountApi> {
 
-    private static Logger log = LoggerFactory.getLogger(AccountApiFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(AccountApiFactory.class);
 
     private final HttpClientProperties serviceProperties;
 
@@ -41,8 +43,9 @@ public class AccountApiFactory implements FactoryBean<AccountApi> {
         this.serviceProperties = serviceProperties;
     }
 
+    @Nonnull
     @Override
-    public AccountApi getObject() throws Exception {
+    protected AccountApi createInstance() {
         if (serviceProperties.isUseStub()) {
             log.info("Using stub user client");
             return new StubAccountApi();

--- a/src/main/java/org/candlepin/subscriptions/user/AccountApiFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/user/AccountApiFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.user;
+
+import org.candlepin.subscriptions.http.HttpClient;
+import org.candlepin.subscriptions.http.HttpClientProperties;
+import org.candlepin.subscriptions.user.api.resources.AccountApi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Factory bean for AccountApi.
+ */
+public class AccountApiFactory implements FactoryBean<AccountApi> {
+
+    private static Logger log = LoggerFactory.getLogger(AccountApiFactory.class);
+
+    private final HttpClientProperties serviceProperties;
+
+    public AccountApiFactory(HttpClientProperties serviceProperties) {
+        this.serviceProperties = serviceProperties;
+    }
+
+    @Override
+    public AccountApi getObject() throws Exception {
+        if (serviceProperties.isUseStub()) {
+            log.info("Using stub user client");
+            return new StubAccountApi();
+        }
+        ApiClient apiClient = Configuration.getDefaultApiClient();
+        apiClient.setHttpClient(HttpClient.buildHttpClient(serviceProperties, apiClient.getJSON(),
+            apiClient.isDebugging()));
+        if (serviceProperties.getUrl() != null) {
+            log.info("User service URL: {}", serviceProperties.getUrl());
+            apiClient.setBasePath(serviceProperties.getUrl());
+        }
+        else {
+            log.warn("User service URL not set...");
+        }
+        return new AccountApi(apiClient);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return AccountApi.class;
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/user/AccountService.java
+++ b/src/main/java/org/candlepin/subscriptions/user/AccountService.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.user;
+
+import org.candlepin.subscriptions.exception.ErrorCode;
+import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.candlepin.subscriptions.user.api.model.AccountCriteria;
+import org.candlepin.subscriptions.user.api.model.AccountSearch;
+import org.candlepin.subscriptions.user.api.resources.AccountApi;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Wraps IT User Service account APIs in more convenient interfaces.
+ */
+@Component
+public class AccountService {
+
+    private final AccountApi accountApi;
+
+    @Autowired
+    public AccountService(AccountApi accountApi) {
+        this.accountApi = accountApi;
+    }
+
+    public String lookupOrgId(String accountNumber) {
+        try {
+            return Optional.ofNullable(accountApi
+                .findAccount(new AccountSearch().by(new AccountCriteria().ebsAccountNumber(accountNumber))))
+                .orElseThrow(() -> new SubscriptionsException(
+                    ErrorCode.REQUEST_PROCESSING_ERROR,
+                    Response.Status.INTERNAL_SERVER_ERROR,
+                    String.format("Account number %s not found", accountNumber),
+                    (String) null
+                )).getId();
+        }
+        catch (ApiException e) {
+            throw new SubscriptionsException(
+                ErrorCode.REQUEST_PROCESSING_ERROR,
+                Response.Status.INTERNAL_SERVER_ERROR,
+                "Error looking up orgId",
+                e
+            );
+        }
+    }
+
+    public String lookupAccountNumber(String orgId) {
+        try {
+            return Optional.ofNullable(Optional.ofNullable(accountApi
+                .findAccount(new AccountSearch().by(new AccountCriteria().id(orgId))))
+                .orElseThrow(() -> new SubscriptionsException(
+                    ErrorCode.REQUEST_PROCESSING_ERROR,
+                    Response.Status.INTERNAL_SERVER_ERROR,
+                    String.format("Account w/ orgId %s not found", orgId),
+                    (String) null
+                )).getEbsAccountNumber()).orElseThrow(() -> new SubscriptionsException(
+                    ErrorCode.REQUEST_PROCESSING_ERROR,
+                    Response.Status.INTERNAL_SERVER_ERROR,
+                    String.format("Account w/ orgId %s has no account number", orgId),
+                    (String) null
+                ));
+        }
+        catch (ApiException e) {
+            throw new SubscriptionsException(
+                ErrorCode.REQUEST_PROCESSING_ERROR,
+                Response.Status.INTERNAL_SERVER_ERROR,
+                "Error looking up account number",
+                e
+            );
+        }
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/user/StubAccountApi.java
+++ b/src/main/java/org/candlepin/subscriptions/user/StubAccountApi.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.user;
+
+import org.candlepin.subscriptions.user.api.model.Account;
+import org.candlepin.subscriptions.user.api.model.AccountSearch;
+import org.candlepin.subscriptions.user.api.resources.AccountApi;
+
+/**
+ * Stub implementation of the Account API that returns a canned response.
+ */
+public class StubAccountApi extends AccountApi {
+
+    @Override
+    public Account findAccount(AccountSearch accountSearch) throws ApiException {
+        return new Account().ebsAccountNumber("account123").id("org123");
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/user/UserServiceClientConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/user/UserServiceClientConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.user;
+
+import org.candlepin.subscriptions.http.HttpClientProperties;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring configuration for the IT User service client.
+ *
+ * Note that the service is called "User", but the API we are using is an "Account API". The IT service has
+ * other APIs around account & user management, but we're only interested in the findAccount API.
+ */
+@Configuration
+@ComponentScan(basePackages = "org.candlepin.subscriptions.user")
+public class UserServiceClientConfiguration {
+    @Bean
+    @Qualifier("user-service")
+    @ConfigurationProperties(prefix = "rhsm-subscriptions.user-service")
+    public HttpClientProperties userServiceProperties() {
+        return new HttpClientProperties();
+    }
+
+    @Bean
+    public AccountApiFactory accountApiFactory(@Qualifier("user-service") HttpClientProperties props) {
+        return new AccountApiFactory(props);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/user/UserServiceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/user/UserServiceProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.user;
+
+import org.candlepin.subscriptions.http.HttpClientProperties;
+
+import lombok.Data;
+
+import java.time.Duration;
+
+/**
+ * Properties for interacting with the RH IT User service.
+ */
+@Data
+public class UserServiceProperties extends HttpClientProperties {
+    /**
+     * How many attempts before giving up.
+     */
+    private Integer maxAttempts;
+
+    /**
+     * Retry backoff interval.
+     */
+    private Duration backOffInitialInterval;
+
+    /**
+     * Retry backoff interval.
+     */
+    private Duration backOffMaxInterval;
+
+    /**
+     * Retry exponential backoff multiplier.
+     */
+    private Double backOffMultiplier;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -129,3 +129,7 @@ rhsm-subscriptions:
     max-connections: ${USER_MAX_CONNECTIONS:100}
     keystore: ${RHSM_KEYSTORE:}
     keystore-password: ${RHSM_KEYSTORE_PASSWORD:changeit}
+    back-off-initial-interval: ${USER_BACK_OFF_INITIAL_INTERVAL:1s}
+    back-off-max-interval: ${USER_BACK_OFF_MAX_INTERVAL:1m}
+    back-off-multiplier: ${USER_BACK_OFF_MULTIPLIER:2}
+    max-attempts: ${USER_MAX_ATTEMPTS:1}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -123,3 +123,9 @@ rhsm-subscriptions:
     backOffInitialInterval: ${SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL:1s}
     maxRetryAttempts: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS:4}
     pageSize: ${SUBSCRIPTION_PAGE_SIZE:500}
+  user-service:
+    use-stub: ${USER_USE_STUB:false}
+    url: https://${USER_HOST:localhost}:${USER_PORT:443}
+    max-connections: ${USER_MAX_CONNECTIONS:100}
+    keystore: ${RHSM_KEYSTORE:}
+    keystore-password: ${RHSM_KEYSTORE_PASSWORD:changeit}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -14,6 +14,8 @@ rhsm-subscriptions:
   account-batch-size: 2
   subscription:
     use-stub: true
+  user-service:
+    use-stub: true
 logging:
   level:
     org:

--- a/templates/metrics-worker.yml
+++ b/templates/metrics-worker.yml
@@ -73,6 +73,18 @@ parameters:
     value: '25'
   - name: OPENSHIFT_BILLING_MODEL_FILTER
     value: 'marketplace'
+  - name: USER_HOST
+    required: true
+  - name: USER_MAX_CONNECTIONS
+    value: '100'
+  - name: USER_MAX_ATTEMPTS
+    value: '10'
+  - name: USER_BACK_OFF_MAX_INTERVAL
+    value: 64s
+  - name: USER_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: USER_BACK_OFF_MULTIPLIER
+    value: '2'
 
 objects:
   - apiVersion: v1
@@ -225,6 +237,18 @@ objects:
                   value: ${PROM_URL}
                 - name: OPENSHIFT_BILLING_MODEL_FILTER
                   value: ${OPENSHIFT_BILLING_MODEL_FILTER}
+                - name: USER_HOST
+                  value: ${USER_HOST}
+                - name: USER_MAX_CONNECTIONS
+                  value: ${USER_MAX_CONNECTIONS}
+                - name: USER_MAX_ATTEMPTS
+                  value: ${USER_MAX_ATTEMPTS}
+                - name: USER_BACK_OFF_MAX_INTERVAL
+                  value: ${USER_BACK_OFF_MAX_INTERVAL}
+                - name: USER_BACK_OFF_INITIAL_INTERVAL
+                  value: ${USER_BACK_OFF_INITIAL_INTERVAL}
+                - name: USER_BACK_OFF_MULTIPLIER
+                  value: ${USER_BACK_OFF_MULTIPLIER}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -63,6 +63,18 @@ parameters:
     value: '30000'
   - name: INVENTORY_DATABASE_MAX_POOL_SIZE
     value: '25'
+  - name: USER_HOST
+    required: true
+  - name: USER_MAX_CONNECTIONS
+    value: '100'
+  - name: USER_MAX_ATTEMPTS
+    value: '10'
+  - name: USER_BACK_OFF_MAX_INTERVAL
+    value: 64s
+  - name: USER_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: USER_BACK_OFF_MULTIPLIER
+    value: '2'
 
 objects:
   - apiVersion: v1
@@ -215,6 +227,18 @@ objects:
                   value: ${CLOUDIGRADE_HOST}
                 - name: CLOUDIGRADE_PORT
                   value: ${CLOUDIGRADE_PORT}
+                - name: USER_HOST
+                  value: ${USER_HOST}
+                - name: USER_MAX_CONNECTIONS
+                  value: ${USER_MAX_CONNECTIONS}
+                - name: USER_MAX_ATTEMPTS
+                  value: ${USER_MAX_ATTEMPTS}
+                - name: USER_BACK_OFF_MAX_INTERVAL
+                  value: ${USER_BACK_OFF_MAX_INTERVAL}
+                - name: USER_BACK_OFF_INITIAL_INTERVAL
+                  value: ${USER_BACK_OFF_INITIAL_INTERVAL}
+                - name: USER_BACK_OFF_MULTIPLIER
+                  value: ${USER_BACK_OFF_MULTIPLIER}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:

--- a/user-client/user-api-spec.yaml
+++ b/user-client/user-api-spec.yaml
@@ -1,0 +1,55 @@
+# This is a file maintained by the rhsm-subscriptions project that describes
+# a portion of the Red Hat IT User API.
+openapi: 3.0.2
+info:
+  title: user-api
+  description: Third-party specification for User API
+  version: 1.0.0
+
+paths:
+  /v2/findAccount:
+    description: Find an account
+    post:
+      summary: Find Account
+      operationId: findAccount
+      tags:
+        - account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountSearch'
+      responses:
+        '200':
+          description: The operation completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+        '204':
+          description: No account found
+
+components:
+  schemas:
+    Account:
+      required:
+        - ebsAccountNumber
+        - id
+      properties:
+        ebsAccountNumber:
+          type: string
+        id:
+          type: string
+    AccountSearch:
+      required:
+        - by
+      properties:
+        by:
+          $ref: '#/components/schemas/AccountCriteria'
+    AccountCriteria:
+      properties:
+        ebsAccountNumber:
+          type: string
+        id:
+          type: string

--- a/user-client/user-client-config.json
+++ b/user-client/user-client-config.json
@@ -1,0 +1,8 @@
+{
+  "modelPackage": "org.candlepin.subscriptions.user.api.model",
+  "apiPackage": "org.candlepin.subscriptions.user.api.resources",
+  "invokerPackage": "org.candlepin.subscriptions.user",
+  "groupId": "org.candlepin",
+  "artifactId": "user-client",
+  "java8": true
+}


### PR DESCRIPTION
I also added a few corresponding methods to the opt-in JMX bean.

The lookup only happens if the account doesn't already have an opt-in record.

Testing
-------

1. Clear the account_config and org_config tables:

```sql
truncate table account_config;
truncate table org_config;
```

2. Run the application with modified PromQL and connected to the QA user
   service - replace `$RHSM_KEYSTORE` and `$RHSM_KEYSTORE_PASSWORD`:

Run a proxy to prometheus per (internal) https://docs.engineering.redhat.com/display/ENT/Connecting+to+Observatorium+to+Fetch+Prometheus+Metrics

```
DEV_MODE=true \
  OPENSHIFT_MAX_ATTEMPTS=1 \
  RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_METRIC_OPENSHIFT_ENABLED_ACCOUNT_PROM_Q_L="group(min_over_time(subscription_labels{ebs_account != '', billing_model='standard'}[1h])) by (ebs_account)" \
  PROM_URL=http://localhost:8082/api/v1 \
  USER_HOST=user.qa.api.redhat.com \
  RHSM_KEYSTORE=$RHSM_KEYSTORE \
  RHSM_KEYSTORE_PASSWORD=$RHSM_KEYSTORE_PASSWORD \
  ./gradlew bootRun
```

3. Invoke the JMX API to get the service to tally accounts.

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performOpenshiftMetering()","arguments":[]}'
```

It is normal to see some warnings about account not being found due to data differences between prometheus and the user API.

4. View resulting records in `account_config` and `org_config` tables.

```sql
select * from org_config;
select * from account_config;
````

5. Try some of the new methods on the OptInJmxBean if desired (http://localhost:8080/actuator/hawtio) Hint: you can use the log messages to get some sample org IDs and account numbers.