### PR TITLE
ENT-3713: [PART 1/2] Fix duplicate snapshot generation when rolling hourly snapshots

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -130,8 +130,7 @@ public class TallySnapshotController {
                 .filter(TallySnapshotController::isCombiningRollupStrategySupported)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-            combiningRollupSnapshotStrategy
-                .produceSnapshotsFromCalculations(accountNumber, startDateTime, endDateTime,
+            combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(accountNumber,
                 applicableUsageCalculations, Granularity.HOURLY, Double::sum);
             log.info("Finished producing hourly snapshots for account: {}", accountNumber);
         }

--- a/src/main/java/org/candlepin/subscriptions/util/DateRange.java
+++ b/src/main/java/org/candlepin/subscriptions/util/DateRange.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * A simple class that represents a date range.
+ */
+@Getter
+@Setter
+public class DateRange {
+
+    private final OffsetDateTime startDate;
+    private final OffsetDateTime endDate;
+
+    public DateRange(OffsetDateTime startDate, OffsetDateTime endDate) {
+        verifyRange(startDate, endDate);
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    /**
+     * Given a collection of dates, create a range spanning the earliest date in the collection to the
+     * latest date.
+     *
+     * @param dates the dates to build the range from.
+     * @return the date range made up of the passed collection of dates.
+     */
+    public static DateRange from(Collection<OffsetDateTime> dates) {
+        OffsetDateTime maxTime = null;
+        OffsetDateTime minTime = null;
+        for (OffsetDateTime next : dates) {
+            if (Objects.isNull(maxTime) || next.isAfter(maxTime)) {
+                maxTime = next;
+            }
+
+            if (Objects.isNull(minTime) || next.isBefore(minTime)) {
+                minTime = next;
+            }
+        }
+        return new DateRange(minTime, maxTime);
+    }
+
+    private void verifyRange(OffsetDateTime start, OffsetDateTime end) {
+        if (!start.equals(end) && start.isAfter(end)) {
+            throw new IllegalArgumentException("Start date must be before end date!");
+        }
+    }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
@@ -79,8 +79,6 @@ class CombiningRollupSnapshotStrategyTest {
         AccountUsageCalculation noonUsage = createAccountUsageCalculation(usageKey, 4.0);
         AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
         combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations("account123",
-            OffsetDateTime.parse("2021-02-25T11:00:00Z"),
-            OffsetDateTime.parse("2021-02-25T14:00:00Z"),
             Map.of(OffsetDateTime.parse("2021-02-25T12:00:00Z"), noonUsage,
             OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Granularity.HOURLY, Double::sum);
 
@@ -114,8 +112,6 @@ class CombiningRollupSnapshotStrategyTest {
         AccountUsageCalculation day1Usage = createAccountUsageCalculation(usageKey, 4.0);
         AccountUsageCalculation day2Usage = createAccountUsageCalculation(usageKey, 3.0);
         combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations("account123",
-            hourlyTimestamp1,
-            hourlyTimestamp2,
             Map.of(hourlyTimestamp1, day1Usage, hourlyTimestamp2, day2Usage), Granularity.HOURLY,
             Double::sum);
 
@@ -157,8 +153,6 @@ class CombiningRollupSnapshotStrategyTest {
         AccountUsageCalculation noonUsage = createAccountUsageCalculation(usageKey, 4.0);
         AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
         combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations("account123",
-            OffsetDateTime.parse("2021-02-25T11:00:00Z"),
-            OffsetDateTime.parse("2021-02-25T14:00:00Z"),
             Map.of(OffsetDateTime.parse("2021-02-25T12:00:00Z"), noonUsage,
             OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Granularity.HOURLY, Double::sum);
 
@@ -192,8 +186,6 @@ class CombiningRollupSnapshotStrategyTest {
         AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
 
         combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations("account123",
-            OffsetDateTime.parse("2021-02-25T11:00:00Z"),
-            OffsetDateTime.parse("2021-02-25T14:00:00Z"),
             Map.of(OffsetDateTime.parse("2021-02-25T12:00:00Z"), noonUsage,
             OffsetDateTime.parse("2021-02-25T13:00:00Z"), afternoonUsage), Granularity.HOURLY, Double::sum);
 

--- a/src/test/java/org/candlepin/subscriptions/util/DateRangeTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/DateRangeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+
+class DateRangeTest {
+
+    @Test
+    void testCreateFromCollection() {
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime expectedStart = now.minusMonths(4);
+        OffsetDateTime expectedEnd = now.plusMonths(4);
+
+        List<OffsetDateTime> dates = List.of(now, expectedStart, expectedEnd, expectedEnd, expectedStart);
+        DateRange range = DateRange.from(dates);
+        assertEquals(expectedStart, range.getStartDate());
+        assertEquals(expectedEnd, range.getEndDate());
+    }
+
+    @Test
+    void testValidateStartDateIsBeforeOrOnEndDate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        new DateRange(now, now.plusHours(1)); // Verify starts before end date case.
+        new DateRange(now, now); // Verify on end date case.
+
+        // Start can't be after the end date.
+        OffsetDateTime start = now;
+        OffsetDateTime end = now.minusHours(1);
+        assertThrows(IllegalArgumentException.class, () -> new DateRange(start, end));
+    }
+}


### PR DESCRIPTION
[BUG ENT-3713](https://issues.redhat.com/browse/ENT-3713)

**NOTE: THERE WILL BE A FOLLOW ON PR THAT WILL ADD CONSTRAINTS TO THE tally_snapshots TABLE AND TO CLEAN UP EXISTING DUPLICATE DATA. THIS PR WILL AT LEAST STOP THE BLEEDING.**

Roll hourly snapshots based on date range of calculations

Duplicate snapshots were getting created when events were processed
and snapshots were rolled due to date ranges.

Given that the date range can be modified when the calculations are
being done, use the range provided by the resulting calculations so
we are sure that the entire range is covered.

## Test
Start with a fresh database and ensure you have prometheus server available.

```bash
$ dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```

**From the 'develop' branch**
Deploy the app
```bash
$ OPENSHIFT_BILLING_MODEL_FILTER='' DEV_MODE=true PROM_URL="http://localhost:8082/api/v1" ./gradlew clean bootRun
```

Pull in some events from prometheus metrics
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=openshiftJmxBean,type=OpenShiftJmxBean","operation":"performCustomOpenshiftMeteringForAccount(java.lang.String, java.lang.String, java.lang.Integer)","arguments":["6661312", null, 50000]}'
```

Generate the snapshots for the account a few times.
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6661312", "2021-03-30T13:00:00Z", "2021-04-01T13:00:00Z"]}'

$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6661312", "2021-03-30T13:00:00Z", "2021-04-01T13:00:00Z"]}'

$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6661312", "2021-03-30T13:00:00Z", "2021-04-01T13:00:00Z"]}'

$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6661312", "2021-03-30T13:00:00Z", "2021-04-01T13:00:00Z"]}'
```

Check the database to see the duplicate snapshots. Each hour will have an entry for each time you ran the tally.
```sql
rhsm-subscriptions=# select s.id, s.account_number, s.snapshot_date, s.usage, s.sla, s.granularity, m.* from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.account_number = '6661312' and s.granularity='HOURLY' and EXTRACT(MONTH from s.snapshot_date) = 3 and s.sla='_ANY' and s.usage='_ANY' and s.product_id='OpenShift-metrics' and measurement_type='TOTAL' order by snapshot_date;
                  id                  | account_number |     snapshot_date      | usage | sla  | granularity |             snapshot_id              | measurement_type |  uom  |       value        
--------------------------------------+----------------+------------------------+-------+------+-------------+--------------------------------------+------------------+-------+--------------------
 414111d9-deb1-41e7-831f-95b7ca74ae8e | 6661312        | 2021-03-21 21:00:00-03 | _ANY  | _ANY | HOURLY      | 414111d9-deb1-41e7-831f-95b7ca74ae8e | TOTAL            | CORES | 33.230769230769226
 84cddac8-8353-4a39-92a8-aed677ce6360 | 6661312        | 2021-03-21 21:00:00-03 | _ANY  | _ANY | HOURLY      | 84cddac8-8353-4a39-92a8-aed677ce6360 | TOTAL            | CORES | 33.230769230769226
 06b367d1-1f01-45a2-a7ac-671de651ba9e | 6661312        | 2021-03-21 21:00:00-03 | _ANY  | _ANY | HOURLY      | 06b367d1-1f01-45a2-a7ac-671de651ba9e | TOTAL            | CORES | 33.230769230769226
 b91d1a26-256d-4163-8408-3ea0c60616a4 | 6661312        | 2021-03-21 21:00:00-03 | _ANY  | _ANY | HOURLY      | b91d1a26-256d-4163-8408-3ea0c60616a4 | TOTAL            | CORES | 33.230769230769226
 89d6ee6c-dff6-4330-aa58-3c50ff0e02db | 6661312        | 2021-03-21 22:00:00-03 | _ANY  | _ANY | HOURLY      | 89d6ee6c-dff6-4330-aa58-3c50ff0e02db | TOTAL            | CORES |                 36
 515669a7-b9a5-48da-90c6-4eb424fc6056 | 6661312        | 2021-03-21 22:00:00-03 | _ANY  | _ANY | HOURLY      | 515669a7-b9a5-48da-90c6-4eb424fc6056 | TOTAL            | CORES |                 36
 36559287-0ff7-4969-954b-a3b2536f6b14 | 6661312        | 2021-03-21 22:00:00-03 | _ANY  | _ANY | HOURLY      | 36559287-0ff7-4969-954b-a3b2536f6b14 | TOTAL            | CORES |                 36
 28ded4c7-59fd-41aa-978c-076d2b52413d | 6661312        | 2021-03-21 22:00:00-03 | _ANY  | _ANY | HOURLY      | 28ded4c7-59fd-41aa-978c-076d2b52413d | TOTAL            | CORES |                 36
 4473e830-b26d-4045-965e-c53ff9bedb28 | 6661312        | 2021-03-21 23:00:00-03 | _ANY  | _ANY | HOURLY      | 4473e830-b26d-4045-965e-c53ff9bedb28 | TOTAL            | CORES |                 36
 ee18af66-4d5a-4cfe-9e5a-5dbf90f88c9b | 6661312        | 2021-03-21 23:00:00-03 | _ANY  | _ANY | HOURLY      | ee18af66-4d5a-4cfe-9e5a-5dbf90f88c9b | TOTAL            | CORES |                 36

-- snip --
```

Clean the database
```sql
TRUNCATE tally_snapshots CASCADE;
```

**DEPLOY THIS BRANCH**
Kick off the tally as you did above (multiple times) and verify in the database with the same query that there are no longer duplicates generated.

```sql
rhsm-subscriptions=# select s.id, s.account_number, s.snapshot_date, s.usage, s.sla, s.granularity, m.* from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.account_number = '6661312' and s.granularity='HOURLY' and EXTRACT(MONTH from s.snapshot_date) = 3 and s.sla='_ANY' and s.usage='_ANY' and s.product_id='OpenShift-metrics' and measurement_type='TOTAL' order by snapshot_date;
                  id                  | account_number |     snapshot_date      | usage | sla  | granularity |             snapshot_id              | measurement_type |  uom  |       value        
--------------------------------------+----------------+------------------------+-------+------+-------------+--------------------------------------+------------------+-------+--------------------
 884aa60c-7e08-4f79-8e0c-85ce978c7ddc | 6661312        | 2021-03-21 21:00:00-03 | _ANY  | _ANY | HOURLY      | 884aa60c-7e08-4f79-8e0c-85ce978c7ddc | TOTAL            | CORES | 33.230769230769226
 be0864b7-d6b3-4425-9bf7-e0e63fe89ec0 | 6661312        | 2021-03-21 22:00:00-03 | _ANY  | _ANY | HOURLY      | be0864b7-d6b3-4425-9bf7-e0e63fe89ec0 | TOTAL            | CORES |                 36
 f748956b-c48a-4a91-a49f-bea484208800 | 6661312        | 2021-03-21 23:00:00-03 | _ANY  | _ANY | HOURLY      | f748956b-c48a-4a91-a49f-bea484208800 | TOTAL            | CORES |                 36
 8fd8684d-8f13-4e70-a65c-adedcc558b33 | 6661312        | 2021-03-22 00:00:00-03 | _ANY  | _ANY | HOURLY      | 8fd8684d-8f13-4e70-a65c-adedcc558b33 | TOTAL            | CORES |                 36
 b3c61330-afe6-4a18-a7e7-bb179b5f2888 | 6661312        | 2021-03-22 01:00:00-03 | _ANY  | _ANY | HOURLY      | b3c61330-afe6-4a18-a7e7-bb179b5f2888 | TOTAL            | CORES |                 36
 dee55d40-8437-4d14-8b3e-5706432dc364 | 6661312        | 2021-03-22 02:00:00-03 | _ANY  | _ANY | HOURLY      | dee55d40-8437-4d14-8b3e-5706432dc364 | TOTAL            | CORES |                 36
 8eb1ffca-8c26-4e14-bb7f-7add73f5213c | 6661312        | 2021-03-22 03:00:00-03 | _ANY  | _ANY | HOURLY      | 8eb1ffca-8c26-4e14-bb7f-7add73f5213c | TOTAL            | CORES |                 36

-- snip --
```
