### PR TITLE
Bump splunk forwarder memory limits

### DIFF
--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -44,7 +44,7 @@ parameters:
   - name: SPLUNK_FORWARDER_MEMORY_REQUEST
     value: 128Mi
   - name: SPLUNK_FORWARDER_MEMORY_LIMIT
-    value: 150Mi
+    value: 256Mi
   - name: SPLUNK_FORWARDER_CPU_REQUEST
     value: 50m
   - name: SPLUNK_FORWARDER_CPU_LIMIT

--- a/templates/metrics-worker.yml
+++ b/templates/metrics-worker.yml
@@ -44,7 +44,7 @@ parameters:
   - name: SPLUNK_FORWARDER_MEMORY_REQUEST
     value: 128Mi
   - name: SPLUNK_FORWARDER_MEMORY_LIMIT
-    value: 150Mi
+    value: 256Mi
   - name: SPLUNK_FORWARDER_CPU_REQUEST
     value: 50m
   - name: SPLUNK_FORWARDER_CPU_LIMIT


### PR DESCRIPTION
Noticed that the metrics-worker and marketplace-worker have had the splunk forwarder crashing with OOM in our staging environment.

Not pressing. I'll manually override these in stage in short-term.