### PR TITLE
ENT-3713: [Part 2/2] Add constraints to tally_snapshots table

### DIFF
--- a/src/main/resources/liquibase/202104051823-add-constraints-to-tally-snapshots.xml
+++ b/src/main/resources/liquibase/202104051823-add-constraints-to-tally-snapshots.xml
@@ -1,0 +1,32 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202104051823-1" author="mstead">
+        <comment>Remove hourly snapshots from products that should not have them.</comment>
+        <sql dbms="postgresql">
+            delete from tally_snapshots where product_id not like 'OpenShift-%' and granularity = 'HOURLY';
+        </sql>
+    </changeSet>
+
+    <changeSet id="202104051823-2" author="mstead">
+        <comment>Remove duplicate snapshots from database.</comment>
+        <sql dbms="postgresql">
+            with to_keep as (
+                select id,rn from (select id, ROW_NUMBER() over
+                (partition by product_id, account_number, granularity, owner_id, snapshot_date, usage, sla, unit_of_measure) rn
+                from tally_snapshots) tmp
+            )
+            delete from tally_snapshots where id in (select id from to_keep where to_keep.rn > 1);
+        </sql>
+    </changeSet>
+
+    <changeSet id="202104051823-3" author="mstead">
+        <comment>Add constraints to tally_snapshots to prevent duplicates.</comment>
+        <addUniqueConstraint constraintName="tally_snapshot_unique_constraint" tableName="tally_snapshots"
+          columnNames="product_id, account_number, granularity, owner_id, snapshot_date, usage, sla, unit_of_measure"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -44,5 +44,6 @@
     <include file="liquibase/202102261751-add-marketplace-subscription-id.xml" />
     <include file="liquibase/202103031601-modify-hosts-instance-id-not-null.xml" />
     <include file="liquibase/202102251446-add-constraints-indexes-fields-to-events.xml" />
+    <include file="liquibase/202104051823-add-constraints-to-tally-snapshots.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
A follow on to [BUG ENT-3713](https://issues.redhat.com/browse/ENT-3713)

Added constraints to the tally_snapshots table to
prevent duplicate data. It also cleans up any duplicate
snapshots that exist in the DB due to the bug being in the
wild for a little while.

## Testing
Grab a copy of the CI database and load it into a local database. Please reach out if you are not able to get one. Some tips can be found [HERE](https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=ENT&title=RDS+Operations+and+Hints)

Make note of the total number of snapshots in the database.
```sql
-- QUERY #1
select count(*) from tally_snapshots;
```

List any duplicate snapshots and count how many other snapshots are duplicated with each. No results here and the database is in good shape.
```sql
-- QUERY #2
select * from (select  product_id, account_number, granularity, owner_id, snapshot_date, usage, sla, unit_of_measure, count(*) over (partition by product_id, account_number, granularity, owner_id, snapshot_date, usage, sla, unit_of_measure) as count from tally_snapshots) snapsWithCounts where snapsWithCounts.count > 1;
```

We had a bug where we were doing hourly tallies for all products. Take a look to see if there are any in the database. Make note of the total here.
```sql
-- QUERY #3
select count(*) from tally_snapshots where product_id  not like 'OpenShift-%' and granularity = 'HOURLY';
```

Deploy this branch. After the application loads, verify that there are no results returned from queries ```#2``` and ```#3```

## Running Tallies
Please run both tally processes to ensure that the constraints are not going to be hit on next update.

## Additional Notes
I've tested to make sure that the production database will not be affected by the cleanup queries but it would be a good idea to double check my SQL statements and for someone else to do double check my work here JUST IN CASE. 