### PR TITLE
ENT-3767: Fix HV000151 regression on capacity ingress API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/IngressResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/IngressResource.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 /**
  * Updates subscription capacity based on Candlepin pool data.
@@ -43,7 +44,7 @@ public class IngressResource implements IngressApi {
 
     @SuppressWarnings("java:S125")
     @Override
-    public void updateCapacityFromCandlepinPools(String orgId, @Valid List<CandlepinPool> pools) {
+    public void updateCapacityFromCandlepinPools(String orgId, @Valid @NotNull List<CandlepinPool> pools) {
         controller.updateCapacityForOrg(orgId, pools);
 
         //Card to address this: ENT-3573


### PR DESCRIPTION
Generated api spec appears to have added `@NonNull` that was not previously present, which broke capacity-ingress API.

I suspect this is due to a library update we did at some point.

Testing
-------

```
curl -X 'POST' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/ingress/candlepin_pools/org123' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '[
  {
    "accountNumber": "string",
    "activeSubscription": true,
    "startDate": "2021-04-13T00:27:44.588Z",
    "endDate": "2021-04-13T00:27:44.588Z",
    "quantity": 0,
    "productId": "string",
    "productAttributes": [
      {
        "name": "string",
        "value": "string"
      }
    ],
    "providedProducts": [
      {
        "productId": "string"
      }
    ],
    "derivedProvidedProducts": [
      {
        "productId": "string"
      }
    ],
    "subscriptionId": "string",
    "type": "string"
  }
]'
```

Before the change (e.g. on `develop`, response has message like:

```
javax.validation.ConstraintDeclarationException: HV000151: A method overriding another method must not redefine the parameter constraint configuration, but method IngressResource#updateCapacityFromCandlepinPools(String, List) redefines the configuration of IngressApi#updateCapacityFromCandlepinPools(String, List).
```

After the change, response will be a 204.