### PR TITLE
Fix error when user service keystore unspecified

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -127,7 +127,7 @@ rhsm-subscriptions:
     use-stub: ${USER_USE_STUB:false}
     url: https://${USER_HOST:localhost}:${USER_PORT:443}
     max-connections: ${USER_MAX_CONNECTIONS:100}
-    keystore: ${RHSM_KEYSTORE:}
+    keystore: file:${RHSM_KEYSTORE:}
     keystore-password: ${RHSM_KEYSTORE_PASSWORD:changeit}
     back-off-initial-interval: ${USER_BACK_OFF_INITIAL_INTERVAL:1s}
     back-off-max-interval: ${USER_BACK_OFF_MAX_INTERVAL:1m}


### PR DESCRIPTION
TBH, I'm unsure why this works, but the pattern was applied to
subscription service and worked there, and works repeated here...

Fixes:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Failed to bind properties under 'rhsm-subscriptions.user-service.keystore' to java.io.File:

    Property: rhsm-subscriptions.user-service.keystore
    Value: ${RHSM_KEYSTORE:}
    Origin: class path resource [application.yaml] from rhsm-subscriptions-1.0.40-SNAPSHOT.jar - 130:15
    Reason: failed to convert java.lang.String to java.io.File
```

I already deployed to our CI environment to verify.