### PR TITLE
ENT-3738: Add platform_metadata as now required by HBI

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/HostOperationMessage.java
+++ b/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/HostOperationMessage.java
@@ -20,6 +20,10 @@
  */
 package org.candlepin.subscriptions.conduit.inventory.kafka;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
 /**
  * Represents the kafka message that should be sent to the inventory service. Each message
  * should include an operation, a metadata object and a data object that will be converted
@@ -29,7 +33,7 @@ package org.candlepin.subscriptions.conduit.inventory.kafka;
  * <pre>
  *    {
  *      "operation": $SUPPORTED_OPERATION,
- *      "metadata": $M_AS_JSON_STRING,
+ *      "platform_metadata": $M_AS_JSON_STRING,
  *      "data": $D_AS_JSON_STRING
  *    }
  * </pre>
@@ -37,9 +41,11 @@ package org.candlepin.subscriptions.conduit.inventory.kafka;
  * @param <M> the type of the metadata object to be included in the JSON message.
  * @param <D> the type of the data object to be included in the JSON message.
  */
+@Data
 public abstract class HostOperationMessage<M, D> {
 
     protected String operation;
+    @JsonProperty("platform_metadata")
     protected M metadata;
     protected D data;
 
@@ -49,30 +55,6 @@ public abstract class HostOperationMessage<M, D> {
     protected HostOperationMessage(String operation, M metadata, D data) {
         this.operation = operation;
         this.metadata = metadata;
-        this.data = data;
-    }
-
-    public String getOperation() {
-        return operation;
-    }
-
-    public void setOperation(String operation) {
-        this.operation = operation;
-    }
-
-    public M getMetadata() {
-        return metadata;
-    }
-
-    public void setMetadata(M metadata) {
-        this.metadata = metadata;
-    }
-
-    public D getData() {
-        return data;
-    }
-
-    public void setData(D data) {
         this.data = data;
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryService.java
+++ b/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryService.java
@@ -37,6 +37,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * An InventoryService implementation that includes a Kafka producer that is capable
@@ -107,6 +108,7 @@ public class KafkaEnabledInventoryService extends InventoryService {
 
     private void sendToKafka(OffsetDateTime now, ConduitFacts factSet) {
         CreateUpdateHostMessage message = new CreateUpdateHostMessage(createHost(factSet, now));
+        message.setMetadata("request_id", UUID.randomUUID().toString());
         producer.send(hostIngressTopic, message).addCallback(this::recordSuccess, this::recordFailure);
     }
 


### PR DESCRIPTION
Testing
-------

Trigger the rhsm-conduit sync (stubbed API is fine).

View the messages in the Kafka topics ui at localhost:3030, observe the
new field/value.