### PR TITLE
Prefix keystore property with Spring Resource notation

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -127,7 +127,7 @@ rhsm-subscriptions:
     use-stub: ${USER_USE_STUB:false}
     url: https://${USER_HOST:localhost}:${USER_PORT:443}
     max-connections: ${USER_MAX_CONNECTIONS:100}
-    keystore: ${RHSM_KEYSTORE:}
+    keystore: file:${RHSM_KEYSTORE:}
     keystore-password: ${RHSM_KEYSTORE_PASSWORD:changeit}
     back-off-initial-interval: ${USER_BACK_OFF_INITIAL_INTERVAL:1s}
     back-off-max-interval: ${USER_BACK_OFF_MAX_INTERVAL:1m}


### PR DESCRIPTION
Really weird issue.  For some reason, unit tests fail to run for me _within IntelliJ only_ if I am missing this notation.  They work fine on the command line with or without it, but running the tests in the IDE without it fails with the error 

```
Caused by: org.springframework.core.convert.ConversionFailedException: Failed to convert from type [java.lang.String] to type [java.io.File] for value '';
```

Ideally, I think we would actually have the property in HttpClient be a string and load it ourselves as a `Resource` since that allows for things like reading stuff off the classpath or from URLs or from InputStreams in test cases.