### PR TITLE
ENT-3751: Update Rhsm API to Filter Out Billing Model

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -61,6 +61,7 @@ public class InventoryHostFacts {
     private String syspurposeSla;
     private String syspurposeUsage;
     private String syspurposeUnits;
+    private String billingModel;
     private String cloudProvider;
     private OffsetDateTime staleTimestamp;
 
@@ -69,14 +70,13 @@ public class InventoryHostFacts {
     }
 
     @SuppressWarnings("squid:S00107")
-    public InventoryHostFacts(UUID inventoryId, OffsetDateTime modifiedOn, String account,
-        String displayName, String orgId, String cores, String sockets,
-        String products, String syncTimestamp, String systemProfileInfrastructureType,
-        String systemProfileCores, String systemProfileSockets, String qpcProducts, String qpcProductIds,
-        String systemProfileProductIds, String syspurposeRole, String syspurposeSla,
-        String syspurposeUsage, String syspurposeUnits, String isVirtual, String hypervisorUuid,
-        String satelliteHypervisorUuid, String guestId, String subscriptionManagerId, String insightsId,
-        String cloudProvider, OffsetDateTime staleTimestamp) {
+    public InventoryHostFacts(UUID inventoryId, OffsetDateTime modifiedOn, String account, String displayName,
+        String orgId, String cores, String sockets, String products, String syncTimestamp,
+        String systemProfileInfrastructureType, String systemProfileCores, String systemProfileSockets,
+        String qpcProducts, String qpcProductIds, String systemProfileProductIds, String syspurposeRole,
+        String syspurposeSla, String syspurposeUsage, String syspurposeUnits, String isVirtual,
+        String hypervisorUuid, String satelliteHypervisorUuid, String guestId, String subscriptionManagerId,
+        String insightsId, String billingModel, String cloudProvider, OffsetDateTime staleTimestamp) {
         this.inventoryId = inventoryId;
         this.modifiedOn = modifiedOn;
         this.account = account;
@@ -102,6 +102,7 @@ public class InventoryHostFacts {
         this.guestId = guestId;
         this.subscriptionManagerId = subscriptionManagerId;
         this.insightsId = insightsId;
+        this.billingModel = billingModel;
         this.cloudProvider = cloudProvider;
         this.staleTimestamp = staleTimestamp;
     }


### PR DESCRIPTION
Filter out 'marketplace' billing_model from the HBI data.


# Insert HBI mock data
```sql
-- BILLING_MODEL = standard
insert into hosts( id, account, display_name, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ( '8e8a5cd2-8603-4669-8d51-4f64a4bf7f85', 'bananas123', 'grapefruit0', '{ "satellite": { "virtual_host_uuid": "hypervisor_uuid0" }, "rhsm": { "RH_PROD": [ 69 ], "BILLING_MODEL": "standard" } }', '{"subscription_manager_id":"guest0"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test' );

-- BILLING_MODEL = marketplace
insert into hosts( id, account, display_name, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ( '176949e5-5515-4d4c-ac8a-ce7366cfda67', 'bananas123', 'grapefruit1', '{ "satellite": { "virtual_host_uuid": "hypervisor_uuid1" }, "rhsm": { "RH_PROD": [ 69 ], "BILLING_MODEL": "marketplace" } }', '{"subscription_manager_id":"guest1"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test' );

-- BILLING_MODEL IS MISSING
insert into hosts( id, account, display_name, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ( '0241934c-e9b9-44c3-b349-e047d97f8d7d', 'bananas123', 'grapefruit2', '{ "satellite": { "virtual_host_uuid": "hypervisor_uuid2" }, "rhsm": { "RH_PROD": [ 69 ] } }', '{"subscription_manager_id":"guest2"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test' );

-- BILLING_MODEL = ''
insert into hosts( id, account, display_name, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ( '404c3323-c12d-4538-b3cf-420e707a3f8b', 'bananas123', 'grapefruit3', '{ "satellite": { "virtual_host_uuid": "hypervisor_uuid3" }, "rhsm": { "RH_PROD": [ 69 ], "BILLING_MODEL": "" } }', '{"subscription_manager_id":"guest3"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test' );

-- BILLING_MODEL IS NULL
insert into hosts( id, account, display_name, facts, canonical_facts, system_profile_facts, created_on, modified_on, stale_timestamp, reporter) values ( 'faea5137-358e-4dac-9c45-207654101376', 'bananas123', 'grapefruit4', '{ "satellite": { "virtual_host_uuid": "hypervisor_uuid4" }, "rhsm": { "RH_PROD": [ 69 ], "BILLING_MODEL": null } }', '{"subscription_manager_id":"guest4"}', '{"cores_per_socket":2,"number_of_sockets":2,"infrastructure_type":"virtual"}', now(), now(), now(), 'test' );
```

# Run tally for test account
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' \
  -H 'Content-Type: text/json' \
  --data-raw '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccount(java.lang.String)","arguments":["bananas123"]}' \
  --compressed
```

# Check rhsm-subscriptions.public.hosts table
```sql
SELECT display_name, * FROM hosts WHERE account_number = 'bananas123';
```
Four out of the five HBI hosts should now appear in the hosts table...the ones that didn't have a billing_model of 'marketplace' (display_name = grapefruit1)
```
+------------+------------------------------------+------------------------------------+--------------+-----------+------+------------+-----------------------+-----+-------+--------+---------------+-------------+-------------+--------------------------+-----------------+-------------+--------------+-------------+------------------------------------+
|display_name|id                                  |inventory_id                        |account_number|insights_id|org_id|display_name|subscription_manager_id|cores|sockets|is_guest|hypervisor_uuid|hardware_type|num_of_guests|last_seen                 |is_unmapped_guest|is_hypervisor|cloud_provider|instance_type|instance_id                         |
+------------+------------------------------------+------------------------------------+--------------+-----------+------+------------+-----------------------+-----+-------+--------+---------------+-------------+-------------+--------------------------+-----------------+-------------+--------------+-------------+------------------------------------+
|grapefruit0 |98dfa80b-df07-4e8f-9f94-e429e1e680de|8e8a5cd2-8603-4669-8d51-4f64a4bf7f85|bananas123    |guest11    |NULL  |grapefruit0 |NULL                   |NULL |NULL   |true    |NULL           |VIRTUALIZED  |NULL         |2021-04-14 22:30:36.617644|true             |false        |NULL          |HBI_HOST     |8e8a5cd2-8603-4669-8d51-4f64a4bf7f85|
|grapefruit2 |704009a2-804b-4272-8423-60533f19165b|0241934c-e9b9-44c3-b349-e047d97f8d7d|bananas123    |guest11    |NULL  |grapefruit2 |NULL                   |NULL |NULL   |true    |NULL           |VIRTUALIZED  |NULL         |2021-04-14 22:30:36.642580|true             |false        |NULL          |HBI_HOST     |0241934c-e9b9-44c3-b349-e047d97f8d7d|
|grapefruit3 |5c5ac5a1-931b-430d-8fbe-bd1d567d09ac|404c3323-c12d-4538-b3cf-420e707a3f8b|bananas123    |guest11    |NULL  |grapefruit3 |NULL                   |NULL |NULL   |true    |NULL           |VIRTUALIZED  |NULL         |2021-04-14 22:30:36.679592|true             |false        |NULL          |HBI_HOST     |404c3323-c12d-4538-b3cf-420e707a3f8b|
|grapefruit4 |9ee0fe46-7b37-47a8-bbfa-4cbcc54e948d|faea5137-358e-4dac-9c45-207654101376|bananas123    |guest11    |NULL  |grapefruit4 |NULL                   |NULL |NULL   |true    |NULL           |VIRTUALIZED  |NULL         |2021-04-14 22:30:36.710603|true             |false        |NULL          |HBI_HOST     |faea5137-358e-4dac-9c45-207654101376|
+------------+------------------------------------+------------------------------------+--------------+-----------+------+------------+-----------------------+-----+-------+--------+---------------+-------------+-------------+--------------------------+-----------------+-------------+--------------+-------------+------------------------------------+

```
