### PR TITLE
ENT-3736: Update API Host coreHours using queried month

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.db.model;
 
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 
 import lombok.Getter;
@@ -366,7 +367,7 @@ public class Host implements Serializable {
                 isUnmappedGuest, isHypervisor, cloudProvider, instanceId, instanceType);
     }
 
-    public org.candlepin.subscriptions.utilization.api.model.Host asTallyHostViewApiHost() {
+    public org.candlepin.subscriptions.utilization.api.model.Host asTallyHostViewApiHost(String monthId) {
         var host = new org.candlepin.subscriptions.utilization.api.model.Host();
 
         host.inventoryId(getInventoryId());
@@ -396,13 +397,12 @@ public class Host implements Serializable {
         host.measurementType(
             Objects.requireNonNullElse(measurementType, HardwareMeasurementType.PHYSICAL).toString());
 
-
         // Core Hours is currently only applicable to the OpenShift-metrics OpenShift-dedicated-metrics
         // ProductIDs, and the UI is only query the host api in one month timeframes.  If the
         // granularity of that API changes in the future, other work will have to be done first to
         // capture relationships between hosts & snapshots to derive coreHours within dynamic timeframes
 
-        host.coreHours(getMonthlyTotals().values().stream().findFirst().orElse(null));
+        host.coreHours(getMonthlyTotal(monthId, Uom.CORES));
 
         return host;
     }

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -148,7 +148,8 @@ public class HostsResource implements HostsApi {
 
             hosts = repository.findAllBy(accountNumber, productId.toString(), sanitizedSla, sanitizedUsage,
                 sanitizedDisplayNameSubstring, minCores, minSockets, month, page);
-            payload = ((Page<Host>) hosts).getContent().stream().map(Host::asTallyHostViewApiHost)
+            payload = ((Page<Host>) hosts).getContent().stream()
+                .map(h -> h.asTallyHostViewApiHost(month))
                 .collect(Collectors.toList());
         }
         else {

--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
@@ -29,6 +29,7 @@ import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
+import java.util.Set;
 import java.util.UUID;
 
 
@@ -88,6 +89,22 @@ class HostTest {
         host.clearMonthlyTotals(OffsetDateTime.parse("2021-01-01T00:00:00Z"),
             OffsetDateTime.parse("2021-02-01T00:00:00Z"));
         assertTrue(host.getMonthlyTotals().isEmpty());
+    }
+
+    @Test
+    void testAsTallyHostViewApiHostSetsMonthlyCoreHours() {
+        HostTallyBucket b1 = new HostTallyBucket();
+        b1.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+
+        Host host = new Host();
+        host.setBuckets(Set.of(b1));
+        host.addToMonthlyTotal("2021-01", Measurement.Uom.CORES, 1.0);
+        host.addToMonthlyTotal("2021-01", Measurement.Uom.CORES, 1.0);
+        host.addToMonthlyTotal("2021-02", Measurement.Uom.CORES, 2.0);
+        host.addToMonthlyTotal("2021-02", Measurement.Uom.CORES, 3.0);
+
+        assertEquals(2.0, host.asTallyHostViewApiHost("2021-01").getCoreHours());
+        assertEquals(5.0, host.asTallyHostViewApiHost("2021-02").getCoreHours());
     }
 
     private InventoryHostFacts getInventoryHostFactsFull() {

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -20,20 +20,31 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyHostView;
 import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.HostReport;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
+import org.candlepin.subscriptions.utilization.api.model.UsageType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +54,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -50,6 +62,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 @SpringBootTest
 @ActiveProfiles({"api", "test"})
@@ -85,16 +99,16 @@ class HostsResourceTest {
             HostReportSort.DISPLAY_NAME, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(0),
-            eq(0),
-            eq(PageRequest.of(0, 1, Sort.by(
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            0,
+            PageRequest.of(0, 1, Sort.by(
                 Sort.Order.asc(HostsResource.HOST_SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
-                IMPLICIT_ORDER)))
+                IMPLICIT_ORDER))
         );
     }
 
@@ -105,17 +119,17 @@ class HostsResourceTest {
             HostReportSort.CORES, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(0),
-            eq(0),
-            eq(
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            0,
+
             PageRequest.of(0, 1,
             Sort.by(Sort.Order.asc(HostsResource.HOST_SORT_PARAM_MAPPING.get(HostReportSort.CORES)),
-            IMPLICIT_ORDER)))
+            IMPLICIT_ORDER))
         );
     }
 
@@ -126,16 +140,16 @@ class HostsResourceTest {
             HostReportSort.SOCKETS, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(0),
-            eq(0),
-            eq(PageRequest.of(0, 1,
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            0,
+            PageRequest.of(0, 1,
             Sort.by(Sort.Order.asc(HostsResource.HOST_SORT_PARAM_MAPPING.get(HostReportSort.SOCKETS)),
-            IMPLICIT_ORDER)))
+            IMPLICIT_ORDER))
         );
     }
 
@@ -146,16 +160,16 @@ class HostsResourceTest {
             HostReportSort.LAST_SEEN, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(0),
-            eq(0),
-            eq(PageRequest.of(0, 1,
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            0,
+            PageRequest.of(0, 1,
             Sort.by(Sort.Order.asc(HostsResource.HOST_SORT_PARAM_MAPPING.get(HostReportSort.LAST_SEEN)),
-            IMPLICIT_ORDER)))
+            IMPLICIT_ORDER))
         );
     }
 
@@ -166,16 +180,16 @@ class HostsResourceTest {
             HostReportSort.HARDWARE_TYPE, SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(0),
-            eq(0),
-            eq(PageRequest.of(0, 1,
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            0,
+            PageRequest.of(0, 1,
             Sort.by(Sort.Order.asc(HostsResource.HOST_SORT_PARAM_MAPPING.get(HostReportSort.HARDWARE_TYPE)),
-            IMPLICIT_ORDER)))
+            IMPLICIT_ORDER))
         );
     }
 
@@ -186,14 +200,14 @@ class HostsResourceTest {
             SortDirection.ASC);
 
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(0),
-            eq(0),
-            eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            0,
+            PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))
         );
     }
 
@@ -204,16 +218,16 @@ class HostsResourceTest {
             HostReportSort.DISPLAY_NAME, null);
 
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(0),
-            eq(0),
-            eq(PageRequest.of(0, 1,
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            0,
+            PageRequest.of(0, 1,
             Sort.by(Sort.Order.asc(HostsResource.HOST_SORT_PARAM_MAPPING.get(HostReportSort.DISPLAY_NAME)),
-            IMPLICIT_ORDER)))
+            IMPLICIT_ORDER))
         );
     }
 
@@ -223,14 +237,14 @@ class HostsResourceTest {
             NULL_BEGINNING_ENDING_PARAM, NULL_BEGINNING_ENDING_PARAM,
             null, null);
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(1),
-            eq(0),
-            eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            1,
+            0,
+            PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))
         );
     }
 
@@ -241,15 +255,58 @@ class HostsResourceTest {
             null, null);
 
         verify(repository, only()).getTallyHostViews(
-            eq("account123456"),
-            eq(ProductId.RHEL.toString()),
-            eq(ServiceLevel._ANY),
-            eq(Usage._ANY),
-            eq(SANITIZED_MISSING_DISPLAY_NAME),
-            eq(0),
-            eq(1),
-            eq(PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)))
+            "account123456",
+            ProductId.RHEL.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            1,
+            PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))
         );
+    }
+
+    @Test
+    void testProperlySetsCoreHours() {
+        ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+        String may2019 = InstanceMonthlyTotalKey.formatMonthId(clock.now());
+        assertEquals("2019-05", may2019);
+
+        OffsetDateTime juneDate = clock.now().plusMonths(1L);
+        String june2019 = InstanceMonthlyTotalKey.formatMonthId(juneDate);
+        assertEquals("2019-06", june2019);
+
+        HostTallyBucket b1 = new HostTallyBucket();
+        b1.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+
+        Host host = new Host();
+        host.setBuckets(Set.of(b1));
+        host.addToMonthlyTotal(may2019, Measurement.Uom.CORES, 1.0);
+        host.addToMonthlyTotal(june2019, Measurement.Uom.CORES, 3.0);
+
+        Page page = mock(Page.class);
+        when(page.getContent()).thenReturn(List.of(host));
+
+        when(repository.findAllBy(
+            "account123456",
+            ProductId.OPENSHIFT_DEDICATED_METRICS.toString(),
+            ServiceLevel._ANY,
+            Usage._ANY,
+            SANITIZED_MISSING_DISPLAY_NAME,
+            0,
+            1,
+            june2019,
+            PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))
+        )).thenReturn(page);
+
+        HostReport hostReport = resource.getHosts(ProductId.OPENSHIFT_DEDICATED_METRICS, 0, 1,
+            ServiceLevelType._ANY, UsageType._ANY,
+            Uom.SOCKETS, null, clock.startOfMonth(juneDate), clock.endOfMonth(juneDate),
+            null, null);
+        assertEquals(1, hostReport.getData().size());
+        var hostView = hostReport.getData().get(0);
+        assertEquals(3.0, hostView.getCoreHours());
+
     }
 
     @ParameterizedTest(name = "testInvalidBeginningAndEndingDates[{index}] {arguments}")


### PR DESCRIPTION
[ENT-3736 DETAILS](https://issues.redhat.com/browse/ENT-3736)

Update the API Host's coreHours based on the the specified date
range in the request, instead of using the first monthly total
found.

## How To Test

I recommend starting with a fresh DB
```bash
$ dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```

Deploy the app now so the schema is re-created.
```bash
$ DEV_MODE=true ./gradlew clean bootRun
```

Add events spanning a month boundary.
```sql
insert into events(id, account_number, timestamp, instance_id, data) values ('033a45b7-e8c4-440a-b0bb-76c3f3f67d85','account123', '2021-03-31T22:00Z', '4e8534b5-42b5-4f00-9969-29046e2b1986', '{"account_number":"account123","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d85","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}], "timestamp": "2021-03-31T22:00Z", "role" : "osd"}');
insert into events(id, account_number, timestamp, instance_id, data) values ('033a45b7-e8c4-440a-b0bb-76c3f3f67d86','account123', '2021-03-31T23:00Z', '4e8534b5-42b5-4f00-9969-29046e2b1986', '{"account_number":"account123","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d86","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}], "timestamp": "2021-03-31T23:00Z", "role" : "osd"}');
insert into events(id, account_number, timestamp, instance_id, data) values ('a66ac2a1-17c0-4bc3-bc29-0430953d626c','account123', '2021-04-01T00:00Z', '4e8534b5-42b5-4f00-9969-29046e2b1986', '{"account_number":"account123","event_id":"a66ac2a1-17c0-4bc3-bc29-0430953d626c","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":14.0}], "timestamp": "2021-04-01T00:00Z", "role" : "osd"}');
insert into events(id, account_number, timestamp, instance_id, data) values ('fad48795-ae0a-4674-b864-822ddfb799d0','account123', '2021-04-01T01:00Z', '4e8534b5-42b5-4f00-9969-29046e2b1986', '{"account_number":"account123","event_id":"fad48795-ae0a-4674-b864-822ddfb799d0","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":100.0}], "timestamp": "2021-04-01T01:00Z", "role" : "osd"}');
```

Opt-in our test account
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["account123","123456",true,true,true]}'
```

Run an hourly tally for account123
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123", "2021-03-30T00:00Z", "2021-04-02T00:00Z"]}'
```

Get the list of hosts for the month of **March**. You should see a core_hours value of **8** based on the events we added.
```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-03-01T00:00:00.000Z&ending=2021-03-31T23:59:59.999Z" | python -mjson.tool
```

Get the list of hosts for the month of **April**. You should see a core_hours value of **114** based on the events we added.
```bash
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-04-01T00:00:00.000Z&ending=2021-04-30T23:59:59.999Z" | python -mjson.tool
```
