### PR TITLE
ENT-3706: Separate hourly tally cron job and shorten to 1 hour

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -30,6 +30,7 @@ import org.candlepin.subscriptions.retention.PurgeSnapshotsConfiguration;
 import org.candlepin.subscriptions.security.SecurityConfig;
 import org.candlepin.subscriptions.subscription.SubscriptionServiceConfiguration;
 import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
+import org.candlepin.subscriptions.tally.job.CaptureHourlySnapshotsConfiguration;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsConfiguration;
 import org.candlepin.subscriptions.user.UserServiceClientConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -62,11 +63,11 @@ import javax.validation.Validator;
 @Configuration
 @Import({
     ApiConfiguration.class, ConduitConfiguration.class, CapacityIngressConfiguration.class,
-    CaptureSnapshotsConfiguration.class, PurgeSnapshotsConfiguration.class,
-    LiquibaseUpdateOnlyConfiguration.class, TallyWorkerConfiguration.class, OrgSyncConfiguration.class,
-    MarketplaceWorkerConfiguration.class, DevModeConfiguration.class, SecurityConfig.class,
-    HawtioConfiguration.class, MeteringConfiguration.class, SubscriptionServiceConfiguration.class,
-    UserServiceClientConfiguration.class
+    CaptureSnapshotsConfiguration.class, CaptureHourlySnapshotsConfiguration.class,
+    PurgeSnapshotsConfiguration.class, LiquibaseUpdateOnlyConfiguration.class, TallyWorkerConfiguration.class,
+    OrgSyncConfiguration.class, MarketplaceWorkerConfiguration.class, DevModeConfiguration.class,
+    SecurityConfig.class, HawtioConfiguration.class, MeteringConfiguration.class,
+    SubscriptionServiceConfiguration.class, UserServiceClientConfiguration.class
 })
 public class ApplicationConfiguration implements WebMvcConfigurer {
     @Bean

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -162,9 +162,9 @@ public class ApplicationProperties {
 
     /**
      * Amount of time from current timestamp to start looking for metrics during a tally,
-     * indepedent of the prometheus latency duration
+     * independent of the prometheus latency duration
      */
-    private Duration metricLookupRangeDuration = Duration.ofHours(24L);
+    private Duration metricLookupRangeDuration = Duration.ofHours(1L);
 
     /**
      * Latency offset: how far back to set the hourly tally window.

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.jmx;
 
 import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
+import org.candlepin.subscriptions.util.DateRange;
 import org.candlepin.subscriptions.validator.ParameterDuration;
 
 import org.slf4j.Logger;
@@ -88,7 +89,8 @@ public class TallyJmxBean {
         @NotNull String endDateTime) {
         log.info("Hourly tally between {} and {} for account {} triggered over JMX by {}",
             startDateTime, endDateTime, accountNumber, ResourceUtils.getPrincipal());
-        tasks.tallyAccountByHourly(accountNumber, startDateTime, endDateTime);
+        var tallyRange = DateRange.fromStrings(startDateTime, endDateTime);
+        tasks.tallyAccountByHourly(accountNumber, tallyRange);
     }
 
     @ManagedOperation(description = "Trigger hourly tally for all configured accounts")

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobProperties.java
@@ -24,12 +24,24 @@ package org.candlepin.subscriptions.jobs;
  * Contains the configuration properties for all jobs.
  */
 public class JobProperties {
+    // Every hour on the hour
+    private String captureHourlySnapshotSchedule = "0 0 * * * ?";
 
     private String captureSnapshotSchedule = "0 5 * * * ?";
+
     // Once a day at 3am
     private String purgeSnapshotSchedule = "0 0 3 * * ?";
 
-    private String meteringSchedule = "0 0 * ? * *"; // Every hour, on the hour.
+    // Every hour, on the hour
+    private String meteringSchedule = "0 0 * * * ?";
+
+    public String getCaptureHourlySnapshotSchedule() {
+        return captureHourlySnapshotSchedule;
+    }
+
+    public void setCaptureHourlySnapshotSchedule(String captureHourlySnapshotSchedule) {
+        this.captureHourlySnapshotSchedule = captureHourlySnapshotSchedule;
+    }
 
     public String getCaptureSnapshotSchedule() {
         return captureSnapshotSchedule;

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -24,6 +24,7 @@ import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
+import org.candlepin.subscriptions.util.DateRange;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
 
 import org.slf4j.Logger;
@@ -118,13 +119,12 @@ public class TallySnapshotController {
     }
 
     @Timed("rhsm-subscriptions.snapshots.single.hourly")
-    public void produceHourlySnapshotsForAccount(String accountNumber, OffsetDateTime startDateTime,
-        OffsetDateTime endDateTime) {
+    public void produceHourlySnapshotsForAccount(String accountNumber, DateRange snapshotRange) {
         log.info("Producing hourly snapshot for account {} between startDateTime {} and endDateTime {}",
-            accountNumber, startDateTime, endDateTime);
+            accountNumber, snapshotRange.getStartString(), snapshotRange.getEndString());
         try {
             var accountCalcs = retryTemplate.execute(
-                context -> metricUsageCollector.collect(accountNumber, startDateTime, endDateTime));
+                context -> metricUsageCollector.collect(accountNumber, snapshotRange));
 
             var applicableUsageCalculations = accountCalcs.entrySet().stream()
                 .filter(TallySnapshotController::isCombiningRollupStrategySupported)

--- a/src/main/java/org/candlepin/subscriptions/tally/job/CaptureHourlySnapshotsConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/CaptureHourlySnapshotsConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.job;
+
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.candlepin.subscriptions.task.queue.TaskProducerConfiguration;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * A class to hold all job related configuration.
+ */
+@Configuration
+@Profile("capture-hourly-snapshots")
+@Import(TaskProducerConfiguration.class)
+@ComponentScan("org.candlepin.subscriptions.tally.job")
+public class CaptureHourlySnapshotsConfiguration {
+    @Bean
+    JobRunner jobRunner(CaptureHourlySnapshotsJob job, ApplicationContext applicationContext) {
+        return new JobRunner(job, applicationContext);
+    }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/job/CaptureHourlySnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/CaptureHourlySnapshotsJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,26 +27,26 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * A cron job that captures all usage snapshots on a configured schedule.
+ * A cron job that captures hourly usage snapshots on a configured schedule.
  */
 @Component
-public class CaptureSnapshotsJob implements Runnable {
+public class CaptureHourlySnapshotsJob implements Runnable {
 
     private final CaptureSnapshotsTaskManager tasks;
 
     @Autowired
-    public CaptureSnapshotsJob(CaptureSnapshotsTaskManager taskManager) {
+    public CaptureHourlySnapshotsJob(CaptureSnapshotsTaskManager taskManager) {
         this.tasks = taskManager;
     }
 
     @Override
-    @Scheduled(cron = "${rhsm-subscriptions.jobs.capture-snapshot-schedule}")
+    @Scheduled(cron = "${rhsm-subscriptions.jobs.capture-hourly-snapshot-schedule}")
     public void run() {
         try {
-            tasks.updateSnapshotsForAllAccounts();
+            tasks.updateHourlySnapshotsForAllAccounts();
         }
         catch (Exception e) {
-            throw new JobFailureException("Failed to run CaptureSnapshotsJob.", e);
+            throw new JobFailureException("Failed to run CaptureHourlySnapshotsJob.", e);
         }
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/tasks/CaptureMetricsSnapshotTask.java
@@ -22,11 +22,10 @@ package org.candlepin.subscriptions.tally.tasks;
 
 import org.candlepin.subscriptions.tally.TallySnapshotController;
 import org.candlepin.subscriptions.task.Task;
+import org.candlepin.subscriptions.util.DateRange;
 import org.candlepin.subscriptions.validator.ParameterDuration;
 
 import org.springframework.validation.annotation.Validated;
-
-import java.time.OffsetDateTime;
 
 /**
  * Captures hourly metrics between a given timeframe for a given account
@@ -36,23 +35,19 @@ public class CaptureMetricsSnapshotTask implements Task {
 
     private final String accountNumber;
     private final TallySnapshotController snapshotController;
-    private final String startDateTime;
-    private final String endDateTime;
+    private final DateRange dateRange;
 
     @ParameterDuration("@jmxProperties.tallyBean.hourlyTallyDurationLimitDays")
     public CaptureMetricsSnapshotTask(TallySnapshotController snapshotController, String accountNumber,
         String startDateTime, String endDateTime) {
         this.snapshotController = snapshotController;
         this.accountNumber = accountNumber;
-        this.startDateTime = startDateTime;
-        this.endDateTime = endDateTime;
+        this.dateRange = DateRange.fromStrings(startDateTime, endDateTime);
 
     }
 
     @Override
     public void execute() {
-        OffsetDateTime startDate = OffsetDateTime.parse(startDateTime);
-        OffsetDateTime endDate = OffsetDateTime.parse(endDateTime);
-        snapshotController.produceHourlySnapshotsForAccount(accountNumber, startDate, endDate);
+        snapshotController.produceHourlySnapshotsForAccount(accountNumber, dateRange);
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -235,4 +235,8 @@ public class ApplicationClock {
         return startDateTime.isEqual(startOfHour(startDateTime)) &&
             endDateTime.isEqual(startOfHour(endDateTime));
     }
+
+    public boolean isHourlyRange(DateRange dateRange) {
+        return isHourlyRange(dateRange.getStartDate(), dateRange.getEndDate());
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/util/DateRange.java
+++ b/src/main/java/org/candlepin/subscriptions/util/DateRange.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -41,6 +42,33 @@ public class DateRange {
         verifyRange(startDate, endDate);
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+    /**
+     * Create a DateRange object from a set of strings formatted in the ISO Offset Date Time format as seen
+     * in {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME}
+     * @param start a string with the start date
+     * @param end a string with the end date
+     * @return a DateRange object spanning the start and end
+     */
+    public static DateRange fromStrings(String start, String end) {
+        return fromStrings(start, end, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    /**
+     * Create a DateRange object from a set of strings formatted using the provided DateTimeFormatter.
+     * Note that the strings will be parsed with
+     * {@link OffsetDateTime#parse(CharSequence, DateTimeFormatter)} so a compatible formatter is required
+     * to avoid runtime exceptions.
+     * @param start a string with the start date
+     * @param end a string with the end date
+     * @param formatter a DateTimeFormatter compatible with OffsetDateTime
+     * @return a DateRange object spanning the start and end
+     */
+    public static DateRange fromStrings(String start, String end, DateTimeFormatter formatter) {
+        var startDateTime = OffsetDateTime.parse(start, formatter);
+        var endDateTime = OffsetDateTime.parse(end, formatter);
+        return new DateRange(startDateTime, endDateTime);
     }
 
     /**
@@ -69,5 +97,13 @@ public class DateRange {
         if (!start.equals(end) && start.isAfter(end)) {
             throw new IllegalArgumentException("Start date must be before end date!");
         }
+    }
+
+    public String getStartString() {
+        return startDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    public String getEndString() {
+        return endDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -87,6 +87,7 @@ rhsm-subscriptions:
       connection-timeout: ${DATABASE_CONNECTION_TIMEOUT_MS:30000}
       maximum-pool-size: ${DATABASE_MAX_POOL_SIZE:10}
   jobs:
+    capture-hourly-snapshot-schedule: ${CAPTURE_HOURLY_SNAPSHOT_SCHEDULE:0 0 * * * ?}
     capture-snapshot-schedule: ${CAPTURE_SNAPSHOT_SCHEDULE:0 0 1 * * ?}
     purge-snapshot-schedule: ${PURGE_SNAPSHOT_SCHEDULE:0 0 1 * * ?}
     metering:

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -42,6 +42,7 @@ import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Event.Role;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.util.DateRange;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -401,7 +402,8 @@ class MetricUsageCollectorTest {
                 return Stream.of();
             });
 
-        metricUsageCollector.collect("account123", instanceDate.minusHours(1), instanceDate.plusHours(1));
+        metricUsageCollector.collect("account123", new DateRange(instanceDate.minusHours(1),
+            instanceDate.plusHours(1)));
         assertEquals(Double.valueOf(42.0), activeInstance.getMonthlyTotal(monthId, Measurement.Uom.CORES));
     }
 
@@ -446,17 +448,15 @@ class MetricUsageCollectorTest {
                 return Stream.of();
             });
 
-        metricUsageCollector.collect("account123", instanceDate.minusHours(1), instanceDate.plusHours(1));
+        metricUsageCollector.collect("account123", new DateRange(instanceDate.minusHours(1),
+            instanceDate.plusHours(1)));
         assertEquals(Double.valueOf(42.0), activeInstance.getMonthlyTotal(monthId, Measurement.Uom.CORES));
         assertNull(staleInstance.getMonthlyTotal(monthId, Measurement.Uom.CORES));
     }
 
     @Test
     void collectionThrowsExceptionWhenDateRangeIsNotRounded() {
-        OffsetDateTime start = clock.startOfCurrentHour();
-        OffsetDateTime end = clock.now();
-
-        assertThrows(IllegalArgumentException.class,
-            () -> metricUsageCollector.collect("account123", start, end));
+        DateRange range = new DateRange(clock.startOfCurrentHour(), clock.now());
+        assertThrows(IllegalArgumentException.class, () -> metricUsageCollector.collect("account123", range));
     }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
@@ -175,8 +175,8 @@ class CaptureSnapshotsTaskManagerTest {
                 .setSingleValuedArg("accountNumber", accountNumber)
                 // 2019-05-24T12:35Z truncated to top of the hour - 4 hours prometheus latency - 1 hour
                 // tally latency - 24 hour metric range
-                .setSingleValuedArg("startDateTime", "2019-05-23T07:00Z")
-                .setSingleValuedArg("endDateTime", "2019-05-24T07:00Z")
+                .setSingleValuedArg("startDateTime", "2019-05-23T07:00:00Z")
+                .setSingleValuedArg("endDateTime", "2019-05-24T07:00:00Z")
                 .build());
         });
     }

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -19,6 +19,8 @@ parameters:
     value: 0 3 * * *
   - name: CAPTURE_SNAPSHOT_SCHEDULE
     value: 0 1 * * *
+  - name: CAPTURE_HOURLY_SNAPSHOT_SCHEDULE
+    value: 0 0 * * *
   - name: OPENSHIFT_METERING_SCHEDULE
     value: 0 * * * *
   - name: OPENSHIFT_METERING_RANGE
@@ -269,7 +271,90 @@ objects:
                     limits:
                       cpu: ${CPU_LIMIT}
                       memory: ${MEMORY_LIMIT}
-
+  - apiVersion: batch/v1beta1
+    kind: CronJob
+    metadata:
+      name: rhsm-subscriptions-cron-hourly-tally
+    spec:
+      schedule: ${CAPTURE_HOURLY_SNAPSHOT_SCHEDULE}
+      jobTemplate:
+        spec:
+          activeDeadlineSeconds: 1800
+          template:
+            spec:
+              activeDeadlineSeconds: 1800
+              restartPolicy: Never
+              imagePullSecrets:
+                - name: ${IMAGE_PULL_SECRET}
+                - name: quay-cloudservices-pull
+              containers:
+                - image: ${IMAGE}:${IMAGE_TAG}
+                  name: rhsm-subscriptions-cron-hourly-tally
+                  env:
+                    - name: SPRING_PROFILES_ACTIVE
+                      value: capture-hourly-snapshots,kafka-queue
+                    - name: JAVA_MAX_MEM_RATIO
+                      value: '85'
+                    - name: GC_MAX_METASPACE_SIZE
+                      value: '256'
+                    - name: LOGGING_LEVEL_ROOT
+                      value: ${LOGGING_LEVEL_ROOT}
+                    - name: LOGGING_LEVEL_ORG_CANDLEPIN
+                      value: ${LOGGING_LEVEL}
+                    - name: KAFKA_BOOTSTRAP_HOST
+                      value: ${KAFKA_BOOTSTRAP_HOST}
+                    - name: DATABASE_HOST
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.host
+                    - name: DATABASE_PORT
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.port
+                    - name: DATABASE_USERNAME
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.user
+                    - name: DATABASE_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.password
+                    - name: DATABASE_DATABASE
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.name
+                    - name: INVENTORY_DATABASE_HOST
+                      valueFrom:
+                        secretKeyRef:
+                          name: host-inventory-db-readonly
+                          key: db.host
+                    - name: INVENTORY_DATABASE_DATABASE
+                      valueFrom:
+                        secretKeyRef:
+                          name: host-inventory-db-readonly
+                          key: db.name
+                    - name: INVENTORY_DATABASE_USERNAME
+                      valueFrom:
+                        secretKeyRef:
+                          name: host-inventory-db-readonly
+                          key: db.user
+                    - name: INVENTORY_DATABASE_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: host-inventory-db-readonly
+                          key: db.password
+                  resources:
+                    requests:
+                      cpu: ${CPU_REQUEST}
+                      memory: ${MEMORY_REQUEST}
+                    limits:
+                      cpu: ${CPU_LIMIT}
+                      memory: ${MEMORY_LIMIT}
   - apiVersion: batch/v1beta1
     kind: CronJob
     metadata:


### PR DESCRIPTION
Marketplace is expecting to be receiving payloads hourly so this patch
sets the metric range duration property to one hour.