### PR TITLE
ENT-3339: Implement EventPurger

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -72,4 +72,10 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
      */
     Stream<EventRecord> findByAccountNumberAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
         String accountNumber, String eventSource, String eventType, OffsetDateTime begin, OffsetDateTime end);
+
+    /**
+     * Delete old event records given a cutoff date
+     * @param cutoffDate Dates BEFORE this timestamp get deleted
+     */
+    void deleteEventRecordsByTimestampBefore(OffsetDateTime cutoffDate);
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
@@ -24,6 +24,10 @@ import org.candlepin.subscriptions.json.Event;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -42,10 +46,10 @@ import javax.validation.Valid;
  */
 @Entity
 @Table(name = "events")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class EventRecord {
-    public EventRecord() {
-        /* intentionally empty */
-    }
 
     /**
      * Create a new EventRecord from a given Event.

--- a/src/main/java/org/candlepin/subscriptions/jobs/JobProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/jobs/JobProperties.java
@@ -20,9 +20,14 @@
  */
 package org.candlepin.subscriptions.jobs;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Contains the configuration properties for all jobs.
  */
+@Getter
+@Setter
 public class JobProperties {
 
     private String captureSnapshotSchedule = "0 5 * * * ?";
@@ -31,28 +36,5 @@ public class JobProperties {
 
     private String meteringSchedule = "0 0 * ? * *"; // Every hour, on the hour.
 
-    public String getCaptureSnapshotSchedule() {
-        return captureSnapshotSchedule;
-    }
-
-    public void setCaptureSnapshotSchedule(String captureSnapshotSchedule) {
-        this.captureSnapshotSchedule = captureSnapshotSchedule;
-    }
-
-    public String getPurgeSnapshotSchedule() {
-        return purgeSnapshotSchedule;
-    }
-
-    public void setPurgeSnapshotSchedule(String purgeSnapshotSchedule) {
-        this.purgeSnapshotSchedule = purgeSnapshotSchedule;
-    }
-
-    public String getMeteringSchedule() {
-        return meteringSchedule;
-    }
-
-    public void setMeteringSchedule(String meteringSchedule) {
-        this.meteringSchedule = meteringSchedule;
-    }
 
 }

--- a/src/main/java/org/candlepin/subscriptions/retention/EventRecordsRetentionProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/EventRecordsRetentionProperties.java
@@ -18,21 +18,20 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.metering.service.prometheus;
+package org.candlepin.subscriptions.retention;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
 import lombok.Getter;
 import lombok.Setter;
 
-/**
- * Properties related to all metrics that are to be gathered from the prometheus service.
- */
+import java.time.Duration;
+
 @Getter
 @Setter
-@ConfigurationProperties(prefix = "rhsm-subscriptions.metering.prometheus.metric")
-public class PrometheusMetricsProperties {
-
-    private MetricProperties openshift = new MetricProperties();
-
+@Component
+@ConfigurationProperties(prefix = "rhsm-subscriptions.event-retention-policy")
+public class EventRecordsRetentionProperties {
+    private Duration eventRetentionDuration = Duration.ofDays(90L);
 }

--- a/src/main/java/org/candlepin/subscriptions/retention/PurgeEventRecordsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/PurgeEventRecordsJob.java
@@ -18,21 +18,32 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.metering.service.prometheus;
+package org.candlepin.subscriptions.retention;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
-import lombok.Getter;
-import lombok.Setter;
+@Component
+public class PurgeEventRecordsJob implements Runnable {
 
-/**
- * Properties related to all metrics that are to be gathered from the prometheus service.
- */
-@Getter
-@Setter
-@ConfigurationProperties(prefix = "rhsm-subscriptions.metering.prometheus.metric")
-public class PrometheusMetricsProperties {
+    private static final Logger log = LoggerFactory.getLogger(PurgeEventRecordsJob.class);
 
-    private MetricProperties openshift = new MetricProperties();
+    private final TallyRetentionController retentionController;
 
+    public PurgeEventRecordsJob(TallyRetentionController retentionController) {
+        this.retentionController = retentionController;
+    }
+
+    @Override
+    @Scheduled(cron = "${rhsm-subscriptions.jobs.purge-snapshot-schedule}")
+    public void run() {
+        log.info("Starting PurgeEventRecordsJob job.");
+
+        retentionController.purgeOldEventRecords();
+
+        log.info("PurgeEventRecordsJob complete.");
+
+    }
 }

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
@@ -21,14 +21,20 @@
 package org.candlepin.subscriptions.retention;
 
 import org.candlepin.subscriptions.db.AccountListSource;
+import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
 
@@ -37,16 +43,23 @@ import java.util.stream.Stream;
  */
 @Component
 public class TallyRetentionController {
+    private static final Logger log = LoggerFactory.getLogger(TallyRetentionController.class);
 
-    private final TallySnapshotRepository repository;
+    private final TallySnapshotRepository tallySnapshotRepository;
+    private final EventRecordRepository eventRecordRepository;
     private final TallyRetentionPolicy policy;
-
+    private final EventRecordsRetentionProperties eventRecordsRetentionProperties;
     private final AccountListSource accountListSource;
 
-    public TallyRetentionController(TallySnapshotRepository repository, TallyRetentionPolicy policy,
+    @Autowired
+    public TallyRetentionController(TallySnapshotRepository tallySnapshotRepository,
+        EventRecordRepository eventRecordRepository, TallyRetentionPolicy policy,
+        EventRecordsRetentionProperties eventRecordsRetentionProperties,
         AccountListSource accountListSource) {
-        this.repository = repository;
+        this.tallySnapshotRepository = tallySnapshotRepository;
+        this.eventRecordRepository = eventRecordRepository;
         this.policy = policy;
+        this.eventRecordsRetentionProperties = eventRecordsRetentionProperties;
         this.accountListSource = accountListSource;
     }
 
@@ -63,8 +76,19 @@ public class TallyRetentionController {
             if (cutoffDate == null) {
                 continue;
             }
-            repository.deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(accountNumber,
+            tallySnapshotRepository.deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(accountNumber,
                 granularity, cutoffDate);
         }
+    }
+
+    public void purgeOldEventRecords() {
+        Duration eventRetentionDuration = eventRecordsRetentionProperties.getEventRetentionDuration();
+
+        OffsetDateTime cutoffDate = OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS)
+            .minus(eventRetentionDuration);
+
+        log.info("Purging event records older than Duration {}", cutoffDate);
+
+        eventRecordRepository.deleteEventRecordsByTimestampBefore(cutoffDate);
     }
 }

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
@@ -82,7 +82,7 @@ public class TallyRetentionController {
     }
 
     public void purgeOldEventRecords() {
-        Duration eventRetentionDuration = eventRecordsRetentionProperties.getEventRetentionDuration();
+        var eventRetentionDuration = eventRecordsRetentionProperties.getEventRetentionDuration();
 
         OffsetDateTime cutoffDate = OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS)
             .minus(eventRetentionDuration);

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;

--- a/src/main/resources/application-purge-snapshots.yaml
+++ b/src/main/resources/application-purge-snapshots.yaml
@@ -1,18 +1,14 @@
 rhsm-subscriptions:
+  event-retention-policy.eventRetentionDuration: ${EVENT_RECORD_RETENTION:90d}
   tally-retention-policy:
     # 70 days worth
     hourly: ${TALLY_RETENTION_HOURLY:1680}
-
     # A year and change
     daily: ${TALLY_RETENTION_DAILY:370}
-
     # Roughly 3 months worth
     weekly: ${TALLY_RETENTION_WEEKLY:12}
-
     # A year's worth
     monthly: ${TALLY_RETENTION_MONTHLY:12}
-
     # Four year's worth
     quarterly: ${TALLY_RETENTION_QUARTERLY:16}
-
     yearly: ${TALLY_RETENTION_YEARLY:5}

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -149,6 +149,25 @@ class EventRecordRepositoryTest {
         assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(e2));
     }
 
+    @Test
+    void testDeleteByTimestamp() {
+        var now = OffsetDateTime.now();
+
+        EventRecord event = EventRecord.builder().id(UUID.randomUUID()).accountNumber("bananas1")
+            .timestamp(now.minusDays(91L)).build();
+        EventRecord event2 = EventRecord.builder().id(UUID.randomUUID()).accountNumber("bananas1")
+            .timestamp(now.minusDays(1L)).build();
+
+        repository.saveAll(List.of(event, event2));
+
+        repository.deleteEventRecordsByTimestampBefore(now.minusDays(30L));
+
+        var results = repository.findAll();
+
+        assertEquals(1, results.size());
+
+    }
+
     private Event event(String account, String source, String type, String instanceId, OffsetDateTime time) {
         UUID eventId = UUID.randomUUID();
         Event event = new Event();

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -21,6 +21,8 @@ parameters:
     value: 0 1 * * *
   - name: OPENSHIFT_METERING_SCHEDULE
     value: 0 * * * *
+  - name: EVENT_RECORD_RETENTION
+    value: 90d
   - name: OPENSHIFT_METERING_RANGE
     value: '60'
   - name: IMAGE
@@ -302,6 +304,8 @@ objects:
                       value: ${LOGGING_LEVEL}
                     - name: KAFKA_BOOTSTRAP_HOST
                       value: ${KAFKA_BOOTSTRAP_HOST}
+                    - name: EVENT_RECORD_RETENTION
+                    - value: ${EVENT_RECORD_RETENTION}
                     - name: DATABASE_HOST
                       valueFrom:
                         secretKeyRef:


### PR DESCRIPTION
- Have events in rhsm-subscriptions.events table
Purge EventRecord entries on the same schedule as the PurgeSnapshotsJob


- Pick a duration for how far back you want to purge events and set rhsm-subscriptions.metering.prometheus.metric.eventRetentionDuration
- Change the cron schedule for rhsm-subscriptions.jobs.purge-snapshot-schedule so the job gets ran
- After a cycle of the job completes (log statements in the console), check your events table and confirm that expected  events were deleted