### PR TITLE
ENT-3791: Fix InventoryHostFacts constructor param ordering

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -74,9 +74,10 @@ public class InventoryHostFacts {
         String orgId, String cores, String sockets, String products, String syncTimestamp,
         String systemProfileInfrastructureType, String systemProfileCores, String systemProfileSockets,
         String qpcProducts, String qpcProductIds, String systemProfileProductIds, String syspurposeRole,
-        String syspurposeSla, String syspurposeUsage, String syspurposeUnits, String isVirtual,
-        String hypervisorUuid, String satelliteHypervisorUuid, String guestId, String subscriptionManagerId,
-        String insightsId, String billingModel, String cloudProvider, OffsetDateTime staleTimestamp) {
+        String syspurposeSla, String syspurposeUsage, String syspurposeUnits,
+        String billingModel, String isVirtual, String hypervisorUuid, String satelliteHypervisorUuid,
+        String guestId, String subscriptionManagerId, String insightsId, String cloudProvider,
+        OffsetDateTime staleTimestamp) {
         this.inventoryId = inventoryId;
         this.modifiedOn = modifiedOn;
         this.account = account;


### PR DESCRIPTION
We got the params out of order when adding billing model. Doh!

Testing
-------

Insert some data into the HBI hosts table locally:

```sql
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter) VALUES ('4137e66e-2ff4-4cb5-9068-395c7db7f3a7', '6661312', '4137e66e-2ff4-4cb5-9068-395c7db7f3a7', '2021-04-17 13:39:51.414184', '2021-04-18 00:31:37.741987', '{"rhsm": {"orgId": "13259775", "RH_PROD": [], "CPU_SOCKETS": 1, "SYNC_TIMESTAMP": "2021-04-18T00:31:37.632438Z", "SYSPURPOSE_ADDONS": []}}', '{}', '{"bios_uuid": "59052905-eda0-4b29-8fa9-e58376de29d7", "subscription_manager_id": "6221b689-d5df-4342-ada5-194028699ea0"}', '{"owner_id": "6221b689-d5df-4342-ada5-194028699ea0", "number_of_sockets": 1}', null, '2021-04-20 00:31:37.632438', 'rhsm-conduit');
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter) VALUES ('2b3399e7-0bd4-49de-9ee3-e71cb20f953e', '6661312', '2b3399e7-0bd4-49de-9ee3-e71cb20f953e', '2021-04-17 13:34:57.181373', '2021-04-18 00:31:37.726189', '{"rhsm": {"orgId": "13259775", "RH_PROD": [], "CPU_SOCKETS": 1, "SYNC_TIMESTAMP": "2021-04-18T00:31:37.631983Z", "SYSPURPOSE_ADDONS": []}}', '{}', '{"bios_uuid": "6cbf76b5-6fdd-423b-81ad-2f75359c0ef1", "subscription_manager_id": "31060444-5d9b-44a0-a95f-5a7e1125f9aa"}', '{"owner_id": "31060444-5d9b-44a0-a95f-5a7e1125f9aa", "number_of_sockets": 1}', null, '2021-04-20 00:31:37.631983', 'rhsm-conduit');
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter) VALUES ('67beff5b-7c43-4f53-8efc-b765cda421cc', '6661312', 'virtual_ggesbmji.test.com', '2021-04-17 13:39:51.372991', '2021-04-18 00:31:37.709838', '{"rhsm": {"orgId": "13259775", "MEMORY": 1, "RH_PROD": ["69"], "VM_HOST": "ghkmznbx.hypervisorfakeswatch.com", "GUEST_ID": "f3d8c2e8-775f-4f88-9ddf-5b160940165b", "CPU_CORES": 1, "IS_VIRTUAL": true, "CPU_SOCKETS": 1, "ARCHITECTURE": "x86_64", "VM_HOST_UUID": "6221b689-d5df-4342-ada5-194028699ea0", "SYNC_TIMESTAMP": "2021-04-18T00:31:37.631509Z", "SYSPURPOSE_ADDONS": []}}', '{}', '{"fqdn": "virtual_ggesbmji.test.com", "bios_uuid": "f3d8c2e8-775f-4f88-9ddf-5b160940165b", "insights_id": "e587b289-7db1-4d3a-b068-d8675e98c889", "subscription_manager_id": "c0444f3e-db3f-4fd5-a6a0-566d17a3f561"}', '{"arch": "x86_64", "owner_id": "c0444f3e-db3f-4fd5-a6a0-566d17a3f561", "cores_per_socket": 1, "number_of_sockets": 1, "infrastructure_type": "virtual", "system_memory_bytes": 39936}', null, '2021-04-20 00:31:37.631509', 'rhsm-conduit');
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter) VALUES ('161e22c1-53f2-440e-8c1b-dd5c6f04c9c9', '6661312', 'virtual_imdbmhce.example.biz', '2021-04-17 13:34:57.162090', '2021-04-18 00:31:37.693366', '{"rhsm": {"orgId": "13259775", "MEMORY": 1, "RH_PROD": ["69"], "VM_HOST": "tbktehpn.hypervisorfakeswatch.info", "GUEST_ID": "e7cd6fda-d6e9-4b38-bd62-75815a747146", "CPU_CORES": 1, "IS_VIRTUAL": true, "CPU_SOCKETS": 1, "ARCHITECTURE": "x86_64", "VM_HOST_UUID": "31060444-5d9b-44a0-a95f-5a7e1125f9aa", "SYNC_TIMESTAMP": "2021-04-18T00:31:37.630778Z", "SYSPURPOSE_ADDONS": []}}', '{}', '{"fqdn": "virtual_imdbmhce.example.biz", "bios_uuid": "e7cd6fda-d6e9-4b38-bd62-75815a747146", "insights_id": "33d1ece0-abb0-4f10-a3c2-768323ff3c97", "subscription_manager_id": "ea29a784-2b97-434e-bd25-b06d9455a50e"}', '{"arch": "x86_64", "owner_id": "ea29a784-2b97-434e-bd25-b06d9455a50e", "cores_per_socket": 1, "number_of_sockets": 1, "infrastructure_type": "virtual", "system_memory_bytes": 58368}', null, '2021-04-20 00:31:37.630778', 'rhsm-conduit');
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter) VALUES ('45adfb99-2df9-4f07-bcc5-61077f167764', '6661312', 'virtual_hdgmxenq.example.gov', '2021-04-17 13:39:51.396372', '2021-04-18 00:31:37.675856', '{"rhsm": {"orgId": "13259775", "MEMORY": 1, "RH_PROD": ["69"], "VM_HOST": "ghkmznbx.hypervisorfakeswatch.com", "GUEST_ID": "b166b847-d7ab-44e5-9d7c-2b80a2450ff4", "CPU_CORES": 1, "IS_VIRTUAL": true, "CPU_SOCKETS": 1, "ARCHITECTURE": "x86_64", "VM_HOST_UUID": "6221b689-d5df-4342-ada5-194028699ea0", "SYNC_TIMESTAMP": "2021-04-18T00:31:37.629625Z", "SYSPURPOSE_ADDONS": []}}', '{}', '{"fqdn": "virtual_hdgmxenq.example.gov", "bios_uuid": "b166b847-d7ab-44e5-9d7c-2b80a2450ff4", "insights_id": "f1f3edd7-8fbb-4ab0-b842-26dc5029150c", "subscription_manager_id": "99a1f10b-5686-484e-89a3-990331e51b52"}', '{"arch": "x86_64", "owner_id": "99a1f10b-5686-484e-89a3-990331e51b52", "cores_per_socket": 1, "number_of_sockets": 1, "infrastructure_type": "virtual", "system_memory_bytes": 43008}', null, '2021-04-20 00:31:37.629625', 'rhsm-conduit');
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter) VALUES ('eca2f655-b9a0-44ce-a855-b5ffd2e0945d', '6661312', 'physical_vzqnpssz.example.info', '2021-04-17 13:38:12.892124', '2021-04-18 00:31:37.660695', '{"rhsm": {"orgId": "13259775", "MEMORY": 1, "RH_PROD": ["69"], "CPU_CORES": 16, "IS_VIRTUAL": false, "CPU_SOCKETS": 8, "ARCHITECTURE": "x86_64", "SYNC_TIMESTAMP": "2021-04-18T00:31:37.628747Z", "SYSPURPOSE_ADDONS": []}}', '{}', '{"fqdn": "physical_vzqnpssz.example.info", "bios_uuid": "2cd20d54-e95e-443f-a2e2-48abe2b02052", "insights_id": "e9b6c32e-c5e5-4984-9c81-b9c175751c92", "subscription_manager_id": "7d5af54b-bc0d-4bdc-9338-69af6f36f5f6"}', '{"arch": "x86_64", "owner_id": "7d5af54b-bc0d-4bdc-9338-69af6f36f5f6", "cores_per_socket": 2, "number_of_sockets": 8, "infrastructure_type": "physical", "system_memory_bytes": 33792}', null, '2021-04-20 00:31:37.628747', 'rhsm-conduit');
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter) VALUES ('da986fca-1e50-422b-8b64-3b6d31faf17b', '6661312', 'virtual_machbphm.test.org', '2021-04-17 13:34:57.101668', '2021-04-18 00:31:37.644161', '{"rhsm": {"orgId": "13259775", "MEMORY": 1, "RH_PROD": ["69"], "VM_HOST": "tbktehpn.hypervisorfakeswatch.info", "GUEST_ID": "bbb3976c-e3e4-4491-914e-b15a23c061a5", "CPU_CORES": 1, "IS_VIRTUAL": true, "CPU_SOCKETS": 1, "ARCHITECTURE": "x86_64", "VM_HOST_UUID": "31060444-5d9b-44a0-a95f-5a7e1125f9aa", "SYNC_TIMESTAMP": "2021-04-18T00:31:37.626012Z", "SYSPURPOSE_ADDONS": []}}', '{}', '{"fqdn": "virtual_machbphm.test.org", "bios_uuid": "bbb3976c-e3e4-4491-914e-b15a23c061a5", "insights_id": "796b46af-dc58-4df2-b7f5-9e51537618a9", "subscription_manager_id": "b753a050-ed94-435e-9ba9-469e15917314"}', '{"arch": "x86_64", "owner_id": "b753a050-ed94-435e-9ba9-469e15917314", "cores_per_socket": 1, "number_of_sockets": 1, "infrastructure_type": "virtual", "system_memory_bytes": 13312}', null, '2021-04-20 00:31:37.626012', 'rhsm-conduit');
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter) VALUES ('7b394ea4-50cf-433d-b946-badb42f4d3be', '6661312', 'physical_ofirqjuf.test.biz', '2021-04-15 19:58:53.798809', '2021-04-16 00:09:11.938367', '{"rhsm": {"orgId": "13259775", "MEMORY": 1, "RH_PROD": [], "CPU_CORES": 1, "IS_VIRTUAL": false, "CPU_SOCKETS": 1, "ARCHITECTURE": "x86_64", "SYNC_TIMESTAMP": "2021-04-16T00:09:11.925065Z", "SYSPURPOSE_USAGE": "Production", "SYSPURPOSE_ADDONS": []}}', '{}', '{"fqdn": "physical_ofirqjuf.test.biz", "bios_uuid": "0964305e-f6c2-4924-af1a-87d820a54d44", "insights_id": "878a7f90-d73f-42a3-b26d-7e279e62c46a", "subscription_manager_id": "1142e7ff-0ed9-45a4-b6b6-14969a2ad5d1"}', '{"arch": "x86_64", "owner_id": "1142e7ff-0ed9-45a4-b6b6-14969a2ad5d1", "cores_per_socket": 1, "number_of_sockets": 1, "infrastructure_type": "physical", "system_memory_bytes": 102400}', null, '2021-04-18 00:09:11.925065', 'rhsm-conduit');
```

Observe with `develop` that the two hypervisors are missing after doing a tally:

```
curl -H 'Origin: cloud.redhat.com' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccount(java.lang.String)","arguments":["6661312"]}' http://localhost:8080/actuator/jolokia
```

Repeat the tally with this branch and see that the hypervisors show up as expected.