### PR TITLE
ENT-3674: Change PAYG tally output to running total format

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.filler;
 
+import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.SnapshotTimeAdjuster;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -43,13 +44,16 @@ public class ReportFiller {
     private static final Logger log = LoggerFactory.getLogger(ReportFiller.class);
 
     private final SnapshotTimeAdjuster timeAdjuster;
+    private final ApplicationClock clock;
 
-    public ReportFiller(SnapshotTimeAdjuster timeAdjuster) {
+    public ReportFiller(SnapshotTimeAdjuster timeAdjuster, ApplicationClock applicationClock) {
         this.timeAdjuster = timeAdjuster;
+        this.clock = applicationClock;
     }
 
     @Timed("rhsm-subscriptions.tally.fillReport")
-    public void fillGaps(TallyReport report, OffsetDateTime start, OffsetDateTime end) {
+    public void fillGaps(TallyReport report, OffsetDateTime start, OffsetDateTime end,
+        boolean useRunningTotalFormat) {
         TemporalAmount offset = timeAdjuster.getSnapshotOffset();
 
         OffsetDateTime firstDate = timeAdjuster.adjustToPeriodStart(start);
@@ -57,19 +61,22 @@ public class ReportFiller {
 
         List<TallySnapshot> existingSnaps = report.getData();
         if (existingSnaps == null || existingSnaps.isEmpty()) {
-            report.setData(fillWithRange(firstDate, lastDate, offset));
+            report.setData(fillWithRange(firstDate, lastDate, offset, null,
+                useRunningTotalFormat));
         }
         else {
-            report.setData(fillAndFilterSnapshots(offset, firstDate, lastDate, existingSnaps));
+            report.setData(fillAndFilterSnapshots(offset, firstDate, lastDate, existingSnaps,
+                useRunningTotalFormat));
         }
     }
 
     @SuppressWarnings("squid:S2583")
-    private List<TallySnapshot> fillAndFilterSnapshots(TemporalAmount offset,
-        OffsetDateTime firstDate, OffsetDateTime lastDate, List<TallySnapshot> existingSnaps) {
+    private List<TallySnapshot> fillAndFilterSnapshots(TemporalAmount offset, OffsetDateTime firstDate,
+        OffsetDateTime lastDate, List<TallySnapshot> existingSnaps, boolean useRunningTotalFormat) {
 
         List<TallySnapshot> result = new ArrayList<>();
         OffsetDateTime nextDate = firstDate;
+        TallySnapshot lastSnap = null;
         OffsetDateTime lastSnapDate = null;
         Optional<TallySnapshot> pending = Optional.empty();
         Optional<OffsetDateTime> pendingSnapDate = Optional.empty();
@@ -90,27 +97,33 @@ public class ReportFiller {
 
             if (pending.isPresent() && lastSnapDate.isAfter(pendingSnapDate.get())) {
                 result.add(pending.get());
+                lastSnap = pending.get();
                 pending = Optional.empty();
                 pendingSnapDate = Optional.empty();
             }
 
             // Fill report up until the next snapshot, then add the snapshot to the report list.
-            result.addAll(fillWithRange(nextDate, lastSnapDate.minus(offset), offset));
+            result.addAll(fillWithRange(nextDate, lastSnapDate.minus(offset), offset, lastSnap,
+                useRunningTotalFormat));
             if (!pending.isPresent() || snapshotIsLarger(pending.get(), snapshot)) {
                 pending = Optional.of(snapshot);
                 pendingSnapDate = Optional.of(lastSnapDate);
             }
             nextDate = lastSnapDate.plus(offset);
         }
-        pending.ifPresent(result::add);
+        if (pending.isPresent()) {
+            result.add(pending.get());
+            lastSnap = pending.get();
+        }
 
         // If no snaps contain dates, just use the start of the range. Otherwise,
         // fill from the date of the last snapshot found, to the end of the range.
         if (lastSnapDate == null) {
-            result.addAll(fillWithRange(firstDate, lastDate, offset));
+            result.addAll(fillWithRange(firstDate, lastDate, offset, null, useRunningTotalFormat));
         }
         else if (lastSnapDate.isBefore(lastDate)) {
-            result.addAll(fillWithRange(lastSnapDate.plus(offset), lastDate, offset));
+            result.addAll(fillWithRange(lastSnapDate.plus(offset), lastDate, offset, lastSnap,
+                useRunningTotalFormat));
         }
         return result;
     }
@@ -121,30 +134,60 @@ public class ReportFiller {
             newSnap.getSockets() > oldSnap.getSockets();
     }
 
-    private TallySnapshot createDefaultSnapshot(OffsetDateTime snapshotDate) {
+    private TallySnapshot createDefaultSnapshot(OffsetDateTime snapshotDate, TallySnapshot previous,
+        boolean useRunningTotalFormat) {
+        if (snapshotDate.isBefore(clock.now()) && useRunningTotalFormat && previous != null) {
+            return new TallySnapshot()
+                .date(snapshotDate)
+                .cores(previous.getCores())
+                .sockets(previous.getSockets())
+                .instanceCount(previous.getInstanceCount())
+                .physicalSockets(previous.getPhysicalSockets())
+                .physicalCores(previous.getPhysicalCores())
+                .physicalInstanceCount(previous.getPhysicalInstanceCount())
+                .hypervisorSockets(previous.getHypervisorSockets())
+                .hypervisorCores(previous.getHypervisorCores())
+                .hypervisorInstanceCount(previous.getHypervisorInstanceCount())
+                .cloudInstanceCount(previous.getCloudInstanceCount())
+                .cloudSockets(previous.getCloudSockets())
+                .cloudCores(previous.getCloudCores())
+                .coreHours(previous.getCoreHours())
+                .hasData(false);
+        }
+        Integer defaultValueInteger;
+        Double defaultValue;
+        if (snapshotDate.isBefore(clock.now())) {
+            defaultValueInteger = 0;
+            defaultValue = 0.0;
+        }
+        else {
+            defaultValueInteger = null;
+            defaultValue = null;
+        }
         return new TallySnapshot()
             .date(snapshotDate)
-            .cores(0)
-            .sockets(0)
-            .instanceCount(0)
-            .physicalSockets(0)
-            .physicalCores(0)
-            .physicalInstanceCount(0)
-            .hypervisorSockets(0)
-            .hypervisorCores(0)
-            .hypervisorInstanceCount(0)
-            .cloudInstanceCount(0)
-            .cloudSockets(0)
-            .cloudCores(0)
+            .cores(defaultValueInteger)
+            .sockets(defaultValueInteger)
+            .instanceCount(defaultValueInteger)
+            .physicalSockets(defaultValueInteger)
+            .physicalCores(defaultValueInteger)
+            .physicalInstanceCount(defaultValueInteger)
+            .hypervisorSockets(defaultValueInteger)
+            .hypervisorCores(defaultValueInteger)
+            .hypervisorInstanceCount(defaultValueInteger)
+            .cloudInstanceCount(defaultValueInteger)
+            .cloudSockets(defaultValueInteger)
+            .cloudCores(defaultValueInteger)
+            .coreHours(defaultValue)
             .hasData(false);
     }
 
-    private List<TallySnapshot> fillWithRange(OffsetDateTime start, OffsetDateTime end,
-        TemporalAmount offset) {
+    private List<TallySnapshot> fillWithRange(OffsetDateTime start, OffsetDateTime end, TemporalAmount offset,
+        TallySnapshot snapshot, boolean useRunningTotalFormat) {
         List<TallySnapshot> result = new ArrayList<>();
         OffsetDateTime next = timeAdjuster.adjustToPeriodStart(OffsetDateTime.from(start));
         while (next.isBefore(end) || next.isEqual(end)) {
-            result.add(createDefaultSnapshot(next));
+            result.add(createDefaultSnapshot(next, snapshot, useRunningTotalFormat));
             next = timeAdjuster.adjustToPeriodStart(next.plus(offset));
         }
         return result;

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
@@ -42,7 +42,7 @@ public class ReportFillerFactory {
      */
     public static ReportFiller getInstance(ApplicationClock clock, Granularity granularity) {
         SnapshotTimeAdjuster timeAdjuster = SnapshotTimeAdjuster.getTimeAdjuster(clock, granularity);
-        return new ReportFiller(timeAdjuster);
+        return new ReportFiller(timeAdjuster, clock);
     }
 
 

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -374,14 +374,14 @@ public class TallyResourceTest {
 
         Mockito.when(repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-                Mockito.eq("account123456"),
-                Mockito.eq(ProductId.OPENSHIFT_DEDICATED_METRICS.toString()),
-                Mockito.eq(Granularity.DAILY),
-                Mockito.eq(ServiceLevel.PREMIUM),
-                Mockito.eq(Usage.PRODUCTION),
-                Mockito.eq(OffsetDateTime.parse("2019-05-01T00:00Z")),
-                Mockito.eq(OffsetDateTime.parse("2019-05-31T11:59:59.999Z")),
-                Mockito.eq(null)
+                "account123456",
+                ProductId.OPENSHIFT_DEDICATED_METRICS.toString(),
+                Granularity.DAILY,
+                ServiceLevel.PREMIUM,
+                Usage.PRODUCTION,
+                OffsetDateTime.parse("2019-05-01T00:00Z"),
+                OffsetDateTime.parse("2019-05-31T11:59:59.999Z"),
+                null
             )).thenReturn(new PageImpl<>(snapshots));
 
         TallyReport report = resource.getTallyReport(ProductId.OPENSHIFT_DEDICATED_METRICS,

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
@@ -51,14 +51,14 @@ public class DailyReportFillerTest {
         OffsetDateTime end = start.plusDays(3);
 
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), clock.startOfDay(start), 0, 0, 0, false);
-        assertSnapshot(filled.get(1), clock.startOfDay(start.plusDays(1)), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), clock.startOfDay(start.plusDays(3)), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), clock.startOfDay(start.plusDays(1)), null, null, null, false);
+        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), null, null, null, false);
+        assertSnapshot(filled.get(3), clock.startOfDay(start.plusDays(3)), null, null, null, false);
     }
 
     @Test
@@ -74,14 +74,14 @@ public class DailyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), clock.startOfDay(start), 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
             snap1.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), null, null, null, false);
         assertSnapshot(filled.get(3), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
     }
@@ -98,14 +98,14 @@ public class DailyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusDays(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusDays(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusDays(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusDays(1), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusDays(2), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusDays(3), null, null, null, false);
     }
 
     @Test
@@ -122,15 +122,15 @@ public class DailyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), clock.startOfDay(start), 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), clock.startOfDay(start.plusDays(3)), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), null, null, null, false);
+        assertSnapshot(filled.get(3), clock.startOfDay(start.plusDays(3)), null, null, null, false);
     }
 
     @Test
@@ -147,15 +147,15 @@ public class DailyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap2, snap1);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), clock.startOfDay(start), 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), clock.startOfDay(start.plusDays(3)), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), clock.startOfDay(start.plusDays(2)), null, null, null, false);
+        assertSnapshot(filled.get(3), clock.startOfDay(start.plusDays(3)), null, null, null, false);
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/HourlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/HourlyReportFillerTest.java
@@ -51,14 +51,14 @@ class HourlyReportFillerTest {
         OffsetDateTime end = start.plusHours(3);
 
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), clock.startOfHour(start), 0, 0, 0, false);
-        assertSnapshot(filled.get(1), clock.startOfHour(start.plusHours(1)), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), clock.startOfHour(start.plusHours(1)), null, null, null, false);
+        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), null, null, null, false);
+        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), null, null, null, false);
     }
 
     @Test
@@ -74,23 +74,23 @@ class HourlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(5, filled.size());
         OffsetDateTime reportStart = clock.startOfHour(start);
         assertSnapshot(filled.get(0), reportStart, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), reportStart.plusHours(1), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), reportStart.plusHours(1), null, null, null, false);
         assertSnapshot(filled.get(2), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
             snap1.getInstanceCount(), true);
-        assertSnapshot(filled.get(3), reportStart.plusHours(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(3), reportStart.plusHours(3), null, null, null, false);
         assertSnapshot(filled.get(4), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
     }
 
     @Test
     void testSnapshotsIgnoredWhenNoDatesSet() {
-        OffsetDateTime start = clock.startOfToday();
+        OffsetDateTime start = clock.startOfCurrentHour();
         OffsetDateTime end = start.plusHours(3);
 
         TallySnapshot snap1 = new TallySnapshot().cores(12).instanceCount(4)
@@ -100,14 +100,14 @@ class HourlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusHours(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusHours(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusHours(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusHours(1), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusHours(2), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusHours(3), null, null, null, false);
     }
 
     @Test
@@ -124,15 +124,15 @@ class HourlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), clock.startOfHour(start), 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), null, null, null, false);
+        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), null, null, null, false);
     }
 
     @Test
@@ -149,15 +149,15 @@ class HourlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap2, snap1);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), clock.startOfHour(start), 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), clock.startOfHour(start.plusHours(2)), null, null, null, false);
+        assertSnapshot(filled.get(3), clock.startOfHour(start.plusHours(3)), null, null, null, false);
     }
 
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
@@ -51,14 +51,14 @@ public class MonthlyReportFillerTest {
         OffsetDateTime end = start.plusMonths(3);
 
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusMonths(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusMonths(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusMonths(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusMonths(1), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusMonths(2), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusMonths(3), null, null, null, false);
     }
 
     @Test
@@ -72,14 +72,14 @@ public class MonthlyReportFillerTest {
         OffsetDateTime expectedStart = clock.startOfMonth(start);
 
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), expectedStart, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), expectedStart.plusMonths(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), expectedStart.plusMonths(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), expectedStart.plusMonths(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), expectedStart.plusMonths(1), null, null, null, false);
+        assertSnapshot(filled.get(2), expectedStart.plusMonths(2), null, null, null, false);
+        assertSnapshot(filled.get(3), expectedStart.plusMonths(3), null, null, null, false);
     }
 
     @Test
@@ -94,14 +94,14 @@ public class MonthlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusMonths(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusMonths(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusMonths(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusMonths(1), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusMonths(2), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusMonths(3), null, null, null, false);
     }
 
     @Test
@@ -117,14 +117,14 @@ public class MonthlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
             snap1.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), start.plusMonths(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusMonths(2), null, null, null, false);
         assertSnapshot(filled.get(3), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
@@ -50,15 +50,15 @@ public class QuarterlyReportFillerTest {
         OffsetDateTime start = clock.startOfCurrentQuarter();
         OffsetDateTime end = start.plusYears(1);
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(5, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusMonths(3), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusMonths(6), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusMonths(9), 0, 0, 0, false);
-        assertSnapshot(filled.get(4), start.plusMonths(12), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusMonths(3), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusMonths(6), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusMonths(9), null, null, null, false);
+        assertSnapshot(filled.get(4), start.plusMonths(12), null, null, null, false);
     }
 
     @Test
@@ -71,15 +71,15 @@ public class QuarterlyReportFillerTest {
         OffsetDateTime expectedStart = clock.startOfQuarter(start);
 
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(5, filled.size());
         assertSnapshot(filled.get(0), expectedStart, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), expectedStart.plusMonths(3), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), expectedStart.plusMonths(6), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), expectedStart.plusMonths(9), 0, 0, 0, false);
-        assertSnapshot(filled.get(4), expectedStart.plusMonths(12), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), expectedStart.plusMonths(3), null, null, null, false);
+        assertSnapshot(filled.get(2), expectedStart.plusMonths(6), null, null, null, false);
+        assertSnapshot(filled.get(3), expectedStart.plusMonths(9), null, null, null, false);
+        assertSnapshot(filled.get(4), expectedStart.plusMonths(12), null, null, null, false);
     }
 
     @Test
@@ -94,15 +94,15 @@ public class QuarterlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(5, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusMonths(3), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusMonths(6), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusMonths(9), 0, 0, 0, false);
-        assertSnapshot(filled.get(4), start.plusMonths(12), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusMonths(3), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusMonths(6), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusMonths(9), null, null, null, false);
+        assertSnapshot(filled.get(4), start.plusMonths(12), null, null, null, false);
     }
 
     @Test
@@ -118,15 +118,15 @@ public class QuarterlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(5, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
             snap1.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), start.plusMonths(6), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusMonths(9), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusMonths(6), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusMonths(9), null, null, null, false);
         assertSnapshot(filled.get(4), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
@@ -51,14 +51,14 @@ public class WeeklyReportFillerTest {
         OffsetDateTime end = start.plusWeeks(3);
 
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusWeeks(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusWeeks(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusWeeks(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusWeeks(1), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusWeeks(2), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusWeeks(3), null, null, null, false);
     }
 
     @Test
@@ -72,14 +72,14 @@ public class WeeklyReportFillerTest {
         OffsetDateTime expectedStart = clock.startOfWeek(start);
 
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), expectedStart, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), expectedStart.plusWeeks(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), expectedStart.plusWeeks(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), expectedStart.plusWeeks(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), expectedStart.plusWeeks(1), null, null, null, false);
+        assertSnapshot(filled.get(2), expectedStart.plusWeeks(2), null, null, null, false);
+        assertSnapshot(filled.get(3), expectedStart.plusWeeks(3), null, null, null, false);
     }
 
     @Test
@@ -94,14 +94,14 @@ public class WeeklyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusWeeks(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusWeeks(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusWeeks(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusWeeks(1), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusWeeks(2), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusWeeks(3), null, null, null, false);
     }
 
     @Test
@@ -117,14 +117,14 @@ public class WeeklyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
             snap1.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), start.plusWeeks(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusWeeks(2), null, null, null, false);
         assertSnapshot(filled.get(3), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
@@ -51,14 +51,14 @@ public class YearlyReportFillerTest {
         OffsetDateTime start = clock.startOfCurrentYear();
         OffsetDateTime end = start.plusYears(3);
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusYears(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusYears(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusYears(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusYears(1), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusYears(2), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusYears(3), null, null, null, false);
     }
 
     @Test
@@ -71,14 +71,14 @@ public class YearlyReportFillerTest {
         OffsetDateTime expectedStart = clock.startOfYear(start);
 
         TallyReport report = new TallyReport();
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), expectedStart, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), expectedStart.plusYears(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), expectedStart.plusYears(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), expectedStart.plusYears(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), expectedStart.plusYears(1), null, null, null, false);
+        assertSnapshot(filled.get(2), expectedStart.plusYears(2), null, null, null, false);
+        assertSnapshot(filled.get(3), expectedStart.plusYears(3), null, null, null, false);
     }
 
     @Test
@@ -93,14 +93,14 @@ public class YearlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
-        assertSnapshot(filled.get(1), start.plusYears(1), 0, 0, 0, false);
-        assertSnapshot(filled.get(2), start.plusYears(2), 0, 0, 0, false);
-        assertSnapshot(filled.get(3), start.plusYears(3), 0, 0, 0, false);
+        assertSnapshot(filled.get(1), start.plusYears(1), null, null, null, false);
+        assertSnapshot(filled.get(2), start.plusYears(2), null, null, null, false);
+        assertSnapshot(filled.get(3), start.plusYears(3), null, null, null, false);
     }
 
     @Test
@@ -116,14 +116,14 @@ public class YearlyReportFillerTest {
         List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
         TallyReport report = new TallyReport().data(snaps);
-        filler.fillGaps(report, start, end);
+        filler.fillGaps(report, start, end, false);
 
         List<TallySnapshot> filled = report.getData();
         assertEquals(4, filled.size());
         assertSnapshot(filled.get(0), start, 0, 0, 0, false);
         assertSnapshot(filled.get(1), snap1.getDate(), snap1.getCores(), snap1.getSockets(),
             snap1.getInstanceCount(), true);
-        assertSnapshot(filled.get(2), start.plusYears(2), 0, 0, 0, false);
+        assertSnapshot(filled.get(2), start.plusYears(2), null, null, null, false);
         assertSnapshot(filled.get(3), snap2.getDate(), snap2.getCores(), snap2.getSockets(),
             snap2.getInstanceCount(), true);
     }


### PR DESCRIPTION
This introduces into the TallyResource the concept of "running total format". Running total format is currently enabled when the product ID supports hourly granularity.

Running total format does two things:
1. It transforms tally snapshot data by making it additive (snapshot for a given date is the sum of previous dates in the response.
2. It alters the filler to use previous snapshots for generating snapshots (rather than 0-valued snapshots).

Another related change I made was if we are producing a default snapshot for a given timestamp in the future, the values are set to `null`. This should cause the graph to omit the data point (making the dropoff abrupt at the edge of data).

Testing Suggestions
-------------------

Deploy via `RBAC_USE_STUB=true ./gradlew bootRun`

Truncate existing tally data and insert some new:

```sql
truncate table tally_snapshots cascade;
INSERT INTO tally_snapshots (id, product_id, account_number, granularity, snapshot_date, sla, usage) VALUES ('1718a2fd-12eb-4c51-a7f1-7774bce33bfd', 'OpenShift-dedicated-metrics', 'account123', 'DAILY', '2021-04-01', '_ANY', '_ANY');
INSERT INTO tally_measurements (snapshot_id, measurement_type, uom, value) VALUES ('1718a2fd-12eb-4c51-a7f1-7774bce33bfd', 'TOTAL', 'CORES', 2);
INSERT INTO tally_snapshots (id, product_id, account_number, granularity, snapshot_date, sla, usage) VALUES ('dbb8e7c7-84da-4e80-a512-85e6a560b833', 'OpenShift-dedicated-metrics', 'account123', 'DAILY', '2021-04-02', '_ANY', '_ANY');
INSERT INTO tally_measurements (snapshot_id, measurement_type, uom, value) VALUES ('dbb8e7c7-84da-4e80-a512-85e6a560b833', 'TOTAL', 'CORES', 4);
INSERT INTO tally_snapshots (id, product_id, account_number, granularity, snapshot_date, sla, usage) VALUES ('96e8f3cb-8f71-4b3e-98cf-94c170e59e51', 'OpenShift-dedicated-metrics', 'account123', 'DAILY', '2021-04-08', '_ANY', '_ANY');
INSERT INTO tally_measurements (snapshot_id, measurement_type, uom, value) VALUES ('96e8f3cb-8f71-4b3e-98cf-94c170e59e51', 'TOTAL', 'CORES', 16);
```

Next, hit the endpoint for April 2021, and see the resulting snapshot values (esp. notice that future dates have `null` to visually indicate there is definitely no data for them yet):

```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=Daily&beginning=2021-04-01T00%3A00%3A00Z&ending=2021-04-30T23%3A59%3A59.999Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

(can also use swagger-ui at http://localhost:8080/api-docs)