### PR TITLE
Show tooltip for all running total values

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFiller.java
@@ -152,7 +152,7 @@ public class ReportFiller {
                 .cloudSockets(previous.getCloudSockets())
                 .cloudCores(previous.getCloudCores())
                 .coreHours(previous.getCoreHours())
-                .hasData(false);
+                .hasData(true); // has_data = true means that the frontend should show the value in a tooltip
         }
         Integer defaultValueInteger;
         Double defaultValue;


### PR DESCRIPTION
Tiny follow-up to #415

Without this change, days without any recorded usage show up in the tooltip as "no data", rather than the cumulative total.

![image](https://user-images.githubusercontent.com/1716882/115624288-6c5b1700-a2c8-11eb-96e4-469a67b8859b.png)

See https://github.com/RedHatInsights/curiosity-frontend/pull/282 for explanation of GUI logic wrt `has_data`.