### PR TITLE
Fixing syntax issue with the rhsm-subscriptions-scheduler os template

### DIFF
--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -390,7 +390,7 @@ objects:
                     - name: KAFKA_BOOTSTRAP_HOST
                       value: ${KAFKA_BOOTSTRAP_HOST}
                     - name: EVENT_RECORD_RETENTION
-                    - value: ${EVENT_RECORD_RETENTION}
+                      value: ${EVENT_RECORD_RETENTION}
                     - name: DATABASE_HOST
                       valueFrom:
                         secretKeyRef:


### PR DESCRIPTION
Because intellij likes to add characters by itself when you hit enter