### PR TITLE
Document all existing Spring profiles in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,22 @@ We have a number of profiles. Each profile activates a subset of components in t
 
 - `api`: Run the user-facing API
 - `capacity-ingress`: Run the internal only capacity ingress API
-- `purge-snapshots`: Run the retention job and exit
+- `capture-hourly-snapshots`: Run the tally job for hourly snapshots
 - `capture-snapshots`: Run the tally job and exit
 - `kafka-queue`: Run with a kafka queue (instead of the default in-memory queue)
-- `rhsm-conduit`: Run the worker for syncing systems between Hosted Candlepin and HBI
-- `marketplace`: Run the worker responsible for processing tally summaries and emitting usage to Marketplace.
+- `liquibase-only`: Run the Liquibase migrations and stop
+- `marketplace`: Run the worker responsible for processing tally summaries and
+  emitting usage to Marketplace.
+- `openshift-metering-jmx`: Expose the JMX bean to create OpenShift metering
+  jobs
+- `openshift-metering-job`: Create OpenShift metering jobs and place them on the
+  job queue
+- `openshift-metering-worker`: Process OpenShift metering jobs off the job queue
+- `orgsync`:
+- `purge-snapshots`: Run the retention job and exit
+- `rhsm-conduit`: Run the worker for syncing systems between Hosted Candlepin
+  and HBI
+- `worker`: Process jobs off the job queue
 
 These can be specified most easily via the `SPRING_PROFILES_ACTIVE` environment variable. For example:
 


### PR DESCRIPTION
I extracted the profiles using the following command

```
grep -rh '@Profile' **/*.java | cut -d\" -f2- | tr -d ' '\"\)\} | tr ',' '\n' | sort | uniq
```

This greps for @Profile annotations then takes the annotation
arguments and removes quotes, spaces, parenthesis, and curly braces.
Commas are converted to newlines and then the list of individual
profiles is sorted and deduplicated.