### PR TITLE
Set database to UTC during testing

### DIFF
--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -20,3 +20,12 @@ logging:
   level:
     org:
       candlepin: INFO
+spring:
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          # Force the testing database into UTC to prevent test failures when the database
+          # determines the 'current' time in a query. NOTE: This is primarily when tests
+          # are run in a local environment and the DB is running in local time zone.
+          time_zone: UTC


### PR DESCRIPTION
A few failing tests have come up when running them locally
and were caused by what appears to be updates to various
jpa/hibernate libs. The app is run locally in UTC, and this
change ensures that the DB will be run in UTC as well. This
also mirrors how the application is currently deployed.

## Testing
To test, run the tests locally, before and after this fix is applied.