### PR TITLE
ENT-3743: Lookup sub IDs by orgId instead of account

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionCollector.java
@@ -27,6 +27,7 @@ import org.candlepin.subscriptions.subscription.SubscriptionService;
 import org.candlepin.subscriptions.subscription.api.model.Subscription;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * Class responsible for communicating with the Marketplace API and fetching the subscription ID.
@@ -43,14 +44,18 @@ public class MarketplaceSubscriptionCollector {
   }
 
   /**
-   * Given an account number, query the IT Subscription Service and return subscriptions that have
-   * an ibm marketplace external reference as part of its payload
+   * Given an org ID, query the IT Subscription Service and return subscriptions that have an ibm
+   * marketplace external reference as part of its payload
    *
-   * @param accountNumber - account number aka oracle account number aka ebs account number
+   * @param orgId - org ID used to look up subscriptions.
    * @return subscriptions
    */
-  public List<Subscription> requestSubscriptions(String accountNumber) {
-    var subscriptions = subscriptionService.getSubscriptionsByAccountNumber(accountNumber);
+  public List<Subscription> requestSubscriptions(String orgId) {
+    if (!StringUtils.hasText(orgId)) {
+      throw new IllegalArgumentException("The orgId parameter can not be null or empty.");
+    }
+
+    var subscriptions = subscriptionService.getSubscriptionsByOrgId(orgId);
     return filterNonApplicableSubscriptions(subscriptions);
   }
 

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionIdProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionIdProvider.java
@@ -76,7 +76,11 @@ public class MarketplaceSubscriptionIdProvider {
   }
 
   public Optional<String> findSubscriptionId(
-      String accountNumber, Key usageKey, OffsetDateTime rangeStart, OffsetDateTime rangeEnd) {
+      String accountNumber,
+      String orgId,
+      Key usageKey,
+      OffsetDateTime rangeStart,
+      OffsetDateTime rangeEnd) {
     Assert.isTrue(Usage._ANY != usageKey.getUsage(), "Usage cannot be _ANY");
     Assert.isTrue(ServiceLevel._ANY != usageKey.getSla(), "Service Level cannot be _ANY");
 
@@ -91,7 +95,8 @@ public class MarketplaceSubscriptionIdProvider {
     if (result.isEmpty()) {
       /* If we are missing the subscription, call out to the MarketplaceSubscriptionCollector
       to fetch from Marketplace.  Sync all those subscriptions. Query again. */
-      var subscriptions = collector.requestSubscriptions(accountNumber);
+      log.info("Syncing subscriptions for account {} using orgId {}", accountNumber, orgId);
+      var subscriptions = collector.requestSubscriptions(orgId);
       subscriptions.forEach(syncController::syncSubscription);
       result = fetchSubscriptions(accountNumber, usageKey, roles, rangeStart, rangeEnd);
     }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionService.java
@@ -126,6 +126,24 @@ public class SubscriptionService {
     return fluxRetryWrapper(supplier);
   }
 
+  public List<Subscription> getSubscriptionsByOrgId(String orgId) {
+    var index = 0;
+    var pageSize = properties.getPageSize();
+    int latestResultCount;
+
+    Set<Subscription> total = new HashSet<>();
+    do {
+      List<Subscription> subscriptionsByOrgId;
+
+      subscriptionsByOrgId = getSubscriptionsByOrgId(orgId, index, pageSize);
+      latestResultCount = subscriptionsByOrgId.size();
+      total.addAll(subscriptionsByOrgId);
+      index = index + pageSize;
+    } while (latestResultCount == pageSize);
+
+    return new ArrayList<>(total);
+  }
+
   /**
    * Obtain Subscription Service Subscription Models for an orgId.
    *

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplacePayloadMapperTest.java
@@ -42,6 +42,7 @@ import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.marketplace.api.model.UsageEvent;
 import org.candlepin.subscriptions.marketplace.api.model.UsageMeasurement;
 import org.candlepin.subscriptions.tally.UsageCalculation;
+import org.candlepin.subscriptions.user.AccountService;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,8 @@ class MarketplacePayloadMapperTest {
   @Mock ProductProfileRegistry profileRegistry;
   @Mock MarketplaceProperties marketplaceProperties;
   @Mock MarketplaceSubscriptionIdProvider mockProvider;
+
+  @Mock AccountService accountService;
 
   @InjectMocks MarketplacePayloadMapper marketplacePayloadMapper;
 
@@ -266,6 +269,7 @@ class MarketplacePayloadMapperTest {
 
     when(mockProvider.findSubscriptionId(
             any(String.class),
+            any(String.class),
             any(UsageCalculation.Key.class),
             any(OffsetDateTime.class),
             any(OffsetDateTime.class)))
@@ -285,8 +289,12 @@ class MarketplacePayloadMapperTest {
             .withSla(TallySnapshot.Sla.PREMIUM)
             .withGranularity(TallySnapshot.Granularity.HOURLY);
 
+    String account = "test123";
+    String orgId = "org123";
     var summary =
-        new TallySummary().withTallySnapshots(List.of(snapshot)).withAccountNumber("test123");
+        new TallySummary().withTallySnapshots(List.of(snapshot)).withAccountNumber(account);
+
+    when(accountService.lookupOrgId(account)).thenReturn(orgId);
 
     var usageMeasurement =
         new UsageMeasurement().value(36.0).metricId("redhat.com:openshift:cpu_hour");

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionCollectorTest.java
@@ -64,12 +64,12 @@ class MarketplaceSubscriptionCollectorTest {
   @Test
   void testRequestSubscriptions() {
 
-    when(subscriptionService.getSubscriptionsByAccountNumber(anyString()))
+    when(subscriptionService.getSubscriptionsByOrgId(anyString()))
         .thenReturn(List.of(SUB_WITH_IBMMARKETPLACE));
 
     assertEquals(
         List.of(SUB_WITH_IBMMARKETPLACE),
-        marketplaceSubscriptionCollector.requestSubscriptions("account123"));
+        marketplaceSubscriptionCollector.requestSubscriptions("org123"));
   }
 
   @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionIdProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionIdProviderTest.java
@@ -82,10 +82,10 @@ class MarketplaceSubscriptionIdProviderTest {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> idProvider.findSubscriptionId("1000", key1, rangeStart, rangeEnd));
+        () -> idProvider.findSubscriptionId("1000", "org1000", key1, rangeStart, rangeEnd));
     assertThrows(
         IllegalArgumentException.class,
-        () -> idProvider.findSubscriptionId("1000", key2, rangeStart, rangeEnd));
+        () -> idProvider.findSubscriptionId("1000", "org1000", key2, rangeStart, rangeEnd));
   }
 
   @Test
@@ -112,7 +112,8 @@ class MarketplaceSubscriptionIdProviderTest {
         .thenReturn(new ArrayList<>())
         .thenReturn(result);
 
-    Optional<String> actual = idProvider.findSubscriptionId("1000", key, rangeStart, rangeEnd);
+    Optional<String> actual =
+        idProvider.findSubscriptionId("1000", "org1000", key, rangeStart, rangeEnd);
     assertEquals("xyz", actual.get());
   }
 
@@ -140,9 +141,10 @@ class MarketplaceSubscriptionIdProviderTest {
         .thenReturn(new ArrayList<>())
         .thenReturn(result);
 
-    Optional<String> actual = idProvider.findSubscriptionId("1000", key, rangeStart, rangeEnd);
+    Optional<String> actual =
+        idProvider.findSubscriptionId("1000", "org1000", key, rangeStart, rangeEnd);
     assertEquals("abc", actual.get());
 
-    verify(collector).requestSubscriptions("1000");
+    verify(collector).requestSubscriptions("org1000");
   }
 }

--- a/subscription-client/subscription-api-spec.yaml
+++ b/subscription-client/subscription-api-spec.yaml
@@ -63,7 +63,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Subscription"
-  /search/criteria;web_customer_id={orgId}/options;products=ALL;isCustomer=false;firstResultIndex={index};maxResults={pageSize}:
+  /search/criteria;web_customer_id={orgId}/options;products=ALL;showExternalReferences=true;firstResultIndex={index};maxResults={pageSize}:
     description: "Search subscriptions on owner, index, and pageSize"
     parameters:
       - name: orgId


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-3743

Use the user service to determine the org ID for an account
and use it to find the subscriptions for the org as it is
more reliable.

## Testing

```sql
TRUNCATE events cascade;
TRUNCATE subscription cascade;
TRUNCATE sku_child_sku cascade;
TRUNCATE offering cascade;

insert into events(id, account_number, timestamp, instance_id, data) values ('033a45b7-e8c4-440a-b0bb-76c3f3f67d85','6043640', '2021-04-16T22:00Z', '4e8534b5-42b5-4f00-9969-29046e2b1986', '{"account_number":"6043640","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d85","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}], "timestamp": "2021-04-16T22:00Z", "role" : "osd"}');
insert into events(id, account_number, timestamp, instance_id, data) values ('033a45b7-e8c4-440a-b0bb-76c3f3f67d86','6043640', '2021-04-16T23:00Z', '4e8534b5-42b5-4f00-9969-29046e2b1986', '{"account_number":"6043640","event_id":"033a45b7-e8c4-440a-b0bb-76c3f3f67d86","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":4.0}], "timestamp": "2021-04-16T23:00Z", "role" : "osd"}');
insert into events(id, account_number, timestamp, instance_id, data) values ('a66ac2a1-17c0-4bc3-bc29-0430953d626c','6043640', '2021-04-28T00:00Z', '4e8534b5-42b5-4f00-9969-29046e2b1986', '{"account_number":"6043640","event_id":"a66ac2a1-17c0-4bc3-bc29-0430953d626c","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":14.0}], "timestamp": "2021-04-28T00:00Z", "role" : "osd"}');
insert into events(id, account_number, timestamp, instance_id, data) values ('fad48795-ae0a-4674-b864-822ddfb799d0','6043640', '2021-04-28T01:00Z', '4e8534b5-42b5-4f00-9969-29046e2b1986', '{"account_number":"6043640","event_id":"fad48795-ae0a-4674-b864-822ddfb799d0","service_type":"OpenShift Cluster","instance_id":"4e8534b5-42b5-4f00-9969-29046e2b1986","measurements": [{"uom":"Cores","value":100.0}], "timestamp": "2021-04-28T01:00Z", "role" : "osd"}');
```

```bash
$ SUBSCRIPTION_KEYSTORE=$YOUR_KEYSTORE SUBSCRIPTION_KEYSTORE_PASSWORD=$YOUR_KEYSTORE_PASS SUBSCRIPTION_URL="https://subscription.stage.api.redhat.com/svcrest/subscription/v5" PROM_URL="http://localhost:8082/api/v1" RHSM_KEYSTORE="YOUR_KEYSTORE.jks" RHSM_KEYSTORE_PASSWORD=$YOUR_KEYSTORE_PASS USER_HOST=user.stage.api.redhat.com DEV_MODE=true ./gradlew clean bootRun
```

```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["6043640","6592901",true,true,true]}'
```

```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["6043640", "2021-04-01T00:00Z", "2021-04-30T00:00Z"]}'
```

Take a look at the logs to see that the subscription IDs are being looked up by the correct Org ID.