### PR TITLE
ENT-3543: Handle satellite syspurpose attributes

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -67,6 +67,9 @@ import lombok.Setter;
             @ColumnResult(name = "is_virtual"),
             @ColumnResult(name = "hypervisor_uuid"),
             @ColumnResult(name = "satellite_hypervisor_uuid"),
+            @ColumnResult(name = "satellite_role"),
+            @ColumnResult(name = "satellite_sla"),
+            @ColumnResult(name = "satellite_usage"),
             @ColumnResult(name = "guest_id"),
             @ColumnResult(name = "subscription_manager_id"),
             @ColumnResult(name = "insights_id"),
@@ -88,6 +91,9 @@ import lombok.Setter;
             + "h.facts->'rhsm'->>'IS_VIRTUAL' as is_virtual, "
             + "h.facts->'rhsm'->>'VM_HOST_UUID' as hypervisor_uuid, "
             + "h.facts->'satellite'->>'virtual_host_uuid' as satellite_hypervisor_uuid, "
+            + "h.facts->'satellite'->>'system_purpose_role' as satellite_role, "
+            + "h.facts->'satellite'->>'system_purpose_sla' as satellite_sla, "
+            + "h.facts->'satellite'->>'system_purpose_usage' as satellite_usage, "
             + "h.facts->'rhsm'->>'GUEST_ID' as guest_id, "
             + "h.facts->'rhsm'->>'SYNC_TIMESTAMP' as sync_timestamp, "
             + "h.facts->'rhsm'->>'SYSPURPOSE_ROLE' as syspurpose_role, "

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -47,6 +47,9 @@ public class InventoryHostFacts {
   private boolean isVirtual;
   private String hypervisorUuid;
   private String satelliteHypervisorUuid;
+  private String satelliteRole;
+  private String satelliteSla;
+  private String satelliteUsage;
   private String guestId;
   private String subscriptionManagerId;
   private String insightsId;
@@ -90,6 +93,9 @@ public class InventoryHostFacts {
       String isVirtual,
       String hypervisorUuid,
       String satelliteHypervisorUuid,
+      String satelliteRole,
+      String satelliteSla,
+      String satelliteUsage,
       String guestId,
       String subscriptionManagerId,
       String insightsId,
@@ -117,6 +123,9 @@ public class InventoryHostFacts {
     this.isVirtual = asBoolean(isVirtual);
     this.hypervisorUuid = hypervisorUuid;
     this.satelliteHypervisorUuid = satelliteHypervisorUuid;
+    this.satelliteRole = satelliteRole;
+    this.satelliteSla = satelliteSla;
+    this.satelliteUsage = satelliteUsage;
     this.guestId = guestId;
     this.subscriptionManagerId = subscriptionManagerId;
     this.insightsId = insightsId;


### PR DESCRIPTION
Testing
-------

Insert a mocked Satellite record into local HBI DB.

```
cat <<EOF | psql -h localhost -U insights
insert into hosts(id, account, display_name, created_on, modified_on, facts, tags, canonical_facts,
                  system_profile_facts, ansible_host, stale_timestamp, reporter)
values ('7ff17db8-3c3b-429f-8eea-b026655d10b6', 'account123', 'sat-host', now(), now(), '{
  "satellite": {
    "system_purpose_role": "Red Hat Enterprise Linux Server",
    "system_purpose_sla": "Premium",
    "system_purpose_usage": "Production"
  }
}', null, '{}', '{"cores_per_socket": 2, "sockets": 1}', null, now() + '7 days', 'satellite');
EOF
```

Run tally for the account:

```
curl -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccount(java.lang.String)","arguments":["account123"]}' http://localhost:8080/actuator/jolokia
```

Check the resulting buckets applied to the host - note they they include
RHEL Server, Premium, Production:

```
cat <<EOF | psql -h localhost -U rhsm-subscriptions
select * from host_tally_buckets join hosts h on host_id=h.id where inventory_id='7ff17db8-3c3b-429f-8eea-b026655d10b6';
EOF
```