### PR TITLE
ENT-3815: Add splunk sidecar configuration to jobs to help with debugging

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
@@ -58,6 +58,8 @@ public class PrometheusMetricsTaskManager {
 
   public void updateOpenshiftMetricsForAccount(
       String account, OffsetDateTime start, OffsetDateTime end) {
+    log.info(
+        "Queuing OpenShift metrics update for account {} between {} and {}", account, start, end);
     this.queue.enqueue(createOpenshiftMetricsTask(account, start, end));
   }
 

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -36,11 +36,21 @@ parameters:
   - name: MEMORY_REQUEST
     value: 1000Mi
   - name: MEMORY_LIMIT
-    value: 1744Mi
+    value: 1650Mi
   - name: CPU_REQUEST
     value: 500m
   - name: CPU_LIMIT
-    value: 1900m
+    value: 1800m
+  - name: SPLUNK_FORWARDER_IMAGE
+    value: quay.io/cloudservices/rhsm-splunk-forwarder:8f72cfb
+  - name: SPLUNK_FORWARDER_MEMORY_REQUEST
+    value: 128Mi
+  - name: SPLUNK_FORWARDER_MEMORY_LIMIT
+    value: 150Mi
+  - name: SPLUNK_FORWARDER_CPU_REQUEST
+    value: 50m
+  - name: SPLUNK_FORWARDER_CPU_LIMIT
+    value: 100m
   - name: HOURLY_TALLY_OFFSET
     value: 60m
   - name: TOKEN_REFRESHER_IMAGE
@@ -84,6 +94,8 @@ objects:
                       value: '85'
                     - name: GC_MAX_METASPACE_SIZE
                       value: '256'
+                    - name: LOG_FILE
+                      value: /logs/server.log
                     - name: LOGGING_LEVEL_ROOT
                       value: ${LOGGING_LEVEL_ROOT}
                     - name: LOGGING_LEVEL_ORG_CANDLEPIN
@@ -151,7 +163,33 @@ objects:
                     limits:
                       cpu: ${CPU_LIMIT}
                       memory: ${MEMORY_LIMIT}
-
+                  volumeMounts:
+                    - name: logs
+                      mountPath: /logs
+                - name: splunk
+                  env:
+                    - name: SPLUNKMETA_namespace
+                      valueFrom:
+                        fieldRef:
+                          apiVersion: v1
+                          fieldPath: metadata.namespace
+                  image: ${SPLUNK_FORWARDER_IMAGE}
+                  resources:
+                    requests:
+                      cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                    limits:
+                      cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+                  terminationMessagePath: /dev/termination-log
+                  terminationMessagePolicy: File
+                  volumeMounts:
+                    - mountPath: /var/log/app
+                      name: logs
+                      readOnly: true
+                    - mountPath: /tls/splunk.pem
+                      name: splunk
+                      subPath: splunk.pem
                 - name: token-refresher
                   image: ${TOKEN_REFRESHER_IMAGE}
                   args:
@@ -189,6 +227,12 @@ objects:
                     limits:
                       cpu: ${TOKEN_REFRESHER_CPU_LIMIT}
                       memory: ${TOKEN_REFRESHER_MEMORY_LIMIT}
+              volumes:
+                - name: splunk
+                  secret:
+                    secretName: splunk
+                - name: logs
+                  emptyDir:
   - apiVersion: batch/v1beta1
     kind: CronJob
     metadata:
@@ -215,6 +259,8 @@ objects:
                       value: '85'
                     - name: GC_MAX_METASPACE_SIZE
                       value: '256'
+                    - name: LOG_FILE
+                      value: /logs/server.log
                     - name: LOGGING_LEVEL_ROOT
                       value: ${LOGGING_LEVEL_ROOT}
                     - name: LOGGING_LEVEL_ORG_CANDLEPIN
@@ -273,6 +319,39 @@ objects:
                     limits:
                       cpu: ${CPU_LIMIT}
                       memory: ${MEMORY_LIMIT}
+                  volumeMounts:
+                    - name: logs
+                      mountPath: /logs
+                - name: splunk
+                  env:
+                    - name: SPLUNKMETA_namespace
+                      valueFrom:
+                        fieldRef:
+                          apiVersion: v1
+                          fieldPath: metadata.namespace
+                  image: ${SPLUNK_FORWARDER_IMAGE}
+                  resources:
+                    requests:
+                      cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                    limits:
+                      cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+                  terminationMessagePath: /dev/termination-log
+                  terminationMessagePolicy: File
+                  volumeMounts:
+                    - mountPath: /var/log/app
+                      name: logs
+                      readOnly: true
+                    - mountPath: /tls/splunk.pem
+                      name: splunk
+                      subPath: splunk.pem
+              volumes:
+                - name: splunk
+                  secret:
+                    secretName: splunk
+                - name: logs
+                  emptyDir:
   - apiVersion: batch/v1beta1
     kind: CronJob
     metadata:
@@ -299,6 +378,8 @@ objects:
                       value: '85'
                     - name: GC_MAX_METASPACE_SIZE
                       value: '256'
+                    - name: LOG_FILE
+                      value: /logs/server.log
                     - name: LOGGING_LEVEL_ROOT
                       value: ${LOGGING_LEVEL_ROOT}
                     - name: LOGGING_LEVEL_ORG_CANDLEPIN
@@ -357,6 +438,39 @@ objects:
                     limits:
                       cpu: ${CPU_LIMIT}
                       memory: ${MEMORY_LIMIT}
+                  volumeMounts:
+                    - name: logs
+                      mountPath: /logs
+                - name: splunk
+                  env:
+                    - name: SPLUNKMETA_namespace
+                      valueFrom:
+                        fieldRef:
+                          apiVersion: v1
+                          fieldPath: metadata.namespace
+                  image: ${SPLUNK_FORWARDER_IMAGE}
+                  resources:
+                    requests:
+                      cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                    limits:
+                      cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+                  terminationMessagePath: /dev/termination-log
+                  terminationMessagePolicy: File
+                  volumeMounts:
+                    - mountPath: /var/log/app
+                      name: logs
+                      readOnly: true
+                    - mountPath: /tls/splunk.pem
+                      name: splunk
+                      subPath: splunk.pem
+              volumes:
+                - name: splunk
+                  secret:
+                    secretName: splunk
+                - name: logs
+                  emptyDir:
   - apiVersion: batch/v1beta1
     kind: CronJob
     metadata:
@@ -383,6 +497,8 @@ objects:
                       value: '85'
                     - name: GC_MAX_METASPACE_SIZE
                       value: '256'
+                    - name: LOG_FILE
+                      value: /logs/server.log
                     - name: LOGGING_LEVEL_ROOT
                       value: ${LOGGING_LEVEL_ROOT}
                     - name: LOGGING_LEVEL_ORG_CANDLEPIN
@@ -443,3 +559,36 @@ objects:
                     limits:
                       cpu: ${CPU_LIMIT}
                       memory: ${MEMORY_LIMIT}
+                  volumeMounts:
+                    - name: logs
+                      mountPath: /logs
+                - name: splunk
+                  env:
+                    - name: SPLUNKMETA_namespace
+                      valueFrom:
+                        fieldRef:
+                          apiVersion: v1
+                          fieldPath: metadata.namespace
+                  image: ${SPLUNK_FORWARDER_IMAGE}
+                  resources:
+                    requests:
+                      cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                    limits:
+                      cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+                  terminationMessagePath: /dev/termination-log
+                  terminationMessagePolicy: File
+                  volumeMounts:
+                    - mountPath: /var/log/app
+                      name: logs
+                      readOnly: true
+                    - mountPath: /tls/splunk.pem
+                      name: splunk
+                      subPath: splunk.pem
+              volumes:
+                - name: splunk
+                  secret:
+                    secretName: splunk
+                - name: logs
+                  emptyDir:


### PR DESCRIPTION
Currently we do not have access to job logs in splunk. These
logs are important when trying to determine whether a
particular process has been run for a particular account.

By configuring a Splunk sidecar for each job, it will give
us access to important logging info that will help with debugging
issues.

## Testing
Testing this is a little painful and should be done CI environment.

1. Do a deployment of the job templates to the CI environment via Jenkins ([HERE](https://stage-jenkins-csb-smqe.apps.ocp4.prod.psi.redhat.com/job/Swatch%20deploy%20CI/))
* Click 'Build With Parameters', enter this PR's branch, select only DEPLOY_SUBSCRIPTIONS_SCHEDULER box.

2. Once the build completes, wait for the top of the hour when a job runs. Check the OpenShift console for CI and ensure that after the job runs, a pod exists for each job.
3. Make sure that the logs for a job can be found in splunk using a search similar to the one below.
```
index=rh_rhsm namespace="rhsm-ci*" "Queuing OpenShift metrics update for account"
```
