### PR TITLE
ENT-3866: Default metric range lookup to 1h in YAML

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -114,7 +114,7 @@ rhsm-subscriptions:
         kafka-group-id: ${OPENSHIFT_METERING_TASK_GROUP_ID:openshift-metering-task-processor}
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:4h}
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
-  metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:24h}
+  metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:1h}
   subscription:
     useStub: ${SUBSCRIPTION_USE_STUB:false}
     url: ${SUBSCRIPTION_URL:https://subscription.qa.api.redhat.com/svcrest/subscription/v5}

--- a/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
@@ -175,8 +175,8 @@ class CaptureSnapshotsTaskManagerTest {
                       .setSingleValuedArg("accountNumber", accountNumber)
                       // 2019-05-24T12:35Z truncated to top of the hour - 4 hours prometheus latency
                       // - 1 hour
-                      // tally latency - 24 hour metric range
-                      .setSingleValuedArg("startDateTime", "2019-05-23T07:00:00Z")
+                      // tally latency - 1 hour metric range
+                      .setSingleValuedArg("startDateTime", "2019-05-24T06:00:00Z")
                       .setSingleValuedArg("endDateTime", "2019-05-24T07:00:00Z")
                       .build());
         });


### PR DESCRIPTION
In #410, we changed the default range to 1h in ApplicationProperties. However, we didn't change it in the YAML file.

I'm thinking to avoid this type of gotcha in the future, we should avoid setting a default value in Properties classes, and only keep a value in the YAML. I'll create a backlog task for this.

Testing
-------
Ensure you have some records in the account_config table:

```
cat << EOF | psql -h localhost -U rhsm-subscriptions
INSERT INTO public.account_config (account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated) VALUES ('account123', true, true, 'JMX', now(), now());
EOF
```

Run the following *without the change* (on `develop` branch):

```
SPRING_PROFILES_ACTIVE=capture-hourly-snapshots,kafka-queue ./gradlew bootRun
```

Observe messages such as:

```
2021-05-13 13:30:29,937 [thread=restartedMain] [INFO ] [org.candlepin.subscriptions.task.queue.kafka.KafkaTaskQueue] - Queuing task: TaskDescriptor[groupId: platform.rhsm-subscriptions.tasks, taskType: UPDATE_HOURLY_SNAPSHOTS, args: [startDateTime: [2021-05-12T08:00:00Z], accountNumber: [account123], endDateTime: [2021-05-13T08:00:00Z]]]
```

Note the time range is 24 hours.

Run the job again and observe messages such as:

```
2021-05-13 13:38:50,321 [thread=restartedMain] [INFO ] [org.candlepin.subscriptions.task.queue.kafka.KafkaTaskQueue] - Queuing task: TaskDescriptor[groupId: platform.rhsm-subscriptions.tasks, taskType: UPDATE_HOURLY_SNAPSHOTS, args: [startDateTime: [2021-05-13T07:00:00Z], accountNumber: [account123], endDateTime: [2021-05-13T08:00:00Z]]]
```

Observe that the time range is 1 hour.