### PR TITLE
ENT-3837: Add instance_hours as a metric type across data models (DB, API, event)

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1060,6 +1060,7 @@ components:
         - last_seen
         - measurement_type
         - core_hours
+        - instance_hours
     HostReport:
       properties:
         data:

--- a/schemas/event.yaml
+++ b/schemas/event.yaml
@@ -82,6 +82,7 @@ properties:
             - Cores
             - Sockets
             - Core-seconds
+            - Instance-hours
     required: false
   cloud_provider:
     description: Identifier for the cloud provider of the subject.

--- a/schemas/tally_summary.yaml
+++ b/schemas/tally_summary.yaml
@@ -63,6 +63,7 @@ properties:
                   - ''  # UNSPECIFIED
                   - Cores
                   - Sockets
+                  - Instance-hours
                 required: false
               value:
                 description: Measurement value.


### PR DESCRIPTION
This is a preparatory PR to thread new instance_hours to the API, database, and event.  I don't believe there are any unit tests for this, as it is a form of preparation for adding functionality.  