### PR TITLE
ENT-3824: Support subscriptions:reports:read permission

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-build
-buildSrc/build

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -119,9 +119,6 @@ public class ApplicationProperties {
    */
   private int antiCsrfPort = 443;
 
-  /** The RBAC application name that defines the permissions for this application. */
-  private String rbacApplicationName = "subscriptions";
-
   /** The base path for hawtio. Needed to serve hawtio behind a reverse proxy. */
   private String hawtioBasePath;
 

--- a/src/main/java/org/candlepin/subscriptions/http/HttpClientProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/http/HttpClientProperties.java
@@ -21,8 +21,10 @@
 package org.candlepin.subscriptions.http;
 
 import java.io.File;
+import lombok.Data;
 
 /** HTTP service client configuration. */
+@Data
 public class HttpClientProperties {
 
   /** Use a stub of the service. */
@@ -46,52 +48,4 @@ public class HttpClientProperties {
 
   /** Certificate authenticate file password */
   private char[] keystorePassword;
-
-  public boolean isUseStub() {
-    return useStub;
-  }
-
-  public void setUseStub(boolean useStub) {
-    this.useStub = useStub;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public void setUrl(String url) {
-    this.url = url;
-  }
-
-  public String getToken() {
-    return token;
-  }
-
-  public void setToken(String token) {
-    this.token = token;
-  }
-
-  public int getMaxConnections() {
-    return maxConnections;
-  }
-
-  public void setMaxConnections(int maxConnections) {
-    this.maxConnections = maxConnections;
-  }
-
-  public File getKeystore() {
-    return keystore;
-  }
-
-  public void setKeystore(File keystorePath) {
-    this.keystore = keystorePath;
-  }
-
-  public char[] getKeystorePassword() {
-    return keystorePassword;
-  }
-
-  public void setKeystorePassword(char[] keystorePassword) {
-    this.keystorePassword = keystorePassword;
-  }
 }

--- a/src/main/java/org/candlepin/subscriptions/http/HttpClientProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/http/HttpClientProperties.java
@@ -21,10 +21,12 @@
 package org.candlepin.subscriptions.http;
 
 import java.io.File;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 /** HTTP service client configuration. */
-@Data
+@Getter
+@Setter
 public class HttpClientProperties {
 
   /** Use a stub of the service. */

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacApiFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacApiFactory.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.rbac;
 
 import org.candlepin.subscriptions.http.HttpClient;
-import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.FactoryBean;
@@ -34,9 +33,9 @@ public class RbacApiFactory implements FactoryBean<RbacApi> {
 
   private static Logger log = LoggerFactory.getLogger(RbacApiFactory.class);
 
-  private final HttpClientProperties serviceProperties;
+  private final RbacProperties serviceProperties;
 
-  public RbacApiFactory(HttpClientProperties serviceProperties) {
+  public RbacApiFactory(RbacProperties serviceProperties) {
     this.serviceProperties = serviceProperties;
   }
 
@@ -44,7 +43,7 @@ public class RbacApiFactory implements FactoryBean<RbacApi> {
   public RbacApi getObject() throws Exception {
     if (serviceProperties.isUseStub()) {
       log.info("Using stub RBAC client");
-      return new StubRbacApi();
+      return new StubRbacApi(serviceProperties);
     }
     ApiClient apiClient = new RbacApiClient();
     apiClient.setHttpClient(

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacProperties.java
@@ -21,12 +21,14 @@
 package org.candlepin.subscriptions.rbac;
 
 import java.util.List;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 
 /** RBAC-specific properties */
-@Data
+@Getter
+@Setter
 @EqualsAndHashCode(callSuper = true)
 public class RbacProperties extends HttpClientProperties {
 

--- a/src/main/java/org/candlepin/subscriptions/rbac/RbacProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/RbacProperties.java
@@ -18,27 +18,21 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.security.auth;
+package org.candlepin.subscriptions.rbac;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import org.candlepin.subscriptions.security.RoleProvider;
-import org.springframework.security.access.prepost.PreAuthorize;
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.candlepin.subscriptions.http.HttpClientProperties;
 
-/**
- * Must have the SWATCH_ADMIN_ROLE and account must be whitelisted for reporting.
- *
- * @see RoleProvider
- */
-@Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize(
-    "hasAnyRole('"
-        + RoleProvider.SWATCH_ADMIN_ROLE
-        + "','"
-        + RoleProvider.SWATCH_REPORT_READER
-        + "') and "
-        + "@reportAccessService.providesAccessTo(authentication)")
-public @interface ReportingAccessRequired {}
+/** RBAC-specific properties */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class RbacProperties extends HttpClientProperties {
+
+  /** The list of permissions to return when using the stub */
+  private List<String> stubPermissions;
+
+  /** The RBAC application name that defines the permissions for this application. */
+  private String applicationName = "subscriptions";
+}

--- a/src/main/java/org/candlepin/subscriptions/rbac/StubRbacApi.java
+++ b/src/main/java/org/candlepin/subscriptions/rbac/StubRbacApi.java
@@ -20,15 +20,23 @@
  */
 package org.candlepin.subscriptions.rbac;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.candlepin.subscriptions.rbac.model.Access;
 
 /** Stub implementation of the RbacApi. */
 public class StubRbacApi implements RbacApi {
 
+  private final RbacProperties serviceProperties;
+
+  public StubRbacApi(RbacProperties serviceProperties) {
+    this.serviceProperties = serviceProperties;
+  }
+
   @Override
   public List<Access> getCurrentUserAccess(String applicationName) throws RbacApiException {
-    return Arrays.asList(new Access().permission("subscriptions:*:*"));
+    return serviceProperties.getStubPermissions().stream()
+        .map(p -> new Access().permission(p))
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.rbac.RbacApiException;
+import org.candlepin.subscriptions.rbac.RbacProperties;
 import org.candlepin.subscriptions.rbac.RbacService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,13 +49,16 @@ public class IdentityHeaderAuthenticationDetailsService
 
   private Attributes2GrantedAuthoritiesMapper authMapper;
   private ApplicationProperties props;
+  private RbacProperties rbacProps;
   private RoleProvider roleProvider;
   private RbacService rbacController;
 
   public IdentityHeaderAuthenticationDetailsService(
       ApplicationProperties props,
+      RbacProperties rbacProps,
       Attributes2GrantedAuthoritiesMapper authMapper,
       RbacService rbacController) {
+    this.rbacProps = rbacProps;
     this.authMapper = authMapper;
     this.props = props;
     this.rbacController = rbacController;
@@ -62,7 +66,7 @@ public class IdentityHeaderAuthenticationDetailsService
     if (props.isDevMode()) {
       log.info("Running in DEV mode. Security will be disabled.");
     }
-    this.roleProvider = new RoleProvider(props.getRbacApplicationName(), props.isDevMode());
+    this.roleProvider = new RoleProvider(rbacProps.getApplicationName(), props.isDevMode());
   }
 
   protected Collection<String> getUserRoles() {
@@ -98,7 +102,7 @@ public class IdentityHeaderAuthenticationDetailsService
 
   private List<String> getPermissions() {
     try {
-      return rbacController.getPermissions(props.getRbacApplicationName());
+      return rbacController.getPermissions(rbacProps.getApplicationName());
     } catch (RbacApiException e) {
       log.warn("Unable to determine roles from RBAC service.", e);
       return Collections.emptyList();

--- a/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RoleProvider.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class RoleProvider {
 
   public static final String SWATCH_ADMIN_ROLE = "SUBSCRIPTION_WATCH_ADMIN";
+  public static final String SWATCH_REPORT_READER = "SUBSCRIPTION_WATCH_REPORT_READER";
 
   private String rulePrefix;
   private boolean devModeEnabled;
@@ -50,6 +51,9 @@ public class RoleProvider {
     // configured otherwise).
     if (devModeEnabled || permissions.contains(rulePrefix + ":*:*")) {
       roles.add(SWATCH_ADMIN_ROLE);
+    }
+    if (permissions.contains(rulePrefix + ":reports:read")) {
+      roles.add(SWATCH_REPORT_READER);
     }
     return roles;
   }

--- a/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
+++ b/src/main/java/org/candlepin/subscriptions/security/SecurityConfig.java
@@ -23,13 +23,12 @@ package org.candlepin.subscriptions.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
-import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.candlepin.subscriptions.rbac.RbacApiFactory;
+import org.candlepin.subscriptions.rbac.RbacProperties;
 import org.candlepin.subscriptions.rbac.RbacService;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -94,6 +93,7 @@ public class SecurityConfig {
   public static class ApiConfiguration extends WebSecurityConfigurerAdapter {
     @Autowired protected ObjectMapper mapper;
     @Autowired protected ApplicationProperties appProps;
+    @Autowired protected RbacProperties rbacProperties;
     @Autowired protected ConfigurableEnvironment env;
     @Autowired protected RbacService rbacService;
 
@@ -102,14 +102,14 @@ public class SecurityConfig {
       // Add our AuthenticationProvider to the Provider Manager's list
       auth.authenticationProvider(
           identityHeaderAuthenticationProvider(
-              identityHeaderAuthenticationDetailsService(appProps, rbacService)));
+              identityHeaderAuthenticationDetailsService(appProps, rbacProperties, rbacService)));
     }
 
     @Bean
     public IdentityHeaderAuthenticationDetailsService identityHeaderAuthenticationDetailsService(
-        ApplicationProperties appProps, RbacService rbacService) {
+        ApplicationProperties appProps, RbacProperties rbacProperties, RbacService rbacService) {
       return new IdentityHeaderAuthenticationDetailsService(
-          appProps, identityHeaderAuthoritiesMapper(), rbacService);
+          appProps, rbacProperties, identityHeaderAuthoritiesMapper(), rbacService);
     }
 
     @Bean
@@ -124,14 +124,13 @@ public class SecurityConfig {
     }
 
     @Bean
-    @Qualifier("rbac")
     @ConfigurationProperties(prefix = "rhsm-subscriptions.rbac-service")
-    public HttpClientProperties rbacServiceProperties() {
-      return new HttpClientProperties();
+    public RbacProperties rbacServiceProperties() {
+      return new RbacProperties();
     }
 
     @Bean
-    public RbacApiFactory rbacApiFactory(@Qualifier("rbac") HttpClientProperties props) {
+    public RbacApiFactory rbacApiFactory(RbacProperties props) {
       return new RbacApiFactory(props);
     }
 

--- a/src/main/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnly.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/SubscriptionWatchAdminOnly.java
@@ -35,5 +35,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("hasRole('" + RoleProvider.SWATCH_ADMIN_ROLE + "')")
+@PreAuthorize(
+    "hasAnyRole('"
+        + RoleProvider.SWATCH_ADMIN_ROLE
+        + "','"
+        + RoleProvider.SWATCH_REPORT_READER
+        + "')")
 public @interface SubscriptionWatchAdminOnly {}

--- a/src/main/resources/application-api.yaml
+++ b/src/main/resources/application-api.yaml
@@ -1,8 +1,8 @@
 rhsm-subscriptions:
   pretty-print-json: ${PRETTY_PRINT_JSON:false}
-  # Use Spring Resource notation for this (e.g. "classpath:" or "file:")
-  rbac-application-name: ${RBAC_APPLICATION_NAME:subscriptions}
   rbac-service:
+    application-name: ${RBAC_APPLICATION_NAME:subscriptions}
     use-stub: ${RBAC_USE_STUB:false}
     url: http://${RBAC_HOST:localhost}:${RBAC_PORT:8819}/api/rbac/v1
     max-connections: ${RBAC_MAX_CONNECTIONS:100}
+    stub-permissions: ${RBAC_STUB_PERMISSIONS:subscriptions:*:*}

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
@@ -61,14 +61,14 @@ class IdentityHeaderAuthenticationDetailsServiceTest {
   void testAdminRoleGranted() throws Exception {
     when(rbacApi.getCurrentUserAccess(eq("subscriptions")))
         .thenReturn(Arrays.asList(new Access().permission("subscriptions:*:*")));
-    assertRoles(false, RoleProvider.SWATCH_ADMIN_ROLE);
+    assertThat(extractRoles(false), Matchers.contains(RoleProvider.SWATCH_ADMIN_ROLE));
   }
 
   @Test
   void testReportReaderRoleGranted() throws RbacApiException {
     when(rbacApi.getCurrentUserAccess(eq("subscriptions")))
         .thenReturn(List.of(new Access().permission("subscriptions:reports:read")));
-    assertRoles(false, RoleProvider.SWATCH_REPORT_READER);
+    assertThat(extractRoles(false), Matchers.contains(RoleProvider.SWATCH_REPORT_READER));
   }
 
   @Test
@@ -93,18 +93,16 @@ class IdentityHeaderAuthenticationDetailsServiceTest {
 
   @Test
   void testDevModeGrantsAllRoles() {
-    assertRoles(true, RoleProvider.SWATCH_ADMIN_ROLE);
+    assertThat(extractRoles(true), Matchers.contains(RoleProvider.SWATCH_ADMIN_ROLE));
   }
 
-  private void assertRoles(boolean devMode, String... expectedRoles) {
+  private Collection<String> extractRoles(boolean devMode) {
     ApplicationProperties props = new ApplicationProperties();
     RbacProperties rbacProps = new RbacProperties();
     props.setDevMode(devMode);
     IdentityHeaderAuthenticationDetailsService source =
         new IdentityHeaderAuthenticationDetailsService(
             props, rbacProps, new IdentityHeaderAuthoritiesMapper(), rbacService);
-    Collection<String> roles = source.getUserRoles();
-    assertEquals(expectedRoles.length, roles.size());
-    assertThat(roles, Matchers.containsInAnyOrder(expectedRoles));
+    return source.getUserRoles();
   }
 }


### PR DESCRIPTION
I also did some light refactoring around the RBAC properties, primarily pulling all rbac properties into a single properties class.

Testing
-------

Launch and run the following steps with two different configurations:

1. `RBAC_USE_STUB=true ./gradlew bootRun` (stub returns
   `subscriptions:*:*`).
2. `RBAC_USE_STUB=true RBAC_STUB_PERMISSIONS=subscriptions:reports:read
   ./gradlew bootRun`.

(you can try other arguments to RBAC_STUB_PERMISSIONS if desired)

Verify that the following two APIs still work (this hits both the security SPEL expressions we use):

1. Opt-in:
```
curl -X PUT \
  'http://localhost:8080/api/rhsm-subscriptions/v1/opt-in?enable_tally_sync=true&enable_tally_reporting=true&enable_conduit_sync=true' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

2. Check tally:
```
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift%20Container%20Platform?granularity=Daily&beginning=2017-07-21T17%3A32%3A28Z&ending=2017-07-21T17%3A32%3A28Z&use_running_totals_format=false' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

Launch w/ `RBAC_USE_STUB=true ./gradlew bootRun`. By default, the stub returns `subscriptions:*:*` for permissions. Verify that the opt-in endpoint continues to function: