### PR TITLE
Make compatible with Spring Boot 2.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,8 @@ dependencies {
     compile "org.springframework.retry:spring-retry"
     compile "org.springframework:spring-context-support"
     compile "org.springframework.kafka:spring-kafka"
+    // the following dep is necessary to avoid jackson kotlin warnings
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin"
 
     compile "io.micrometer:micrometer-registry-prometheus"
     compile "org.liquibase:liquibase-core"

--- a/src/main/java/org/candlepin/subscriptions/BootApplication.java
+++ b/src/main/java/org/candlepin/subscriptions/BootApplication.java
@@ -45,6 +45,8 @@ public class BootApplication {
     ApplicationClock! Setting it here means the whole application deals exclusively with UTC.
      */
     TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+    // Force liquibase-hub to off to avoid unnecessary warnings in our logs
+    System.setProperty("liquibase.hub.mode", "off");
     SpringApplication app = new SpringApplication(BootApplication.class);
     app.run(args);
   }

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LiquibaseCustomTask.java
@@ -29,6 +29,7 @@ import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import liquibase.Scope;
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
@@ -234,5 +235,7 @@ public abstract class LiquibaseCustomTask implements CustomTaskChange, Closeable
 
   public abstract boolean disableAutoCommit();
 
-  public abstract Logger getLogger();
+  public Logger getLogger() {
+    return Scope.getCurrentScope().getLog(this.getClass());
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/liquibase/LoadConfigsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/LoadConfigsTask.java
@@ -27,8 +27,6 @@ import java.sql.SQLException;
 import java.util.stream.Stream;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
-import liquibase.logging.LogService;
-import liquibase.logging.Logger;
 
 /**
  * Custom liquibase task for loading org_config and account_config files from text files.
@@ -111,11 +109,6 @@ public class LoadConfigsTask extends LiquibaseCustomTask {
   @Override
   public boolean disableAutoCommit() {
     return false;
-  }
-
-  @Override
-  public Logger getLogger() {
-    return LogService.getLog(LoadConfigsTask.class);
   }
 
   @Override

--- a/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/MigrateTallyColumnsTask.java
@@ -25,8 +25,6 @@ import java.sql.SQLException;
 import java.util.UUID;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
-import liquibase.logging.LogService;
-import liquibase.logging.Logger;
 
 /**
  * This class is responsible for moving the various cores/instance_count/sockets columns over to a
@@ -92,10 +90,5 @@ public class MigrateTallyColumnsTask extends LiquibaseCustomTask {
   @Override
   public String getConfirmationMessage() {
     return "Migration of tally_snapshots core/sockets/instance_count columns complete";
-  }
-
-  @Override
-  public Logger getLogger() {
-    return LogService.getLog(MigrateTallyColumnsTask.class);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -71,7 +71,7 @@ public class InventoryAccountUsageCollector {
     this.inventory = inventory;
     this.hostRepository = hostRepository;
     this.culledOffsetDays = props.getCullingOffsetDays();
-    this.totalHosts = meterRegistry.counter("rhsm-subscriptions.capacity.records_total");
+    this.totalHosts = meterRegistry.counter("rhsm-subscriptions.tally.hbi_hosts");
   }
 
   @SuppressWarnings("squid:S3776")

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -548,7 +548,7 @@ public class InventoryAccountUsageCollectorTest {
   @Test
   void testTotalHosts() {
     List<String> targetAccounts = Arrays.asList("A1");
-    Counter counter = meterRegistry.counter("rhsm-subscriptions.capacity.records_total");
+    Counter counter = meterRegistry.counter("rhsm-subscriptions.tally.hbi_hosts");
     double initialCount = counter.count();
 
     InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID, 12, 3);


### PR DESCRIPTION
1. Because spring-boot 2.5 comes with newer liquibase, needed to change how we fetch the logger in custom tasks.

2. Since newer liquibase comes with liquibase hub, I added a system property to disable it (otherwise we get an unnecessary warning in our logs).

3. Newer promtheus client surfaces a conflict in the naming of one of our custom metrics that was actually a copy-paste error anyways. Startup failed otherwise.

4. Add `jackson-module-kotlin` as a dep in order to avoid warnings. `spring-kafka` upgrade added kotlin deps, causing messages like:

```
WARN org.springframework.http.converter.json.Jackson2ObjectMapperBuilder - For Jackson Kotlin classes support please add "com.fasterxml.jackson.module:jackson-module-kotlin" to the classpath
```

After these changes are applied we can merge #449 and #447.