### PR TITLE
ENT-3890: Add user service env vars to marketplace-worker

### DIFF
--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -81,6 +81,18 @@ parameters:
     value: '4'
   - name: SUBSCRIPTION_PAGE_SIZE
     value: '500'
+  - name: USER_HOST
+    required: true
+  - name: USER_MAX_CONNECTIONS
+    value: '100'
+  - name: USER_MAX_ATTEMPTS
+    value: '10'
+  - name: USER_BACK_OFF_MAX_INTERVAL
+    value: 64s
+  - name: USER_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: USER_BACK_OFF_MULTIPLIER
+    value: '2'
 
 objects:
   - apiVersion: apps.openshift.io/v1
@@ -248,6 +260,18 @@ objects:
                   value: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS}
                 - name: SUBSCRIPTION_PAGE_SIZE
                   value: ${SUBSCRIPTION_PAGE_SIZE}
+                - name: USER_HOST
+                  value: ${USER_HOST}
+                - name: USER_MAX_CONNECTIONS
+                  value: ${USER_MAX_CONNECTIONS}
+                - name: USER_MAX_ATTEMPTS
+                  value: ${USER_MAX_ATTEMPTS}
+                - name: USER_BACK_OFF_MAX_INTERVAL
+                  value: ${USER_BACK_OFF_MAX_INTERVAL}
+                - name: USER_BACK_OFF_INITIAL_INTERVAL
+                  value: ${USER_BACK_OFF_INITIAL_INTERVAL}
+                - name: USER_BACK_OFF_MULTIPLIER
+                  value: ${USER_BACK_OFF_MULTIPLIER}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-3890

Otherwise, the defaults of localhost were being used, resulting in errors like:

```
Caused by: org.apache.http.conn.HttpHostConnectException: Connect to localhost:443 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused) at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:156)
org.springframework.kafka.listener.ListenerExecutionFailedException: Listener method 'public void org.candlepin.subscriptions.marketplace.MarketplaceWorker.receive(org.candlepin.subscriptions.json.TallySummary)' threw exception; nested exception is javax.ws.rs.ProcessingException: RESTEASY004655: Unable to invoke request; nested exception is javax.ws.rs.ProcessingException: RESTEASY004655: Unable to invoke request
```

Testing
-------

1. Login to the CI environment via `oc`.
2. Use the internal ci deploy script (use the branch named `khowell/ent-3890`) as:

```
RHSM_SUBSCRIPTIONS_BRANCH=khowell/ent-3890-user-service-marketplace-worker ./deploy.sh
```

3. Verify that marketplace worker is functional (can check back in ~1 hour).