### PR TITLE
ENT-3928: Disable the plain jar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,12 @@ jsonSchema2Pojo {
     includeSetters = true
 }
 
+// Disable the default jar; otherwise we end up with two different jars in the final image
+// See https://docs.spring.io/spring-boot/docs/2.5.0/gradle-plugin/reference/htmlsingle/#packaging-executable.and-plain-archives
+jar {
+    enabled = false
+}
+
 bootJar {
     mainClassName = "org.candlepin.subscriptions.BootApplication"
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-3928

Otherwise, we end up with two different JARs in the image, and the ubi8 java image doesn't know which one to run.

This started to happen because Spring Boot 2.5 no longer automatically disables the default jar.

See:

- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#gradle-default-jar-and-war-tasks
- https://docs.spring.io/spring-boot/docs/2.5.0/gradle-plugin/reference/htmlsingle/#packaging-executable.and-plain-archives

NOTE: I also symlinked `.gitignore` to `.dockerignore` to make building a pristine container image locally easier (syntax is compatible). Without this change, you needed to build from a clean checkout.

Testing
-------

On `develop`, run `./gradlew clean assemble`, observe that two jars are produced into `build/libs/`.

With this change, run `./gradlew clean assemble`, observe one jar.

If desired you can also run a broken image from `main`:

```
podman run --rm -ti quay.io/cloudservices/rhsm-subscriptions:eaa7b86
```

Note that the application does not get started, instead we get a message like:

```
ERROR Neither $JAVA_MAIN_CLASS nor $JAVA_APP_JAR is set and 2 JARs found in /deployments (1 expected)
```

Then compare with an image built with this change:

```
podman build . -t rhsm-subscriptions-patched
podman run --rm -ti rhsm-subscriptions-patched
```

Note the second command will run the application, but will exit due to not having DB env vars specified correctly.