### PR TITLE
Remove open paren from .dockerignore comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@
 **/prometheumultiprocess
 
 # Spring Boot reads local configuration out of a directory named config.
-# However, Gradle also looks for project configurations (most notably
-# Checkstyle configuration) in the config directory.  This section hides
+# However, Gradle also looks for project configurations - most notably
+# Checkstyle configuration - in the config directory.  This section hides
 # everything under the config directory except what Gradle is going to use.
 config/
 !config/codestyle/**


### PR DESCRIPTION
OpenShift v3 builds were failing due to this.

Possibly due to https://github.com/containers/buildah/issues/2686