### PR TITLE
Update build_deploy.sh

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,12 +4,19 @@ set -exv
 
 IMAGE="quay.io/cloudservices/rhsm-subscriptions"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+SMOKE_TEST_TAG="latest"
 
-docker build -t "${IMAGE}:${IMAGE_TAG}" .
-
-if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
-    DOCKER_CONF="$PWD/.docker"
-    mkdir -p "$DOCKER_CONF"
-    docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
+    echo "QUAY_USER and QUAY_TOKEN must be set"
+    exit 1
 fi
+
+DOCKER_CONF="$PWD/.docker"
+mkdir -p "$DOCKER_CONF"
+docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+docker --config="$DOCKER_CONF" build --no-cache -t "${IMAGE}:${IMAGE_TAG}" .
+docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
+docker --config="$DOCKER_CONF" push "${IMAGE}:${SMOKE_TEST_TAG}"
+docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
+docker --config="$DOCKER_CONF" push "${IMAGE}:qa"


### PR DESCRIPTION
I used RBAC's script: https://raw.githubusercontent.com/RedHatInsights/insights-rbac/master/build_deploy.sh

as a reference. Note that we don't need to pull from
registry.redhat.io, so I removed the login pieces for that.

Notably, this adds `latest` and `qa` tags.