### PR TITLE
ENT-3973: Fix TagProfile loading from classpath

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/files/ProductMappingConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/files/ProductMappingConfiguration.java
@@ -20,13 +20,12 @@
  */
 package org.candlepin.subscriptions.files;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.util.ResourceUtils;
+import org.springframework.core.io.ResourceLoader;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -41,8 +40,8 @@ public class ProductMappingConfiguration {
   }
 
   @Bean
-  public TagProfile tagProfile() throws FileNotFoundException {
+  public TagProfile tagProfile(ResourceLoader resourceLoader) throws IOException {
     Yaml parser = new Yaml(new Constructor(TagProfile.class));
-    return parser.load(new FileInputStream(ResourceUtils.getFile("classpath:tag_profile.yaml")));
+    return parser.load(resourceLoader.getResource("classpath:tag_profile.yaml").getInputStream());
   }
 }


### PR DESCRIPTION
Using `ResourceUtils.getFile()` for a file that is on the classpath, and not the filesystem won't work. Doh!

Testing
-------
`./gradlew assemble` from `develop`, run `java -jar build/libs/rhsm-subscriptions-1.0.53-SNAPSHOT.jar`, observe message w/

```
java.io.FileNotFoundException: class path resource [tag_profile.yaml] cannot be resolved to absolute file path because it does not reside in the file system: jar:file:/deployments/rhsm-subscriptions-1.0.53-SNAPSHOT.jar!/BOOT-INF/classes!/tag_profile.yaml
```

Repeat steps with this branch, observe that the app starts without errors.