### PR TITLE
ENT-3842: Add {total_,}instance_hours to tally API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -267,6 +267,7 @@ paths:
                 meta:
                   count: 10
                   total_core_hours: 30
+                  total_instance_hours: 20
                   product: RHEL
                   granularity: Daily
                   service_level: Premium
@@ -838,6 +839,8 @@ components:
               type: integer
             total_core_hours:
               type: double
+            total_instance_hours:
+              type: double
             product:
               $ref: '#/components/schemas/ProductId'
             service_level:
@@ -884,6 +887,11 @@ components:
           minimum: 0
           default: 0
         core_hours:
+          type: number
+          format: double
+          minimum: 0
+          default: 0
+        instance_hours:
           type: number
           format: double
           minimum: 0

--- a/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -275,6 +275,9 @@ public class TallySnapshot implements Serializable {
 
     snapshot.setCoreHours(
         tallyMeasurements.get(new TallyMeasurementKey(HardwareMeasurementType.TOTAL, Uom.CORES)));
+    snapshot.setInstanceHours(
+        tallyMeasurements.get(
+            new TallyMeasurementKey(HardwareMeasurementType.TOTAL, Uom.INSTANCE_HOURS)));
 
     snapshot.setHasData(id != null);
     return snapshot;

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -137,6 +137,7 @@ public class TallyResource implements TallyApi {
     report.getMeta().setServiceLevel(sla);
     report.getMeta().setUsage(usageType == null ? null : effectiveUsage.asOpenApiEnum());
     report.getMeta().setTotalCoreHours(getTotalCoreHours(report));
+    report.getMeta().setTotalInstanceHours(getTotalInstanceHours(report));
 
     if (Boolean.TRUE.equals(useRunningTotalsFormat)) {
       transformToRunningTotalFormat(report);
@@ -162,6 +163,12 @@ public class TallyResource implements TallyApi {
   private Double getTotalCoreHours(TallyReport report) {
     return report.getData().stream()
         .mapToDouble(snapshot -> Optional.ofNullable(snapshot.getCoreHours()).orElse(0.0))
+        .sum();
+  }
+
+  private Double getTotalInstanceHours(TallyReport report) {
+    return report.getData().stream()
+        .mapToDouble(snapshot -> Optional.ofNullable(snapshot.getInstanceHours()).orElse(0.0))
         .sum();
   }
 

--- a/src/test/java/org/candlepin/subscriptions/db/model/TallySnapshotTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/TallySnapshotTest.java
@@ -140,4 +140,15 @@ class TallySnapshotTest {
         snapshot.asApiSnapshot();
     assertEquals(expCoreHours, apiSnapshot.getCoreHours());
   }
+
+  @Test
+  void shouldAddInstanceHoursWhenCreatingApiSnapshot() {
+    Double expCoreHours = 22.2;
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setMeasurement(HardwareMeasurementType.TOTAL, Uom.INSTANCE_HOURS, expCoreHours);
+
+    org.candlepin.subscriptions.utilization.api.model.TallySnapshot apiSnapshot =
+        snapshot.asApiSnapshot();
+    assertEquals(expCoreHours, apiSnapshot.getInstanceHours());
+  }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -518,14 +518,14 @@ public class TallyResourceTest {
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)
         .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-            Mockito.eq("account123456"),
-            Mockito.eq(RHEL_PRODUCT_ID.toString()),
-            Mockito.eq(Granularity.DAILY),
-            Mockito.eq(ServiceLevel.PREMIUM),
-            Mockito.eq(Usage.PRODUCTION),
-            Mockito.eq(min),
-            Mockito.eq(max),
-            Mockito.eq(expectedPageable));
+            "account123456",
+            RHEL_PRODUCT_ID.toString(),
+            Granularity.DAILY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            min,
+            max,
+            expectedPageable);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -42,6 +42,7 @@ import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.RoleProvider;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
@@ -468,6 +469,51 @@ public class TallyResourceTest {
             UsageType.PRODUCTION,
             false);
     assertEquals(1, report.getData().size());
+
+    Pageable expectedPageable = PageRequest.of(1, 10);
+    Mockito.verify(repository)
+        .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+            Mockito.eq("account123456"),
+            Mockito.eq(RHEL_PRODUCT_ID.toString()),
+            Mockito.eq(Granularity.DAILY),
+            Mockito.eq(ServiceLevel.PREMIUM),
+            Mockito.eq(Usage.PRODUCTION),
+            Mockito.eq(min),
+            Mockito.eq(max),
+            Mockito.eq(expectedPageable));
+  }
+
+  @Test
+  void testShouldPopulateTotalInstanceHours() throws Exception {
+    TallySnapshot snap = new TallySnapshot();
+    snap.setMeasurement(HardwareMeasurementType.TOTAL, Uom.INSTANCE_HOURS, 42.0);
+
+    Mockito.when(
+            repository
+                .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                    Mockito.eq("account123456"),
+                    Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                    Mockito.eq(Granularity.DAILY),
+                    Mockito.eq(ServiceLevel.PREMIUM),
+                    Mockito.eq(Usage.PRODUCTION),
+                    Mockito.eq(min),
+                    Mockito.eq(max),
+                    Mockito.any(Pageable.class)))
+        .thenReturn(new PageImpl<>(Arrays.asList(snap)));
+
+    TallyReport report =
+        resource.getTallyReport(
+            RHEL_PRODUCT_ID,
+            GranularityType.DAILY,
+            min,
+            max,
+            10,
+            10,
+            ServiceLevelType.PREMIUM,
+            UsageType.PRODUCTION,
+            false);
+    assertEquals(1, report.getData().size());
+    assertEquals(42.0, report.getMeta().getTotalInstanceHours());
 
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)


### PR DESCRIPTION
Testing
-------

Mock some data for instance hours:

```
cat <<EOF | psql -h localhost -U rhsm-subscriptions
insert into tally_snapshots(id, product_id, account_number, granularity, owner_id, instance_count,
                            snapshot_date, sla, usage)
values ('b099d1fc-118f-4255-8500-aa7f9660663d', 'OpenShift-metrics', 'account123', 'DAILY', 'org123', 1, '2017-07-29',
        '_ANY', '_ANY');
insert into tally_measurements(snapshot_id, measurement_type, uom, value)
values ('b099d1fc-118f-4255-8500-aa7f9660663d', 'TOTAL', 'INSTANCE_HOURS', 4.0);
EOF
```

Hit the API:

```
curl 'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics?granularity=Daily&sla=_ANY&usage=_ANY&beginning=2017-07-29T00%3A00%3A00Z&ending=2017-07-30T23%3A59%3A59Z&use_running_totals_format=false'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' | jq
```

Observe values of 4 for both the first tally item in `instance_hours`,
as well as for `total_instance_hours`.