### PR TITLE
ENT-3871/ENT-3978: Update metrics task to use tag profile

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/files/TagMetric.java
+++ b/src/main/java/org/candlepin/subscriptions/files/TagMetric.java
@@ -20,8 +20,12 @@
  */
 package org.candlepin.subscriptions.files;
 
+import static org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder.DEFAULT_METRIC_QUERY_KEY;
+
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,7 +45,6 @@ public class TagMetric {
   private String tag;
   private String metricId;
   private Uom uom;
-  private String prometheusQueryTemplateKey;
-  private String prometheusMetric;
-  private String prometheusMetadataMetric;
+  @Default private String queryKey = DEFAULT_METRIC_QUERY_KEY;
+  private Map<String, String> queryParams;
 }

--- a/src/main/java/org/candlepin/subscriptions/files/TagMetric.java
+++ b/src/main/java/org/candlepin/subscriptions/files/TagMetric.java
@@ -46,5 +46,6 @@ public class TagMetric {
   private String metricId;
   private Uom uom;
   @Default private String queryKey = DEFAULT_METRIC_QUERY_KEY;
+  @Default private String accountQueryKey = DEFAULT_METRIC_QUERY_KEY;
   private Map<String, String> queryParams;
 }

--- a/src/main/java/org/candlepin/subscriptions/files/TagProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/files/TagProfile.java
@@ -100,10 +100,11 @@ public class TagProfile {
   private void handleTagMetaData(TagMetaData tagMetaData) {
     tagMetaData
         .getTags()
-        .forEach(tag -> {
-          tagMetaDataToTagLookup.put(tag, tagMetaData);
-          finestGranularityLookup.put(tag, tagMetaData.getFinestGranularity());
-        });
+        .forEach(
+            tag -> {
+              tagMetaDataToTagLookup.put(tag, tagMetaData);
+              finestGranularityLookup.put(tag, tagMetaData.getFinestGranularity());
+            });
   }
 
   public boolean tagSupportsEngProduct(String tag, String engId) {
@@ -136,5 +137,4 @@ public class TagProfile {
     }
     return Optional.ofNullable(tagMetaDataToTagLookup.get(productTag));
   }
-
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -46,10 +46,10 @@ public class MeteringEventFactory {
   }
 
   /**
-   * Creates an Event object that represents a cores snapshot for a given OpenShift cluster.
+   * Creates an Event object that represents a cores snapshot for a given instance.
    *
    * @param accountNumber the account number.
-   * @param clusterId the ID of the cluster that was measured.
+   * @param instanceId the ID of the cluster that was measured.
    * @param serviceLevel the service level of the cluster.
    * @param usage the usage of the cluster.
    * @param role the role of the cluster.
@@ -59,10 +59,10 @@ public class MeteringEventFactory {
    * @return a populated Event instance.
    */
   @SuppressWarnings("java:S107")
-  public static Event openShiftClusterCores(
+  public static Event createMetricEvent(
       String accountNumber,
       String metricId,
-      String clusterId,
+      String instanceId,
       String serviceLevel,
       String usage,
       String role,
@@ -72,11 +72,11 @@ public class MeteringEventFactory {
       Uom measuredMetric,
       Double measuredValue) {
     Event event = new Event();
-    updateOpenShiftClusterCores(
+    updateMetricEvent(
         event,
         accountNumber,
         metricId,
-        clusterId,
+        instanceId,
         serviceLevel,
         usage,
         role,
@@ -89,11 +89,11 @@ public class MeteringEventFactory {
   }
 
   @SuppressWarnings("java:S107")
-  public static void updateOpenShiftClusterCores(
+  public static void updateMetricEvent(
       Event toUpdate,
       String accountNumber,
       String metricId,
-      String clusterId,
+      String instanceId,
       String serviceLevel,
       String usage,
       String role,
@@ -107,15 +107,15 @@ public class MeteringEventFactory {
         .withEventType(getEventType(metricId))
         .withServiceType(serviceType)
         .withAccountNumber(accountNumber)
-        .withInstanceId(clusterId)
+        .withInstanceId(instanceId)
         .withTimestamp(measuredTime)
         .withExpiration(Optional.of(expired))
-        .withDisplayName(Optional.of(clusterId))
-        .withSla(getSla(serviceLevel, accountNumber, clusterId))
-        .withUsage(getUsage(usage, accountNumber, clusterId))
+        .withDisplayName(Optional.of(instanceId))
+        .withSla(getSla(serviceLevel, accountNumber, instanceId))
+        .withUsage(getUsage(usage, accountNumber, instanceId))
         .withMeasurements(
             List.of(new Measurement().withUom(measuredMetric).withValue(measuredValue)))
-        .withRole(getRole(role, accountNumber, clusterId));
+        .withRole(getRole(role, accountNumber, instanceId));
   }
 
   public static String getEventType(String metricId) {

--- a/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
@@ -58,32 +58,27 @@ public class MeteringJmxBean {
 
   @ManagedOperation(description = "Perform product metering for a single account.")
   @ManagedOperationParameter(name = "accountNumber", description = "Red Hat Account Number")
-  @ManagedOperationParameter(name = "productProfileId", description = "Product profile identifier")
-  public void performMeteringForAccount(String accountNumber, String productProfileId)
+  @ManagedOperationParameter(name = "productTag", description = "Product tag identifier")
+  public void performMeteringForAccount(String accountNumber, String productTag)
       throws IllegalArgumentException {
     Object principal = ResourceUtils.getPrincipal();
-    log.info(
-        "{} metering for {} triggered via JMX by {}", productProfileId, accountNumber, principal);
+    log.info("{} metering for {} triggered via JMX by {}", productTag, accountNumber, principal);
 
     OffsetDateTime end = getDate(null);
     OffsetDateTime start =
-        getStartDate(
-            end, prometheusMetricsProperties.getRangeInMinutesForProductProfile(productProfileId));
+        getStartDate(end, prometheusMetricsProperties.getRangeInMinutesForProductTag(productTag));
 
     try {
-      tasks.updateMetricsForAccount(accountNumber, productProfileId, start, end);
+      tasks.updateMetricsForAccount(accountNumber, productTag, start, end);
     } catch (Exception e) {
       log.error(
-          "Error triggering {} metering for account {} via JMX.",
-          productProfileId,
-          accountNumber,
-          e);
+          "Error triggering {} metering for account {} via JMX.", productTag, accountNumber, e);
     }
   }
 
   @ManagedOperation(description = "Perform custom product metering for a single account.")
   @ManagedOperationParameter(name = "accountNumber", description = "Red Hat Account Number")
-  @ManagedOperationParameter(name = "productProfileId", description = "Product profile identifier")
+  @ManagedOperationParameter(name = "productTag", description = "Product tag identifier")
   @ManagedOperationParameter(
       name = "endDate",
       description =
@@ -93,46 +88,41 @@ public class MeteringJmxBean {
       description =
           "Period of time (before the end date) to start metrics gathering. Must be >= 0.")
   public void performCustomMeteringForAccount(
-      String accountNumber, String productProfileId, String endDate, Integer rangeInMinutes)
+      String accountNumber, String productTag, String endDate, Integer rangeInMinutes)
       throws IllegalArgumentException {
     Object principal = ResourceUtils.getPrincipal();
-    log.info(
-        "{} metering for {} triggered via JMX by {}", productProfileId, accountNumber, principal);
+    log.info("{} metering for {} triggered via JMX by {}", productTag, accountNumber, principal);
 
     OffsetDateTime end = getDate(endDate);
     OffsetDateTime start = getStartDate(end, rangeInMinutes);
 
     try {
-      tasks.updateMetricsForAccount(accountNumber, productProfileId, start, end);
+      tasks.updateMetricsForAccount(accountNumber, productTag, start, end);
     } catch (Exception e) {
       log.error(
-          "Error triggering {} metering for account {} via JMX.",
-          productProfileId,
-          accountNumber,
-          e);
+          "Error triggering {} metering for account {} via JMX.", productTag, accountNumber, e);
     }
   }
 
   @ManagedOperation(description = "Perform a product metering for all accounts.")
-  public void performMetering(String productProfileId) throws IllegalArgumentException {
+  public void performMetering(String productTag) throws IllegalArgumentException {
     Object principal = ResourceUtils.getPrincipal();
     log.info("Metering for all accounts triggered via JMX by {}", principal);
 
     OffsetDateTime end = getDate(null);
     // ENT-3835 will change the data structures used here
     OffsetDateTime start =
-        getStartDate(
-            end, prometheusMetricsProperties.getRangeInMinutesForProductProfile(productProfileId));
+        getStartDate(end, prometheusMetricsProperties.getRangeInMinutesForProductTag(productTag));
 
     try {
-      tasks.updateMetricsForAllAccounts(productProfileId, start, end);
+      tasks.updateMetricsForAllAccounts(productTag, start, end);
     } catch (Exception e) {
-      log.error("Error triggering {} metering for all accounts via JMX.", productProfileId, e);
+      log.error("Error triggering {} metering for all accounts via JMX.", productTag, e);
     }
   }
 
   @ManagedOperation(description = "Perform custom product metering for all accounts.")
-  @ManagedOperationParameter(name = "productProfileId", description = "Product profile identifier")
+  @ManagedOperationParameter(name = "productTag", description = "Product tag identifier")
   @ManagedOperationParameter(
       name = "endDate",
       description =
@@ -141,7 +131,7 @@ public class MeteringJmxBean {
       name = "rangeInMinutes",
       description =
           "Period of time (before the end date) to start metrics gathering. Must be >= 0.")
-  public void performCustomMetering(String productProfileId, String endDate, Integer rangeInMinutes)
+  public void performCustomMetering(String productTag, String endDate, Integer rangeInMinutes)
       throws IllegalArgumentException {
     Object principal = ResourceUtils.getPrincipal();
     log.info("Metering for all accounts triggered via JMX by {}", principal);
@@ -150,9 +140,9 @@ public class MeteringJmxBean {
     OffsetDateTime start = getStartDate(end, rangeInMinutes);
 
     try {
-      tasks.updateMetricsForAllAccounts(productProfileId, start, end);
+      tasks.updateMetricsForAllAccounts(productTag, start, end);
     } catch (Exception e) {
-      log.error("Error triggering {} metering for all accounts via JMX.", productProfileId, e);
+      log.error("Error triggering {} metering for all accounts via JMX.", productTag, e);
     }
   }
 

--- a/src/main/java/org/candlepin/subscriptions/metering/job/MeteringJob.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/job/MeteringJob.java
@@ -25,6 +25,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.exception.JobFailureException;
+import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -39,16 +40,19 @@ public class MeteringJob implements Runnable {
 
   private PrometheusMetricsTaskManager tasks;
   private ApplicationClock clock;
+  private final TagProfile tagProfile;
   private ApplicationProperties appProps;
   private PrometheusMetricsProperties prometheusMetricsProperties;
 
   public MeteringJob(
       PrometheusMetricsTaskManager tasks,
       ApplicationClock clock,
+      TagProfile tagProfile,
       PrometheusMetricsProperties prometheusMetricsProperties,
       ApplicationProperties appProps) {
     this.tasks = tasks;
     this.clock = clock;
+    this.tagProfile = tagProfile;
     this.prometheusMetricsProperties = prometheusMetricsProperties;
     this.appProps = appProps;
   }
@@ -57,7 +61,7 @@ public class MeteringJob implements Runnable {
   @Scheduled(cron = "${rhsm-subscriptions.jobs.metering-schedule}")
   public void run() {
     Duration latency = appProps.getPrometheusLatencyDuration();
-    for (String productTag : prometheusMetricsProperties.getMetricsEnabledProductTags()) {
+    for (String productTag : tagProfile.getTagsWithPrometheusEnabledLookup()) {
       int range = prometheusMetricsProperties.getRangeInMinutesForProductTag(productTag);
       OffsetDateTime startDate = clock.startOfHour(clock.now().minus(latency).minusMinutes(range));
       // Minus 1 minute to ensure that we use the last hour's maximum time. If the end

--- a/src/main/java/org/candlepin/subscriptions/metering/job/MeteringJob.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/job/MeteringJob.java
@@ -57,8 +57,8 @@ public class MeteringJob implements Runnable {
   @Scheduled(cron = "${rhsm-subscriptions.jobs.metering-schedule}")
   public void run() {
     Duration latency = appProps.getPrometheusLatencyDuration();
-    for (String productProfileId : prometheusMetricsProperties.getMetricsEnabledProductProfiles()) {
-      int range = prometheusMetricsProperties.getRangeInMinutesForProductProfile(productProfileId);
+    for (String productTag : prometheusMetricsProperties.getMetricsEnabledProductTags()) {
+      int range = prometheusMetricsProperties.getRangeInMinutesForProductTag(productTag);
       OffsetDateTime startDate = clock.startOfHour(clock.now().minus(latency).minusMinutes(range));
       // Minus 1 minute to ensure that we use the last hour's maximum time. If the end
       // time
@@ -74,10 +74,9 @@ public class MeteringJob implements Runnable {
           clock.endOfHour(
               startDate.plusMinutes(range).truncatedTo(ChronoUnit.HOURS).minusMinutes(1));
 
-      log.info(
-          "Queuing {} metric updates for range: {} -> {}", productProfileId, startDate, endDate);
+      log.info("Queuing {} metric updates for range: {} -> {}", productTag, startDate, endDate);
       try {
-        tasks.updateMetricsForAllAccounts(productProfileId, startDate, endDate);
+        tasks.updateMetricsForAllAccounts(productTag, startDate, endDate);
       } catch (Exception e) {
         throw new JobFailureException("Unable to run MeteringJob.", e);
       }

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.metering.profile;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.jobs.JobProperties;
 import org.candlepin.subscriptions.metering.job.MeteringJob;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
@@ -40,6 +41,7 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 @Profile("metering-job")
 @Import({
+  ProductMappingConfiguration.class,
   PrometheusServiceConfiguration.class,
   MeteringTasksConfiguration.class,
   TaskProducerConfiguration.class

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.metering.profile;
 
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.files.ProductMappingConfiguration;
+import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.jobs.JobProperties;
 import org.candlepin.subscriptions.metering.job.MeteringJob;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
@@ -57,9 +58,10 @@ public class MeteringJobProfile {
   MeteringJob meteringJob(
       PrometheusMetricsTaskManager tasks,
       ApplicationClock clock,
+      TagProfile tagProfile,
       PrometheusMetricsProperties metricProperties,
       ApplicationProperties appProps) {
-    return new MeteringJob(tasks, clock, metricProperties, appProps);
+    return new MeteringJob(tasks, clock, tagProfile, metricProperties, appProps);
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -76,6 +76,7 @@ public class OpenShiftWorkerProfile {
     return retryTemplate;
   }
 
+  @SuppressWarnings("java:S107")
   @Bean
   PrometheusMeteringController getController(
       ApplicationClock clock,

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -21,10 +21,12 @@
 package org.candlepin.subscriptions.metering.profile;
 
 import org.candlepin.subscriptions.event.EventController;
+import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService;
 import org.candlepin.subscriptions.metering.service.prometheus.config.PrometheusServiceConfiguration;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.metering.task.MeteringTasksConfiguration;
 import org.candlepin.subscriptions.security.OptInController;
 import org.candlepin.subscriptions.task.queue.TaskConsumerConfiguration;
@@ -49,6 +51,7 @@ import org.springframework.retry.support.RetryTemplate;
 @Configuration
 @Profile("openshift-metering-worker")
 @Import({
+  ProductMappingConfiguration.class,
   PrometheusServiceConfiguration.class,
   TaskConsumerConfiguration.class,
   MeteringTasksConfiguration.class
@@ -77,10 +80,17 @@ public class OpenShiftWorkerProfile {
       ApplicationClock clock,
       PrometheusMetricsProperties mProps,
       PrometheusService service,
+      QueryBuilder queryBuilder,
       EventController eventController,
       @Qualifier("openshiftMetricRetryTemplate") RetryTemplate openshiftRetryTemplate,
       OptInController optInController) {
     return new PrometheusMeteringController(
-        clock, mProps, service, eventController, openshiftRetryTemplate, optInController);
+        clock,
+        mProps,
+        service,
+        queryBuilder,
+        eventController,
+        openshiftRetryTemplate,
+        optInController);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.metering.profile;
 
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.files.ProductMappingConfiguration;
+import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService;
@@ -83,7 +84,8 @@ public class OpenShiftWorkerProfile {
       QueryBuilder queryBuilder,
       EventController eventController,
       @Qualifier("openshiftMetricRetryTemplate") RetryTemplate openshiftRetryTemplate,
-      OptInController optInController) {
+      OptInController optInController,
+      TagProfile tagProfile) {
     return new PrometheusMeteringController(
         clock,
         mProps,
@@ -91,6 +93,7 @@ public class OpenShiftWorkerProfile {
         queryBuilder,
         eventController,
         openshiftRetryTemplate,
-        optInController);
+        optInController,
+        tagProfile);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
@@ -28,9 +28,6 @@ import lombok.Setter;
 @Setter
 public class MetricProperties {
 
-  /** The PromQL to run when gathering the configured metric */
-  private String metricPromQL;
-
   /** The PromQL to run when gathering a list of accounts to enable for this metric. */
   private String enabledAccountPromQL;
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
@@ -28,9 +28,6 @@ import lombok.Setter;
 @Setter
 public class MetricProperties {
 
-  /** The PromQL to run when gathering a list of accounts to enable for this metric. */
-  private String enabledAccountPromQL;
-
   /** How long to wait for results from the query. */
   private int queryTimeout = 10000;
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSource.java
@@ -21,8 +21,13 @@
 package org.candlepin.subscriptions.metering.service.prometheus;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.candlepin.subscriptions.files.TagMetric;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryDescriptor;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
 import org.springframework.util.StringUtils;
 
@@ -31,17 +36,22 @@ public class PrometheusAccountSource {
 
   private PrometheusService service;
   private PrometheusMetricsProperties prometheusProps;
+  private QueryBuilder queryBuilder;
 
   public PrometheusAccountSource(
-      PrometheusService service, PrometheusMetricsProperties prometheusProps) {
+      PrometheusService service,
+      PrometheusMetricsProperties prometheusProps,
+      QueryBuilder queryBuilder) {
     this.service = service;
     this.prometheusProps = prometheusProps;
+    this.queryBuilder = queryBuilder;
   }
 
-  public Set<String> getMarketplaceAccounts(String productProfileId, OffsetDateTime time) {
+  public Set<String> getMarketplaceAccounts(
+      String productProfileId, Uom metric, OffsetDateTime time) {
     QueryResult result =
         service.runQuery(
-            prometheusProps.getEnabledAccountPromQLforProductTag(productProfileId),
+            buildQuery(productProfileId, metric),
             time,
             prometheusProps.getMetricsTimeoutForProductTag(productProfileId));
 
@@ -49,5 +59,14 @@ public class PrometheusAccountSource {
         .map(r -> r.getMetric().getOrDefault("ebs_account", ""))
         .filter(StringUtils::hasText)
         .collect(Collectors.toSet());
+  }
+
+  private String buildQuery(String productTag, Uom metric) {
+    Optional<TagMetric> tag = prometheusProps.getTagMetric(productTag, metric);
+    if (tag.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format("Could not find TagMetric for %s %s", productTag, metric));
+    }
+    return queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag.get()));
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSource.java
@@ -41,9 +41,9 @@ public class PrometheusAccountSource {
   public Set<String> getMarketplaceAccounts(String productProfileId, OffsetDateTime time) {
     QueryResult result =
         service.runQuery(
-            prometheusProps.getEnabledAccountPromQLforProductProfile(productProfileId),
+            prometheusProps.getEnabledAccountPromQLforProductTag(productProfileId),
             time,
-            prometheusProps.getMetricsTimeoutForProductProfile(productProfileId));
+            prometheusProps.getMetricsTimeoutForProductTag(productProfileId));
 
     return result.getData().getResult().stream()
         .map(r -> r.getMetric().getOrDefault("ebs_account", ""))

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -62,7 +62,7 @@ public class PrometheusMeteringController {
   private final PrometheusService prometheusService;
   private final EventController eventController;
   private final ApplicationClock clock;
-  private final PrometheusMetricsProperties promMetricsProperties;
+  private final PrometheusMetricsProperties prometheusMetricsProperties;
   private final RetryTemplate openshiftRetry;
   private final OptInController optInController;
   private final QueryBuilder prometheusQueryBuilder;
@@ -70,7 +70,7 @@ public class PrometheusMeteringController {
 
   public PrometheusMeteringController(
       ApplicationClock clock,
-      PrometheusMetricsProperties promMetricsProperties,
+      PrometheusMetricsProperties prometheusMetricsProperties,
       PrometheusService service,
       QueryBuilder queryBuilder,
       EventController eventController,
@@ -78,7 +78,7 @@ public class PrometheusMeteringController {
       OptInController optInController,
       TagProfile tagProfile) {
     this.clock = clock;
-    this.promMetricsProperties = promMetricsProperties;
+    this.prometheusMetricsProperties = prometheusMetricsProperties;
     this.prometheusService = service;
     this.prometheusQueryBuilder = queryBuilder;
     this.eventController = eventController;
@@ -95,7 +95,7 @@ public class PrometheusMeteringController {
   @Transactional
   public void collectMetrics(
       String tag, Uom metric, String account, OffsetDateTime start, OffsetDateTime end) {
-    Optional<TagMetric> tagMetric = promMetricsProperties.getTagMetric(tag, metric);
+    Optional<TagMetric> tagMetric = prometheusMetricsProperties.getTagMetric(tag, metric);
     if (tagMetric.isEmpty()) {
       throw new UnsupportedOperationException(
           String.format("Unable to find TagMetric for tag %s and metric %s!", tag, metric));
@@ -108,7 +108,7 @@ public class PrometheusMeteringController {
     }
 
     MetricProperties metricProps =
-        promMetricsProperties.getSupportedMetricsForProduct(tag).get(metric);
+        prometheusMetricsProperties.getSupportedMetricsForProduct(tag).get(metric);
 
     // Reset the start/end dates to ensure they span a complete hour.
     // NOTE: If the prometheus query step changes, we will need to adjust this.
@@ -146,8 +146,8 @@ public class PrometheusMeteringController {
                     // We need to shift the start and end dates by the step, to account for the
                     // shift in the event start date when it is created. See note about eventDate
                     // below.
-                    startDate.minusSeconds(promMetricsProperties.getOpenshift().getStep()),
-                    endDate.minusSeconds(promMetricsProperties.getOpenshift().getStep()));
+                    startDate.minusSeconds(prometheusMetricsProperties.getOpenshift().getStep()),
+                    endDate.minusSeconds(prometheusMetricsProperties.getOpenshift().getStep()));
             log.debug("Found {} existing events.", existing.size());
 
             Map<EventKey, Event> events = new HashMap<>();
@@ -173,7 +173,7 @@ public class PrometheusMeteringController {
                 // actually represents the end of the measured period. The start of the event
                 // should be at the beginning.
                 OffsetDateTime eventDate =
-                    eventTermDate.minusSeconds(promMetricsProperties.getOpenshift().getStep());
+                    eventTermDate.minusSeconds(prometheusMetricsProperties.getOpenshift().getStep());
 
                 Event event =
                     createOrUpdateEvent(

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -173,7 +173,8 @@ public class PrometheusMeteringController {
                 // actually represents the end of the measured period. The start of the event
                 // should be at the beginning.
                 OffsetDateTime eventDate =
-                    eventTermDate.minusSeconds(prometheusMetricsProperties.getOpenshift().getStep());
+                    eventTermDate.minusSeconds(
+                        prometheusMetricsProperties.getOpenshift().getStep());
 
                 Event event =
                     createOrUpdateEvent(

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -68,6 +68,7 @@ public class PrometheusMeteringController {
   private final QueryBuilder prometheusQueryBuilder;
   private final TagProfile tagProfile;
 
+  @SuppressWarnings("java:S107")
   public PrometheusMeteringController(
       ApplicationClock clock,
       PrometheusMetricsProperties prometheusMetricsProperties,

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
@@ -72,10 +72,6 @@ public class PrometheusMetricsProperties {
     return metrics;
   }
 
-  public Collection<String> getMetricsEnabledProductTags() {
-    return tagProfile.getTagsWithPrometheusEnabledLookup();
-  }
-
   public Integer getMetricsTimeoutForProductTag(String productTag) {
     // NOTE(khowell): doesn't make sense for a given product tag (e.g. OSD) to have different
     // metrics timeouts. Grabbing the first one for now.

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
@@ -42,7 +42,7 @@ import org.springframework.util.StringUtils;
 @ConfigurationProperties(prefix = "rhsm-subscriptions.metering.prometheus.metric")
 public class PrometheusMetricsProperties {
 
-  @Autowired TagProfile tagProfile;
+  private final TagProfile tagProfile;
 
   private Map<String, String> queryTemplates = new HashMap<>();
 
@@ -55,6 +55,11 @@ public class PrometheusMetricsProperties {
   private int templateParameterDepth = 3;
 
   private MetricProperties openshift = new MetricProperties();
+
+  @Autowired
+  public PrometheusMetricsProperties(TagProfile tagProfile) {
+    this.tagProfile = tagProfile;
+  }
 
   public Map<Uom, MetricProperties> getSupportedMetricsForProduct(String productTag) {
     if (!tagProfile.tagIsPrometheusEnabled(productTag)) {

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
@@ -54,47 +54,42 @@ public class PrometheusMetricsProperties {
 
   private MetricProperties openshift = new MetricProperties();
 
-  public Map<Uom, MetricProperties> getSupportedMetricsForProduct(String productProfileId) {
-    if (!tagProfile.tagIsPrometheusEnabled(productProfileId)) {
+  public Map<Uom, MetricProperties> getSupportedMetricsForProduct(String productTag) {
+    if (!tagProfile.tagIsPrometheusEnabled(productTag)) {
       throw new UnsupportedOperationException(
-          String.format("Metrics gathering for %s is not currently supported!", productProfileId));
+          String.format("Metrics gathering for %s is not currently supported!", productTag));
     }
 
     Map<Uom, MetricProperties> metrics = new EnumMap<>(Uom.class);
-    tagProfile
-        .measurementsByTag(productProfileId)
-        .forEach(metric -> metrics.put(metric, openshift));
+    tagProfile.measurementsByTag(productTag).forEach(metric -> metrics.put(metric, openshift));
     return metrics;
   }
 
-  public Collection<String> getMetricsEnabledProductProfiles() {
+  public Collection<String> getMetricsEnabledProductTags() {
     return tagProfile.getTagsWithPrometheusEnabledLookup();
   }
 
-  // ENT-3835 will change the data structures used here and should refactor this method as needed
-  public String getEnabledAccountPromQLforProductProfile(String productProfileId) {
-    // NOTE(khowell): doesn't make sense for a given product profile (e.g. OSD) to have different
+  public String getEnabledAccountPromQLforProductTag(String productTag) {
+    // NOTE(khowell): doesn't make sense for a given product tag (e.g. OSD) to have different
     // queries per-metric. Grabbing the first non-empty one for now.
-    return getSupportedMetricsForProduct(productProfileId).values().stream()
+    return getSupportedMetricsForProduct(productTag).values().stream()
         .map(MetricProperties::getEnabledAccountPromQL)
         .filter(StringUtils::hasText)
         .findFirst()
         .orElseThrow();
   }
 
-  // ENT-3835 will change the data structures used here and should refactor this method as needed
-  public Integer getMetricsTimeoutForProductProfile(String productProfileId) {
-    // NOTE(khowell): doesn't make sense for a given product profile (e.g. OSD) to have different
+  public Integer getMetricsTimeoutForProductTag(String productTag) {
+    // NOTE(khowell): doesn't make sense for a given product tag (e.g. OSD) to have different
     // metrics timeouts. Grabbing the first one for now.
-    return getSupportedMetricsForProduct(productProfileId).values().stream()
+    return getSupportedMetricsForProduct(productTag).values().stream()
         .map(MetricProperties::getQueryTimeout)
         .findFirst()
         .orElseThrow();
   }
 
-  // ENT-3835 will change the data structures used here and should refactor this method as needed
-  public Integer getRangeInMinutesForProductProfile(String productProfileId) {
-    return getSupportedMetricsForProduct(productProfileId).values().stream()
+  public Integer getRangeInMinutesForProductTag(String productTag) {
+    return getSupportedMetricsForProduct(productTag).values().stream()
         .map(MetricProperties::getRangeInMinutes)
         .findFirst()
         .orElseThrow();
@@ -106,23 +101,23 @@ public class PrometheusMetricsProperties {
         : Optional.empty();
   }
 
-  public Optional<TagMetric> getTagMetric(String tag, Uom metric) {
-    if (!StringUtils.hasText(tag) || Objects.isNull(metric)) {
+  public Optional<TagMetric> getTagMetric(String productTag, Uom metric) {
+    if (!StringUtils.hasText(productTag) || Objects.isNull(metric)) {
       return Optional.empty();
     }
 
     return tagProfile.getTagMetrics().stream()
-        .filter(x -> tag.equals(x.getTag()) && metric.equals(x.getUom()))
+        .filter(x -> productTag.equals(x.getTag()) && metric.equals(x.getUom()))
         .findFirst();
   }
 
-  public Optional<TagMetaData> getTagMetadata(String tag) {
-    if (!StringUtils.hasText(tag)) {
+  public Optional<TagMetaData> getTagMetadata(String productTag) {
+    if (!StringUtils.hasText(productTag)) {
       return Optional.empty();
     }
 
     return tagProfile.getTagMetaData().stream()
-        .filter(meta -> meta.getTags().contains(tag))
+        .filter(meta -> meta.getTags().contains(productTag))
         .findFirst();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus;
 
-import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +27,6 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
-import org.candlepin.subscriptions.files.TagMetaData;
 import org.candlepin.subscriptions.files.TagMetric;
 import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.json.Measurement.Uom;
@@ -109,5 +107,4 @@ public class PrometheusMetricsProperties {
         .filter(x -> productTag.equals(x.getTag()) && metric.equals(x.getUom()))
         .findFirst();
   }
-
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
@@ -21,8 +21,10 @@
 package org.candlepin.subscriptions.metering.service.prometheus;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 import org.candlepin.subscriptions.json.Measurement.Uom;
@@ -36,6 +38,14 @@ import org.springframework.util.StringUtils;
 public class PrometheusMetricsProperties {
 
   public static final String OPENSHIFT_PRODUCT_PROFILE_ID = "OpenShift";
+
+  private Map<String, String> queryTemplates = new HashMap<>();
+
+  /**
+   * SPEL templates do not support nested expressions so the QueryBuilder will apply template
+   * parameters a set number of times to prevent recursion.
+   */
+  private int templateParameterDepth = 3;
 
   private MetricProperties openshift = new MetricProperties();
 
@@ -80,5 +90,11 @@ public class PrometheusMetricsProperties {
         .map(MetricProperties::getRangeInMinutes)
         .findFirst()
         .orElseThrow();
+  }
+
+  public Optional<String> getQueryTemplate(String templateKey) {
+    return queryTemplates.containsKey(templateKey)
+        ? Optional.of(queryTemplates.get(templateKey))
+        : Optional.empty();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
@@ -46,6 +46,8 @@ public class PrometheusMetricsProperties {
 
   private Map<String, String> queryTemplates = new HashMap<>();
 
+  private Map<String, String> accountQueryTemplates = new HashMap<>();
+
   /**
    * SPEL templates do not support nested expressions so the QueryBuilder will apply template
    * parameters a set number of times to prevent recursion.
@@ -69,16 +71,6 @@ public class PrometheusMetricsProperties {
     return tagProfile.getTagsWithPrometheusEnabledLookup();
   }
 
-  public String getEnabledAccountPromQLforProductTag(String productTag) {
-    // NOTE(khowell): doesn't make sense for a given product tag (e.g. OSD) to have different
-    // queries per-metric. Grabbing the first non-empty one for now.
-    return getSupportedMetricsForProduct(productTag).values().stream()
-        .map(MetricProperties::getEnabledAccountPromQL)
-        .filter(StringUtils::hasText)
-        .findFirst()
-        .orElseThrow();
-  }
-
   public Integer getMetricsTimeoutForProductTag(String productTag) {
     // NOTE(khowell): doesn't make sense for a given product tag (e.g. OSD) to have different
     // metrics timeouts. Grabbing the first one for now.
@@ -98,6 +90,12 @@ public class PrometheusMetricsProperties {
   public Optional<String> getQueryTemplate(String templateKey) {
     return queryTemplates.containsKey(templateKey)
         ? Optional.of(queryTemplates.get(templateKey))
+        : Optional.empty();
+  }
+
+  public Optional<String> getAccountQueryTemplate(String templateKey) {
+    return accountQueryTemplates.containsKey(templateKey)
+        ? Optional.of(accountQueryTemplates.get(templateKey))
         : Optional.empty();
   }
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMetricsProperties.java
@@ -110,13 +110,4 @@ public class PrometheusMetricsProperties {
         .findFirst();
   }
 
-  public Optional<TagMetaData> getTagMetadata(String productTag) {
-    if (!StringUtils.hasText(productTag)) {
-      return Optional.empty();
-    }
-
-    return tagProfile.getTagMetaData().stream()
-        .filter(meta -> meta.getTags().contains(productTag))
-        .findFirst();
-  }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
@@ -25,6 +25,7 @@ import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.prometheus.api.ApiProvider;
 import org.candlepin.subscriptions.prometheus.api.ApiProviderFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -60,5 +61,10 @@ public class PrometheusServiceConfiguration {
   @Bean
   EventController prometheusEventController(EventRecordRepository repo) {
     return new EventController(repo);
+  }
+
+  @Bean
+  QueryBuilder queryBuilder(PrometheusMetricsProperties props) {
+    return new QueryBuilder(props);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.metering.service.prometheus.config;
 
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.event.EventController;
+import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService;
@@ -49,8 +50,8 @@ public class PrometheusServiceConfiguration {
   }
 
   @Bean
-  public PrometheusMetricsProperties metricProperties() {
-    return new PrometheusMetricsProperties();
+  public PrometheusMetricsProperties metricProperties(TagProfile tagProfile) {
+    return new PrometheusMetricsProperties(tagProfile);
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -22,6 +22,8 @@ package org.candlepin.subscriptions.metering.service.prometheus.promql;
 
 import java.util.Optional;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -31,6 +33,8 @@ import org.springframework.stereotype.Component;
 /** Builds PromQL queries based on a configured template. */
 @Component
 public class QueryBuilder {
+
+  private static final Logger log = LoggerFactory.getLogger(QueryBuilder.class);
 
   /**
    * The default metric query key. A query with this key must be defined in the config file as a
@@ -54,6 +58,7 @@ public class QueryBuilder {
       throw new IllegalArgumentException(
           String.format("Unable to find query template for key: %s", templateKey));
     }
+    log.debug("Building metric lookup PromQL.");
     return buildQuery(template.get(), queryDescriptor);
   }
 
@@ -64,6 +69,7 @@ public class QueryBuilder {
       throw new IllegalArgumentException(
           String.format("Unable to find account query template for key: %s", templateKey));
     }
+    log.debug("Building account lookup PromQL.");
     return buildQuery(template.get(), queryDescriptor);
   }
 
@@ -81,6 +87,7 @@ public class QueryBuilder {
             String.format("Unable to parse query template! %s", template));
       }
     }
+    log.debug("PromQL: {}", query);
     return query;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering.service.prometheus.promql;
+
+import java.util.Optional;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.common.TemplateParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+/** Builds PromQL queries based on a configured template. */
+@Component
+public class QueryBuilder {
+
+  private final PrometheusMetricsProperties metricsProperties;
+
+  public QueryBuilder(PrometheusMetricsProperties metricsProperties) {
+    this.metricsProperties = metricsProperties;
+  }
+
+  public String build(QueryDescriptor queryDescriptor) {
+    ExpressionParser parser = new SpelExpressionParser();
+    StandardEvaluationContext context = new StandardEvaluationContext(queryDescriptor);
+
+    String templateKey = queryDescriptor.getTag().getPrometheusQueryTemplateKey();
+    Optional<String> template = metricsProperties.getQueryTemplate(templateKey);
+
+    if (template.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "The query descriptor's tag did not define an existing template key: %s",
+              templateKey));
+    }
+
+    // Only allow nested expressions based on a config setting. We need to do this
+    // to prevent potential infinite recursion.
+    String query = template.get();
+    for (int i = 0; i < metricsProperties.getTemplateParameterDepth(); i++) {
+      // TODO [mstead] Might be worth checking for another #{expression} to prevent unneeded
+      // processing.
+      Expression expression = parser.parseExpression(query, new TemplateParserContext());
+      query = (String) expression.getValue(context);
+    }
+
+    return query;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -75,9 +75,11 @@ public class QueryBuilder {
     // to prevent potential infinite recursion.
     String query = template;
     for (int i = 0; i < metricsProperties.getTemplateParameterDepth(); i++) {
-      // Silly hack to make sonar happy.
-      assert query != null;
       query = (String) parser.parseExpression(query, new TemplateParserContext()).getValue(context);
+      if (query == null) {
+        throw new IllegalStateException(
+            String.format("Unable to parse query template! %s", template));
+      }
     }
     return query;
   }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -47,7 +47,7 @@ public class QueryBuilder {
   }
 
   public String build(QueryDescriptor queryDescriptor) {
-    String templateKey = queryDescriptor.getTag().getQueryKey();
+    String templateKey = queryDescriptor.getMetric().getQueryKey();
     Optional<String> template = metricsProperties.getQueryTemplate(templateKey);
 
     if (template.isEmpty()) {
@@ -58,7 +58,7 @@ public class QueryBuilder {
   }
 
   public String buildAccountLookupQuery(QueryDescriptor queryDescriptor) {
-    String templateKey = queryDescriptor.getTag().getAccountQueryKey();
+    String templateKey = queryDescriptor.getMetric().getAccountQueryKey();
     Optional<String> template = metricsProperties.getAccountQueryTemplate(templateKey);
     if (template.isEmpty()) {
       throw new IllegalArgumentException(

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryDescriptor.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryDescriptor.java
@@ -29,19 +29,19 @@ import org.candlepin.subscriptions.files.TagMetric;
  * Describes the variables to be applied to a query template. Within a template, these variables can
  * be utilized as follows:
  *
- * <p>#{tag.metricId} #{runtime[yourCustomProperty]}
+ * <p>#{metric.metricId} #{runtime[yourCustomProperty]}
  */
 @Getter
 public class QueryDescriptor {
 
   /** Any variables that should be provided by the tag configuration. */
-  private TagMetric tag;
+  private TagMetric metric;
 
   /** Any variable that are specified at runtime. */
   private Map<String, String> runtime;
 
-  public QueryDescriptor(TagMetric tag) {
-    this.tag = tag;
+  public QueryDescriptor(TagMetric metric) {
+    this.metric = metric;
     this.runtime = new HashMap<>();
   }
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryDescriptor.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryDescriptor.java
@@ -18,30 +18,31 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.files;
+package org.candlepin.subscriptions.metering.service.prometheus.promql;
 
-import lombok.AllArgsConstructor;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.files.TagMetric;
 
-/** A composite class for tag profiles. Describes tag metric information. */
-@AllArgsConstructor
-@Builder
-@EqualsAndHashCode
+/**
+ * Describes the variables to be applied to a query template. Within a template, these variables can
+ * be utilized as follows:
+ *
+ * <p>#{tag.metricId} #{runtime.yourCustomProperty}
+ */
 @Getter
-@NoArgsConstructor
-@Setter
-@ToString
-public class TagMetric {
-  private String tag;
-  private String metricId;
-  private Uom uom;
-  private String prometheusQueryTemplateKey;
-  private String prometheusMetric;
-  private String prometheusMetadataMetric;
+@Builder
+public class QueryDescriptor {
+
+  /** Any variables that should be provided by the tag configuration. */
+  @Builder.Default private TagMetric tag = new TagMetric();
+
+  /** Any variable that are specified at runtime. */
+  @Builder.Default private Map<String, String> runtime = new HashMap<>();
+
+  public void addRuntimeVar(String name, String value) {
+    this.runtime.put(name, value);
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryDescriptor.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryDescriptor.java
@@ -22,7 +22,6 @@ package org.candlepin.subscriptions.metering.service.prometheus.promql;
 
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Builder;
 import lombok.Getter;
 import org.candlepin.subscriptions.files.TagMetric;
 
@@ -30,17 +29,21 @@ import org.candlepin.subscriptions.files.TagMetric;
  * Describes the variables to be applied to a query template. Within a template, these variables can
  * be utilized as follows:
  *
- * <p>#{tag.metricId} #{runtime.yourCustomProperty}
+ * <p>#{tag.metricId} #{runtime[yourCustomProperty]}
  */
 @Getter
-@Builder
 public class QueryDescriptor {
 
   /** Any variables that should be provided by the tag configuration. */
-  @Builder.Default private TagMetric tag = new TagMetric();
+  private TagMetric tag;
 
   /** Any variable that are specified at runtime. */
-  @Builder.Default private Map<String, String> runtime = new HashMap<>();
+  private Map<String, String> runtime;
+
+  public QueryDescriptor(TagMetric tag) {
+    this.tag = tag;
+    this.runtime = new HashMap<>();
+  }
 
   public void addRuntimeVar(String name, String value) {
     this.runtime.put(name, value);

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactory.java
@@ -45,7 +45,7 @@ public class PrometheusMeteringTaskFactory implements TaskFactory {
       return new MetricsTask(
           controller,
           validateString(taskDescriptor, "account"),
-          validateString(taskDescriptor, "productProfileId"),
+          validateString(taskDescriptor, "productTag"),
           Uom.fromValue(validateString(taskDescriptor, "metric")),
           validateDate(taskDescriptor, "start"),
           validateDate(taskDescriptor, "end"));

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
@@ -97,7 +97,13 @@ public class PrometheusMetricsTaskManager {
       Uom metric,
       OffsetDateTime start,
       OffsetDateTime end) {
-    log.debug("ACCOUNT: {} PRODUCT: {} START: {} END: {}", account, productProfileId, start, end);
+    log.info(
+        "ACCOUNT: {} PRODUCT: {} METRIC: {} START: {} END: {}",
+        account,
+        productProfileId,
+        metric,
+        start,
+        end);
     TaskDescriptorBuilder builder =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, topic)
             .setSingleValuedArg("account", account)

--- a/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
@@ -24,6 +24,7 @@ import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccount
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMeteringTaskFactory;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.task.TaskFactory;
@@ -49,8 +50,10 @@ public class MeteringTasksConfiguration {
 
   @Bean
   PrometheusAccountSource accountSource(
-      PrometheusService service, PrometheusMetricsProperties metricProperties) {
-    return new PrometheusAccountSource(service, metricProperties);
+      PrometheusService service,
+      PrometheusMetricsProperties metricProperties,
+      QueryBuilder queryBuilder) {
+    return new PrometheusAccountSource(service, metricProperties, queryBuilder);
   }
 
   // Qualify this bean so that a new instance is created in the case that another

--- a/src/main/java/org/candlepin/subscriptions/metering/task/MetricsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/MetricsTask.java
@@ -35,7 +35,7 @@ public class MetricsTask implements Task {
   private static final Logger log = LoggerFactory.getLogger(MetricsTask.class);
 
   private final String account;
-  private final String productProfileId;
+  private final String productTag;
   private final Uom metric;
   private final OffsetDateTime start;
   private final OffsetDateTime end;
@@ -45,13 +45,13 @@ public class MetricsTask implements Task {
   public MetricsTask(
       PrometheusMeteringController controller,
       String account,
-      String productProfileId,
+      String productTag,
       Uom metric,
       OffsetDateTime start,
       OffsetDateTime end) {
     this.controller = controller;
     this.account = account;
-    this.productProfileId = productProfileId;
+    this.productTag = productTag;
     this.metric = metric;
     this.start = start;
     this.end = end;
@@ -59,13 +59,10 @@ public class MetricsTask implements Task {
 
   @Override
   public void execute() {
-    log.info("Running {} {} metrics update for account: {}", productProfileId, metric, account);
-    if (!productProfileId.equals("OpenShift") || metric != Uom.CORES) {
-      throw new UnsupportedOperationException("To be implemented in ENT-3871");
-    }
+    log.info("Running {} {} metrics update for account: {}", productTag, metric, account);
     try {
-      controller.collectOpenshiftMetrics(this.account, start, end);
-      log.info("{} {} metrics task complete.", productProfileId, metric);
+      controller.collectMetrics(productTag, metric, this.account, start, end);
+      log.info("{} {} metrics task complete.", productTag, metric);
     } catch (Exception e) {
       log.error("Problem running task: {}", this.getClass().getSimpleName(), e);
     }

--- a/src/main/java/org/candlepin/subscriptions/metering/task/MetricsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/MetricsTask.java
@@ -59,7 +59,7 @@ public class MetricsTask implements Task {
 
   @Override
   public void execute() {
-    log.info("Running {} {} metrics update for account: {}", productTag, metric, account);
+    log.info("Running {} {} metrics update task for account: {}", productTag, metric, account);
     try {
       controller.collectMetrics(productTag, metric, this.account, start, end);
       log.info("{} {} metrics task complete.", productTag, metric);

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -6,12 +6,13 @@ rhsm-subscriptions:
   metering:
     prometheus:
       metric:
+        queryTemplates:
+          default: >-
+            max(sum_over_time(#{tag.queryParams[prometheusMetric]}[1h:5m]) / 13.0) by (_id)
+            * on(_id) group_right
+            min_over_time(#{tag.queryParams[prometheusMetadataMetric]}[1h])
         openshift:
           maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
           backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
           backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}
           backOffMultiplier: ${OPENSHIFT_BACK_OFF_MULTIPLIER:1.5}
-          metricPromQL: >-
-            max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / 13.0) by (_id)
-            * on(_id) group_right
-            min_over_time(subscription_labels{ebs_account="%s", billing_model="${OPENSHIFT_BILLING_MODEL_FILTER:marketplace}", support=~"Premium|Standard|Self-Support|None"}[1h])

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -10,7 +10,7 @@ rhsm-subscriptions:
           default: >-
             max(sum_over_time(#{metric.queryParams[prometheusMetric]}[1h:5m]) / 13.0) by (_id)
             * on(_id) group_right
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}[1h])
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
         openshift:
           maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
           backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -8,9 +8,9 @@ rhsm-subscriptions:
       metric:
         queryTemplates:
           default: >-
-            max(sum_over_time(#{tag.queryParams[prometheusMetric]}[1h:5m]) / 13.0) by (_id)
+            max(sum_over_time(#{metric.queryParams[prometheusMetric]}[1h:5m]) / 13.0) by (_id)
             * on(_id) group_right
-            min_over_time(#{tag.queryParams[prometheusMetadataMetric]}[1h])
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}[1h])
         openshift:
           maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
           backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -108,7 +108,7 @@ rhsm-subscriptions:
       metric:
         accountQueryTemplates:
           default: >-
-            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(subscription_labels{product='#{tag.queryParams[product]}', ebs_account != '', billing_model='marketplace'}[1h]))
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(subscription_labels{product='#{metric.queryParams[product]}', ebs_account != '', billing_model='marketplace'}[1h]))
             by (ebs_account)}
     tasks:
       topic: ${METERING_TASK_TOPIC:platform.rhsm-subscriptions.metering-tasks}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -108,7 +108,7 @@ rhsm-subscriptions:
       metric:
         accountQueryTemplates:
           default: >-
-            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(subscription_labels{product='#{metric.queryParams[product]}', ebs_account != '', billing_model='marketplace'}[1h]))
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product='#{metric.queryParams[product]}', ebs_account != '', billing_model='marketplace'}[1h]))
             by (ebs_account)}
     tasks:
       topic: ${METERING_TASK_TOPIC:platform.rhsm-subscriptions.metering-tasks}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -106,9 +106,9 @@ rhsm-subscriptions:
         token: ${PROM_AUTH_TOKEN:}
         url: ${PROM_URL:https://localhost/api/v1}
       metric:
-        openshift:
-          enabledAccountPromQL: >-
-            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(subscription_labels{ebs_account != '', billing_model='marketplace'}[1h]))
+        accountQueryTemplates:
+          default: >-
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(subscription_labels{product='#{tag.queryParams[product]}', ebs_account != '', billing_model='marketplace'}[1h]))
             by (ebs_account)}
     tasks:
       topic: ${METERING_TASK_TOPIC:platform.rhsm-subscriptions.metering-tasks}

--- a/src/main/resources/tag_profile.yaml
+++ b/src/main/resources/tag_profile.yaml
@@ -30,20 +30,23 @@ tagMetrics:
   - tag: OpenShift-metrics
     metricId: redhat.com:openshift_container_platform:cpu_hour
     uom: CORES
-    prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-    prometheusMetadataMetric: subscription_labels
+    queryParams:
+      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
+      prometheusMetadataMetric: subscription_labels{product="ocp", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
 
   # OSD metrics
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
-    prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-    prometheusMetadataMetric: subscription_labels
+    queryParams:
+      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
+      prometheusMetadataMetric: subscription_labels{product="osd", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
-    prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
-    prometheusMetadataMetric: subscription_labels
+    queryParams:
+      prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
+      prometheusMetadataMetric: subscription_labels{product="osd", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
 
 tagMetaData:
   - tags:

--- a/src/main/resources/tag_profile.yaml
+++ b/src/main/resources/tag_profile.yaml
@@ -31,22 +31,25 @@ tagMetrics:
     metricId: redhat.com:openshift_container_platform:cpu_hour
     uom: CORES
     queryParams:
+      product: ocp
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-      prometheusMetadataMetric: subscription_labels{product="ocp", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels{product="#{tag.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
 
   # OSD metrics
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
     queryParams:
+      product: osd
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-      prometheusMetadataMetric: subscription_labels{product="osd", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels{product="#{tag.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
     queryParams:
+      product: osd
       prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
-      prometheusMetadataMetric: subscription_labels{product="osd", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels{product="#{tag.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
 
 tagMetaData:
   - tags:

--- a/src/main/resources/tag_profile.yaml
+++ b/src/main/resources/tag_profile.yaml
@@ -33,7 +33,7 @@ tagMetrics:
     queryParams:
       product: ocp
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-      prometheusMetadataMetric: subscription_labels{product="#{tag.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
 
   # OSD metrics
   - tag: OpenShift-dedicated-metrics
@@ -42,14 +42,14 @@ tagMetrics:
     queryParams:
       product: osd
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-      prometheusMetadataMetric: subscription_labels{product="#{tag.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
     queryParams:
       product: osd
       prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
-      prometheusMetadataMetric: subscription_labels{product="#{tag.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
 
 tagMetaData:
   - tags:

--- a/src/main/resources/tag_profile.yaml
+++ b/src/main/resources/tag_profile.yaml
@@ -33,7 +33,7 @@ tagMetrics:
     queryParams:
       product: ocp
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-      prometheusMetadataMetric: subscription_labels{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels
 
   # OSD metrics
   - tag: OpenShift-dedicated-metrics
@@ -42,14 +42,14 @@ tagMetrics:
     queryParams:
       product: osd
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-      prometheusMetadataMetric: subscription_labels{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
     queryParams:
       product: osd
       prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
-      prometheusMetadataMetric: subscription_labels{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
+      prometheusMetadataMetric: subscription_labels
 
 tagMetaData:
   - tags:

--- a/src/test/java/org/candlepin/subscriptions/files/TagProfileFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/TagProfileFactoryTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.db.model.Granularity;
@@ -93,5 +94,17 @@ class TagProfileFactoryTest {
     assertTrue(
         tagProfile.tagSupportsGranularity(
             ProductId.OPENSHIFT_METRICS.toString(), Granularity.HOURLY));
+  }
+
+  @Test
+  void canLookupMetaDataByTag() {
+    Optional<TagMetaData> ocpMeta = tagProfile.getTagMetaDataByTag("OpenShift-metrics");
+    assertFalse(ocpMeta.isEmpty());
+    assertTrue(ocpMeta.get().getTags().contains("OpenShift-metrics"));
+  }
+
+  @Test
+  void lookupMetaDataByTagWhenNotFound() {
+    assertTrue(tagProfile.getTagMetaDataByTag("UNKNOWN").isEmpty());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/files/TagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/TagProfileTest.java
@@ -22,7 +22,9 @@ package org.candlepin.subscriptions.files;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -45,13 +47,13 @@ class TagProfileTest {
             .build();
     TagMapping tagMapping2 =
         TagMapping.builder().value("x86_64").valueType("arch").tags(Set.of("RHEL for x86")).build();
+
+    Map<String, String> params = new HashMap<>();
+    params.put("prometheusMetric", "cluster:usage:workload:capacity_physical_cpu_cores:max:5m");
+    params.put("prometheusMetadataMetric", "subscription_labels");
+
     TagMetric tagMetric1 =
-        TagMetric.builder()
-            .tag("OpenShift-metrics")
-            .metricId("Cores")
-            .prometheusMetric("cluster:usage:workload:capacity_physical_cpu_cores:max:5m")
-            .prometheusMetadataMetric("subscription_labels")
-            .build();
+        TagMetric.builder().tag("OpenShift-metrics").metricId("Cores").queryParams(params).build();
     TagMetaData tagMetaData =
         TagMetaData.builder()
             .tags(Set.of("Openshift-metrics", "Openshift-dedicated-metrics"))

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -49,7 +49,7 @@ class MeteringEventFactoryTest {
     Uom uom = Uom.CORES;
 
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             account,
             metricId,
             clusterId,
@@ -81,7 +81,7 @@ class MeteringEventFactoryTest {
   @Test
   void testOpenShiftClusterCoresHandlesNullServiceLevel() throws Exception {
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             "my-account",
             "metric-id",
             "cluster-id",
@@ -99,7 +99,7 @@ class MeteringEventFactoryTest {
   @Test
   void testOpenShiftClusterCoresSlaSetToEmptyForSlaValueNone() throws Exception {
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             "my-account",
             "metric-id",
             "cluster-id",
@@ -117,7 +117,7 @@ class MeteringEventFactoryTest {
   @Test
   void testOpenShiftClusterCoresInvalidSlaWillNotBeSetOnEvent() throws Exception {
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             "my-account",
             "metric-id",
             "cluster-id",
@@ -135,7 +135,7 @@ class MeteringEventFactoryTest {
   @Test
   void testOpenShiftClusterCoresInvalidUsageSetsNullValue() throws Exception {
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             "my-account",
             "metric-id",
             "cluster-id",
@@ -153,7 +153,7 @@ class MeteringEventFactoryTest {
   @Test
   void testOpenShiftClusterCoresHandlesNullUsage() throws Exception {
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             "my-account",
             "metric-id",
             "cluster-id",
@@ -171,7 +171,7 @@ class MeteringEventFactoryTest {
   @Test
   void testOpenShiftClusterCoresInvalidRoleSetsNullValue() {
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             "my-account",
             "metric-id",
             "cluster-id",
@@ -189,7 +189,7 @@ class MeteringEventFactoryTest {
   @Test
   void testOpenShiftClusterCoresHandlesNullRole() {
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             "my-account",
             "metric-id",
             "cluster-id",
@@ -207,7 +207,7 @@ class MeteringEventFactoryTest {
   @Test
   void testEventTypeGeneratedOnEventCreation() {
     Event event =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             "my-account",
             "metric-id",
             "cluster-id",

--- a/src/test/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBeanTest.java
@@ -53,8 +53,7 @@ class MeteringJmxBeanTest {
 
   @BeforeEach
   void setupTests() {
-    metricProps = new PrometheusMetricsProperties();
-    metricProps.setTagProfile(tagProfile);
+    metricProps = new PrometheusMetricsProperties(tagProfile);
     metricProps.getOpenshift().setRangeInMinutes(60);
 
     clock = new FixedClockConfiguration().fixedClock();

--- a/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
@@ -21,12 +21,16 @@
 package org.candlepin.subscriptions.metering.job;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.files.TagProfile;
+import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -40,6 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class MeteringJobTest {
 
   @Mock private PrometheusMetricsTaskManager tasks;
+  @Mock private TagProfile tagProfile;
 
   private ApplicationClock clock;
   private PrometheusMetricsProperties metricProps;
@@ -49,6 +54,7 @@ class MeteringJobTest {
   @BeforeEach
   void setupTests() {
     metricProps = new PrometheusMetricsProperties();
+    metricProps.setTagProfile(tagProfile);
     metricProps.getOpenshift().setRangeInMinutes(180); // 3h
 
     appProps = new ApplicationProperties();
@@ -56,6 +62,10 @@ class MeteringJobTest {
 
     clock = new FixedClockConfiguration().fixedClock();
     job = new MeteringJob(tasks, clock, metricProps, appProps);
+
+    when(tagProfile.getTagsWithPrometheusEnabledLookup()).thenReturn(Set.of("OpenShift-metrics"));
+    when(tagProfile.measurementsByTag("OpenShift-metrics")).thenReturn(Set.of(Uom.CORES));
+    when(tagProfile.tagIsPrometheusEnabled("OpenShift-metrics")).thenReturn(true);
   }
 
   @Test
@@ -71,6 +81,6 @@ class MeteringJobTest {
             expStartDate.plusMinutes(range).truncatedTo(ChronoUnit.HOURS).minusMinutes(1));
     job.run();
 
-    verify(tasks).updateMetricsForAllAccounts("OpenShift", expStartDate, expEndDate);
+    verify(tasks).updateMetricsForAllAccounts("OpenShift-metrics", expStartDate, expEndDate);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
@@ -53,8 +53,7 @@ class MeteringJobTest {
 
   @BeforeEach
   void setupTests() {
-    metricProps = new PrometheusMetricsProperties();
-    metricProps.setTagProfile(tagProfile);
+    metricProps = new PrometheusMetricsProperties(tagProfile);
     metricProps.getOpenshift().setRangeInMinutes(180); // 3h
 
     appProps = new ApplicationProperties();

--- a/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
@@ -60,7 +60,7 @@ class MeteringJobTest {
     appProps.setPrometheusLatencyDuration(Duration.ofHours(6L));
 
     clock = new FixedClockConfiguration().fixedClock();
-    job = new MeteringJob(tasks, clock, metricProps, appProps);
+    job = new MeteringJob(tasks, clock, tagProfile, metricProps, appProps);
 
     when(tagProfile.getTagsWithPrometheusEnabledLookup()).thenReturn(Set.of("OpenShift-metrics"));
     when(tagProfile.measurementsByTag("OpenShift-metrics")).thenReturn(Set.of(Uom.CORES));

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
@@ -29,6 +29,8 @@ import java.time.OffsetDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import org.candlepin.subscriptions.files.TagProfile;
+import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
 import org.candlepin.subscriptions.prometheus.model.QueryResultData;
 import org.candlepin.subscriptions.prometheus.model.QueryResultDataResult;
@@ -44,9 +46,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class PrometheusAccountSourceTest {
 
   final String TEST_QUERY = "TEST_QUERY";
-  final String TEST_PROFILE_ID = "OpenShift";
+  final String TEST_PROFILE_ID = "OpenShift-metrics";
 
   @Mock PrometheusService service;
+  @Mock TagProfile tagProfile;
 
   PrometheusAccountSource accountSource;
   PrometheusMetricsProperties promProps;
@@ -57,8 +60,12 @@ class PrometheusAccountSourceTest {
     osProps.setEnabledAccountPromQL(TEST_QUERY);
 
     promProps = new PrometheusMetricsProperties();
+    promProps.setTagProfile(tagProfile);
     promProps.setOpenshift(osProps);
     accountSource = new PrometheusAccountSource(service, promProps);
+
+    when(tagProfile.tagIsPrometheusEnabled(TEST_PROFILE_ID)).thenReturn(true);
+    when(tagProfile.measurementsByTag(TEST_PROFILE_ID)).thenReturn(Set.of(Uom.CORES));
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
@@ -28,9 +28,13 @@ import static org.mockito.Mockito.when;
 import java.time.OffsetDateTime;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.candlepin.subscriptions.files.TagMetric;
 import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryDescriptor;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
 import org.candlepin.subscriptions.prometheus.model.QueryResultData;
 import org.candlepin.subscriptions.prometheus.model.QueryResultDataResult;
@@ -45,39 +49,55 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class PrometheusAccountSourceTest {
 
-  final String TEST_QUERY = "TEST_QUERY";
-  final String TEST_PROFILE_ID = "OpenShift-metrics";
+  final String TEST_ACCT_QUERY_KEY = "TEST_QUERY";
+  final String TEST_ACCOUNT_QUERY = "ACCOUNT QUERY";
+  final String TEST_PROD_TAG = "OpenShift-metrics";
 
   @Mock PrometheusService service;
   @Mock TagProfile tagProfile;
 
   PrometheusAccountSource accountSource;
   PrometheusMetricsProperties promProps;
+  QueryBuilder queryBuilder;
+  TagMetric tag1;
 
   @BeforeEach
   void setupTest() {
     MetricProperties osProps = new MetricProperties();
-    osProps.setEnabledAccountPromQL(TEST_QUERY);
 
     promProps = new PrometheusMetricsProperties();
     promProps.setTagProfile(tagProfile);
     promProps.setOpenshift(osProps);
-    accountSource = new PrometheusAccountSource(service, promProps);
+    promProps.setAccountQueryTemplates(Map.of(TEST_ACCT_QUERY_KEY, TEST_ACCOUNT_QUERY));
 
-    when(tagProfile.tagIsPrometheusEnabled(TEST_PROFILE_ID)).thenReturn(true);
-    when(tagProfile.measurementsByTag(TEST_PROFILE_ID)).thenReturn(Set.of(Uom.CORES));
+    queryBuilder = new QueryBuilder(promProps);
+    accountSource = new PrometheusAccountSource(service, promProps, queryBuilder);
+
+    tag1 =
+        TagMetric.builder()
+            .tag(TEST_PROD_TAG)
+            .uom(Uom.CORES)
+            .accountQueryKey(TEST_ACCT_QUERY_KEY)
+            .build();
+
+    when(tagProfile.tagIsPrometheusEnabled(TEST_PROD_TAG)).thenReturn(true);
+    when(tagProfile.getTagMetrics()).thenReturn(List.of(tag1));
+    when(tagProfile.measurementsByTag(TEST_PROD_TAG)).thenReturn(Set.of(Uom.CORES));
   }
 
   @Test
-  void usesPromQLFromConfig() {
+  void buildsPromQLByAccountLookupTemplateKey() {
     OffsetDateTime expectedDate = OffsetDateTime.now();
-    when(service.runQuery(TEST_QUERY, expectedDate, promProps.getOpenshift().getQueryTimeout()))
+    when(service.runQuery(
+            queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag1)),
+            expectedDate,
+            promProps.getOpenshift().getQueryTimeout()))
         .thenReturn(buildAccountQueryResult(List.of("A1")));
 
-    accountSource.getMarketplaceAccounts(TEST_PROFILE_ID, expectedDate);
+    accountSource.getMarketplaceAccounts(TEST_PROD_TAG, Uom.CORES, expectedDate);
     verify(service)
         .runQuery(
-            promProps.getOpenshift().getEnabledAccountPromQL(),
+            queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag1)),
             expectedDate,
             promProps.getOpenshift().getQueryTimeout());
   }
@@ -93,10 +113,14 @@ class PrometheusAccountSourceTest {
     accountList.add("");
     accountList.add(expectedAccount);
 
-    when(service.runQuery(TEST_QUERY, expectedDate, promProps.getOpenshift().getQueryTimeout()))
+    when(service.runQuery(
+            queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag1)),
+            expectedDate,
+            promProps.getOpenshift().getQueryTimeout()))
         .thenReturn(buildAccountQueryResult(accountList));
 
-    Set<String> accounts = accountSource.getMarketplaceAccounts(TEST_PROFILE_ID, expectedDate);
+    Set<String> accounts =
+        accountSource.getMarketplaceAccounts(TEST_PROD_TAG, Uom.CORES, expectedDate);
     assertEquals(1, accounts.size());
     assertTrue(accounts.contains(expectedAccount));
   }
@@ -106,10 +130,14 @@ class PrometheusAccountSourceTest {
     List<String> expectedAccounts = List.of("A1", "A2");
     OffsetDateTime expectedDate = OffsetDateTime.now();
 
-    when(service.runQuery(TEST_QUERY, expectedDate, promProps.getOpenshift().getQueryTimeout()))
+    when(service.runQuery(
+            queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag1)),
+            expectedDate,
+            promProps.getOpenshift().getQueryTimeout()))
         .thenReturn(buildAccountQueryResult(expectedAccounts));
 
-    Set<String> accounts = accountSource.getMarketplaceAccounts(TEST_PROFILE_ID, expectedDate);
+    Set<String> accounts =
+        accountSource.getMarketplaceAccounts(TEST_PROD_TAG, Uom.CORES, expectedDate);
     assertEquals(2, accounts.size());
     assertTrue(accounts.containsAll(expectedAccounts));
   }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
@@ -65,8 +65,7 @@ class PrometheusAccountSourceTest {
   void setupTest() {
     MetricProperties osProps = new MetricProperties();
 
-    promProps = new PrometheusMetricsProperties();
-    promProps.setTagProfile(tagProfile);
+    promProps = new PrometheusMetricsProperties(tagProfile);
     promProps.setOpenshift(osProps);
     promProps.setAccountQueryTemplates(Map.of(TEST_ACCT_QUERY_KEY, TEST_ACCOUNT_QUERY));
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -216,7 +216,7 @@ class PrometheusMeteringControllerTest {
 
     List<Event> expectedEvents =
         List.of(
-            MeteringEventFactory.openShiftClusterCores(
+            MeteringEventFactory.createMetricEvent(
                 expectedAccount,
                 expectedMetricId,
                 expectedClusterId,
@@ -228,7 +228,7 @@ class PrometheusMeteringControllerTest {
                 expectedServiceType,
                 expectedUom,
                 val1.doubleValue()),
-            MeteringEventFactory.openShiftClusterCores(
+            MeteringEventFactory.createMetricEvent(
                 expectedAccount,
                 expectedMetricId,
                 expectedClusterId,
@@ -288,7 +288,7 @@ class PrometheusMeteringControllerTest {
     OffsetDateTime end = clock.endOfHour(start.plusDays(1));
 
     Event updatedEvent =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             expectedAccount,
             expectedMetricId,
             expectedClusterId,
@@ -304,7 +304,7 @@ class PrometheusMeteringControllerTest {
     List<Event> expectedEvents =
         List.of(
             updatedEvent,
-            MeteringEventFactory.openShiftClusterCores(
+            MeteringEventFactory.createMetricEvent(
                 expectedAccount,
                 expectedMetricId,
                 expectedClusterId,
@@ -318,7 +318,7 @@ class PrometheusMeteringControllerTest {
                 val2.doubleValue()));
 
     Event purgedEvent =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             expectedAccount,
             expectedMetricId,
             "CLUSTER_NO_LONGER_EXISTS",
@@ -334,7 +334,7 @@ class PrometheusMeteringControllerTest {
     List<Event> existingEvents =
         List.of(
             // This event will get updated by the incoming data from prometheus.
-            MeteringEventFactory.openShiftClusterCores(
+            MeteringEventFactory.createMetricEvent(
                 expectedAccount,
                 expectedMetricId,
                 expectedClusterId,
@@ -420,7 +420,7 @@ class PrometheusMeteringControllerTest {
     OffsetDateTime end = clock.endOfHour(start.plusDays(1));
 
     Event updatedEvent =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             expectedAccount,
             expectedMetricId,
             expectedClusterId,
@@ -439,7 +439,7 @@ class PrometheusMeteringControllerTest {
     List<Event> expectedEvents = List.of(updatedEvent);
 
     var existingEvent =
-        MeteringEventFactory.openShiftClusterCores(
+        MeteringEventFactory.createMetricEvent(
             expectedAccount,
             expectedMetricId,
             expectedClusterId,

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -37,6 +37,7 @@ import org.candlepin.subscriptions.db.model.EventKey;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
 import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.event.EventController;
+import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.MeteringEventFactory;
@@ -80,6 +81,8 @@ class PrometheusMeteringControllerTest {
 
   @Autowired private QueryBuilder queryBuilder;
 
+  @Autowired private TagProfile tagProfile;
+
   @MockBean private OptInController optInController;
 
   @Autowired
@@ -111,7 +114,8 @@ class PrometheusMeteringControllerTest {
             queryBuilder,
             eventController,
             openshiftRetry,
-            optInController);
+            optInController,
+            tagProfile);
 
     queries = new QueryHelper(promProps, queryBuilder);
   }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.net.UrlEscapers;
 import java.time.OffsetDateTime;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.prometheus.api.ApiProvider;
 import org.candlepin.subscriptions.prometheus.api.StubApiProvider;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
@@ -48,11 +49,13 @@ class PrometheusServiceTest {
 
   @Autowired private PrometheusMetricsProperties props;
 
+  @Autowired private QueryBuilder queryBuilder;
+
   @Test
   void testRangeQueryApi() throws Exception {
-
-    String expectedQuery =
-        UrlEscapers.urlFragmentEscaper().escape(props.getOpenshift().getMetricPromQL());
+    QueryHelper queries = new QueryHelper(props, queryBuilder);
+    String query = queries.expectedQuery("OpenShift-metrics", "a1");
+    String expectedQuery = UrlEscapers.urlFragmentEscaper().escape(query);
     QueryResult expectedResult = new QueryResult();
 
     OffsetDateTime end = OffsetDateTime.now();
@@ -65,15 +68,15 @@ class PrometheusServiceTest {
     ApiProvider provider = new StubApiProvider(queryApi, rangeApi);
     PrometheusService service = new PrometheusService(provider);
 
-    QueryResult result =
-        service.runRangeQuery(props.getOpenshift().getMetricPromQL(), start, end, 3600, 1);
+    QueryResult result = service.runRangeQuery(query, start, end, 3600, 1);
     assertEquals(expectedResult, result);
   }
 
   @Test
   void testQueryApi() throws Exception {
-    String expectedQuery =
-        UrlEscapers.urlFragmentEscaper().escape(props.getOpenshift().getMetricPromQL());
+    QueryHelper queries = new QueryHelper(props, queryBuilder);
+    String query = queries.expectedQuery("OpenShift-metrics", "a1");
+    String expectedQuery = UrlEscapers.urlFragmentEscaper().escape(query);
     QueryResult expectedResult = new QueryResult();
 
     OffsetDateTime time = OffsetDateTime.now();
@@ -82,7 +85,7 @@ class PrometheusServiceTest {
     ApiProvider provider = new StubApiProvider(queryApi, rangeApi);
     PrometheusService service = new PrometheusService(provider);
 
-    QueryResult result = service.runQuery(props.getOpenshift().getMetricPromQL(), time, 1);
+    QueryResult result = service.runQuery(query, time, 1);
     assertEquals(expectedResult, result);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/QueryHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/QueryHelper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering.service.prometheus;
+
+import java.util.Optional;
+import org.candlepin.subscriptions.files.TagMetric;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
+import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryDescriptor;
+
+/** Common query utilities used for testing. */
+public class QueryHelper {
+
+  private PrometheusMetricsProperties props;
+  private QueryBuilder queryBuilder;
+
+  public QueryHelper(PrometheusMetricsProperties props, QueryBuilder builder) {
+    this.props = props;
+    this.queryBuilder = builder;
+  }
+
+  public String expectedQuery(String productTag, String account) {
+    Optional<TagMetric> tag = props.getTagMetric(productTag, Uom.CORES);
+    if (tag.isEmpty()) {
+      throw new RuntimeException("Bad test configuration! Could not find TagMetric!");
+    }
+
+    QueryDescriptor descriptor = new QueryDescriptor(tag.get());
+    descriptor.addRuntimeVar("account", account);
+    return queryBuilder.build(descriptor);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.HashMap;
 import java.util.Map;
 import org.candlepin.subscriptions.files.TagMetric;
+import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +45,7 @@ class QueryBuilderTest {
     String account = "12345";
     String param1 = "PARAM_1";
 
-    PrometheusMetricsProperties props = new PrometheusMetricsProperties();
+    PrometheusMetricsProperties props = new PrometheusMetricsProperties(new TagProfile());
     props.getQueryTemplates().put(templateKey, template);
 
     Map<String, String> params = new HashMap<>();
@@ -68,7 +69,7 @@ class QueryBuilderTest {
   @Test
   void testExceptionWhenInvalidTemplateSpecified() {
     String key = "UNKNOWN_KEY";
-    QueryBuilder builder = new QueryBuilder(new PrometheusMetricsProperties());
+    QueryBuilder builder = new QueryBuilder(new PrometheusMetricsProperties(new TagProfile()));
     QueryDescriptor descriptor = new QueryDescriptor(TagMetric.builder().queryKey(key).build());
     Throwable e = assertThrows(IllegalArgumentException.class, () -> builder.build(descriptor));
 
@@ -86,7 +87,7 @@ class QueryBuilderTest {
     String metricId = "CORES";
     String account = "12345";
 
-    PrometheusMetricsProperties props = new PrometheusMetricsProperties();
+    PrometheusMetricsProperties props = new PrometheusMetricsProperties(new TagProfile());
     props.getQueryTemplates().put(templateKey, template);
 
     Map<String, String> queryParams = new HashMap<>();

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
@@ -39,7 +39,7 @@ class QueryBuilderTest {
   void testBuildQuery() {
     String templateKey = "test_template";
     String template =
-        "Account: #{runtime[account]} Metric ID: #{tag.metricId} P1: #{tag.queryParams[p1]}";
+        "Account: #{runtime[account]} Metric ID: #{metric.metricId} P1: #{metric.queryParams[p1]}";
 
     String metricId = "CORES";
     String account = "12345";
@@ -79,10 +79,10 @@ class QueryBuilderTest {
   @Test
   void supportsNestedExpressions() {
     String templateKey = "test_template";
-    String template = "#{tag.queryParams[account_exp]} #{tag.queryParams[metric_exp]}";
+    String template = "#{metric.queryParams[account_exp]} #{metric.queryParams[metric_exp]}";
 
     String accountExp = "Account: #{runtime[account]}";
-    String metricExp = "Metric ID: #{tag.metricId}";
+    String metricExp = "Metric ID: #{metric.metricId}";
 
     String metricId = "CORES";
     String account = "12345";

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
@@ -72,10 +72,7 @@ class QueryBuilderTest {
     QueryDescriptor descriptor = new QueryDescriptor(TagMetric.builder().queryKey(key).build());
     Throwable e = assertThrows(IllegalArgumentException.class, () -> builder.build(descriptor));
 
-    assertEquals(
-        String.format(
-            "The query descriptor's tag did not define an existing template key: %s", key),
-        e.getMessage());
+    assertEquals(String.format("Unable to find query template for key: %s", key), e.getMessage());
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering.service.prometheus.promql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.candlepin.subscriptions.files.TagMetric;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class QueryBuilderTest {
+
+  @Autowired private PrometheusMetricsProperties props2;
+
+  @Test
+  void testBuildQuery() {
+    String templateKey = "test_template";
+    String template = "Account: #{runtime['account']} Metric ID: #{tag.metricId}";
+
+    String metricId = "CORES";
+    String account = "12345";
+
+    PrometheusMetricsProperties props = new PrometheusMetricsProperties();
+    props.getQueryTemplates().put(templateKey, template);
+
+    Map<String, String> runtimeParams = new HashMap<>();
+    runtimeParams.put("account", account);
+
+    QueryDescriptor queryDesc =
+        QueryDescriptor.builder()
+            .tag(
+                TagMetric.builder()
+                    .prometheusQueryTemplateKey(templateKey)
+                    .metricId(metricId)
+                    .build())
+            .runtime(runtimeParams)
+            .build();
+
+    QueryBuilder builder = new QueryBuilder(props);
+    String query = builder.build(queryDesc);
+    assertEquals(query, String.format("Account: %s Metric ID: %s", account, metricId));
+  }
+
+  @Test
+  void testExceptionWhenInvalidTemplateSpecified() {
+    String key = "UNKNOWN_KEY";
+    QueryBuilder builder = new QueryBuilder(new PrometheusMetricsProperties());
+    Throwable e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              builder.build(
+                  QueryDescriptor.builder()
+                      .tag(TagMetric.builder().prometheusQueryTemplateKey(key).build())
+                      .build());
+            });
+
+    assertEquals(
+        String.format(
+            "The query descriptor's tag did not define an existing template key: %s", key),
+        e.getMessage());
+  }
+
+  @Test
+  void supportsNestedExpressions() {
+    String templateKey = "test_template";
+    String template = "#{runtime['account_exp']} #{runtime['metric_exp']}";
+
+    String accountExp = "Account: #{runtime['account']}";
+    String metricExp = "Metric ID: #{tag.metricId}";
+
+    String metricId = "CORES";
+    String account = "12345";
+
+    PrometheusMetricsProperties props = new PrometheusMetricsProperties();
+    props.getQueryTemplates().put(templateKey, template);
+
+    Map<String, String> runtimeParams = new HashMap<>();
+    runtimeParams.put("account", account);
+    // TODO [mstead] These should come from the tag data once in place.
+    runtimeParams.put("account_exp", accountExp);
+    runtimeParams.put("metric_exp", metricExp);
+
+    QueryDescriptor queryDesc =
+        QueryDescriptor.builder()
+            .tag(
+                TagMetric.builder()
+                    .prometheusQueryTemplateKey(templateKey)
+                    .metricId(metricId)
+                    .build())
+            .runtime(runtimeParams)
+            .build();
+
+    QueryBuilder builder = new QueryBuilder(props);
+    String query = builder.build(queryDesc);
+    assertEquals(query, String.format("Account: %s Metric ID: %s", account, metricId));
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactoryTest.java
@@ -70,7 +70,7 @@ class PrometheusMeteringTaskFactoryTest {
         factory.build(
             TaskDescriptor.builder(TaskType.METRICS_COLLECTION, "a-group")
                 .setSingleValuedArg("account", "12234")
-                .setSingleValuedArg("productProfileId", "OpenShift")
+                .setSingleValuedArg("productTag", "OpenShift")
                 .setSingleValuedArg("metric", "Cores")
                 .setSingleValuedArg("start", start.toString())
                 .setSingleValuedArg("end", end.toString())
@@ -88,7 +88,7 @@ class PrometheusMeteringTaskFactoryTest {
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, "a-group")
             .setSingleValuedArg("start", "2018-03-20T09:12:28Z")
             .setSingleValuedArg("end", "2018-03-20T09:12:28Z")
-            .setSingleValuedArg("productProfileId", "OpenShift")
+            .setSingleValuedArg("productTag", "OpenShift")
             .setSingleValuedArg("metric", "Cores")
             .setSingleValuedArg("step", "1h")
             .build();
@@ -101,7 +101,7 @@ class PrometheusMeteringTaskFactoryTest {
     TaskDescriptor descriptor =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, "a-group")
             .setSingleValuedArg("account", "1234")
-            .setSingleValuedArg("productProfileId", "OpenShift")
+            .setSingleValuedArg("productTag", "OpenShift")
             .setSingleValuedArg("metric", "Cores")
             .setSingleValuedArg("start", "2018-03-20")
             .setSingleValuedArg("end", "2018-03-20T09:12:28Z")
@@ -117,7 +117,7 @@ class PrometheusMeteringTaskFactoryTest {
     TaskDescriptor descriptor =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, "a-group")
             .setSingleValuedArg("account", "1234")
-            .setSingleValuedArg("productProfileId", "OpenShift")
+            .setSingleValuedArg("productTag", "OpenShift")
             .setSingleValuedArg("metric", "Cores")
             .setSingleValuedArg("start", "2018-03-20T09:12:28Z")
             .setSingleValuedArg("end", "2018-03-20T09")

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactoryTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.OffsetDateTime;
 import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.task.MetricsTask;
 import org.candlepin.subscriptions.task.Task;
@@ -78,7 +79,7 @@ class PrometheusMeteringTaskFactoryTest {
     assertTrue(task instanceof MetricsTask);
 
     task.execute();
-    verify(controller).collectOpenshiftMetrics("12234", start, end);
+    verify(controller).collectMetrics("OpenShift", Uom.CORES, "12234", start, end);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -78,7 +78,7 @@ class PrometheusMetricsTaskManagerTest {
     TaskDescriptor expectedTask =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, TASK_TOPIC)
             .setSingleValuedArg("account", account)
-            .setSingleValuedArg("productProfileId", TEST_PROFILE_ID)
+            .setSingleValuedArg("productTag", TEST_PROFILE_ID)
             .setSingleValuedArg("metric", "Cores")
             .setSingleValuedArg("start", start.toString())
             .setSingleValuedArg("end", end.toString())
@@ -97,7 +97,7 @@ class PrometheusMetricsTaskManagerTest {
     TaskDescriptor account1Task =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, TASK_TOPIC)
             .setSingleValuedArg("account", "a1")
-            .setSingleValuedArg("productProfileId", TEST_PROFILE_ID)
+            .setSingleValuedArg("productTag", TEST_PROFILE_ID)
             .setSingleValuedArg("metric", "Cores")
             .setSingleValuedArg("start", start.toString())
             .setSingleValuedArg("end", end.toString())
@@ -105,7 +105,7 @@ class PrometheusMetricsTaskManagerTest {
     TaskDescriptor account2Task =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, TASK_TOPIC)
             .setSingleValuedArg("account", "a2")
-            .setSingleValuedArg("productProfileId", TEST_PROFILE_ID)
+            .setSingleValuedArg("productTag", TEST_PROFILE_ID)
             .setSingleValuedArg("metric", "Cores")
             .setSingleValuedArg("start", start.toString())
             .setSingleValuedArg("end", end.toString())

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -92,7 +92,7 @@ class PrometheusMetricsTaskManagerTest {
     OffsetDateTime end = OffsetDateTime.now();
     OffsetDateTime start = end.minusDays(1);
 
-    when(accountSource.getMarketplaceAccounts(eq(TEST_PROFILE_ID), any()))
+    when(accountSource.getMarketplaceAccounts(eq(TEST_PROFILE_ID), eq(Uom.CORES), any()))
         .thenReturn(Set.of("a1", "a2"));
     TaskDescriptor account1Task =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, TASK_TOPIC)

--- a/src/test/java/org/candlepin/subscriptions/metering/task/MetricsTaskTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/task/MetricsTaskTest.java
@@ -34,7 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class OpenShiftMetricsTaskTest {
+class MetricsTaskTest {
 
   @Mock private PrometheusMeteringController controller;
 
@@ -50,6 +50,6 @@ class OpenShiftMetricsTaskTest {
     MetricsTask task =
         new MetricsTask(controller, expAccount, expProductProfileId, expMetric, expStart, expEnd);
     task.execute();
-    verify(controller).collectOpenshiftMetrics(expAccount, expStart, expEnd);
+    verify(controller).collectMetrics("OpenShift", Uom.CORES, expAccount, expStart, expEnd);
   }
 }


### PR DESCRIPTION
This PR combines changes for:
[ENT-3871](https://issues.redhat.com/browse/ENT-3871)
[ENT-3978](https://issues.redhat.com/browse/ENT-3978)

### Added a PromQL query builder

The QueryBuilder uses Spring Expression Language (SPEL) to apply
variables to a configured query template.

A query template is expected to be a well formed PromQL query.
Query templates are to be defined as a map (templateKey: promql)
in a configurationfile and can be be accessed via
PrometheusMetricsProperties:

   rhsm-subscriptions.metering.prometheus.metric.queryTemplates

A template can include template variables via a SPEL expressions.
These variables are substituted when the query is built and template
values are defined in the QueryDescriptor passed to the builder
at build time. Every property defined in the descriptor object will
accessible as template variables when the query is built. Variable
names are specified in dot notation and can be nested to access any
value defiend in the descriptor.

A QueryDescriptor contains two key fields that can be accessed in
a query template.
* **tag**: Comes from a configured TagMetric
* **runtime**: A generic collection of runtime args passed at runtime.

While the example below is not PromQL, an example of accessing
descriptor values would be as follows:

```
Metric #{tag.metricId} looked up for Account #{runtime[account]}
```

NOTE:
Template variables can contain other SPEL expressions, but it is important
note that we support 3 levels of nesting out of the box. This is not a
supported feature of SPEL. The number of levels we support was made
configurable, but I can't see us needing to change it.

###  Update metrics task to dynamically run query

* When the MeteringJob runs, pull the supported tags
  and UOMs from the tag profile definition.
* Defined a default query template for metrics.
* Add query parameters to TagMetric definitions that automatically
  get applied to the prometeus query based on the tag/uom when the task runs.
* Apply appropriate tag properties to events when they are generated
  from prometheus metrics.

### Testing
1. Configure access to telemeter.
```
podman run --rm -d -ti -p 8082:8080 quay.io/observatorium/token-refresher:master-2021-02-05-5da9663 --oidc.client-secret=$(cat ~/.token-refresher-stage) --oidc.client-id=observatorium-subwatch-staging --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external --url=https://observatorium.api.stage.openshift.com
```

2. Run the app
```
USER_USE_STUB=true PROM_URL="http://localhost:8082/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean bootRun
```

3. Kick off metrics gathering for OpenShift-metrics and observe in the logs that a task is created for each account for metering Cores. Verify that events are created.
```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMetering(java.lang.String, java.lang.String, java.lang.Integer)","arguments":["OpenShift-metrics", null, 1440]}'
```

4. In an ideal test environment, data would exist in prometheus that would allow us to properly test each product, but sadly in stage prometheus there is currently only data for OpenShift-metrics. We can test that Events are getting created for OpenShift-dedicated-metrics though, if we modify the tag_profile.yaml. Modify the yaml file and kick off metrics gathering for OpenShift-dedicated-metrics and observe in the logs that a task is created for each account for metering BOTH Cores AND Instance-hours. Verify that events are created for cores and instance-hours.
```yaml
# Modify the prometheusMetadataMetric query param in tag_profile.yaml so that the product filter is osd

# OSD metrics
- tag: OpenShift-dedicated-metrics
    metricId: redhat.com:openshift_dedicated:4cpu_hour
    uom: CORES
    queryParams:
      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
      prometheusMetadataMetric: subscription_labels{product="ocp", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
  - tag: OpenShift-dedicated-metrics
    metricId: redhat.com:openshift_dedicated:cluster_hour\
    uom: INSTANCE_HOURS
    queryParams:
      prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
      prometheusMetadataMetric: subscription_labels{product="ocp", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}
```
```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMetering(java.lang.String, java.lang.String, java.lang.Integer)","arguments":["OpenShift-dedicated-metrics", null, 1440]}'
```

Tip:
Query the event data as follows to clean up the output.
```sql
select instance_id, account_number, event_type, data->>'sla', data->>'role', data->>'usage', data->>'measurements' from events;
```
