### PR TITLE
ENT-3949: Add support for instance-hours to hosts API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1168,6 +1168,9 @@ components:
         core_hours:
           type: number
           format: double
+        instance_hours:
+          type: number
+          format: double
         hardware_type:
           description: What the type of the host is (e.g. hypervisor, physical, etc.).
           type: string

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -35,6 +35,7 @@ import javax.validation.Validator;
 import org.candlepin.subscriptions.capacity.CapacityIngressConfiguration;
 import org.candlepin.subscriptions.conduit.ConduitConfiguration;
 import org.candlepin.subscriptions.conduit.job.OrgSyncConfiguration;
+import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.marketplace.MarketplaceWorkerConfiguration;
 import org.candlepin.subscriptions.metering.MeteringConfiguration;
 import org.candlepin.subscriptions.resource.ApiConfiguration;
@@ -73,6 +74,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
   TallyWorkerConfiguration.class,
   OrgSyncConfiguration.class,
   MarketplaceWorkerConfiguration.class,
+  ProductMappingConfiguration.class,
   DevModeConfiguration.class,
   SecurityConfig.class,
   HawtioConfiguration.class,

--- a/src/main/java/org/candlepin/subscriptions/db/TagProfileLookup.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TagProfileLookup.java
@@ -18,24 +18,11 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.capacity;
+package org.candlepin.subscriptions.db;
 
-import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
-import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
+import org.candlepin.subscriptions.files.TagProfile;
 
-/**
- * Configuration for the "capacity-ingress" profile.
- *
- * <p>This profile is used to receive capacity records from an internal service.
- */
-@Configuration
-@Profile("capacity-ingress")
-@Import({ResteasyConfiguration.class, RhsmSubscriptionsDataSourceConfiguration.class})
-@ComponentScan(basePackages = "org.candlepin.subscriptions.capacity")
-public class CapacityIngressConfiguration {
-  /* Intentionally empty */
+/** Repository "fragment interface" that can be used to access tag profile from a Repository */
+public interface TagProfileLookup {
+  TagProfile getTagProfile();
 }

--- a/src/main/java/org/candlepin/subscriptions/db/TagProfileLookupImpl.java
+++ b/src/main/java/org/candlepin/subscriptions/db/TagProfileLookupImpl.java
@@ -18,24 +18,27 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.capacity;
+package org.candlepin.subscriptions.db;
 
-import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
-import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
+import org.candlepin.subscriptions.files.TagProfile;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /**
- * Configuration for the "capacity-ingress" profile.
- *
- * <p>This profile is used to receive capacity records from an internal service.
+ * Repository "mixin" that can provides access to the tag profile. To use, extend TagProfileLookup
  */
-@Configuration
-@Profile("capacity-ingress")
-@Import({ResteasyConfiguration.class, RhsmSubscriptionsDataSourceConfiguration.class})
-@ComponentScan(basePackages = "org.candlepin.subscriptions.capacity")
-public class CapacityIngressConfiguration {
-  /* Intentionally empty */
+@Component
+public class TagProfileLookupImpl implements TagProfileLookup {
+
+  private final TagProfile tagProfile;
+
+  @Autowired
+  public TagProfileLookupImpl(TagProfile tagProfile) {
+    this.tagProfile = tagProfile;
+  }
+
+  @Override
+  public TagProfile getTagProfile() {
+    return tagProfile;
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -422,6 +422,7 @@ public class Host implements Serializable {
     // capture relationships between hosts & snapshots to derive coreHours within dynamic timeframes
 
     host.coreHours(getMonthlyTotal(monthId, Uom.CORES));
+    host.instanceHours(getMonthlyTotal(monthId, Uom.INSTANCE_HOURS));
 
     return host;
   }

--- a/src/main/java/org/candlepin/subscriptions/files/TagProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/files/TagProfile.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.files;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,6 +37,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.json.TallyMeasurement;
 import org.springframework.util.StringUtils;
@@ -58,6 +60,7 @@ public class TagProfile {
   private Map<String, String> offeringProductNameToTagLookup;
   private Map<String, Granularity> finestGranularityLookup;
   private Map<String, TagMetaData> tagMetaDataToTagLookup;
+  private Map<String, List<Measurement.Uom>> tagToUomLookup;
 
   /** Initialize lookup fields */
   @PostConstruct
@@ -69,6 +72,7 @@ public class TagProfile {
     offeringProductNameToTagLookup = new HashMap<>();
     tagMetaDataToTagLookup = new HashMap<>();
     finestGranularityLookup = new HashMap<>();
+    tagToUomLookup = new HashMap<>();
     tagMappings.forEach(this::handleTagMapping);
     tagMetrics.forEach(this::handleTagMetric);
     tagMetaData.forEach(this::handleTagMetaData);
@@ -95,6 +99,8 @@ public class TagProfile {
     measurementsByTagLookup
         .computeIfAbsent(tagMetric.getTag(), k -> new HashSet<>())
         .add(tagMetric.getUom());
+    List<Uom> uomList = tagToUomLookup.computeIfAbsent(tagMetric.getTag(), k -> new ArrayList<>());
+    uomList.add(tagMetric.getUom());
   }
 
   private void handleTagMetaData(TagMetaData tagMetaData) {
@@ -136,5 +142,9 @@ public class TagProfile {
       return Optional.empty();
     }
     return Optional.ofNullable(tagMetaDataToTagLookup.get(productTag));
+  }
+
+  public List<Measurement.Uom> uomsForTag(String tag) {
+    return tagToUomLookup.get(tag);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceWorkerConfiguration.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.marketplace;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.subscription.SubscriptionServiceConfiguration;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
@@ -42,7 +41,7 @@ import org.springframework.retry.support.RetryTemplateBuilder;
 /** Configuration for the Marketplace integration worker. */
 @Profile("marketplace")
 @ComponentScan(basePackages = "org.candlepin.subscriptions.marketplace")
-@Import({SubscriptionServiceConfiguration.class, ProductMappingConfiguration.class})
+@Import(SubscriptionServiceConfiguration.class)
 public class MarketplaceWorkerConfiguration {
   @Bean
   @Qualifier("marketplaceRetryTemplate")

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.metering.profile;
 
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.jobs.JobProperties;
 import org.candlepin.subscriptions.metering.job.MeteringJob;
@@ -42,7 +41,6 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 @Profile("metering-job")
 @Import({
-  ProductMappingConfiguration.class,
   PrometheusServiceConfiguration.class,
   MeteringTasksConfiguration.class,
   TaskProducerConfiguration.class

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.metering.profile;
 
 import org.candlepin.subscriptions.event.EventController;
-import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMetricsProperties;
@@ -52,7 +51,6 @@ import org.springframework.retry.support.RetryTemplate;
 @Configuration
 @Profile("openshift-metering-worker")
 @Import({
-  ProductMappingConfiguration.class,
   PrometheusServiceConfiguration.class,
   TaskConsumerConfiguration.class,
   MeteringTasksConfiguration.class

--- a/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.resource;
 
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
-import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
 import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -40,8 +39,7 @@ import org.springframework.context.annotation.Profile;
 @Import({
   ResteasyConfiguration.class,
   RhsmSubscriptionsDataSourceConfiguration.class,
-  TallyWorkerConfiguration.class,
-  ProductMappingConfiguration.class
+  TallyWorkerConfiguration.class
 })
 public class ApiConfiguration {
   /* Intentionally empty */

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -85,7 +85,8 @@ public class HostsResource implements HostsApi {
           .putAll(getUomSorts())
           .build();
 
-  public static final Map<HostReportSort, Measurement.Uom> SORT_TO_UOM_MAP = getSortToUomMap();
+  public static final Map<HostReportSort, Measurement.Uom> SORT_TO_UOM_MAP =
+      ImmutableMap.copyOf(getSortToUomMap());
 
   private static Map<HostReportSort, Measurement.Uom> getSortToUomMap() {
     return Arrays.stream(Measurement.Uom.values())

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -39,7 +39,6 @@ import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyHostView;
 import org.candlepin.subscriptions.db.model.Usage;
-import org.candlepin.subscriptions.files.TagProfile;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
@@ -109,14 +108,11 @@ public class HostsResource implements HostsApi {
 
   private final HostRepository repository;
   private final PageLinkCreator pageLinkCreator;
-  private final TagProfile tagProfile;
   @Context UriInfo uriInfo;
 
-  public HostsResource(
-      HostRepository repository, PageLinkCreator pageLinkCreator, TagProfile tagProfile) {
+  public HostsResource(HostRepository repository, PageLinkCreator pageLinkCreator) {
     this.repository = repository;
     this.pageLinkCreator = pageLinkCreator;
-    this.tagProfile = tagProfile;
   }
 
   @SuppressWarnings("java:S3776")

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -182,17 +182,7 @@ public class HostsResource implements HostsApi {
       // the selected month. This is also used for sorting purposes (same join). See
       // org.candlepin.subscriptions.db.HostSpecification#toPredicate and
       // org.candlepin.subscriptions.db.HostRepository#findAllBy.
-      Measurement.Uom referenceUom;
-      if (SORT_TO_UOM_MAP.containsKey(sort)) {
-        referenceUom = SORT_TO_UOM_MAP.get(sort);
-      } else {
-        referenceUom =
-            Optional.ofNullable(tagProfile.uomsForTag(productId.toString()))
-                .orElse(List.of())
-                .stream()
-                .findFirst()
-                .orElse(null);
-      }
+      Measurement.Uom referenceUom = SORT_TO_UOM_MAP.get(sort);
       hosts =
           repository.findAllBy(
               accountNumber,

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -28,7 +28,6 @@ import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.cloudigrade.ConcurrentApiFactory;
 import org.candlepin.subscriptions.db.AccountRepository;
 import org.candlepin.subscriptions.event.EventController;
-import org.candlepin.subscriptions.files.ProductMappingConfiguration;
 import org.candlepin.subscriptions.files.ProductProfile;
 import org.candlepin.subscriptions.files.ProductProfileRegistry;
 import org.candlepin.subscriptions.http.HttpClientProperties;
@@ -65,7 +64,6 @@ import org.springframework.retry.support.RetryTemplate;
 @Import({
   TallyTaskQueueConfiguration.class,
   TaskConsumerConfiguration.class,
-  ProductMappingConfiguration.class,
   InventoryDataSourceConfiguration.class,
   ProductConfiguration.class,
   JmxBeansConfiguration.class

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -393,7 +393,7 @@ class HostsResourceTest {
             0,
             1,
             june2019,
-            Measurement.Uom.CORES,
+            null,
             PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))))
         .thenReturn(page);
 

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -393,6 +393,7 @@ class HostsResourceTest {
             0,
             1,
             june2019,
+            Measurement.Uom.CORES,
             PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))))
         .thenReturn(page);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-3949

Note that I explored a couple of different options. The tricky thing with dynamic metrics and our data model is the join seen in
HostSpecification, where a single metric/UOM is joined against for filtering and sorting.

I considered generating joins dynamically based on the ProductProfile, but it got messy quickly, so I instead opted to change the single UOM used in the join dynamically, defaulting to the first configured UOM for a tag, or specified by the sort param.

I named this new parameter "reference UOM".

There is one gap here: if a multi-metric product has *missing* metrics for a given instance, then that instance may be incorrectly filtered out. If we encounter such a use case in the future, I think we should revisit the specification class, and dynamically join to all relevant metrics, and change the month filter to an or across all metrics.

Testing
-------

First, it may be helpful to put the following lines in `config/application.properties` in order to see the resulting SQL queries:

```
logging.level.org.hibernate.SQL=DEBUG
logging.level.org.hibernate.type=TRACE
spring.jpa.properties.hibernate.format_sql=true
```

Insert some data for the a couple of instances:

```
cat << EOF | psql -h localhost -U rhsm-subscriptions
insert into hosts(id, account_number, org_id, display_name, hardware_type, last_seen, instance_id, is_guest, is_hypervisor, is_unmapped_guest)
values ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', 'account123', 'org123', 'cluster1.example.com', 'PHYSICAL', now(),
        '72f0a6a0-adcf-4e16-80a0-4933dea47ff0', false, false, false);
insert into instance_monthly_totals(instance_id, month, uom, value) values ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', '2021-05', 'CORES', 1.0);
insert into instance_monthly_totals(instance_id, month, uom, value) values ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', '2021-05', 'INSTANCE_HOURS', 100.0);
insert into instance_monthly_totals(instance_id, month, uom, value) values ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', '2021-06', 'CORES', 1.0);
insert into instance_monthly_totals(instance_id, month, uom, value) values ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', '2021-06', 'INSTANCE_HOURS', 100.0);
insert into host_tally_buckets(host_id, product_id, sla, as_hypervisor, measurement_type, usage, cores) values ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', 'OpenShift-dedicated-metrics', '_ANY', false, 'PHYSICAL', '_ANY', 0);

insert into hosts(id, account_number, org_id, display_name, hardware_type, last_seen, instance_id, is_guest, is_hypervisor, is_unmapped_guest)
values ('7f62e968-08a4-449e-adc2-8ab7812609df', 'account123', 'org123', 'cluster2.example.com', 'PHYSICAL', now(),
        '7f62e968-08a4-449e-adc2-8ab7812609df', false, false, false);
insert into instance_monthly_totals(instance_id, month, uom, value) values ('7f62e968-08a4-449e-adc2-8ab7812609df', '2021-05', 'CORES', 100.0);
insert into instance_monthly_totals(instance_id, month, uom, value) values ('7f62e968-08a4-449e-adc2-8ab7812609df', '2021-05', 'INSTANCE_HOURS', 1.0);
insert into instance_monthly_totals(instance_id, month, uom, value) values ('7f62e968-08a4-449e-adc2-8ab7812609df', '2021-06', 'CORES', 100.0);
insert into instance_monthly_totals(instance_id, month, uom, value) values ('7f62e968-08a4-449e-adc2-8ab7812609df', '2021-06', 'INSTANCE_HOURS', 1.0);
insert into host_tally_buckets(host_id, product_id, sla, as_hypervisor, measurement_type, usage) values ('7f62e968-08a4-449e-adc2-8ab7812609df', 'OpenShift-dedicated-metrics', '_ANY', false, 'PHYSICAL', '_ANY');
EOF
```

Next, try sorting with both UOM (can also use swagger-ui if desired):

```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-06-01T00%3A00%3A00Z&ending=2021-06-30T11%3A59%3A59.999Z&sort=instance_hours' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-06-01T00%3A00%3A00Z&ending=2021-06-30T11%3A59%3A59.999Z&sort=core_hours' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

Cleanup (optional)

```
cat << EOF | psql -h localhost -U rhsm-subscriptions
delete from hosts where id in ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', '7f62e968-08a4-449e-adc2-8ab7812609df');
delete from instance_monthly_totals where instance_id in ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', '7f62e968-08a4-449e-adc2-8ab7812609df');
delete from host_tally_buckets where host_id in ('72f0a6a0-adcf-4e16-80a0-4933dea47ff0', '7f62e968-08a4-449e-adc2-8ab7812609df');
EOF
```