### PR TITLE
ENT-4025: Change config to release from `release` branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ release {
     newVersionCommitMessage = '[Subscriptions Release] - version bump: '
     pushReleaseVersionBranch = 'main'
     git {
-        requireBranch = /develop|hotfix.*/
+        requireBranch = /release|hotfix.*/
         pushToRemote = false
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4025

The idea is that we split development efforts in two:

1. Changes against `develop` per usual.
2. Fixes against the current release "train" (that hasn't graduated to prod yet).

Updated processes below:

Begin a new release train
-------------------------

```
git fetch  # ensure we have latest state
git checkout release
git merge --ff-only origin/develop  # FF the release branch to latest develop, if this fails, we should merge release into develop first
```

Bugfixing current release train
-------------------------------

1. Fix should initially land with a PR against `release`.
2. Fix should subsequently land in `develop` via a PR merging `release` into `develop` (ideally handled by the same author as the `release` PR).

Tagging a release candidate
---------------------------

Now involves an extra step (merging `release` back into `develop`)

```
git checkout release
./gradlew release
git checkout develop
git pull --ff-only  # ensure develop is up-to-date
git merge --no-ff release
git push --follow-tags origin develop release main
```

Thoughts
--------

There are some interesting opportunities/considerations for automation here...

Immediately after a release train is released to prod, a new release train can be started. The above steps can be fully automated.

Any time there are changes on the `release` branch that are not on the develop branch, a PR to merge `release` into `develop` is appropriate (most of the time this will be a trivial PR).

Tagging a release candidate could be done anytime the tip of the release branch has non-version changes (ignoring `gradle.properties`).