### PR TITLE
Suppress certain stacktraces from error messages.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
@@ -44,16 +44,22 @@ public abstract class BaseExceptionMapper<T extends Throwable> implements Except
   @Override
   public Response toResponse(T exception) {
     Error error = buildError(exception);
-    String message =
-        StringUtils.hasText(error.getCode())
-            ? String.format("%s: %s", error.getCode(), error.getTitle())
-            : error.getTitle();
+
+    StringBuilder messageBuf = new StringBuilder();
+    if (StringUtils.hasText(error.getCode())) {
+      messageBuf.append(error.getCode()).append(": ");
+    }
+    messageBuf.append(error.getTitle());
+    if (StringUtils.hasText(error.getDetail())) {
+      messageBuf.append(" - ").append(error.getDetail());
+    }
+
     Class<?> exClass = exception.getClass();
     if (AccessDeniedException.class.isAssignableFrom(exClass)
         || AuthenticationException.class.isAssignableFrom(exClass)) {
-      log.error(SECURITY_STACKTRACE, message, exception);
+      log.error(SECURITY_STACKTRACE, "{}", messageBuf, exception);
     } else {
-      log.error(message, exception);
+      log.error("{}", messageBuf, exception);
     }
     return ExceptionUtil.toResponse(error);
   }

--- a/src/main/java/org/candlepin/subscriptions/logback/OnMdcEvaluator.java
+++ b/src/main/java/org/candlepin/subscriptions/logback/OnMdcEvaluator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.logback;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.boolex.EvaluationException;
+import ch.qos.logback.core.boolex.EventEvaluatorBase;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Logback EventEvaluator that filters messages based on the contents of the MDC. This class
+ * exists to cope with the problem that where exceptions are thrown is often very different from
+ * where they are logged. Many times we do not want to print a stacktrace for a more mundane
+ * exception, but at logging time we no longer have the context to make that decision (especially if
+ * the exception is a very general one like BadRequestException).
+ *
+ * <p>This class is similar in design to the {@link ch.qos.logback.classic.boolex.OnMarkerEvaluator}
+ * class. With this evaluator, classes can add an item to the thread-wide MDC when an exception is
+ * thrown and then when it is time to log the exception in the {@link
+ * org.candlepin.subscriptions.exception.mapper.BaseExceptionMapper}, we can use the MDC contents to
+ * decide whether to print a full stacktrace or not.
+ *
+ * <p>This evaluator looks for given MDC keys that are set to "true".
+ */
+public class OnMdcEvaluator extends EventEvaluatorBase<ILoggingEvent> {
+  List<String> mdcKeyList = new ArrayList<>();
+
+  public void addMdcKey(String mdcKey) {
+    mdcKeyList.add(mdcKey);
+  }
+
+  @Override
+  public boolean evaluate(ILoggingEvent event) throws NullPointerException, EvaluationException {
+    Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
+
+    if (mdcPropertyMap == null) {
+      return false;
+    }
+
+    return mdcPropertyMap.entrySet().stream()
+        .anyMatch(
+            x -> Boolean.TRUE.toString().equals(x.getValue()) && mdcKeyList.contains(x.getKey()));
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -51,6 +51,7 @@ import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
 import org.candlepin.subscriptions.utilization.api.resources.TallyApi;
+import org.slf4j.MDC;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -109,6 +110,9 @@ public class TallyResource implements TallyApi {
        * their request is a non sequitur. */
       productProfileRegistry.validateGranularityCompatibility(productId, granularityFromValue);
     } catch (IllegalStateException e) {
+      // Combined with our logging configuration, this tells the OnMdcEvaluator class to suppress
+      // the stacktrace
+      MDC.put("INVALID_GRANULARITY", Boolean.TRUE.toString());
       throw new BadRequestException(e.getMessage());
     }
 

--- a/src/main/java/org/candlepin/subscriptions/resteasy/EnumParamConverterProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/EnumParamConverterProvider.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 /** ParamConverterProvider to enable use of enums in query providers. */
@@ -95,10 +96,13 @@ public class EnumParamConverterProvider implements ParamConverterProvider {
       T result = stringToEnumMap.get(lookupValue);
       if (result != null) {
         return result;
+      } else {
+        // Combined with our logging configuration, this tells the OnMdcEvaluator class to suppress
+        // the stacktrace
+        MDC.put("INVALID_" + className.getSimpleName().toUpperCase(), Boolean.TRUE.toString());
+        throw new IllegalArgumentException(
+            String.format(INVALID_VALUE_EXCEPTION_MSG, value, className));
       }
-
-      throw new IllegalArgumentException(
-          String.format(INVALID_VALUE_EXCEPTION_MSG, value, className));
     }
 
     @Override

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,11 +5,18 @@
         <marker>SECURITY_STACKTRACE</marker>
     </evaluator>
 
+    <evaluator name="MDC_STACKTRACE_EVAL" class="org.candlepin.subscriptions.logback.OnMdcEvaluator">
+        <!-- Log events with the MDC keys listed below set to "true" will not have their stacktraces printed -->
+        <mdcKey>INVALID_GRANULARITY</mdcKey>
+        <mdcKey>INVALID_USAGETYPE</mdcKey>
+        <mdcKey>INVALID_SERVICELEVELTYPE</mdcKey>
+    </evaluator>
+
     <appender name="ConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <!-- %ex{full, SECURITY_STACKTRACE_EVAL} will display the full stack trace of the exception only
              if the evaluator called SECURITY_STACKTRACE_EVAL returns false. -->
-            <pattern>%d{ISO8601} [thread=%thread] [%-5p] [%c] %X{user}- %m%n%ex{full, SECURITY_STACKTRACE_EVAL}</pattern>
+            <pattern>%d{ISO8601} [thread=%thread] [%-5p] [%c] %X{user}- %m%n%ex{full, SECURITY_STACKTRACE_EVAL, MDC_STACKTRACE_EVAL}</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
The reason for this is that frequently the location an exception is
created is quite distant from the location where it is logged.  Our
exceptions are generally logged in the BaseExceptionMapper class but the
application class that threw the exception has no way of communicating
that the exception thrown is mundane and does not warrant a stacktrace.
The MDC (mapped diagnostic context) is a thread local data structure
that we can use as a communications channel.

This commit creates an OnMdcEvaluator that suppresses stacktraces from
error log messages based on the content of the MDC.  The intent is for
the developer to drop a known key set to "true" into the MDC at the time
an exception is thrown.  If the OnMdcEvaluator is set to look for that
key, the stacktrace will be suppressed.

This commit suppresses the stacktraces for requests that use an invalid
SLA or usage and for requests specify a granularity too fine for the
given product.

---
# Testing
Since these changes revolve around logging, I don't know of an *easy* way to unit test this.  It would probably be possible to set up some sort of MemoryBufferAppender that receives the log messages and then examine it afterward, but I don't know that putting all that together is going to offer a big return on investment.  If reviewers feel otherwise, I can work on putting a unit test together.  Otherwise...

* Test a bad SLA
```
curl 'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=Daily&sla=ZAP&usage=_ANY&beginning=2017-07-29T00%3A00%3A00Z&ending=2017-07-30T23%3A59%3A59Z&use_running_totals_format=false'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

* Test a bad Usage
```
curl 'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=Daily&sla=_ANY&usage=ZAP&beginning=2017-07-29T00%3A00%3A00Z&ending=2017-07-30T23%3A59%3A59Z&use_running_totals_format=false'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

* Test a bad granularity
```
curl 'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=Hourly&sla=_ANY&usage=_ANY&beginning=2017-07-29T00%3A00%3A00Z&ending=2017-07-30T23%3A59%3A59Z&use_running_totals_format=false'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' 
```

End result: no stacktraces for these errors

* Apply this patch
```diffdiff --git a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
index 94b96052..01ea28ff 100644
--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -116,6 +116,10 @@ public class TallyResource implements TallyApi {
       throw new BadRequestException(e.getMessage());
     }
 
+    if (sla == ServiceLevelType._ANY) {
+      throw new BadRequestException("Some other exception");
+    }
+
     Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage =
         repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
```

* Trigger that exception and observe that a stacktrace **is** printed
```
curl 'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=Daily&sla=_ANY&usage=_ANY&beginning=2017-07-29T00%3A00%3A00Z&ending=2017-07-30T23%3A59%3A59Z&use_running_totals_format=false'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

