### PR TITLE
No longer suppress Prometheus API errors

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
@@ -60,12 +60,8 @@ public class PrometheusService {
           .queryRange(
               query, start.toEpochSecond(), end.toEpochSecond(), Integer.toString(step), timeout);
     } catch (ApiException apie) {
-      // ApiException message returned from prometheus server are huge and include the
-      // HTML error page body. Just output the code here.
       throw new ExternalServiceException(
-          ErrorCode.REQUEST_PROCESSING_ERROR,
-          String.format("Prometheus API Error! CODE: %s", apie.getCode()),
-          new ApiException(String.format("Prometheus API response code: %s", apie.getCode())));
+          ErrorCode.REQUEST_PROCESSING_ERROR, formatErrorMessage(apie), apie);
     }
   }
 
@@ -77,12 +73,9 @@ public class PrometheusService {
       log.debug("Running prometheus query: Time: {}, Query: {}", time.toEpochSecond(), query);
       return apiProvider.queryApi().query(query, time, timeout);
     } catch (ApiException apie) {
-      // ApiException message returned from prometheus server are huge and include the
-      // HTML error page body. Just output the code here.
+
       throw new ExternalServiceException(
-          ErrorCode.REQUEST_PROCESSING_ERROR,
-          String.format("Prometheus API Error! CODE: %s", apie.getCode()),
-          new ApiException(String.format("Prometheus API response code: %s", apie.getCode())));
+          ErrorCode.REQUEST_PROCESSING_ERROR, formatErrorMessage(apie), apie);
     }
   }
 
@@ -91,5 +84,10 @@ public class PrometheusService {
     //       it does not handle the curly braces correctly causing issues
     //       when the request is made.
     return UrlEscapers.urlFragmentEscaper().escape(promQL);
+  }
+
+  private String formatErrorMessage(ApiException apie) {
+    return String.format(
+        "Prometheus API Error! CODE: %s MESSAGE: %s", apie.getCode(), apie.getMessage());
   }
 }


### PR DESCRIPTION
It appears that the latest upgrade of the telemeter
APIs address the really long and bloated response
message and body when an error occurs on the query
API. Now that this has been fixed, we can include
the actual cause of the error in our logs!

### Testing

1. Force error in account lookup query in application.yaml
```
...

      metric:
        accountQueryTemplates:
          default: >-
            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_te(#{metric.queryParams[prometheusMetadataMetric]}{product='#{metric.queryParams[product]}', ebs_account != '', billing_model='marketplace'}[1h]))
            by (ebs_account)}

...
```

2. Launch the app
```bash
$ USER_USE_STUB=true PROM_URL="http://localhost:8082/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean bootRun
```

3. Kick off a metering task and watch the logs for the error.
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMetering(java.lang.String, java.lang.String, java.lang.Integer)","arguments":["OpenShift-metrics", null, 1440]}'
```

