### PR TITLE
ENT-3815: Add retry to MeteringJob

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -74,6 +75,15 @@ public class MetricProperties {
    * parameters a set number of times to prevent recursion.
    */
   private int templateParameterDepth = 3;
+
+  /** How many attempts before giving up on the MeteringJob. */
+  private Integer jobMaxAttempts;
+
+  /** Retry backoff initial interval of the MeteringJob. */
+  private Duration jobBackOffInitialInterval;
+
+  /** Retry backoff interval of the MeteringJob. */
+  private Duration jobBackOffMaxInterval;
 
   public Optional<String> getQueryTemplate(String templateKey) {
     return queryTemplates.containsKey(templateKey)

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
@@ -34,6 +34,7 @@ import org.candlepin.subscriptions.task.queue.TaskQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
 
 /** Produces task messages related to pulling metrics back from Telemeter. */
@@ -89,22 +90,33 @@ public class PrometheusMetricsTaskManager {
   @Transactional
   public void updateMetricsForAllAccounts(
       String productTag, OffsetDateTime start, OffsetDateTime end) {
+    updateMetricsForAllAccounts(
+        productTag, start, end, RetryTemplate.builder().maxAttempts(1).build());
+  }
+
+  @Transactional
+  public void updateMetricsForAllAccounts(
+      String productTag, OffsetDateTime start, OffsetDateTime end, RetryTemplate retry) {
     tagProfile
         .getSupportedMetricsForProduct(productTag)
         .forEach(
-            metric -> {
-              try (Stream<String> accountStream =
-                  accountSource.getMarketplaceAccounts(productTag, metric, end).stream()) {
-                log.info(
-                    "Queuing {} {} metric updates for all configured accounts.",
-                    productTag,
-                    metric);
-                accountStream.forEach(
-                    account ->
-                        queueMetricUpdateForAccount(account, productTag, metric, start, end));
-                log.info("Done queuing updates of {} {} metric", productTag, metric);
-              }
-            });
+            metric ->
+                retry.execute(
+                    context -> {
+                      queueMetricUpdateForAllAccounts(productTag, metric, start, end);
+                      return null;
+                    }));
+  }
+
+  private void queueMetricUpdateForAllAccounts(
+      String productTag, Uom metric, OffsetDateTime start, OffsetDateTime end) {
+    try (Stream<String> accountStream =
+        accountSource.getMarketplaceAccounts(productTag, metric, end).stream()) {
+      log.info("Queuing {} {} metric updates for all configured accounts.", productTag, metric);
+      accountStream.forEach(
+          account -> queueMetricUpdateForAccount(account, productTag, metric, start, end));
+      log.info("Done queuing updates of {} {} metric", productTag, metric);
+    }
   }
 
   private TaskDescriptor createMetricsTask(

--- a/src/main/resources/application-metering-job.yaml
+++ b/src/main/resources/application-metering-job.yaml
@@ -6,3 +6,7 @@ rhsm-subscriptions:
     prometheus:
       metric:
         rangeInMinutes: ${OPENSHIFT_METERING_RANGE:60}
+        jobMaxAttempts: ${METERING_JOB_MAX_ATTEMPTS:50}
+        jobBackOffMaxInterval: ${METERING_JOB_BACK_OFF_MAX_INTERVAL:50000}
+        jobBackOffInitialInterval: ${METERING_JOB_BACK_OFF_INITIAL_INTERVAL:1000}
+        jobBackOffMultiplier: ${METERING_JOB_BACK_OFF_MULTIPLIER:1.5}

--- a/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
@@ -38,12 +38,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.retry.support.RetryTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class MeteringJobTest {
 
   @Mock private PrometheusMetricsTaskManager tasks;
   @Mock private TagProfile tagProfile;
+  @Mock private RetryTemplate retryTemplate;
 
   private ApplicationClock clock;
   private MetricProperties metricProps;
@@ -59,7 +61,7 @@ class MeteringJobTest {
     appProps.setPrometheusLatencyDuration(Duration.ofHours(6L));
 
     clock = new FixedClockConfiguration().fixedClock();
-    job = new MeteringJob(tasks, clock, tagProfile, metricProps, appProps);
+    job = new MeteringJob(tasks, clock, tagProfile, metricProps, appProps, retryTemplate);
 
     when(tagProfile.getTagsWithPrometheusEnabledLookup()).thenReturn(Set.of("OpenShift-metrics"));
   }
@@ -77,6 +79,7 @@ class MeteringJobTest {
             expStartDate.plusMinutes(range).truncatedTo(ChronoUnit.HOURS).minusMinutes(1));
     job.run();
 
-    verify(tasks).updateMetricsForAllAccounts("OpenShift-metrics", expStartDate, expEndDate);
+    verify(tasks)
+        .updateMetricsForAllAccounts("OpenShift-metrics", expStartDate, expEndDate, retryTemplate);
   }
 }


### PR DESCRIPTION
Since we require that the job runs each hour, if a required
service should go down when the job is run, we should retry
the operation to ensure that we do not miss a metrics update.

This was done in an attempt to avoid issues such as the one
outlined in: ENT-3815

### Testing
A simple way of testing retry is to stop the token refresher pod and start the app with the job profile. The job will fail and will begin to retry. Restart the refresher pod and the job should start working correctly.



