### PR TITLE
ENT-4100: Fix syntax issue with capacity template causing CI deployment failure

### DIFF
--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -46,7 +46,7 @@ parameters:
   - name: DATABASE_MAX_POOL_SIZE
     value: '10'
   - name: SUBSCRIPTION_SYNC_ENABLED
-    value: false
+    value: 'false'
 
 objects:
   - apiVersion: v1


### PR DESCRIPTION
Fixes bug by https://github.com/RedHatInsights/rhsm-subscriptions/pull/475 being merged


If you have CRC running on your local, you can test using the `oc process` command to reproduce/test


`oc process -f rhsm-subscriptions-capacity-ingress.yml`

```
error: failed to read input object (not a Template?): unable to decode "rhsm-subscriptions-capacity-ingress.yml": v1.Template.Parameters: []v1.Parameter: v1.Parameter.Value: ReadString: expects " or n, but found f, error found in #10 byte of ...|,"value":false}]}|..., bigger context ...|10"},{"name":"SUBSCRIPTION_SYNC_ENABLED","value":false}]}|...
```