### PR TITLE
ENT-4055: Update event source/type in existing data

### DIFF
--- a/src/main/resources/liquibase/202107140929-ent-4055-cleanup-event-data.xml
+++ b/src/main/resources/liquibase/202107140929-ent-4055-cleanup-event-data.xml
@@ -1,0 +1,50 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202107140929-1"  author="mstead" dbms="postgresql">
+    <comment>Temporarily drop unique constraint on events to temporarily allow duplicates.</comment>
+    <dropUniqueConstraint tableName="events" constraintName="events_event_type_event_source_instance_id_account_number_t_key" />
+  </changeSet>
+
+  <changeSet id="202107140929-2"  author="mstead" dbms="postgresql">
+    <comment>Update the OSD event source and type, which could cause duplicates.</comment>
+    <update tableName="events">
+      <column name="event_type" value="snapshot_redhat.com:openshift_dedicated:4cpu_hour"/>
+      <column name="event_source" value="prometheus"/>
+      <column name="data" valueComputed="jsonb_set(jsonb_set(data, '{event_type}', '&quot;snapshot_redhat.com:openshift_dedicated:4cpu_hour&quot;'), '{event_source}', '&quot;prometheus&quot;')" />
+      <where>data->>'role'='osd' and event_type='snapshot'</where>
+    </update>
+  </changeSet>
+
+  <changeSet id="202107140929-3"  author="mstead" dbms="postgresql">
+    <comment>Update the OCP event source and type, which could cause duplicates.</comment>
+    <update tableName="events">
+      <column name="event_type" value="snapshot_redhat.com:openshift_container_platform:cpu_hour"/>
+      <column name="event_source" value="prometheus"/>
+      <column name="data" valueComputed="jsonb_set(jsonb_set(data, '{event_type}', '&quot;snapshot_redhat.com:openshift_container_platform:cpu_hour&quot;'), '{event_source}', '&quot;prometheus&quot;')" />
+      <where>data->>'role'='ocp' and event_type='snapshot'</where>
+    </update>
+  </changeSet>
+
+  <changeSet id="202107140929-4"  author="mstead" dbms="postgresql">
+    <comment>Remove any duplicate events that we may have created.</comment>
+    <sql dbms="postgresql">
+      with to_keep as (
+      select id, rn from (select id, ROW_NUMBER() over (
+      partition by event_type, event_source, instance_id, account_number, timestamp) rn
+      from events) tmp
+      )
+      delete from events where id in (select id from to_keep where to_keep.rn > 1);
+    </sql>
+  </changeSet>
+
+  <changeSet id="202107140929-5"  author="mstead" dbms="postgresql">
+    <comment>Add the unique constraint back to the events table.</comment>
+    <addUniqueConstraint tableName="events"
+      columnNames="event_type, event_source, instance_id, account_number, timestamp"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -46,5 +46,6 @@
     <include file="liquibase/202102251446-add-constraints-indexes-fields-to-events.xml" />
     <include file="liquibase/202104051823-add-constraints-to-tally-snapshots.xml" />
     <include file="liquibase/202104091791-insert-openshift-skus.xml" />
+    <include file="liquibase/202107140929-ent-4055-cleanup-event-data.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
When adding support for instance_hours metering, we changed
the event_source and event_type to be more metric specific.
After it was deployed, when metrics gathering happens
the metrics for a given month would include any older events
with the old static source and type, causing the instance
hours to be doubled.

This patch adds a liquibase changeset that re-aligns the
event table's data with what is now expected in terms of
event_type and event_source.

Because there are environments that already have the
instance_hours functionality running, this patch is a
little cumbersome.

First the unique constraint on the events table has to be
removed because converting old records to the new style
can cause duplicate records once the data updates are run.
We then need to remove the duplicates and add back the
unique constraint.

## Reproducing The Issue

First, ensure you have set up the forwarder for prometheus (I can help with that).
``` bash
# Drop the DB to start fresh (I use my local DB, but same can be applied to the pod)
$ dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions

# Checkout the branch before the instance_hours refactor work went in.
$ git checkout -b 1.0.54 rhsm-subscriptions-1.0.54

# Launch the app as follows
$ USER_USE_STUB=true PROM_URL="http://localhost:8082/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean bootRun

# Kick off metrics gathering for OpenShift product profile for the last month
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMeteringForAccount(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer)","arguments":["941133", "OpenShift", null, 68000]}'

# Verify that the Events were populated in the DB
select instance_id, timestamp, account_number, event_source, event_type, data->>'sla', data->>'role', data->>'usage', data->>'measurements' from events where account_number='941133' order by timestamp, event_type;

# Take note of the initial event counts by type
select distinct event_type, count(*) from events group by event_type;

# Take note of the event counts by role
select distinct data->>'role', count(*) from events where event_type='snapshot' group by data->>'role';

# Run an hourly tally on the events that were created.
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["941133", "2021-06-01T00:00Z", "2021-07-15T00:00Z"]}'

# Capture the current OCP hourly snapshot totals for June
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics?granularity=hourly&beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool > ~/ocp_hourly_june_1.0.54.json

# Capture the current OSD hourly snapshot totals for june
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool > ~/osd_hourly_june_1.0.54.json

# Capture the monthly instance hours for CORES
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from instance_monthly_totals where uom = 'CORES' order by instance_id, month;" > ~/instance_hours_1.0.54

# Checkout the current release branch
$ git checkout -b 1.0.55 rhsm-subscriptions-1.0.55

# Start the app again
$ USER_USE_STUB=true PROM_URL="http://localhost:8082/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean bootRun

# Collect the OCP metrics again. NOTE: The API has changed slightly
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMeteringForAccount(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer)","arguments":["941133", "OpenShift-metrics", null, 68000]}'

# Collect the OSD metrics again. NOTE the API change.
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMeteringForAccount(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer)","arguments":["941133", "OpenShift-dedicated-metrics", null, 68000]}'

# Check the events again. You should see events for source/type:
#     prometheus-openshift/snapshot
#     prometheus/snapshot_redhat.com:openshift_dedicated:4cpu_hour
#     prometheus/snapshot_redhat.com:openshift_dedicated:cluster_hour
#
# The prometheus-openshift/snapshot events are causing the issue when the monthly calculations are done.
select instance_id, timestamp, account_number, event_source, event_type, data->>'sla', data->>'role', data->>'usage', data->>'measurements' from events where account_number='941133' order by timestamp, event_type;

# Take note of the events by type. Ignoring the cluster_hour types (these are new events and do not
# apply as they are new types), add up the cpu_hour and 4cpu_hour counts and they should be equal.
# If they are not, then it is likely because a new cluster was added when the metrics were gathered the
# second time. We will need to make sure that is the case.
select distinct event_type, count(*) from events group by event_type;

# Run the hourly tally again
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["941133", "2021-06-01T00:00Z", "2021-07-15T00:00Z"]}'

# Capture the current OCP hourly snapshot totals for june
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics?granularity=hourly&beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool > ~/ocp_hourly_june_1.0.55.json

# Capture the current OSD hourly snapshot totals for june
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool > ~/osd_hourly_june_1.0.55.json

# Capture the instance hours
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from instance_monthly_totals where uom = 'CORES' order by instance_id, month;" > ~/instance_hours_1.0.55
```

At this point, if you look at the differences between _~/instance_hours_1.0.54_ and _~/instance_hours_1.0.55_ you will notice that the values for each instance has doubled. **NOTE** that you could potentially end up with more records for 1.0.55 if the cluster instances were added in prometheus between runs.

**PRO TIP:** Take a snapshot of your current DB just in case you wanna retest something and want to avoid doing the setup steps again.
```bash
$ pg_dump -U rhsm-subscriptions rhsm-subscriptions > ~/double-cores-bkp.sql
```

# Applying the fix
1. First check out this branch.
2. Deploy the app as you did before.
3. Liquibase changes should apply successfully.
