### PR TITLE
ENT-4197 Use description for product name

### DIFF
--- a/product-client/product-api-spec.yaml
+++ b/product-client/product-api-spec.yaml
@@ -64,7 +64,7 @@ components:
       properties:
         sku:
           type: string
-        name:
+        description:
           type: string
         status:
           type: string

--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -67,9 +67,10 @@ import org.slf4j.LoggerFactory;
     SOCKET_LIMIT,
     SERVICE_TYPE,
     PRODUCT_FAMILY,
-    PRODUCT_NAME,
     USAGE,
-    /** Role originates from opProd field roles, not an attribute. */
+    /** Name of Offering comes from opProd description field, not the PRODUCT_NAME attribute. */
+    X_DESCRIPTION,
+    /** Role originates from opProd roles field, not an attribute. */
     X_ROLE;
   }
 
@@ -125,6 +126,8 @@ import org.slf4j.LoggerFactory;
     var children = products.subList(1, products.size());
 
     var offer = new UpstreamProductData(parent.getSku());
+    String name = parent.getDescription();
+    offer.attrs.put(Attr.X_DESCRIPTION, name);
     // Though theoretically possible, none of the products in use by Candlepin (which includes the
     // allowlisted swatch products) ever has more than one role.
     String role = parent.getRoles().stream().findFirst().orElse(null);
@@ -152,7 +155,7 @@ import org.slf4j.LoggerFactory;
     offering.setProductIds(Set.copyOf(engOids));
     offering.setRole(attrs.get(Attr.X_ROLE));
     offering.setProductFamily(attrs.get(Attr.PRODUCT_FAMILY));
-    offering.setProductName(attrs.get(Attr.PRODUCT_NAME));
+    offering.setProductName(attrs.get(Attr.X_DESCRIPTION));
 
     calcCapacityForOffering(offering);
 

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
@@ -158,7 +158,7 @@ class OfferingSyncControllerTest {
             69, 70, 185, 194, 197, 201, 205, 240, 271, 290, 311, 317, 318, 326, 329, 408, 458, 473,
             479, 491, 518, 519, 546, 579, 588, 603, 604, 608, 610, 645));
     expected.setProductFamily("OpenShift Enterprise");
-    expected.setProductName("OpenShift Container Platform");
+    expected.setProductName("Red Hat OpenShift Container Platform (Hourly)");
     expected.setServiceLevel(ServiceLevel.PREMIUM);
 
     // When getting the upstream Offering,
@@ -177,7 +177,7 @@ class OfferingSyncControllerTest {
     expected.setChildSkus(Set.of("SVCMW01484A", "SVCMW01484B"));
     expected.setProductIds(Collections.emptySet());
     expected.setProductFamily("OpenShift Enterprise");
-    expected.setProductName("OpenShift Dedicated");
+    expected.setProductName("Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)");
     expected.setServiceLevel(ServiceLevel.PREMIUM);
 
     // When getting the upstream Offering,
@@ -204,7 +204,8 @@ class OfferingSyncControllerTest {
     expected.setPhysicalSockets(2);
     expected.setVirtualSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName("RHEL for SAP HANA");
+    expected.setProductName(
+        "Red Hat Enterprise Linux Server for SAP HANA for Virtual Datacenters with Smart Management, Premium");
     expected.setServiceLevel(ServiceLevel.PREMIUM);
     // (Usage ends up coming from derived SKU RH00618F5)
     expected.setUsage(Usage.PRODUCTION);
@@ -233,7 +234,8 @@ class OfferingSyncControllerTest {
     expected.setRole("Red Hat Enterprise Linux Server");
     expected.setPhysicalSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName("RHEL Server");
+    expected.setProductName(
+        "Red Hat Enterprise Linux Server, Standard (1-2 sockets) (Up to 4 guests) with Smart Management");
     expected.setServiceLevel(ServiceLevel.STANDARD);
     expected.setUsage(Usage.PRODUCTION);
 
@@ -260,7 +262,7 @@ class OfferingSyncControllerTest {
     expected.setPhysicalCores(4); // Because IFL is 1 which gets multiplied by magical constant 4
     expected.setPhysicalSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName("RHEL Developer Workstation");
+    expected.setProductName("Red Hat Enterprise Linux Developer Workstation, Enterprise");
     expected.setServiceLevel(ServiceLevel.EMPTY); // Because Dev-Enterprise isn't a ServiceLevel yet
     expected.setUsage(Usage.DEVELOPMENT_TEST);
 


### PR DESCRIPTION
Up to now, the PRODUCT_NAME attribute was used for the product name that is displayed in the subscription table for Offerings. It now uses the description field instead, which aligns with how customer portal displays a product's name.