### PR TITLE
ENT-4161: Add smokeTest and integrationTest tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,22 @@ allprojects {
     }
 
     test {
-        useJUnitPlatform()
+        useJUnitPlatform {
+            excludeTags("smoke", "integration")
+        }
+    }
+
+    tasks.register("smokeTest", Test) {
+        useJUnitPlatform {
+            includeTags("smoke")
+            excludeTags("integration")
+        }
+    }
+
+    tasks.register("integrationTest", Test) {
+        useJUnitPlatform {
+            includeTags("integration")
+        }
     }
 
     jacocoTestReport {
@@ -119,9 +134,13 @@ allprojects {
         testCompile "org.mockito:mockito-core"
         testCompile "org.mockito:mockito-junit-jupiter"
         testCompile "org.hamcrest:hamcrest"
+        testCompile "io.projectreactor:reactor-core"
+        testImplementation "org.testcontainers:postgresql:1.15.3"
 
         testRuntime "org.junit.jupiter:junit-jupiter-engine"
         testRuntime "ch.qos.logback:logback-classic"
+        testRuntime "org.springframework:spring-webflux"
+        testRuntime "io.projectreactor.netty:reactor-netty-http"
     }
 }
 

--- a/src/test/java/org/candlepin/subscriptions/ApiIntegrationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/ApiIntegrationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@Tag("integration")
+@ActiveProfiles({"test", "api"})
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {"RBAC_USE_STUB=true"})
+class ApiIntegrationTest extends ApiSmokeTest {
+
+  @Autowired WebTestClient webTestClient;
+  @LocalServerPort Integer port;
+
+  @Override
+  protected int getServerPort() {
+    return port;
+  }
+
+  @Test
+  void testOptInAntiCsrf() {
+    // check anti-csrf on /opt-in delete
+    user.delete()
+        .uri("/opt-in")
+        .headers(headers -> headers.set("Origin", "bad.example.com"))
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/ApiSmokeTest.java
+++ b/src/test/java/org/candlepin/subscriptions/ApiSmokeTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions;
+
+import java.net.URI;
+import java.util.UUID;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.reactive.server.WebTestClient.Builder;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.web.util.UriBuilder;
+
+@Tag("smoke")
+class ApiSmokeTest {
+
+  WebTestClient anon;
+  WebTestClient user;
+
+  /** To be overridden if used in an integration test */
+  protected int getServerPort() {
+    return 8080;
+  }
+
+  /** Can be overridden to point to a different host */
+  protected String getServerHost() {
+    return "localhost";
+  }
+
+  protected Builder configureClient() {
+    return WebTestClient.bindToServer()
+        .defaultHeader("Origin", "example.redhat.com") // for anti-csrf
+        .uriBuilderFactory(
+            new DefaultUriBuilderFactory(
+                String.format(
+                    "http://%s:%d/api/rhsm-subscriptions/v1", getServerHost(), getServerPort())));
+  }
+
+  @BeforeEach
+  void setup() {
+    anon = configureClient().build();
+    user =
+        configureClient()
+            .defaultHeaders(IntegrationTestUtils.auth(IntegrationTestUtils.DEFAULT_IDENTITY))
+            .build();
+    // ensure opted in
+    user.put().uri("/opt-in").exchange().expectStatus().isOk();
+  }
+
+  Function<UriBuilder, URI> createReportURI(String basePath) {
+    return uriBuilder ->
+        uriBuilder
+            .path(basePath)
+            .queryParam("granularity", "Daily")
+            .queryParam("beginning", "2021-07-01T00:00:00Z")
+            .queryParam("ending", "2021-07-05T00:00:00Z")
+            .build("OpenShift Container Platform");
+  }
+
+  @Test
+  void testVersion() {
+    anon.get().uri("/version").exchange().expectStatus().isOk();
+    user.get().uri("/version").exchange().expectStatus().isOk();
+  }
+
+  @Test
+  void testOptIn() {
+    anon.get().uri("/opt-in").exchange().expectStatus().isUnauthorized();
+    anon.delete().uri("/opt-in").exchange().expectStatus().isUnauthorized();
+    anon.put().uri("/opt-in").exchange().expectStatus().isUnauthorized();
+
+    user.get()
+        .uri("/opt-in")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.meta")
+        .exists();
+
+    user.delete().uri("/opt-in").exchange().expectStatus().isNoContent();
+
+    user.put().uri("/opt-in").exchange().expectStatus().isOk();
+  }
+
+  @Test
+  void testTally() {
+    anon.get()
+        .uri(createReportURI("/tally/products/{product}"))
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+
+    user.get().uri(createReportURI("/tally/products/{product}")).exchange().expectStatus().isOk();
+  }
+
+  @Test
+  void testCapacity() {
+    anon.get()
+        .uri(createReportURI("/capacity/products/{product}"))
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+
+    user.get()
+        .uri(createReportURI("/capacity/products/{product}"))
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void testHosts() {
+    anon.get()
+        .uri(createReportURI("/hosts/products/{product}"))
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+    anon.get()
+        .uri("/hosts/{hostId}/guests", UUID.randomUUID())
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+
+    user.get().uri(createReportURI("/hosts/products/{product}")).exchange().expectStatus().isOk();
+    user.get().uri("/hosts/{hostId}/guests", UUID.randomUUID()).exchange().expectStatus().isOk();
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/IngressIntegrationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/IngressIntegrationTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@Tag("integration")
+@SpringBootTest(
+    properties = {"SUBSCRIPTION_SYNC_ENABLED=false"},
+    webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"test", "capacity-ingress"})
+class IngressIntegrationTest extends IngressSmokeTest {
+  @LocalServerPort Integer serverPort;
+
+  @Override
+  protected int getServerPort() {
+    return serverPort;
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/IngressSmokeTest.java
+++ b/src/test/java/org/candlepin/subscriptions/IngressSmokeTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+@Slf4j
+@Tag("smoke")
+class IngressSmokeTest {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  WebTestClient client;
+
+  /** To be overridden if used in an integration test */
+  protected int getServerPort() {
+    return 8080;
+  }
+
+  /** Can be overridden to point to a different host */
+  protected String getServerHost() {
+    return "localhost";
+  }
+
+  @BeforeEach
+  void setup() {
+    client =
+        WebTestClient.bindToServer()
+            .uriBuilderFactory(
+                new DefaultUriBuilderFactory(
+                    String.format(
+                        "http://%s:%d/api/rhsm-subscriptions/v1",
+                        getServerHost(), getServerPort())))
+            .build();
+  }
+
+  @Test
+  void testIngress() {
+    CandlepinPool pool =
+        new CandlepinPool()
+            .accountNumber("account123")
+            .activeSubscription(true)
+            .startDate(OffsetDateTime.parse("2019-01-01T00:00Z"))
+            .endDate(OffsetDateTime.parse("2021-01-01T00:00Z"))
+            .quantity(1L)
+            .productId("MW01484")
+            .subscriptionId("12345")
+            .type("NORMAL");
+    client
+        .post()
+        .uri("/ingress/candlepin_pools/{org}", "org123")
+        .bodyValue(List.of(pool))
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/IntegrationTestUtils.java
+++ b/src/test/java/org/candlepin/subscriptions/IntegrationTestUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Base64;
+import java.util.Base64.Encoder;
+import java.util.function.Consumer;
+import org.candlepin.subscriptions.security.InsightsUserPrincipal;
+import org.candlepin.subscriptions.security.InsightsUserPrincipal.Internal;
+import org.candlepin.subscriptions.security.RhAssociatePrincipal;
+import org.candlepin.subscriptions.security.RhAssociatePrincipal.SamlAssertions;
+import org.candlepin.subscriptions.security.RhIdentity;
+import org.springframework.http.HttpHeaders;
+
+public class IntegrationTestUtils {
+
+  static final RhIdentity ADMIN_IDENTITY = new RhIdentity();
+  static final RhIdentity DEFAULT_IDENTITY = new RhIdentity();
+  static final ObjectMapper mapper = new ObjectMapper();
+  static final Encoder b64 = Base64.getEncoder();
+
+  static {
+    InsightsUserPrincipal user = new InsightsUserPrincipal();
+    user.setAccountNumber("account123");
+    Internal internal = new Internal();
+    internal.setOrgId("org123");
+    user.setInternal(internal);
+
+    DEFAULT_IDENTITY.setIdentity(user);
+
+    RhAssociatePrincipal associate = new RhAssociatePrincipal();
+    SamlAssertions samlAssertions = new SamlAssertions();
+    samlAssertions.setEmail("example@redhat.com");
+    associate.setSamlAssertions(samlAssertions);
+    ADMIN_IDENTITY.setIdentity(associate);
+  }
+
+  static Consumer<HttpHeaders> auth(RhIdentity identity) {
+    return headers -> {
+      if (identity != null) {
+        headers.add("x-rh-identity", encodeIdentity(identity));
+      }
+    };
+  }
+
+  static String encodeIdentity(RhIdentity identity) {
+    try {
+      return b64.encodeToString(mapper.writeValueAsBytes(identity));
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/TallyJmxIntegrationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/TallyJmxIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@Slf4j
+@EmbeddedKafka(
+    partitions = 1,
+    topics = {
+      "${rhsm-subscriptions.tasks.topic}",
+      "${rhsm-subscriptions.subscription.tasks.topic}"
+    })
+@Tag("integration")
+@AutoConfigureMetrics
+@ActiveProfiles({"worker", "kafka-queue", "test", "test-kafka"})
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {
+      "spring.jmx.enabled=true",
+      "rhsm-subscriptions.inventory-service.datasource.url=jdbc:tc:postgresql:latest:///inventory?TC_DAEMON=true",
+      "rhsm-subscriptions.inventory-service.datasource.platform=postgresql",
+      "rhsm-subscriptions.inventory-service.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver",
+    })
+class TallyJmxIntegrationTest extends TallyJmxSmokeTest {
+  @LocalServerPort Integer serverPort;
+
+  @Autowired
+  @Qualifier("inventoryDataSource")
+  HikariDataSource inventoryDataSource;
+
+  @Override
+  protected int getServerPort() {
+    return serverPort;
+  }
+
+  @BeforeEach
+  void initDb() throws SQLException {
+    try (Connection connection = inventoryDataSource.getConnection()) {
+      Statement statement = connection.createStatement();
+      statement.executeUpdate(
+          "create table if not exists hosts\n"
+              + "(\n"
+              + "    id                   uuid                     not null\n"
+              + "        constraint hosts_pkey\n"
+              + "            primary key,\n"
+              + "    account              varchar(10)              not null,\n"
+              + "    display_name         varchar(200),\n"
+              + "    created_on           timestamp with time zone not null,\n"
+              + "    modified_on          timestamp with time zone not null,\n"
+              + "    facts                jsonb,\n"
+              + "    tags                 jsonb,\n"
+              + "    canonical_facts      jsonb                    not null,\n"
+              + "    system_profile_facts jsonb,\n"
+              + "    ansible_host         varchar(255),\n"
+              + "    stale_timestamp      timestamp with time zone not null,\n"
+              + "    reporter             varchar(255)             not null\n"
+              + ");");
+    }
+  }
+
+  @Test
+  void tallyJmxEnforcesAntiCsrf() {
+    WebTestClient wrongOrigin = client.mutate().defaultHeader("Origin", "bad.example.com").build();
+    invokeViaJmx(
+            wrongOrigin,
+            "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
+            "tallyAccount(java.lang.String)",
+            List.of("account123"))
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/TallyJmxSmokeTest.java
+++ b/src/test/java/org/candlepin/subscriptions/TallyJmxSmokeTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions;
+
+import static org.candlepin.subscriptions.IntegrationTestUtils.auth;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.reactive.server.WebTestClient.RequestHeadersSpec;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+@Slf4j
+@Tag("smoke")
+class TallyJmxSmokeTest {
+  WebTestClient client;
+
+  @BeforeEach
+  void setup() {
+    client =
+        WebTestClient.bindToServer()
+            .uriBuilderFactory(
+                new DefaultUriBuilderFactory(
+                    String.format("http://%s:%d/", getServerHost(), getServerPort())))
+            .defaultHeaders(auth(IntegrationTestUtils.ADMIN_IDENTITY))
+            .defaultHeader("Origin", "example.redhat.com")
+            .build();
+  }
+
+  /** To be overridden if used in an integration test */
+  protected int getServerPort() {
+    return 8080;
+  }
+
+  /** Can be overridden to point to a different host */
+  protected String getServerHost() {
+    return "localhost";
+  }
+
+  @Test
+  void testTallyViaJmx() {
+    log.info("{}", getServerPort());
+    Double initialCount = fetchTaskCount();
+    log.info("Initial tally count: {}", initialCount);
+    invokeViaJmx(
+            client,
+            "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
+            "tallyAccount(java.lang.String)",
+            List.of("account123"))
+        .exchange()
+        .expectStatus()
+        .isOk();
+    RetryTemplate.builder()
+        .fixedBackoff(200)
+        .maxAttempts(15)
+        .build()
+        .execute(
+            execution -> {
+              Double currentCount = fetchTaskCount();
+              if (currentCount != initialCount + 1.0) {
+                throw new RuntimeException("count not incremented yet!");
+              }
+              assertEquals(currentCount, initialCount + 1.0);
+              log.info("Final tally count: {}", currentCount);
+              return null;
+            });
+  }
+
+  RequestHeadersSpec<?> invokeViaJmx(
+      WebTestClient client, String mbean, String operation, List<String> arguments) {
+    Map<String, Object> request = new HashMap<>();
+    request.put("type", "exec");
+    request.put("mbean", mbean);
+    request.put("operation", operation);
+    request.put("arguments", arguments);
+    return client
+        .post()
+        .uri("/actuator/hawtio/jolokia")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request);
+  }
+
+  @Nullable
+  private Double fetchTaskCount() {
+    return client
+        .get()
+        .uri("/actuator/prometheus")
+        .exchange()
+        .returnResult(String.class)
+        .getResponseBody()
+        .filter(line -> line.startsWith("spring_kafka_listener_seconds_count"))
+        .filter(line -> line.contains("exception=\"none\""))
+        .filter(line -> line.contains("rhsm-subscriptions-task-processor"))
+        .defaultIfEmpty(" 0.0")
+        .map(line -> line.substring(line.indexOf(" ") + 1))
+        .map(Double::parseDouble)
+        .blockFirst();
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4161

I added two new tags: `smoke` and `integration`, and modified the default test task to skip both smoke and integration tests.

Smoke tests exercise the APIs via WebTestClient against localhost:8080, while integration tests use `@SpringBootTest` along with `@ActiveProfiles` and setting properties to spin up a given component.

To use invoke either `./gradlew smokeTest` or `./gradlew integrationTest`.

Please see README for setup steps for running the integration tests...

There are some good patterns and gotchas embedded. For example I discovered that you need to enable JMX via a property override to invoke jolokia from a `@SpringBootTest`. I also found if you wish to access promotheus, you need to use `@AutoConfigureMetrics`.

@Januson pointed me to testcontainers some time ago, and I found a good use here: being able to integration test the inventory SQL query.

I'm open to suggestions on organization, whether we really need these types of tests, etc.

I'm thinking the integration tests could replace the testing section we usually include in our PR description...