### PR TITLE
Fix issues with missing beans

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -53,6 +53,7 @@ import org.candlepin.subscriptions.util.LiquibaseUpdateOnlyConfiguration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
@@ -84,6 +85,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
   // NOTE(khowell): actually not needed in marketplace worker
   RhsmSubscriptionsDataSourceConfiguration.class,
 })
+@ComponentScan("org.candlepin.subscriptions.util")
 public class ApplicationConfiguration implements WebMvcConfigurer {
   @Bean
   ApplicationProperties applicationProperties() {

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -50,10 +50,10 @@ import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.user.UserServiceClientConfiguration;
 import org.candlepin.subscriptions.util.HawtioConfiguration;
 import org.candlepin.subscriptions.util.LiquibaseUpdateOnlyConfiguration;
+import org.candlepin.subscriptions.util.UtilConfiguration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
@@ -84,8 +84,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
   UserServiceClientConfiguration.class,
   // NOTE(khowell): actually not needed in marketplace worker
   RhsmSubscriptionsDataSourceConfiguration.class,
+  UtilConfiguration.class,
 })
-@ComponentScan("org.candlepin.subscriptions.util")
 public class ApplicationConfiguration implements WebMvcConfigurer {
   @Bean
   ApplicationProperties applicationProperties() {

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.capacity;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration that should be imported for any component that needs to be able to use capacity
+ * reconciliation logic.
+ */
+@Configuration
+@ComponentScan(basePackages = "org.candlepin.subscriptions.capacity")
+public class CapacityReconciliationConfiguration {
+  /* Intentionally empty */
+}

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationWorker.java
@@ -25,9 +25,11 @@ import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
+@Profile("capacity-ingress")
 @Service
 @Slf4j
 public class CapacityReconciliationWorker extends SeekableKafkaConsumer {

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationWorkerConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
+/** Configuration for the kafka listener that handles capacity reconciliation tasks. */
 @Profile("capacity-ingress")
 @ComponentScan(basePackages = "org.candlepin.subscriptions.capacity")
 @Configuration

--- a/src/main/java/org/candlepin/subscriptions/capacity/IngressResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/IngressResource.java
@@ -25,9 +25,11 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.candlepin.subscriptions.utilization.api.model.CandlepinPool;
 import org.candlepin.subscriptions.utilization.api.resources.IngressApi;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /** Updates subscription capacity based on Candlepin pool data. */
+@Profile("capacity-ingress")
 @Component
 public class IngressResource implements IngressApi {
 

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.subscription;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.capacity.CapacityReconciliationConfiguration;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.registry.RegistryConfiguration;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
@@ -31,18 +32,17 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
 import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
 /** Configuration class for subscription package. */
-@Profile("capacity-ingress")
 @Configuration
 @Import({
   ResteasyConfiguration.class,
   RhsmSubscriptionsDataSourceConfiguration.class,
-  RegistryConfiguration.class
+  RegistryConfiguration.class,
+  CapacityReconciliationConfiguration.class
 })
 @ComponentScan({"org.candlepin.subscriptions.subscription"})
 public class SubscriptionServiceConfiguration {

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorker.java
@@ -25,11 +25,13 @@ import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@Profile("capacity-ingress")
 public class SubscriptionWorker extends SeekableKafkaConsumer {
 
   SubscriptionSyncController subscriptionSyncController;

--- a/src/main/java/org/candlepin/subscriptions/util/UtilConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/util/UtilConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/** Provides access to common utility beans. */
+@Configuration
+@ComponentScan("org.candlepin.subscriptions.util")
+public class UtilConfiguration {
+  /* Intentionally empty */
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
@@ -35,7 +35,6 @@ import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnMa
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
@@ -52,7 +51,6 @@ import org.springframework.util.StringUtils;
 @Configuration
 @ConditionalOnManagementPort(ManagementPortType.SAME)
 @AutoConfigureAfter(HawtioManagementConfiguration.class)
-@ComponentScan("org.candlepin.subscriptions.util")
 public class HawtioConfiguration {
   @Autowired
   public void modifyBaseTagHrefFilter(


### PR DESCRIPTION
Mostly issues introduced in #500.

To reproduce, first you need a very specific set of env vars.

capacity-ingress has issues, because it has different ports for management (8080) and ingress (8443) when deployed in our OpenShift environments. `MANAGEMENT_SERVER_PORT=8081` mimics this.

marketplace deployment had issues related to missing beans from the `capacity` package.

Testing
-------

```
MANAGEMENT_SERVER_PORT=8081 DEV_MODE=false SPRING_PROFILES_ACTIVE=capacity-ingress ./gradlew :bootRun
```

fails to start without this PR.

Others have issues because `SubscriptionServiceConfiguration` had `@Profile("capacity-ingress")` added.

```
DEV_MODE=false SPRING_PROFILES_ACTIVE=marketplace ./gradlew :bootRun
```

fails to start without this PR.