### PR TITLE
Make report beginning and ending not required 

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -640,7 +640,6 @@ paths:
           description: "Include only capacity for the specified usage level."
         - name: beginning
           in: query
-          required: true
           schema:
             type: string
             format: date-time
@@ -648,7 +647,6 @@ paths:
              format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z"
         - name: ending
           in: query
-          required: true
           schema:
             type: string
             format: date-time

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionResource.java
@@ -41,12 +41,12 @@ public class SubscriptionResource implements SubscriptionsApi {
   @Override
   public SkuCapacityReport getSkuCapacityReport(
       ProductId productId,
-      OffsetDateTime beginning,
-      OffsetDateTime ending,
       @Min(0) Integer offset,
       @Min(1) Integer limit,
       ServiceLevelType sla,
       UsageType usage,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
       Uom uom,
       SkuCapacityReportSort sort,
       SortDirection dir) {

--- a/src/test/java/org/candlepin/subscriptions/resource/SubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/SubscriptionResourceTest.java
@@ -52,12 +52,12 @@ class SubscriptionResourceTest {
         () ->
             subscriptionResource.getSkuCapacityReport(
                 RHEL_SERVER,
-                min,
-                max,
                 0,
                 10,
                 null,
                 UsageType.PRODUCTION,
+                min,
+                max,
                 null,
                 SkuCapacityReportSort.SKU,
                 null));
@@ -73,12 +73,12 @@ class SubscriptionResourceTest {
         () ->
             subscriptionResource.getSkuCapacityReport(
                 RHEL,
-                min,
-                max,
                 0,
                 10,
                 null,
                 UsageType.PRODUCTION,
+                min,
+                max,
                 null,
                 SkuCapacityReportSort.SKU,
                 null));


### PR DESCRIPTION
For MVP, the UI will not allow customers to filter by dates to get the skuCapacityReport. Updated the beginning and ending fields to be Nullable.