### PR TITLE
Update README to fix typo where I said docker instead of podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, ensure you have podman-compose, podman and java 11 installed:
 sudo dnf install -y podman-compose podman java-11-openjdk-devel
 ```
 
-*NOTE*: You can also use docker if don't want to or are unable to use docker. Make sure docker and docker-compose are installed.
+*NOTE*: You can also use docker if don't want to or are unable to use podman. Make sure docker and docker-compose are installed.
 
 Ensure the checkout has the HBI submodule initialized:
 


### PR DESCRIPTION
Instead of `You can also use docker if don't want to or are unable to use podman` it was `You can also use docker if don't want to or are unable to use docker` before. This PR fixes that typo.