### PR TITLE
ENT-4234: Move kafka producer beans for capacity reconciliation

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationConfiguration.java
@@ -20,8 +20,16 @@
  */
 package org.candlepin.subscriptions.capacity;
 
+import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
+
+import org.candlepin.subscriptions.subscription.SyncSubscriptionsTask;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 
 /**
  * Configuration that should be imported for any component that needs to be able to use capacity
@@ -30,5 +38,29 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ComponentScan(basePackages = "org.candlepin.subscriptions.capacity")
 public class CapacityReconciliationConfiguration {
-  /* Intentionally empty */
+  @Bean
+  public ProducerFactory<String, SyncSubscriptionsTask> syncSubscriptionsProducerFactory(
+      KafkaProperties kafkaProperties) {
+    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+  }
+
+  @Bean
+  public ProducerFactory<String, ReconcileCapacityByOfferingTask>
+      reconcileCapacityByOfferingProducerFactory(KafkaProperties kafkaProperties) {
+    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+  }
+
+  @Bean
+  public KafkaTemplate<String, SyncSubscriptionsTask> syncSubscriptionsKafkaTemplate(
+      ProducerFactory<String, SyncSubscriptionsTask> syncSubscriptionsProducerFactory) {
+    return new KafkaTemplate<>(syncSubscriptionsProducerFactory);
+  }
+
+  @Bean
+  public KafkaTemplate<String, ReconcileCapacityByOfferingTask>
+      reconcileCapacityByOfferingTaskKafkaTemplate(
+          ProducerFactory<String, ReconcileCapacityByOfferingTask>
+              reconcileCapacityByOfferingProducerFactory) {
+    return new KafkaTemplate<>(reconcileCapacityByOfferingProducerFactory);
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationWorkerConfiguration.java
@@ -20,29 +20,23 @@
  */
 package org.candlepin.subscriptions.capacity;
 
-import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
-
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.candlepin.subscriptions.subscription.SyncSubscriptionsTask;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 /** Configuration for the kafka listener that handles capacity reconciliation tasks. */
 @Profile("capacity-ingress")
-@ComponentScan(basePackages = "org.candlepin.subscriptions.capacity")
 @Configuration
+@Import(CapacityReconciliationConfiguration.class)
 public class CapacityReconciliationWorkerConfiguration {
 
   @Bean
@@ -80,31 +74,5 @@ public class CapacityReconciliationWorkerConfiguration {
     // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
     factory.getContainerProperties().setConsumerRebalanceListener(registry);
     return factory;
-  }
-
-  @Bean
-  public ProducerFactory<String, SyncSubscriptionsTask> syncSubscriptionsProducerFactory(
-      KafkaProperties kafkaProperties) {
-    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
-  }
-
-  @Bean
-  public ProducerFactory<String, ReconcileCapacityByOfferingTask>
-      reconcileCapacityByOfferingProducerFactory(KafkaProperties kafkaProperties) {
-    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
-  }
-
-  @Bean
-  public KafkaTemplate<String, SyncSubscriptionsTask> syncSubscriptionsKafkaTemplate(
-      ProducerFactory<String, SyncSubscriptionsTask> syncSubscriptionsProducerFactory) {
-    return new KafkaTemplate<>(syncSubscriptionsProducerFactory);
-  }
-
-  @Bean
-  public KafkaTemplate<String, ReconcileCapacityByOfferingTask>
-      reconcileCapacityByOfferingTaskKafkaTemplate(
-          ProducerFactory<String, ReconcileCapacityByOfferingTask>
-              reconcileCapacityByOfferingProducerFactory) {
-    return new KafkaTemplate<>(reconcileCapacityByOfferingProducerFactory);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
@@ -20,21 +20,22 @@
  */
 package org.candlepin.subscriptions.task;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
 
 import org.candlepin.subscriptions.tally.TallyTaskFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@SpringBootTest
-@ActiveProfiles({"worker", "test"})
-public class TaskWorkerTest {
+@ExtendWith(MockitoExtension.class)
+class TaskWorkerTest {
 
-  @MockBean private TallyTaskFactory factory;
+  @Mock private TallyTaskFactory factory;
 
   @Mock private Task mockTask;
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.task.queue.TaskQueue;
 import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +32,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
-import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
@@ -63,24 +61,12 @@ public class KafkaTaskProducerConfiguration {
     return kafkaConfigurator.taskMessageKafkaTemplate(factory);
   }
 
-  @Bean
-  public ProducerFactory<String, TallySummary> tallySummaryProducerFactory(
-      KafkaProperties kafkaProperties) {
-    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
-  }
-
   @NotNull
   public static Map<String, Object> getConfigProps(KafkaProperties kafkaProperties) {
     return Map.of(
         ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers(),
         ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
         ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-  }
-
-  @Bean
-  public KafkaTemplate<String, TallySummary> tallySummaryKafkaTemplate(
-      ProducerFactory<String, TallySummary> tallySummaryProducerFactory) {
-    return new KafkaTemplate<>(tallySummaryProducerFactory);
   }
 
   @Bean


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4234

Run the following ways (to mimic profiles used during deployment).

Each should start the application successfully. The job profiles will automatically exit; running services will need to be interrupted/killed manually.

```
SPRING_PROFILES_ACTIVE=api ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=capacity-ingress ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=capture-hourly-snapshots,kafka-queue ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=capture-snapshots,kafka-queue ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=liquibase-only ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=marketplace,kafka-queue ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=metering-job,kafka-queue ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=openshift-metering-worker,kafka-queue ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=orgsync,kafka-queue ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=purge-snapshots,kafka-queue ./gradlew :bootRun
SPRING_PROFILES_ACTIVE=worker,kafka-queue ./gradlew :bootRun
```