### PR TITLE
ENT-4235: swatch-system-conduit: Add resteasy-jackson2-provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ allprojects {
                 entry "resteasy-client"
                 entry "resteasy-multipart-provider"
                 entry "resteasy-validator-provider-11"
+                entry "resteasy-jackson2-provider"
             }
             dependency "io.confluent:kafka-avro-serializer:$kafka_avro_serializer_version"
             dependency "org.apache.avro:avro:$avro_version"

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -70,4 +70,5 @@ dependencies {
 
     runtime "org.hsqldb:hsqldb"
     runtime "org.jolokia:jolokia-core"
+    runtime "org.jboss.resteasy:resteasy-jackson2-provider"
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4235

Happened because we missed pulling in the jackson provider for resteasy, so the client wasn't able to deserialize the JSON returned by the client.

NOTE: Using `RHSM_USE_STUB=true` does not exercise the resteasy response handling... which is probably why this wasn't caught in development.

Testing
-------

I found the easiest way to reproduce and test the fix was to use wiremock standalone to mock an api response. Download the wiremock standalone jar:

```
curl -O https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/2.30.1/wiremock-jre8-standalone-2.30.1.jar
```

Create a mappings file for wiremock to configure it to return a canned response to the feed API endpoint:

```
mkdir mappings
cat <<EOF > mappings/rhsm.json
{
    "request": {
        "method": "GET",
        "urlPattern": "/candlepin/consumers/feeds.*"
    },
    "response": {
        "status": 200,
        "jsonBody": {
            "pagination": {
                "offset": "foo",
                "limit": 10
            },
            "body": [
                {
                    "id": "foobar",
                    "uuid": "dcb2e36e-ee1e-4971-b53a-8b2f3ebb2016",
                    "accountNumber": "account123",
                    "name": "foobar",
                    "orgId": "org123",
                    "facts": {},
                    "installedProducts": []
                }
            ]
        },
        "headers": {
            "Content-Type": "application/json"
        }
    }
}
EOF
```

Start wiremock on port 8089:

```
java -jar wiremock-jre8-standalone-2.30.1.jar --port=8089
```

Start conduit pointed to wiremock:

```
RHSM_URL=http://localhost:8089 ./gradlew swatch-system-conduit:bootRun
```

Use hawtio/jolokia to sync an org (curl provided for convenience):

```
curl -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.conduit.jmx:name=rhsmConduitJmxBean,type=RhsmConduitJmxBean","operation":"syncOrg(java.lang.String)","arguments":["foobar"]}' http://localhost:8080/actuator/jolokia
```

Without this change, you should see the issue:

```
RESTEASY003145: Unable to find a MessageBodyReader of content-type application\/json and type class org.candlepin.subscriptions.conduit.rhsm.client.model.OrgInventory
```

With this change, you'll get a successful org sync.