### PR TITLE
ENT-4113: Properly re-align tally when events change

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.event;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -80,10 +81,9 @@ public class EventController {
    * @return the event ID
    */
   @Transactional
-  public UUID saveEvent(Event event) {
+  public Event saveEvent(Event event) {
     EventRecord eventRecord = new EventRecord(event);
-    repo.save(eventRecord);
-    return eventRecord.getId();
+    return repo.save(eventRecord).getEvent();
   }
 
   /**
@@ -92,8 +92,10 @@ public class EventController {
    * @param events the event JSON objects to save.
    */
   @Transactional
-  public void saveAll(Collection<Event> events) {
-    repo.saveAll(events.stream().map(EventRecord::new).collect(Collectors.toList()));
+  public List<Event> saveAll(Collection<Event> events) {
+    return repo.saveAll(events.stream().map(EventRecord::new).collect(Collectors.toList())).stream()
+        .map(EventRecord::getEvent)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -114,5 +116,10 @@ public class EventController {
   @Transactional
   public void deleteEvents(Collection<Event> toDelete) {
     repo.deleteInBatch(toDelete.stream().map(EventRecord::new).collect(Collectors.toList()));
+  }
+
+  @Transactional
+  public void deleteEvent(UUID eventId) {
+    repo.deleteById(eventId);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
@@ -276,13 +276,7 @@ public class CombiningRollupSnapshotStrategy {
 
     // Reset the measurements for all existing finest granularity snapshots so that
     // they reflect the values of the incoming account calculations.
-    affectedSnaps.values().stream()
-        .forEach(
-            existing ->
-                existing
-                    .getTallyMeasurements()
-                    .keySet()
-                    .forEach(key -> existing.getTallyMeasurements().put(key, 0.0)));
+    affectedSnaps.values().stream().forEach(existing -> existing.getTallyMeasurements().clear());
 
     accountCalcs.forEach(
         (offset, accountCalc) -> {

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -24,12 +24,16 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.core.Response;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.candlepin.subscriptions.db.AccountRepository;
 import org.candlepin.subscriptions.db.model.Account;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -71,8 +75,7 @@ public class MetricUsageCollector {
   }
 
   @Transactional
-  public Map<OffsetDateTime, AccountUsageCalculation> collect(
-      String accountNumber, DateRange range) {
+  public CollectionResult collect(String accountNumber, DateRange range) {
     if (!clock.isHourlyRange(range)) {
       throw new IllegalArgumentException(
           String.format(
@@ -156,27 +159,38 @@ public class MetricUsageCollector {
       }
     }
     accountRepository.save(account);
-    return accountCalcs;
+
+    return new CollectionResult(
+        new DateRange(effectiveStartDateTime, effectiveEndDateTime), accountCalcs, isRecalculating);
   }
 
   @Transactional
   public AccountUsageCalculation collectHour(Account account, OffsetDateTime startDateTime) {
     OffsetDateTime endDateTime = startDateTime.plusHours(1);
 
-    Stream<Event> eventStream =
+    Map<String, List<Event>> eventToHostMapping =
         eventController
             .fetchEventsInTimeRange(account.getAccountNumber(), startDateTime, endDateTime)
-            .filter(event -> event.getServiceType().equals(productProfile.getServiceType()));
+            .filter(event -> event.getServiceType().equals(productProfile.getServiceType()))
+            .collect(Collectors.groupingBy(Event::getInstanceId));
 
     Map<String, Host> thisHoursInstances = new HashMap<>();
-    eventStream.forEach(
-        event -> {
-          String instanceId = event.getInstanceId();
+    eventToHostMapping.forEach(
+        (instanceId, events) -> {
           Host existing = account.getServiceInstances().get(instanceId);
           Host host = existing == null ? new Host() : existing;
-          updateInstanceFromEvent(event, host);
+          // Clear all measurements before processing the events so that we do
+          // not add old measurements to the new account calculations. Once collect()
+          // is completed, the instance will contain the measurements of the last hour
+          // collected.
+          host.getMeasurements().clear();
           thisHoursInstances.put(instanceId, host);
-          account.getServiceInstances().put(instanceId, host);
+
+          events.forEach(
+              event -> {
+                updateInstanceFromEvent(event, host);
+                account.getServiceInstances().put(instanceId, host);
+              });
         });
 
     return tallyCurrentAccountState(account.getAccountNumber(), thisHoursInstances);
@@ -350,5 +364,13 @@ public class MetricUsageCollector {
         .forEach(productIds::addAll);
 
     return productIds;
+  }
+
+  @AllArgsConstructor
+  @Getter
+  public class CollectionResult {
+    private DateRange range;
+    private Map<OffsetDateTime, AccountUsageCalculation> calculations;
+    private boolean wasRecalculated;
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -245,10 +245,10 @@ class PrometheusMeteringControllerTest {
                 expectedUom,
                 val2.doubleValue()));
 
-    ArgumentCaptor<Collection> saveCaptor = ArgumentCaptor.forClass(Collection.class);
-    doNothing().when(eventController).saveAll(saveCaptor.capture());
-
     controller.collectMetrics("OpenShift-metrics", Uom.CORES, expectedAccount, start, end);
+
+    ArgumentCaptor<Collection> saveCaptor = ArgumentCaptor.forClass(Collection.class);
+    verify(eventController).saveAll(saveCaptor.capture());
 
     verify(service)
         .runRangeQuery(
@@ -362,13 +362,13 @@ class PrometheusMeteringControllerTest {
             existingEvents.stream()
                 .collect(Collectors.toMap(EventKey::fromEvent, Function.identity())));
 
+    controller.collectMetrics("OpenShift-metrics", Uom.CORES, expectedAccount, start, end);
+
     ArgumentCaptor<Collection> saveCaptor = ArgumentCaptor.forClass(Collection.class);
-    doNothing().when(eventController).saveAll(saveCaptor.capture());
+    verify(eventController).saveAll(saveCaptor.capture());
 
     ArgumentCaptor<Collection> purgeCaptor = ArgumentCaptor.forClass(Collection.class);
-    doNothing().when(eventController).deleteEvents(purgeCaptor.capture());
-
-    controller.collectMetrics("OpenShift-metrics", Uom.CORES, expectedAccount, start, end);
+    verify(eventController).deleteEvents(purgeCaptor.capture());
 
     verify(service)
         .runRangeQuery(
@@ -377,8 +377,6 @@ class PrometheusMeteringControllerTest {
             end,
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());
-    verify(eventController).saveAll(any());
-    verify(eventController).deleteEvents(any());
 
     // Attempted to verify the eventController calls below, but
     // couldn't find a way to get mockito to match on collection of HashMap.Value.
@@ -470,13 +468,10 @@ class PrometheusMeteringControllerTest {
             existingEvents.stream()
                 .collect(Collectors.toMap(EventKey::fromEvent, Function.identity())));
 
-    var saveCaptor = ArgumentCaptor.forClass(Collection.class);
-    doNothing().when(eventController).saveAll(saveCaptor.capture());
-
-    var purgeCaptor = ArgumentCaptor.forClass(Collection.class);
-    doNothing().when(eventController).deleteEvents(purgeCaptor.capture());
-
     controller.collectMetrics("OpenShift-metrics", Uom.CORES, expectedAccount, start, end);
+
+    var saveCaptor = ArgumentCaptor.forClass(Collection.class);
+    verify(eventController).saveAll(saveCaptor.capture());
 
     verify(service)
         .runRangeQuery(
@@ -485,7 +480,6 @@ class PrometheusMeteringControllerTest {
             end,
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());
-    verify(eventController).saveAll(any());
 
     // Attempted to verify the eventController calls below, but
     // couldn't find a way to get mockito to match on collection of HashMap.Value.


### PR DESCRIPTION
[Resolves ENT-4113](https://issues.redhat.com/browse/ENT-4113)

When a re-tally occurs, we make sure that any existing
snapshots are re-aligned with the existing events. We
reset the appropriate snapshot measurements to 0.0 when
a matching event no longer exists to ensure that
marketplace gets notified that the measurement has
changed.

This PR also provides changes to the EventJmxBean that allows for
better testing of the changes in this PR.


# How To Test
Ensure you have a fresh DB and run the application.
```bash
USER_USE_STUB=true PROM_URL="http://localhost:8082/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean bootRun
```
**NOTE:** MAKE SURE THAT YOU HAVE OPTED IN THE ACCOUNT NUMBER THAT IS USED IN THE FAKE DATA: 941133 

### Import some pre-canned event data and run the tally process.
**NOTE:** The _**init_all_events.json**_ file can be downloaded [here](https://issues.redhat.com/secure/attachment/12637140/12637140_init_all_events.json)!!
This data contains hourly event data from June 01 - Aug 23. It consists of 3 separate clusters(instances) reported as one of ocp - cores, osd - cores, osd - instance-hours.

Each hourly event for ocp has a value of 20.0
Each hourly event for osd - cores has a value of 10.0
Each hourly event for osd - instance_hours has a value of 2.0

```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d @./init_all_events.json
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["941133", "2021-06-01T00:00Z", "2021-08-23T00:00Z"]}'
```

### Check tallies for June, July, Aug and record the totals.
```bash
# Check tally for Aug, record the totals.
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-08-01T00:00:00.000Z&ending=2021-08-31T23:59:59.999Z" | python -mjson.tool

# Check tally for July, record the totals.
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-07-01T00:00:00.000Z&ending=2021-07-31T23:59:59.999Z" | python -mjson.tool

# Check tally for June, record the totals.
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool
```

### Delete all events in june and events at midnight on July 1st
```bash
$ PGTZ=UTC psql -U rhsm-subscriptions rhsm-subscriptions
```
```sql
delete from events where extract(month from timestamp) = 6;
delete from events where timestamp = '2021-07-01 00:00:00+00';
```
### Re-run tally
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["941133", "2021-06-01T00:00Z", "2021-08-23T00:00Z"]}'
```

### Verify the totals for June
```bash
# Check totals in June have been reset to 0.0
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool

# Check the snaps in June has_data, and that the values are reset.
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool | grep has_data -B16 -A3

# Check that the monthly totals are accurate. Nothing for June as all events were deleted.
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-metrics?beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool

curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z" | python -mjson.tool

curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-06-01T00:00:00.000Z&ending=2021-06-30T23:59:59.999Z&sort=INSTANCE_HOURS" | python -mjson.tool
```

### Verify the totals for July
```bash
# Check that the tally for july was reduced by correct amounts. Should be -2 for instance hours and -10 for core_hours.
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-07-01T00:00:00.000Z&ending=2021-07-31T23:59:59.999Z" | python -mjson.tool

#Check that the monthly totals are accurate.
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-metrics?beginning=2021-07-01T00:00:00.000Z&ending=2021-07-31T23:59:59.999Z" | python -mjson.tool

curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-07-01T00:00:00.000Z&ending=2021-07-31T23:59:59.999Z" | python -mjson.tool

curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-07-01T00:00:00.000Z&ending=2021-07-31T23:59:59.999Z&sort=INSTANCE_HOURS" | python -mjson.tool
```

### Verify the totals for August
```bash
# Aug should remain the same.
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-08-01T00:00:00.000Z&ending=2021-08-31T23:59:59.999Z" | python -mjson.tool

# Check that the monthly totals are accurate.
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-metrics?beginning=2021-07-01T00:00:00.000Z&ending=2021-07-31T23:59:59.999Z" | python -mjson.tool

curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-08-01T00:00:00.000Z&ending=2021-08-31T23:59:59.999Z" | python -mjson.tool

curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ijk0MTEzMyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2021-08-01T00:00:00.000Z&ending=2021-08-31T23:59:59.999Z&sort=INSTANCE_HOURS" | python -mjson.tool
```

### SPOT CHECK THE TOTALS VIA THE DB (JULY)

```bash
# OCP (these totals should align)
select sum(m.value) from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.account_number = '941133' and s.granularity='HOURLY' and EXTRACT(MONTH from s.snapshot_date) = 7 and  s.sla='_ANY' and s.usage='_ANY' and s.product_id='OpenShift-metrics' and uom='CORES' and m.measurement_type = 'TOTAL';

select sum(m.value) from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.account_number = '941133' and s.granularity='DAILY' and EXTRACT(MONTH from s.snapshot_date) = 7 and  s.sla='_ANY' and s.usage='_ANY' and s.product_id='OpenShift-metrics' and uom='CORES' and m.measurement_type = 'TOTAL';

select sum((data->'measurements'->0->>'value')::numeric) as total_for_month from events where account_number='941133' and extract(month from timestamp) = 7 and event_type='snapshot_redhat.com:openshift_container_platform:cpu_hour';

# OSD - CORES (these totals should align)
select sum(m.value) from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.account_number = '941133' and s.granularity='HOURLY' and EXTRACT(MONTH from s.snapshot_date) = 7 and  s.sla='_ANY' and s.usage='_ANY' and s.product_id='OpenShift-dedicated-metrics' and uom='CORES' and m.measurement_type = 'TOTAL';

select sum(m.value) from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.account_number = '941133' and s.granularity='DAILY' and EXTRACT(MONTH from s.snapshot_date) = 7 and  s.sla='_ANY' and s.usage='_ANY' and s.product_id='OpenShift-dedicated-metrics' and uom='CORES' and m.measurement_type = 'TOTAL';

select sum((data->'measurements'->0->>'value')::numeric) as total_for_month from events where account_number='941133' and extract(month from timestamp) = 7 and event_type='snapshot_redhat.com:openshift_dedicated:4cpu_hour';

# OSD - INSTANCE_HOURS (these totals should align)
select sum(m.value) from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.account_number = '941133' and s.granularity='HOURLY' and EXTRACT(MONTH from s.snapshot_date) = 7 and  s.sla='_ANY' and s.usage='_ANY' and s.product_id='OpenShift-dedicated-metrics' and uom='INSTANCE_HOURS' and m.measurement_type = 'TOTAL';

select sum(m.value) from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.account_number = '941133' and s.granularity='DAILY' and EXTRACT(MONTH from s.snapshot_date) = 7 and  s.sla='_ANY' and s.usage='_ANY' and s.product_id='OpenShift-dedicated-metrics' and uom='INSTANCE_HOURS' and m.measurement_type = 'TOTAL';

select sum((data->'measurements'->0->>'value')::numeric) as total_for_month from events where account_number='941133' and extract(month from timestamp) = 7 and event_type='snapshot_redhat.com:openshift_dedicated:cluster_hour';
```

