### PR TITLE
ENT-4212: Update capacity mapping for openshift products

### DIFF
--- a/src/main/resources/product-stub-data/engprods-MW00330.json
+++ b/src/main/resources/product-stub-data/engprods-MW00330.json
@@ -1,0 +1,10 @@
+{
+  "entries": [
+    {
+      "sku": "MW00330",
+      "engProducts": {
+        "engProducts": []
+      }
+    }
+  ]
+}

--- a/src/main/resources/product-stub-data/tree-MW00330_attrs-true.json
+++ b/src/main/resources/product-stub-data/tree-MW00330_attrs-true.json
@@ -1,0 +1,32 @@
+{
+  "products": [
+    {
+      "sku": "MW00330",
+      "description": "Red Hat OpenShift Container Platform for Customer Entitlement qty",
+      "status": "ACTIVE",
+      "attributes": [
+        {
+          "code": "PRODUCT_FAMILY",
+          "value": "OpenShift Enterprise"
+        },
+        {
+          "code": "ENTITLEMENT_QTY",
+          "value": "32"
+        },
+        {
+          "code": "CORES",
+          "value": "16"
+        },
+        {
+          "code": "SERVICE_TYPE",
+          "value": "Standard"
+        },
+        {
+          "code": "PRODUCT_NAME",
+          "value": "Red Hat OpenShift Container Platform, Standard (16 Cores or 32 vCPUs)"
+        }
+      ],
+      "roles": []
+    }
+  ]
+}

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
@@ -298,4 +298,18 @@ class OfferingSyncControllerTest {
     // Then there is no resulting offering.
     assertTrue(actual.isEmpty(), "When a sku doesn't exist upstream, return an empty Optional.");
   }
+
+  /** Valid given MW00330 sku with core value set to 16, physical core value is 16 */
+  @Test()
+  void testOpenShiftUpSteamProductPhysicalCores() {
+    // Given an Openshift SKU that does exist upstream,
+    var sku = "MW00330";
+    // create file for MW00330
+
+    // When given the result of a physical,
+    var actual = subject.getUpstreamOffering(sku).orElseThrow();
+
+    // Then cores equals 16
+    assertEquals(16, actual.getPhysicalCores());
+  }
 }


### PR DESCRIPTION
This PR is for [ENT-4212](https://issues.redhat.com/browse/ENT-4212)

- Add new Test Case to OfferingSyncControllerTest
- Create new tree & engprod files for MW00330 sku.

These additions show that we can leverage OfferingSyncController to get the accurate number of cores for the MW00330 sku.

**Test Case**:
The unit test uses OfferingSyncController method for productUpstream and checks for 16 physical cores without additional logic.

Fail Condition:
To determine that the Test case is accurate, simply go to tree-MW00330_attrs-true.json, and change the value of the "CORES" to another integer. The Test case should fail.
