### PR TITLE
ENT-4259 Periodically sync offerings

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -38,6 +38,7 @@ import org.candlepin.subscriptions.clowder.ClowderConfiguration;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.marketplace.MarketplaceWorkerConfiguration;
 import org.candlepin.subscriptions.metering.MeteringConfiguration;
+import org.candlepin.subscriptions.product.OfferingWorkerConfiguration;
 import org.candlepin.subscriptions.registry.RegistryConfiguration;
 import org.candlepin.subscriptions.resource.ApiConfiguration;
 import org.candlepin.subscriptions.retention.PurgeSnapshotsConfiguration;
@@ -47,6 +48,7 @@ import org.candlepin.subscriptions.subscription.SubscriptionWorkerConfiguration;
 import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
 import org.candlepin.subscriptions.tally.job.CaptureHourlySnapshotsConfiguration;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsConfiguration;
+import org.candlepin.subscriptions.tally.job.OfferingSyncConfiguration;
 import org.candlepin.subscriptions.tally.job.SubscriptionSyncConfiguration;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.user.UserServiceClientConfiguration;
@@ -78,6 +80,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
   SubscriptionWorkerConfiguration.class,
   SubscriptionSyncConfiguration.class,
   CapacityReconciliationWorkerConfiguration.class,
+  OfferingWorkerConfiguration.class,
+  OfferingSyncConfiguration.class,
   RegistryConfiguration.class,
   ClowderConfiguration.class,
   DevModeConfiguration.class,
@@ -114,6 +118,13 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   @Qualifier("reconcileCapacityTasks")
   @ConfigurationProperties(prefix = "rhsm-subscriptions.capacity.tasks")
   TaskQueueProperties reconcileCapacityQueueProperties() {
+    return new TaskQueueProperties();
+  }
+
+  @Bean
+  @Qualifier("offeringSyncTasks")
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.product.tasks")
+  TaskQueueProperties offeringSyncQueueProperties() {
     return new TaskQueueProperties();
   }
 

--- a/src/main/java/org/candlepin/subscriptions/capacity/files/ProductWhitelist.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/files/ProductWhitelist.java
@@ -20,6 +20,9 @@
  */
 package org.candlepin.subscriptions.capacity.files;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 import javax.annotation.PostConstruct;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.files.PerLineFileSource;
@@ -64,6 +67,26 @@ public class ProductWhitelist implements ResourceLoaderAware {
     } catch (Exception e) {
       log.error("Error reading whitelist", e);
       return false;
+    }
+  }
+
+  /**
+   * Lists all products allowed by the list.
+   *
+   * @return a set of all allowed products, or an empty set if no products are allowed or no source
+   *     was specified.
+   */
+  public Set<String> allProducts() {
+    if (source == null) {
+      log.warn("No source exists.");
+      return Collections.emptySet();
+    }
+
+    try {
+      return Collections.unmodifiableSet(source.set());
+    } catch (IOException e) {
+      log.error("Error reading whitelist", e);
+      return Collections.emptySet();
     }
   }
 

--- a/src/main/java/org/candlepin/subscriptions/product/OfferingJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingJmxBean.java
@@ -67,6 +67,20 @@ public class OfferingJmxBean {
     }
   }
 
+  @ManagedOperation(
+      description = "Syncs all offerings listed in allow list from the upstream source.")
+  public String syncAllOfferings() {
+    try {
+      Object principal = ResourceUtils.getPrincipal();
+      log.info("Sync all offerings triggered over JMX by {}", principal);
+      int numProducts = offeringSync.syncAllOfferings();
+
+      return "Enqueued " + numProducts + " offerings to be synced.";
+    } catch (RuntimeException e) {
+      throw new JmxException("Error enqueueing offerings to be synced. See log for details.");
+    }
+  }
+
   @ManagedOperation(description = "Reconcile capacity for an offering from the upstream source.")
   @ManagedOperationParameter(name = "sku", description = "A marketing SKU")
   public void forceReconcileOffering(String sku) {

--- a/src/main/java/org/candlepin/subscriptions/product/OfferingSyncTask.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingSyncTask.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.product;
+
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+public class OfferingSyncTask {
+  @NonNull private final String sku;
+
+  // Use ConstructorProperties for Jackson deserialization
+  @java.beans.ConstructorProperties("sku")
+  public OfferingSyncTask(String sku) {
+    this.sku = sku;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/product/OfferingWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingWorker.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.product;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.model.Offering;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@Profile("capacity-ingress")
+public class OfferingWorker extends SeekableKafkaConsumer {
+
+  private final Timer syncTimer;
+  private final OfferingSyncController controller;
+
+  @Autowired
+  protected OfferingWorker(
+      @Qualifier("offeringSyncTasks") TaskQueueProperties taskQueueProperties,
+      KafkaConsumerRegistry kafkaConsumerRegistry,
+      MeterRegistry meterRegistry,
+      OfferingSyncController controller) {
+    super(taskQueueProperties, kafkaConsumerRegistry);
+    this.syncTimer = meterRegistry.timer("swatch_offering_sync");
+    this.controller = controller;
+  }
+
+  @KafkaListener(
+      id = "#{__listener.groupId}",
+      topics = "#{__listener.topic}",
+      containerFactory = "offeringSyncListenerContainerFactory")
+  public void receive(OfferingSyncTask task) {
+    String sku = task.getSku();
+    log.info("Sync for offeringSku={} triggered by OfferingSyncTask", sku);
+    Timer.Sample syncTime = Timer.start();
+
+    Optional<Offering> upstream = controller.getUpstreamOffering(sku);
+    upstream.ifPresentOrElse(
+        controller::syncOffering,
+        () -> log.warn("offeringSku={} was not found in upstream service.", sku));
+
+    Duration syncDuration = Duration.ofNanos(syncTime.stop(syncTimer));
+    log.info(
+        "Fetched and synced offeringSku={} in offeringSyncedTimeMillis={}",
+        sku,
+        syncDuration.toMillis());
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/product/OfferingWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingWorkerConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.product;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.candlepin.subscriptions.capacity.CapacityReconciliationConfiguration;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Profile("capacity-ingress")
+@ComponentScan(basePackages = "org.candlepin.subscriptions.product")
+@Import({ProductConfiguration.class, CapacityReconciliationConfiguration.class})
+@Configuration
+public class OfferingWorkerConfiguration {
+
+  @Bean
+  ConsumerFactory<String, OfferingSyncTask> offeringSyncConsumerFactory(
+      KafkaProperties kafkaProperties) {
+    return new DefaultKafkaConsumerFactory<>(
+        kafkaProperties.buildConsumerProperties(),
+        new StringDeserializer(),
+        new JsonDeserializer<>(OfferingSyncTask.class));
+  }
+
+  @Bean
+  ConcurrentKafkaListenerContainerFactory<String, OfferingSyncTask>
+      offeringSyncListenerContainerFactory(
+          ConsumerFactory<String, OfferingSyncTask> consumerFactory,
+          KafkaProperties kafkaProperties,
+          KafkaConsumerRegistry registry) {
+
+    var factory = new ConcurrentKafkaListenerContainerFactory<String, OfferingSyncTask>();
+    factory.setConsumerFactory(consumerFactory);
+    // Concurrency should be set to the number of partitions for the target topic.
+    factory.setConcurrency(kafkaProperties.getListener().getConcurrency());
+    if (kafkaProperties.getListener().getIdleEventInterval() != null) {
+      factory
+          .getContainerProperties()
+          .setIdleEventInterval(kafkaProperties.getListener().getIdleEventInterval().toMillis());
+    }
+    // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
+    factory.getContainerProperties().setConsumerRebalanceListener(registry);
+    return factory;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/product/ProductConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/product/ProductConfiguration.java
@@ -20,19 +20,26 @@
  */
 package org.candlepin.subscriptions.product;
 
+import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
+
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 
 /** Configuration class for product package. */
 @Configuration
 @ComponentScan(
     basePackages = {
       "org.candlepin.subscriptions.product",
-      "org.candlepin.subscriptions.capacity.files"
+      "org.candlepin.subscriptions.capacity.files",
+      "org.candlepin.subscriptions.task.queue.kafka"
     })
 public class ProductConfiguration {
   @Bean
@@ -45,5 +52,17 @@ public class ProductConfiguration {
   @Bean
   public ProductApiFactory productApiFactory(@Qualifier("product") HttpClientProperties props) {
     return new ProductApiFactory(props);
+  }
+
+  @Bean
+  public ProducerFactory<String, OfferingSyncTask> offeringSyncProducerFactory(
+      KafkaProperties kafkaProperties) {
+    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+  }
+
+  @Bean
+  public KafkaTemplate<String, OfferingSyncTask> offeringSyncKafkaTemplate(
+      ProducerFactory<String, OfferingSyncTask> offeringSyncProducerFactory) {
+    return new KafkaTemplate<>(offeringSyncProducerFactory);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/job/OfferingSyncConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/OfferingSyncConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.job;
+
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.candlepin.subscriptions.task.queue.TaskProducerConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+
+/** A class to hold all job related configuration. */
+@Configuration
+@Profile("offering-sync")
+@Import(TaskProducerConfiguration.class)
+@ComponentScan({"org.candlepin.subscriptions.product"})
+public class OfferingSyncConfiguration {
+  @Bean
+  JobRunner jobRunner(OfferingSyncJob job, ApplicationContext applicationContext) {
+    return new JobRunner(job, applicationContext);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/job/OfferingSyncJob.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/OfferingSyncJob.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.job;
+
+import org.candlepin.subscriptions.exception.JobFailureException;
+import org.candlepin.subscriptions.product.OfferingSyncController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** A cron job to sync offerings to the latest upstream state for all allowlisted offerings. */
+@Component
+public class OfferingSyncJob implements Runnable {
+
+  private final OfferingSyncController controller;
+
+  @Autowired
+  public OfferingSyncJob(OfferingSyncController controller) {
+    this.controller = controller;
+  }
+
+  @Override
+  @Scheduled(cron = "${rhsm-subscriptions.jobs.offering-sync-schedule}")
+  public void run() {
+    try {
+      controller.syncAllOfferings();
+    } catch (Exception e) {
+      throw new JobFailureException("Failed to run " + this.getClass().getSimpleName(), e);
+    }
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,6 +46,8 @@ rhsm-subscriptions:
     capture-snapshot-schedule: ${CAPTURE_SNAPSHOT_SCHEDULE:0 0 1 * * ?}
     purge-snapshot-schedule: ${PURGE_SNAPSHOT_SCHEDULE:0 0 1 * * ?}
     metering-schedule: ${METERING_SCHEDULE:0 0 1 * * ?}
+    subscription-sync-schedule: ${SUBSCRIPTION_SYNC_SCHEDULE:0 10 * * *}
+    offering-sync-schedule: ${OFFERING_SYNC_SCHEDULE:0 2 * * *}
   account-batch-size: ${ACCOUNT_BATCH_SIZE:1}
   tasks:
     topic: ${KAFKA_TOPIC:platform.rhsm-subscriptions.tasks}

--- a/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductWhitelistTest.java
@@ -23,6 +23,8 @@ package org.candlepin.subscriptions.files;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.capacity.files.ProductWhitelist;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -49,6 +51,18 @@ class ProductWhitelistTest {
   void testDisallowsProductsNotInWhitelist() throws IOException {
     ProductWhitelist whitelist = initProductWhitelist("classpath:item_per_line.txt");
     assertFalse(whitelist.productIdMatches("not on the list :-("));
+  }
+
+  @Test
+  void testAllProducts() throws IOException {
+    ProductWhitelist whitelist = initProductWhitelist("classpath:item_per_line.txt");
+    assertEquals(Set.of("I1", "I2", "I3"), whitelist.allProducts());
+  }
+
+  @Test
+  void testAllProductsNoSource() throws IOException {
+    ProductWhitelist whitelist = initProductWhitelist("");
+    assertEquals(Collections.emptySet(), whitelist.allProducts());
   }
 
   private ProductWhitelist initProductWhitelist(String resourceLocation) throws IOException {

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingJmxBeanTest.java
@@ -87,4 +87,17 @@ class OfferingJmxBeanTest {
     assertEquals(
         "{\"message\": \"offeringSku=\"" + sku + "\" was not found/allowlisted.\"}", actualMessage);
   }
+
+  @Test
+  void testSyncAllOfferings() {
+    when(offeringSync.syncAllOfferings()).thenReturn(2);
+    OfferingJmxBean subject = new OfferingJmxBean(offeringSync, capacityReconciliationController);
+
+    // When requesting all offerings to be synced via the JMX bean interface,
+    String message = subject.syncAllOfferings();
+
+    // Then the offering sync controller's sync all method is called and a message of how many
+    // offerings were enqueued is returned.
+    assertEquals("Enqueued 2 offerings to be synced.", message);
+  }
 }

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
@@ -22,8 +22,10 @@ package org.candlepin.subscriptions.product;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +47,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = {OfferingSyncControllerTest.TestProductConfiguration.class})
@@ -72,6 +75,7 @@ class OfferingSyncControllerTest {
 
   @MockBean OfferingRepository repo;
   @MockBean ProductWhitelist allowlist;
+  @MockBean KafkaTemplate<String, OfferingSyncTask> offeringSyncKafkaTemplate;
   @Autowired OfferingSyncController subject;
 
   @BeforeEach
@@ -287,7 +291,7 @@ class OfferingSyncControllerTest {
     verify(allowlist).productIdMatches(sku);
   }
 
-  @Test()
+  @Test
   void testGetUpstreamOfferingNotFound() {
     // Given a marketing SKU that doesn't exist upstream,
     var sku = "BOGUS";
@@ -311,5 +315,32 @@ class OfferingSyncControllerTest {
 
     // Then cores equals 16
     assertEquals(16, actual.getPhysicalCores());
+  }
+
+  @Test
+  void testSyncAllOfferings() {
+    // Given the allowlist has a list of SKUs,
+    when(allowlist.allProducts()).thenReturn(Set.of("RH00604F5", "RH0180191"));
+
+    // When a request is made to sync all offerings,
+    int numEnqueued = subject.syncAllOfferings();
+
+    // Then the SKUs are enqueud to sync.
+    assertEquals(
+        2, numEnqueued, "Number of enqueued offerings should match what was given by allowlist.");
+    verify(offeringSyncKafkaTemplate, times(2)).send(anyString(), any(OfferingSyncTask.class));
+  }
+
+  @Test
+  void testSyncAllOfferingsEmptyWithAllowList() {
+    // Given the allowlist has no source (that is, no allowlist is provided),
+    when(allowlist.allProducts()).thenReturn(Collections.emptySet());
+
+    // When a request is made to sync all offerings,
+    int numEnqueued = subject.syncAllOfferings();
+
+    // Then no SKUs are synced.
+    assertEquals(0, numEnqueued, "Nothing should be synced when no allowlist exists.");
+    verify(offeringSyncKafkaTemplate, never()).send(anyString(), any(OfferingSyncTask.class));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingWorkerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.product;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.Optional;
+import org.candlepin.subscriptions.db.model.Offering;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.junit.jupiter.api.Test;
+
+class OfferingWorkerTest {
+
+  @Test
+  void testReceive() {
+    // Given a SKU is allowlisted and retrievable from upstream,
+    TaskQueueProperties props = mock(TaskQueueProperties.class);
+    KafkaConsumerRegistry consumerReg = mock(KafkaConsumerRegistry.class);
+    MeterRegistry meterReg = mock(MeterRegistry.class);
+    OfferingSyncController controller = mock(OfferingSyncController.class);
+
+    Offering expected = new Offering();
+    when(controller.getUpstreamOffering(anyString())).thenReturn(Optional.of(expected));
+    when(meterReg.timer(anyString())).thenReturn(mock(Timer.class));
+
+    OfferingWorker subject = new OfferingWorker(props, consumerReg, meterReg, controller);
+
+    // When an allowlisted SKU is received,
+    subject.receive(new OfferingSyncTask("RH00604F5"));
+
+    // Then the offering should be synced.
+    verify(controller).getUpstreamOffering(anyString());
+    verify(controller).syncOffering(expected);
+  }
+
+  @Test
+  void testReceiveUnfetchable() {
+    // Given a SKU is allowlisted, but isn't retrieveable from upstream for some reason,
+    TaskQueueProperties props = mock(TaskQueueProperties.class);
+    KafkaConsumerRegistry consumerReg = mock(KafkaConsumerRegistry.class);
+    MeterRegistry meterReg = mock(MeterRegistry.class);
+    OfferingSyncController controller = mock(OfferingSyncController.class);
+
+    when(controller.getUpstreamOffering(anyString())).thenReturn(Optional.empty());
+    when(meterReg.timer(anyString())).thenReturn(mock(Timer.class));
+
+    OfferingWorker subject = new OfferingWorker(props, consumerReg, meterReg, controller);
+
+    // When an allowlisted SKU is received,
+    subject.receive(new OfferingSyncTask("RH00604F5"));
+
+    // Then the offering should not be synced.
+    verify(controller).getUpstreamOffering(anyString());
+    verify(controller, never()).syncOffering(any());
+  }
+}

--- a/swatch-core-test/src/main/resources/application-test.yaml
+++ b/swatch-core-test/src/main/resources/application-test.yaml
@@ -26,6 +26,11 @@ rhsm-subscriptions:
     use-stub: true
   clowder:
     json-resource-location: classpath:/test-clowder-config.json
+  product:
+    use-stub: true
+    tasks:
+      topic: platform.rhsm-subscriptions.offering-sync
+      kafka-group-id: offering-worker
 logging:
   level:
     org:

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -120,5 +120,8 @@ rhsm-subscriptions:
     keystore: file:${PRODUCT_KEYSTORE:}
     keystorePassword: ${PRODUCT_KEYSTORE_PASSWORD:redhat}
     maxConnections: ${PRODUCT_MAX_CONNECTIONS:100}
+    tasks:
+      topic: platform.rhsm-subscriptions.offering-sync
+      kafka-group-id: offering-worker
   clowder:
     json-resource-location: file:/cdapp/cdappconfig.json

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -25,6 +25,8 @@ parameters:
     value: 0 10 * * *
   - name: METERING_SCHEDULE
     value: 0 * * * *
+  - name: OFFERING_SYNC_SCHEDULE
+    value: 0 2 * * *
   - name: EVENT_RECORD_RETENTION
     value: 90d
   - name: OPENSHIFT_METERING_RANGE
@@ -673,6 +675,105 @@ objects:
                         secretKeyRef:
                           name: host-inventory-db-readonly
                           key: db.password
+                  resources:
+                    requests:
+                      cpu: ${CPU_REQUEST}
+                      memory: ${MEMORY_REQUEST}
+                    limits:
+                      cpu: ${CPU_LIMIT}
+                      memory: ${MEMORY_LIMIT}
+                  volumeMounts:
+                    - name: logs
+                      mountPath: /logs
+                - name: splunk
+                  env:
+                    - name: SPLUNKMETA_namespace
+                      valueFrom:
+                        fieldRef:
+                          apiVersion: v1
+                          fieldPath: metadata.namespace
+                  image: ${SPLUNK_FORWARDER_IMAGE}
+                  resources:
+                    requests:
+                      cpu: ${SPLUNK_FORWARDER_CPU_REQUEST}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_REQUEST}
+                    limits:
+                      cpu: ${SPLUNK_FORWARDER_CPU_LIMIT}
+                      memory: ${SPLUNK_FORWARDER_MEMORY_LIMIT}
+                  terminationMessagePath: /dev/termination-log
+                  terminationMessagePolicy: File
+                  volumeMounts:
+                    - mountPath: /var/log/app
+                      name: logs
+                      readOnly: true
+                    - mountPath: /tls/splunk.pem
+                      name: splunk
+                      subPath: splunk.pem
+              volumes:
+                - name: splunk
+                  secret:
+                    secretName: splunk
+                - name: logs
+                  emptyDir:
+  - apiVersion: batch/v1beta1
+    kind: CronJob
+    metadata:
+      name: offering-sync
+    spec:
+      schedule: ${OFFERING_SYNC_SCHEDULE}
+      jobTemplate:
+        spec:
+          activeDeadlineSeconds: 1800
+          template:
+            spec:
+              activeDeadlineSeconds: 1800
+              restartPolicy: Never
+              imagePullSecrets:
+                - name: ${IMAGE_PULL_SECRET}
+                - name: quay-cloudservices-pull
+              containers:
+                - image: ${IMAGE}:${IMAGE_TAG}
+                  name: offering-sync
+                  env:
+                    - name: SPRING_PROFILES_ACTIVE
+                      value: offering-sync,kafka-queue
+                    - name: JAVA_MAX_MEM_RATIO
+                      value: '85'
+                    - name: GC_MAX_METASPACE_SIZE
+                      value: '256'
+                    - name: LOG_FILE
+                      value: /logs/server.log
+                    - name: LOGGING_LEVEL_ROOT
+                      value: ${LOGGING_LEVEL_ROOT}
+                    - name: LOGGING_LEVEL_ORG_CANDLEPIN
+                      value: ${LOGGING_LEVEL}
+                    - name: KAFKA_BOOTSTRAP_HOST
+                      value: ${KAFKA_BOOTSTRAP_HOST}
+                    - name: DATABASE_HOST
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.host
+                    - name: DATABASE_PORT
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.port
+                    - name: DATABASE_USERNAME
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.user
+                    - name: DATABASE_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.password
+                    - name: DATABASE_DATABASE
+                      valueFrom:
+                        secretKeyRef:
+                          name: rhsm-db
+                          key: db.name
                   resources:
                     requests:
                       cpu: ${CPU_REQUEST}


### PR DESCRIPTION
Offerings will periodically sync via specifications in templates/rhsm-subscriptions-scheduler.yml. The job will run every 24-hours and enqueues all SKUs listed in the allowlist to be synced with upstream. Because there was yet no kafka message tasking set up to sync offerings, that is added as part of this commit.

To test the enqueueing functionality:
- Create a product allowlist file with a handful of entries. Example
  allowlist.csv file:
```
MW0030
MW01484
MW01485
RH00604F5
RH00618F5
RH0180191
RH3413336
```
- Point to that allowlist.csv file in src/main/resources/application-worker.yaml:
```
...
rhsm-subscriptions:
  product-whitelist-resource-location: file:/path/to/allowlist.csv
  ...
```
- Make sure swatch-core-src/main/resources/swatch-core/application.yaml, product section, has the correct url, keystore, and keystorePassword
- Start a local instance like you would normally
- Kick off the sync all offerings operation using the  [Offering JMX Bean](http://localhost:8080/actuator/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.product-OfferingJmxBean-offeringJmxBean)
- Logs should show offerings getting synced

Currently there is no way to test the cron operation local as that is an OpenShift config.
