### PR TITLE
ENT-4284: build_deploy.sh: Fix tagging commands for subprojects

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -27,8 +27,8 @@ for service in $SERVICES; do
   SERVICE_IMAGE="quay.io/cloudservices/$service"
   docker --config="$DOCKER_CONF" build --no-cache -t "${SERVICE_IMAGE}:${IMAGE_TAG}" . -f $service/Dockerfile
   docker --config="$DOCKER_CONF" push "${SERVICE_IMAGE}:${IMAGE_TAG}"
-  docker --config="$DOCKER_CONF" tag "${SERVICE_IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
+  docker --config="$DOCKER_CONF" tag "${SERVICE_IMAGE}:${IMAGE_TAG}" "${SERVICE_IMAGE}:${SMOKE_TEST_TAG}"
   docker --config="$DOCKER_CONF" push "${SERVICE_IMAGE}:${SMOKE_TEST_TAG}"
-  docker --config="$DOCKER_CONF" tag "${SERVICE_IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
+  docker --config="$DOCKER_CONF" tag "${SERVICE_IMAGE}:${IMAGE_TAG}" "${SERVICE_IMAGE}:qa"
   docker --config="$DOCKER_CONF" push "${SERVICE_IMAGE}:qa"
 done


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4284

Basically the immediately following push commands fail because they try to push images that weren't tagged correctly.

Testing
--------
Because it's inconvenient to log into quay if you haven't before, I recommend simply prefixing the docker commands in `build_deploy.sh` with `echo `, and then running as ` QUAY_USER=foo QUAY_TOKEN=foo sh build_deploy.sh`.

Observe the updated commands echoed:

```
+ echo docker --config=/home/khowell/github/rhsm-subscriptions/.docker tag quay.io/cloudservices/swatch-system-conduit:7779a51 quay.io/cloudservices/swatch-system-conduit:latest
docker --config=/home/khowell/github/rhsm-subscriptions/.docker tag quay.io/cloudservices/swatch-system-conduit:7779a51 quay.io/cloudservices/swatch-system-conduit:latest
+ echo docker --config=/home/khowell/github/rhsm-subscriptions/.docker push quay.io/cloudservices/swatch-system-conduit:latest
docker --config=/home/khowell/github/rhsm-subscriptions/.docker push quay.io/cloudservices/swatch-system-conduit:latest
+ echo docker --config=/home/khowell/github/rhsm-subscriptions/.docker tag quay.io/cloudservices/swatch-system-conduit:7779a51 quay.io/cloudservices/swatch-system-conduit:qa
docker --config=/home/khowell/github/rhsm-subscriptions/.docker tag quay.io/cloudservices/swatch-system-conduit:7779a51 quay.io/cloudservices/swatch-system-conduit:qa
+ echo docker --config=/home/khowell/github/rhsm-subscriptions/.docker push quay.io/cloudservices/swatch-system-conduit:qa
docker --config=/home/khowell/github/rhsm-subscriptions/.docker push quay.io/cloudservices/swatch-system-conduit:qa
```

Note that the tag command actually tags the `swatch-system-conduit` image rather than the general `rhsm-subscriptions` one.