### PR TITLE
Update kafka topic names for sub sync and capacity reconciliation

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,11 +80,11 @@ rhsm-subscriptions:
     maxRetryAttempts: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS:4}
     pageSize: ${SUBSCRIPTION_PAGE_SIZE:500}
     tasks:
-      topic: platform.rhsm-subscriptions.sync
+      topic: platform.rhsm-subscriptions.subscription-sync
       kafka-group-id: subscription-worker
   capacity:
     tasks:
-      topic: platform.rhsm-subscriptions.capacity.reconcile
+      topic: platform.rhsm-subscriptions.capacity-reconcile
       kafka-group-id: capacity-reconciliation-worker
   user-service:
     use-stub: ${USER_USE_STUB:false}

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
@@ -278,7 +278,7 @@ class CapacityReconciliationControllerTest {
     capacityReconciliationController.reconcileCapacityForOffering(offering.getSku(), 0, 2);
     verify(reconcileCapacityByOfferingKafkaTemplate)
         .send(
-            "platform.rhsm-subscriptions.capacity.reconcile",
+            "platform.rhsm-subscriptions.capacity-reconcile",
             ReconcileCapacityByOfferingTask.builder().sku("MCT3718").offset(2).limit(2).build());
   }
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -144,7 +144,7 @@ class SubscriptionSyncControllerTest {
     subscriptionSyncController.syncSubscriptions("100", 0, 2);
     verify(subscriptionsKafkaTemplate)
         .send(
-            "platform.rhsm-subscriptions.sync",
+            "platform.rhsm-subscriptions.subscription-sync",
             SyncSubscriptionsTask.builder().orgId("100").offset(2).limit(2).build());
   }
 

--- a/swatch-core-test/src/main/resources/application-test.yaml
+++ b/swatch-core-test/src/main/resources/application-test.yaml
@@ -16,11 +16,11 @@ rhsm-subscriptions:
   subscription:
     use-stub: true
     tasks:
-      topic: platform.rhsm-subscriptions.sync
+      topic: platform.rhsm-subscriptions.subscription-sync
       kafka-group-id: subscription-worker
   capacity:
     tasks:
-      topic: platform.rhsm-subscriptions.capacity.reconcile
+      topic: platform.rhsm-subscriptions.capacity-reconcile
       kafka-group-id: capacity-reconciliation-worker
   user-service:
     use-stub: true


### PR DESCRIPTION
This makes the topic names follow a pattern established for other topics.

The topic names are [merged into platform-mq](https://github.com/RedHatInsights/platform-mq/pull/148). This will make the names match in swatch.