### PR TITLE
ENT-4296: Add missing beans to jolokia security config

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -25,6 +25,7 @@ import org.candlepin.subscriptions.rbac.RbacApiFactory;
 import org.candlepin.subscriptions.rbac.RbacProperties;
 import org.candlepin.subscriptions.rbac.RbacService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -93,7 +94,8 @@ public class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   @Bean
   public AuthenticationProvider identityHeaderAuthenticationProvider(
-      IdentityHeaderAuthenticationDetailsService detailsService) {
+      @Qualifier("identityHeaderAuthenticationDetailsService")
+          IdentityHeaderAuthenticationDetailsService detailsService) {
     return new IdentityHeaderAuthenticationProvider(detailsService);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
@@ -38,6 +38,7 @@ import org.candlepin.subscriptions.rbac.model.Access;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
@@ -54,7 +55,9 @@ class IdentityHeaderAuthenticationDetailsServiceTest {
 
   @Autowired private RbacService rbacService;
 
-  @Autowired IdentityHeaderAuthenticationDetailsService detailsService;
+  @Autowired
+  @Qualifier("identityHeaderAuthenticationDetailsService")
+  IdentityHeaderAuthenticationDetailsService detailsService;
 
   @Test
   void testAdminRoleGranted() throws Exception {

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.*;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -42,9 +43,13 @@ class IdentityHeaderAuthenticationProviderTest {
 
   @MockBean PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails details;
 
-  @MockBean IdentityHeaderAuthenticationDetailsService detailsService;
+  @MockBean
+  @Qualifier("identityHeaderAuthenticationDetailsService")
+  IdentityHeaderAuthenticationDetailsService detailsService;
 
-  @Autowired AuthenticationProvider manager;
+  @Autowired
+  @Qualifier("identityHeaderAuthenticationProvider")
+  AuthenticationProvider manager;
 
   @Test
   void testMissingOrgId() {


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4296

Testing
-------

Run with dev mode off (you may need to edit
`~/.config/spring-boot/spring-boot-devtools.yaml` or other ways you have
dev mode turned on).

```
DEV_MODE=false RHSM_USE_STUB=true ./gradlew swatch-system-conduit:bootRun
```

Confirm you see

```
Origin & Referer checking (anti-csrf) enabled for .redhat.com:443
```

in the logs (confirms you successfully turned dev mode off).

First try `release` branch, then try this branch.

```
curl \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhc3NvY2lhdGUiOnsiZW1haWwiOiJ0ZXN0QGV4YW1wbGUuY29tIn0sImF1dGhfdHlwZSI6InNhbWwtYXV0aCIsInR5cGUiOiAiQXNzb2NpYXRlIn19Cg==' \
  -H "Origin: https://cloud.redhat.com" \
  -H "Content-Type: application/json" \
  -d '{"type":"exec","mbean": "org.candlepin.subscriptions.conduit.jmx:name=rhsmConduitJmxBean,type=RhsmConduitJmxBean","operation":"syncOrg(java.lang.String)","arguments":["123456"]}' \
  http://localhost:8080/actuator/jolokia
```

Without the change you should see

```
2021-09-03 18:17:01,066 [thread=http-nio-8080-exec-2] [ERROR] [org.candlepin.subscriptions.security.IdentityHeaderAuthenticationFailureHandler] - Could not authenticate the user.: No AuthenticationProvider found for org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
2021-09-03 18:17:01,078 [thread=http-nio-8080-exec-2] [ERROR] [org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/].[jolokia-actuator-endpoint]] - Servlet.service() for servlet [jolokia-actuator-endpoint] in context with path [] threw exception
org.springframework.security.authentication.ProviderNotFoundException: No AuthenticationProvider found for org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
        [stack trace omitted]
```

in the logs

and curl output will be

```
{"errors":[{"status":"401","code":"SUBSCRIPTIONS1001","title":"Could not authenticate the user.","detail":"No AuthenticationProvider found for org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken"}]}
```

-----------------------

With the change, you'll see

```
2021-09-03 18:04:41,439 [thread=http-nio-8080-exec-2] [INFO ] [org.candlepin.subscriptions.conduit.jmx.RhsmConduitJmxBean] RhAssociatePrincipal{email='test@example.com'}- Starting JMX-initiated sync for org ID 123456 by RhAssociatePrincipal{email='test@example.com'}
2021-09-03 18:04:41,456 [thread=http-nio-8080-exec-2] [INFO ] [org.candlepin.subscriptions.conduit.rhsm.client.StubRhsmApi] RhAssociatePrincipal{email='test@example.com'}- Returning canned rhsm response: class OrgInventory {
    pagination: class Pagination {
        offset: null
        limit: 1000
        count: 1
    }
    body: [class Consumer {
        type: null
        id: null
        uuid: 75be7436-71b9-4fca-b730-cc5b1abe5d0d
        name: null
        orgId: 123456
        accountNumber: ACCOUNT_1
        lastCheckin: null
        installedProducts: [class InstalledProducts {
            productId: 72
            productName: null
            productVersion: null
        }]
        serviceLevel: Premium
        sysPurposeRole: null
        sysPurposeUsage: null
        sysPurposeAddons: []
        facts: {ocm.units=Sockets, uname.machine=x86_64, Ip-addresses=192.168.1.1, 10.0.0.1, dmi.system.uuid=a11406f8-cce4-4234-89f5-ae7a449e7339, Mac-addresses=00:00:00:00:00:00, ff:ff:ff:ff:ff:ff, cpu.core(s)_per_socket=2, ocm.billing_model=standard, network.fqdn=host1.test.com, cpu.cpu_socket(s)=2, memory.memtotal=32757812, virt.is_guest=True}
        hypervisorUuid: null
        hypervisorName: hypervisor1.test.com
        guestId: null
    }]
}
2021-09-03 18:04:41,549 [thread=http-nio-8080-exec-2] [INFO ] [org.candlepin.subscriptions.conduit.InventoryController] RhAssociatePrincipal{email='test@example.com'}- Host inventory update completed for org 123456.
```

in the logs and curl output will be similar to

```
{"request":{"mbean":"org.candlepin.subscriptions.conduit.jmx:name=rhsmConduitJmxBean,type=RhsmConduitJmxBean","arguments":["123456"],"type":"exec","operation":"syncOrg(java.lang.String)"},"value":null,"timestamp":1630692281,"status":200}
```