### PR TITLE
Add logic for vCPU counting of virtual x86 cpu.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -56,6 +56,7 @@ import lombok.Setter;
             @ColumnResult(name = "system_profile_infrastructure_type"),
             @ColumnResult(name = "system_profile_cores_per_socket"),
             @ColumnResult(name = "system_profile_sockets"),
+            @ColumnResult(name = "system_profile_arch"),
             @ColumnResult(name = "qpc_products"),
             @ColumnResult(name = "qpc_product_ids"),
             @ColumnResult(name = "system_profile_product_ids"),
@@ -80,6 +81,12 @@ import lombok.Setter;
 /* This query is complex so that we can fetch all the product IDs as a comma-delimited string all in one
  * query.  It's inspired by https://dba.stackexchange.com/a/54289. See also
  * https://stackoverflow.com/a/28557803/6124862
+ *
+ * To add new query date must make updates in the following order
+ * First step -> update queries with the following structure (h.facts ->> rhsm ->> new field as new field,)
+ * check insights-host-inventory/blob/master/swagger/system_profile.spec.yaml for queries on HBI Database.
+ * Second step: Add new field as a ColumnResult
+ * Third step : update inventory host facts contstructor for new column
  */
 @NamedNativeQuery(
     name = "InventoryHost.getFacts",
@@ -106,6 +113,7 @@ import lombok.Setter;
             + "h.system_profile_facts->>'cores_per_socket' as system_profile_cores_per_socket, "
             + "h.system_profile_facts->>'number_of_sockets' as system_profile_sockets, "
             + "h.system_profile_facts->>'cloud_provider' as cloud_provider, "
+            + "h.system_profile_facts->>'arch' as system_profile_arch,"
             + "h.canonical_facts->>'subscription_manager_id' as subscription_manager_id, "
             + "h.canonical_facts->>'insights_id' as insights_id, "
             + "rhsm_products.products, "

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -44,6 +44,7 @@ public class InventoryHostFacts {
   private String systemProfileInfrastructureType;
   private Integer systemProfileCoresPerSocket;
   private Integer systemProfileSockets;
+  private String systemProfileArch;
   private boolean isVirtual;
   private String hypervisorUuid;
   private String satelliteHypervisorUuid;
@@ -69,6 +70,10 @@ public class InventoryHostFacts {
   }
 
   @SuppressWarnings("squid:S00107")
+  /**
+   * Constructor represent current query structure for reads from HBI Must be consistent with
+   * InventoryHost (Any changes here must be made in this Object. vice versa)
+   */
   public InventoryHostFacts(
       UUID inventoryId,
       OffsetDateTime modifiedOn,
@@ -82,6 +87,7 @@ public class InventoryHostFacts {
       String systemProfileInfrastructureType,
       String systemProfileCores,
       String systemProfileSockets,
+      String systemProfileArch,
       String qpcProducts,
       String qpcProductIds,
       String systemProfileProductIds,
@@ -115,6 +121,7 @@ public class InventoryHostFacts {
     this.systemProfileInfrastructureType = systemProfileInfrastructureType;
     this.systemProfileCoresPerSocket = asInt(systemProfileCores);
     this.systemProfileSockets = asInt(systemProfileSockets);
+    this.systemProfileArch = systemProfileArch;
     this.systemProfileProductIds = asStringSet(systemProfileProductIds);
     this.syspurposeRole = syspurposeRole;
     this.syspurposeSla = syspurposeSla;

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -224,7 +224,7 @@ public class FactNormalizer {
         virtualFacts.getSystemProfileCoresPerSocket() * virtualFacts.getSystemProfileSockets();
 
     var threadsPerCore = 2.0;
-    return Double.valueOf(Math.ceil(cpu / threadsPerCore)).intValue();
+    return (int) Math.ceil(cpu / threadsPerCore);
   }
 
   private void getProductsFromProductIds(

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -206,8 +206,10 @@ public class FactNormalizer {
       normalizedFacts.setCores(
           hostFacts.getSystemProfileCoresPerSocket() * hostFacts.getSystemProfileSockets());
     }
-    if (hostFacts.getSystemProfileArch().equals("x86_64")
-        && hostFacts.getSystemProfileInfrastructureType().equals("virtual")) {
+    if ("x86_64".equals(hostFacts.getSystemProfileArch())
+        && HardwareMeasurementType.VIRTUAL
+            .toString()
+            .equalsIgnoreCase(hostFacts.getSystemProfileInfrastructureType())) {
       var effectiveCores = calculateVirtualCPU(hostFacts);
       normalizedFacts.setCores(effectiveCores);
     }
@@ -221,8 +223,8 @@ public class FactNormalizer {
     int cpu =
         virtualFacts.getSystemProfileCoresPerSocket() * virtualFacts.getSystemProfileSockets();
 
-    // If we have the actual threads per core, you can use it here.
-    return Double.valueOf(Math.ceil(cpu / 2.0)).intValue();
+    var threadsPerCore = 2.0;
+    return Double.valueOf(Math.ceil(cpu / threadsPerCore)).intValue();
   }
 
   private void getProductsFromProductIds(

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -206,7 +206,23 @@ public class FactNormalizer {
       normalizedFacts.setCores(
           hostFacts.getSystemProfileCoresPerSocket() * hostFacts.getSystemProfileSockets());
     }
+    if (hostFacts.getSystemProfileArch().equals("x86_64")
+        && hostFacts.getSystemProfileInfrastructureType().equals("virtual")) {
+      var effectiveCores = calculateVirtualCPU(hostFacts);
+      normalizedFacts.setCores(effectiveCores);
+    }
     getProductsFromProductIds(normalizedFacts, hostFacts.getSystemProfileProductIds());
+  }
+
+  private Integer calculateVirtualCPU(InventoryHostFacts virtualFacts) {
+    //  For x86, guests: if we know the number of threads per core and its greater than one,
+    //  then we divide the number of cores by that number.
+    //  Otherwise we divide by two.
+    int cpu =
+        virtualFacts.getSystemProfileCoresPerSocket() * virtualFacts.getSystemProfileSockets();
+
+    // If we have the actual threads per core, you can use it here.
+    return Double.valueOf(Math.ceil(cpu / 2.0)).intValue();
   }
 
   private void getProductsFromProductIds(

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -603,6 +603,30 @@ public class FactNormalizerTest {
     assertEquals(Usage.DEVELOPMENT_TEST, normalized.getUsage());
   }
 
+  @Test
+  void testCalculationOfVirtualCPU() {
+    InventoryHostFacts facts = createBaseHost("V1", "01");
+    facts.setSystemProfileArch("x86_64");
+    facts.setSystemProfileCoresPerSocket(16);
+    facts.setSystemProfileSockets(1);
+    facts.setSystemProfileInfrastructureType("virtual");
+    NormalizedFacts normalizedFacts = normalizer.normalize(facts, Collections.emptyMap());
+    assertEquals(8, normalizedFacts.getCores());
+    assertEquals(HostHardwareType.VIRTUALIZED, normalizedFacts.getHardwareType());
+  }
+
+  @Test
+  void testCalculationOfVirtualCPURoundsUP() {
+    InventoryHostFacts facts = createBaseHost("V1", "01");
+    facts.setSystemProfileArch("x86_64");
+    facts.setSystemProfileCoresPerSocket(9);
+    facts.setSystemProfileSockets(1);
+    facts.setSystemProfileInfrastructureType("virtual");
+    NormalizedFacts normalizedFacts = normalizer.normalize(facts, Collections.emptyMap());
+    assertEquals(5, normalizedFacts.getCores());
+    assertEquals(HostHardwareType.VIRTUALIZED, normalizedFacts.getHardwareType());
+  }
+
   private void assertClassification(
       NormalizedFacts check, boolean isHypervisor, boolean isHypervisorUnknown, boolean isVirtual) {
     assertEquals(isHypervisor, check.isHypervisor());


### PR DESCRIPTION
Add system profile arch to begin leverage for vCPU counting.
Add logic for for x86 virtual guests to get a more accurate count of vCPUs.
Add test case to test method within the normalize workflow.
Refactor vCPU counting to account for odd number value of cpu.