### PR TITLE
Subscription table API naming updates

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -391,7 +391,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
       tags:
-        - capacity
+        - subscriptions
   /hosts/products/{product_id}:
     description: 'Operations for hosts for a given account and product'
     parameters:
@@ -1429,11 +1429,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SkuCapacitySubscription"
-        upcoming_event_date:
+        next_event_date:
           description: "The most immediate date for a subscription event."
           type: string
           format: date-time
-        upcoming_event_type:
+        next_event_type:
           description: "The most immediate subscription event, such as a subscription beginning or ending."
           $ref: "#/components/schemas/SubscriptionEventType"
         quantity:
@@ -1460,9 +1460,9 @@ components:
       type: string
       enum:
         - sku
-        - sla
+        - service_level
         - usage
-        - next_event
+        - next_event_date
         - next_event_type
         - quantity
 

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -55,7 +55,7 @@ public class SubscriptionTableController {
       ProductId productId,
       @Min(0) Integer offset,
       @Min(1) Integer limit,
-      ServiceLevelType sla,
+      ServiceLevelType serviceLevel,
       UsageType usage,
       Uom uom,
       SkuCapacityReportSort sort,
@@ -71,14 +71,14 @@ public class SubscriptionTableController {
 
     OffsetDateTime reportEnd = clock.now();
     OffsetDateTime reportStart = clock.now();
-    ServiceLevel sanitizedServiceLevel = sanitizeServiceLevel(sla);
+    ServiceLevel sanitizedServiceLevel = sanitizeServiceLevel(serviceLevel);
     Usage sanitizedUsage = sanitizeUsage(usage);
 
     log.info(
         "Finding all subscription capacities for "
             + "owner: {}, "
             + "productId: {}, "
-            + "SLA: {}, "
+            + "Service Level: {}, "
             + "Usage: {} "
             + "between {} and {}",
         getOwnerId(),
@@ -120,7 +120,7 @@ public class SubscriptionTableController {
         .meta(
             new HostReportMeta()
                 .count(reportItems.size())
-                .serviceLevel(sla)
+                .serviceLevel(serviceLevel)
                 .usage(usage)
                 .uom(uom)
                 .product(productId));
@@ -170,14 +170,14 @@ public class SubscriptionTableController {
       SkuCapacity skuCapacity,
       OffsetDateTime now) {
 
-    OffsetDateTime nearestEventDate = skuCapacity.getUpcomingEventDate();
+    OffsetDateTime nearestEventDate = skuCapacity.getNextEventDate();
     OffsetDateTime subEnd = subscriptionCapacityView.getEndDate();
     if (subEnd != null
         && now.isBefore(subEnd)
         && (nearestEventDate == null || subEnd.isBefore(nearestEventDate))) {
       nearestEventDate = subEnd;
-      skuCapacity.setUpcomingEventDate(nearestEventDate);
-      skuCapacity.setUpcomingEventType(SubscriptionEventType.END);
+      skuCapacity.setNextEventDate(nearestEventDate);
+      skuCapacity.setNextEventType(SubscriptionEventType.END);
     }
   }
 
@@ -241,7 +241,7 @@ public class SubscriptionTableController {
             case SKU:
               diff = left.getSku().compareTo(right.getSku());
               break;
-            case SLA:
+            case SERVICE_LEVEL:
               diff = left.getServiceLevel().compareTo(right.getServiceLevel());
               break;
             case USAGE:
@@ -250,11 +250,11 @@ public class SubscriptionTableController {
             case QUANTITY:
               diff = left.getQuantity().compareTo(right.getQuantity());
               break;
-            case NEXT_EVENT:
-              diff = left.getUpcomingEventDate().compareTo(right.getUpcomingEventDate());
+            case NEXT_EVENT_DATE:
+              diff = left.getNextEventDate().compareTo(right.getNextEventDate());
               break;
             case NEXT_EVENT_TYPE:
-              diff = left.getUpcomingEventType().compareTo(right.getUpcomingEventType());
+              diff = left.getNextEventType().compareTo(right.getNextEventType());
               break;
           }
           // If the two items are sorted by some other field than SKU and are equal, then break the

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -143,8 +143,8 @@ class SubscriptionTableControllerTest {
     assertCapacities(8, 0, Uom.SOCKETS, actualItem);
     assertSubscription(expectedSub, actualItem.getSubscriptions().get(0));
     assertEquals(
-        SubscriptionEventType.END, actualItem.getUpcomingEventType(), "Wrong upcoming event type");
-    assertEquals(expectedSub.end, actualItem.getUpcomingEventDate(), "Wrong upcoming event date");
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(expectedSub.end, actualItem.getNextEventDate(), "Wrong upcoming event date");
   }
 
   @Test
@@ -182,10 +182,10 @@ class SubscriptionTableControllerTest {
         9, actualItem.getQuantity(), "Item should contain the sum of all subs' quantities");
     assertCapacities(18, 0, Uom.SOCKETS, actualItem);
     assertEquals(
-        SubscriptionEventType.END, actualItem.getUpcomingEventType(), "Wrong upcoming event type");
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
     assertEquals(
         expectedOlderSub.end,
-        actualItem.getUpcomingEventDate(),
+        actualItem.getNextEventDate(),
         "Wrong upcoming event date. Given two or more subs, the even take should be the subscription enddate closest to now.");
 
     SkuCapacitySubscription actualSub = actualItem.getSubscriptions().get(0);
@@ -234,9 +234,8 @@ class SubscriptionTableControllerTest {
     assertCapacities(10, 10, Uom.SOCKETS, actualItem);
     assertSubscription(expectedOlderSub, actualItem.getSubscriptions().get(0));
     assertEquals(
-        SubscriptionEventType.END, actualItem.getUpcomingEventType(), "Wrong upcoming event type");
-    assertEquals(
-        expectedOlderSub.end, actualItem.getUpcomingEventDate(), "Wrong upcoming event date");
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(expectedOlderSub.end, actualItem.getNextEventDate(), "Wrong upcoming event date");
 
     actualItem = actual.getData().get(1);
     assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
@@ -247,9 +246,8 @@ class SubscriptionTableControllerTest {
     assertCapacities(8, 0, Uom.SOCKETS, actualItem);
     assertSubscription(expectedNewerSub, actualItem.getSubscriptions().get(0));
     assertEquals(
-        SubscriptionEventType.END, actualItem.getUpcomingEventType(), "Wrong upcoming event type");
-    assertEquals(
-        expectedNewerSub.end, actualItem.getUpcomingEventDate(), "Wrong upcoming event date");
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(expectedNewerSub.end, actualItem.getNextEventDate(), "Wrong upcoming event date");
   }
 
   @Test


### PR DESCRIPTION
Update naming for sort parameters and fields in Json response for Subscription table api to be consistent with other apis

The final agreed upon names:

next_event_date
next_event_type
service_level

Also updated the tag for this API to be 'subscriptions'

To test, startup application locally and review update at http://localhost:8080/api-docs/index.html#/