### PR TITLE
ENT-4259 Add profiles to offering and subscription sync jobs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/job/OfferingSyncConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/OfferingSyncConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 @Profile("offering-sync")
 @Import(TaskProducerConfiguration.class)
-@ComponentScan({"org.candlepin.subscriptions.product"})
+@ComponentScan({"org.candlepin.subscriptions.tally.job", "org.candlepin.subscriptions.product"})
 public class OfferingSyncConfiguration {
   @Bean
   JobRunner jobRunner(OfferingSyncJob job, ApplicationContext applicationContext) {

--- a/src/main/java/org/candlepin/subscriptions/tally/job/OfferingSyncJob.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/OfferingSyncJob.java
@@ -23,11 +23,13 @@ package org.candlepin.subscriptions.tally.job;
 import org.candlepin.subscriptions.exception.JobFailureException;
 import org.candlepin.subscriptions.product.OfferingSyncController;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /** A cron job to sync offerings to the latest upstream state for all allowlisted offerings. */
 @Component
+@Profile("offering-sync")
 public class OfferingSyncJob implements Runnable {
 
   private final OfferingSyncController controller;

--- a/src/main/java/org/candlepin/subscriptions/tally/job/SubscriptionSyncJob.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/SubscriptionSyncJob.java
@@ -26,11 +26,13 @@ import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /** A cron job to sync subscriptions to the latest upstream state for all opted-in organizations. */
 @Component
+@Profile("subscription-sync")
 public class SubscriptionSyncJob implements Runnable {
   private static final Logger log = LoggerFactory.getLogger(SubscriptionSyncJob.class);
 


### PR DESCRIPTION
This is to prevent any beans the jobs use from being pulled in when other profiles are active.
Also adds "org.candlepin.subscriptions.tally.job" to the OfferingSyncConfiguration component scan so that the bean can be properly loaded when offering-sync profile is active.