### PR TITLE
Refactor Sync Offering JMX implementation

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/product/OfferingJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingJmxBean.java
@@ -60,7 +60,10 @@ public class OfferingJmxBean {
       return upstream
           .map(Offering::toString)
           .orElseGet(
-              () -> "{\"message\": \"offeringSku=\"" + sku + "\" was not found/allowlisted.\"}");
+              () ->
+                  "{\"message\": \"offeringSku=\""
+                      + sku
+                      + "\" was not found in upstream service\"}");
     } catch (Exception e) {
       log.error("Error syncing offering", e);
       throw new JmxException("Error syncing offering. See log for details.");

--- a/src/main/java/org/candlepin/subscriptions/product/OfferingSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingSyncController.java
@@ -58,7 +58,8 @@ public class OfferingSyncController {
   public Optional<Offering> getUpstreamOffering(String sku) {
     if (!productAllowlist.productIdMatches(sku)) {
       LOGGER.info("sku=\"{}\" is not in allowlist. Will not retrieve offering from upstream.", sku);
-      return Optional.empty();
+      throw new RuntimeException(
+          "sku=" + sku + " is not in allowlist. Will not retrieve offering from upstream.");
     }
     LOGGER.debug("Retrieving product tree for offering sku=\"{}\"", sku);
     return UpstreamProductData.offeringFromUpstream(sku, productService);

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingJmxBeanTest.java
@@ -85,6 +85,7 @@ class OfferingJmxBeanTest {
     verify(offeringSync).getUpstreamOffering(sku);
     verify(offeringSync, never()).syncOffering(any());
     assertEquals(
-        "{\"message\": \"offeringSku=\"" + sku + "\" was not found/allowlisted.\"}", actualMessage);
+        "{\"message\": \"offeringSku=\"" + sku + "\" was not found in upstream service\"}",
+        actualMessage);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
@@ -20,16 +20,6 @@
  */
 package org.candlepin.subscriptions.product;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
 import org.candlepin.subscriptions.capacity.files.ProductWhitelist;
 import org.candlepin.subscriptions.db.OfferingRepository;
 import org.candlepin.subscriptions.db.model.Offering;
@@ -46,6 +36,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest(classes = {OfferingSyncControllerTest.TestProductConfiguration.class})
 @ActiveProfiles({"worker", "test"})
@@ -279,11 +277,13 @@ class OfferingSyncControllerTest {
     when(allowlist.productIdMatches(anyString())).thenReturn(false);
     var sku = "MW01485"; // The SKU would normally be successfully retrieved, but is denied
 
-    // When getting the upstream Offering,
-    var actual = subject.getUpstreamOffering(sku);
-
-    // Then there is no resulting offering.
-    assertTrue(actual.isEmpty(), "A sku not in the allowlist should not be returned.");
+    assertEquals(
+        "sku=MW01485 is not in allowlist. Will not retrieve offering from upstream.",
+        assertThrows(
+                RuntimeException.class,
+                () -> subject.getUpstreamOffering(sku),
+                "A sku not in the allowlist should not be returned.")
+            .getMessage());
     verify(allowlist).productIdMatches(sku);
   }
 


### PR DESCRIPTION
There are 2 possible scenarios when an offering will not be synced

1. If it is not present on the allowlist
2. If it is present on the allowlist but not present in the product service

As each of these error scenarios requires different actions i.e, 

for 1, we will either ignore the error because it is expected behavior or the add the offering to the allowlist (depends on the sku)

 for 2, we will need to figure out why a sku is missing from product service and take appropriate steps to fix it.

I am recommending we separate the exception logging for these 2 scenarios, so we can alert based on the specific scenario in splunk (if that's our preferred option).

Currently we are returning a string message for an offering that's missing in Product Service but to me it feels more appropriate to throw an exception. That requires a little more refactoring than this, so if there is agreement, I would like to make that update as well.