### PR TITLE
ENT-4319 Add syncOffering(sku) to OfferingSyncController

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/product/OfferingJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingJmxBean.java
@@ -20,10 +20,8 @@
  */
 package org.candlepin.subscriptions.product;
 
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.capacity.CapacityReconciliationController;
-import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jmx.JmxException;
@@ -55,12 +53,9 @@ public class OfferingJmxBean {
     try {
       Object principal = ResourceUtils.getPrincipal();
       log.info("Sync for offering {} triggered over JMX by {}", sku, principal);
-      Optional<Offering> upstream = offeringSync.getUpstreamOffering(sku);
-      upstream.ifPresent(offeringSync::syncOffering);
-      return upstream
-          .map(Offering::toString)
-          .orElseGet(
-              () -> "{\"message\": \"offeringSku=\"" + sku + "\" was not found/allowlisted.\"}");
+      SyncResult result = offeringSync.syncOffering(sku);
+
+      return String.format("%s for offeringSku=\"%s\".", result, sku);
     } catch (Exception e) {
       log.error("Error syncing offering", e);
       throw new JmxException("Error syncing offering. See log for details.");

--- a/src/main/java/org/candlepin/subscriptions/product/SyncResult.java
+++ b/src/main/java/org/candlepin/subscriptions/product/SyncResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.product;
+
+public enum SyncResult {
+  FETCHED_AND_SYNCED("Successfully fetched and synced updated value from upstream"),
+  FAILED("Failed to fetch and/or sync"),
+  SKIPPED_MATCHING("Upstream matches stored item, did not sync"),
+  SKIPPED_NOT_FOUND("Was not found upstream, did not sync"),
+  SKIPPED_NOT_ALLOWLISTED("Not in allowlist, did not sync");
+
+  private final String description;
+
+  SyncResult(String description) {
+    this.description = description;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("syncResult=%s (%s)", name(), description());
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -106,7 +106,7 @@ class UpstreamProductData {
     } catch (ApiException e) {
       throw new ExternalServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR,
-          "Unable to retrieve upstream offering sku=\"" + sku + "\"",
+          "Unable to retrieve upstream offeringSku=\"" + sku + "\"",
           e);
     }
   }

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.product;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
@@ -36,7 +35,6 @@ import org.candlepin.subscriptions.capacity.files.ProductWhitelist;
 import org.candlepin.subscriptions.db.OfferingRepository;
 import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
-import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,234 +85,94 @@ class OfferingSyncControllerTest {
   void testSyncOfferingNew() {
     // Given an Offering that is not yet persisted,
     when(repo.findById(anyString())).thenReturn(Optional.empty());
-
-    Offering sku = new Offering();
-    sku.setSku("RH00003");
-    sku.setProductIds(Set.of(68, 69, 70, 71, 72));
+    String sku = "MW01485";
 
     // When syncing the Offering,
-    subject.syncOffering(sku);
+    SyncResult result = subject.syncOffering(sku);
 
     // Then the Offering should be persisted.
-    verify(repo).save(sku);
+    assertEquals(SyncResult.FETCHED_AND_SYNCED, result);
+    verify(repo).save(any(Offering.class));
   }
 
   @Test
   void testSyncOfferingChanged() {
     // Given an Offering that is different from what is persisted,
+    String sku = "MW01485";
     Offering persisted = new Offering();
-    persisted.setSku("RH00003");
-    persisted.setProductIds(Set.of(68));
-    when(repo.findById(anyString())).thenReturn(Optional.of(persisted));
-
-    Offering sku = new Offering();
-    sku.setSku("RH00003");
-    sku.setProductIds(Set.of(68, 69, 70, 71, 72));
+    persisted.setSku(sku);
+    persisted.setProductName("Red Hat OpenShift Container Platform (Hourly)");
+    persisted.setProductFamily("OpenShift Enterprise");
+    persisted.setChildSkus(Set.of("SVCMW01485"));
+    persisted.setProductIds(
+        Set.of(
+            491, 311, 194, 197, 317, 318, 201, 205, 326, 329, 271, 518, 579, 519, 458, 645, 588,
+            408, 290, 473, 479, 240, 603, 604, 185, 546, 608, 69, 70, 610));
+    persisted.setServiceLevel(ServiceLevel.PREMIUM);
 
     // When syncing the Offering,
-    subject.syncOffering(sku);
+    SyncResult result = subject.syncOffering(sku);
 
     // Then the updated Offering should be persisted.
-    verify(repo).save(sku);
+    assertEquals(SyncResult.FETCHED_AND_SYNCED, result);
+    verify(repo).save(any(Offering.class));
   }
 
   @Test
   void testSyncOfferingUnchanged() {
     // Given an Offering that is equal to what is persisted,
+    String sku = "MW01485";
     Offering persisted = new Offering();
-    persisted.setSku("RH00003");
-    persisted.setProductIds(Set.of(68, 69, 70, 71, 72));
+    persisted.setSku(sku);
+    persisted.setProductName("Red Hat OpenShift Container Platform (Hourly)");
+    persisted.setProductFamily("OpenShift Enterprise");
+    persisted.setChildSkus(Set.of("SVCMW01485"));
+    persisted.setProductIds(
+        Set.of(
+            491, 311, 194, 197, 317, 318, 201, 205, 326, 329, 271, 518, 579, 519, 458, 645, 588,
+            408, 290, 473, 479, 240, 603, 604, 185, 546, 608, 69, 70, 610));
+    persisted.setServiceLevel(ServiceLevel.PREMIUM);
     when(repo.findById(anyString())).thenReturn(Optional.of(persisted));
 
-    Offering sku = new Offering();
-    sku.setSku("RH00003");
-    sku.setProductIds(Set.of(68, 69, 70, 71, 72));
-
     // When syncing the Offering,
-    subject.syncOffering(sku);
+    SyncResult result = subject.syncOffering(sku);
 
     // Then no persisting should happen.
-    verify(repo, never()).save(sku);
+    assertEquals(SyncResult.SKIPPED_MATCHING, result);
+    verify(repo, never()).save(any(Offering.class));
   }
 
   @Test
   void testSyncOfferingNoProductIdsShouldPersist() {
     // Given an Offering that has no engineering product ids,
-    Offering sku = new Offering();
-    sku.setSku("MW01484"); // This is an actual Offering that has no engineering product ids
+    Offering offering = new Offering();
+    offering.setSku("MW01484"); // This is an actual Offering that has no engineering product ids
+
+    when(repo.findById(anyString())).thenReturn(Optional.empty());
 
     // When syncing the Offering,
-    subject.syncOffering(sku);
+    SyncResult result = subject.syncOffering("MW01484");
 
     // Then it should still persist, since there are Offerings that we need that have no eng prods.
-    verify(repo).save(sku);
+    assertEquals(SyncResult.FETCHED_AND_SYNCED, result);
+    verify(repo).save(any(Offering.class));
   }
 
   @Test
-  void testGetUpstreamOfferingForOcpOffering() {
-    // Given a marketing SKU for OpenShift Container Platform
-    var sku = "MW01485";
-    var expected = new Offering();
-    expected.setSku(sku);
-    expected.setChildSkus(Set.of("SVCMW01485"));
-    expected.setProductIds(
-        Set.of(
-            69, 70, 185, 194, 197, 201, 205, 240, 271, 290, 311, 317, 318, 326, 329, 408, 458, 473,
-            479, 491, 518, 519, 546, 579, 588, 603, 604, 608, 610, 645));
-    expected.setProductFamily("OpenShift Enterprise");
-    expected.setProductName("Red Hat OpenShift Container Platform (Hourly)");
-    expected.setServiceLevel(ServiceLevel.PREMIUM);
-
-    // When getting the upstream Offering,
-    var actual = subject.getUpstreamOffering(sku).orElseThrow();
-
-    // Then the resulting Offering has the expected child SKUs, engProd OIDs, and values.
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testGetUpstreamOfferingForNoEngProductOffering() {
-    // Given a marketing SKU MW01484 (special for being engProduct-less),
-    var sku = "MW01484";
-    var expected = new Offering();
-    expected.setSku(sku);
-    expected.setChildSkus(Set.of("SVCMW01484A", "SVCMW01484B"));
-    expected.setProductIds(Collections.emptySet());
-    expected.setProductFamily("OpenShift Enterprise");
-    expected.setProductName("Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)");
-    expected.setServiceLevel(ServiceLevel.PREMIUM);
-
-    // When getting the upstream Offering,
-    var actual = subject.getUpstreamOffering(sku).orElseThrow();
-
-    // Then the resulting Offering has the expected child SKUs, values, and no engProdIds.
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testGetUpstreamOfferingForOfferingWithDerivedSku() {
-    // Given a marketing SKU that has a derived SKU,
-    var sku = "RH00604F5";
-    var expected = new Offering();
-    expected.setSku(sku);
-    // (For now, Derived SKU and Derived SKU children are included as child SKUs.)
-    expected.setChildSkus(Set.of("RH00618F5", "SVCRH00604", "SVCRH00618"));
-    // (Neither the parent (as typical) nor the child SKU have eng products. These end up
-    //  coming from the derived SKU RH00048.)
-    expected.setProductIds(
-        Set.of(
-            69, 70, 83, 84, 86, 91, 92, 93, 127, 176, 180, 182, 201, 205, 240, 241, 246, 248, 317,
-            318, 394, 395, 408, 479, 491, 588));
-    expected.setPhysicalSockets(2);
-    expected.setVirtualSockets(2);
-    expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName(
-        "Red Hat Enterprise Linux Server for SAP HANA for Virtual Datacenters with Smart Management, Premium");
-    expected.setServiceLevel(ServiceLevel.PREMIUM);
-    // (Usage ends up coming from derived SKU RH00618F5)
-    expected.setUsage(Usage.PRODUCTION);
-
-    // When getting the upstream Offering,
-    var actual = subject.getUpstreamOffering(sku).orElseThrow();
-
-    // Then the resulting Offering has the expected virtual sockets from derived sku,
-    // and engOIDs from the derived sku child.
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testGetUpstreamOfferingForOfferingWithRoleAndUsage() {
-    // This checks that role and usage are calculated correctly.
-
-    // Given a marketing SKU that has a defined role and usage,
-    var sku = "RH0180191";
-    var expected = new Offering();
-    expected.setSku(sku);
-    expected.setChildSkus(Set.of("SVCMPV4", "SVCRH01", "SVCRH01V4"));
-    expected.setProductIds(
-        Set.of(
-            69, 70, 84, 86, 91, 92, 93, 94, 127, 133, 176, 180, 182, 201, 205, 240, 246, 271, 272,
-            273, 274, 317, 318, 394, 395, 408, 479, 491, 588, 605));
-    expected.setRole("Red Hat Enterprise Linux Server");
-    expected.setPhysicalSockets(2);
-    expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName(
-        "Red Hat Enterprise Linux Server, Standard (1-2 sockets) (Up to 4 guests) with Smart Management");
-    expected.setServiceLevel(ServiceLevel.STANDARD);
-    expected.setUsage(Usage.PRODUCTION);
-
-    // When getting the upstream Offering,
-    var actual = subject.getUpstreamOffering(sku).orElseThrow();
-
-    // Then the resulting Offering has the expected child SKUs, values, and engProdIds.
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testGetUpstreamOfferingWithIflAttrCode() {
-    // Given a marketing SKU wiht attribute code "IFL" in its tree (in this case, in SVCMPV4)
-    var sku = "RH3413336";
-    var expected = new Offering();
-    expected.setSku(sku);
-    expected.setChildSkus(
-        Set.of("SVCEUSRH34", "SVCHPNRH34", "SVCMPV4", "SVCRH34", "SVCRH34V4", "SVCRS", "SVCSFS"));
-    expected.setProductIds(
-        Set.of(
-            68, 69, 70, 71, 83, 84, 85, 86, 90, 91, 92, 93, 132, 133, 172, 176, 179, 180, 190, 201,
-            202, 203, 205, 206, 207, 240, 242, 244, 246, 273, 274, 287, 293, 317, 318, 342, 343,
-            394, 395, 396, 397, 408, 479, 491, 588));
-    expected.setPhysicalCores(4); // Because IFL is 1 which gets multiplied by magical constant 4
-    expected.setPhysicalSockets(2);
-    expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName("Red Hat Enterprise Linux Developer Workstation, Enterprise");
-    expected.setServiceLevel(ServiceLevel.EMPTY); // Because Dev-Enterprise isn't a ServiceLevel yet
-    expected.setUsage(Usage.DEVELOPMENT_TEST);
-
-    // When getting the upstream Offering,
-    var actual = subject.getUpstreamOffering(sku).orElseThrow();
-
-    // Then the resulting Offering has the expected child SKUs, engProd OIDs, and values.
-    assertEquals(expected, actual);
-  }
-
-  @Test()
-  void testGetUpstreamOfferingNotInAllowlist() {
+  void testSyncOfferingNotInAllowlist() {
     // Given a marketing SKU not listed in allowlist,
     when(allowlist.productIdMatches(anyString())).thenReturn(false);
     var sku = "MW01485"; // The SKU would normally be successfully retrieved, but is denied
 
     // When getting the upstream Offering,
-    var actual = subject.getUpstreamOffering(sku);
+    var actual = subject.syncOffering(sku);
 
-    // Then there is no resulting offering.
-    assertTrue(actual.isEmpty(), "A sku not in the allowlist should not be returned.");
+    // Then syncing the offering is rejected and no attempt was made to fetch or store it.
+    assertEquals(
+        SyncResult.SKIPPED_NOT_ALLOWLISTED,
+        actual,
+        "A sku not in the allowlist should not be synced.");
     verify(allowlist).productIdMatches(sku);
-  }
-
-  @Test
-  void testGetUpstreamOfferingNotFound() {
-    // Given a marketing SKU that doesn't exist upstream,
-    var sku = "BOGUS";
-
-    // When attempting to get the upstream Offering,
-    var actual = subject.getUpstreamOffering(sku);
-
-    // Then there is no resulting offering.
-    assertTrue(actual.isEmpty(), "When a sku doesn't exist upstream, return an empty Optional.");
-  }
-
-  /** Valid given MW00330 sku with core value set to 16, physical core value is 16 */
-  @Test()
-  void testOpenShiftUpSteamProductPhysicalCores() {
-    // Given an Openshift SKU that does exist upstream,
-    var sku = "MW00330";
-    // create file for MW00330
-
-    // When given the result of a physical,
-    var actual = subject.getUpstreamOffering(sku).orElseThrow();
-
-    // Then cores equals 16
-    assertEquals(16, actual.getPhysicalCores());
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.product;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Set;
+import org.candlepin.subscriptions.db.model.Offering;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.junit.jupiter.api.Test;
+
+class UpstreamProductDataTest {
+
+  private final ProductService stub = new ProductService(new StubProductApi());
+
+  @Test
+  void testOfferingFromUpstreamForOcpOffering() {
+    // Given a marketing SKU for OpenShift Container Platform
+    var sku = "MW01485";
+    var expected = new Offering();
+    expected.setSku(sku);
+    expected.setChildSkus(Set.of("SVCMW01485"));
+    expected.setProductIds(
+        Set.of(
+            69, 70, 185, 194, 197, 201, 205, 240, 271, 290, 311, 317, 318, 326, 329, 408, 458, 473,
+            479, 491, 518, 519, 546, 579, 588, 603, 604, 608, 610, 645));
+    expected.setProductFamily("OpenShift Enterprise");
+    expected.setProductName("Red Hat OpenShift Container Platform (Hourly)");
+    expected.setServiceLevel(ServiceLevel.PREMIUM);
+
+    // When getting the upstream Offering,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
+
+    // Then the resulting Offering has the expected child SKUs, engProd OIDs, and values.
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testOfferingFromUpstreamForNoEngProductOffering() {
+    // Given a marketing SKU MW01484 (special for being engProduct-less),
+    var sku = "MW01484";
+    var expected = new Offering();
+    expected.setSku(sku);
+    expected.setChildSkus(Set.of("SVCMW01484A", "SVCMW01484B"));
+    expected.setProductIds(Collections.emptySet());
+    expected.setProductFamily("OpenShift Enterprise");
+    expected.setProductName("Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)");
+    expected.setServiceLevel(ServiceLevel.PREMIUM);
+
+    // When getting the upstream Offering,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
+
+    // Then the resulting Offering has the expected child SKUs, values, and no engProdIds.
+    assertEquals(expected, actual);
+  }
+
+  /** Valid given MW00330 sku with core value set to 16, physical core value is 16 */
+  @Test
+  void testOfferingFromUpstreamOpenShiftPhysicalCores() {
+    // Given an Openshift SKU that exists upstream,
+    var sku = "MW00330";
+
+    // When given the result of a physical,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
+
+    // Then cores equals 16
+    assertEquals(16, actual.getPhysicalCores());
+  }
+
+  @Test
+  void testOfferingFromUpstreamForOfferingWithDerivedSku() {
+    // Given a marketing SKU that has a derived SKU,
+    var sku = "RH00604F5";
+    var expected = new Offering();
+    expected.setSku(sku);
+    // (For now, Derived SKU and Derived SKU children are included as child SKUs.)
+    expected.setChildSkus(Set.of("RH00618F5", "SVCRH00604", "SVCRH00618"));
+    // (Neither the parent (as typical) nor the child SKU have eng products. These end up
+    //  coming from the derived SKU RH00048.)
+    expected.setProductIds(
+        Set.of(
+            69, 70, 83, 84, 86, 91, 92, 93, 127, 176, 180, 182, 201, 205, 240, 241, 246, 248, 317,
+            318, 394, 395, 408, 479, 491, 588));
+    expected.setPhysicalSockets(2);
+    expected.setVirtualSockets(2);
+    expected.setProductFamily("Red Hat Enterprise Linux");
+    expected.setProductName(
+        "Red Hat Enterprise Linux Server for SAP HANA for Virtual Datacenters with Smart Management, Premium");
+    expected.setServiceLevel(ServiceLevel.PREMIUM);
+    // (Usage ends up coming from derived SKU RH00618F5)
+    expected.setUsage(Usage.PRODUCTION);
+
+    // When getting the upstream Offering,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
+
+    // Then the resulting Offering has the expected virtual sockets from derived sku,
+    // and engOIDs from the derived sku child.
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testOfferingFromUpstreamForOfferingWithRoleAndUsage() {
+    // This checks that role and usage are calculated correctly.
+
+    // Given a marketing SKU that has a defined role and usage,
+    var sku = "RH0180191";
+    var expected = new Offering();
+    expected.setSku(sku);
+    expected.setChildSkus(Set.of("SVCMPV4", "SVCRH01", "SVCRH01V4"));
+    expected.setProductIds(
+        Set.of(
+            69, 70, 84, 86, 91, 92, 93, 94, 127, 133, 176, 180, 182, 201, 205, 240, 246, 271, 272,
+            273, 274, 317, 318, 394, 395, 408, 479, 491, 588, 605));
+    expected.setRole("Red Hat Enterprise Linux Server");
+    expected.setPhysicalSockets(2);
+    expected.setProductFamily("Red Hat Enterprise Linux");
+    expected.setProductName(
+        "Red Hat Enterprise Linux Server, Standard (1-2 sockets) (Up to 4 guests) with Smart Management");
+    expected.setServiceLevel(ServiceLevel.STANDARD);
+    expected.setUsage(Usage.PRODUCTION);
+
+    // When getting the upstream Offering,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
+
+    // Then the resulting Offering has the expected child SKUs, values, and engProdIds.
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testOfferingFromUpstreamWithIflAttrCode() {
+    // Given a marketing SKU wiht attribute code "IFL" in its tree (in this case, in SVCMPV4)
+    var sku = "RH3413336";
+    var expected = new Offering();
+    expected.setSku(sku);
+    expected.setChildSkus(
+        Set.of("SVCEUSRH34", "SVCHPNRH34", "SVCMPV4", "SVCRH34", "SVCRH34V4", "SVCRS", "SVCSFS"));
+    expected.setProductIds(
+        Set.of(
+            68, 69, 70, 71, 83, 84, 85, 86, 90, 91, 92, 93, 132, 133, 172, 176, 179, 180, 190, 201,
+            202, 203, 205, 206, 207, 240, 242, 244, 246, 273, 274, 287, 293, 317, 318, 342, 343,
+            394, 395, 396, 397, 408, 479, 491, 588));
+    expected.setPhysicalCores(4); // Because IFL is 1 which gets multiplied by magical constant 4
+    expected.setPhysicalSockets(2);
+    expected.setProductFamily("Red Hat Enterprise Linux");
+    expected.setProductName("Red Hat Enterprise Linux Developer Workstation, Enterprise");
+    expected.setServiceLevel(ServiceLevel.EMPTY); // Because Dev-Enterprise isn't a ServiceLevel yet
+    expected.setUsage(Usage.DEVELOPMENT_TEST);
+
+    // When getting the upstream Offering,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
+
+    // Then the resulting Offering has the expected child SKUs, engProd OIDs, and values.
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testOfferingFromUpstreamNotFound() {
+    // Given a marketing SKU that doesn't exist upstream,
+    var sku = "BOGUS";
+
+    // When attempting to get the upstream Offering,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub);
+
+    // Then there is no resulting offering.
+    assertTrue(actual.isEmpty(), "When a sku doesn't exist upstream, return an empty Optional.");
+  }
+}


### PR DESCRIPTION
This adds a method that was missing in the implementation for a different ticket, ENT-2664. Since this simplifies how to sync an
offering, the callers OfferingJmxBean and OfferingWorker are updated to use the new method. Unit tests have been moved around as a result: All of the conversion tests are now in UpstreamProductDataTest. Tests for if syncing should happen or not will remain in OfferingSyncCiontrollerTest.

Since syncing is only exposed by that one method, the logging around syncing is updated to make it easier to determine if an offering has been synced or not synced and why.