### PR TITLE
ENT-3284, ENT-3952: Adjust WebApplicationException error handling

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/exception/mapper/WebApplicationExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/exception/mapper/WebApplicationExceptionMapperTest.java
@@ -35,9 +35,9 @@ class WebApplicationExceptionMapperTest {
 
   @Test
   void testMapsWebApplicationException() {
-    String expectedDetail = "FORCED!";
+    String expectedTitle = "FORCED!";
 
-    WebApplicationException exception = new NotFoundException(expectedDetail);
+    WebApplicationException exception = new NotFoundException(expectedTitle);
 
     WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper();
     Response resp = mapper.toResponse(exception);
@@ -49,7 +49,28 @@ class WebApplicationExceptionMapperTest {
 
     Error error = errors.getErrors().get(0);
     assertEquals(String.valueOf(exception.getResponse().getStatus()), error.getStatus());
-    assertEquals(WebApplicationExceptionMapper.ERROR_TITLE, error.getTitle());
+    assertEquals(expectedTitle, error.getTitle());
+  }
+
+  @Test
+  void testMapsWrappedWebApplicationException() {
+    String expectedTitle = "FORCED!";
+    String expectedDetail = "Bad argument";
+
+    IllegalArgumentException cause = new IllegalArgumentException(expectedDetail);
+    WebApplicationException exception = new NotFoundException(expectedTitle, cause);
+
+    WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper();
+    Response resp = mapper.toResponse(exception);
+    Object entityObj = resp.getEntity();
+    assertNotNull(entityObj);
+    assertThat(entityObj, instanceOf(Errors.class));
+    Errors errors = (Errors) entityObj;
+    assertEquals(1, errors.getErrors().size());
+
+    Error error = errors.getErrors().get(0);
+    assertEquals(String.valueOf(exception.getResponse().getStatus()), error.getStatus());
+    assertEquals(expectedTitle, error.getTitle());
     assertEquals(expectedDetail, error.getDetail());
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
@@ -23,6 +23,8 @@ package org.candlepin.subscriptions.exception.mapper;
 import static org.candlepin.subscriptions.security.SecurityConfig.*;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.ext.ExceptionMapper;
 import org.candlepin.subscriptions.exception.ExceptionUtil;
 import org.candlepin.subscriptions.utilization.api.model.Error;
@@ -58,6 +60,10 @@ public abstract class BaseExceptionMapper<T extends Throwable> implements Except
     if (AccessDeniedException.class.isAssignableFrom(exClass)
         || AuthenticationException.class.isAssignableFrom(exClass)) {
       log.error(SECURITY_STACKTRACE, "{}", messageBuf, exception);
+    } else if (Status.fromStatusCode(Integer.parseInt(error.getStatus())).getFamily()
+        == Family.CLIENT_ERROR) {
+      // if it's a 4xx error, log at warn level to prevent log noise
+      log.warn("{}", messageBuf);
     } else {
       log.error("{}", messageBuf, exception);
     }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/WebApplicationExceptionMapper.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/WebApplicationExceptionMapper.java
@@ -34,14 +34,19 @@ import org.springframework.stereotype.Component;
 @Component
 @Provider
 public class WebApplicationExceptionMapper extends BaseExceptionMapper<WebApplicationException> {
-  public static final String ERROR_TITLE = "An rhsm-conduit API error has occurred.";
-
   @Override
   protected Error buildError(WebApplicationException wae) {
-    return new Error()
-        .code(ErrorCode.REQUEST_PROCESSING_ERROR.getCode())
-        .status(String.valueOf(wae.getResponse().getStatus()))
-        .title(ERROR_TITLE)
-        .detail(wae.getMessage());
+    // Because WebApplicationException is an HTTP-oriented wrapper around an exception, we handle
+    // it a little differently. We assume that the message makes a good error title, and we use
+    // the wrapped exception's message as detail (if a wrapped exception is present).
+    Error error =
+        new Error()
+            .code(ErrorCode.REQUEST_PROCESSING_ERROR.getCode())
+            .status(String.valueOf(wae.getResponse().getStatus()))
+            .title(wae.getMessage());
+    if (wae.getCause() != null) {
+      error.setDetail(wae.getCause().getMessage());
+    }
+    return error;
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-3284
https://issues.redhat.com/browse/ENT-3952

I made two adjustments:

1. Use WebApplicationException's message as the error title, and the
   wrapped exceptions message as the error detail (if present).
2. Log any 4xx errors (client errors) at WARN level instead of ERROR.

Testing
-------

Run the application via `RBAC_USE_STUB=true ./gradlew :bootRun`.

Try both:

```
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/foobar' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' \
  | jq

curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/capacity/products/OpenShift%20Container%20Platform?granularity=Hourly2&sla=Premium&beginning=2017-07-21T17%3A32%3A28Z&ending=2017-07-22T17%3A32%3A28Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' \
  | jq
```

Observe that both are logged in the server logs as WARN, and that the
error objects in the response have sufficient detail to distinguish a
non-existent endpoint from a bad enum.