### PR TITLE
Add deployment tests for each profile

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/deployment/ApiDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/ApiDeploymentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.resource.ApiConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"api", "test"})
+class ApiDeploymentTest {
+  @Autowired ApiConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/CapacityIngressDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/CapacityIngressDeploymentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.capacity.CapacityIngressConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"capacity-ingress", "test"})
+class CapacityIngressDeploymentTest {
+  @Autowired CapacityIngressConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/CaptureHourlySnapshotsJobDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/CaptureHourlySnapshotsJobDeploymentTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.candlepin.subscriptions.tally.job.CaptureHourlySnapshotsConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"capture-hourly-snapshots", "kafka-queue", "test"})
+class CaptureHourlySnapshotsJobDeploymentTest {
+  @MockBean JobRunner jobRunner;
+
+  @Autowired CaptureHourlySnapshotsConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/CaptureSnapshotsJobDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/CaptureSnapshotsJobDeploymentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.candlepin.subscriptions.tally.job.CaptureSnapshotsConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"capture-snapshots", "kafka-queue", "test"})
+class CaptureSnapshotsJobDeploymentTest {
+  @MockBean JobRunner jobRunner;
+  @Autowired CaptureSnapshotsConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/LiquibaseDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/LiquibaseDeploymentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.candlepin.subscriptions.util.LiquibaseUpdateOnlyConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"liquibase-only", "test"})
+class LiquibaseDeploymentTest {
+  @MockBean JobRunner jobRunner;
+  @Autowired LiquibaseUpdateOnlyConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/MarketplaceWorkerDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/MarketplaceWorkerDeploymentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.marketplace.MarketplaceWorkerConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"marketplace", "kafka-queue", "test"})
+class MarketplaceWorkerDeploymentTest {
+  @Autowired MarketplaceWorkerConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/MeteringJobDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/MeteringJobDeploymentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.metering.profile.MeteringJobProfile;
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"metering-job", "kafka-queue", "test"})
+class MeteringJobDeploymentTest {
+  @MockBean JobRunner jobRunner;
+  @Autowired MeteringJobProfile configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/MetricsWorkerDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/MetricsWorkerDeploymentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.metering.MeteringConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"openshift-metering-worker", "test"})
+class MetricsWorkerDeploymentTest {
+  @Autowired MeteringConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/OfferingSyncJobDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/OfferingSyncJobDeploymentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.candlepin.subscriptions.tally.job.OfferingSyncConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"offering-sync", "kafka-queue", "test"})
+class OfferingSyncJobDeploymentTest {
+  @MockBean JobRunner jobRunner;
+  @Autowired OfferingSyncConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/PurgeSnapshotsJobDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/PurgeSnapshotsJobDeploymentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.retention.PurgeSnapshotsConfiguration;
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"purge-snapshots", "kafka-queue", "test"})
+class PurgeSnapshotsJobDeploymentTest {
+  @MockBean JobRunner jobRunner;
+  @Autowired PurgeSnapshotsConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/SubscriptionSyncJobDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/SubscriptionSyncJobDeploymentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.candlepin.subscriptions.tally.job.SubscriptionSyncConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"subscription-sync", "kafka-queue", "test"})
+class SubscriptionSyncJobDeploymentTest {
+  @MockBean JobRunner jobRunner;
+  @Autowired SubscriptionSyncConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/deployment/WorkerDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/WorkerDeploymentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"worker", "kafka-queue", "test"})
+class WorkerDeploymentTest {
+  @Autowired TallyWorkerConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskQueueSchemaRegistryTest.java
@@ -41,6 +41,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -118,6 +119,7 @@ public class KafkaTaskQueueSchemaRegistryTest extends KafkaTaskQueueTester {
   }
 
   @TestConfiguration
+  @Profile("test-kafka")
   static class KafkaTaskQueueSchemaRegistryTestConfiguration {
 
     @Bean

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/deployment/OrgSyncJobDeploymentTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/deployment/OrgSyncJobDeploymentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.conduit.job.OrgSyncConfiguration;
+import org.candlepin.subscriptions.spring.JobRunner;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"orgsync", "test"})
+class OrgSyncJobDeploymentTest {
+  @MockBean JobRunner jobRunner;
+  @Autowired OrgSyncConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/deployment/SystemConduitDeploymentTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/deployment/SystemConduitDeploymentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.SystemConduitApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"test"})
+class SystemConduitDeploymentTest {
+  @Autowired SystemConduitApplication configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}


### PR DESCRIPTION
The idea is that each "Deployment Test" simply instantiates the context as is done in deployment instantiates with all necessary beans.

Note I also had to limit the TestConfiguration defined as an inner class in KafkaTaskQueueSchemaRegistryTest to the `kafka-test` profile as it was causing some issues otherwise.