### PR TITLE
Enable subscription sync by default

### DIFF
--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -46,7 +46,7 @@ parameters:
   - name: DATABASE_MAX_POOL_SIZE
     value: '10'
   - name: SUBSCRIPTION_SYNC_ENABLED
-    value: 'false'
+    value: 'true'
 
 objects:
   - apiVersion: v1


### PR DESCRIPTION
Enabling subscription sync by default in all environments. This [PR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/25401) will allow us to toggle it off as needed in higher envs 