### PR TITLE
Add allowlist volume to offering-sync cron config

### DIFF
--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -786,6 +786,8 @@ objects:
                   volumeMounts:
                     - name: logs
                       mountPath: /logs
+                    - name: capacity-allowlist
+                      mountPath: /capacity-allowlist
                 - name: splunk
                   env:
                     - name: SPLUNKMETA_namespace
@@ -816,3 +818,6 @@ objects:
                     secretName: splunk
                 - name: logs
                   emptyDir:
+                - name: capacity-allowlist
+                  configMap:
+                    name: capacity-allowlist


### PR DESCRIPTION
In a previous commit the allowlist was added to the application config but the volume was not mounted. This adds the allowlist volume.