### PR TITLE
Bugfix that addresses ENT-4348.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -212,6 +212,7 @@ public class FactNormalizer {
             .equalsIgnoreCase(hostFacts.getSystemProfileInfrastructureType())) {
       var effectiveCores = calculateVirtualCPU(hostFacts);
       normalizedFacts.setCores(effectiveCores);
+      hostFacts.setCores(effectiveCores); // <-- workaround to prevent rhsm from overwriting logic
     }
     getProductsFromProductIds(normalizedFacts, hostFacts.getSystemProfileProductIds());
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -627,6 +627,19 @@ public class FactNormalizerTest {
     assertEquals(HostHardwareType.VIRTUALIZED, normalizedFacts.getHardwareType());
   }
 
+  @Test
+  void testCalculationOfRhsmVirtualCPUFacts() {
+    InventoryHostFacts facts = createRhsmHost(Arrays.asList(1), 7, 1, null, clock.now());
+
+    facts.setSystemProfileArch("x86_64");
+    facts.setSystemProfileCoresPerSocket(7);
+    facts.setSystemProfileSockets(1);
+    facts.setSystemProfileInfrastructureType("virtual");
+    NormalizedFacts normalizedFacts = normalizer.normalize(facts, Collections.emptyMap());
+    assertEquals(4, normalizedFacts.getCores());
+    assertEquals(HostHardwareType.VIRTUALIZED, normalizedFacts.getHardwareType());
+  }
+
   private void assertClassification(
       NormalizedFacts check, boolean isHypervisor, boolean isHypervisorUnknown, boolean isVirtual) {
     assertEquals(isHypervisor, check.isHypervisor());


### PR DESCRIPTION
Adjust vCPU counting logic to set core values in the InventoryHost. So the same values are consistent within rhsm.
https://issues.redhat.com/browse/ENT-4348

Add new test case for rhsm facts vCU logic
Set the effective cores for virtual x86 hosts in the InventoryHost cores.