### PR TITLE
ENT-3376 Enable subscription sync for cron job

### DIFF
--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -67,6 +67,8 @@ parameters:
     value: 128Mi
   - name: TOKEN_REFRESHER_MEMORY_LIMIT
     value: 150Mi
+  - name: SUBSCRIPTION_SYNC_ENABLED
+    value: true
   # TODO: this should be removed once OCM has non-standard billing_model clusters
   - name: OPENSHIFT_ENABLED_ACCOUNT_PROMQL
     value: "group(min_over_time(subscription_labels{ebs_account != '', billing_model='standard'}[1h])) by (ebs_account)"
@@ -630,6 +632,8 @@ objects:
                       value: ${LOGGING_LEVEL}
                     - name: KAFKA_BOOTSTRAP_HOST
                       value: ${KAFKA_BOOTSTRAP_HOST}
+                    - name: SUBSCRIPTION_SYNC_ENABLED
+                      value: ${SUBSCRIPTION_SYNC_ENABLED}
                     - name: DATABASE_HOST
                       valueFrom:
                         secretKeyRef:


### PR DESCRIPTION
This will set SUBSCRIPTION_SYNC_ENABLED to true for the subscription-sync cron job. With the updates to app-interface (https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/25597) which sets it to false for QA, STAGE, and PROD, this allows only CI to run the periodic subscription sync, until we're ready.