### PR TITLE
Skip hourly processing if there are no events

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -122,4 +122,11 @@ public class EventController {
   public void deleteEvent(UUID eventId) {
     repo.deleteById(eventId);
   }
+
+  @Transactional
+  public boolean hasEventsInTimeRange(
+      String accountNumber, OffsetDateTime startDate, OffsetDateTime endDate) {
+    return repo.existsByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThan(
+        accountNumber, startDate, endDate);
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -83,6 +83,11 @@ public class MetricUsageCollector {
               range.getStartString(), range.getEndString()));
     }
 
+    if (!eventController.hasEventsInTimeRange(
+        accountNumber, range.getStartDate(), range.getEndDate())) {
+      return null;
+    }
+
     /* load the latest account state, so we can update host records conveniently */
     Account account =
         accountRepository

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -130,6 +130,9 @@ public class TallySnapshotController {
       var result =
           retryTemplate.execute(
               context -> metricUsageCollector.collect(accountNumber, snapshotRange));
+      if (result == null) {
+        return;
+      }
 
       var applicableUsageCalculations =
           result.getCalculations().entrySet().stream()

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -64,6 +64,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -462,6 +463,7 @@ class MetricUsageCollectorTest {
               }
               return Stream.of();
             });
+    when(eventController.hasEventsInTimeRange(any(), any(), any())).thenReturn(true);
 
     metricUsageCollector.collect(
         "account123", new DateRange(instanceDate.minusHours(1), instanceDate.plusHours(1)));
@@ -511,6 +513,7 @@ class MetricUsageCollectorTest {
               }
               return Stream.of();
             });
+    when(eventController.hasEventsInTimeRange(any(), any(), any())).thenReturn(true);
 
     metricUsageCollector.collect(
         "account123", new DateRange(instanceDate.minusHours(1), instanceDate.plusHours(1)));
@@ -565,5 +568,15 @@ class MetricUsageCollectorTest {
         Double.valueOf(expectedCoresMeasurement), activeInstance.getMeasurement(Uom.CORES));
     // Instance hours measurement should no longer be present since it was not reported by an event.
     assertNull(activeInstance.getMeasurement(Uom.INSTANCE_HOURS));
+  }
+
+  @Test
+  void testAccountRepoNotTouchedIfNoEventsExist() {
+    when(eventController.hasEventsInTimeRange(any(), any(), any())).thenReturn(false);
+    metricUsageCollector.collect(
+        "account123",
+        new DateRange(
+            clock.startOfCurrentHour().minusHours(1), clock.startOfCurrentHour().plusHours(1)));
+    Mockito.verifyNoInteractions(accountRepo);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -53,6 +53,9 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
       findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
           String accountNumber, OffsetDateTime begin, OffsetDateTime end);
 
+  boolean existsByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThan(
+      String accountNumber, OffsetDateTime begin, OffsetDateTime end);
+
   /**
    * Fetch a stream of events for a given account, event type and event source for a given time
    * range.


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4372

Otherwise, we pull in whole accounts which is wasteful (and causes problematic amounts of load).

This is a forward-port of #590 to the `release` branch.

Also note that given this cleanly merges to `develop` as well, so once we perform the R.C. process, it'll get into develop naturally. (Though I'm happy to do a third PR instead if anyone wants).