### PR TITLE
ENT-4377: Fix count returned in meta to be equal to the no of matched records

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -119,7 +119,7 @@ public class SubscriptionTableController {
         .data(reportItems)
         .meta(
             new HostReportMeta()
-                .count(reportItems.size())
+                .count(capacities.size())
                 .serviceLevel(serviceLevel)
                 .usage(usage)
                 .uom(uom)

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -379,6 +379,35 @@ class SubscriptionTableControllerTest {
   }
 
   @Test
+  void testCountReturnedInMetaIgnoresOffsetAndLimit() {
+
+    List<SubscriptionCapacityView> givenCapacities =
+        givenCapacities(
+            Org.STANDARD,
+            RHEL_SERVER,
+            RH0180191.withSub(Sub.sub("1236", "1237", 5, 6, 6)),
+            RH00604F5.withSub(Sub.sub("1234", "1235", 4, 5, 7)),
+            SubCapSpec.offering(
+                    "RH00604F6", "RHEL Server", 2, 0, 2, 0, ServiceLevel.PREMIUM, Usage.PRODUCTION)
+                .withSub(Sub.sub("1237", "1235", 4, 5, 7)),
+            SubCapSpec.offering(
+                    "RH00604F7", "RHEL Server", 2, 0, 2, 0, ServiceLevel.PREMIUM, Usage.PRODUCTION)
+                .withSub(Sub.sub("1238", "1235", 4, 5, 7)),
+            SubCapSpec.offering(
+                    "RH0060192", "RHEL Server", 2, 0, 2, 0, ServiceLevel.PREMIUM, Usage.PRODUCTION)
+                .withSub(Sub.sub("1239", "1235", 4, 5, 7)));
+
+    when(subscriptionCapacityViewRepository.findAllBy(any(), any(), any(), any(), any(), any()))
+        .thenReturn(givenCapacities);
+
+    SkuCapacityReport reportWithOffsetAndLimit =
+        subscriptionTableController.capacityReportBySku(
+            RHEL_SERVER, 0, 2, null, null, null, SkuCapacityReportSort.SKU, null);
+    assertEquals(2, reportWithOffsetAndLimit.getData().size());
+    assertEquals(5, reportWithOffsetAndLimit.getMeta().getCount());
+  }
+
+  @Test
   void testShouldThrowExceptionOnBadOffset() {
     SubscriptionsException e =
         assertThrows(


### PR DESCRIPTION
Addressing the issue reported in https://issues.redhat.com/browse/ENT-4377.

Currently we set the value of count in meta to be equal to whatever is matched + limit applied. This PR updates that to be equal to the no of records that are matched and ignores the limit.