### PR TITLE
ENT-3376 Add subscription-sync-enabled to application.yaml

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -73,6 +73,7 @@ rhsm-subscriptions:
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:4h}
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:1h}
+  subscription-sync-enabled: ${SUBSCRIPTION_SYNC_ENABLED:false}
   subscription:
     useStub: ${SUBSCRIPTION_USE_STUB:false}
     url: ${SUBSCRIPTION_URL:https://subscription.qa.api.redhat.com/svcrest/subscription/v5}


### PR DESCRIPTION
Without this config option, subscription-sync OpenShift cron job cannot
enqueue subscription sync tasks.

For now, the subscription-sync-enabled option will remain in
application-test.yaml and application-capacity-ingress.yaml. Eventually
the option will become obsolete and can be removed from code and all
configs, or the subscription syncing functionality is fully tested and
deployed and the option can default to true and be removed from the
application-*.yaml files.