### PR TITLE
ENT-3870: Gracefully handle lack of amendment support

### DIFF
--- a/clients/marketplace-client/marketplace-api-spec.yaml
+++ b/clients/marketplace-client/marketplace-api-spec.yaml
@@ -147,6 +147,8 @@ components:
       properties:
         status:
           type: string
+        message:
+          type: string
         batchId:
           type: string
 

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProperties.java
@@ -61,4 +61,7 @@ public class MarketplaceProperties extends HttpClientProperties {
 
   /** Allows manually submitting marketplace tally summary. */
   private boolean isManualMarketplaceSubmissionEnabled;
+
+  /** Log message marker for amendment not enabled/supported. */
+  private String amendmentNotSupportedMarker;
 }

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceUsageSubmissionException.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceUsageSubmissionException.java
@@ -22,15 +22,17 @@ package org.candlepin.subscriptions.marketplace;
 
 import lombok.Getter;
 import lombok.ToString;
+import org.candlepin.subscriptions.marketplace.api.model.StatusResponse;
 
 /** Exception for any issue submitting usage to Marketplace. */
 @Getter
 @ToString
 public class MarketplaceUsageSubmissionException extends RuntimeException {
-  private final String status;
+  public MarketplaceUsageSubmissionException(StatusResponse status) {
+    super(extractMessage(status));
+  }
 
-  public MarketplaceUsageSubmissionException(String message, String status) {
-    super(message);
-    this.status = status;
+  private static String extractMessage(StatusResponse status) {
+    return status.toString();
   }
 }

--- a/src/main/resources/application-marketplace.yaml
+++ b/src/main/resources/application-marketplace.yaml
@@ -13,3 +13,4 @@ rhsm-subscriptions:
       - OpenShift-dedicated-metrics
     verify-batches: ${MARKETPLACE_VERIFY_BATCHES:true}
     manual-marketplace-submission-enabled: ${MARKETPLACE_MANUAL_SUBMISSION_ENABLED:false}
+    amendment-not-supported-marker: ${MARKETPLACE_AMENDMENT_NOT_SUPPORTED_MARKER:(amendments) is not available}

--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -67,6 +67,8 @@ parameters:
     value: 'true'
   - name: MARKETPLACE_MANUAL_SUBMISSION_ENABLED
     value: 'false'
+  - name: MARKETPLACE_AMENDMENT_NOT_SUPPORTED_MARKER
+    value: '(amendments) is not available'
   - name: DATABASE_CONNECTION_TIMEOUT_MS
     value: '30000'
   - name: DATABASE_MAX_POOL_SIZE
@@ -243,6 +245,8 @@ objects:
                   value: ${MARKETPLACE_VERIFY_BATCHES}
                 - name: MARKETPLACE_MANUAL_SUBMISSION_ENABLED
                   value: ${MARKETPLACE_MANUAL_SUBMISSION_ENABLED}
+                - name: MARKETPLACE_AMENDMENT_NOT_SUPPORTED_MARKER
+                  value: ${MARKETPLACE_AMENDMENT_NOT_SUPPORTED_MARKER}
                 - name: SUBSCRIPTION_KEYSTORE_PASSWORD
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-3870

Currently, the only way to detect a submission failed due to lack of
amendment support is to read the error message.

I re-added a dev-only endpoint in order to directly submit Marketplace
usage submission requests.

I also changed the logging to be more useful generally (see example
response below, generally `data`->`*`->`message` has useful info).

<details>
<summary>
Currently the amendment not supported response looks like
</summary>

```json
{
    "status": "failed",
    "message": "One or more events are in progress or failed to process.",
    "errorDetails": [],
    "data": [
        {
            "status": "failed",
            "message": "Requested feature (amendments) is not available on this environment",
            "batchId": REDACTED,
            "payload": {
                "eventId": REDACTED,
                "_eventId": REDACTED,
                "start": 1631178000000,
                "end": 1631181600000,
                "accountId": REDACTED,
                "subscriptionId": REDACTED,
                "additionalAttributes": {},
                "measuredUsage": [
                    {
                        "chargeId": "redhat.com:openshift_dedicated:cluster_hour",
                        "value": 1.0
                    },
                    {
                        "chargeId": "redhat.com:openshift_dedicated:4cpu_hour",
                        "value": 1.5
                    }
                ]
            }
        }
    ]
}
```
</details>

Testing
-------
Reach out for a sandbox API token if needed, please export or replace
below (e.g. `export MARKETPLACE_API_KEY=foobar`)

Run via:

```
MARKETPLACE_MAX_ATTEMPTS=1 \
  DEV_MODE=true \
  MARKETPLACE_API_KEY=$MARKETPLACE_API_KEY \
  MARKETPLACE_URL=https://sandbox.marketplace.redhat.com \
  SPRING_PROFILES_ACTIVE=marketplace \
  ./gradlew :bootRun
```

With the API token in place, use the JMX endpoint at
http://localhost:8080/actuator/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.marketplace-MarketplaceJmxBean-marketplaceJmxBean

Use submitUsage to submit two different types of failures...

See the JIRA issue for values you can use for `EVENTID`, `ACCOUNTID`,
and `SUBSCRIPTIONID`.

<details>
<summary>
First, submit usage with missing fields (example has metricId missing):
</summary>

```json
{
    "data": [
        {
            "eventId": EVENTID,
            "start": 1631178000000,
            "end": 1631181600000,
            "accountId": ACCOUNTID,
            "subscriptionId": SUBSCRIPTIONID,
            "additionalAttributes": {},
            "measuredUsage": [
                {
                    "value": 1.0
                },
                {
                    "value": 1.5
                }
            ]
        }
    ]
}
```
</details>

<details>
<summary>
Observe that the logs contain the whole response object for better
debugging:
</summary>

```
2021-09-21 20:54:53,355 [thread=http-nio-8080-exec-7] [ERROR] [org.candlepin.subscriptions.marketplace.MarketplaceProducer] - Error submitting usage for snapshot IDs: REDACTED
org.candlepin.subscriptions.marketplace.MarketplaceUsageSubmissionException: class StatusResponse {
    status: failed
    message: One or more events are in progress or failed to process.
    data: [class BatchStatus {
        status: failed
        message: Event is not in a valid format
        batchId: REDACTED
    }]
}
```
</details>

<details>
<summary>
Next, try resubmitting an EVENTID that was already processed:
</summary>

```json
{
    "data": [
        {
            "eventId": EVENTID,
            "start": 1631178000000,
            "end": 1631181600000,
            "accountId": ACCOUNTID,
            "subscriptionId": SUBSCRIPTIONID,
            "additionalAttributes": {},
            "measuredUsage": [
                {
                    "metricId": "redhat.com:openshift_dedicated:cluster_hour",
                    "value": 1.0
                },
                {
                    "metricId": "redhat.com:openshift_dedicated:4cpu_hour",
                    "value": 1.5
                }
            ]
        }
    ]
}
```
</details>

<details>
<summary>
Observe in this case the following messages:
</summary>

```
2021-09-21 20:30:34,598 [thread=http-nio-8080-exec-5] [INFO ] [org.candlepin.subscriptions.marketplace.MarketplaceProducer] - Marketplace Batch: REDACTED for Tally Snapshot IDs: REDACTED
2021-09-21 20:30:34,598 [thread=http-nio-8080-exec-5] [WARN ] [org.candlepin.subscriptions.marketplace.MarketplaceProducer] - Amendment attempted (but not supported) w/ eventIds=REDACTED. Skipping verification.
```
</details>