### PR TITLE
ENT-3376 Increase capacity ingress kafka threads

### DIFF
--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -15,6 +15,8 @@ parameters:
     value: INFO
   - name: KAFKA_BOOTSTRAP_HOST
     required: true
+  - name: KAFKA_MESSAGE_THREADS
+    value: '24'
   - name: REPLICAS
     value: '1'
   - name: IMAGE
@@ -138,6 +140,8 @@ objects:
                   value: ${LOGGING_LEVEL}
                 - name: KAFKA_BOOTSTRAP_HOST
                   value: ${KAFKA_BOOTSTRAP_HOST}
+                - name: KAFKA_MESSAGE_THREADS
+                  value: ${KAFKA_MESSAGE_THREADS}
                 - name: DATABASE_HOST
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Bumping up capacity-ingress KAFKA_MESSAGE_THREADS so it can process the
subscription syncs in less than a day.