### PR TITLE
Fix bug in filtering by UOM 

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepositoryTest.java
@@ -511,7 +511,7 @@ class SubscriptionCapacityViewRepositoryTest {
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     socketsAndCores.setSubscriptionId("socketsAndCores");
     socketsAndCores.setPhysicalCores(10);
-    socketsAndCores.setVirtualCores(10);
+    socketsAndCores.setVirtualCores(null);
     socketsAndCores.setPhysicalSockets(10);
     socketsAndCores.setVirtualSockets(10);
 
@@ -553,10 +553,6 @@ class SubscriptionCapacityViewRepositoryTest {
                     SearchCriteria.builder()
                         .key(SubscriptionCapacityView_.physicalCores.getName())
                         .operation(SearchOperation.IS_NOT_NULL)
-                        .build(),
-                    SearchCriteria.builder()
-                        .key(SubscriptionCapacityView_.virtualCores.getName())
-                        .operation(SearchOperation.IS_NOT_NULL)
                         .build()))
             .build();
     List<SubscriptionCapacityView> found = repository.findAll(specification);
@@ -590,7 +586,7 @@ class SubscriptionCapacityViewRepositoryTest {
     socketsAndCores.setPhysicalCores(10);
     socketsAndCores.setVirtualCores(10);
     socketsAndCores.setPhysicalSockets(10);
-    socketsAndCores.setVirtualSockets(10);
+    socketsAndCores.setVirtualSockets(null);
 
     subscriptionRepository.saveAllAndFlush(
         List.of(
@@ -629,10 +625,6 @@ class SubscriptionCapacityViewRepositoryTest {
                 List.of(
                     SearchCriteria.builder()
                         .key(SubscriptionCapacityView_.physicalSockets.getName())
-                        .operation(SearchOperation.IS_NOT_NULL)
-                        .build(),
-                    SearchCriteria.builder()
-                        .key(SubscriptionCapacityView_.virtualSockets.getName())
                         .operation(SearchOperation.IS_NOT_NULL)
                         .build()))
             .build();

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
@@ -96,28 +96,18 @@ public interface SubscriptionCapacityViewRepository
         .build();
   }
 
-  private List<SearchCriteria> searchCriteriaMatchingUomOfCores() {
-    return List.of(
-        SearchCriteria.builder()
-            .key(SubscriptionCapacityView_.physicalCores.getName())
-            .operation(SearchOperation.IS_NOT_NULL)
-            .build(),
-        SearchCriteria.builder()
-            .key(SubscriptionCapacityView_.virtualCores.getName())
-            .operation(SearchOperation.IS_NOT_NULL)
-            .build());
+  private SearchCriteria searchCriteriaMatchingUomOfCores() {
+    return SearchCriteria.builder()
+        .key(SubscriptionCapacityView_.physicalCores.getName())
+        .operation(SearchOperation.IS_NOT_NULL)
+        .build();
   }
 
-  private List<SearchCriteria> searchCriteriaMatchingUomOfSockets() {
-    return List.of(
-        SearchCriteria.builder()
-            .key(SubscriptionCapacityView_.physicalSockets.getName())
-            .operation(SearchOperation.IS_NOT_NULL)
-            .build(),
-        SearchCriteria.builder()
-            .key(SubscriptionCapacityView_.virtualSockets.getName())
-            .operation(SearchOperation.IS_NOT_NULL)
-            .build());
+  private SearchCriteria searchCriteriaMatchingUomOfSockets() {
+    return SearchCriteria.builder()
+        .key(SubscriptionCapacityView_.physicalSockets.getName())
+        .operation(SearchOperation.IS_NOT_NULL)
+        .build();
   }
 
   private List<SearchCriteria> buildSearchCriteria(
@@ -130,8 +120,8 @@ public interface SubscriptionCapacityViewRepository
       Uom uom) {
 
     List<SearchCriteria> searchCriteria = defaultSearchCriteria(ownerId, productId);
-    if (Uom.CORES.equals(uom)) searchCriteria.addAll(searchCriteriaMatchingUomOfCores());
-    if (Uom.SOCKETS.equals(uom)) searchCriteria.addAll(searchCriteriaMatchingUomOfSockets());
+    if (Uom.CORES.equals(uom)) searchCriteria.add(searchCriteriaMatchingUomOfCores());
+    if (Uom.SOCKETS.equals(uom)) searchCriteria.add(searchCriteriaMatchingUomOfSockets());
     if (Objects.nonNull(serviceLevel) && !serviceLevel.equals(ServiceLevel._ANY))
       searchCriteria.add(searchCriteriaMatchingSLA(serviceLevel));
     if (Objects.nonNull(usage) && !usage.equals(Usage._ANY))

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewSpecification.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewSpecification.java
@@ -30,6 +30,7 @@ import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityKey_;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityView;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacityView_;
 import org.springframework.data.jpa.domain.Specification;
 
 @Builder
@@ -60,7 +61,17 @@ public class SubscriptionCapacityViewSpecification
         || SubscriptionCapacityKey_.PRODUCT_ID.equals(criteria.getKey()))
       expression = root.get("key");
 
-    if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_EQUAL)) {
+    if (SubscriptionCapacityView_.PHYSICAL_SOCKETS.equals(criteria.getKey())
+        && criteria.getOperation().equals(SearchOperation.IS_NOT_NULL)) {
+      return builder.or(
+          builder.isNotNull(expression.get(SubscriptionCapacityView_.VIRTUAL_SOCKETS)),
+          builder.isNotNull(expression.get(SubscriptionCapacityView_.PHYSICAL_SOCKETS)));
+    } else if (SubscriptionCapacityView_.PHYSICAL_CORES.equals(criteria.getKey())
+        && criteria.getOperation().equals(SearchOperation.IS_NOT_NULL)) {
+      return builder.or(
+          builder.isNotNull(expression.get(SubscriptionCapacityView_.VIRTUAL_CORES)),
+          builder.isNotNull(expression.get(SubscriptionCapacityView_.PHYSICAL_CORES)));
+    } else if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_EQUAL)) {
       return builder.greaterThanOrEqualTo(
           expression.get(criteria.getKey()), criteria.getValue().toString());
     } else if (criteria.getOperation().equals(SearchOperation.LESS_THAN_EQUAL)) {
@@ -76,8 +87,6 @@ public class SubscriptionCapacityViewSpecification
       return builder.in(expression.get(criteria.getKey())).value(criteria.getValue());
     } else if (criteria.getOperation().equals(SearchOperation.NOT_IN)) {
       return builder.in(expression.get(criteria.getKey())).value(criteria.getValue()).not();
-    } else if (criteria.getOperation().equals(SearchOperation.IS_NOT_NULL)) {
-      return builder.isNotNull(expression.get(criteria.getKey()));
     } else {
       return builder.equal(expression.get(criteria.getKey()), criteria.getValue());
     }


### PR DESCRIPTION
Issue: When filtering by UOM we need the JPA query to do an OR between physical and virtual sockets(or cores), but the current impl does an AND restricting the results returned if some subscription capacity records only have the virtual or physical values populated