### PR TITLE
ENT-4373 Reconcile capacities when offering synced

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
@@ -112,6 +112,12 @@ public class CapacityReconciliationController {
     }
   }
 
+  public void enqueueReconcileCapacityForOffering(String sku) {
+    reconcileCapacityByOfferingKafkaTemplate.send(
+        reconcileCapacityTopic,
+        ReconcileCapacityByOfferingTask.builder().sku(sku).offset(0).limit(100).build());
+  }
+
   private Collection<SubscriptionCapacity> mapSubscriptionToCapacities(Subscription subscription) {
 
     Offering offering = offeringRepository.getById(subscription.getSku());

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -172,8 +172,7 @@ public class SubscriptionSyncController {
     boolean hasMore = subscriptions.size() >= pageSize;
     subscriptions.forEach(this::syncSubscription);
     if (hasMore) {
-      offset = offset + limit;
-      enqueueSubscriptionSync(orgId, offset, limit);
+      enqueueSubscriptionSync(orgId, offset + limit, limit);
     }
     Duration syncDuration = Duration.ofNanos(syncTime.stop(syncTimer));
     log.info(


### PR DESCRIPTION
If an offering's data is changed in the course of getting synced, then
any capacities relating to that offering should be reconciled.

Because reconciling capacities could add time to an offering sync, and
because there could be many offerings to sync each day, a reconciliation
job will be enqueued into kafka per each sku.

Test overview:

- Pick an offering that has at least one or more customers
- Sync the offering, if it isn't already in the swatch DB
- Sync the subscriptions of at least one of those customers
- Change one of the details of the offering in the swatch DB
- Re-sync the offering. Because the offering was changed, the
  capacities for the customer should be reconciled (async).
- Sync the offering a third time. Because the offering was not changed,
  capacities for the customer should not be reconciled

Testing this commit with locally running containers would look like the
following example:

- When running this locally, make sure the logs from bootRun can be seen
- All of these JMX bean commands will use the following bash function
  (copy and paste into bash terminal):

```bash
curl_jmx() {
  curl 'http://localhost:8080/actuator/hawtio/jolokia/?maxDepth=7&maxCollectionSize=50000&ignoreErrors=true&canonicalNaming=false' \
    -H 'Accept: application/json' \
    -H 'Content-Type: text/json' \
    --silent \
    --data-raw "$1"
}
```

- Sync the offering using the OfferingJmxBean, let it complete:
```bash
curl_jmx '{"type":"exec","mbean":"org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean","operation":"syncOffering(java.lang.String)","arguments":["RH00006"]}'
```
- Sync the subscriptions of that org (depending on the org, this may
  take a few seconds to a few minutes, and the operation works in pages,
  so could continue even after the command returns)
```bash
curl_jmx '{"type":"exec","mbean":"org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean","operation":"syncSubscriptionsForOrg(java.lang.String)","arguments":["ASK_FOR_ORGID"]}'
```
- Edit the entry of that offering in the DB, so that when it gets synced
  again, it will change:
```bash
psql -U rhsm-subscriptions -d rhsm-subscriptions  -h localhost -p 5432 -c "UPDATE offering SET role = 'bogus' WHERE sku = 'RH00006';"
```
- Sync the offering a second time. The logs should show the offering was
  updated and the capacities reconciled. The output should have:
  syncResult=FETCHED_AND_SYNCED
```bash
curl_jmx '{"type":"exec","mbean":"org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean","operation":"syncOffering(java.lang.String)","arguments":["RH00006"]}'
```
- Sync the offering a third time. The logs should show the offering
  matches what was previously stored, so was not updated nor were the
  capacities reconciled. The output should have:
  syncResult=SKIPPED_MATCHING
```bash
curl_jmx '{"type":"exec","mbean":"org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean","operation":"syncOffering(java.lang.String)","arguments":["RH00006"]}'
```