### PR TITLE
ENT-3315 Reduce sub-sync page size to 100

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -49,7 +49,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class SubscriptionSyncController {
-  private static final int SUBS_PAGE_SIZE = 2000;
+  private static final int SUBS_PAGE_SIZE = 100;
 
   private SubscriptionRepository subscriptionRepository;
   private OrgConfigRepository orgRepository;


### PR DESCRIPTION
Currently each subscription task is taking longer than kafka timeouts
allow (currently 1hr per task). Reducing page size from 2000 to 100
for now so that the same tasks do not keep blocking the processing of
subscription sync tasks.