### PR TITLE
mstead/ent 4399 update default metric query template

### DIFF
--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -8,6 +8,10 @@ rhsm-subscriptions:
       metric:
         queryTemplates:
           default: >-
+            #{metric.queryParams[prometheusMetric]}
+            * on(_id) group_right
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+          5mSamples: >-
             max(sum_over_time(#{metric.queryParams[prometheusMetric]}[1h:5m]) / 13.0) by (_id)
             * on(_id) group_right
             min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -42,6 +42,7 @@ tagMetrics:
   - tag: OpenShift-metrics
     metricId: redhat.com:openshift_container_platform:cpu_hour
     uom: CORES
+    queryKey: 5mSamples
     queryParams:
       product: ocp
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
@@ -51,6 +52,7 @@ tagMetrics:
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
+    queryKey: 5mSamples
     queryParams:
       product: osd
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
@@ -58,6 +60,7 @@ tagMetrics:
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
+    queryKey: 5mSamples
     queryParams:
       product: osd
       prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)


### PR DESCRIPTION
# Determine generated promql on develop

```
git checkout develop
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_METERING_SERVICE_PROMETHEUS_PROMQL=debug ./gradlew clean bootRun
```

```
curl -X POST --location "http://localhost:8080/actuator/hawtio/jolokia/?maxDepth=7&maxCollectionSize=50000&ignoreErrors=true&canonicalNaming=false" \
    -H "Content-Type: text/json" \
    -d "{\"type\":\"exec\",\"mbean\":\"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean\",\"operation\":\"performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)\",\"arguments\":[\"account123\",\"OpenShift-metrics\",\"2021-09-30T00:00:00Z\",60]}"
```

From log:

2021-09-30 18:28:01,995 [thread=pool-11-thread-1] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder] - PromQL: **max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / 13.0) by (_id) * on(_id) group_right min_over_time(subscription_labels{product="ocp", ebs_account="account123", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])**


# Compare generated promql with change
```
git checkout mstead/ENT-4399-update-default-metric-query-template
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_METERING_SERVICE_PROMETHEUS_PROMQL=debug ./gradlew clean bootRun
```

```
curl -X POST --location "http://localhost:8080/actuator/hawtio/jolokia/?maxDepth=7&maxCollectionSize=50000&ignoreErrors=true&canonicalNaming=false" \
    -H "Content-Type: text/json" \
    -d "{\"type\":\"exec\",\"mbean\":\"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean\",\"operation\":\"performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)\",\"arguments\":[\"account123\",\"OpenShift-metrics\",\"2021-09-30T00:00:00Z\",60]}"
```

From log:
2021-09-30 18:30:37,385 [thread=pool-11-thread-1] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder] - PromQL: **max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / 13.0) by (_id) * on(_id) group_right min_over_time(subscription_labels{product="ocp", ebs_account="account123", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])**

Confirm the PromQL is the same that was generated on the dev branch.

# Test default for defaultKey when omitted from tag_profile.yaml
```
git checkout mstead/ENT-4399-update-default-metric-query-template
```

Open swatch-core/src/main/resources/tag_profile.yaml and delete the three lines that have `queryKey`.  For this we're just testing that the default template still works to generate promQL, but note that this will NOT return correct values to the event table.

```
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_METERING_SERVICE_PROMETHEUS_PROMQL=debug ./gradlew clean bootRun
```

```
curl -X POST --location "http://localhost:8080/actuator/hawtio/jolokia/?maxDepth=7&maxCollectionSize=50000&ignoreErrors=true&canonicalNaming=false" \
    -H "Content-Type: text/json" \
    -d "{\"type\":\"exec\",\"mbean\":\"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean\",\"operation\":\"performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)\",\"arguments\":[\"account123\",\"OpenShift-metrics\",\"2021-09-30T00:00:00Z\",60]}"
```

From log:
2021-09-30 18:35:33,138 [thread=pool-11-thread-1] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder] - PromQL: **cluster:usage:workload:capacity_physical_cpu_cores:max:5m * on(_id) group_right min_over_time(subscription_labels{product="ocp", ebs_account="account123", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])**

Confirm the namespace side of the PromQL is simplified now, including only the defined prometheusMetric name.