### PR TITLE
ENT-4380: Implement new Tally API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -952,6 +952,19 @@ components:
     # If we need additional responses, look at
     # https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/ to reduce
     # redundancy
+    PageLinks:
+      properties:
+        first:
+          type: string
+        last:
+          type: string
+        previous:
+          type: string
+        next:
+          type: string
+      required:
+        - first
+        - last
     TallyReport:
       properties:
         data:
@@ -959,19 +972,7 @@ components:
           items:
             $ref: "#/components/schemas/TallySnapshot"
         links:
-          type: object
-          properties:
-            first:
-              type: string
-            last:
-              type: string
-            previous:
-              type: string
-            next:
-              type: string
-          required:
-            - first
-            - last
+          $ref: "#/components/schemas/PageLinks"
         meta:
           type: object
           properties:
@@ -1117,19 +1118,7 @@ components:
           items:
             $ref: "#/components/schemas/CapacitySnapshot"
         links:
-          type: object
-          properties:
-            first:
-              type: string
-            last:
-              type: string
-            previous:
-              type: string
-            next:
-              type: string
-          required:
-            - first
-            - last
+          $ref: "#/components/schemas/PageLinks"
         meta:
           type: object
           properties:
@@ -1218,19 +1207,7 @@ components:
           items:
             $ref: "#/components/schemas/Host"
         links:
-          type: object
-          properties:
-            first:
-              type: string
-            last:
-              type: string
-            previous:
-              type: string
-            next:
-              type: string
-          required:
-            - first
-            - last
+          $ref: "#/components/schemas/PageLinks"
         meta:
           type: object
           properties:
@@ -1259,19 +1236,7 @@ components:
           items:
             $ref: "#/components/schemas/Host"
         links:
-          type: object
-          properties:
-            first:
-              type: string
-            last:
-              type: string
-            previous:
-              type: string
-            next:
-              type: string
-          required:
-            - first
-            - last
+          $ref: "#/components/schemas/PageLinks"
         meta:
           type: object
           properties:
@@ -1476,19 +1441,7 @@ components:
           items:
             $ref: '#/components/schemas/SkuCapacity'
         links:
-          type: object
-          properties:
-            first:
-              type: string
-            last:
-              type: string
-            previous:
-              type: string
-            next:
-              type: string
-          required:
-            - first
-            - last
+          $ref: "#/components/schemas/PageLinks"
         meta:
           type: object
           properties:

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -167,7 +167,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/MetricId'
         description: "The metric ID to fetch graph data for"
       - name: category
         in: query
@@ -942,6 +942,15 @@ components:
         - OpenShift-metrics
         - OpenShift-dedicated-metrics
         - rhosak
+    MetricId:
+      type: string
+      enum:
+        - Cores
+        - Sockets
+        - Core-seconds
+        - Instance-hours
+        - Storage-gibibytes
+        - Transfer-gibibytes
     ReportCategory:
       type: string
       enum:

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -154,6 +154,91 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /tally/products/{product_id}/{metric_id}:
+    description: "Operations on a data set of a given tally report."
+    parameters:
+      - name: product_id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/ProductId'
+        description: "The product to fetch graph data for"
+      - name: metric_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: "The metric ID to fetch graph data for"
+      - name: category
+        in: query
+        schema:
+          $ref: '#/components/schemas/ReportCategory'
+        description: 'The category to fetch graph data for (optional)'
+      - name: granularity
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/GranularityType'
+        description: "Include only report data matching the specified granularity."
+      - name: sla
+        in: query
+        schema:
+          $ref: '#/components/schemas/ServiceLevelType'
+        description: "Include only report data matching the specified service level."
+      - name: usage
+        in: query
+        schema:
+          $ref: '#/components/schemas/UsageType'
+        description: "Include only report data matching the specified usage."
+      - name: beginning
+        in: query
+        required: true
+        schema:
+          type: string
+          format: date-time
+        description: "Defines the start of the report period. Dates should be provided in ISO 8601
+          format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z"
+      - name: ending
+        in: query
+        required: true
+        schema:
+          type: string
+          format: date-time
+        description: "Defines the end of the report period.  Defaults to the current time. Dates should
+            be provided in UTC."
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: "The number of items to skip before starting to collect the result set"
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+        description: "The numbers of items to return"
+    get:
+      summary: "Fetch tally report data for an account and product. "
+      description: "If page header parameters are omitted, any dates missing data will have an entry with null as the value."
+      operationId: getTallyReportData
+      responses:
+        '200':
+          description: 'The request for a tally report was successful.'
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/TallyReportData"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      tags:
+        - tally
+
   /tally/products/{product_id}:
     description: "Operations for a tally report of a specific account and product."
     parameters:
@@ -175,6 +260,7 @@ paths:
           minimum: 1
         description: "The numbers of items to return"
     get:
+      deprecated: true
       summary: "Fetch a tally report for an account and product. If page header parameters are omitted,
                 then any gaps in the resulting report snapshots are filled with a default fake snapshot."
       operationId: getTallyReport
@@ -855,6 +941,12 @@ components:
         - OpenShift-metrics
         - OpenShift-dedicated-metrics
         - rhosak
+    ReportCategory:
+      type: string
+      enum:
+        - physical
+        - virtual
+        - cloud
     Uom:
       type: string
       enum:
@@ -965,7 +1057,57 @@ components:
       required:
         - first
         - last
+    TallyReportData:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/TallyReportDataPoint"
+        links:
+          $ref: "#/components/schemas/PageLinks"
+        meta:
+          type: object
+          properties:
+            count:
+              type: integer
+            total_monthly:
+              $ref: "#/components/schemas/TallyReportDataPoint"
+            has_cloudigrade_data:
+              type: boolean
+            has_cloudigrade_mismatch:
+              type: boolean
+            product:
+              $ref: '#/components/schemas/ProductId'
+            metric_id:
+              type: string
+            service_level:
+              $ref: '#/components/schemas/ServiceLevelType'
+            usage:
+              $ref: '#/components/schemas/UsageType'
+            granularity:
+              $ref: '#/components/schemas/GranularityType'
+          required:
+            - count
+            - product
+            - metric_id
+            - granularity
+    TallyReportDataPoint:
+      description: "Data point for a given tally report."
+      required:
+        - date
+        - value
+      properties:
+        date:
+          description: "The date for this datapoint."
+          type: string
+          format: date-time
+        value:
+          type: number
+          format: double
+        has_data:
+          type: boolean
     TallyReport:
+      deprecated: true
       properties:
         data:
           type: array
@@ -1004,10 +1146,7 @@ components:
             - product
             - granularity
     TallySnapshot:
-      # Container for fields we capture from the IT endpoint for upload to inventory service.  The element
-      # being reported should be the only non-required element.  E.g. snapshots containing memory will have
-      # date, instance count, and memory elements while snapshots containing cores will contain date,
-      # instance count, and cores.
+      deprecated: true
       required:
         - date
         - instance_count

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 info:
   title: "rhsm-subscriptions-api"
-  description: "REST interface for the rhsm-subscriptions service."
+  description: "REST interface for the rhsm-subscriptions service. Please note any deprecated APIs. Our current deprecation policy is to keep deprecated APIs around for at least 6 months."
   version: 1.0.0
 
 servers:
@@ -261,8 +261,9 @@ paths:
         description: "The numbers of items to return"
     get:
       deprecated: true
-      summary: "Fetch a tally report for an account and product. If page header parameters are omitted,
+      summary: "(Deprecated for removal after 2022-05-01). Fetch a tally report for an account and product. If page header parameters are omitted,
                 then any gaps in the resulting report snapshots are filled with a default fake snapshot."
+      description: "Deprecated: use /tally/products/{product_id}/{metric_id} instead"
       operationId: getTallyReport
       parameters:
         - name: granularity

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -978,9 +978,11 @@ components:
             count:
               type: integer
             total_core_hours:
-              type: double
+              type: number
+              format: double
             total_instance_hours:
-              type: double
+              type: number
+              format: double
             product:
               $ref: '#/components/schemas/ProductId'
             service_level:

--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -42,6 +42,7 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
                 'infrastructure_type': hardware_type or 'PHYSICAL',
                 'cores_per_socket': cores // sockets,
                 'number_of_sockets': sockets,
+                'cloud_provider': cloud_provider,
             }),
             'stale_timestamp': '2030-01-01',
             'reporter': 'rhsm-conduit',
@@ -135,6 +136,10 @@ parser.add_argument('--num-guests',
                     type=int,
                     default=0,
                     help='Insert a number of mock guests, running on a single hypervisor')
+parser.add_argument('--num-aws',
+                    type=int,
+                    default=0,
+                    help='Insert a number of mock aws instances')
 parser.add_argument('--unmapped-guests',
                     default=False,
                     help='Are the guests to be created unmapped?')
@@ -151,9 +156,9 @@ parser.add_argument('--sla',
 parser.add_argument('--usage',
                     help='Set the usage for the inserted hosts')
 parser.add_argument('--cores', default=4,
-                    help='Set the cores for the inserted hosts')
+                    help='Set the cores for the inserted hosts', type=int)
 parser.add_argument('--sockets', default=1,
-                    help='Set the sockets for the inserted hosts')
+                    help='Set the sockets for the inserted hosts', type=int)
 parser.add_argument('--output-sql', action='store_true')
 parser.add_argument('--hbi', action='store_true', dest='is_hbi',
                     help='Mock HBI data rather than tally data')
@@ -200,6 +205,11 @@ for i in range(args.num_accounts):
 
     product = args.product or "RHEL"
 
+    for i in range(args.num_aws):
+        generate_host(account_number=account, hardware_type='VIRTUAL', measurement_type='CLOUD',
+                    product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hbi=args.is_hbi,
+                    cloud_provider='AWS')
+
     for i in range(args.num_physical):
         generate_host(account_number=account, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
                     product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hbi=args.is_hbi)
@@ -207,7 +217,7 @@ for i in range(args.num_accounts):
     hypervisor = None
     for i in range(args.num_hypervisors):
         hypervisor = generate_host(account_number=account, hardware_type='PHYSICAL', measurement_type='VIRTUAL', product=args.product,
-                                sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True)
+                                sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True, is_hbi=args.is_hbi)
         # create a physical entry for the host as well.
         generate_host(account_number=account, hardware_type='PHYSICAL', measurement_type='PHYSICAL', product=args.product,
                     sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True, is_hbi=args.is_hbi)
@@ -217,7 +227,7 @@ for i in range(args.num_accounts):
         if args.hypervisor_id:
             hypervisor_uuid = args.hypervisor_id
         elif hypervisor is not None:
-            hypervisor_uuid = hypervisor['subscription_manager_id']
+            hypervisor_uuid = hypervisor.get('subscription_manager_id') or json.loads(hypervisor['canonical_facts'])['subscription_manager_id']
             # If we are associating the guests with a created hypervisor host, don't allow it to be unmapped
             # since it was considered as reported.
             create_unmapped = False

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -44,9 +44,9 @@ import org.candlepin.subscriptions.utilization.api.model.CapacityReport;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
 import org.candlepin.subscriptions.utilization.api.model.GranularityType;
+import org.candlepin.subscriptions.utilization.api.model.PageLinks;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportLinks;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
 import org.candlepin.subscriptions.utilization.api.resources.CapacityApi;
 import org.springframework.data.domain.Page;
@@ -112,7 +112,7 @@ public class CapacityResource implements CapacityApi {
             ending);
 
     List<CapacitySnapshot> data;
-    TallyReportLinks links;
+    PageLinks links;
     if (offset != null || limit != null) {
       Pageable pageable = ResourceUtils.getPageable(offset, limit);
       data = paginate(capacities, pageable);

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -47,10 +47,10 @@ import org.candlepin.subscriptions.utilization.api.model.HostReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 import org.candlepin.subscriptions.utilization.api.model.HypervisorGuestReport;
 import org.candlepin.subscriptions.utilization.api.model.HypervisorGuestReportMeta;
+import org.candlepin.subscriptions.utilization.api.model.PageLinks;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportLinks;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
 import org.candlepin.subscriptions.utilization.api.resources.HostsApi;
@@ -218,7 +218,7 @@ public class HostsResource implements HostsApi {
               .getContent().stream().map(TallyHostView::asApiHost).collect(Collectors.toList());
     }
 
-    TallyReportLinks links;
+    PageLinks links;
     if (offset != null || limit != null) {
       links = pageLinkCreator.getPaginationLinks(uriInfo, hosts);
     } else {
@@ -253,7 +253,7 @@ public class HostsResource implements HostsApi {
     String accountNumber = ResourceUtils.getAccountNumber();
     Pageable page = ResourceUtils.getPageable(offset, limit);
     Page<Host> guests = repository.getHostsByHypervisor(accountNumber, hypervisorUuid, page);
-    TallyReportLinks links;
+    PageLinks links;
     if (offset != null || limit != null) {
       links = pageLinkCreator.getPaginationLinks(uriInfo, guests);
     } else {

--- a/src/main/java/org/candlepin/subscriptions/resource/ReportCriteria.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ReportCriteria.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource;
+
+import java.time.OffsetDateTime;
+import lombok.Builder;
+import lombok.Data;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
+import org.springframework.data.domain.Pageable;
+
+@Data
+@Builder
+public class ReportCriteria {
+  private String accountNumber;
+  private String productId;
+  private String metricId;
+  private ReportCategory reportCategory;
+  private Granularity granularity;
+  private ServiceLevel serviceLevel;
+  private Usage usage;
+  private OffsetDateTime beginning;
+  private OffsetDateTime ending;
+  private Pageable pageable;
+}

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -49,6 +49,7 @@ import org.candlepin.subscriptions.tally.filler.ReportFiller;
 import org.candlepin.subscriptions.tally.filler.ReportFillerFactory;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.GranularityType;
+import org.candlepin.subscriptions.utilization.api.model.MetricId;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
@@ -98,7 +99,7 @@ public class TallyResource implements TallyApi {
   @Override
   public TallyReportData getTallyReportData(
       ProductId productId,
-      String metricId,
+      MetricId metricId,
       GranularityType granularityType,
       OffsetDateTime beginning,
       OffsetDateTime ending,
@@ -132,7 +133,7 @@ public class TallyResource implements TallyApi {
                 reportCriteria.getEnding(),
                 reportCriteria.getPageable());
 
-    Uom uom = Uom.fromValue(metricId);
+    Uom uom = Uom.fromValue(metricId.toString());
 
     List<org.candlepin.subscriptions.db.model.TallySnapshot> snapshots =
         snapshotPage.stream().collect(Collectors.toList());
@@ -231,7 +232,7 @@ public class TallyResource implements TallyApi {
   @SuppressWarnings("java:S107")
   private ReportCriteria extractReportCriteria(
       ProductId productId,
-      String metricId,
+      MetricId metricId,
       GranularityType granularityType,
       OffsetDateTime beginning,
       OffsetDateTime ending,
@@ -265,7 +266,7 @@ public class TallyResource implements TallyApi {
     return ReportCriteria.builder()
         .accountNumber(ResourceUtils.getAccountNumber())
         .productId(productId.toString())
-        .metricId(metricId)
+        .metricId(Optional.ofNullable(metricId).map(MetricId::toString).orElse(null))
         .granularity(granularityFromValue)
         .reportCategory(category)
         .serviceLevel(serviceLevel)

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -22,9 +22,12 @@ package org.candlepin.subscriptions.resource;
 
 import java.time.OffsetDateTime;
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -33,6 +36,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurement;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
@@ -45,13 +50,18 @@ import org.candlepin.subscriptions.tally.filler.ReportFillerFactory;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.GranularityType;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
+import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportData;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportDataMeta;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
 import org.candlepin.subscriptions.utilization.api.resources.TallyApi;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -60,6 +70,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class TallyResource implements TallyApi {
 
+  private static final Map<ReportCategory, Set<HardwareMeasurementType>> CATEGORY_MAP =
+      Map.of(
+          ReportCategory.PHYSICAL, Set.of(HardwareMeasurementType.PHYSICAL),
+          ReportCategory.VIRTUAL,
+              Set.of(HardwareMeasurementType.VIRTUAL, HardwareMeasurementType.HYPERVISOR),
+          ReportCategory.CLOUD, new HashSet<>(HardwareMeasurementType.getCloudProviderTypes()));
   private final TallySnapshotRepository repository;
   private final PageLinkCreator pageLinkCreator;
   private final ApplicationClock clock;
@@ -67,6 +83,7 @@ public class TallyResource implements TallyApi {
 
   @Context private UriInfo uriInfo;
 
+  @Autowired
   public TallyResource(
       TallySnapshotRepository repository,
       PageLinkCreator pageLinkCreator,
@@ -78,28 +95,158 @@ public class TallyResource implements TallyApi {
     this.productProfileRegistry = productProfileRegistry;
   }
 
-  @SuppressWarnings("linelength")
   @Override
-  @ReportingAccessRequired
-  public TallyReport getTallyReport(
+  public TallyReportData getTallyReportData(
       ProductId productId,
-      @NotNull GranularityType granularityType,
-      @NotNull OffsetDateTime beginning,
-      @NotNull OffsetDateTime ending,
-      Integer offset,
-      @Min(1) Integer limit,
+      String metricId,
+      GranularityType granularityType,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      ReportCategory category,
       ServiceLevelType sla,
       UsageType usageType,
-      Boolean useRunningTotalsFormat) {
+      Integer offset,
+      Integer limit) {
+    ReportCriteria reportCriteria =
+        extractReportCriteria(
+            productId,
+            metricId,
+            granularityType,
+            beginning,
+            ending,
+            category,
+            sla,
+            usageType,
+            offset,
+            limit);
+
+    Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage =
+        repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                reportCriteria.getAccountNumber(),
+                reportCriteria.getProductId(),
+                reportCriteria.getGranularity(),
+                reportCriteria.getServiceLevel(),
+                reportCriteria.getUsage(),
+                reportCriteria.getBeginning(),
+                reportCriteria.getEnding(),
+                reportCriteria.getPageable());
+
+    Uom uom = Uom.fromValue(metricId);
+
+    List<org.candlepin.subscriptions.db.model.TallySnapshot> snapshots =
+        snapshotPage.stream().collect(Collectors.toList());
+
+    List<TallyReportDataPoint> snaps =
+        snapshots.stream()
+            .map(snapshot -> dataPointFromSnapshot(uom, category, snapshot))
+            .collect(Collectors.toList());
+
+    TallyReportData report = new TallyReportData();
+    report.setData(snaps);
+    report.setMeta(new TallyReportDataMeta());
+    report.getMeta().setGranularity(reportCriteria.getGranularity().asOpenApiEnum());
+    report.getMeta().setProduct(productId);
+    report.getMeta().setServiceLevel(sla);
+    report.getMeta().setUsage(usageType == null ? null : reportCriteria.getUsage().asOpenApiEnum());
+
+    Page<org.candlepin.subscriptions.db.model.TallySnapshot> monthlySnaps =
+        repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                reportCriteria.getAccountNumber(),
+                reportCriteria.getProductId(),
+                Granularity.MONTHLY,
+                reportCriteria.getServiceLevel(),
+                reportCriteria.getUsage(),
+                reportCriteria.getBeginning(),
+                reportCriteria.getEnding(),
+                reportCriteria.getPageable());
+
+    // there should be only one monthly retrieved, but just in case, we'll pick the last
+    monthlySnaps.stream()
+        .map(snapshot -> dataPointFromSnapshot(uom, category, snapshot))
+        .forEachOrdered(report.getMeta()::setTotalMonthly);
+
+    // Only set page links if we are paging (not filling).
+    if (reportCriteria.getPageable() != null) {
+      report.setLinks(pageLinkCreator.getPaginationLinks(uriInfo, snapshotPage));
+    }
+
+    // Fill the report gaps if no paging was requested.
+    if (reportCriteria.getPageable() == null) {
+      ReportFiller<TallyReportDataPoint> reportFiller =
+          ReportFillerFactory.getDataPointReportFiller(clock, reportCriteria.getGranularity());
+      report.setData(reportFiller.fillGaps(report.getData(), beginning, ending, false));
+    }
+
+    // Set the count last since the report may have gotten filled.
+    report.getMeta().setCount(report.getData().size());
+    report
+        .getMeta()
+        .setHasCloudigradeData(
+            snapshots.stream().anyMatch(snapshot -> hasCloudigradeData(snapshot, uom)));
+    report
+        .getMeta()
+        .setHasCloudigradeMismatch(
+            snapshots.stream().anyMatch(snapshot -> hasCloudigradeMismatch(snapshot, uom)));
+
+    return report;
+  }
+
+  // NOTE(khowell): deprecated method to be removed by https://issues.redhat.com/browse/ENT-3545
+  @SuppressWarnings("java:S5738")
+  private boolean hasCloudigradeData(
+      org.candlepin.subscriptions.db.model.TallySnapshot tallySnapshot, Uom uom) {
+    if (tallySnapshot.getTallyMeasurements().isEmpty()) {
+      HardwareMeasurement hardwareMeasurement =
+          tallySnapshot.getHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE);
+      return hardwareMeasurement != null && extractLegacyValue(hardwareMeasurement, uom) > 0.0;
+    }
+    Double measurement = tallySnapshot.getMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, uom);
+    return measurement != null && measurement > 0.0;
+  }
+
+  // NOTE(khowell): deprecated method to be removed by https://issues.redhat.com/browse/ENT-3545
+  @SuppressWarnings("java:S5738")
+  private boolean hasCloudigradeMismatch(
+      org.candlepin.subscriptions.db.model.TallySnapshot tallySnapshot, Uom uom) {
+    if (tallySnapshot.getTallyMeasurements().isEmpty()) {
+      HardwareMeasurement cloudigradeMeasurement =
+          tallySnapshot.getHardwareMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE);
+      HardwareMeasurement hbiMeasurement =
+          tallySnapshot.getHardwareMeasurement(HardwareMeasurementType.AWS);
+      return cloudigradeMeasurement != null
+          && (hbiMeasurement == null
+              || extractLegacyValue(cloudigradeMeasurement, uom)
+                  != extractLegacyValue(hbiMeasurement, uom));
+    }
+    Double cloudigradeMeasurement =
+        tallySnapshot.getMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, uom);
+    Double hbiMeasurement = tallySnapshot.getMeasurement(HardwareMeasurementType.AWS, uom);
+    return cloudigradeMeasurement != null
+        && !Objects.equals(cloudigradeMeasurement, hbiMeasurement);
+  }
+
+  /** Validate and extract report criteria */
+  @SuppressWarnings("java:S107")
+  private ReportCriteria extractReportCriteria(
+      ProductId productId,
+      String metricId,
+      GranularityType granularityType,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      ReportCategory category,
+      ServiceLevelType sla,
+      UsageType usageType,
+      Integer offset,
+      Integer limit) {
     // When limit and offset are not specified, we will fill the report with dummy
     // records from beginning to ending dates. Otherwise we page as usual.
     Pageable pageable = null;
-    boolean fill = limit == null && offset == null;
-    if (!fill) {
+    if (limit != null || offset != null) {
       pageable = ResourceUtils.getPageable(offset, limit);
     }
 
-    String accountNumber = ResourceUtils.getAccountNumber();
     ServiceLevel serviceLevel = ResourceUtils.sanitizeServiceLevel(sla);
     Usage effectiveUsage = ResourceUtils.sanitizeUsage(usageType);
     Granularity granularityFromValue = Granularity.fromString(granularityType.toString());
@@ -115,18 +262,115 @@ public class TallyResource implements TallyApi {
       MDC.put("INVALID_GRANULARITY", Boolean.TRUE.toString());
       throw new BadRequestException(e.getMessage());
     }
+    return ReportCriteria.builder()
+        .accountNumber(ResourceUtils.getAccountNumber())
+        .productId(productId.toString())
+        .metricId(metricId)
+        .granularity(granularityFromValue)
+        .reportCategory(category)
+        .serviceLevel(serviceLevel)
+        .usage(effectiveUsage)
+        .pageable(pageable)
+        .beginning(beginning)
+        .ending(ending)
+        .build();
+  }
+
+  private TallyReportDataPoint dataPointFromSnapshot(
+      Uom uom,
+      ReportCategory category,
+      org.candlepin.subscriptions.db.model.TallySnapshot snapshot) {
+    double value;
+    if (snapshot.getTallyMeasurements().isEmpty()) {
+      value = extractLegacyValue(uom, category, snapshot);
+    } else {
+      value = extractValue(uom, category, snapshot);
+    }
+    return new TallyReportDataPoint().date(snapshot.getSnapshotDate()).value(value).hasData(true);
+  }
+
+  // NOTE(khowell): deprecated method to be removed by https://issues.redhat.com/browse/ENT-3545
+  @SuppressWarnings("java:S5738")
+  private double extractLegacyValue(
+      Uom uom,
+      ReportCategory category,
+      org.candlepin.subscriptions.db.model.TallySnapshot snapshot) {
+    Set<HardwareMeasurementType> contributingTypes = getContributingTypes(category);
+    return contributingTypes.stream()
+        .map(snapshot::getHardwareMeasurement)
+        .filter(Objects::nonNull)
+        .mapToDouble(m -> extractLegacyValue(m, uom))
+        .sum();
+  }
+
+  private double extractLegacyValue(HardwareMeasurement hardwareMeasurement, Uom uom) {
+    switch (uom) {
+      case CORES:
+        return hardwareMeasurement.getCores();
+      case SOCKETS:
+        return hardwareMeasurement.getSockets();
+      default:
+        throw new IllegalArgumentException(uom + " cannot be extracted from HardwareMeasurement");
+    }
+  }
+
+  private double extractValue(
+      Uom uom,
+      ReportCategory category,
+      org.candlepin.subscriptions.db.model.TallySnapshot snapshot) {
+    Set<HardwareMeasurementType> contributingTypes = getContributingTypes(category);
+    return contributingTypes.stream()
+        .mapToDouble(type -> Optional.ofNullable(snapshot.getMeasurement(type, uom)).orElse(0.0))
+        .sum();
+  }
+
+  private Set<HardwareMeasurementType> getContributingTypes(ReportCategory category) {
+    Set<HardwareMeasurementType> contributingTypes;
+    if (category == null) {
+      contributingTypes = Set.of(HardwareMeasurementType.TOTAL);
+    } else {
+      contributingTypes = CATEGORY_MAP.get(category);
+    }
+    return contributingTypes;
+  }
+
+  @SuppressWarnings("linelength")
+  @Override
+  @ReportingAccessRequired
+  public TallyReport getTallyReport(
+      ProductId productId,
+      @NotNull GranularityType granularityType,
+      @NotNull OffsetDateTime beginning,
+      @NotNull OffsetDateTime ending,
+      Integer offset,
+      @Min(1) Integer limit,
+      ServiceLevelType sla,
+      UsageType usageType,
+      Boolean useRunningTotalsFormat) {
+    ReportCriteria reportCriteria =
+        extractReportCriteria(
+            productId,
+            null,
+            granularityType,
+            beginning,
+            ending,
+            null,
+            sla,
+            usageType,
+            offset,
+            limit);
 
     Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage =
         repository
             .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
-                accountNumber,
-                productId.toString(),
-                granularityFromValue,
-                serviceLevel,
-                effectiveUsage,
-                beginning,
-                ending,
-                pageable);
+                reportCriteria.getAccountNumber(),
+                reportCriteria.getProductId(),
+                reportCriteria.getGranularity(),
+                reportCriteria.getServiceLevel(),
+                reportCriteria.getUsage(),
+                reportCriteria.getBeginning(),
+                reportCriteria.getEnding(),
+                reportCriteria.getPageable());
 
     List<TallySnapshot> snaps =
         snapshotPage.stream()
@@ -136,10 +380,10 @@ public class TallyResource implements TallyApi {
     TallyReport report = new TallyReport();
     report.setData(snaps);
     report.setMeta(new TallyReportMeta());
-    report.getMeta().setGranularity(granularityFromValue.asOpenApiEnum());
+    report.getMeta().setGranularity(reportCriteria.getGranularity().asOpenApiEnum());
     report.getMeta().setProduct(productId);
     report.getMeta().setServiceLevel(sla);
-    report.getMeta().setUsage(usageType == null ? null : effectiveUsage.asOpenApiEnum());
+    report.getMeta().setUsage(usageType == null ? null : reportCriteria.getUsage().asOpenApiEnum());
     report.getMeta().setTotalCoreHours(getTotalCoreHours(report));
     report.getMeta().setTotalInstanceHours(getTotalInstanceHours(report));
 
@@ -148,14 +392,16 @@ public class TallyResource implements TallyApi {
     }
 
     // Only set page links if we are paging (not filling).
-    if (pageable != null) {
+    if (reportCriteria.getPageable() != null) {
       report.setLinks(pageLinkCreator.getPaginationLinks(uriInfo, snapshotPage));
     }
 
     // Fill the report gaps if no paging was requested.
-    if (fill) {
-      ReportFiller reportFiller = ReportFillerFactory.getInstance(clock, granularityFromValue);
-      reportFiller.fillGaps(report, beginning, ending, useRunningTotalsFormat);
+    if (reportCriteria.getPageable() == null) {
+      ReportFiller<TallySnapshot> reportFiller =
+          ReportFillerFactory.getInstance(clock, reportCriteria.getGranularity());
+      report.setData(
+          reportFiller.fillGaps(report.getData(), beginning, ending, useRunningTotalsFormat));
     }
 
     // Set the count last since the report may have gotten filled.

--- a/src/main/java/org/candlepin/subscriptions/resteasy/PageLinkCreator.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/PageLinkCreator.java
@@ -26,7 +26,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportLinks;
+import org.candlepin.subscriptions.utilization.api.model.PageLinks;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -37,14 +37,14 @@ import org.springframework.stereotype.Component;
 public class PageLinkCreator {
 
   /**
-   * Create a Links object with first, last, previous, next API links.
+   * Create a PageLinks object with first, last, previous, next API links.
    *
    * @param uriInfo pre-existing URI to be used as a template for the page links
    * @param page Spring Data JPA page object
-   * @return a populate TallyReportLinks object
+   * @return a populate PageLinks object
    */
-  public TallyReportLinks getPaginationLinks(UriInfo uriInfo, Page page) {
-    TallyReportLinks links = new TallyReportLinks();
+  public PageLinks getPaginationLinks(UriInfo uriInfo, Page page) {
+    PageLinks links = new PageLinks();
     if (page.previousPageable() != Pageable.unpaged()) {
       links.setPrevious(formatUri(uriWithOffset(uriInfo, page.previousPageable().getOffset())));
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerAdapter.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Interface for an operations for an item that ReportFiller can operate on.
+ *
+ * @param <T> the type of item in the List to be filled.
+ */
+public interface ReportFillerAdapter<T> {
+
+  boolean itemIsLarger(T oldData, T newData);
+
+  T createDefaultItem(OffsetDateTime itemDate, T previous, boolean useRunningTotalFormat);
+
+  OffsetDateTime getDate(T item);
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
@@ -23,6 +23,8 @@ package org.candlepin.subscriptions.tally.filler;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.SnapshotTimeAdjuster;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 
 /** Responsible for creating ReportFiller objects based on granularity. */
 public class ReportFillerFactory {
@@ -32,14 +34,30 @@ public class ReportFillerFactory {
   }
 
   /**
-   * Creates an instance of a ReportFiller based on a Granularity.
+   * Creates an instance of a ReportFiller based on a Granularity, for filling in lists of
+   * TallySnapshot.
    *
    * @param clock an application clock instance to base dates off of.
    * @param granularity the target granularity
    * @return a ReportFiller instance for the specified granularity.
    */
-  public static ReportFiller getInstance(ApplicationClock clock, Granularity granularity) {
+  public static ReportFiller<TallySnapshot> getInstance(
+      ApplicationClock clock, Granularity granularity) {
     SnapshotTimeAdjuster timeAdjuster = SnapshotTimeAdjuster.getTimeAdjuster(clock, granularity);
-    return new ReportFiller(timeAdjuster, clock);
+    return new ReportFiller<>(timeAdjuster, new TallySnapshotAdapter(clock));
+  }
+
+  /**
+   * Creates an instance of a ReportFiller based on a Granularity, for filling in lists of
+   * TallyReportDataPoint.
+   *
+   * @param clock an application clock instance to base dates off of.
+   * @param granularity the target granularity
+   * @return a ReportFiller instance for the specified granularity.
+   */
+  public static ReportFiller<TallyReportDataPoint> getDataPointReportFiller(
+      ApplicationClock clock, Granularity granularity) {
+    SnapshotTimeAdjuster timeAdjuster = SnapshotTimeAdjuster.getTimeAdjuster(clock, granularity);
+    return new ReportFiller<>(timeAdjuster, new TallyReportDataPointAdapter());
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapter.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import java.time.OffsetDateTime;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
+
+public class TallyReportDataPointAdapter implements ReportFillerAdapter<TallyReportDataPoint> {
+
+  @Override
+  public boolean itemIsLarger(TallyReportDataPoint oldData, TallyReportDataPoint newData) {
+    return newData.getValue() >= oldData.getValue();
+  }
+
+  @Override
+  public TallyReportDataPoint createDefaultItem(
+      OffsetDateTime itemDate, TallyReportDataPoint previous, boolean useRunningTotalFormat) {
+    return new TallyReportDataPoint().date(itemDate).hasData(false).value(0.0);
+  }
+
+  @Override
+  public OffsetDateTime getDate(TallyReportDataPoint item) {
+    return item.getDate();
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/TallySnapshotAdapter.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/TallySnapshotAdapter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import java.time.OffsetDateTime;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
+
+public class TallySnapshotAdapter implements ReportFillerAdapter<TallySnapshot> {
+
+  private final ApplicationClock clock;
+
+  public TallySnapshotAdapter(ApplicationClock clock) {
+    this.clock = clock;
+  }
+
+  @Override
+  public boolean itemIsLarger(TallySnapshot oldSnap, TallySnapshot newSnap) {
+    return newSnap.getInstanceCount() > oldSnap.getInstanceCount()
+        || newSnap.getCores() > oldSnap.getCores()
+        || newSnap.getSockets() > oldSnap.getSockets();
+  }
+
+  @Override
+  public TallySnapshot createDefaultItem(
+      OffsetDateTime itemDate, TallySnapshot previous, boolean useRunningTotalFormat) {
+    if (itemDate.isBefore(clock.now()) && useRunningTotalFormat && previous != null) {
+      return new TallySnapshot()
+          .date(itemDate)
+          .cores(previous.getCores())
+          .sockets(previous.getSockets())
+          .instanceCount(previous.getInstanceCount())
+          .physicalSockets(previous.getPhysicalSockets())
+          .physicalCores(previous.getPhysicalCores())
+          .physicalInstanceCount(previous.getPhysicalInstanceCount())
+          .hypervisorSockets(previous.getHypervisorSockets())
+          .hypervisorCores(previous.getHypervisorCores())
+          .hypervisorInstanceCount(previous.getHypervisorInstanceCount())
+          .cloudInstanceCount(previous.getCloudInstanceCount())
+          .cloudSockets(previous.getCloudSockets())
+          .cloudCores(previous.getCloudCores())
+          .coreHours(previous.getCoreHours())
+          .hasData(
+              true); // has_data = true means that the frontend should show the value in a tooltip
+    }
+    Integer defaultValueInteger;
+    Double defaultValue;
+    if (itemDate.isBefore(clock.now())) {
+      defaultValueInteger = 0;
+      defaultValue = 0.0;
+    } else {
+      defaultValueInteger = null;
+      defaultValue = null;
+    }
+    return new TallySnapshot()
+        .date(itemDate)
+        .cores(defaultValueInteger)
+        .sockets(defaultValueInteger)
+        .instanceCount(defaultValueInteger)
+        .physicalSockets(defaultValueInteger)
+        .physicalCores(defaultValueInteger)
+        .physicalInstanceCount(defaultValueInteger)
+        .hypervisorSockets(defaultValueInteger)
+        .hypervisorCores(defaultValueInteger)
+        .hypervisorInstanceCount(defaultValueInteger)
+        .cloudInstanceCount(defaultValueInteger)
+        .cloudSockets(defaultValueInteger)
+        .cloudCores(defaultValueInteger)
+        .coreHours(defaultValue)
+        .hasData(false);
+  }
+
+  @Override
+  public OffsetDateTime getDate(TallySnapshot item) {
+    return item.getDate();
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -51,6 +51,7 @@ import org.candlepin.subscriptions.security.RoleProvider;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.GranularityType;
+import org.candlepin.subscriptions.utilization.api.model.MetricId;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
@@ -661,7 +662,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -687,7 +688,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -718,7 +719,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -747,7 +748,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -775,7 +776,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -803,7 +804,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -827,7 +828,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -859,7 +860,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -888,7 +889,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -924,7 +925,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),
@@ -955,7 +956,7 @@ public class TallyResourceTest {
     TallyReportData response =
         resource.getTallyReportData(
             ProductId.RHEL,
-            "Cores",
+            MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
             OffsetDateTime.parse("2021-10-30T00:00Z"),

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -21,6 +21,8 @@
 package org.candlepin.subscriptions.resource;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.ParameterizedTest.DEFAULT_DISPLAY_NAME;
+import static org.junit.jupiter.params.ParameterizedTest.DISPLAY_NAME_PLACEHOLDER;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -36,6 +38,7 @@ import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurement;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
@@ -49,12 +52,18 @@ import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.GranularityType;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
+import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportData;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -635,5 +644,326 @@ public class TallyResourceTest {
           resource.getTallyReport(
               RHEL_PRODUCT_ID, GranularityType.DAILY, min, max, null, null, null, null, false);
         });
+  }
+
+  @Test
+  void testTallyReportDataTotalUsingHardwareMeasurements() {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    HardwareMeasurement measurement = new HardwareMeasurement();
+    measurement.setCores(4);
+    snapshot.setHardwareMeasurement(HardwareMeasurementType.TOTAL, measurement);
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(
+        4.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+  }
+
+  @Test
+  void testTallyReportDataTotalUsingTallyMeasurements() {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    snapshot.setMeasurement(HardwareMeasurementType.TOTAL, Uom.CORES, 4.0);
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(
+        4.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+  }
+
+  @EnumSource
+  @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
+  void testTallyReportDataCategoriesUsingHardwareMeasurements(ReportCategory category) {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    for (HardwareMeasurementType hardwareMeasurementType : HardwareMeasurementType.values()) {
+      HardwareMeasurement measurement = new HardwareMeasurement();
+      measurement.setCores(4);
+      snapshot.setHardwareMeasurement(hardwareMeasurementType, measurement);
+    }
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(
+        4.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+  }
+
+  @EnumSource
+  @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
+  void testTallyReportDataCategoriesUsingTallyMeasurements(ReportCategory category) {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    for (HardwareMeasurementType hardwareMeasurementType : HardwareMeasurementType.values()) {
+      snapshot.setMeasurement(hardwareMeasurementType, Uom.CORES, 4.0);
+    }
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(
+        4.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+  }
+
+  @Test
+  void testTallyReportDataMonthlyTotalsPopulatedUsingHardwareMeasurements() {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
+    cloudigradeMeasurement.setCores(4);
+    snapshot.setHardwareMeasurement(HardwareMeasurementType.TOTAL, cloudigradeMeasurement);
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(4.0, response.getMeta().getTotalMonthly().getValue());
+    assertEquals(
+        OffsetDateTime.parse("2021-10-05T00:00Z"), response.getMeta().getTotalMonthly().getDate());
+    assertTrue(response.getMeta().getTotalMonthly().getHasData());
+  }
+
+  @Test
+  void testTallyReportDataMonthlyTotalsPopulatedUsingTallyMeasurements() {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    snapshot.setMeasurement(HardwareMeasurementType.TOTAL, Uom.CORES, 4.0);
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(4.0, response.getMeta().getTotalMonthly().getValue());
+    assertEquals(
+        OffsetDateTime.parse("2021-10-05T00:00Z"), response.getMeta().getTotalMonthly().getDate());
+    assertTrue(response.getMeta().getTotalMonthly().getHasData());
+  }
+
+  @Test
+  void testTallyReportDataReportFiller() {
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of()));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(30, response.getMeta().getCount());
+    assertEquals(30, response.getData().size());
+  }
+
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
+  void testTallyReportDataHasCloudigradeDataUsingHardwareMeasurements(boolean hasCloudigradeData) {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    if (hasCloudigradeData) {
+      HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
+      cloudigradeMeasurement.setCores(4);
+      snapshot.setHardwareMeasurement(
+          HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
+    }
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(hasCloudigradeData, response.getMeta().getHasCloudigradeData());
+  }
+
+  @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
+  @ValueSource(booleans = {true, false})
+  void testTallyReportDataHasCloudigradeDataUsingTallyMeasurements(
+      boolean hasCloudigradeMeasurement) {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    if (hasCloudigradeMeasurement) {
+      snapshot.setMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, Uom.CORES, 4.0);
+    }
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(hasCloudigradeMeasurement, response.getMeta().getHasCloudigradeData());
+  }
+
+  @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
+  @ValueSource(booleans = {true, false})
+  void testTallyReportDataHasCloudigradeMismatchUsingHardwareMeasurements(
+      boolean hasCloudigradeMismatch) {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    HardwareMeasurement awsMeasurement = new HardwareMeasurement();
+    awsMeasurement.setCores(4);
+    HardwareMeasurement cloudigradeMeasurement = new HardwareMeasurement();
+    cloudigradeMeasurement.setCores(4);
+    if (hasCloudigradeMismatch) {
+      cloudigradeMeasurement.setCores(8);
+    }
+    snapshot.setHardwareMeasurement(HardwareMeasurementType.AWS, awsMeasurement);
+    snapshot.setHardwareMeasurement(
+        HardwareMeasurementType.AWS_CLOUDIGRADE, cloudigradeMeasurement);
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(hasCloudigradeMismatch, response.getMeta().getHasCloudigradeMismatch());
+  }
+
+  @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
+  @ValueSource(booleans = {true, false})
+  void testTallyReportDataHasCloudigradeMismatchUsingTallyMeasurements(
+      boolean hasCloudigradeMismatch) {
+    TallySnapshot snapshot = new TallySnapshot();
+    snapshot.setAccountNumber("account123");
+    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+    snapshot.setMeasurement(HardwareMeasurementType.AWS, Uom.CORES, 4.0);
+    snapshot.setMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, Uom.CORES, 4.0);
+    if (hasCloudigradeMismatch) {
+      snapshot.setMeasurement(HardwareMeasurementType.AWS_CLOUDIGRADE, Uom.CORES, 8.0);
+    }
+    when(repository
+            .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndSnapshotDateBetweenOrderBySnapshotDate(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            "Cores",
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-10-01T00:00Z"),
+            OffsetDateTime.parse("2021-10-30T00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(hasCloudigradeMismatch, response.getMeta().getHasCloudigradeMismatch());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resteasy/PageLinkCreatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/PageLinkCreatorTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Arrays;
 import java.util.Collections;
 import javax.ws.rs.core.UriInfo;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportLinks;
+import org.candlepin.subscriptions.utilization.api.model.PageLinks;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.jboss.resteasy.specimpl.ResteasyUriBuilder;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +52,7 @@ class PageLinkCreatorTest {
   void testNoResultsOffsets() {
     Pageable pageable = PageRequest.of(0, 50);
     Page<TallySnapshot> page = new PageImpl<>(Collections.emptyList(), pageable, 0);
-    TallyReportLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
+    PageLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
     assertEquals("/?offset=0", links.getFirst());
     assertEquals("/?offset=0", links.getLast());
     assertNull(links.getPrevious());
@@ -67,7 +67,7 @@ class PageLinkCreatorTest {
             Arrays.asList(new TallySnapshot(), new TallySnapshot(), new TallySnapshot()),
             pageable,
             3);
-    TallyReportLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
+    PageLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
     assertEquals("/?offset=0", links.getFirst());
     assertEquals("/?offset=2", links.getLast());
     assertNull(links.getPrevious());
@@ -82,7 +82,7 @@ class PageLinkCreatorTest {
             Arrays.asList(new TallySnapshot(), new TallySnapshot(), new TallySnapshot()),
             pageable,
             3);
-    TallyReportLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
+    PageLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
     assertEquals("/?offset=0", links.getFirst());
     assertEquals("/?offset=2", links.getLast());
     assertEquals("/?offset=1", links.getPrevious());
@@ -97,7 +97,7 @@ class PageLinkCreatorTest {
             Arrays.asList(new TallySnapshot(), new TallySnapshot(), new TallySnapshot()),
             pageable,
             3);
-    TallyReportLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
+    PageLinks links = new PageLinkCreator().getPaginationLinks(uriInfo, page);
     assertEquals("/?offset=0", links.getFirst());
     assertEquals("/?offset=2", links.getLast());
     assertEquals("/?offset=0", links.getPrevious());

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
@@ -49,7 +49,7 @@ public class DailyReportFillerTest {
     OffsetDateTime end = start.plusDays(3);
 
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -72,7 +72,7 @@ public class DailyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -104,7 +104,7 @@ public class DailyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -128,7 +128,7 @@ public class DailyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -158,7 +158,7 @@ public class DailyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap2, snap1);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/HourlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/HourlyReportFillerTest.java
@@ -49,7 +49,7 @@ class HourlyReportFillerTest {
     OffsetDateTime end = start.plusHours(3);
 
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -71,7 +71,7 @@ class HourlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(5, filled.size());
@@ -105,7 +105,7 @@ class HourlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -129,7 +129,7 @@ class HourlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -159,7 +159,7 @@ class HourlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap2, snap1);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
@@ -49,7 +49,7 @@ public class MonthlyReportFillerTest {
     OffsetDateTime end = start.plusMonths(3);
 
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -70,7 +70,7 @@ public class MonthlyReportFillerTest {
     OffsetDateTime expectedStart = clock.startOfMonth(start);
 
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -90,7 +90,7 @@ public class MonthlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -113,7 +113,7 @@ public class MonthlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
@@ -48,7 +48,7 @@ public class QuarterlyReportFillerTest {
     OffsetDateTime start = clock.startOfCurrentQuarter();
     OffsetDateTime end = start.plusYears(1);
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(5, filled.size());
@@ -69,7 +69,7 @@ public class QuarterlyReportFillerTest {
     OffsetDateTime expectedStart = clock.startOfQuarter(start);
 
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(5, filled.size());
@@ -90,7 +90,7 @@ public class QuarterlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(5, filled.size());
@@ -114,7 +114,7 @@ public class QuarterlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(5, filled.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
@@ -49,7 +49,7 @@ public class WeeklyReportFillerTest {
     OffsetDateTime end = start.plusWeeks(3);
 
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -70,7 +70,7 @@ public class WeeklyReportFillerTest {
     OffsetDateTime expectedStart = clock.startOfWeek(start);
 
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -90,7 +90,7 @@ public class WeeklyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -113,7 +113,7 @@ public class WeeklyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
@@ -48,7 +48,7 @@ public class YearlyReportFillerTest {
     OffsetDateTime start = clock.startOfCurrentYear();
     OffsetDateTime end = start.plusYears(3);
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -68,7 +68,7 @@ public class YearlyReportFillerTest {
     OffsetDateTime expectedStart = clock.startOfYear(start);
 
     TallyReport report = new TallyReport();
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -88,7 +88,7 @@ public class YearlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());
@@ -111,7 +111,7 @@ public class YearlyReportFillerTest {
     List<TallySnapshot> snaps = Arrays.asList(snap1, snap2);
 
     TallyReport report = new TallyReport().data(snaps);
-    filler.fillGaps(report, start, end, false);
+    report.setData(filler.fillGaps(report.getData(), start, end, false));
 
     List<TallySnapshot> filled = report.getData();
     assertEquals(4, filled.size());


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4380

In doing so, I had to refactor a couple of things:

1. I refactored ReportFiller to operate on a `List<T>` where `T` can be any type, but an adapter must be built to specify how to create default `T`, extract date from `T`, and to compare `T`.
2. I refactored the parameter handling so that parsing/validation of params is done in a shared function. In doing so, I introduced a parameter object I named ReportCriteria.

Future work could:

- use `ReportCriteria` more directly in the repo.
- use `ReportCriteria` in CapacityResource.

Also, note one small deviation from the card as written: talking with @cdcabrera, he suggested use of `total_monthly` rather than `monthly_total`.

Testing (HBI-based tally)
-------------------------

1. Start the application:

```
SPRING_PROFILES_ACTIVE=worker,api DEV_MODE=true ./gradlew bootRun
```

2. Insert some mock hosts:

```
bin/insert-mock-hosts \
  --clear \
  --hbi \
  --num-physical=1 \
  --num-hypervisor=2 \
  --num-aws=3 \
  --num-guests=5 \
  --sockets=1 \
  --cores=2
bin/insert-mock-hosts \
  --hbi \
  --num-guests=7 \
  --unmapped-guests=true \
  --sockets=1 \
  --cores=2
```

3. Kick off tally:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia' \
  -H 'Content-Type: text/json' \
  -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
    "operation":"tallyAccount(java.lang.String)",
    "arguments":["account123"]
  }'
```

4. Try the new API using the different categories (can also use http://localhost:8080/api-docs instead), each one should have data for today's date.

```
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL/Cores?granularity=Daily&beginning=2021-10-01T00%3A00Z&ending=2021-10-30T00%3A00Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL/Cores?granularity=Daily&beginning=2021-10-01T00%3A00Z&ending=2021-10-30T00%3A00Z&category=physical' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL/Cores?granularity=Daily&beginning=2021-10-01T00%3A00Z&ending=2021-10-30T00%3A00Z&category=virtual' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL/Cores?granularity=Daily&beginning=2021-10-01T00%3A00Z&ending=2021-10-30T00%3A00Z&category=cloud' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

Testing (event-based tally)
---------------------------

1. Start the application:

```
SPRING_PROFILES_ACTIVE=worker,api DEV_MODE=true ./gradlew bootRun
```

2. Insert a mock event:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia' \
  -H 'Content-Type: text/json' \
  -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=eventJmxBean,type=EventJmxBean",
    "operation":"saveEvents(java.lang.String)",
    "arguments":["[{
      \"event_source\": \"prometheus\",
      \"event_type\": \"snapshot_redhat.com:openshift_container_platform:cpu_hour\",
      \"account_number\": \"account123\",
      \"service_type\": \"OpenShift Cluster\",
      \"instance_id\": \"1384bd5e-1358-421f-9043-925fc33193d2\",
      \"timestamp\": \"2021-06-01T00:00:00Z\",
      \"expiration\": \"2021-06-01T01:00:00Z\",
      \"display_name\": \"1384bd5e-1358-421f-9043-925fc33193d2\",
      \"measurements\": [{
        \"value\": 20.0,
        \"uom\": \"Cores\"
      }],
      \"role\": \"ocp\",
      \"sla\": \"Premium\"
    }]"]}'
```

3. Kick off hourly tally:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia' \
  -H 'Content-Type: text/json' \
  -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
    "operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)",
    "arguments":["account123", "2021-06-01T00:00Z", "2021-08-23T00:00Z"]
  }'
```

4. Try the new API (can also use http://localhost:8080/api-docs instead), should see a value for 2021-06-01

```
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics/Cores?granularity=Daily&beginning=2021-06-01T00%3A00Z&ending=2021-06-05T00%3A00Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```