### PR TITLE
ENT-4403: Fixed baseline hourly tally

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -85,6 +85,7 @@ public class MetricUsageCollector {
 
     if (!eventController.hasEventsInTimeRange(
         accountNumber, range.getStartDate(), range.getEndDate())) {
+      log.info("No event metrics to process in range: {}", range);
       return null;
     }
 

--- a/src/test/java/org/candlepin/subscriptions/util/DateRangeTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/DateRangeTest.java
@@ -21,7 +21,9 @@
 package org.candlepin.subscriptions.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -52,5 +54,19 @@ class DateRangeTest {
     OffsetDateTime start = now;
     OffsetDateTime end = now.minusHours(1);
     assertThrows(IllegalArgumentException.class, () -> new DateRange(start, end));
+  }
+
+  @Test
+  void testContains() {
+    OffsetDateTime now = OffsetDateTime.now();
+    OffsetDateTime expectedStart = now.minusHours(4);
+    OffsetDateTime expectedEnd = now.plusHours(4);
+
+    DateRange range = new DateRange(expectedStart, expectedEnd);
+    assertTrue(range.contains(now));
+    assertTrue(range.contains(expectedStart));
+    assertTrue(range.contains(expectedEnd));
+    assertFalse(range.contains(now.minusHours(5)));
+    assertFalse(range.contains(now.plusHours(5)));
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/util/DateRange.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/util/DateRange.java
@@ -104,4 +104,14 @@ public class DateRange {
   public String getEndString() {
     return endDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
   }
+
+  public boolean contains(OffsetDateTime testDate) {
+    return (testDate.isAfter(startDate) && testDate.isBefore(endDate))
+        || testDate.equals(startDate)
+        || testDate.equals(endDate);
+  }
+
+  public String toString() {
+    return String.format("[%s - %s]", getStartString(), getEndString());
+  }
 }


### PR DESCRIPTION
When realigning snapshots, make sure that we only
clear the finest granularity snapshots that are
within the range of the tally. Otherwise, events
outside of that range will not be reflected in
tally.

https://issues.redhat.com/browse/ENT-4403

## Testing

Start with a fresh database, then run the application.

```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions

```

```
USER_USE_STUB=true DEV_MODE=true ./gradlew clean bootRun
```

1.  Opt in your account.

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' \
-H 'Content-Type: application/json' \
-d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["account123","123456",true,true,true]}'
```

2.  Add some event data. The following adds events for 2 difference OSD instances both with Cores/Instance-hours reported on Sept 24 from 12AM - 2AM.

```
# Create a file with the request data.
cat << EOF > events-jmx.json
{"type": "exec", "mbean": "org.candlepin.subscriptions.jmx:name=eventJmxBean,type=EventJmxBean", "operation": "saveEvents(java.lang.String)", "arguments": ["[{\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:4cpu_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"timestamp\": \"2021-09-24T00:00:00Z\", \"expiration\": \"2021-09-24T01:00:00Z\", \"display_name\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"measurements\": [{\"value\": 29.354649, \"uom\": \"Cores\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:cluster_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"timestamp\": \"2021-09-24T00:00:00Z\", \"expiration\": \"2021-09-24T01:00:00Z\", \"display_name\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"measurements\": [{\"value\": 19.562196, \"uom\": \"Instance-hours\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:4cpu_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"timestamp\": \"2021-09-24T00:00:00Z\", \"expiration\": \"2021-09-24T01:00:00Z\", \"display_name\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"measurements\": [{\"value\": 75.149354, \"uom\": \"Cores\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:cluster_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"timestamp\": \"2021-09-24T00:00:00Z\", \"expiration\": \"2021-09-24T01:00:00Z\", \"display_name\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"measurements\": [{\"value\": 97.183116, \"uom\": \"Instance-hours\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:4cpu_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"timestamp\": \"2021-09-24T01:00:00Z\", \"expiration\": \"2021-09-24T02:00:00Z\", \"display_name\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"measurements\": [{\"value\": 54.928335, \"uom\": \"Cores\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:cluster_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"timestamp\": \"2021-09-24T01:00:00Z\", \"expiration\": \"2021-09-24T02:00:00Z\", \"display_name\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"measurements\": [{\"value\": 55.852859, \"uom\": \"Instance-hours\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:4cpu_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"timestamp\": \"2021-09-24T01:00:00Z\", \"expiration\": \"2021-09-24T02:00:00Z\", \"display_name\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"measurements\": [{\"value\": 81.259371, \"uom\": \"Cores\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:cluster_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"timestamp\": \"2021-09-24T01:00:00Z\", \"expiration\": \"2021-09-24T02:00:00Z\", \"display_name\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"measurements\": [{\"value\": 87.966649, \"uom\": \"Instance-hours\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:4cpu_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"timestamp\": \"2021-09-24T02:00:00Z\", \"expiration\": \"2021-09-24T03:00:00Z\", \"display_name\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"measurements\": [{\"value\": 38.480999, \"uom\": \"Cores\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:cluster_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"timestamp\": \"2021-09-24T02:00:00Z\", \"expiration\": \"2021-09-24T03:00:00Z\", \"display_name\": \"668b2c40-2258-4da3-8819-e62c7ceadb44\", \"measurements\": [{\"value\": 41.933459, \"uom\": \"Instance-hours\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:4cpu_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"timestamp\": \"2021-09-24T02:00:00Z\", \"expiration\": \"2021-09-24T03:00:00Z\", \"display_name\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"measurements\": [{\"value\": 43.959846, \"uom\": \"Cores\"}], \"role\": \"osd\", \"sla\": \"Premium\"}, {\"event_source\": \"prometheus\", \"event_type\": \"snapshot_redhat.com:openshift_dedicated:cluster_hour\", \"account_number\": \"account123\", \"service_type\": \"OpenShift Cluster\", \"instance_id\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"timestamp\": \"2021-09-24T02:00:00Z\", \"expiration\": \"2021-09-24T03:00:00Z\", \"display_name\": \"85316ecc-7838-4f9b-a11e-74ed8b5d5fc9\", \"measurements\": [{\"value\": 50.606594, \"uom\": \"Instance-hours\"}], \"role\": \"osd\", \"sla\": \"Premium\"}]"]}
EOF
```

```
# Hit the JMX endpoint with the data above
curl 'http://localhost:8080/actuator/hawtio/jolokia/' \
-H 'Content-Type: application/json' \
-d @events-jmx.json
```


Once the JMX is run, verify that you have events in your DB. It helps to connect to the DB with the UTC timezone as follows.
```
PGTZ=UTC psql -U rhsm-subscriptions rhsm-subscriptions
```
```
-- Should have 12 events.
select timestamp, event_type, instance_id, data->'measurements'->0->>'uom', data->'measurements'->0->>'value' from events order by timestamp, event_type;
```
3.  Run an hourly tally from 12am - 1am on Sept 24

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' \
-H 'Content-Type: application/json' \
-d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123", "2021-09-24T00:00Z", "2021-09-24T01:00Z"]}'
```

4.  Check that the tally report shows the correct values in the tally. Look at the hourly snapshot for 12am. It should have data, and the vaues should include the cores/instance-hours from only the events that occurred at that time. The overall totals should just include the data from this hour. The instance monthly totals should also match these overall totals.

```
select timestamp, event_type, instance_id, data->'measurements'->0->>'uom', data->'measurements'->0->>'value' from events order by timestamp, event_type;
```

```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-09-24T00:00:00.000Z&ending=2021-09-24T05:59:59.999Z" | jq
```
```
select uom, sum(mt.value) from instance_monthly_totals mt, hosts h where h.id = mt.instance_id and month='2021-09' and h.account_number='account123' group by uom;
```
5.  Run the hourly tally from 1am - 2am.

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' \
-H 'Content-Type: application/json' \
-d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123", "2021-09-24T01:00Z", "2021-09-24T02:00Z"]}'
```


6.  Check that the tally report shows the correct values in the tally. Look at the hourly snapshot for 12am and 1am. They should have data, and the vaues should include the cores/instance-hours from only the events that occurred at those times. The overall total should be the sum of all hours.The instance monthly totals should also match these overall totals.

**NOTE: This is where the bug begins to occur. Without this patch, the above validation will fail. The numbers do not line up correctly in the snapshots. You will notice that the snpahot for 12am will have been cleared at this point, and the totals will be off since only the 1am snapshot will appear. The instance monthly totals will be off as well.**


```
select timestamp, event_type, instance_id, data->'measurements'->0->>'uom', data->'measurements'->0->>'value' from events order by timestamp, event_type;
```

```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-09-24T00:00:00.000Z&ending=2021-09-24T05:59:59.999Z" | jq
```
```
select uom, sum(mt.value) from instance_monthly_totals mt, hosts h where h.id = mt.instance_id and month='2021-09' and h.account_number='account123' group by uom;
```
7.  Run the hourly tally from 2am - 3am.

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' \
-H 'Content-Type: application/json' \
-d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123", "2021-09-24T02:00Z", "2021-09-24T03:00Z"]}'
```

8.  Check that the tally report shows the correct values in the tally. Look at the hourly snapshot for 12am, 1am and 2am. They should have data, and the vaues for each should include the cores/instance-hours from only the events that occurred at the corresponding times. The overall total should be the sum of all hours.

```
select timestamp, event_type, instance_id, data->'measurements'->0->>'uom', data->'measurements'->0->>'value' from events order by timestamp, event_type;
```

```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-09-24T00:00:00.000Z&ending=2021-09-24T05:59:59.999Z" | jq
```
```
select uom, sum(mt.value) from instance_monthly_totals mt, hosts h where h.id = mt.instance_id and month='2021-09' and h.account_number='account123' group by uom;
```
9.  Delete all events that occurred at 1am.

```
delete from events where extract(month from timestamp) = 9 and extract(hour from timestamp) = 1;
```

10. Run a tally from 12am - 3am again.

```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' \
-H 'Content-Type: application/json' \
-d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123", "2021-09-24T00:00Z", "2021-09-24T03:00Z"]}'
```

11. Confirm that the totals for 12am and 3am are correct and that the overall totals are correct. Also, verify that the 2am snapshot shows **has_data: true** and cores and instance-hours values are now 0 since there are no events for that hour.

```
select timestamp, event_type, instance_id, data->'measurements'->0->>'uom', data->'measurements'->0->>'value' from events order by timestamp, event_type;
```

```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ==" "http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics?granularity=hourly&beginning=2021-09-24T00:00:00.000Z&ending=2021-09-24T05:59:59.999Z" | jq
```
```
select uom, sum(mt.value) from instance_monthly_totals mt, hosts h where h.id = mt.instance_id and month='2021-09' and h.account_number='account123' group by uom;
```