### PR TITLE
ENT-4406 Speed up per-org subscription syncs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -20,9 +20,11 @@
  */
 package org.candlepin.subscriptions.subscription;
 
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import org.candlepin.subscriptions.subscription.api.model.Subscription;
+import org.candlepin.subscriptions.subscription.api.model.SubscriptionProduct;
 import org.candlepin.subscriptions.subscription.api.resources.SearchApi;
 
 /** Stub version of the SearchApi for the Subscription service for local testing. */
@@ -46,6 +48,11 @@ public class StubSearchApi extends SearchApi {
   }
 
   private Subscription createData() {
-    return new Subscription().subscriptionNumber("2253591");
+    var now = OffsetDateTime.now();
+    return new Subscription()
+        .subscriptionNumber("2253591")
+        .effectiveStartDate(now.minusYears(10).toEpochSecond() * 1000L)
+        .effectiveEndDate(now.plusYears(10).toEpochSecond() * 1000L)
+        .subscriptionProducts(List.of(new SubscriptionProduct().sku("sku")));
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceProperties.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.subscription;
 
 import java.time.Duration;
+import java.time.Period;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -38,7 +39,13 @@ public class SubscriptionServiceProperties extends HttpClientProperties {
   private int maxRetryAttempts = 4;
 
   /** Page size for subscription queries */
-  private int pageSize = 500;
+  private int pageSize = 1000;
+
+  /** Do not sync any subs that have expired longer than this much in the past from now. */
+  private Period ignoreExpiredOlderThan = Period.ofMonths(2);
+
+  /** Do not sync any subs starting later than this much in the future from now. */
+  private Period ignoreStartingLaterThan = Period.ofMonths(2);
 
   /**
    * The initial sleep interval between retries when retrying fetching info from the Subscription

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,14 +75,16 @@ rhsm-subscriptions:
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:1h}
   subscription-sync-enabled: ${SUBSCRIPTION_SYNC_ENABLED:false}
   subscription:
-    useStub: ${SUBSCRIPTION_USE_STUB:false}
+    use-stub: ${SUBSCRIPTION_USE_STUB:false}
     url: ${SUBSCRIPTION_URL:https://subscription.qa.api.redhat.com/svcrest/subscription/v5}
     keystore: file:${SUBSCRIPTION_KEYSTORE:}
-    keystorePassword: ${SUBSCRIPTION_KEYSTORE_PASSWORD:changeit}
-    maxConnections: ${SUBSCRIPTION_MAX_CONNECTIONS:100}
-    backOffInitialInterval: ${SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL:1s}
-    maxRetryAttempts: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS:4}
-    pageSize: ${SUBSCRIPTION_PAGE_SIZE:500}
+    keystore-password: ${SUBSCRIPTION_KEYSTORE_PASSWORD:changeit}
+    max-connections: ${SUBSCRIPTION_MAX_CONNECTIONS:100}
+    back-off-initial-interval: ${SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL:1s}
+    max-retry-attempts: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS:4}
+    page-size: ${SUBSCRIPTION_PAGE_SIZE:1000}
+    ignore-expired-older-than: ${SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN:2m}
+    ignore-starting-later-than: ${SUBSCRIPTION_IGNORE_STARTING_LATER_THAN:2m}
     tasks:
       topic: platform.rhsm-subscriptions.subscription-sync
       kafka-group-id: subscription-worker

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
@@ -94,7 +94,8 @@ class CapacityReconciliationControllerTest {
     when(whitelist.productIdMatches(any())).thenReturn(true);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(new HashSet<>(productIds));
     when(offeringRepository.getById("MCT3718")).thenReturn(offering);
-    when(subscriptionCapacityRepository.findByKeySubscriptionId("456"))
+    when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
+            "123", Collections.singletonList("456")))
         .thenReturn(Collections.emptyList());
 
     capacityReconciliationController.reconcileCapacityForSubscription(newSubscription);
@@ -150,7 +151,8 @@ class CapacityReconciliationControllerTest {
     when(whitelist.productIdMatches(any())).thenReturn(true);
     when(capacityProductExtractor.getProducts(updatedOffering)).thenReturn(productIds);
     when(offeringRepository.getById("MCT3718")).thenReturn(updatedOffering);
-    when(subscriptionCapacityRepository.findByKeySubscriptionId("456"))
+    when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
+            "123", Collections.singletonList("456")))
         .thenReturn(existingCapacities);
 
     capacityReconciliationController.reconcileCapacityForSubscription(updatedSubscription);
@@ -192,7 +194,8 @@ class CapacityReconciliationControllerTest {
     when(capacityProductExtractor.getProducts(offering))
         .thenReturn(Set.of("RHEL", "RHEL Workstation"));
     when(offeringRepository.getById("MCT3718")).thenReturn(offering);
-    when(subscriptionCapacityRepository.findByKeySubscriptionId("456"))
+    when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
+            "123", Collections.singletonList("456")))
         .thenReturn(existingCapacities);
 
     capacityReconciliationController.reconcileCapacityForSubscription(subscription);
@@ -211,7 +214,8 @@ class CapacityReconciliationControllerTest {
     when(whitelist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(Set.of("RHEL1", "RHEL2"));
     when(offeringRepository.getById("MCT3718")).thenReturn(offering);
-    when(subscriptionCapacityRepository.findByKeySubscriptionId("456"))
+    when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
+            "123", Collections.singletonList("456")))
         .thenReturn(Collections.emptyList());
 
     capacityReconciliationController.reconcileCapacityForSubscription(subscription);
@@ -254,7 +258,9 @@ class CapacityReconciliationControllerTest {
     when(whitelist.productIdMatches(any())).thenReturn(true);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(productIds);
     when(offeringRepository.getById("MCT3718")).thenReturn(offering);
-    when(subscriptionCapacityRepository.findByKeySubscriptionId("456")).thenReturn(staleCapacities);
+    when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
+            "123", Collections.singletonList("456")))
+        .thenReturn(staleCapacities);
 
     capacityReconciliationController.reconcileCapacityForSubscription(subscription);
     verify(subscriptionCapacityRepository).saveAll(newCapacities);

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -21,14 +21,17 @@
 package org.candlepin.subscriptions.subscription;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.stream.IntStream;
 import org.candlepin.subscriptions.capacity.CapacityReconciliationController;
 import org.candlepin.subscriptions.capacity.files.ProductWhitelist;
@@ -149,9 +152,10 @@ class SubscriptionSyncControllerTest {
   }
 
   @Test
-  void shouldSyncSubscriptionsWithinLimitForOrgAndQueueTaskForNext() throws InterruptedException {
+  void shouldSyncSubscriptionsWithinLimitForOrgAndQueueTaskForNext() {
+    when(whitelist.productIdMatches(any())).thenReturn(true);
+    Mockito.when(offeringRepository.existsById("testsku")).thenReturn(true);
 
-    CountDownLatch latch = new CountDownLatch(1);
     List<org.candlepin.subscriptions.subscription.api.model.Subscription> subscriptions =
         List.of(
             createDto(100, "456", 10),
@@ -174,10 +178,77 @@ class SubscriptionSyncControllerTest {
         });
 
     subscriptionSyncController.syncSubscriptions("100", 0, 2);
+    verify(subscriptionRepository, times(3)).save(any());
     verify(subscriptionsKafkaTemplate)
         .send(
             "platform.rhsm-subscriptions.subscription-sync",
             SyncSubscriptionsTask.builder().orgId("100").offset(2).limit(2).build());
+  }
+
+  @Test
+  void shouldSyncSubscriptionsSyncSubIfRecent() {
+    when(whitelist.productIdMatches(any())).thenReturn(true);
+    Mockito.when(offeringRepository.existsById(any())).thenReturn(true);
+
+    // When syncing an org's subs, a sub should be synced if it is within effective*Dates
+    var dto = createDto("456", 10);
+    dto.setEffectiveStartDate(toEpochMillis(NOW.minusMonths(6)));
+    dto.setEffectiveEndDate(toEpochMillis(NOW.plusMonths(6)));
+    Mockito.when(subscriptionService.getSubscriptionsByOrgId(any(), anyInt(), anyInt()))
+        .thenReturn(List.of(dto));
+
+    subscriptionSyncController.syncSubscriptions("100", 0, 1);
+
+    verify(subscriptionService).getSubscriptionsByOrgId("100", 0, 2);
+    verify(subscriptionRepository).save(any());
+  }
+
+  @Test
+  void shouldSyncSubscriptionsSkipSubIfTooExpired() {
+    // When syncing an org's subs, don't sync subscriptions that expired more than 2 months ago
+    var dto = createDto("456", 10);
+    dto.setEffectiveStartDate(toEpochMillis(NOW.minusMonths(14)));
+    dto.setEffectiveEndDate(toEpochMillis(NOW.minusMonths(2)));
+    Mockito.when(subscriptionService.getSubscriptionsByOrgId(any(), anyInt(), anyInt()))
+        .thenReturn(List.of(dto));
+
+    subscriptionSyncController.syncSubscriptions("100", 0, 1);
+
+    verify(subscriptionService).getSubscriptionsByOrgId("100", 0, 2);
+    verifyNoInteractions(whitelist, offeringRepository, subscriptionRepository);
+  }
+
+  @Test
+  void shouldSyncSubscriptionsSkipSubIfTooFutureDated() {
+    // When syncing an org's subs, don't sync subscriptions future-dated more than 2 months from now
+    var dto = createDto("456", 10);
+    dto.setEffectiveStartDate(toEpochMillis(NOW.plusMonths(2).plusDays(1)));
+    dto.setEffectiveEndDate(toEpochMillis(NOW.plusMonths(14).plusDays(1)));
+    Mockito.when(subscriptionService.getSubscriptionById("456")).thenReturn(dto);
+
+    Mockito.when(subscriptionService.getSubscriptionsByOrgId(any(), anyInt(), anyInt()))
+        .thenReturn(List.of(dto));
+    subscriptionSyncController.syncSubscriptions("100", 0, 1);
+
+    verify(subscriptionService).getSubscriptionsByOrgId("100", 0, 2);
+    verifyNoInteractions(whitelist, offeringRepository, subscriptionRepository);
+  }
+
+  @Test
+  void shouldSyncSubscriptionsSkipSubIfNullDates() {
+    // It is rare for effective dates from upstream to be null. It could mean a data issue upstream.
+    // Because of this, consider the sub to be invalid, and don't sync its info with swatch.
+    var dto = createDto("456", 10);
+    dto.setEffectiveStartDate(null);
+    dto.setEffectiveEndDate(null);
+    Mockito.when(subscriptionService.getSubscriptionById("456")).thenReturn(dto);
+
+    Mockito.when(subscriptionService.getSubscriptionsByOrgId(any(), anyInt(), anyInt()))
+        .thenReturn(List.of(dto));
+    subscriptionSyncController.syncSubscriptions("100", 0, 1);
+
+    verify(subscriptionService).getSubscriptionsByOrgId("100", 0, 2);
+    verifyNoInteractions(whitelist, offeringRepository, subscriptionRepository);
   }
 
   @Test
@@ -215,8 +286,8 @@ class SubscriptionSyncControllerTest {
     dto.setQuantity(quantity);
     dto.setId(Integer.valueOf(subId));
     dto.setSubscriptionNumber("123");
-    dto.setEffectiveStartDate(NOW.toEpochSecond());
-    dto.setEffectiveEndDate(NOW.plusDays(30).toEpochSecond());
+    dto.setEffectiveStartDate(toEpochMillis(NOW));
+    dto.setEffectiveEndDate(toEpochMillis(NOW.plusDays(30)));
     dto.setWebCustomerId(orgId);
 
     var product = new SubscriptionProduct().parentSubscriptionProductId(null).sku("testsku");
@@ -239,5 +310,12 @@ class SubscriptionSyncControllerTest {
         .endDate(clock.dateFromMilliseconds(subscription.getEffectiveEndDate()))
         .marketplaceSubscriptionId(SubscriptionDtoUtil.extractMarketplaceId(subscription))
         .build();
+  }
+
+  private static Long toEpochMillis(OffsetDateTime offsetDateTime) {
+    if (offsetDateTime == null) {
+      return null;
+    }
+    return offsetDateTime.toEpochSecond() * 1000L;
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -32,6 +32,4 @@ public interface SubscriptionCapacityRepository
 
   List<SubscriptionCapacity> findByKeyOwnerIdAndKeySubscriptionIdIn(
       String ownerId, List<String> subscriptionIds);
-
-  List<SubscriptionCapacity> findByKeySubscriptionId(String subscriptionId);
 }

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -51,6 +51,10 @@ parameters:
     value: 'true'
   - name: SUBSCRIPTION_URL
     value: https://subscription.qa.api.redhat.com/svcrest/subscription/v5
+  - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN
+    value: 2m
+  - name: SUBSCRIPTION_IGNORE_STARTING_LATER_THAN
+    value: 2m
   - name: PRODUCT_URL
     value: https://product.qa.api.redhat.com/svcrest/product/v3
 
@@ -213,6 +217,10 @@ objects:
                   value: /service-certs/keystore.jks
                 - name: SUBSCRIPTION_URL
                   value: ${SUBSCRIPTION_URL}
+                - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN
+                  value: ${SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN}
+                - name: SUBSCRIPTION_IGNORE_STARTING_LATER_THAN
+                  value: ${SUBSCRIPTION_IGNORE_STARTING_LATER_THAN}
                 - name: PRODUCT_URL
                   value: ${PRODUCT_URL}
                 - name: SUBSCRIPTION_KEYSTORE_PASSWORD


### PR DESCRIPTION
The following changes are made to improve performance on per-org
subscription syncs:

- Use SubscriptionCapacityRepository's
  findByKeyOwnerIdAndKeySubscriptionIdIn(
  String ownerId, List<String> subscriptionIds) method instead of
  findByKeySubscriptionId(String subscriptionId), since the former
  can take advantage of the (owner_id, product_id, subscription_id)
  primary key
- Subs expired longer than 2 months or future dated subs more than 2
  months from now will not be synced.
- Fetch more subs-per-page (again)

To test locally:

```bash
    curl 'http://localhost:8080/actuator/hawtio/jolokia/?maxDepth=7&maxCollectionSize=50000&ignoreErrors=true&canonicalNaming=false' \
        -H 'Accept: application/json' \
        -H 'Content-Type: text/json' \
        --data-raw '{"type":"exec","mbean":"org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean","operation":"syncSubscriptionsForOrg(java.lang.String)","arguments":["$ORG_ID"]}'
```

A log message should appear that shows how many subs were fetched and
how many were synced.