### PR TITLE
ENT-4333: Add metering configuration for RHOSAK data storage

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.json.TallyMeasurement;
+import org.candlepin.subscriptions.registry.TagMetaData;
+import org.candlepin.subscriptions.registry.TagMetric;
+import org.candlepin.subscriptions.registry.TagProfile;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"api", "test"})
+class RhosakTagProfileTest {
+
+  @Autowired private TagProfile tagProfile;
+
+  @ParameterizedTest
+  @MethodSource("tagMetricTestArgs")
+  void testTagMetric(String tag, Measurement.Uom uom, TagMetric expectedTagMetric) {
+    Optional<TagMetric> tagMetric = tagProfile.getTagMetric(tag, uom);
+    assertTrue(tagMetric.isPresent());
+    assertEquals(expectedTagMetric, tagMetric.get());
+  }
+
+  static Stream<Arguments> tagMetricTestArgs() {
+    return Stream.of(
+        Arguments.of(
+            "rhosak",
+            Uom.STORAGE_GIBIBYTES,
+            TagMetric.builder()
+                .tag("rhosak")
+                .metricId("redhat.com:rhosak:storage_gb")
+                .uom(Uom.STORAGE_GIBIBYTES)
+                .queryKey("default")
+                .accountQueryKey("default")
+                .queryParams(
+                    Map.of(
+                        "product", "rhosak",
+                        "prometheusMetric",
+                            "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes",
+                        "prometheusMetadataMetric", "subscription_labels"))
+                .build()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("tagMetaDataTestArgs")
+  void testTagMetaData(String tag, TagMetaData expectedTagMetaData) {
+    Optional<TagMetaData> md = tagProfile.getTagMetaDataByTag(tag);
+    assertTrue(md.isPresent());
+    assertEquals(expectedTagMetaData, md.get());
+  }
+
+  static Stream<Arguments> tagMetaDataTestArgs() {
+    return Stream.of(
+        Arguments.of(
+            "rhosak",
+            TagMetaData.builder()
+                .defaultSla(ServiceLevel.PREMIUM)
+                .finestGranularity(Granularity.HOURLY)
+                .serviceType("Kafka Cluster")
+                .defaultUsage(Usage.PRODUCTION)
+                .tags(Set.of("rhosak"))
+                .build()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("promethuesEnabledLookupArgs")
+  void testPrometueusEnabledMeasurements(String tag, TallyMeasurement.Uom uom, String exMetricId) {
+    assertTrue(tagProfile.getTagsWithPrometheusEnabledLookup().contains(tag));
+    assertEquals(exMetricId, tagProfile.metricIdForTagAndUom(tag, uom));
+  }
+
+  static Stream<Arguments> promethuesEnabledLookupArgs() {
+    return Stream.of(
+        Arguments.of(
+            "rhosak", TallyMeasurement.Uom.STORAGE_GIBIBYTES, "redhat.com:rhosak:storage_gb"));
+  }
+}

--- a/swatch-core/schemas/event.yaml
+++ b/swatch-core/schemas/event.yaml
@@ -83,6 +83,7 @@ properties:
             - Sockets
             - Core-seconds
             - Instance-hours
+            - Storage-gibibytes
     required: false
   cloud_provider:
     description: Identifier for the cloud provider of the subject.
@@ -124,6 +125,7 @@ properties:
       - Red Hat Enterprise Linux Compute Node
       - ocp
       - osd
+      - rhosak
     required: false
   sla:
     description: Service level for the subject.

--- a/swatch-core/schemas/tally_summary.yaml
+++ b/swatch-core/schemas/tally_summary.yaml
@@ -64,6 +64,7 @@ properties:
                   - Cores
                   - Sockets
                   - Instance-hours
+                  - Storage-gibibytes
                 required: false
               value:
                 description: Measurement value.

--- a/swatch-core/schemas/tally_summary.yaml
+++ b/swatch-core/schemas/tally_summary.yaml
@@ -65,6 +65,7 @@ properties:
                   - Sockets
                   - Instance-hours
                   - Storage-gibibytes
+                  - Transfer-gibibytes
                 required: false
               value:
                 description: Measurement value.

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -13,7 +13,7 @@ tagMappings:
     tags:
       - OpenShift Container Platform
 
-  # OpenShift syspurpose roles
+  # System Purpose roles
   - value: ocp
     valueType: role
     tags:
@@ -22,16 +22,27 @@ tagMappings:
     valueType: role
     tags:
       - OpenShift-dedicated-metrics
+  - value: rhosak
+    valueType: role
+    tags:
+      - rhosak
 
-  # OpenShift Offering Product Names
+  # Offering Product Names
   - value: OpenShift Dedicated
     valueType: productName
     tags:
       - OpenShift-dedicated-metrics
+
   - value: OpenShift Container Platform
     valueType: productName
     tags:
       - OpenShift-metrics
+
+  - value: OpenShift Streams for Apache Kafka
+    valueType: productName
+    tags:
+      - rhosak
+
 
 # Individual tags can be measured in different ways.  The tagMetrics section defines these
 # measurements.  A tag will, at minimum, have a "uom" attribute (unit of measure) that defines the
@@ -66,6 +77,15 @@ tagMetrics:
       prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
       prometheusMetadataMetric: subscription_labels
 
+  # RHOSAK metrics
+  - tag: rhosak
+    metricId: redhat.com:rhosak:storage_gb
+    uom: STORAGE_GIBIBYTES
+    queryParams:
+      product: rhosak
+      prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
+      prometheusMetadataMetric: subscription_labels
+
 # The tagMetaData section defines additional information around how a tag is tallied.  Most notably,
 # tags need to have their finest granularity defined so that we can create accurate snapshots.  A
 # tag that only supports DAILY granularity shouldn't be tallied hourly, for example.  Other metadata
@@ -78,6 +98,12 @@ tagMetaData:
       - OpenShift-metrics
       - OpenShift-dedicated-metrics
     serviceType: OpenShift Cluster
+    finestGranularity: HOURLY
+    defaultSla: PREMIUM
+    defaultUsage: PRODUCTION
+  - tags:
+      - rhosak
+    serviceType: Kafka Cluster
     finestGranularity: HOURLY
     defaultSla: PREMIUM
     defaultUsage: PRODUCTION


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4333

This PR configures/enables the metering of RHOSAK data storage, which will produce metering events for this metric.

## Testing
1. Get connected to the testing telemeter instance (see: [Connecting To Observatorium](https://docs.engineering.redhat.com/display/ENT/Connecting+to+Observatorium+to+Fetch+Prometheus+Metrics) )
2. Add 'Eval' to the PromQL template in **_application-openshift-metering-worker.yaml_** so that the Kafka cluster metrics get picked up by the query.
```diff
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None|Eval"}[1h])
```
3. Launch the app
```bash
$ USER_USE_STUB=true PROM_URL="http://localhost:8082/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean bootRun
```
4. Initiate metrics gathering for RHOSAK via JMX and monitor the application logs to make sure that some metrics have been picked up.
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)","arguments":["6043640", "rhosak", "2021-09-30T00:00:00Z", 5760]}'
```
5. Check to make sure that events were gathered and put into the tally database.
```
select * from events where event_type = 'snapshot_redhat.com:rhosak:storage_gb';
```