### PR TITLE
ENT-4423: Scope tally operations to a single service-type

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.tally;
 import io.micrometer.core.annotation.Timed;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -103,11 +104,13 @@ public class TallySnapshotController {
       log.debug("Producing snapshots for accounts: {}", String.join(",", accounts));
     }
 
-    Map<String, AccountUsageCalculation> accountCalcs;
+    Map<String, AccountUsageCalculation> accountCalcs = new HashMap<>();
     try {
-      accountCalcs =
-          retryTemplate.execute(
-              context -> usageCollector.collect(this.applicableProducts, accounts));
+      for (String account : accounts) {
+        accountCalcs.putAll(
+            retryTemplate.execute(
+                context -> usageCollector.collect(this.applicableProducts, account)));
+      }
       if (props.isCloudigradeEnabled()) {
         attemptCloudigradeEnrichment(accounts, accountCalcs);
       }

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.cloudigrade.ConcurrentApiFactory;
-import org.candlepin.subscriptions.db.AccountRepository;
+import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.candlepin.subscriptions.inventory.db.InventoryDataSourceConfiguration;
@@ -157,10 +157,11 @@ public class TallyWorkerConfiguration {
   @Bean
   public MetricUsageCollector metricUsageCollector(
       TagProfile tagProfile,
-      AccountRepository accountRepo,
+      AccountServiceInventoryRepository accountServiceInventoryRepository,
       EventController eventController,
       ApplicationClock clock) {
-    return new MetricUsageCollector(tagProfile, accountRepo, eventController, clock);
+    return new MetricUsageCollector(
+        tagProfile, accountServiceInventoryRepository, eventController, clock);
   }
 
   @Bean

--- a/src/main/resources/liquibase/202111331133-add-account-service-table.xml
+++ b/src/main/resources/liquibase/202111331133-add-account-service-table.xml
@@ -1,0 +1,28 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202111331133-1"  author="khowell">
+    <comment>Add table for account service aggregate</comment>
+    <createTable tableName="account_services">
+      <column name="account_number" type="VARCHAR(255)" />
+      <column name="service_type" type="VARCHAR(255)" />
+    </createTable>
+    <addPrimaryKey tableName="account_services" columnNames="account_number,service_type" />
+  </changeSet>
+
+  <changeSet id="202111331133-2"  author="khowell">
+    <comment>Insert data for existing account services, enforce integrity</comment>
+    <sql>
+      insert into account_services(account_number, service_type) select distinct account_number,instance_type from hosts;
+    </sql>
+    <addForeignKeyConstraint baseTableName="hosts"
+      baseColumnNames="account_number,instance_type"
+      constraintName="fk_hosts_account_services"
+      referencedTableName="account_services"
+      referencedColumnNames="account_number,service_type"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -48,5 +48,6 @@
     <include file="liquibase/202104091791-insert-openshift-skus.xml" />
     <include file="liquibase/202107121534-add-subscription-number-to-subscription.xml" />
     <include file="liquibase/202107140929-ent-4055-cleanup-event-data.xml" />
+    <include file="liquibase/202111331133-add-account-service-table.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -38,8 +38,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.FixedClockConfiguration;
-import org.candlepin.subscriptions.db.AccountRepository;
-import org.candlepin.subscriptions.db.model.Account;
+import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
+import org.candlepin.subscriptions.db.model.AccountServiceInventory;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.HostBucketKey;
@@ -58,6 +58,7 @@ import org.candlepin.subscriptions.registry.TagMetric;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.DateRange;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,7 +72,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class MetricUsageCollectorTest {
   MetricUsageCollector metricUsageCollector;
 
-  @Mock AccountRepository accountRepo;
+  @Mock AccountServiceInventoryRepository accountRepo;
 
   @Mock EventController eventController;
 
@@ -148,13 +149,12 @@ class MetricUsageCollectorTest {
             .withServiceType(SERVICE_TYPE)
             .withInstanceId(UUID.randomUUID().toString())
             .withMeasurements(Collections.singletonList(measurement));
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
 
-    metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
-    Host instance = account.getServiceInstances().get(event.getInstanceId());
+    metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
+    Host instance = accountServiceInventory.getServiceInstances().get(event.getInstanceId());
     assertNotNull(instance);
   }
 
@@ -169,12 +169,11 @@ class MetricUsageCollectorTest {
             .withServiceType(SERVICE_TYPE)
             .withInstanceId(UUID.randomUUID().toString())
             .withMeasurements(Collections.singletonList(measurement));
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
     assertNotNull(accountUsageCalculation);
     UsageCalculation.Key usageCalculationKey =
         new UsageCalculation.Key(RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION);
@@ -198,13 +197,20 @@ class MetricUsageCollectorTest {
             .withHardwareType(hardwareType)
             .withCloudProvider(Event.CloudProvider.__EMPTY__)
             .withInstanceId(UUID.randomUUID().toString());
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
     assertNotNull(accountUsageCalculation);
+  }
+
+  @NotNull
+  private AccountServiceInventory createTestAccountServiceInventory() {
+    AccountServiceInventory accountServiceInventory = new AccountServiceInventory();
+    accountServiceInventory.setAccountNumber("account123");
+    accountServiceInventory.setServiceType(SERVICE_TYPE);
+    return accountServiceInventory;
   }
 
   @ParameterizedTest
@@ -218,12 +224,11 @@ class MetricUsageCollectorTest {
             .withHardwareType(Event.HardwareType.CLOUD)
             .withCloudProvider(cloudProvider)
             .withInstanceId(UUID.randomUUID().toString());
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
     assertNotNull(accountUsageCalculation);
   }
 
@@ -239,13 +244,12 @@ class MetricUsageCollectorTest {
             .withInstanceId(UUID.randomUUID().toString())
             .withMeasurements(Collections.singletonList(measurement))
             .withSla(Event.Sla.PREMIUM);
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
-    Host instance = account.getServiceInstances().get(event.getInstanceId());
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
+    Host instance = accountServiceInventory.getServiceInstances().get(event.getInstanceId());
     assertNotNull(instance);
     Set<HostTallyBucket> expected = new HashSet<>();
     Set.of(Usage._ANY, Usage.PRODUCTION)
@@ -279,12 +283,11 @@ class MetricUsageCollectorTest {
             .withInstanceId(UUID.randomUUID().toString())
             .withMeasurements(Collections.singletonList(measurement))
             .withSla(Event.Sla.PREMIUM);
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
     assertNotNull(accountUsageCalculation);
     UsageCalculation.Key usageCalculationKey =
         new UsageCalculation.Key(RHEL, ServiceLevel._ANY, Usage.PRODUCTION);
@@ -309,12 +312,11 @@ class MetricUsageCollectorTest {
             .withInstanceId(UUID.randomUUID().toString())
             .withMeasurements(Collections.singletonList(measurement))
             .withUsage(Event.Usage.PRODUCTION);
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
     assertNotNull(accountUsageCalculation);
     UsageCalculation.Key usageCalculationKey =
         new UsageCalculation.Key(RHEL, ServiceLevel.PREMIUM, Usage._ANY);
@@ -341,13 +343,12 @@ class MetricUsageCollectorTest {
             .withUsage(Event.Usage.PRODUCTION)
             .withRole(Role.OSD);
 
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
 
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
     assertNotNull(accountUsageCalculation);
 
     UsageCalculation.Key serverKey =
@@ -380,13 +381,12 @@ class MetricUsageCollectorTest {
             .withUsage(Event.Usage.PRODUCTION)
             .withProductIds(List.of("1234"));
 
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event));
 
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
     assertNotNull(accountUsageCalculation);
 
     UsageCalculation.Key engIdKey =
@@ -424,12 +424,11 @@ class MetricUsageCollectorTest {
             .withInstanceId(UUID.randomUUID().toString())
             .withMeasurements(Collections.singletonList(measurement))
             .withUsage(Event.Usage.PRODUCTION);
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event, event));
     AccountUsageCalculation accountUsageCalculation =
-        metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
+        metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
     assertNotNull(accountUsageCalculation);
     UsageCalculation.Key usageCalculationKey =
         new UsageCalculation.Key(RHEL, ServiceLevel.PREMIUM, Usage._ANY);
@@ -465,13 +464,13 @@ class MetricUsageCollectorTest {
             .withInstanceId(instanceId)
             .withMeasurements(Collections.singletonList(instanceHoursMeasurement))
             .withUsage(Event.Usage.PRODUCTION);
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(event, event, instanceHoursEvent, instanceHoursEvent));
 
-    metricUsageCollector.collectHour(SERVICE_TYPE, account, OffsetDateTime.MIN);
-    Host instance = account.getServiceInstances().values().stream().findFirst().orElseThrow();
+    metricUsageCollector.collectHour(accountServiceInventory, OffsetDateTime.MIN);
+    Host instance =
+        accountServiceInventory.getServiceInstances().values().stream().findFirst().orElseThrow();
     assertEquals(Double.valueOf(84.0), instance.getMonthlyTotal("2021-02", Measurement.Uom.CORES));
     assertEquals(
         Double.valueOf(86.0), instance.getMonthlyTotal("2021-02", Measurement.Uom.INSTANCE_HOURS));
@@ -490,18 +489,17 @@ class MetricUsageCollectorTest {
             .withInstanceId(instanceId)
             .withMeasurements(Collections.singletonList(measurement))
             .withUsage(Event.Usage.PRODUCTION);
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
 
     OffsetDateTime instanceDate = eventDate.minusDays(1);
     Host activeInstance = new Host();
     activeInstance.setInstanceId(instanceId);
     activeInstance.setInstanceType(SERVICE_TYPE);
     activeInstance.setLastSeen(instanceDate);
-    account.getServiceInstances().put(instanceId, activeInstance);
+    accountServiceInventory.getServiceInstances().put(instanceId, activeInstance);
 
     String monthId = InstanceMonthlyTotalKey.formatMonthId(instanceDate);
-    when(accountRepo.findById(any())).thenReturn(Optional.of(account));
+    when(accountRepo.findById(any())).thenReturn(Optional.of(accountServiceInventory));
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenAnswer(
             m -> {
@@ -535,15 +533,14 @@ class MetricUsageCollectorTest {
             .withInstanceId(instanceId)
             .withMeasurements(Collections.singletonList(measurement))
             .withUsage(Event.Usage.PRODUCTION);
-    Account account = new Account();
-    account.setAccountNumber("account123");
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
 
     OffsetDateTime instanceDate = eventDate.minusDays(1);
     Host activeInstance = new Host();
     activeInstance.setInstanceId(instanceId);
     activeInstance.setInstanceType(SERVICE_TYPE);
     activeInstance.setLastSeen(instanceDate);
-    account.getServiceInstances().put(instanceId, activeInstance);
+    accountServiceInventory.getServiceInstances().put(instanceId, activeInstance);
 
     String monthId = InstanceMonthlyTotalKey.formatMonthId(instanceDate);
     Host staleInstance = new Host();
@@ -551,9 +548,9 @@ class MetricUsageCollectorTest {
     staleInstance.setInstanceType(SERVICE_TYPE);
     staleInstance.setInstanceId(UUID.randomUUID().toString());
     staleInstance.setLastSeen(instanceDate);
-    account.getServiceInstances().put(staleInstance.getInstanceId(), staleInstance);
+    accountServiceInventory.getServiceInstances().put(staleInstance.getInstanceId(), staleInstance);
 
-    when(accountRepo.findById(any())).thenReturn(Optional.of(account));
+    when(accountRepo.findById(any())).thenReturn(Optional.of(accountServiceInventory));
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenAnswer(
             m -> {
@@ -590,8 +587,7 @@ class MetricUsageCollectorTest {
     OffsetDateTime eventDate = clock.startOfCurrentHour();
     double expectedCoresMeasurement = 150.0;
 
-    Account account = new Account();
-    account.setAccountNumber(accountNumber);
+    AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
 
     OffsetDateTime instanceDate = eventDate.minusDays(1);
     Host activeInstance = new Host();
@@ -600,7 +596,7 @@ class MetricUsageCollectorTest {
     activeInstance.setLastSeen(instanceDate);
     activeInstance.setMeasurement(Uom.CORES, 122.5);
     activeInstance.setMeasurement(Uom.INSTANCE_HOURS, 50.0);
-    account.getServiceInstances().put(instanceId, activeInstance);
+    accountServiceInventory.getServiceInstances().put(instanceId, activeInstance);
 
     Measurement coresMeasurement =
         new Measurement().withUom(Uom.CORES).withValue(expectedCoresMeasurement);
@@ -616,7 +612,7 @@ class MetricUsageCollectorTest {
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any()))
         .thenReturn(Stream.of(coresEvent));
 
-    metricUsageCollector.collectHour(SERVICE_TYPE, account, eventDate);
+    metricUsageCollector.collectHour(accountServiceInventory, eventDate);
     // Cores measurement should be present and updated to the new expected value from the event.
     assertEquals(
         Double.valueOf(expectedCoresMeasurement), activeInstance.getMeasurement(Uom.CORES));

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import org.candlepin.subscriptions.db.model.AccountServiceInventory;
+import org.candlepin.subscriptions.db.model.AccountServiceInventoryId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Defines all operations for interacting with the AccountServiceInventory aggregate */
+public interface AccountServiceInventoryRepository
+    extends JpaRepository<AccountServiceInventory, AccountServiceInventoryId> {
+  /* intentionally empty */
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -38,16 +38,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.util.StringUtils;
 
 /** Provides access to Host database entities. */
 @SuppressWarnings({"linelength", "indentation"})
 public interface HostRepository
-    extends JpaRepository<Host, UUID>, JpaSpecificationExecutor<Host>, TagProfileLookup {
+    extends Repository<Host, UUID>, JpaSpecificationExecutor<Host>, TagProfileLookup {
 
   /**
    * Find all Hosts by bucket criteria and return a page of TallyHostView objects. A TallyHostView
@@ -177,4 +177,6 @@ public interface HostRepository
       Pageable pageable);
 
   List<Host> findByAccountNumber(String accountNumber);
+
+  Optional<Host> findById(UUID id);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/AccountServiceInventoryId.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/AccountServiceInventoryId.java
@@ -18,12 +18,23 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.db;
+package org.candlepin.subscriptions.db.model;
 
-import org.candlepin.subscriptions.db.model.Account;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-/** Defines all operations for interacting with the Account aggregate */
-public interface AccountRepository extends JpaRepository<Account, String> {
-  /* intentionally empty */
+@Data
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountServiceInventoryId implements Serializable {
+  @Column(name = "account_number")
+  private String accountNumber;
+
+  @Column(name = "service_type")
+  private String serviceType;
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4423

Essentially, I reworked the Account aggregate into AccountServiceInventory.

Additionally I reworked the InventoryAccountUsageCollector to use the AccountServiceInventory aggregate, and made the HostRepository read-only, so that we're consistent about how instances/hosts are persisted across the codebase.

Testing
-------

1. Start the application:

```
SPRING_PROFILES_ACTIVE=worker,api DEV_MODE=true ./gradlew bootRun
```

2. Insert some mock hosts:

```
bin/insert-mock-hosts \
  --clear \
  --hbi \
  --num-guests=7 \
  --unmapped-guests=true
```

3. Insert a mock event:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia' \
  -H 'Content-Type: text/json' \
  -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=eventJmxBean,type=EventJmxBean",
    "operation":"saveEvents(java.lang.String)",
    "arguments":["[{
      \"event_source\": \"prometheus\",
      \"event_type\": \"snapshot_redhat.com:openshift_container_platform:cpu_hour\",
      \"account_number\": \"account123\",
      \"service_type\": \"OpenShift Cluster\",
      \"instance_id\": \"83e7a5e7-504d-4283-92c2-8a5f6cc341b1\",
      \"timestamp\": \"2021-08-01T00:00:00Z\",
      \"expiration\": \"2021-08-01T01:00:00Z\",
      \"display_name\": \"83e7a5e7-504d-4283-92c2-8a5f6cc341b1\",
      \"measurements\": [{
        \"value\": 20.0,
        \"uom\": \"Cores\"
      }],
      \"role\": \"ocp\",
      \"sla\": \"Premium\"
    }]"]}'
```

4. Kick off tally:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia' \
  -H 'Content-Type: text/json' \
  -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
    "operation":"tallyAccount(java.lang.String)",
    "arguments":["account123"]
  }'
```

5. Kick off hourly tally:

```
curl 'http://localhost:8080/actuator/hawtio/jolokia' \
  -H 'Content-Type: text/json' \
  -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
    "operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)",
    "arguments":["account123", "2021-06-01T00:00Z", "2021-08-23T00:00Z"]
  }'
```

6. Try the hosts API to confirm that the instances are still persisted
   for both HBI-based and metric-based tallies:

```
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/RHEL' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
curl \
  'http://localhost:8080/api/rhsm-subscriptions/v1/hosts/products/OpenShift-metrics?beginning=2021-08-01T00%3A00%3A00Z&ending=2021-08-31T00%3A00%3A00Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```