### PR TITLE
Add host-inventory as dependency

### DIFF
--- a/deploy/dev-clowdenv.yaml
+++ b/deploy/dev-clowdenv.yaml
@@ -61,6 +61,9 @@ objects:
       featureFlags:
         mode: local
 
+      pullSecrets:
+        - name: quay-cloudservices-pull
+          namespace: rhsm
     resourceDefaults:
       limits:
         cpu: "500m"

--- a/deploy/quay-cloudservices-pull.yaml
+++ b/deploy/quay-cloudservices-pull.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: ${REPLACE_ME}
+kind: Secret
+metadata:
+  name: quay-cloudservices-pull
+type: kubernetes.io/dockerconfigjson

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -148,6 +148,7 @@ objects:
     envName: ${ENV_NAME}
     dependencies:
       - rbac
+      - host-inventory
 
     kafkaTopics:
       - replicas: 3
@@ -255,23 +256,23 @@ objects:
           - name: INVENTORY_DATABASE_HOST
             valueFrom:
               secretKeyRef:
-                name: host-inventory-db-readonly
-                key: db.host
+                name: host-inventory-db
+                key: host
           - name: INVENTORY_DATABASE_DATABASE
             valueFrom:
               secretKeyRef:
-                name: host-inventory-db-readonly
-                key: db.name
+                name: host-inventory-db
+                key: name
           - name: INVENTORY_DATABASE_USERNAME
             valueFrom:
               secretKeyRef:
-                name: host-inventory-db-readonly
-                key: db.user
+                name: host-inventory-db
+                key: username
           - name: INVENTORY_DATABASE_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: host-inventory-db-readonly
-                key: db.password
+                name: host-inventory-db
+                key: password
           - name: CLOUDIGRADE_ENABLED
             value: ${CLOUDIGRADE_ENABLED}
           - name: CLOUDIGRADE_HOST
@@ -802,23 +803,23 @@ objects:
           - name: INVENTORY_DATABASE_HOST
             valueFrom:
               secretKeyRef:
-                name: host-inventory-db-readonly
-                key: db.host
+                name: host-inventory-db
+                key: host
           - name: INVENTORY_DATABASE_DATABASE
             valueFrom:
               secretKeyRef:
-                name: host-inventory-db-readonly
-                key: db.name
+                name: host-inventory-db
+                key: name
           - name: INVENTORY_DATABASE_USERNAME
             valueFrom:
               secretKeyRef:
-                name: host-inventory-db-readonly
-                key: db.user
+                name: host-inventory-db
+                key: username
           - name: INVENTORY_DATABASE_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: host-inventory-db-readonly
-                key: db.password
+                name: host-inventory-db
+                key: password
           - name: CLOUDIGRADE_ENABLED
             value: ${CLOUDIGRADE_ENABLED}
           - name: CLOUDIGRADE_HOST


### PR DESCRIPTION
Updates clowdapp template to list host-inventory as a dependency, and reference the secrets correctly
Add quay-cloudservices-pull.yaml file (with redacted secret) for creation of pull secret required for host-inventory
Update clowdenv file to "link" the pull secret for the clowdapp