### PR TITLE
ENT-4334 Configured RHOSAK Cluster Hours metering

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
@@ -74,6 +74,39 @@ class RhosakTagProfileTest {
                         "prometheusMetric",
                             "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes",
                         "prometheusMetadataMetric", "subscription_labels"))
+                .build()),
+        Arguments.of(
+            "rhosak",
+            Uom.TRANSFER_GIBIBYTES,
+            TagMetric.builder()
+                .tag("rhosak")
+                .metricId("redhat.com:rhosak:transfer_gb")
+                .uom(Uom.TRANSFER_GIBIBYTES)
+                .queryKey("default")
+                .accountQueryKey("default")
+                .queryParams(
+                    Map.of(
+                        "product",
+                        "rhosak",
+                        "prometheusMetric",
+                        "kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes",
+                        "prometheusMetadataMetric",
+                        "subscription_labels"))
+                .build()),
+        Arguments.of(
+            "rhosak",
+            Uom.INSTANCE_HOURS,
+            TagMetric.builder()
+                .tag("rhosak")
+                .metricId("redhat.com:rhosak:cluster_hour")
+                .uom(Uom.INSTANCE_HOURS)
+                .queryKey("default")
+                .accountQueryKey("default")
+                .queryParams(
+                    Map.of(
+                        "product", "rhosak",
+                        "prometheusMetric", "kafka_id:strimzi_resource_state:max_over_time1h",
+                        "prometheusMetadataMetric", "subscription_labels"))
                 .build()));
   }
 
@@ -108,6 +141,10 @@ class RhosakTagProfileTest {
   static Stream<Arguments> promethuesEnabledLookupArgs() {
     return Stream.of(
         Arguments.of(
-            "rhosak", TallyMeasurement.Uom.STORAGE_GIBIBYTES, "redhat.com:rhosak:storage_gb"));
+            "rhosak", TallyMeasurement.Uom.STORAGE_GIBIBYTES, "redhat.com:rhosak:storage_gb"),
+        Arguments.of(
+            "rhosak", TallyMeasurement.Uom.TRANSFER_GIBIBYTES, "redhat.com:rhosak:transfer_gb"),
+        Arguments.of(
+            "rhosak", TallyMeasurement.Uom.INSTANCE_HOURS, "redhat.com:rhosak:cluster_hour"));
   }
 }

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -92,6 +92,13 @@ tagMetrics:
       product: rhosak
       prometheusMetric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
       prometheusMetadataMetric: subscription_labels
+  - tag: rhosak
+    metricId: redhat.com:rhosak:cluster_hour
+    uom: INSTANCE_HOURS
+    queryParams:
+      product: rhosak
+      prometheusMetric: kafka_id:strimzi_resource_state:max_over_time1h
+      prometheusMetadataMetric: subscription_labels
 
 # The tagMetaData section defines additional information around how a tag is tallied.  Most notably,
 # tags need to have their finest granularity defined so that we can create accurate snapshots.  A


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4333

This PR configures/enables the metering of RHOSAK data storage, which will produce metering events for this metric.

## Testing
1. Get connected to the testing telemeter instance (see: [Connecting To Observatorium](https://docs.engineering.redhat.com/display/ENT/Connecting+to+Observatorium+to+Fetch+Prometheus+Metrics) )
2. Add 'Eval' to the PromQL template in **_application-openshift-metering-worker.yaml_** so that the Kafka cluster metrics get picked up by the query.
```diff
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None|Eval"}[1h])
```
3. Launch the app
```bash
$ RHSM_SUBSCRIPTIONS_CLOWDER_STRICT_LOADING=false USER_USE_STUB=true PROM_URL="http://localhost:8082/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean bootRun
```
4. Initiate metrics gathering for RHOSAK via JMX and monitor the application logs to make sure that some metrics have been picked up.
```bash
$ curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)","arguments":["6043640", "rhosak", "2021-10-15T00:00:00Z", 15760]}'
```
5. Check to make sure that events were gathered and put into the tally database
```
select * from events where event_type = 'snapshot_redhat.com:rhosak:cluster_hour';
```

7. Verify that the events contain the appropriate data:
* uom: Instance-hours
* role: rhosak
* event_type: snapshot_redhat.com:rhosak:cluster_hour
* service_type: Kafka Cluster
