### PR TITLE
Fix InventoryAccountUsageCollectorTest random failures

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -268,9 +268,12 @@ public class InventoryAccountUsageCollector {
     if (inventoryHostFacts.getInventoryId() != null) {
       host.setInventoryId(inventoryHostFacts.getInventoryId().toString());
       // We assume that the instance ID for any given HBI host record is the inventory ID; compare
-      // to
-      // an OpenShift Cluster from Prometheus data, where we use the cluster ID.
-      host.setInstanceId(inventoryHostFacts.getInventoryId().toString());
+      // to an OpenShift Cluster from Prometheus data, where we use the cluster ID.
+      if (host.getInstanceId() == null) {
+        // Don't overwrite the instanceId if already set, since that would cause potential
+        // duplicates in the serviceInstances map in AccountServiceInventory.
+        host.setInstanceId(inventoryHostFacts.getInventoryId().toString());
+      }
     }
 
     host.setInsightsId(inventoryHostFacts.getInsightsId());

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -23,8 +23,6 @@ package org.candlepin.subscriptions.tally;
 import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.*;
 import static org.candlepin.subscriptions.tally.collector.Assertions.*;
 import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -654,7 +652,6 @@ public class InventoryAccountUsageCollectorTest {
     collector.collect(RHEL_PRODUCTS, account);
 
     assertEquals(1, accountServiceInventory.getServiceInstances().size());
-    assertThat(accountServiceInventory.getServiceInstances(), not(hasKey("i2")));
   }
 
   private void checkTotalsCalculation(


### PR DESCRIPTION
Specifically, removesDuplicateHostRecords was failing because of a few bad assumptions.

First, the test assumed that a specific instance would be removed, but the iteration is on a HashMap, so iteration is dependent on the key hash, so not particular predictable. (see invocation of handleDuplicateHost from collect in InventoryAccountUsageCollector).

Second, because the method updates hosts by populating information from HBI, it changes the instanceId that the test set to its inventory ID.

This resulted in two entries to the Map in AccountServiceInventory, one with the instanceId set in the unit test, and the other with the inventoryId as key.

I altered the logic to not overwrite the instanceId if it's already been set.

Also, given which Host is removed is abritrary, I removed the assertion that was about the "dupe" key being removed.

Testing
-------

I was able to repro consistently by changing
InventoryHostFactTestHelper#createBaseHost to set a fixed UUID:

```
baseFacts.setInventoryId(UUID.fromString("54f765c8-9814-4eb7-b1f2-ec116c768057"));
```

Run

```
./gradlew :test --tests "org.candlepin.subscriptions.tally.InventoryAccountUsageCollectorTest.removesDuplicateHostRecords"
```