### PR TITLE
Fix issue with Subscription table api count 

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -111,6 +111,7 @@ public class SubscriptionTableController {
     }
 
     List<SkuCapacity> reportItems = new ArrayList<>(inventories.values());
+    int reportItemCount = reportItems.size();
     // The pagination and sorting of capacities is done in memory and can cause performance
     // issues
     // As an improvement this should be pushed lower into the Repository layer
@@ -122,7 +123,7 @@ public class SubscriptionTableController {
         .data(reportItems)
         .meta(
             new HostReportMeta()
-                .count(capacities.size())
+                .count(reportItemCount)
                 .serviceLevel(serviceLevel)
                 .usage(usage)
                 .uom(uom)


### PR DESCRIPTION
Issue: The value of meta.count in subscription table currently returns the count of all matched subscriptions, but as per the api contract, it should return the total number of subscription table records. This is equal to the no of records after matches subscriptions have been aggregated by sku.

Fix: Store the original report item list count, after aggregation by sku but before pagination in a count variable and set meta.count to that.

How to test: curl -X 'GET' 'https://ci.cloud.redhat.com/api/rhsm-subscriptions/v1/subscriptions/products/RHEL?offset=20&limit=10' --user mzalewsk-sub-table-2:redhatdemo | jq

returns the correct count.