### PR TITLE
ENT-4457: Populate metricId in new tally API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -148,6 +148,7 @@ public class TallyResource implements TallyApi {
     report.setMeta(new TallyReportDataMeta());
     report.getMeta().setGranularity(reportCriteria.getGranularity().asOpenApiEnum());
     report.getMeta().setProduct(productId);
+    report.getMeta().setMetricId(metricId.toString());
     report.getMeta().setServiceLevel(sla);
     report.getMeta().setUsage(usageType == null ? null : reportCriteria.getUsage().asOpenApiEnum());
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4457

Testing
-------

Ensure you're opted in, and then:

```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift%20Container%20Platform/Cores?granularity=Daily&beginning=2017-07-21T17%3A32%3A28Z&ending=2017-07-30T17%3A32%3A28Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

Observe that response has meta `metricId` field populated.