### PR TITLE
ENT-4461: Apply RBAC check to new tally API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -97,6 +97,7 @@ public class TallyResource implements TallyApi {
   }
 
   @Override
+  @ReportingAccessRequired
   public TallyReportData getTallyReportData(
       ProductId productId,
       MetricId metricId,


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4461

Testing
-------

First test on `develop` and then on this branch.

Run the service, returning canned wrong/missing permissions:
```
RBAC_USE_STUB=true RBAC_STUB_PERMISSIONS="insights:*:*" ./gradlew :bootRun
```

Hit the endpoint; with the fix you'll get access denied, without it you won't:

```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/OpenShift%20Container%20Platform/Cores?granularity=Daily&beginning=2017-07-21T17%3A32%3A28Z&ending=2017-07-25T17%3A32%3A28Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```