### PR TITLE
ENT-4051: Update clowdapp to use RBAC stub

### DIFF
--- a/deploy/clowder.md
+++ b/deploy/clowder.md
@@ -9,8 +9,11 @@
   paste in the contents, replace `$(pwd)` with the directory where your
   subscription-watch checkout is
 
+  You can override parameters as shown below, or alternatively with the bonfire `-p` argument during the deploy step.  The parameters in the example below are useful for development environments.
+
   ```
   bonfire config write-default
+
   cat <<BONFIRE >>  ~/.config/bonfire/config.yaml
   - name: rhsm-subscriptions
     components:
@@ -18,6 +21,11 @@
         host: local
         repo: $(pwd)
         path: deploy/rhsm-clowdapp.yaml
+        parameters:
+            REPLICAS: 1
+            RHSM_RBAC_USE_STUB: 'true'
+            MARKETPLACE_MANUAL_SUBMISSION_ENABLED: 'true'
+
   BONFIRE
   ```
 * Make your life easier and install the [Kubernetes Lens

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -158,6 +158,8 @@ parameters:
     value: 2m
   - name: PRODUCT_URL
     value: https://product.qa.api.redhat.com/svcrest/product/v3
+  - name: RHSM_RBAC_USE_STUB
+    value: 'false'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -182,7 +184,6 @@ objects:
     # The name of the ClowdEnvironment providing the services
     envName: ${ENV_NAME}
     dependencies:
-      - rbac
       - host-inventory
 
     kafkaTopics:
@@ -338,6 +339,8 @@ objects:
                   key: keystore_password
             - name: RHSM_KEYSTORE
               value: /pinhead/keystore.jks
+            - name: RHSM_RBAC_USE_STUB
+              value: ${RHSM_RBAC_USE_STUB}
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
Deploy to ephemeral environment while overriding the RHSM_RBAC_USE_STUB parameter.  See deploy/clowder.md file for detailed instructions.

```
VENV_DIR=~/bonfire_venv
mkdir -p $VENV_DIR
python3 -m venv $VENV_DIR
. $VENV_DIR/bin/activate
pip install crc-bonfire
```
```
bonfire deploy \
   --no-remove-resources all \
   -i quay.io/lburnett/rhsm=scratch \
   -p rhsm-subscriptions/IMAGE=quay.io/lburnett/rhsm rhsm-subscriptions \
   -p rhsm-subscriptions/RHSM_RBAC_USE_STUB=true
```

Take note of which ephemeral environment namespace you get assigned, and monitor it for when the rhsm-api pod starts up and finishes initiating.  `ephemeral-36' is used for the rest of these examples.  Be sure to replace it with whichever environment you reserved.

Find the name of the API pod.  You can get the pod name from the following command.
```
oc -n ephemeral-36 get -o name pod | grep rhsm-api
```

Turn on port-forwarding for the rhsm-api pod.
```
oc port-forward POD_NAME 8000
```

Execute some swatch rest API calls and observe success status responses.  Take note that the `Origin` header needs to be set since dev mode isn't enabled.
```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in?enable_tally_sync=true&enable_tally_reporting=true&enable_conduit_sync=true' \
  -H 'accept: application/vnd.api+json' \
  -H 'Origin: example.redhat.com' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/hosts/products/OpenShift%20Container%20Platform' \
  -H 'accept: application/vnd.api+json' \
  -H 'Origin: example.redhat.com' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```