### PR TITLE
ENT-4301 Only virtual capacity for SKUs with derived SKUs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -275,11 +275,21 @@ class UpstreamProductData {
 
     Integer sockets = nullOrInteger(attrs.get(Attr.SOCKET_LIMIT));
 
-    offering.setPhysicalCores(cores);
-    offering.setPhysicalSockets(sockets);
+    /*
+    There are no SKUs today (2021-10-27) that provide both physical capacity and virtual capacity
+    at the same time. It is one or the other.
 
-    // If there is a derived SKU, then virtual cores and sockets match the physical values.
-    if (attrs.get(Attr.DERIVED_SKU) != null) {
+    If there is no derived SKU, the set the physical capacities. Otherwise, set the virtual
+    capacities. Whenever there is a derived SKU, there are only engProds/content in the
+    derived/derived-children SKUs.
+
+    See https://issues.redhat.com/browse/ENT-4301?focusedCommentId=19210665 for details.
+    */
+
+    if (attrs.get(Attr.DERIVED_SKU) == null) {
+      offering.setPhysicalCores(cores);
+      offering.setPhysicalSockets(sockets);
+    } else {
       offering.setVirtualCores(cores);
       offering.setVirtualSockets(sockets);
     }

--- a/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
@@ -104,7 +104,8 @@ class UpstreamProductDataTest {
         Set.of(
             69, 70, 83, 84, 86, 91, 92, 93, 127, 176, 180, 182, 201, 205, 240, 241, 246, 248, 317,
             318, 394, 395, 408, 479, 491, 588));
-    expected.setPhysicalSockets(2);
+    // (because there is a derived sku, no physical capacity should be set, only virtual capacity.
+    // See https://issues.redhat.com/browse/ENT-4301?focusedCommentId=19210665 for details)
     expected.setVirtualSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
     expected.setProductName(


### PR DESCRIPTION
Fixes the capacity issue described in
https://issues.redhat.com/browse/ENT-4301

Summary:
* Offerings with derived SKUs do not have content in the non-derived
  SKUs (at least currently, and there are no plans for this to change)
* Therefore there should not be physical capacity on offerings with
  derived SKUs, only virtual capacity.