### PR TITLE
ENT-4385: Add subscription_type to sub inventory API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1516,6 +1516,13 @@ components:
           type: string
         detail:
           type: string
+
+    SubscriptionType:
+      type: string
+      enum:
+        - On-demand
+        - Annual
+
     SubscriptionEventType:
       type: string
       enum:
@@ -1607,9 +1614,12 @@ components:
               description: "The usage that the report was made against. Not set if it wasn't specified as a query parameter."
             uom:
               $ref: '#/components/schemas/Uom'
+            subscription_type:
+              $ref: '#/components/schemas/SubscriptionType'
           required:
             - count
             - product
+            - subscription_type
 
 security:
   - 3ScaleIdentity: []

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.subscription;
 
+import static org.candlepin.subscriptions.utilization.api.model.ProductId.OPENSHIFT_METRICS;
 import static org.candlepin.subscriptions.utilization.api.model.ProductId.RHEL;
 import static org.candlepin.subscriptions.utilization.api.model.ProductId.RHEL_SERVER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -486,6 +487,32 @@ class SubscriptionTableControllerTest {
                     SkuCapacityReportSort.SKU,
                     null));
     assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
+  }
+
+  @Test
+  void testShouldPopulateAnnualSubscriptionType() {
+    when(subscriptionCapacityViewRepository.findAllBy(
+            any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(Collections.emptyList());
+
+    SkuCapacityReport report =
+        subscriptionTableController.capacityReportBySku(
+            RHEL_SERVER, null, null, null, null, Uom.CORES, SkuCapacityReportSort.SKU, null);
+
+    assertEquals(SubscriptionType.ANNUAL, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
+  void testShouldPopulateOnDemandSubscriptionType() {
+    when(subscriptionCapacityViewRepository.findAllBy(
+            any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(Collections.emptyList());
+
+    SkuCapacityReport report =
+        subscriptionTableController.capacityReportBySku(
+            OPENSHIFT_METRICS, null, null, null, null, Uom.CORES, SkuCapacityReportSort.SKU, null);
+
+    assertEquals(SubscriptionType.ON_DEMAND, report.getMeta().getSubscriptionType());
   }
 
   private static void assertCapacities(


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4385

Testing
-------

```
DEV_MODE=true SPRING_PROFILES_ACTIVE=api ./gradlew :bootRun
```

```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/subscriptions/products/RHEL' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

Observe `"subscription_type": "Annual"

```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift-metrics' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

Observe `"subscription_type": "On-Demand"