### PR TITLE
ENT-4050: clowder: Set conduit initContainer image, RHSM_URL

### DIFF
--- a/deploy/clowder.md
+++ b/deploy/clowder.md
@@ -164,26 +164,36 @@ but here are some essentials:
   hours you specify.  You can always increase a reservation by reserving the
   namespace again: `bonfire namespace reserve NAMESPACE`.
 
-* Create an account on `quay.io` and create a image repository.  Use `podman
-  login` or `docker login` so that you can build and push your test images
-  there.  For example,
+* Create an account on `quay.io` and create an image repository for each
+  component (Currently, one for rhsm-subscriptions and one for
+  swatch-system-conduit).  Use `podman login` or `docker login` so that you
+  can build and push your test images there.  For example,
 
   ```
   $ podman login quay.io
   $ podman build . -t quay.io/awood/rhsm
+  $ podman build . -f swatch-system-conduit/Dockerfile -t quay.io/awood/swatch-system-conduit
   $ podman push quay.io/awood/rhsm
+  $ podman push quay.io/awood/swatch-system-conduit
   ```
 
 * When you deploy with bonfire during development, specify the image and
   image tag you want to use like so:
 
   `bonfire deploy rhsm-subscriptions -n NAMESPACE --no-remove-resources=all -i
-  quay.io/my-repo/my-image=my-tag -p rhsm-subscriptions/IMAGE=quay.io/my-repo/my-image`
+  quay.io/my-repo/my-image=my-tag
+  -p rhsm-subscriptions/IMAGE=quay.io/my-repo/my-image
+  -p rhsm-subscriptions/CONDUIT_IMAGE=quay.io/my-repo/my-conduit-image`
 
   The `-i` argument overrides the image tag that you're using.  The `-p`
   overrides parameters in specific ClowdApp components (defined in
   `~/.config/bonfire/config.yaml`).  In this case, we override the `IMAGE`
-  parameter in our template with the image to use.
+  and `CONDUIT_IMAGE` parameters in our template with the image to use.
+
+  Note that you can also locally change the images used without the
+  parameters - simply add `IMAGE` and `CONDUIT_IMAGE` to `parameters` in
+  `~/.config/bonfire/config.yaml`. (If you do this, the `-p` arguments to
+  `bonfire` are redundant)
 
   If you don't specify the repo and tag with the `-i`
   argument, `bonfire` is going to use what's defined in the ClowdApp which is

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -24,6 +24,8 @@ parameters:
     value: '1'
   - name: IMAGE
     value: quay.io/cloudservices/rhsm-subscriptions
+  - name: CONDUIT_IMAGE
+    value: quay.io/cloudservices/swatch-system-conduit
   - name: IMAGE_TAG
     value: latest
   - name: IMAGE_PULL_SECRET
@@ -52,9 +54,8 @@ parameters:
     value: 'localhost'
   - name: CLOUDIGRADE_PORT
     value: '8080'
-  # TODO Don't know what this should be. Marked required in the original template.
   - name: RHSM_URL
-    value: FIXME
+    value: https://api.rhsm.qa.redhat.com/v1
 
   - name: TOKEN_REFRESHER_IMAGE
     value: quay.io/observatorium/token-refresher:master-2021-02-05-5da9663
@@ -940,19 +941,20 @@ objects:
               secret:
                 secretName: pinhead
 
-      - name: conduit
+      - name: system-conduit
         webServices:
           public:
             enabled: true
         minReplicas: 1
         podSpec:
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${CONDUIT_IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
             - /usr/local/s2i/run
           initContainers:
-            - env:
+            - image: ${IMAGE}:${IMAGE_TAG}
+              env:
                 - name: SPRING_PROFILES_ACTIVE
                   value: liquibase-only
               inheritEnv: true


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4050

The initContainer image needs to be different than conduit, because the conduit image doesn't do liquibase (and eventually we may have a separate liquibase image for other deployments as well).

Also renamed the deployment to system-conduit for clarity

Testing
-------

After setting up bonfire, deploy to an ephemeral environment. I use increased timeout. Also, it may be worth commenting out other deployments.

```
bonfire deploy --no-remove-resources rhsm-subscriptions -t 9000
```

Then use the hawtio proxy script and try to sync an org.