### PR TITLE
ENT-4463 Marketplace Fixes for RHOSAK

### DIFF
--- a/bin/events.csv
+++ b/bin/events.csv
@@ -1,0 +1,25 @@
+event_type,account,instance,timestamp,expiration,role,sla,uom,value,service_type
+redhat.com:rhosak:storage_gb,account123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,rhosak,Premium,Storage-gibibytes,0.2,Kafka Cluster
+redhat.com:rhosak:storage_gb,account123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,rhosak,Premium,Storage-gibibytes,0.5,Kafka Cluster
+redhat.com:rhosak:storage_gb,account123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,rhosak,Premium,Storage-gibibytes,0.75,Kafka Cluster
+redhat.com:rhosak:storage_gb,account123,c5mu16smf1c22rn8e730,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,rhosak,Premium,Storage-gibibytes,1.5,Kafka Cluster
+redhat.com:rhosak:cluster_hour,account123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,rhosak,Premium,Instance-hours,1,Kafka Cluster
+redhat.com:rhosak:cluster_hour,account123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,rhosak,Premium,Instance-hours,0,Kafka Cluster
+redhat.com:rhosak:cluster_hour,account123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,rhosak,Premium,Instance-hours,1,Kafka Cluster
+redhat.com:rhosak:cluster_hour,account123,c5mu16smf1c22rn8e730,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,rhosak,Premium,Instance-hours,1,Kafka Cluster
+redhat.com:rhosak:transfer_gb,account123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,rhosak,Premium,Transfer-gibibytes,1.5,Kafka Cluster
+redhat.com:rhosak:transfer_gb,account123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,rhosak,Premium,Transfer-gibibytes,2.5,Kafka Cluster
+redhat.com:rhosak:transfer_gb,account123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,rhosak,Premium,Transfer-gibibytes,3.5,Kafka Cluster
+redhat.com:rhosak:transfer_gb,account123,c5mu16smf1c22rn8e730,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,rhosak,Premium,Transfer-gibibytes,2,Kafka Cluster
+redhat.com:openshift_dedicated:4cpu_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e877,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,osd,Premium,Cores,7.6,OpenShift Cluster
+redhat.com:openshift_dedicated:4cpu_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e877,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,osd,Premium,Cores,8.4,OpenShift Cluster
+redhat.com:openshift_dedicated:4cpu_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e877,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,osd,Premium,Cores,5,OpenShift Cluster
+redhat.com:openshift_dedicated:4cpu_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e877,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,osd,Premium,Cores,2.5,OpenShift Cluster
+redhat.com:openshift_dedicated:cluster_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e877,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,osd,Premium,Instance-hours,0.5,OpenShift Cluster
+redhat.com:openshift_dedicated:cluster_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e877,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,osd,Premium,Instance-hours,0.25,OpenShift Cluster
+redhat.com:openshift_dedicated:cluster_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e877,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,osd,Premium,Instance-hours,0.75,OpenShift Cluster
+redhat.com:openshift_dedicated:cluster_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e877,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,osd,Premium,Instance-hours,0.5,OpenShift Cluster
+redhat.com:openshift_container_platform:cpu_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e900,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,ocp,Premium,Cores,5,OpenShift Cluster
+redhat.com:openshift_container_platform:cpu_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e900,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,ocp,Premium,Cores,0.5,OpenShift Cluster
+redhat.com:openshift_container_platform:cpu_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e900,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,ocp,Premium,Cores,10,OpenShift Cluster
+redhat.com:openshift_container_platform:cpu_hour,account123,aeb1f778-af79-4708-8401-35a5a9e8e900,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,ocp,Premium,Cores,2,OpenShift Cluster

--- a/bin/import_events.py
+++ b/bin/import_events.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import sys
+import argparse
+import csv
+import requests
+
+
+try:
+    import jsonpickle
+except ImportError as e:
+    print('Please install jsonpickle: python -m pip install --user "jsonpickle"')
+    sys.exit(1)
+
+
+class Measurement:
+    def __init__(self, uom, value):
+        self.uom = uom
+        self.value = value
+
+
+class Event:
+    def __init__(self, event_type, account, instance, timestamp, expiration, role, sla, uom, value, service_type):
+        self.event_source = "prometheus"
+        self.event_type = "snapshot_" + event_type
+        self.account_number = account
+        self.instance_id = instance
+        self.timestamp = timestamp
+        self.expiration = expiration
+        self.display_name = instance
+        self.measurements = [ Measurement(uom, value)]
+        self.role = role
+        self.sla = sla
+        self.service_type = service_type
+
+
+def import_events(url, csv_path, dry_run):
+    events = parse_csv(csv_path)
+    print("Found {num} records".format(num=len(events)))
+    return post_events(url, events, dry_run=dry_run)
+
+
+def parse_csv(csv_path):
+    with open(csv_path, mode='r') as csv_file:
+        reader = csv.DictReader(csv_file)
+        events = []
+        for row in reader:
+            events.append(Event(**row))
+        return events
+
+
+def post_events(url, events, dry_run=False):
+    payload = {
+        'type': 'exec',
+        'mbean': 'org.candlepin.subscriptions.jmx:name=eventJmxBean,type=EventJmxBean',
+        'operation': 'saveEvents(java.lang.String)',
+        'arguments': [jsonpickle.encode(events, unpicklable=False)]
+    }
+
+    if dry_run:
+        print("Dry run! No request will be made!")
+        return jsonpickle.encode(payload, unpicklable=False)
+    else:
+        return requests.post(url, data=jsonpickle.encode(payload, unpicklable=False))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="""Insert Events from CSV over JMX.
+        The CSV must have a header containing the following rows:
+        event_type, account, instance, timestamp, expiration, role, sla, uom, value, service_type
+    """)
+    parser.add_argument('--host', default='localhost', help='Jolokia host')
+    parser.add_argument('--port', default='8080', help='Jolokia port')
+    parser.add_argument('--file', help='Path to CSV file', required=True)
+    parser.add_argument('--dry-run', action='store_true', help="Only collect the events from the file and do not send.")
+
+    args = parser.parse_args()
+    jolokia_url = "http://{host}:{port}/actuator/hawtio/jolokia/".format(host = args.host, port = args.port)
+    resp = import_events(jolokia_url, args.file, args.dry_run)
+    if hasattr(resp, 'status_code') and resp.status_code == 200:
+        resp_data = jsonpickle.decode(resp.text)
+        if 'error' in resp_data:
+            print("Error creating events! {error}".format(error=resp_data['error']))
+        else:
+            print("Successfully created events.")
+    else:
+        print(resp)

--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -61,7 +61,7 @@ class UpstreamProductData {
     SERVICE_TYPE,
     PRODUCT_FAMILY,
     USAGE,
-    /** Name of Offering comes from opProd description field, not the PRODUCT_NAME attribute. */
+    PRODUCT_NAME,
     X_DESCRIPTION,
     /** Role originates from opProd roles field, not an attribute. */
     X_ROLE;
@@ -148,7 +148,8 @@ class UpstreamProductData {
     offering.setProductIds(Set.copyOf(engOids));
     offering.setRole(attrs.get(Attr.X_ROLE));
     offering.setProductFamily(attrs.get(Attr.PRODUCT_FAMILY));
-    offering.setProductName(attrs.get(Attr.X_DESCRIPTION));
+    offering.setProductName(attrs.get(Attr.PRODUCT_NAME));
+    offering.setDescription(attrs.get(Attr.X_DESCRIPTION));
 
     calcCapacityForOffering(offering);
 

--- a/src/main/resources/application-marketplace.yaml
+++ b/src/main/resources/application-marketplace.yaml
@@ -11,6 +11,7 @@ rhsm-subscriptions:
     eligible-swatch-product-ids:
       - OpenShift-metrics
       - OpenShift-dedicated-metrics
+      - rhosak
     verify-batches: ${MARKETPLACE_VERIFY_BATCHES:true}
     manual-marketplace-submission-enabled: ${MARKETPLACE_MANUAL_SUBMISSION_ENABLED:false}
     amendment-not-supported-marker: ${MARKETPLACE_AMENDMENT_NOT_SUPPORTED_MARKER:(amendments) is not available}

--- a/src/main/resources/liquibase/202110211313-add-rhosak-offering.xml
+++ b/src/main/resources/liquibase/202110211313-add-rhosak-offering.xml
@@ -1,0 +1,22 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202110211313-1" author="mstead">
+    <comment>Add offering for RHOSAK SKU</comment>
+    <insert tableName="offering">
+      <column name="sku" value="MW01882"/>
+      <column name="product_name" value="OpenShift Streams for Apache Kafka"/>
+      <column name="role" value="rhosak"/>
+      <column name="sla" value="Premium"/>
+      <column name="usage" value="Production"/>
+      <column name="physical_cores" value="0"/>
+      <column name="physical_sockets" value="0"/>
+      <column name="virtual_cores" value="0"/>
+      <column name="virtual_sockets" value="0"/>
+    </insert>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/202110211314-add-description-column-to-offering.xml
+++ b/src/main/resources/liquibase/202110211314-add-description-column-to-offering.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202110211010-1" author="mstead">
+    <comment>Add description column to offering table</comment>
+    <addColumn tableName="offering">
+      <column name="description" type="VARCHAR(255)" />
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202110211010-2" author="mstead">
+    <comment>Set the description for existing OpenShift offerings</comment>
+    <update tableName="offering">
+      <column name="description" value="Red Hat OpenShift Container Platform (Hourly)"/>
+      <where>sku='MW01485'</where>
+    </update>
+    <update tableName="offering">
+      <column name="description" value="Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)"/>
+      <where>sku='MW01484'</where>
+    </update>
+    <update tableName="offering">
+      <column name="description" value="Red Hat OpenShift Streams for Apache Kafka (Hourly)"/>
+      <where>sku='MW01882'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>
+  <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -50,5 +50,6 @@
     <include file="liquibase/202107140929-ent-4055-cleanup-event-data.xml" />
     <include file="liquibase/202111331133-add-account-service-table.xml" />
     <include file="liquibase/202110211313-add-rhosak-offering.xml" />
+    <include file="liquibase/202110211314-add-description-column-to-offering.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -49,5 +49,6 @@
     <include file="liquibase/202107121534-add-subscription-number-to-subscription.xml" />
     <include file="liquibase/202107140929-ent-4055-cleanup-event-data.xml" />
     <include file="liquibase/202111331133-add-account-service-table.xml" />
+    <include file="liquibase/202110211313-add-rhosak-offering.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
@@ -53,6 +53,7 @@ class OfferingRepositoryTest {
     offering.setPhysicalSockets(1);
     offering.setProductFamily("test");
     offering.setProductName("test");
+    offering.setDescription("test sku");
     repository.save(offering);
     final Offering actual = repository.getOne("testsku");
     assertEquals(offering, actual);

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -80,17 +80,18 @@ class SubscriptionRepositoryTest {
     Subscription subscription = createSubscription("1", "1000", "testSku1", "123");
     subscriptionRepo.saveAndFlush(subscription);
 
-    Offering o1 = createOffering("testSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+    Offering o1 =
+        createOffering("testSku1", "Test SKU 1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     offeringRepo.save(o1);
-    Offering o2 = createOffering("testSku2", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
+    Offering o2 =
+        createOffering("testSku2", "Test SKU 2", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
     offeringRepo.saveAndFlush(o2);
 
     UsageCalculation.Key key = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage.PRODUCTION);
-    Set<String> roles = Set.of("ocp");
+    Set<String> productNames = Set.of("Test SKU 2");
     var resultList =
-        subscriptionRepo
-            .findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
-                "1000", key, roles, NOW, NOW);
+        subscriptionRepo.findByAccountAndProductNameAndServiceLevel(
+            "1000", key, productNames, NOW, NOW);
     assertEquals(1, resultList.size());
 
     var result = resultList.get(0);
@@ -104,17 +105,20 @@ class SubscriptionRepositoryTest {
     Subscription subscription = createSubscription("1", "1000", "testSku", "123");
     subscriptionRepo.saveAndFlush(subscription);
 
-    Offering o1 = createOffering("otherSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+    Offering o1 =
+        createOffering(
+            "otherSku1", "Other SKU 1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     offeringRepo.saveAndFlush(o1);
-    Offering o2 = createOffering("otherSku2", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
+    Offering o2 =
+        createOffering(
+            "otherSku2", "Other SKU 2", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
     offeringRepo.saveAndFlush(o2);
 
     UsageCalculation.Key key = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage.PRODUCTION);
-    Set<String> roles = Set.of("ocp");
+    Set<String> productNames = Set.of("Other SKU 1", "Other SKU 2");
     var result =
-        subscriptionRepo
-            .findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
-                "1000", key, roles, NOW, NOW);
+        subscriptionRepo.findByAccountAndProductNameAndServiceLevel(
+            "1000", key, productNames, NOW, NOW);
     assertEquals(0, result.size());
   }
 
@@ -129,16 +133,15 @@ class SubscriptionRepositoryTest {
     subscriptionRepo.saveAndFlush(subscription2);
 
     Offering offering =
-        createOffering("testSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+        createOffering("testSku1", "Test SKU 1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     offeringRepo.save(offering);
 
     UsageCalculation.Key key = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage.PRODUCTION);
-    Set<String> roles = Set.of("ocp");
+    Set<String> productNames = Set.of("Test SKU 1");
 
     var resultList =
-        subscriptionRepo
-            .findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
-                "1000", key, roles, NOW, NOW);
+        subscriptionRepo.findByAccountAndProductNameAndServiceLevel(
+            "1000", key, productNames, NOW, NOW);
 
     assertEquals(2, resultList.size());
 
@@ -171,9 +174,10 @@ class SubscriptionRepositoryTest {
   }
 
   private Offering createOffering(
-      String sku, int productId, ServiceLevel sla, Usage usage, String role) {
+      String sku, String productName, int productId, ServiceLevel sla, Usage usage, String role) {
     Offering o = new Offering();
     o.setSku(sku);
+    o.setProductName(productName);
     o.setProductIds(Set.of(productId));
     o.setServiceLevel(sla);
     o.setUsage(usage);

--- a/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionIdProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/marketplace/MarketplaceSubscriptionIdProviderTest.java
@@ -26,24 +26,20 @@ import static org.mockito.Mockito.*;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.candlepin.subscriptions.db.SubscriptionRepository;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Subscription;
 import org.candlepin.subscriptions.db.model.Usage;
-import org.candlepin.subscriptions.registry.ProductProfile;
 import org.candlepin.subscriptions.registry.ProductProfileRegistry;
+import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.UsageCalculation.Key;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -63,17 +59,12 @@ class MarketplaceSubscriptionIdProviderTest {
 
   @MockBean private ProductProfileRegistry profileRegistry;
 
-  @Mock private ProductProfile mockProfile;
+  @MockBean private TagProfile mockProfile;
 
   @Autowired private MarketplaceSubscriptionIdProvider idProvider;
 
   private OffsetDateTime rangeStart = OffsetDateTime.now().minusDays(5);
   private OffsetDateTime rangeEnd = OffsetDateTime.now().plusDays(5);
-
-  @BeforeEach
-  void setUp() {
-    when(profileRegistry.findProfileForSwatchProductId(anyString())).thenReturn(mockProfile);
-  }
 
   @Test
   void doesNotAllowReservedValuesInKey() {
@@ -97,18 +88,14 @@ class MarketplaceSubscriptionIdProviderTest {
     s.setMarketplaceSubscriptionId("xyz");
     List<Subscription> result = Collections.singletonList(s);
 
-    Map<String, Set<String>> roleMap = new HashMap<>();
-    Set<String> ocpRoles = Set.of("ocp");
-    roleMap.put(String.valueOf(1), ocpRoles);
-
-    when(mockProfile.getRolesBySwatchProduct()).thenReturn(roleMap);
-    when(repo
-            .findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
-                eq("1000"),
-                eq(key),
-                eq(ocpRoles),
-                any(OffsetDateTime.class),
-                any(OffsetDateTime.class)))
+    Set<String> productNames = Set.of("OpenShift Container Platform");
+    when(mockProfile.getOfferingProductNamesForTag(any())).thenReturn(productNames);
+    when(repo.findByAccountAndProductNameAndServiceLevel(
+            eq("1000"),
+            eq(key),
+            eq(productNames),
+            any(OffsetDateTime.class),
+            any(OffsetDateTime.class)))
         .thenReturn(new ArrayList<>())
         .thenReturn(result);
 
@@ -126,18 +113,14 @@ class MarketplaceSubscriptionIdProviderTest {
     s.setMarketplaceSubscriptionId("abc");
     List<Subscription> result = Collections.singletonList(s);
 
-    Map<String, Set<String>> roleMap = new HashMap<>();
-    Set<String> ocpRoles = Set.of("ocp");
-    roleMap.put(String.valueOf(1), ocpRoles);
-
-    when(mockProfile.getRolesBySwatchProduct()).thenReturn(roleMap);
-    when(repo
-            .findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
-                eq("1000"),
-                eq(key),
-                eq(ocpRoles),
-                any(OffsetDateTime.class),
-                any(OffsetDateTime.class)))
+    Set<String> productNames = Set.of("OpenShift Container Platform");
+    when(mockProfile.getOfferingProductNamesForTag(anyString())).thenReturn(productNames);
+    when(repo.findByAccountAndProductNameAndServiceLevel(
+            eq("1000"),
+            eq(key),
+            eq(productNames),
+            any(OffsetDateTime.class),
+            any(OffsetDateTime.class)))
         .thenReturn(new ArrayList<>())
         .thenReturn(result);
 

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
@@ -131,7 +131,8 @@ class OfferingSyncControllerTest {
     String sku = "MW01485";
     Offering persisted = new Offering();
     persisted.setSku(sku);
-    persisted.setProductName("Red Hat OpenShift Container Platform (Hourly)");
+    persisted.setProductName("OpenShift Container Platform");
+    persisted.setDescription("Red Hat OpenShift Container Platform (Hourly)");
     persisted.setProductFamily("OpenShift Enterprise");
     persisted.setChildSkus(Set.of("SVCMW01485"));
     persisted.setProductIds(

--- a/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
@@ -46,7 +46,8 @@ class UpstreamProductDataTest {
             69, 70, 185, 194, 197, 201, 205, 240, 271, 290, 311, 317, 318, 326, 329, 408, 458, 473,
             479, 491, 518, 519, 546, 579, 588, 603, 604, 608, 610, 645));
     expected.setProductFamily("OpenShift Enterprise");
-    expected.setProductName("Red Hat OpenShift Container Platform (Hourly)");
+    expected.setProductName("OpenShift Container Platform");
+    expected.setDescription("Red Hat OpenShift Container Platform (Hourly)");
     expected.setServiceLevel(ServiceLevel.PREMIUM);
     expected.setUsage(Usage.EMPTY);
 
@@ -66,7 +67,8 @@ class UpstreamProductDataTest {
     expected.setChildSkus(Set.of("SVCMW01484A", "SVCMW01484B"));
     expected.setProductIds(Collections.emptySet());
     expected.setProductFamily("OpenShift Enterprise");
-    expected.setProductName("Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)");
+    expected.setProductName("OpenShift Dedicated");
+    expected.setDescription("Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)");
     expected.setServiceLevel(ServiceLevel.PREMIUM);
     expected.setUsage(Usage.EMPTY);
 
@@ -108,8 +110,10 @@ class UpstreamProductDataTest {
     // See https://issues.redhat.com/browse/ENT-4301?focusedCommentId=19210665 for details)
     expected.setVirtualSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName(
-        "Red Hat Enterprise Linux Server for SAP HANA for Virtual Datacenters with Smart Management, Premium");
+    expected.setProductName("RHEL for SAP HANA");
+    expected.setDescription(
+        "Red Hat Enterprise Linux Server for SAP HANA for Virtual "
+            + "Datacenters with Smart Management, Premium");
     expected.setServiceLevel(ServiceLevel.PREMIUM);
     // (Usage ends up coming from derived SKU RH00618F5)
     expected.setUsage(Usage.PRODUCTION);
@@ -138,8 +142,10 @@ class UpstreamProductDataTest {
     expected.setRole("Red Hat Enterprise Linux Server");
     expected.setPhysicalSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName(
-        "Red Hat Enterprise Linux Server, Standard (1-2 sockets) (Up to 4 guests) with Smart Management");
+    expected.setProductName("RHEL Server");
+    expected.setDescription(
+        "Red Hat Enterprise Linux Server, Standard (1-2 sockets) "
+            + "(Up to 4 guests) with Smart Management");
     expected.setServiceLevel(ServiceLevel.STANDARD);
     expected.setUsage(Usage.PRODUCTION);
 
@@ -166,7 +172,8 @@ class UpstreamProductDataTest {
     expected.setPhysicalCores(4); // Because IFL is 1 which gets multiplied by magical constant 4
     expected.setPhysicalSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
-    expected.setProductName("Red Hat Enterprise Linux Developer Workstation, Enterprise");
+    expected.setProductName("RHEL Developer Workstation");
+    expected.setDescription("Red Hat Enterprise Linux Developer Workstation, Enterprise");
     expected.setServiceLevel(ServiceLevel.EMPTY); // Because Dev-Enterprise isn't a ServiceLevel yet
     expected.setUsage(Usage.DEVELOPMENT_TEST);
 

--- a/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
@@ -86,7 +86,7 @@ class TagProfileFactoryTest {
 
   @Test
   void testCanLookupTagByOfferingName() {
-    assertNotNull(tagProfile.tagForOfferingProductName("OpenShift Dedicated"));
+    assertNotNull(tagProfile.tagForOfferingProductName("OpenShift Container Platform"));
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/registry/TagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/registry/TagProfileTest.java
@@ -65,6 +65,12 @@ class TagProfileTest {
             .build();
     TagMapping tagMapping2 =
         TagMapping.builder().value("x86_64").valueType("arch").tags(Set.of("RHEL for x86")).build();
+    TagMapping tagMapping3 =
+        TagMapping.builder()
+            .valueType("productName")
+            .tags(Set.of(RHEL_DESKTOP_TAG))
+            .value("RHEL Desktop")
+            .build();
 
     TagMapping openshiftRoleMapping =
         TagMapping.builder()
@@ -114,7 +120,7 @@ class TagProfileTest {
 
     tagProfile =
         TagProfile.builder()
-            .tagMappings(List.of(tagMapping1, tagMapping2, openshiftRoleMapping))
+            .tagMappings(List.of(tagMapping1, tagMapping2, tagMapping3, openshiftRoleMapping))
             .tagMetrics(tagMetrics)
             .tagMetaData(List.of(openshiftClusterMetaData, kafkaClusterMetaData))
             .build();
@@ -221,5 +227,12 @@ class TagProfileTest {
     assertEquals(
         Set.of(OPENSHIFT_TAG, OPENSHIFT_DEDICATED_TAG),
         tagProfile.getTagsForServiceType(OPENSHIFT_CLUSTER_ST));
+  }
+
+  @Test
+  void lookupProductNamesByTag() {
+    Set<String> products = tagProfile.getOfferingProductNamesForTag(RHEL_DESKTOP_TAG);
+    assertEquals(1, products.size());
+    assertTrue(products.contains("RHEL Desktop"));
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -60,16 +60,14 @@ public interface SubscriptionRepository
   @Query(
       "SELECT s FROM Subscription s WHERE s.accountNumber = :accountNumber AND "
           + "s.sku = ALL (SELECT DISTINCT o.sku FROM Offering o WHERE "
-          + ":#{#key.usage} = o.usage AND "
           + ":#{#key.sla} = o.serviceLevel AND "
-          + "o.role IN :#{#roles}) AND s.startDate <= :rangeStart AND s.endDate >= :rangeEnd AND "
+          + "o.productName IN :#{#productNames}) AND s.startDate <= :rangeStart AND s.endDate >= :rangeEnd AND "
           + "s.marketplaceSubscriptionId IS NOT NULL AND s.marketplaceSubscriptionId <> '' "
           + "ORDER BY s.startDate DESC")
-  List<Subscription>
-      findSubscriptionByAccountAndUsageKeyAndStartDateAndEndDateAndMarketplaceSubscriptionId(
-          @Param("accountNumber") String accountNumber,
-          @Param("key") UsageCalculation.Key usageKey,
-          @Param("roles") Set<String> roles,
-          @Param("rangeStart") OffsetDateTime rangeStart,
-          @Param("rangeEnd") OffsetDateTime rangeEnd);
+  List<Subscription> findByAccountAndProductNameAndServiceLevel(
+      @Param("accountNumber") String accountNumber,
+      @Param("key") UsageCalculation.Key usageKey,
+      @Param("productNames") Set<String> productNames,
+      @Param("rangeStart") OffsetDateTime rangeStart,
+      @Param("rangeEnd") OffsetDateTime rangeEnd);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -63,11 +63,19 @@ public class Offering implements Serializable {
   /**
    * Customer-facing name for the offering.
    *
-   * <p>E.g. Red Hat Enterprise Linux Server with Smart Management + Satellite, Standard (Physical
-   * or Virtual Nodes)
+   * <p>E.g. Red Hat Enterprise Linux Server
    */
   @Column(name = "product_name")
   private String productName;
+
+  /**
+   * Customer-facing description for the offering.
+   *
+   * <p>E.g. Red Hat Enterprise Linux Server with Smart Management + Satellite, Standard (Physical
+   * or Virtual Nodes)
+   */
+  @Column(name = "description")
+  private String description;
 
   /**
    * Category for the offering.

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
@@ -50,7 +50,7 @@ import org.hibernate.annotations.Subselect;
         + "sc.has_unlimited_guest_sockets, \n"
         + "s.quantity, \n"
         + "s.subscription_number, \n"
-        + "o.product_name \n"
+        + "o.description as product_name \n"
         + "FROM subscription_capacity sc \n"
         + "JOIN subscription s on sc.subscription_id = s.subscription_id \n"
         + "AND s.end_date > CURRENT_TIMESTAMP \n"

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagProfile.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagProfile.java
@@ -63,6 +63,7 @@ public class TagProfile {
   @Getter private Set<String> tagsWithPrometheusEnabledLookup;
   private Map<String, Set<Uom>> measurementsByTagLookup;
   private Map<String, String> offeringProductNameToTagLookup;
+  private Map<String, Set<String>> tagToOfferingProductNamesLookup;
   private Map<String, Set<String>> roleToTagLookup;
   private Map<String, Granularity> finestGranularityLookup;
   private Map<String, TagMetaData> tagMetaDataToTagLookup;
@@ -76,6 +77,7 @@ public class TagProfile {
     tagsWithPrometheusEnabledLookup = new HashSet<>();
     measurementsByTagLookup = new HashMap<>();
     offeringProductNameToTagLookup = new HashMap<>();
+    tagToOfferingProductNamesLookup = new HashMap<>();
     roleToTagLookup = new HashMap<>();
     tagMetaDataToTagLookup = new HashMap<>();
     finestGranularityLookup = new HashMap<>();
@@ -96,7 +98,15 @@ public class TagProfile {
                       .computeIfAbsent(tag, k -> new HashSet<>())
                       .add(mapping.getValue()));
     } else if ("productName".equals(mapping.getValueType())) {
-      mapping.getTags().forEach(tag -> offeringProductNameToTagLookup.put(mapping.getValue(), tag));
+      mapping
+          .getTags()
+          .forEach(
+              tag -> {
+                offeringProductNameToTagLookup.put(mapping.getValue(), tag);
+                tagToOfferingProductNamesLookup
+                    .computeIfAbsent(tag, k -> new HashSet<>())
+                    .add(mapping.getValue());
+              });
     } else if ("role".equals(mapping.getValueType())) {
       roleToTagLookup
           .computeIfAbsent(mapping.getValue(), k -> new HashSet<>())
@@ -228,5 +238,9 @@ public class TagProfile {
         .map(TagMetaData::getTags)
         .forEach(tags::addAll);
     return tags;
+  }
+
+  public Set<String> getOfferingProductNamesForTag(String productTag) {
+    return tagToOfferingProductNamesLookup.getOrDefault(productTag, Collections.emptySet());
   }
 }


### PR DESCRIPTION
There were quite a few things addressed in this PR in order to send the usage to marketplace.

* Removed the ProductProfileRegistry from the MarketplaceSubscriptionIdProvider
so that product config can all be done in the tag profile. Also updated the
offering lookup query to be based on Offering name instead of role.
* Added rhosak tag to eligible-swatch-product-ids in the marketplace config so that
it will be included in metrics that are sent to marketplace.
* Updated the product name mappings in the tag profile config to reflect the values
that will come from the product service to be ready for turning on subscription
table functionality. Also added a RHOSAK mapping.
* Updated the offering product names in DB for OCP and OSD, as well as added RHOSAK
* Set Offering name from PRODUCT_NAME attribute instead of the DESCRIPTION.
* I also created a small python script to import Events from a CSV file. It is very cumbersome to use the Event JMX API directly and this makes it a little easier to view the event time line without sifting through JSON.

### Testing
The following shows how to test this PR against an account with actual cluster instances running, and allows verifying that data will be sent to Marketplace.

https://docs.engineering.redhat.com/display/ENT/Testing+RHOSAK+metering+in+a+development+environment
