### PR TITLE
ENT-4383: Implementation of InstanceAPI

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -690,6 +690,83 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       tags:
         - ingress
+  /instances/products/{product_id}:
+    parameters:
+      - name: product_id
+        description: The ID for the product we wish to query
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/ProductId'
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: "The number of items to skip before starting to collect the result set"
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+        description: "The numbers of items to return"
+    get:
+      operationId: getInstancesByProduct
+      parameters:
+        - name: sla
+          in: query
+          schema:
+            $ref: '#/components/schemas/ServiceLevelType'
+          description: "Include only hosts for the specified service level."
+        - name: usage
+          in: query
+          schema:
+            $ref: '#/components/schemas/UsageType'
+          description: "Include only hosts for the specified usage level."
+        - name: display_name_contains
+          description: Include only hosts containing the specified display name. Passing an empty string behaves the same way as passing null
+          schema:
+            type: string
+            #Default to empty string to prevent complex jpql statement later
+            default: ''
+          in: query
+        - name: beginning
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the start of the report period. Dates should be provided in ISO 8601
+                     format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z.
+                     Only applicable for OpenShift-dedicated-metrics and OpenShift-metrics products"
+        - name: ending
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the end of the report period. Dates should be provided in ISO 8601
+                     format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z.
+                     Only applicable for OpenShift-dedicated-metrics and OpenShift-metrics products"
+        - name: sort
+          in: query
+          schema:
+            $ref: "#/components/schemas/InstanceReportSort"
+          description: "What property to sort by (optional)"
+        - name: dir
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+          description: "Which direction to sort by (default: asc)"
+      tags:
+        - instances
+      responses:
+        '200':
+          description: The request for instances was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstanceResponse'
   /subscriptions/products/{product_id}:
     description: "Operations for total capacity by SKU for all of the owner's active subscriptions for given Swatch product ID."
     parameters:
@@ -1450,6 +1527,106 @@ components:
         cloud_provider:
           description: If applicable, the cloud provider for this host.
           type: string
+    InstanceMeta:
+      title: Root Type for InstanceMeta
+      description: The details of the entire list of InstanceData
+      type: object
+      properties:
+        count:
+          format: int32
+          type: integer
+        product:
+          $ref: '#/components/schemas/ProductId'
+        service_level:
+          $ref: '#/components/schemas/ServiceLevelType'
+        usage:
+          $ref: '#/components/schemas/UsageType'
+        measurements:
+          type: array
+          items:
+            type: string
+      example:
+        count: 10
+        product: RHEL
+        service_level: Premium
+        usage: Production
+        measurements:
+          - Instance-Hours
+          - Storage-Gibibytes
+          - Transfer-Gibibytes
+    InstanceResponse:
+      title: Root Type for InstanceResponse
+      description: The output data of a product instance metrics
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstanceData'
+        links:
+          $ref: '#/components/schemas/PageLinks'
+        meta:
+          $ref: '#/components/schemas/InstanceMeta'
+          properties:
+            count:
+              format: int32
+              type: integer
+      example:
+        data:
+          - inventory_id: d6214a0b-b344-4778-831c-d53dcacb2da3
+            display_name: guest01.example.com
+            subscription_manager_id: adafd9d5-5b00-42fa-a6c9-75801d45cc6d
+            last_seen: '2020-01-01T00:00:00Z'
+          - inventory_id: 9358e312-1c9f-42f4-8910-dcef6e970852
+            display_name: guest02.example.com
+            subscription_manager_id: b101a72f-1859-4489-acb8-d6d31c2578c4
+            last_seen: '2020-01-01T00:00:00Z'
+        links:
+          first: string
+          last: string
+          next: string
+        meta:
+          count: 10
+    InstanceReportSort:
+      type: string
+      enum:
+        - display_name
+        - last_seen
+        - Cores
+        - Sockets
+        - Core-seconds
+        - Instance-hours
+        - Storage-gibibytes
+        - Transfer-gibibytes
+    InstanceData:
+      title: Root Type for Instance
+      description: The representation of a product cluster data
+      type: object
+      properties:
+        id:
+          type: string
+        display_name:
+          type: string
+        measurements:
+          description: >-
+            Must be in the same order as "measurements" in the meta. (i.e. in the example
+            instance.measurements[0] is the instance-hours, measurements[1] is storage-gibibytes,
+            and measurements[2] is the transfer-gibibytes.
+          type: array
+          items:
+            format: double
+            type: number
+        last_seen:
+          format: date-time
+          type: string
+      example:
+        id: d6214a0b-b344-4778-831c-d53dcacb2da3
+        display_name: rhv.example.com
+        measurements:
+          - 42
+          - null
+          - 1
+        last_seen: '2020-01-01T00:00:00Z'
     CandlepinPool:
       description: Subset of Candlepin pool data that rhsm-subscriptions understands.
       properties:
@@ -1623,3 +1800,4 @@ components:
 
 security:
   - 3ScaleIdentity: []
+

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource;
+
+import com.google.common.collect.ImmutableMap;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.resteasy.PageLinkCreator;
+import org.candlepin.subscriptions.utilization.api.model.*;
+import org.candlepin.subscriptions.utilization.api.resources.InstancesApi;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Instance API implementation. */
+@Component
+public class InstancesResource implements InstancesApi {
+
+  private final HostRepository repository;
+  private final PageLinkCreator pageLinkCreator;
+  private final TagProfile tagProfile;
+
+  public static final Map<InstanceReportSort, String> INSTANCE_SORT_PARAM_MAPPING =
+      ImmutableMap.<InstanceReportSort, String>builder()
+          .put(InstanceReportSort.DISPLAY_NAME, "displayName")
+          .put(InstanceReportSort.LAST_SEEN, "lastSeen")
+          .putAll(getUomSorts())
+          .build();
+
+  public static final Map<InstanceReportSort, Measurement.Uom> SORT_TO_UOM_MAP =
+      ImmutableMap.copyOf(getSortToUomMap());
+
+  @Context UriInfo uriInfo;
+
+  public InstancesResource(
+      HostRepository instancesRepository, PageLinkCreator pageLinkCreator, TagProfile tagProfile) {
+    this.repository = instancesRepository;
+    this.pageLinkCreator = pageLinkCreator;
+    this.tagProfile = tagProfile;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public InstanceResponse getInstancesByProduct(
+      ProductId productId,
+      Integer offset,
+      Integer limit,
+      ServiceLevelType sla,
+      UsageType usage,
+      String displayNameContains,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      InstanceReportSort sort,
+      SortDirection dir) {
+    Sort.Direction dirValue = Sort.Direction.ASC;
+    if (dir == SortDirection.DESC) {
+      dirValue = Sort.Direction.DESC;
+    }
+    Sort.Order implicitOrder = Sort.Order.by("id");
+    Sort sortValue = Sort.by(implicitOrder);
+
+    int minCores = 0;
+    int minSockets = 0;
+
+    String accountNumber = ResourceUtils.getAccountNumber();
+    ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
+    Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
+    String sanitizedDisplayNameSubstring =
+        Objects.nonNull(displayNameContains) ? displayNameContains : "";
+
+    List<InstanceData> payload;
+    Page<Host> hosts;
+    if (sort != null) {
+      Sort.Order userDefinedOrder = new Sort.Order(dirValue, INSTANCE_SORT_PARAM_MAPPING.get(sort));
+      sortValue = Sort.by(userDefinedOrder, implicitOrder);
+    }
+    Pageable page = ResourceUtils.getPageable(offset, limit, sortValue);
+
+    OffsetDateTime now = OffsetDateTime.now();
+    OffsetDateTime start = Optional.ofNullable(beginning).orElse(now);
+    OffsetDateTime end = Optional.ofNullable(ending).orElse(now);
+    var uomSet = tagProfile.measurementsByTag(productId.toString());
+    List<String> measurements =
+        uomSet.stream().map(Measurement.Uom::toString).sorted().collect(Collectors.toList());
+
+    validateBeginningAndEndingDates(start, end);
+
+    String month = InstanceMonthlyTotalKey.formatMonthId(start);
+    // We depend on a "reference UOM" in order to filter out instances that were not active in
+    // the selected month. This is also used for sorting purposes (same join). See
+    // org.candlepin.subscriptions.db.HostSpecification#toPredicate and
+    // org.candlepin.subscriptions.db.HostRepository#findAllBy.
+    Measurement.Uom referenceUom = SORT_TO_UOM_MAP.get(sort);
+    hosts =
+        repository.findAllBy(
+            accountNumber,
+            productId.toString(),
+            sanitizedSla,
+            sanitizedUsage,
+            sanitizedDisplayNameSubstring,
+            minCores,
+            minSockets,
+            month,
+            referenceUom,
+            page);
+    payload =
+        hosts.getContent().stream()
+            .map(h -> asTallyHostViewApiInstance(h, month, measurements))
+            .collect(Collectors.toList());
+
+    PageLinks links;
+    if (offset != null || limit != null) {
+      links = pageLinkCreator.getPaginationLinks(uriInfo, hosts);
+    } else {
+      links = null;
+    }
+
+    return new InstanceResponse()
+        .links(links)
+        .meta(
+            new InstanceMeta()
+                .count((int) hosts.getTotalElements())
+                .product(productId)
+                .serviceLevel(sla)
+                .usage(usage)
+                .measurements(measurements))
+        .data(payload);
+  }
+
+  protected void validateBeginningAndEndingDates(OffsetDateTime beginning, OffsetDateTime ending) {
+    boolean isDateRangePossible = beginning.isBefore(ending) || beginning.isEqual(ending);
+    boolean isBothDatesFromSameMonth = Objects.equals(beginning.getMonth(), ending.getMonth());
+
+    if (!isDateRangePossible || !isBothDatesFromSameMonth) {
+      throw new IllegalArgumentException("Invalid date range.");
+    }
+  }
+
+  private InstanceData asTallyHostViewApiInstance(
+      Host host, String monthId, List<String> measurements) {
+    var instance = new InstanceData();
+    List<Double> measurementList = new ArrayList<>();
+    instance.setId(host.getInstanceId());
+    instance.setDisplayName(host.getDisplayName());
+
+    for (String uom : measurements) {
+      measurementList.add(host.getMonthlyTotal(monthId, Measurement.Uom.fromValue(uom)));
+    }
+    instance.setMeasurements(measurementList);
+    instance.setLastSeen(host.getLastSeen());
+
+    return instance;
+  }
+
+  private static Map<InstanceReportSort, Measurement.Uom> getSortToUomMap() {
+    return Arrays.stream(Measurement.Uom.values())
+        .filter(
+            uom ->
+                Arrays.stream(InstanceReportSort.values())
+                    .map(InstanceReportSort::toString)
+                    .collect(Collectors.toSet())
+                    .contains(uom.value()))
+        .collect(
+            Collectors.toMap(
+                uom -> InstanceReportSort.fromValue(uom.value()), Function.identity()));
+  }
+
+  private static Map<InstanceReportSort, String> getUomSorts() {
+    return getSortToUomMap().keySet().stream()
+        .collect(Collectors.toMap(Function.identity(), key -> "monthlyTotals"));
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource;
+
+import static org.candlepin.subscriptions.utilization.api.model.ProductId.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.*;
+import org.candlepin.subscriptions.db.AccountListSource;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.resteasy.PageLinkCreator;
+import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
+import org.candlepin.subscriptions.tally.AccountListSourceException;
+import org.candlepin.subscriptions.utilization.api.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"api", "test"})
+@WithMockRedHatPrincipal("123456")
+class InstancesResourceTest {
+
+  @MockBean HostRepository repository;
+  @MockBean PageLinkCreator pageLinkCreator;
+  @MockBean AccountListSource accountListSource;
+  @Autowired InstancesResource resource;
+
+  @BeforeEach
+  public void setup() throws AccountListSourceException {
+    when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
+  }
+
+  @Test
+  void testShouldPopulateInstanceResponse() {
+    var host = new Host();
+    host.setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
+    host.setDisplayName("rhv.example.com");
+    host.setLastSeen(OffsetDateTime.now());
+
+    Mockito.when(
+            repository.findAllBy(
+                any(), any(), any(), any(), any(), anyInt(), anyInt(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(host)));
+
+    var expectUom = List.of("Instance-hours", "Storage-gibibytes", "Transfer-gibibytes");
+    List<Double> expectedMeasurement = new ArrayList<>();
+    String month = InstanceMonthlyTotalKey.formatMonthId(host.getLastSeen());
+    for (String uom : expectUom) {
+      expectedMeasurement.add(host.getMonthlyTotal(month, Measurement.Uom.fromValue(uom)));
+    }
+    var data = new InstanceData();
+    data.setId(host.getInstanceId());
+    data.setDisplayName(host.getDisplayName());
+    data.setLastSeen(host.getLastSeen());
+    data.setMeasurements(expectedMeasurement);
+
+    var meta = new InstanceMeta();
+    meta.setCount(1);
+    meta.setProduct(ProductId.RHOSAK);
+    meta.setServiceLevel(ServiceLevelType.PREMIUM);
+    meta.setUsage(UsageType.PRODUCTION);
+    meta.setMeasurements(expectUom);
+
+    var expected = new InstanceResponse();
+    expected.setData(List.of(data));
+    expected.setMeta(meta);
+
+    InstanceResponse report =
+        resource.getInstancesByProduct(
+            RHOSAK,
+            null,
+            null,
+            ServiceLevelType.PREMIUM,
+            UsageType.PRODUCTION,
+            null,
+            null,
+            null,
+            InstanceReportSort.DISPLAY_NAME,
+            null);
+
+    assertEquals(expected, report);
+  }
+}


### PR DESCRIPTION
This PR is to address [ENT-4383](https://issues.redhat.com/browse/ENT-4383)

### Testing Step for Instance
Profiles use for Testing
```
DEV_MODE=true;
USER_USE_STUB=true;
PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1
```


Get connected to the testing telemeter instance:
Uncomment 'Eval' in application-openshift-metering-worker.yaml so that the Kafka cluster metrics get picked up by the query.
```
min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None|Eval"}[1h])
```

1. Gather measurements from Telemeter:
```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)","arguments":["6043640", "rhosak", "2021-10-30T00:00:00Z", 15760]}'
```
2. Start TallyJMX:
```
curl 'http://localhost:8080/actuator/hawtio/jolokia' \
  -H 'Content-Type: text/json' \
  -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
    "operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)",
    "arguments":["6043640", "2021-10-15T00:00Z", "2021-10-31T00:00Z"]
  }'
```
3. Use this curl to test Instance API:
```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/instances/products/rhosak?beginning=2021-10-15T00%3A00Z&ending=2021-10-31T00%3A00Z' \
  -H 'accept: application/json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJhY2NvdW50X251bWJlciI6ICI2MDQzNjQwIiwKICAgICAgICAidHlwZSI6ICJVc2VyIiwKICAgICAgICAidXNlciIgOiB7CiAgICAgICAgICAgICJpc19vcmdfYWRtaW4iOiB0cnVlCiAgICAgICAgfSwKICAgICAgICAiaW50ZXJuYWwiIDogewogICAgICAgICAgICAib3JnX2lkIjogIjYwNDM2NDAiCiAgICAgICAgfQogICAgfQp9'
```
This won't work if you try to Authorize with the default account ID as I'm using a specific account number for RHOSAK.