### PR TITLE
ENT-4052: Validate/fix capacity ingress clowder deployment

### DIFF
--- a/deploy/clowder.md
+++ b/deploy/clowder.md
@@ -177,8 +177,7 @@ but here are some essentials:
   $ podman push quay.io/awood/swatch-system-conduit
   ```
 
-* When you deploy with bonfire during development, specify the image and
-  image tag you want to use like so:
+* When you deploy with bonfire during development, you'll want to specify the image and image tag you want to use like so:
 
   ```
   `bonfire deploy rhsm-subscriptions -n NAMESPACE --no-remove-resources=all
@@ -219,3 +218,19 @@ but here are some essentials:
   ```
   oc get project -l ephemeral-ns-reserved -L ephemeral-ns-requester-name,ephemeral-ns-reserved
   ```
+
+# Special Notes
+## capacity-allowlist ConfigMap
+The capacity-ingress pod relies on a ConfigMap, called `capacity-allowlist`, found in GitLab.  The most straightforward way to get this config map is to manually add it via command line.  Make sure you're in the appropriate namespace using the `oc project` command, and then you can deploy the ConfigMap to that namespace using the following command:
+
+```bash
+curl https://gitlab.cee.redhat.com/rhsm/swatch-product-allowlist/-/raw/main/templates/capacity-allowlist.yml | oc process -f - | oc apply -f -
+```
+## bonfire "deploy" command and namespace reservation
+If you use `bonfire deploy` without already having a namespace reserved, it will reserve the namespace for you **BUT** if the app doesn't start up in the default amount of time, bonfire will take down/give up the namespace it reserved to begin with.  To get around this, you can manually reserve the namespace, then pass `-n <NAMESPACE>` as an argument when running `bonfire deploy`.
+
+# TL;DR Quickstart Steps
+1. Start bonfire virtual environment
+2. Reserve a namespace
+3. Apply the `capacity-allowlist` configmap
+4. Deploy rhsm with `bonfire deploy`


### PR DESCRIPTION
The environment ephemeral-41 has an rhsm-capacity-ingress pod running successfully that was done using the steps added to the clowder.md file as part of this PR.