### PR TITLE
ENT-4053 Add activeDeadlineSeconds to jobs, add sidecars

### DIFF
--- a/deploy/clowder.md
+++ b/deploy/clowder.md
@@ -174,6 +174,9 @@ but here are some essentials:
   $ podman push quay.io/awood/rhsm
   ```
 
+* In order to turn on sidecar support in an ephemeral environment:
+  `bonfire deploy-env -f deploy/rhsm-eph-clowdenv.yaml -n NAMESPACE`
+
 * When you deploy with bonfire during development, specify the image and
   image tag you want to use like so:
 

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -147,7 +147,7 @@ parameters:
   - name: OPENSHIFT_ENABLED_ACCOUNT_PROMQL
     value: "group(min_over_time(subscription_labels{ebs_account != '', billing_model='standard'}[1h])) by (ebs_account)"
   - name: EVENT_RECORD_RETENTION
-    value: 90d
+    value: '90d'
   - name: SUBSCRIPTION_SYNC_ENABLED
     value: 'true'
   - name: SUBSCRIPTION_URL
@@ -939,6 +939,9 @@ objects:
             - name: pinhead
               secret:
                 secretName: pinhead
+          sidecars:
+            - name: token-refresher
+              enabled: true
 
       - name: conduit
         webServices:
@@ -1294,6 +1297,7 @@ objects:
     jobs:
       - name: metrics-cron
         schedule: ${METERING_SCHEDULE}
+        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -1417,9 +1421,13 @@ objects:
           volumes:
             - name: logs
               emptyDir:
+          sidecars:
+            - name: token-refresher
+              enabled: true
 
       - name: cron-tally
         schedule: ${CAPTURE_SNAPSHOT_SCHEDULE}
+        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -1537,6 +1545,7 @@ objects:
 
       - name: hourly-tally
         schedule: ${CAPTURE_HOURLY_SNAPSHOT_SCHEDULE}
+        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -1654,6 +1663,7 @@ objects:
 
       - name: cron-purge
         schedule: ${PURGE_SNAPSHOT_SCHEDULE}
+        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -1773,6 +1783,7 @@ objects:
 
       - name: subscription-sync
         schedule: ${SUBSCRIPTION_SYNC_SCHEDULE}
+        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -1892,6 +1903,7 @@ objects:
 
       - name: offering-sync
         schedule: ${OFFERING_SYNC_SCHEDULE}
+        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:

--- a/deploy/rhsm-eph-clowdenv.yaml
+++ b/deploy/rhsm-eph-clowdenv.yaml
@@ -1,3 +1,5 @@
+# Derived from https://github.com/RedHatInsights/bonfire/blob/master/bonfire/resources/ephemeral-cluster-clowdenvironment.yaml
+# but with the token-refresher sidecar enabled
 apiVersion: v1
 kind: Template
 metadata:

--- a/deploy/rhsm-eph-clowdenv.yaml
+++ b/deploy/rhsm-eph-clowdenv.yaml
@@ -1,0 +1,98 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: ephemeral-clowdenvironment
+
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  metadata:
+    name: ${ENV_NAME}
+  spec:
+    targetNamespace: ${NAMESPACE}
+    resourceDefaults:
+      limits:
+        cpu: 300m
+        memory: 256Mi
+      requests:
+        cpu: 30m
+        memory: 128Mi
+    providers:
+      sidecars:
+        tokenRefresher:
+          enabled: true
+      pullSecrets:
+        - name: ${PULL_SECRET_NAME}
+          namespace: ${PULL_SECRET_NAMESPACE}
+      testing:
+        # Level of access the testing pod has in the namespace
+        k8sAccessLevel: edit
+        # How much environment configuration the testing pod can see
+        configAccess: environment
+        iqe:
+          # Base image for iqe-tests
+          imageBase: "quay.io/cloudservices/iqe-tests"
+          # Grant IQE pod access to vault
+          vaultSecretRef:
+            name: ${IQE_VAULT_SECRET_NAME}
+            namespace: ${IQE_VAULT_SECRET_NAMESPACE}
+          # Resources the IQE pod spins up with
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 1Gi
+      web:
+        port: 8000
+        privatePort: 10000
+        mode: operator
+      featureFlags:
+        mode: local
+      metrics:
+        port: 9000
+        path: "/metrics"
+        prometheus:
+          deploy: true
+        mode: operator
+      kafka:
+        mode: operator
+        pvc: false
+        # disable tls/auth for now until core apps are ready
+        enableLegacyStrimzi: true
+        cluster:
+          version: "2.7.0"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 600Mi
+        connect:
+          version: "2.7.0"
+          image: "quay.io/cloudservices/xjoin-kafka-connect-strimzi:182ab8b"
+      db:
+        mode: local
+        pvc: false
+      logging:
+        mode: none
+      objectStore:
+        mode: minio
+      inMemoryDb:
+        mode: redis
+parameters:
+- name: NAMESPACE
+  description: Namespace that ClowdEnvironment components will be deployed to
+- name: ENV_NAME
+  description: Name of the ClowdEnvironment
+  required: true
+- name: PULL_SECRET_NAME
+  value: quay-cloudservices-pull
+- name: PULL_SECRET_NAMESPACE
+  value: ephemeral-base
+- name: IQE_VAULT_SECRET_NAME
+  value: iqe-vault
+- name: IQE_VAULT_SECRET_NAMESPACE
+  value: ephemeral-base


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4053

activeDeadlineSeconds ensures they are terminated if they hang, and for metrics-cron, it ensures that the sidecar doesn't keep the job from finishing.

Note that activating sidecars requires a change the ClowdEnvironment. I added a note to clowder.md about that.

Note that offering-sync needs the allowlist populated (see #659).