### PR TITLE
ENT-4507 Liquibase: check if RHOSAK SKU has been synced

### DIFF
--- a/src/main/resources/liquibase/202110211313-add-rhosak-offering.xml
+++ b/src/main/resources/liquibase/202110211313-add-rhosak-offering.xml
@@ -5,6 +5,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202110211313-1" author="mstead">
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(1) FROM offering WHERE sku = 'MW01882'
+      </sqlCheck>
+    </preConditions>
     <comment>Add offering for RHOSAK SKU</comment>
     <insert tableName="offering">
       <column name="sku" value="MW01882"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4507

Essentially, this change checks to see if the SKU has been synced
already, and marks the change as run if it has.

Testing
-------

Run w/ `SPRING_PROFILES_ACTIVE=liquibase-only ./gradlew :bootRun`...

1. Run w/ this branch to get the offering added via liquibase.
2. Remove the record that indicates the changeset was run:

```
echo "delete from databasechangelog where id='202110211313-1'" | psql -h localhost -U rhsm-subscriptions
```

3. Using `develop`, run liquibase and observe the error.
4. Using this branch, run liquibase, and observe no error.