### PR TITLE
ENT-4236 Add payload to marketplace response object

### DIFF
--- a/clients/marketplace-client/marketplace-api-spec.yaml
+++ b/clients/marketplace-client/marketplace-api-spec.yaml
@@ -128,6 +128,8 @@ components:
         - metricId
         - value
       properties:
+        chargeId:  # NOTE: metricId is used in the request, but becomes chargeId in the response
+          type: string
         metricId:
           type: string
         value:
@@ -151,6 +153,8 @@ components:
           type: string
         batchId:
           type: string
+        payload:
+          $ref: "#/components/schemas/UsageEvent"
 
   securitySchemes:
     accessToken:

--- a/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/marketplace/MarketplaceProducer.java
@@ -136,6 +136,7 @@ public class MarketplaceProducer {
             batchId,
             status,
             response.getMessage());
+        log.debug("Marketplace response: {}", response);
         rejectedCounter.increment();
       } else {
         acceptedCounter.increment();


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4236

I also added chargeId as a field to the UsageMeasurement, as I found during experimentation that the `metricId` is returned as `chargeId`.

Testing
-------

Run (replace `$MARKETPLACE_API_KEY` with a sandbox token):

```
DEV_MODE=true \
  MARKETPLACE_URL=https://sandbox.marketplace.redhat.com \
  MARKETPLACE_API_KEY=$MARKETPLACE_API_KEY \
  ./gradlew bootRun
```

Using the [marketplaceJmxBean](http://localhost:8080/actuator/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.marketplace-MarketplaceJmxBean-marketplaceJmxBean), submitUsage method, submit the following JSON (can create a fresh uuid via `uuidgen` as needed):

```json
{
    "data": [
        {
            "start": 1637011016000,
            "end": 1637011076000,
            "subscriptionId": "this_is_not_a_real_sub!!",
            "eventId": "67da8025-f276-467e-8b0d-16bfd40d0d43",
            "additionalAttributes": {},
            "measuredUsage": [
                {
                    "metricId": "redhat.com:openshiftdedicated:cpu_hour",
                    "value": 42
                }
            ]
        }
    ]
}
```

Note in the logs you'll see message similar to

```
2021-11-16 16:15:53,692 [thread=http-nio-8080-exec-4] [ERROR] [org.candlepin.subscriptions.marketplace.MarketplaceProducer] - Error submitting usage for snapshot IDs: b0037dbb-1b3a-449e-a350-13876f65b7db
org.candlepin.subscriptions.marketplace.MarketplaceUsageSubmissionException: class StatusResponse {
    status: failed
    message: One or more events are in progress or failed to process.
    data: [class BatchStatus {
        status: failed
        message: Failed to resolve the provided subscription
        batchId: 6193d93947074a71fd326afd
        payload: class UsageEvent {
            start: 1637011016000
            end: 1637011076000
            subscriptionId: this_is_not_a_real_sub!!
            eventId: b0037dbb-1b3a-449e-a350-13876f65b7db
            additionalAttributes: {}
            measuredUsage: [class UsageMeasurement {
                metricId: null
                value: 42.0
            }]
        }
    }]
}
```

Notice the payload which shows the original request to marketplace.

I also added a debug logging statement, but could not find a way to get it to trigger.

Also try the `getUsageEventStatus` event w/ batchId `6193b981b88886497dbc6cc9` to see the added `chargeId` field.