### PR TITLE
Reduce log level for AccessDenied errors.

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
@@ -60,7 +60,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
       throws IOException, ServletException {
 
     Error error = RestAccessDeniedHandler.buildError(accessDeniedException);
-    log.error(
+    log.warn(
         SECURITY_STACKTRACE, "{}: {}", error.getTitle(), error.getDetail(), accessDeniedException);
 
     Response r = ExceptionUtil.toResponse(error);


### PR DESCRIPTION
AccessDenied can happen whenever a user attempts access when an organization has
not opted in. They get a warning back with the reason. As this is not an
application error we should reduce the log level so that real errors can be found
in the logs more easily.