### PR TITLE
Replace deprecated methods for Spring Boot 2.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ jar {
 }
 
 bootJar {
-    mainClassName = "org.candlepin.subscriptions.BootApplication"
+    mainClass = "org.candlepin.subscriptions.BootApplication"
 }
 
 springBoot {

--- a/src/test/java/org/candlepin/subscriptions/capacity/PoolIngressControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/PoolIngressControllerTest.java
@@ -62,7 +62,7 @@ class PoolIngressControllerTest {
     CandlepinPool pool = createTestPool("12345");
     controller.updateCapacityFromPools("org", Collections.singletonList(pool));
 
-    verifyZeroInteractions(mapper);
+    verifyNoInteractions(mapper);
     verify(subscriptionCapacityRepository).saveAll(Collections.emptyList());
   }
 

--- a/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionControllerTest.java
@@ -68,7 +68,7 @@ class TallyRetentionControllerTest {
   void retentionControllerShouldIgnoreGranularityWithoutCutoff() throws Exception {
     when(policy.getCutoffDate(Granularity.DAILY)).thenReturn(null);
     controller.cleanStaleSnapshotsForAccount("123456");
-    verifyZeroInteractions(repository);
+    verifyNoInteractions(repository);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
@@ -23,7 +23,7 @@ package org.candlepin.subscriptions.security;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -80,7 +80,7 @@ class IdentityHeaderAuthenticationDetailsServiceTest {
     assertEquals(
         Collections.singleton(new SimpleGrantedAuthority("ROLE_RH_INTERNAL")),
         userDetails.getAuthorities());
-    verifyZeroInteractions(rbacApi);
+    verifyNoInteractions(rbacApi);
   }
 
   @Test
@@ -90,7 +90,7 @@ class IdentityHeaderAuthenticationDetailsServiceTest {
     assertEquals(
         Collections.singleton(new SimpleGrantedAuthority("ROLE_RH_INTERNAL")),
         userDetails.getAuthorities());
-    verifyZeroInteractions(rbacApi);
+    verifyNoInteractions(rbacApi);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -87,14 +87,14 @@ class TallySnapshotControllerTest {
   void testCloudigradeAccountUsageCollectorDisabled() {
     props.setCloudigradeEnabled(false);
     controller.produceSnapshotsForAccount(ACCOUNT);
-    verifyZeroInteractions(cloudigradeCollector);
+    verifyNoInteractions(cloudigradeCollector);
   }
 
   @Test
   void testBatchesLargerThanConfigIgnored() {
     controller.produceSnapshotsForAccounts(
         Collections.nCopies(props.getAccountBatchSize() + 1, "foo"));
-    verifyZeroInteractions(cloudigradeCollector);
-    verifyZeroInteractions(inventoryCollector);
+    verifyNoInteractions(cloudigradeCollector);
+    verifyNoInteractions(inventoryCollector);
   }
 }

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -115,7 +115,7 @@ class InventoryControllerTest {
 
     controller.updateInventoryForOrg("org123");
 
-    verifyZeroInteractions(taskManager);
+    verifyNoInteractions(taskManager);
   }
 
   private OrgInventory pageOf(Consumer... consumers) {

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -146,7 +146,7 @@ class KafkaEnabledInventoryServiceTest {
         new KafkaEnabledInventoryService(props, producer, meterRegistry, retryTemplate);
     service.sendHostUpdate(Arrays.asList());
 
-    verifyZeroInteractions(producer);
+    verifyNoInteractions(producer);
   }
 
   @Test


### PR DESCRIPTION
To be precise:

```
sed -i s/verifyZeroInteractions/verifyNoInteractions/ $(git grep -l verifyZeroInteractions)
sed -i s/mainClassName/mainClass/ build.gradle
```

`verifyZeroInteractions` was removed from the mockito version pulled in by Spring Boot 2.6. Hope to see the 2.6 dependabot PR pass once this is merged (specifically the dependencies one).

`mainClassName` was removed. Hope to see the 2.6 dependabot PR pass once this is merged (specifically the gradle plugin one).