### PR TITLE
Change subs query for marketplace ID to use in

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -88,7 +88,7 @@ class SubscriptionRepositoryTest {
     offeringRepo.saveAndFlush(o2);
 
     UsageCalculation.Key key = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage.PRODUCTION);
-    Set<String> productNames = Set.of("Test SKU 2");
+    Set<String> productNames = Set.of("Test SKU 1");
     var resultList =
         subscriptionRepo.findByAccountAndProductNameAndServiceLevel(
             "1000", key, productNames, NOW, NOW);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -59,7 +59,7 @@ public interface SubscriptionRepository
 
   @Query(
       "SELECT s FROM Subscription s WHERE s.accountNumber = :accountNumber AND "
-          + "s.sku = ALL (SELECT DISTINCT o.sku FROM Offering o WHERE "
+          + "s.sku in (SELECT DISTINCT o.sku FROM Offering o WHERE "
           + ":#{#key.sla} = o.serviceLevel AND "
           + "o.productName IN :#{#productNames}) AND s.startDate <= :rangeStart AND s.endDate >= :rangeEnd AND "
           + "s.marketplaceSubscriptionId IS NOT NULL AND s.marketplaceSubscriptionId <> '' "


### PR DESCRIPTION
Instead of `all`

We're unsure why, but it seems when multiple rows are returned by the
subquery, at least in prod (but not locally :-/), we get no results.