### PR TITLE
ENT-3785: Add prune subs JMX endpoint and dev/test endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ RBAC_USE_STUB=true ./gradlew bootRun
 ### Environment Variables
 
 * `DEV_MODE`: disable anti-CSRF, account filtering, and RBAC role check
+* `DEVTEST_SUBSCRIPTION_EDITING_ENABLED`: allow subscription/offering edits via JMX.
+* `DEVTEST_EVENT_EDITING_ENABLED`: allow event edits via JMX.
 * `PRETTY_PRINT_JSON`: configure Jackson to indent outputted JSON
 * `APP_NAME`: application name for URLs (default: rhsm-subscriptions)
 * `PATH_PREFIX`: path prefix in the URLs (default: api)

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ allprojects {
         testCompileOnly "org.projectlombok:lombok"
         testAnnotationProcessor "org.projectlombok:lombok"
         annotationProcessor('org.hibernate:hibernate-jpamodelgen')
+        annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
         testCompile "org.springframework.boot:spring-boot-starter-test"
         testCompile "org.springframework:spring-test"
@@ -168,7 +169,6 @@ dependencies {
     implementation project(':swatch-core')
     // Generates configuration metadata that IntelliJ can use
     annotationProcessor('org.hibernate:hibernate-jpamodelgen')
-    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     // For the LiveReload feature of spring boot as long as IntelliJ is set to build/make automatically on
     // code changes
     compile('org.springframework.boot:spring-boot-devtools')

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -113,6 +113,13 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   }
 
   @Bean
+  @Qualifier
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.subscription-prune.tasks")
+  TaskQueueProperties pruneSubscriptionTasks() {
+    return new TaskQueueProperties();
+  }
+
+  @Bean
   @Qualifier("reconcileCapacityTasks")
   @ConfigurationProperties(prefix = "rhsm-subscriptions.capacity.tasks")
   TaskQueueProperties reconcileCapacityQueueProperties() {

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationConfiguration.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.capacity;
 
 import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
 
+import org.candlepin.subscriptions.subscription.PruneSubscriptionsTask;
 import org.candlepin.subscriptions.subscription.SyncSubscriptionsTask;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
@@ -45,6 +46,12 @@ public class CapacityReconciliationConfiguration {
   }
 
   @Bean
+  public ProducerFactory<String, PruneSubscriptionsTask> pruneSubscriptionsProducerFactory(
+      KafkaProperties kafkaProperties) {
+    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+  }
+
+  @Bean
   public ProducerFactory<String, ReconcileCapacityByOfferingTask>
       reconcileCapacityByOfferingProducerFactory(KafkaProperties kafkaProperties) {
     return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
@@ -54,6 +61,12 @@ public class CapacityReconciliationConfiguration {
   public KafkaTemplate<String, SyncSubscriptionsTask> syncSubscriptionsKafkaTemplate(
       ProducerFactory<String, SyncSubscriptionsTask> syncSubscriptionsProducerFactory) {
     return new KafkaTemplate<>(syncSubscriptionsProducerFactory);
+  }
+
+  @Bean
+  public KafkaTemplate<String, PruneSubscriptionsTask> pruneSubscriptionsKafkaTemplate(
+      ProducerFactory<String, PruneSubscriptionsTask> pruneSubscriptionsProducerFactory) {
+    return new KafkaTemplate<>(pruneSubscriptionsProducerFactory);
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/product/JsonProductDataSource.java
+++ b/src/main/java/org/candlepin/subscriptions/product/JsonProductDataSource.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.product;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.product.api.model.EngineeringProduct;
+import org.candlepin.subscriptions.product.api.model.EngineeringProductMap;
+import org.candlepin.subscriptions.product.api.model.RESTProductTree;
+import org.candlepin.subscriptions.product.api.model.SkuEngProduct;
+
+/**
+ * Data source for product data that uses static JSON.
+ *
+ * @see OfferingJmxBean#saveOfferings(String, String, String, boolean)
+ */
+class JsonProductDataSource implements ProductDataSource {
+  private final Map<String, RESTProductTree> productTreeMap;
+  private final Map<String, RESTProductTree> derivedProductTreeMap;
+  private final Map<String, List<EngineeringProduct>> engineeringProductsMap;
+
+  public JsonProductDataSource(
+      ObjectMapper objectMapper,
+      String offeringsJsonArray,
+      String derivedSkuDataJsonArray,
+      String engProdJsonArray) {
+    try {
+      RESTProductTree[] productTrees =
+          objectMapper.readValue(offeringsJsonArray, RESTProductTree[].class);
+      productTreeMap =
+          Arrays.stream(productTrees)
+              .collect(Collectors.toMap(UpstreamProductData::findSku, Function.identity()));
+
+      RESTProductTree[] derivedSkuTrees =
+          objectMapper.readValue(derivedSkuDataJsonArray, RESTProductTree[].class);
+      derivedProductTreeMap =
+          Arrays.stream(derivedSkuTrees)
+              .collect(Collectors.toMap(UpstreamProductData::findSku, Function.identity()));
+      EngineeringProductMap[] engineeringProductMaps =
+          objectMapper.readValue(engProdJsonArray, EngineeringProductMap[].class);
+      engineeringProductsMap =
+          Arrays.stream(engineeringProductMaps)
+              .map(EngineeringProductMap::getEntries)
+              .filter(Objects::nonNull)
+              .flatMap(Collection::stream)
+              .collect(Collectors.toMap(SkuEngProduct::getSku, this::getEngineeringProducts));
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Error processing provided JSON", e);
+    }
+  }
+
+  public Stream<String> getTopLevelSkus() {
+    return productTreeMap.keySet().stream();
+  }
+
+  @Override
+  public Optional<RESTProductTree> getTree(String sku) {
+    if (productTreeMap.containsKey(sku)) {
+      return Optional.of(productTreeMap.get(sku));
+    }
+    if (derivedProductTreeMap.containsKey(sku)) {
+      return Optional.of(derivedProductTreeMap.get(sku));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public Map<String, List<EngineeringProduct>> getEngineeringProductsForSkus(
+      Collection<String> skus) {
+    return engineeringProductsMap;
+  }
+
+  private List<EngineeringProduct> getEngineeringProducts(SkuEngProduct product) {
+    if (product.getEngProducts() == null || product.getEngProducts().getEngProducts() == null) {
+      return Collections.emptyList();
+    }
+    return product.getEngProducts().getEngProducts();
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/product/ProductDataSource.java
+++ b/src/main/java/org/candlepin/subscriptions/product/ProductDataSource.java
@@ -18,21 +18,20 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.db;
+package org.candlepin.subscriptions.product;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.stream.Stream;
-import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
-import org.candlepin.subscriptions.db.model.SubscriptionCapacityKey;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Map;
+import java.util.Optional;
+import org.candlepin.subscriptions.product.api.model.EngineeringProduct;
+import org.candlepin.subscriptions.product.api.model.RESTProductTree;
 
-/** Repository for subscription-provided product capacities. */
-public interface SubscriptionCapacityRepository
-    extends JpaRepository<SubscriptionCapacity, SubscriptionCapacityKey>,
-        CustomizedSubscriptionCapacityRepository {
+/** Abstraction to allow product data to be pulled from API or provided directly. */
+public interface ProductDataSource {
 
-  List<SubscriptionCapacity> findByKeyOwnerIdAndKeySubscriptionIdIn(
-      String ownerId, List<String> subscriptionIds);
+  Optional<RESTProductTree> getTree(String sku) throws ApiException;
 
-  Stream<SubscriptionCapacity> findByKeyOwnerId(String ownerId);
+  Map<String, List<EngineeringProduct>> getEngineeringProductsForSkus(Collection<String> skus)
+      throws ApiException;
 }

--- a/src/main/java/org/candlepin/subscriptions/product/ProductService.java
+++ b/src/main/java/org/candlepin/subscriptions/product/ProductService.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
 
 /** Retrieves product information. */
 @Component
-public class ProductService {
+public class ProductService implements ProductDataSource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProductService.class);
 
@@ -50,6 +50,7 @@ public class ProductService {
    * @return An optional containing the product tree, or an empty if the pro
    * @throws ApiException if fails to make API call
    */
+  @Override
   public Optional<RESTProductTree> getTree(String sku) throws ApiException {
     LOGGER.debug("Retrieving product tree for sku={}", sku);
     Optional<RESTProductTree> skuTree =
@@ -71,6 +72,7 @@ public class ProductService {
     return getEngineeringProductsForSkus(skus).get(sku);
   }
 
+  @Override
   public Map<String, List<EngineeringProduct>> getEngineeringProductsForSkus(
       Collection<String> skus) throws ApiException {
     String skusQuery = String.join(",", skus);

--- a/src/main/java/org/candlepin/subscriptions/subscription/PruneSubscriptionsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/PruneSubscriptionsTask.java
@@ -18,21 +18,23 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.db;
+package org.candlepin.subscriptions.subscription;
 
-import java.util.List;
-import java.util.stream.Stream;
-import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
-import org.candlepin.subscriptions.db.model.SubscriptionCapacityKey;
-import org.springframework.data.jpa.repository.JpaRepository;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-/** Repository for subscription-provided product capacities. */
-public interface SubscriptionCapacityRepository
-    extends JpaRepository<SubscriptionCapacity, SubscriptionCapacityKey>,
-        CustomizedSubscriptionCapacityRepository {
-
-  List<SubscriptionCapacity> findByKeyOwnerIdAndKeySubscriptionIdIn(
-      String ownerId, List<String> subscriptionIds);
-
-  Stream<SubscriptionCapacity> findByKeyOwnerId(String ownerId);
+/** Task message for pruning unlisted subscriptions for an org. */
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@ToString
+@EqualsAndHashCode
+public class PruneSubscriptionsTask {
+  private String orgId;
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionJmxBean.java
@@ -23,8 +23,12 @@ package org.candlepin.subscriptions.subscription;
 import javax.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.resource.ResourceUtils;
+import org.candlepin.subscriptions.security.SecurityProperties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
+import org.springframework.jmx.JmxException;
 import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedOperationParameter;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.stereotype.Component;
 
@@ -34,10 +38,18 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class SubscriptionJmxBean {
 
-  SubscriptionSyncController subscriptionSyncController;
+  private final SubscriptionSyncController subscriptionSyncController;
+  private final SubscriptionPruneController subscriptionPruneController;
+  private final SecurityProperties properties;
 
-  SubscriptionJmxBean(SubscriptionSyncController subscriptionSyncController) {
+  @Autowired
+  SubscriptionJmxBean(
+      SubscriptionSyncController subscriptionSyncController,
+      SubscriptionPruneController subscriptionPruneController,
+      SecurityProperties properties) {
     this.subscriptionSyncController = subscriptionSyncController;
+    this.subscriptionPruneController = subscriptionPruneController;
+    this.properties = properties;
   }
 
   @Transactional
@@ -63,5 +75,47 @@ public class SubscriptionJmxBean {
     Object principal = ResourceUtils.getPrincipal();
     log.info("Sync for all sync enabled orgs triggered over JMX by {}", principal);
     subscriptionSyncController.syncAllSubscriptionsForAllOrgs();
+  }
+
+  @Transactional
+  @ManagedOperation(
+      description = "Remove subscription and capacity records that are not in the allowlist.")
+  public void pruneUnlistedSubscriptions() {
+    Object principal = ResourceUtils.getPrincipal();
+    log.info("Prune of unlisted subscriptions triggered over JMX by {}", principal);
+    subscriptionPruneController.pruneAllUnlistedSubscriptions();
+  }
+
+  @ManagedOperation(
+      description = "Save subscriptions manually, ignoring allowlist. Supported only in dev-mode.")
+  @ManagedOperationParameter(
+      name = "subscriptionsJson",
+      description = "JSON array containing subscriptions to save")
+  @ManagedOperationParameter(
+      name = "reconcileCapacity",
+      description =
+          "Invoke reconciliation logic to create capacity? (hint: offering for the SKU must be present)")
+  public void saveSubscriptions(String subscriptionsJson, boolean reconcileCapacity) {
+    if (!properties.isDevMode() && !properties.isManualSubscriptionEditingEnabled()) {
+      throw new JmxException("This feature is not currently enabled.");
+    }
+    try {
+      Object principal = ResourceUtils.getPrincipal();
+      log.info("Save of new subscriptions triggered over JMX by {}", principal);
+      subscriptionSyncController.saveSubscriptions(subscriptionsJson, reconcileCapacity);
+    } catch (Exception e) {
+      log.error("Error saving subscriptions", e);
+      throw new JmxException("Error saving subscriptions. See log for details.");
+    }
+  }
+
+  @ManagedOperation(description = "Delete a subscription manually. Supported only in dev-mode.")
+  public void deleteSubscription(String subscriptionId) {
+    if (!properties.isDevMode() && !properties.isManualSubscriptionEditingEnabled()) {
+      throw new JmxException("This feature is not currently enabled.");
+    }
+    Object principal = ResourceUtils.getPrincipal();
+    log.info("Save of new subscriptions triggered over JMX by {}", principal);
+    subscriptionSyncController.deleteSubscription(subscriptionId);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionPruneController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionPruneController.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.stream.Stream;
+import javax.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.capacity.files.ProductWhitelist;
+import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
+import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.model.OrgConfigRepository;
+import org.candlepin.subscriptions.db.model.Subscription;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/** Logic for pruning unlisted subscriptions (where the SKU is not in the allowlist). */
+@Slf4j
+@Component
+public class SubscriptionPruneController {
+  private final SubscriptionRepository subscriptionRepository;
+  private final SubscriptionCapacityRepository subscriptionCapacityRepository;
+  private final OrgConfigRepository orgRepository;
+  private final Timer pruneAllTimer;
+  private final KafkaTemplate<String, PruneSubscriptionsTask>
+      pruneSubscriptionsByOrgTaskKafkaTemplate;
+  private final String pruneSubscriptionsTopic;
+  private final ProductWhitelist productWhitelist;
+
+  @Autowired
+  public SubscriptionPruneController(
+      SubscriptionRepository subscriptionRepository,
+      SubscriptionCapacityRepository subscriptionCapacityRepository,
+      OrgConfigRepository orgRepository,
+      MeterRegistry meterRegistry,
+      KafkaTemplate<String, PruneSubscriptionsTask> pruneSubscriptionsByOrgTaskKafkaTemplate,
+      ProductWhitelist productWhitelist,
+      @Qualifier("pruneSubscriptionTasks") TaskQueueProperties pruneQueueProperties) {
+    this.subscriptionRepository = subscriptionRepository;
+    this.subscriptionCapacityRepository = subscriptionCapacityRepository;
+    this.orgRepository = orgRepository;
+    this.pruneAllTimer = meterRegistry.timer("swatch_subscription_prune_enqueue_all");
+    this.productWhitelist = productWhitelist;
+    this.pruneSubscriptionsTopic = pruneQueueProperties.getTopic();
+    this.pruneSubscriptionsByOrgTaskKafkaTemplate = pruneSubscriptionsByOrgTaskKafkaTemplate;
+  }
+
+  public void pruneAllUnlistedSubscriptions() {
+    Timer.Sample enqueueAllTime = Timer.start();
+    orgRepository.findSyncEnabledOrgs().forEach(this::enqueueSubscriptionPrune);
+    Duration enqueueAllDuration = Duration.ofNanos(enqueueAllTime.stop(pruneAllTimer));
+    log.info(
+        "Enqueued orgs to prune subscriptions in enqueueTimeMillis={}",
+        enqueueAllDuration.toMillis());
+  }
+
+  @Transactional
+  public void pruneUnlistedSubscriptions(String orgId) {
+    Stream<Subscription> subscriptions = subscriptionRepository.findByOwnerId(orgId);
+    subscriptions.forEach(
+        subscription -> {
+          if (!productWhitelist.productIdMatches(subscription.getSku())) {
+            log.info(
+                "Removing subscriptionId={} for orgId={} w/ sku={}",
+                subscription.getSubscriptionId(),
+                orgId,
+                subscription.getSku());
+            subscriptionRepository.delete(subscription);
+          }
+        });
+    Stream<org.candlepin.subscriptions.db.model.SubscriptionCapacity> capacityRecords =
+        subscriptionCapacityRepository.findByKeyOwnerId(orgId);
+    capacityRecords.forEach(
+        capacityRecord -> {
+          if (!productWhitelist.productIdMatches(capacityRecord.getSku())) {
+            log.info(
+                "Removing capacity record for subscriptionId={} for orgId={} w/ sku={}",
+                capacityRecord.getSubscriptionId(),
+                orgId,
+                capacityRecord.getSku());
+            subscriptionCapacityRepository.delete(capacityRecord);
+          }
+        });
+  }
+
+  private void enqueueSubscriptionPrune(String orgId) {
+    log.debug("Enqueuing subscription prune for orgId={}", orgId);
+    pruneSubscriptionsByOrgTaskKafkaTemplate.send(
+        pruneSubscriptionsTopic, PruneSubscriptionsTask.builder().orgId(orgId).build());
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionPruneListener.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionPruneListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription;
+
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+/** Listener for prune messages from Kafka */
+@Service
+@Slf4j
+@Profile("capacity-ingress")
+public class SubscriptionPruneListener extends SeekableKafkaConsumer {
+
+  SubscriptionPruneController subscriptionPruneController;
+
+  protected SubscriptionPruneListener(
+      @Qualifier("pruneSubscriptionTasks") TaskQueueProperties taskQueueProperties,
+      KafkaConsumerRegistry kafkaConsumerRegistry,
+      SubscriptionPruneController subscriptionPruneController) {
+    super(taskQueueProperties, kafkaConsumerRegistry);
+    this.subscriptionPruneController = subscriptionPruneController;
+  }
+
+  @KafkaListener(
+      id = "#{__listener.groupId}",
+      topics = "#{__listener.topic}",
+      containerFactory = "subscriptionPruneListenerContainerFactory")
+  public void receive(PruneSubscriptionsTask pruneSubscriptionsTask) {
+    log.info(
+        "Prune Subscription Worker is pruning subs with values: {} ",
+        pruneSubscriptionsTask.toString());
+    subscriptionPruneController.pruneUnlistedSubscriptions(pruneSubscriptionsTask.getOrgId());
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,6 +88,10 @@ rhsm-subscriptions:
     tasks:
       topic: platform.rhsm-subscriptions.subscription-sync
       kafka-group-id: subscription-worker
+  subscription-prune:
+    tasks:
+      topic: platform.rhsm-subscriptions.subscription-prune
+      kafka-group-id: subscription-prune-worker
   capacity:
     tasks:
       topic: platform.rhsm-subscriptions.capacity-reconcile

--- a/src/main/resources/liquibase/202112171721-add-subscription-indexes.xml
+++ b/src/main/resources/liquibase/202112171721-add-subscription-indexes.xml
@@ -1,0 +1,21 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202112171721-1"  author="khowell">
+    <comment>Add indexes to subscription table</comment>
+    <createIndex tableName="subscription" indexName="subscription_sku_idx">
+      <column name="sku"/>
+    </createIndex>
+    <createIndex tableName="subscription" indexName="subscription_account_number_sku_idx">
+      <column name="account_number"/>
+      <column name="sku"/>
+    </createIndex>
+    <createIndex tableName="subscription" indexName="subscription_owner_id_idx">
+      <column name="owner_id"/>
+    </createIndex>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -51,5 +51,6 @@
     <include file="liquibase/202111331133-add-account-service-table.xml" />
     <include file="liquibase/202110211313-add-rhosak-offering.xml" />
     <include file="liquibase/202110211314-add-description-column-to-offering.xml" />
+    <include file="liquibase/202112171721-add-subscription-indexes.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -169,8 +168,6 @@ class SubscriptionRepositoryTest {
 
     var result = subscriptionRepo.findBySku("MCT3718", Pageable.ofSize(5));
     assertEquals(5, result.stream().count());
-    assertThat(result.getContent().get(0).getSubscriptionId())
-        .isLessThan(result.getContent().get(1).getSubscriptionId());
   }
 
   private Offering createOffering(

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionPruneControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionPruneControllerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.capacity.files.ProductWhitelist;
+import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
+import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.model.OrgConfigRepository;
+import org.candlepin.subscriptions.db.model.Subscription;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionPruneControllerTest {
+  private final SubscriptionRepository subscriptionRepo;
+  private final SubscriptionCapacityRepository capacityRepo;
+  private final OrgConfigRepository orgConfigRepo;
+  private final KafkaTemplate<String, PruneSubscriptionsTask> kafkaTemplate;
+  private final SubscriptionPruneController controller;
+
+  SubscriptionPruneControllerTest(
+      @Mock SubscriptionRepository subscriptionRepo,
+      @Mock SubscriptionCapacityRepository capacityRepo,
+      @Mock OrgConfigRepository orgConfigRepo,
+      @Mock MeterRegistry meterRegistry,
+      @Mock Timer timer,
+      @Mock KafkaTemplate<String, PruneSubscriptionsTask> kafkaTemplate,
+      @Mock ProductWhitelist allowList) {
+    this.subscriptionRepo = subscriptionRepo;
+    this.capacityRepo = capacityRepo;
+    this.orgConfigRepo = orgConfigRepo;
+    this.kafkaTemplate = kafkaTemplate;
+    TaskQueueProperties queueProperties = new TaskQueueProperties();
+    when(meterRegistry.timer(any())).thenReturn(timer);
+    when(allowList.productIdMatches("allowed")).thenReturn(true);
+    when(allowList.productIdMatches("denied")).thenReturn(false);
+    controller =
+        new SubscriptionPruneController(
+            subscriptionRepo,
+            capacityRepo,
+            orgConfigRepo,
+            meterRegistry,
+            kafkaTemplate,
+            allowList,
+            queueProperties);
+  }
+
+  @Test
+  void testPruneUnlistedOnlyEnqueuesWork() {
+    when(orgConfigRepo.findSyncEnabledOrgs()).thenReturn(Stream.of("org1", "org2"));
+    controller.pruneAllUnlistedSubscriptions();
+    verify(kafkaTemplate, times(2)).send(any(), any());
+    verifyNoInteractions(subscriptionRepo, capacityRepo);
+  }
+
+  @Test
+  void testPruneDoesNothingIfSkuOnAllowlist() {
+    Subscription allowedSub = new Subscription();
+    allowedSub.setSku("allowed");
+    when(subscriptionRepo.findByOwnerId("up-to-date")).thenReturn(Stream.of(allowedSub));
+    SubscriptionCapacity allowedCapacity = new SubscriptionCapacity();
+    allowedCapacity.setSku("allowed");
+    when(capacityRepo.findByKeyOwnerId("up-to-date")).thenReturn(Stream.of(allowedCapacity));
+    controller.pruneUnlistedSubscriptions("up-to-date");
+    verify(subscriptionRepo).findByOwnerId("up-to-date");
+    verify(capacityRepo).findByKeyOwnerId("up-to-date");
+    verifyNoMoreInteractions(subscriptionRepo, capacityRepo);
+  }
+
+  @Test
+  void testPruneRemovesDelistedCapacity() {
+    when(subscriptionRepo.findByOwnerId("stale-capacity")).thenReturn(Stream.of());
+    SubscriptionCapacity staleCapacity = new SubscriptionCapacity();
+    staleCapacity.setSku("denied");
+    when(capacityRepo.findByKeyOwnerId("stale-capacity")).thenReturn(Stream.of(staleCapacity));
+    controller.pruneUnlistedSubscriptions("stale-capacity");
+    verify(subscriptionRepo).findByOwnerId("stale-capacity");
+    verify(capacityRepo).findByKeyOwnerId("stale-capacity");
+    verify(capacityRepo).delete(staleCapacity);
+    verifyNoMoreInteractions(subscriptionRepo);
+  }
+
+  @Test
+  void testPruneRemovesDelistedSubscription() {
+    Subscription staleSub = new Subscription();
+    staleSub.setSku("denied");
+    when(subscriptionRepo.findByOwnerId("stale-sub")).thenReturn(Stream.of(staleSub));
+    when(capacityRepo.findByKeyOwnerId("stale-sub")).thenReturn(Stream.of());
+    controller.pruneUnlistedSubscriptions("stale-sub");
+    verify(subscriptionRepo).findByOwnerId("stale-sub");
+    verify(capacityRepo).findByKeyOwnerId("stale-sub");
+    verify(subscriptionRepo).delete(staleSub);
+    verifyNoMoreInteractions(capacityRepo);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -24,6 +24,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.model.Subscription;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.springframework.data.domain.Page;
@@ -35,20 +36,6 @@ import org.springframework.data.repository.query.Param;
 /** Repository for Subscription Entities */
 public interface SubscriptionRepository
     extends JpaRepository<Subscription, Subscription.SubscriptionCompoundId> {
-
-  /**
-   * Object a set of subscriptions
-   *
-   * @param ownerId the ownerId of the subscriptions
-   * @param subscriptionIds the list of subscriptionIds to filter on
-   * @return a list of subscriptions with the specified ownerId and a subscriptionId from the
-   *     provided list
-   */
-  @Query(
-      "SELECT s FROM Subscription s where s.endDate > CURRENT_TIMESTAMP "
-          + "AND s.ownerId = :ownerId AND s.subscriptionId IN :subscriptionIds")
-  List<Subscription> findActiveByOwnerIdAndSubscriptionIdIn(
-      @Param("ownerId") String ownerId, @Param("subscriptionIds") List<String> subscriptionIds);
 
   @Query(
       "SELECT s FROM Subscription s where s.endDate > CURRENT_TIMESTAMP "
@@ -70,4 +57,8 @@ public interface SubscriptionRepository
       @Param("productNames") Set<String> productNames,
       @Param("rangeStart") OffsetDateTime rangeStart,
       @Param("rangeEnd") OffsetDateTime rangeEnd);
+
+  Stream<Subscription> findByOwnerId(String ownerId);
+
+  void deleteBySubscriptionId(String subscriptionId);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityProperties.java
@@ -31,6 +31,20 @@ public class SecurityProperties {
   private boolean devMode = false;
 
   /**
+   * Whether to allow manual subscription/offering edits.
+   *
+   * <p>For development/testing only.
+   */
+  private boolean isManualSubscriptionEditingEnabled = false;
+
+  /**
+   * Whether to allow manual event edits.
+   *
+   * <p>For development/testing only.
+   */
+  private boolean isManualEventEditingEnabled = false;
+
+  /**
    * Expected domain suffix for origin or referer headers.
    *
    * @see AntiCsrfFilter

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -27,6 +27,8 @@ HAWTIO_LOCAL_ADDRESS_PROBING: true
 HAWTIO_BASE_PATH:
 
 DEV_MODE: false
+DEVTEST_SUBSCRIPTION_EDITING_ENABLED: false
+DEVTEST_EVENT_EDITING_ENABLED: false
 PATH_PREFIX: api
 APP_NAME: rhsm-subscriptions
 
@@ -100,6 +102,8 @@ hawtio:
 rhsm-subscriptions:
   security:
     dev-mode: ${DEV_MODE}
+    is-manual-subscription-editing-enabled: ${DEVTEST_SUBSCRIPTION_EDITING_ENABLED}
+    is-manual-event-editing-enabled: ${DEVTEST_EVENT_EDITING_ENABLED}
   package_uri_mappings:
     # this mapping required here because it is used by our SecurityConfig, which is shared
     org.candlepin.subscriptions.resteasy: ${PATH_PREFIX}/${APP_NAME}/v1

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -49,6 +49,8 @@ parameters:
     value: '10'
   - name: SUBSCRIPTION_SYNC_ENABLED
     value: 'true'
+  - name: DEVTEST_SUBSCRIPTION_EDITING_ENABLED
+    value: 'false'
   - name: SUBSCRIPTION_URL
     value: https://subscription.qa.api.redhat.com/svcrest/subscription/v5
   - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -79,6 +79,8 @@ parameters:
     value: 1s
   - name: USER_BACK_OFF_MULTIPLIER
     value: '2'
+  - name: DEVTEST_EVENT_EDITING_ENABLED
+    value: 'false'
 
 objects:
   - apiVersion: v1


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-3785

I also added some indexes for queries that weren't using any, and removed an unused repo method.

I moved the annotationProcessor for spring boot to the `allprojects` section in order to resolve IDE warnings.

I also noticed that the event JMX beans don't currently check dev mode. I went ahead and added checks along with a couple new ENV vars:

- `DEVTEST_SUBSCRIPTION_EDITING_ENABLED`: when true, allows subscription/offering editing via JMX, even if dev-mode is off.
- `DEVTEST_EVENT_EDITING_ENABLED`: when true, allows event editing via JMX, even if dev-mode is off.

Testing
-------

First, create an allowlist locally:

```
echo -e 'MW00330\nRH3413336\n' > /tmp/allowlist.txt
```

Run the server via:

```
DEV_MODE=true \
  PRODUCT_WHITELIST_RESOURCE_LOCATION=file:/tmp/allowlist.txt \
  RHSM_SUBSCRIPTIONS_PRODUCT_WHITE_LIST_CACHE_TTL=0s \
  ./gradlew :bootRun
```

Note: if you wish to see the sql queries, you may also find it useful to create a file: `config/application.properties` with contents:

```
logging.level.org.hibernate.SQL=DEBUG
logging.level.org.hibernate.type=TRACE
spring.jpa.properties.hibernate.format_sql=true
```

Perform some setup via jolokia (can also use hawtio GUI for this):

Opt-in:

```
curl \
  -H 'Content-Type: application/json' \
  -d '{
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean",
    "operation": "createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)",
    "arguments": [
      "123",
      "123",
      true,
      true,
      true
    ]
  }' \
  http://localhost:8080/actuator/jolokia
```

Insert offering data... note that the endpoint takes three arguments, and the data for these arrays has the same format as the files in `src/main/resources/product-stub-data`. Generally, you can simply wrap some of these objects in an array. For the sake of simplifying testing, you can join the product data together like so:

```
cat src/main/resources/product-stub-data/tree-*.json | jq -s
```

```
cat src/main/resources/product-stub-data/engprods-*.json | jq -s
```

Technically, this also enters a derived SKU as a top-level product, but this really doesn't matter in practice.

Here's some bash to get all the stub data in at once:

```
curl \
  -H 'Content-Type: application/json' \
  -d "{
    \"type\": \"exec\",
    \"mbean\": \"org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean\",
    \"operation\": \"saveOfferings(java.lang.String,java.lang.String,java.lang.String,boolean)\",
    \"arguments\": [
        $(cat src/main/resources/product-stub-data/tree-*.json | jq -s),
        $(cat src/main/resources/product-stub-data/tree-*.json | jq -s),
        $(cat src/main/resources/product-stub-data/engprods-*.json | jq -s),
        false
    ]
  }" \
  http://localhost:8080/actuator/jolokia
```

Insert a subscription:

```
curl \
  -H 'Content-Type: application/json' \
  -d '{
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean",
    "operation": "saveSubscriptions(java.lang.String,boolean)",
    "arguments": [
      "[{
         \"id\": 1234576,
         \"quantity\": 2,
         \"webCustomerId\": 123,
         \"effectiveStartDate\": 1639002100392,
         \"effectiveEndDate\": 1639003100392,
         \"subscriptionProducts\": [
           {
             \"sku\": \"RH3413336\"
           }
         ]
      }]",
      true
    ]
  }' \
  http://localhost:8080/actuator/jolokia
```

Confirm both subscription and subscription_capacity rows in the DB:

```
psql -h localhost -U rhsm-subscriptions -c 'select * from subscription'
psql -h localhost -U rhsm-subscriptions -c 'select * from subscription_capacity'
```

Delete from the allowlist RH3413336:

```
sed -i '/RH3413336/d' /tmp/allowlist.txt
```

Run the prune operation:

```
curl \
  -H 'Content-Type: application/json' \
  -d ' {
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean",
    "operation": "pruneUnlistedSubscriptions()"
  }' \
  http://localhost:8080/actuator/jolokia
```

Confirm both subscription and subscription_capacity rows are removed:

```
psql -h localhost -U rhsm-subscriptions -c 'select * from subscription'
psql -h localhost -U rhsm-subscriptions -c 'select * from subscription_capacity'
```