### PR TITLE
ENT-4488 Skip sending summnary with no measurements

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.json.TallyMeasurement;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class SnapshotSummaryProducerTest {
+
+  @Mock private KafkaTemplate<String, TallySummary> kafka;
+
+  @Captor private ArgumentCaptor<TallySummary> summaryCaptor;
+
+  private TaskQueueProperties props;
+
+  private SnapshotSummaryProducer producer;
+
+  @BeforeEach
+  void setup() {
+    props = new TaskQueueProperties();
+    props.setTopic("summary-topic");
+
+    this.producer = new SnapshotSummaryProducer(kafka, props);
+  }
+
+  @Test
+  void testProduceSummary() {
+    Map<String, List<TallySnapshot>> updateMap = new HashMap<>();
+    updateMap.put(
+        "a1",
+        List.of(
+            buildSnapshot(
+                "a1",
+                "OSD",
+                Granularity.HOURLY,
+                ServiceLevel.PREMIUM,
+                Usage.PRODUCTION,
+                Uom.CORES,
+                20.4)));
+    updateMap.put(
+        "a2",
+        List.of(
+            buildSnapshot(
+                "a2",
+                "OCP",
+                Granularity.HOURLY,
+                ServiceLevel.PREMIUM,
+                Usage.PRODUCTION,
+                Uom.CORES,
+                22.2)));
+    producer.produceTallySummaryMessages(updateMap);
+    verify(kafka, times(2)).send(eq(props.getTopic()), summaryCaptor.capture());
+
+    List<TallySummary> summaries = summaryCaptor.getAllValues();
+    assertEquals(2, summaries.size());
+    Map<String, List<TallySummary>> results =
+        summaries.stream().collect(Collectors.groupingBy(TallySummary::getAccountNumber));
+    assertSummary(
+        results,
+        "a1",
+        "OSD",
+        Granularity.HOURLY,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        Uom.CORES,
+        20.4);
+    assertSummary(
+        results,
+        "a2",
+        "OCP",
+        Granularity.HOURLY,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        Uom.CORES,
+        22.2);
+  }
+
+  void assertSummary(
+      Map<String, List<TallySummary>> results,
+      String account,
+      String product,
+      Granularity granularity,
+      ServiceLevel sla,
+      Usage usage,
+      Uom uom,
+      double value) {
+    assertTrue(results.containsKey(account));
+    List<TallySummary> accountSummaries = results.get(account);
+    assertEquals(1, accountSummaries.size());
+    TallySummary expectedSummary = accountSummaries.get(0);
+    assertEquals(account, expectedSummary.getAccountNumber());
+
+    assertEquals(1, expectedSummary.getTallySnapshots().size());
+    org.candlepin.subscriptions.json.TallySnapshot snapshot =
+        expectedSummary.getTallySnapshots().get(0);
+    assertEquals(product, snapshot.getProductId());
+    assertEquals(granularity.toString(), snapshot.getGranularity().value().toUpperCase());
+    assertEquals(sla.toString(), snapshot.getSla().value().toUpperCase());
+    assertEquals(usage.toString(), snapshot.getUsage().value().toUpperCase());
+    assertEquals(2, snapshot.getTallyMeasurements().size());
+
+    Map<String, List<TallyMeasurement>> measurements =
+        snapshot.getTallyMeasurements().stream()
+            .collect(Collectors.groupingBy(TallyMeasurement::getHardwareMeasurementType));
+    assertMeasurement(measurements, "TOTAL", uom, value);
+    assertMeasurement(measurements, "PHYSICAL", uom, value);
+  }
+
+  @Test
+  void testSummarySkippedWhenItHasNoMeasurements() {
+    Map<String, List<TallySnapshot>> updateMap = new HashMap<>();
+    updateMap.put(
+        "a1",
+        List.of(
+            buildSnapshot(
+                "a1",
+                "OSD",
+                Granularity.HOURLY,
+                ServiceLevel.PREMIUM,
+                Usage.PRODUCTION,
+                Uom.CORES,
+                20.4)));
+    updateMap.get("a1").get(0).getTallyMeasurements().clear();
+    producer.produceTallySummaryMessages(updateMap);
+    verify(kafka, never()).send(anyString(), any());
+  }
+
+  void assertMeasurement(
+      Map<String, List<TallyMeasurement>> measurements,
+      String hardwareType,
+      Uom uom,
+      double value) {
+    Optional<List<TallyMeasurement>> optionalTotal =
+        Optional.ofNullable(measurements.get(hardwareType));
+    assertTrue(optionalTotal.isPresent());
+    assertEquals(1, optionalTotal.get().size());
+    TallyMeasurement measurement = optionalTotal.get().get(0);
+
+    assertEquals(hardwareType, measurement.getHardwareMeasurementType());
+    assertEquals(uom.value(), measurement.getUom().value());
+    assertEquals(value, measurement.getValue());
+  }
+
+  TallySnapshot buildSnapshot(
+      String account,
+      String productId,
+      Granularity granularity,
+      ServiceLevel sla,
+      Usage usage,
+      Uom uom,
+      double val) {
+    Map<TallyMeasurementKey, Double> measurements = new HashMap<>();
+    measurements.put(new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, uom), val);
+    measurements.put(new TallyMeasurementKey(HardwareMeasurementType.TOTAL, uom), val);
+    return TallySnapshot.builder()
+        .accountNumber(account)
+        .productId(productId)
+        .snapshotDate(OffsetDateTime.now())
+        .tallyMeasurements(measurements)
+        .granularity(granularity)
+        .serviceLevel(sla)
+        .usage(usage)
+        .build();
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4488

When producing tally summaries, skip any that do not have
measurements associated with them.

This was done to prevent marketplace API errors when sending
an event with 0 measurements. This can happen when event metrics
are updated via the JMX endpoint and a metric event was no longer
found during the refresh.

### Testing
It is easiest to start with a fresh DB, otherwise you need to delete all of the snapshots and events for the account 'account123'.

```sql
delete from tally_snapshots where account_number='account123';
delete from events where account_number='account123';
```

Run the application:
```bash
$ SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true USER_STUB=true DEV_MODE=true PROM_URL="http://localhost:8888/api/metrics/v1/telemeter/api/v1" ./gradlew bootRun
```

Use the event import script (it uses JMX) to import some events. The existing test data in `${checkout}/bin/events.csv` is good enough to test the fix.
```bash
$ ./bin/import_events.py --file bin/events.csv
Found 24 records
Successfully created events.
```

Run a tally for the account that covers the events that you just imported.
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-10-18T00:00Z","2021-10-20T00:00Z"]}'
```

Next, you want to delete some of the events for the account, but not all of them.
```sql
delete from events where id in (select id from events limit(20));
```

Re-run the tally again, and monitor the logs for the WARNING message added to this PR.
```
curl 'http://localhost:8080/actuator/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123","2021-10-18T00:00Z","2021-10-20T00:00Z"]}'
```

Sample log message:
```
2021-12-14 15:57:52,240 [thread=rhsm-subscriptions-task-processor-0-C-1] [WARN ] [org.candlepin.subscriptions.tally.SnapshotSummaryProducer] - One or more tally summary snapshots did not have measurements. No usage will be sent to marketplace for this summary.
org.candlepin.subscriptions.json.TallySummary@1e5adaf1[accountNumber=account123,tallySnapshots=[org.candlepin.subscriptions.json.TallySnapshot@6b720c82[id=dad40160-68ef-4cfa-a7c5-e5b7d65e8993,snapshotDate=2021-10-18T20:00Z,productId=OpenShift-dedicated-metrics,sla=_ANY,usage=_ANY,granularity=Hourly,tallyMeasurements=[]]]]
```