### PR TITLE
Zero out Marketplace instances

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -57,6 +57,7 @@ import lombok.Setter;
             @ColumnResult(name = "system_profile_cores_per_socket"),
             @ColumnResult(name = "system_profile_sockets"),
             @ColumnResult(name = "system_profile_arch"),
+            @ColumnResult(name = "is_marketplace"),
             @ColumnResult(name = "qpc_products"),
             @ColumnResult(name = "qpc_product_ids"),
             @ColumnResult(name = "system_profile_product_ids"),
@@ -86,7 +87,7 @@ import lombok.Setter;
  * First step -> update queries with the following structure (h.facts ->> rhsm ->> new field as new field,)
  * check insights-host-inventory/blob/master/swagger/system_profile.spec.yaml for queries on HBI Database.
  * Second step: Add new field as a ColumnResult
- * Third step : update inventory host facts contstructor for new column
+ * Third step : update inventory host facts constructor with new column
  */
 @NamedNativeQuery(
     name = "InventoryHost.getFacts",
@@ -113,7 +114,8 @@ import lombok.Setter;
             + "h.system_profile_facts->>'cores_per_socket' as system_profile_cores_per_socket, "
             + "h.system_profile_facts->>'number_of_sockets' as system_profile_sockets, "
             + "h.system_profile_facts->>'cloud_provider' as cloud_provider, "
-            + "h.system_profile_facts->>'arch' as system_profile_arch,"
+            + "h.system_profile_facts->>'arch' as system_profile_arch, "
+            + "h.system_profile_facts->>'is_marketplace' as is_marketplace, "
             + "h.canonical_facts->>'subscription_manager_id' as subscription_manager_id, "
             + "h.canonical_facts->>'insights_id' as insights_id, "
             + "rhsm_products.products, "

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -45,6 +45,7 @@ public class InventoryHostFacts {
   private Integer systemProfileCoresPerSocket;
   private Integer systemProfileSockets;
   private String systemProfileArch;
+  private boolean isMarketplace;
   private boolean isVirtual;
   private String hypervisorUuid;
   private String satelliteHypervisorUuid;
@@ -88,6 +89,7 @@ public class InventoryHostFacts {
       String systemProfileCores,
       String systemProfileSockets,
       String systemProfileArch,
+      String isMarketplace,
       String qpcProducts,
       String qpcProductIds,
       String systemProfileProductIds,
@@ -122,6 +124,7 @@ public class InventoryHostFacts {
     this.systemProfileCoresPerSocket = asInt(systemProfileCores);
     this.systemProfileSockets = asInt(systemProfileSockets);
     this.systemProfileArch = systemProfileArch;
+    this.isMarketplace = asBoolean(isMarketplace);
     this.systemProfileProductIds = asStringSet(systemProfileProductIds);
     this.syspurposeRole = syspurposeRole;
     this.syspurposeSla = syspurposeSla;

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -78,6 +78,7 @@ public class FactNormalizer {
     normalizeRhsmFacts(normalizedFacts, hostFacts);
     normalizeQpcFacts(normalizedFacts, hostFacts);
     normalizeSocketCount(normalizedFacts, hostFacts);
+    normalizeMarketplace(normalizedFacts, hostFacts);
     normalizeConflictingOrMissingRhelVariants(normalizedFacts);
     pruneProducts(normalizedFacts);
     normalizeUnits(normalizedFacts, hostFacts);
@@ -215,6 +216,20 @@ public class FactNormalizer {
       hostFacts.setCores(effectiveCores); // <-- workaround to prevent rhsm from overwriting logic
     }
     getProductsFromProductIds(normalizedFacts, hostFacts.getSystemProfileProductIds());
+  }
+
+  private void normalizeMarketplace(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
+    if (!hostFacts.isMarketplace()) {
+      return;
+    }
+
+    if (hostFacts.getCores() != 0 || normalizedFacts.getCores() != 0) {
+      normalizedFacts.setCores(0);
+    }
+
+    if (hostFacts.getSockets() != 0 || normalizedFacts.getSockets() != 0) {
+      normalizedFacts.setSockets(0);
+    }
   }
 
   private Integer calculateVirtualCPU(InventoryHostFacts virtualFacts) {

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -640,6 +640,15 @@ public class FactNormalizerTest {
     assertEquals(HostHardwareType.VIRTUALIZED, normalizedFacts.getHardwareType());
   }
 
+  @Test
+  void testCalculationOfMarketplaceMeasurements() {
+    InventoryHostFacts facts = createRhsmHost(List.of(1), 7, 1, null, clock.now());
+    facts.setMarketplace(true);
+    NormalizedFacts normalizedFacts = normalizer.normalize(facts, Collections.emptyMap());
+    assertEquals(0, normalizedFacts.getCores());
+    assertEquals(0, normalizedFacts.getSockets());
+  }
+
   private void assertClassification(
       NormalizedFacts check, boolean isHypervisor, boolean isHypervisorUnknown, boolean isVirtual) {
     assertEquals(isHypervisor, check.isHypervisor());


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4520
This PR is to zero out Marketplace instances to zero when `is_marketplace == true`.

Testing (HBI-based tally)
-------------------------

1.Environment Variables:

```
SPRING_PROFILES_ACTIVE=worker,api DEV_MODE=true
```

2. Local database setup:
Login into the localhost db insights role (if this is confusing just ping me).
Next insert mock data in DB

```
insert into hosts(
    id,
    account,
    display_name,
    created_on,
    modified_on,
    facts,
    canonical_facts,
    system_profile_facts,
    stale_timestamp,
    reporter
) values (
             gen_random_uuid(),
             'account123',
             'marketplace-test',
             now(),
             now(),
             '{"rhsm": {"orgId": "org123", "CPU_CORES": 4, "CPU_SOCKETS": 1, "IS_VIRTUAL": true,"SYNC_TIMESTAMP": "2020-07-01T00:00:00Z"}}'::jsonb,
             '{"subscription_manager_id": "$submanId", "insights_id": "$insightsId"}'::jsonb,
             '{"infrastructure_type": "virtual", "is_marketplace": true, "cores_per_socket": "4", "number_of_sockets": 1, "installed_products": [{"id": 72}]}'::jsonb,
             now() + interval '20' day,
             'rhsm-conduit'
         );

insert into hosts(
    id,
    account,
    display_name,
    created_on,
    modified_on,
    facts,
    canonical_facts,
    system_profile_facts,
    stale_timestamp,
    reporter
) values (
             gen_random_uuid(),
             'account123',
             'marketplace-test',
             now(),
             now(),
             '{"rhsm": {"orgId": "org123", "CPU_CORES": 4, "CPU_SOCKETS": 1, "IS_VIRTUAL": true,"SYNC_TIMESTAMP": "2020-07-01T00:00:00Z"}}'::jsonb,
             '{"subscription_manager_id": "$submanId", "insights_id": "$insightsId"}'::jsonb,
             '{"infrastructure_type": "virtual", "is_marketplace": false, "cores_per_socket": "4", "number_of_sockets": 1, "installed_products": [{"id": 72}]}'::jsonb,
             now() + interval '20' day,
             'rhsm-conduit'
         )
```
3. Start up tally using the curl command below or http://localhost:8080/actuator/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-TallyJmxBean-tallyJmxBean use 'account123' as a argument

```
curl 'http://localhost:8080/actuator/hawtio/jolokia' \
  -H 'Content-Type: text/json' \
  -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
    "operation":"tallyAccount(java.lang.String)",
    "arguments":["account123"]
  }'
```
4. Use the curl command or http://localhost:8080/api-docs:
```
curl -X 'GET' \
  'http://localhost:8080/api/rhsm-subscriptions/v1/tally/products/RHEL/Cores?category=virtual&granularity=Daily&sla=_ANY&usage=_ANY&beginning=2021-12-23T00%3A00%3A00Z&ending=2021-12-23T00%3A00%3A00Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo'
```
If you want to be sure toggle `is_marketplace` from the insight.host table to true and the total value should be present.