### PR TITLE
ENT-4412 Add account reset JMX method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,14 @@ allprojects {
         testRuntime "org.junit.jupiter:junit-jupiter-engine"
         testRuntime "ch.qos.logback:logback-classic"
     }
+
+    sourceSets {
+      main.java.srcDirs+=generatedMetamodels
+    }
+
+  compileJava {
+      options.annotationProcessorGeneratedSourcesDirectory = file(generatedMetamodels)
+  }
 }
 
 // Disable the default jar; otherwise we end up with two different jars in the final image

--- a/deploy/clowder.md
+++ b/deploy/clowder.md
@@ -28,6 +28,7 @@
             RHSM_RBAC_USE_STUB: 'true'
             MARKETPLACE_MANUAL_SUBMISSION_ENABLED: 'true'
             DEV_MODE: 'true'
+            ENABLE_ACCOUNT_RESET: 'true'
 
   BONFIRE
   ```
@@ -184,7 +185,7 @@ but here are some essentials:
   image and image tag you want to use like so:
 
   ```
-  `bonfire deploy rhsm-subscriptions -n NAMESPACE --no-remove-resources=all
+  bonfire deploy rhsm-subscriptions -n NAMESPACE --no-remove-resources=rhsm-subscriptions
   -i quay.io/my-repo/my-image=my-tag -p rhsm-subscriptions/IMAGE=quay.io/my-repo/my-image
   -i quay.io/my-repo/my-conduit-image=my-tag -p rhsm-subscriptions/CONDUIT_IMAGE=quay.
   io/my-repo/my-conduit-image

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -163,8 +163,7 @@ parameters:
   - name: DEV_MODE
     value: 'false'
   - name: ENABLE_ACCOUNT_RESET
-    value: 'true'
-
+    value: 'false'
   - name: ENABLE_SPLUNK_HEC
     value: 'true'
   - name: SPLUNK_SOURCE

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -162,6 +162,8 @@ parameters:
   # TODO after enable individual functionality (see ENT-4487)
   - name: DEV_MODE
     value: 'false'
+  - name: ENABLE_ACCOUNT_RESET
+    value: 'true'
 
   - name: ENABLE_SPLUNK_HEC
     value: 'true'
@@ -597,6 +599,8 @@ objects:
               value: /pinhead/keystore.jks
             - name: DEV_MODE
               value: ${DEV_MODE}
+            - name: ENABLE_ACCOUNT_RESET
+              value: ${ENABLE_ACCOUNT_RESET}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/src/main/java/org/candlepin/subscriptions/jmx/AccountResetJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/AccountResetJmxBean.java
@@ -61,7 +61,11 @@ public class AccountResetJmxBean {
 
     log.info("Received request to delete all data associated with account {}", accountNumber);
 
-    accountResetService.deleteDataForAccount(accountNumber);
+    try {
+      accountResetService.deleteDataForAccount(accountNumber);
+    } catch (Exception e) {
+      throw new JmxException("Unable to delete data for account " + accountNumber, e);
+    }
 
     var successMessage = "Finished deleting data associated with account " + accountNumber;
 

--- a/src/main/java/org/candlepin/subscriptions/jmx/AccountResetJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/AccountResetJmxBean.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.jmx;
+
+import javax.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.security.SecurityProperties;
+import org.candlepin.subscriptions.tally.AccountResetService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jmx.JmxException;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedOperationParameter;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.stereotype.Component;
+
+/** JMX Bean for clearing/resetting account data. */
+@Slf4j
+@Component
+@ManagedResource
+public class AccountResetJmxBean {
+
+  public static final String FEATURE_NOT_ENABLED_MESSSAGE = "Account Reset feature not enabled.";
+  private final AccountResetService accountResetService;
+  private final SecurityProperties properties;
+
+  @Autowired
+  public AccountResetJmxBean(
+      AccountResetService accountResetService, SecurityProperties properties) {
+    this.accountResetService = accountResetService;
+    this.properties = properties;
+  }
+
+  @Transactional
+  @ManagedOperation(
+      description =
+          "Clear tallies, hosts, and events for a given account number.  Enabled via ENABLE_ACCOUNT_RESET environment variable.  Intended only for non-prod environments.")
+  @ManagedOperationParameter(name = "accountNumber", description = "Account number")
+  public String deleteDataAssociatedWithAccount(String accountNumber) {
+    if (!properties.isResetAccountEnabled() && !properties.isDevMode()) {
+      log.error(FEATURE_NOT_ENABLED_MESSSAGE);
+      throw new JmxException(FEATURE_NOT_ENABLED_MESSSAGE);
+    }
+
+    log.info("Received request to delete all data associated with account {}", accountNumber);
+
+    accountResetService.deleteDataForAccount(accountNumber);
+
+    var successMessage = "Finished deleting data associated with account " + accountNumber;
+
+    log.info(successMessage);
+
+    return successMessage;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import javax.transaction.Transactional;
+import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
+import org.candlepin.subscriptions.db.EventRecordRepository;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
+import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AccountResetService {
+
+  private final EventRecordRepository eventRecordRepo;
+  private final HostRepository hostRepo;
+  private final TallySnapshotRepository tallySnapshotRepository;
+  private final AccountServiceInventoryRepository accountServiceInventoryRepository;
+  private final SubscriptionCapacityRepository subscriptionCapacityRepository;
+  private final SubscriptionRepository subscriptionRepository;
+
+  @Autowired
+  public AccountResetService(
+      EventRecordRepository eventRecordRepo,
+      HostRepository hostRepo,
+      TallySnapshotRepository tallySnapshotRepository,
+      AccountServiceInventoryRepository accountServiceInventoryRepository,
+      SubscriptionCapacityRepository subscriptionCapacityRepository,
+      SubscriptionRepository subscriptionRepository) {
+    this.eventRecordRepo = eventRecordRepo;
+    this.hostRepo = hostRepo;
+    this.tallySnapshotRepository = tallySnapshotRepository;
+    this.accountServiceInventoryRepository = accountServiceInventoryRepository;
+    this.subscriptionCapacityRepository = subscriptionCapacityRepository;
+    this.subscriptionRepository = subscriptionRepository;
+  }
+
+  @Transactional
+  public void deleteDataForAccount(String accountNumber) {
+
+    accountServiceInventoryRepository.deleteByIdAccountNumber(accountNumber);
+    hostRepo.deleteByAccountNumber(accountNumber);
+    eventRecordRepo.deleteByAccountNumber(accountNumber);
+    tallySnapshotRepository.deleteByAccountNumber(accountNumber);
+    subscriptionRepository.deleteByAccountNumber(accountNumber);
+    subscriptionCapacityRepository.deleteByAccountNumber(accountNumber);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepository.java
@@ -27,5 +27,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 /** Defines all operations for interacting with the AccountServiceInventory aggregate */
 public interface AccountServiceInventoryRepository
     extends JpaRepository<AccountServiceInventory, AccountServiceInventoryId> {
-  /* intentionally empty */
+
+  void deleteByIdAccountNumber(String accountNumber);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -127,4 +127,6 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
           @Param("serviceType") String serviceType,
           @Param("begin") OffsetDateTime begin,
           @Param("end") OffsetDateTime end);
+
+  void deleteByAccountNumber(String accountNumber);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -38,16 +38,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.util.StringUtils;
 
 /** Provides access to Host database entities. */
 @SuppressWarnings({"linelength", "indentation"})
 public interface HostRepository
-    extends Repository<Host, UUID>, JpaSpecificationExecutor<Host>, TagProfileLookup {
+    extends JpaRepository<Host, UUID>, JpaSpecificationExecutor<Host>, TagProfileLookup {
 
   /**
    * Find all Hosts by bucket criteria and return a page of TallyHostView objects. A TallyHostView
@@ -179,4 +179,6 @@ public interface HostRepository
   List<Host> findByAccountNumber(String accountNumber);
 
   Optional<Host> findById(UUID id);
+
+  void deleteByAccountNumber(String accountNumber);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -35,4 +35,6 @@ public interface SubscriptionCapacityRepository
       String ownerId, List<String> subscriptionIds);
 
   Stream<SubscriptionCapacity> findByKeyOwnerId(String ownerId);
+
+  void deleteByAccountNumber(String accountNumber);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -61,4 +61,6 @@ public interface SubscriptionRepository
   Stream<Subscription> findByOwnerId(String ownerId);
 
   void deleteBySubscriptionId(String subscriptionId);
+
+  void deleteByAccountNumber(String accountNumber);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -61,4 +61,6 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
       Granularity granularity,
       OffsetDateTime beginning,
       OffsetDateTime ending);
+
+  void deleteByAccountNumber(String accountNumber);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityProperties.java
@@ -45,6 +45,12 @@ public class SecurityProperties {
   private boolean manualEventEditingEnabled = false;
 
   /**
+   * Whether resetting an account by account number is enabled. Resetting entails clearing tallies,
+   * hosts, and events.
+   */
+  private boolean resetAccountEnabled = false;
+
+  /**
    * Expected domain suffix for origin or referer headers.
    *
    * @see AntiCsrfFilter

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -45,6 +45,7 @@ HAWTIO_BASE_PATH:
 DEV_MODE: false
 DEVTEST_SUBSCRIPTION_EDITING_ENABLED: false
 DEVTEST_EVENT_EDITING_ENABLED: false
+ENABLE_ACCOUNT_RESET: false
 PATH_PREFIX: api
 APP_NAME: rhsm-subscriptions
 
@@ -134,6 +135,7 @@ rhsm-subscriptions:
     dev-mode: ${DEV_MODE}
     manual-subscription-editing-enabled: ${DEVTEST_SUBSCRIPTION_EDITING_ENABLED}
     manual-event-editing-enabled: ${DEVTEST_EVENT_EDITING_ENABLED}
+    reset-account-enabled: ${ENABLE_ACCOUNT_RESET}
   package_uri_mappings:
     # this mapping required here because it is used by our SecurityConfig, which is shared
     org.candlepin.subscriptions.resteasy: ${PATH_PREFIX}/${APP_NAME}/v1

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -81,6 +81,8 @@ parameters:
     value: '2'
   - name: DEVTEST_EVENT_EDITING_ENABLED
     value: 'false'
+  - name: ENABLE_ACCOUNT_RESET
+    value: 'false'
 
 objects:
   - apiVersion: v1


### PR DESCRIPTION
Related MR: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/31838/diffs

Test steps:

* add event & hbi data to your instance for an account
* * found the easiest way to do this is to use the `bin/insert-mock-hosts` and `bin/import_events.py` scripts
* * probably a good idea to use an account number that's not already in your database
* use JMX to initiate an hourly tally and a "regular" tally for the account number you created data for
* * ```http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-TallyJmxBean-tallyJmxBean```
* observe & take note of tally data in database
* use new JMX endpoint to initiate resetting the account by an account number
* * ```http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-AccountResetJmxBean-accountResetJmxBean```
* observe & take note of data in the database now, confirming that there is nothing left for the account number, and that it didn't accidentally delete another account's data

---

```
ENABLE_ACCOUNT_RESET=true ./gradlew bootRun
```

Update `bin/events.csv` to contain events for account345 in addition to account123.

Then if you navigate to the `bin` directory, you can execute the following commands to help execute the test steps listed in the beginning.

```bash
#!/bin/bash

DB_HOST='localhost'
DB_USER='rhsm-subscriptions'
DB_PASSWORD='rhsm-subscriptions'
DB_NAME='rhsm-subscriptions'
NUM_PHYSICAL='1'
NUM_HYPERVISORS='0'
NUM_GUESTS='0'
NUM_AWS='0'
UNMAPPED_GUESTS='0'
NUM_ACCOUNTS='1'
HYPERVISOR_ID='hypervisorIdPlaceholder'
PRODUCT='RHEL'
SLA='_ANY'
USAGE='_ANY'
CORES='2'
SOCKETS='2'

# insert hosts for account123
ACCOUNT='account123'
./insert-mock-hosts --db-host ${DB_HOST} --db-user ${DB_USER} --db-password ${DB_PASSWORD} --db-name ${DB_NAME} \
  --num-physical ${NUM_PHYSICAL} \
  --num-hypervisors ${NUM_HYPERVISORS} \
  --num-guests ${NUM_GUESTS} \
  --num-aws ${NUM_AWS} \
  --unmapped-guests ${UNMAPPED_GUESTS} \
  --account ${ACCOUNT} \
  --num-accounts ${NUM_ACCOUNTS} \
  --hypervisor-id ${HYPERVISOR_ID} \
  --product ${PRODUCT}

# insert hosts for account345
ACCOUNT='account345'
./insert-mock-hosts --db-host ${DB_HOST} --db-user ${DB_USER} --db-password ${DB_PASSWORD} --db-name ${DB_NAME} \
  --num-physical ${NUM_PHYSICAL} \
  --num-hypervisors ${NUM_HYPERVISORS} \
  --num-guests ${NUM_GUESTS} \
  --num-aws ${NUM_AWS} \
  --unmapped-guests ${UNMAPPED_GUESTS} \
  --account ${ACCOUNT} \
  --num-accounts ${NUM_ACCOUNTS} \
  --hypervisor-id ${HYPERVISOR_ID} \
  --product ${PRODUCT}

#create events for hourly tallying
./import_events.py --file events.csv

#jmx start tally
curl --request POST \
  --url http://localhost:9000/hawtio/jolokia/ \
  --header 'Accept: application/json, text/javascript, */*; q=0.01' \
  --header 'Content-Type: text/json' \
  --header 'Origin: http://localhost:9000' \
  --header 'Referer: http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-AccountResetJmxBean-accountResetJmxBean' \
  --header 'X-Requested-With: XMLHttpRequest' \
  --header 'content-type: application/json' \
  --data '{
  "type": "exec",
  "mbean": "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
  "operation": "tallyAccount(java.lang.String)",
  "arguments": [
    "account123"
  ]
}'

curl --request POST \
  --url http://localhost:9000/hawtio/jolokia/ \
  --header 'Accept: application/json, text/javascript, */*; q=0.01' \
  --header 'Content-Type: text/json' \
  --header 'Origin: http://localhost:9000' \
  --header 'Referer: http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-AccountResetJmxBean-accountResetJmxBean' \
  --header 'X-Requested-With: XMLHttpRequest' \
  --header 'content-type: application/json' \
  --data '{
  "type": "exec",
  "mbean": "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
  "operation": "tallyAccount(java.lang.String)",
  "arguments": [
    "account345"
  ]
}'

#jmx start hourly tally
curl --request POST \
  --url http://localhost:9000/hawtio/jolokia/ \
  --header 'Accept: application/json, text/javascript, */*; q=0.01' \
  --header 'Content-Type: text/json' \
  --header 'Origin: http://localhost:9000' \
  --header 'Referer: http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-AccountResetJmxBean-accountResetJmxBean' \
  --header 'X-Requested-With: XMLHttpRequest' \
  --header 'content-type: application/json' \
  --data '{
  "type": "exec",
  "mbean": "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
  "operation": "tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)",
  "arguments": [
    "account123",
    "2021-10-01T00:00Z",
    "2021-11-01T00:00Z"
  ]
}'

curl --request POST \
  --url http://localhost:9000/hawtio/jolokia/ \
  --header 'Accept: application/json, text/javascript, */*; q=0.01' \
  --header 'Content-Type: text/json' \
  --header 'Origin: http://localhost:9000' \
  --header 'Referer: http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-AccountResetJmxBean-accountResetJmxBean' \
  --header 'X-Requested-With: XMLHttpRequest' \
  --header 'content-type: application/json' \
  --data '{
  "type": "exec",
  "mbean": "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
  "operation": "tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)",
  "arguments": [
    "account345",
    "2021-10-01T00:00Z",
    "2021-11-01T00:00Z"
  ]
}'

#curl API get hosts for account123
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/hosts/products/rhosak' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='

# one result

# JMX for reset account123
curl --request POST \
  --url http://localhost:9000/hawtio/jolokia/ \
  --header 'Accept: application/json, text/javascript, */*; q=0.01' \
  --header 'Content-Type: text/json' \
  --header 'Origin: http://localhost:9000' \
  --header 'Referer: http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-AccountResetJmxBean-accountResetJmxBean' \
  --header 'X-Requested-With: XMLHttpRequest' \
  --header 'content-type: application/json' \
  --data '{
  "type": "exec",
  "mbean": "org.candlepin.subscriptions.jmx:name=accountResetJmxBean,type=AccountResetJmxBean",
  "operation": "deleteDataAssociatedWithAccount(java.lang.String)",
  "arguments": [
    "account123"
  ]
}'

#curl API get usage/hosts for account123 (should be nothing this time)

#curl API get hosts for account123
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/hosts/products/rhosak' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

