### PR TITLE
ENT-4649 Fix spring boot 2.6 compatibility

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -21,15 +21,14 @@
 package org.candlepin.subscriptions.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.candlepin.subscriptions.rbac.RbacApiFactory;
 import org.candlepin.subscriptions.rbac.RbacProperties;
 import org.candlepin.subscriptions.rbac.RbacService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -69,6 +68,7 @@ import org.springframework.security.web.csrf.CsrfFilter;
  * </ol>
  */
 @Configuration
+@Import(RbacConfiguration.class)
 public class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   @Autowired protected ObjectMapper mapper;
@@ -97,22 +97,6 @@ public class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
       @Qualifier("identityHeaderAuthenticationDetailsService")
           IdentityHeaderAuthenticationDetailsService detailsService) {
     return new IdentityHeaderAuthenticationProvider(detailsService);
-  }
-
-  @Bean
-  public RbacService rbacService() {
-    return new RbacService();
-  }
-
-  @Bean
-  @ConfigurationProperties(prefix = "rhsm-subscriptions.rbac-service")
-  public RbacProperties rbacServiceProperties() {
-    return new RbacProperties();
-  }
-
-  @Bean
-  public RbacApiFactory rbacApiFactory(RbacProperties props) {
-    return new RbacApiFactory(props);
   }
 
   // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application

--- a/src/main/java/org/candlepin/subscriptions/security/RbacConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/RbacConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.candlepin.subscriptions.rbac.RbacApiFactory;
+import org.candlepin.subscriptions.rbac.RbacProperties;
+import org.candlepin.subscriptions.rbac.RbacService;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Configuration for consoledot RBAC service client */
+@Configuration
+public class RbacConfiguration {
+
+  @Bean
+  public RbacService rbacService() {
+    return new RbacService();
+  }
+
+  @Bean
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.rbac-service")
+  public RbacProperties rbacServiceProperties() {
+    return new RbacProperties();
+  }
+
+  @Bean
+  public RbacApiFactory rbacApiFactory(RbacProperties props) {
+    return new RbacApiFactory(props);
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4649

Essentially, it looks like changes to how deps are resolved in Spring Boot applications made it so that Spring was unable to resolve the beans for RBAC in our security config. Moving them to a separate configuration class and then simply depending on that via `@Import` has resolved the issue.

Testing
---------
Checkout this branch, merge `dependabot/gradle/develop/org.springframework.boot-spring-boot-dependencies-2.6.2` branch to get updated spring deps, `./gradlew test`, and observe that all tests still pass.