### PR TITLE
Update attribute names to play nicely with lombok generated setters

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityProperties.java
@@ -35,14 +35,14 @@ public class SecurityProperties {
    *
    * <p>For development/testing only.
    */
-  private boolean isManualSubscriptionEditingEnabled = false;
+  private boolean manualSubscriptionEditingEnabled = false;
 
   /**
    * Whether to allow manual event edits.
    *
    * <p>For development/testing only.
    */
-  private boolean isManualEventEditingEnabled = false;
+  private boolean manualEventEditingEnabled = false;
 
   /**
    * Expected domain suffix for origin or referer headers.

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -126,8 +126,8 @@ hawtio:
 rhsm-subscriptions:
   security:
     dev-mode: ${DEV_MODE}
-    is-manual-subscription-editing-enabled: ${DEVTEST_SUBSCRIPTION_EDITING_ENABLED}
-    is-manual-event-editing-enabled: ${DEVTEST_EVENT_EDITING_ENABLED}
+    manual-subscription-editing-enabled: ${DEVTEST_SUBSCRIPTION_EDITING_ENABLED}
+    manual-event-editing-enabled: ${DEVTEST_EVENT_EDITING_ENABLED}
   package_uri_mappings:
     # this mapping required here because it is used by our SecurityConfig, which is shared
     org.candlepin.subscriptions.resteasy: ${PATH_PREFIX}/${APP_NAME}/v1


### PR DESCRIPTION
Lombok is weird about getters/setters for booleans that have the word "is" in them.  They don't follow the same naming convention that spring expects when doing naming matching for `@ConfigurationProperties`

Example:
```
private boolean isFruit = true;

  //getter generated = isFruit(): boolean
  //setter generated = setFruit(boolean): void
```

For spring to match on naming convention when reading application.properties, what's expected for a setter would be `setIsFruit(boolean)`.

Because of this, the `SecurityProperties` class was never having its default values overwritten by the env vars listed in swatch-core's application.yaml

