### PR TITLE
Fix routing issues for our services

### DIFF
--- a/templates/marketplace-worker.yml
+++ b/templates/marketplace-worker.yml
@@ -301,8 +301,9 @@ objects:
                   cpu: ${CPU_LIMIT}
                   memory: ${MEMORY_LIMIT}
               ports:
-                - containerPort: 8080
+                - containerPort: 8000
                   protocol: TCP
+                  name: web
                 - containerPort: 9000
                   protocol: TCP
                   name: metrics-port

--- a/templates/metrics-worker.yml
+++ b/templates/metrics-worker.yml
@@ -294,8 +294,9 @@ objects:
                   cpu: ${CPU_LIMIT}
                   memory: ${MEMORY_LIMIT}
               ports:
-                - containerPort: 8080
+                - containerPort: 8000
                   protocol: TCP
+                  name: web
                 - containerPort: 9000
                   protocol: TCP
                   name: metrics-port

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -233,8 +233,9 @@ objects:
                 cpu: ${CPU_LIMIT}
                 memory: ${MEMORY_LIMIT}
             ports:
-              - containerPort: 8080
+              - containerPort: 8000
                 protocol: TCP
+                name: web
               - containerPort: 9000
                 protocol: TCP
                 name: metrics-port
@@ -293,10 +294,14 @@ objects:
       prometheus: rhsm
   spec:
     ports:
+      - port: 8000
+        name: "8000"
+        protocol: TCP
+        targetPort: web
       - port: 8080
         name: "8080"
         protocol: TCP
-        targetPort: 8080
+        targetPort: web
       - port: 9000
         name: "9000"
         protocol: TCP

--- a/templates/rhsm-subscriptions-api.yml
+++ b/templates/rhsm-subscriptions-api.yml
@@ -235,8 +235,9 @@ objects:
                   cpu: ${CPU_LIMIT}
                   memory: ${MEMORY_LIMIT}
               ports:
-                - containerPort: 8080
+                - containerPort: 8000
                   protocol: TCP
+                  name: web
                 - containerPort: 9000
                   protocol: TCP
                   name: metrics-port
@@ -298,10 +299,14 @@ objects:
         prometheus: rhsm
     spec:
       ports:
+        - port: 8000
+          name: "8000"
+          protocol: TCP
+          targetPort: web
         - port: 8080
           name: "8080"
           protocol: TCP
-          targetPort: 8080
+          targetPort: web
         - port: 9000
           name: "9000"
           protocol: TCP

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -267,8 +267,10 @@ objects:
               ports:
                 - containerPort: 8443
                   protocol: TCP
-                - containerPort: 8080
+                  name: web-secure
+                - containerPort: 8000
                   protocol: TCP
+                  name: web
                 - containerPort: 9000
                   protocol: TCP
                   name: metrics-port
@@ -342,7 +344,7 @@ objects:
       ports:
         - port: 8443
           protocol: TCP
-          targetPort: 8443
+          targetPort: web-secure
       selector:
         deploymentconfig: rhsm-subscriptions-capacity-ingress
 

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -274,8 +274,9 @@ objects:
                   cpu: ${CPU_LIMIT}
                   memory: ${MEMORY_LIMIT}
               ports:
-                - containerPort: 8080
+                - containerPort: 8000
                   protocol: TCP
+                  name: web
                 - containerPort: 9000
                   protocol: TCP
                   name: metrics-port


### PR DESCRIPTION
The web port for our apps was changed to 8000 to support clowder,
so we need to also update the target ports for our service
definitions to remain on 8080 but target 8000.

Exposed web services will expose both 8080 and 8000 to support
the async update 3scale and turnpike.