### PR TITLE
ENT-4661 Set DEVTEST_EVENT_EDITING_ENABLED param as env var

### DIFF
--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -256,6 +256,8 @@ objects:
                       key: keystore_password
                 - name: RHSM_KEYSTORE
                   value: /pinhead/keystore.jks
+                - name: DEVTEST_EVENT_EDITING_ENABLED
+                  value: ${DEVTEST_EVENT_EDITING_ENABLED}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4661

When the template parameter was added to the deploy template,
we forgot to also pass it as an env var for the deployment.

NOTE:
* The needful has already been done for the stage environment configuration for app-interface and the issue should be fixed on the next deployment.