### PR TITLE
Downgrading spring boot back to 2.5.6 because our implementation of /api-docs is broken

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     swagger_annotations_version = "1.6.4"
     swagger_ui_version = "4.2.1"
     resteasy_version = "3.6.3.Final"
-    spring_boot_version = "2.6.3"
+    spring_boot_version = "2.5.6"
     jboss_jaxrs_api_version = "2.0.2.Final"
     resteasy_spring_boot_starter_version = "3.9.1.Final"
     kafka_avro_serializer_version = "7.0.1"


### PR DESCRIPTION
http://localhost:8000/api-docs was displaying a 404, unable to find openapi.yaml.  Tracked it back to the upgrade of our spring boot library version.  Reverting for now so we can get our swagger ui documentation back while we find out how to correct it in the 2.6.X version.

Caused by dependabot PR: https://github.com/RedHatInsights/rhsm-subscriptions/pull/709

JIRA ticket for resolving https://issues.redhat.com/browse/ENT-4670 