### PR TITLE
ENT-4670 Change path for openapi.yaml in swagger-ui

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -53,11 +53,4 @@ public class ResteasyConfiguration implements WebMvcConfigurer {
     registry.addViewController("/api-docs").setViewName("redirect:/api-docs/index.html");
     registry.addViewController("/api-docs/").setViewName("redirect:/api-docs/index.html");
   }
-
-  @Override
-  public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry
-        .addResourceHandler("/api-docs/openapi.*")
-        .addResourceLocations("classpath:openapi.yaml", "classpath:openapi.json");
-  }
 }

--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 

--- a/src/main/resources/static/api-docs/index.html
+++ b/src/main/resources/static/api-docs/index.html
@@ -14,7 +14,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "openapi.yaml",
+        url: "/api/rhsm-subscriptions/v1/openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4670

Rather than serving the openapi docs in multiple places just to make our
old scheme of hosting them at `/api-docs/openapi.yaml`, it's easier to
just point at their location served from our API root.

Closes #735