### PR TITLE
Fix podman-compose so the inventory container works

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,12 @@ services:
       - "3030:3030"
       - "9092:9092"
       - "29092:29092"
+    expose:
+      - "9092"
   inventory:
     build:
       context: insights-host-inventory
       dockerfile: dev.dockerfile
+    environment:
+      - INVENTORY_DB_HOST=db
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092


### PR DESCRIPTION
The inventory container needs to talk to both the database container (so
it needed the correct hostname) and the kafka container (where it needed
the correct hostname and for the kafka container to expose the correct
port to the internal network).