### PR TITLE
ENT-4598 Add major and minor version attributes to operating system details of HBI messages

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import argparse
-import uuid
-import os
 import json
+import os
 import subprocess
 import sys
+import uuid
 
 output = sys.stdout
 
@@ -16,13 +16,13 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
                   skip_buckets=False, is_hbi=False):
 
     account = account_number or "account123"
-    _create_account_service(account, 'HBI_HOST')
-
     host_id = uuid.uuid4()
     inventory_id=inventory_id or uuid.uuid4()
     insights_id=insights_id or uuid.uuid4()
+
     if not is_guest:
         hypervisor_uuid = None
+
     if is_hbi:
         host_fields = {
             'id': inventory_id,
@@ -52,6 +52,7 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
             'reporter': 'rhsm-conduit',
         }
     else:
+        _create_account_service(account, 'HBI_HOST')
         host_fields = {
             'id': host_id,
             'instance_id': inventory_id,

--- a/build.gradle
+++ b/build.gradle
@@ -6,15 +6,15 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:5.3.1"
+        classpath "org.openapitools:openapi-generator-gradle-plugin:5.4.0"
         classpath "org.jsonschema2pojo:jsonschema2pojo-gradle-plugin:1.1.1"
-        classpath "de.undercouch:gradle-download-task:4.1.2"
+        classpath "de.undercouch:gradle-download-task:5.0.1"
     }
 }
 
 plugins {
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
-    id "com.diffplug.spotless" version "6.2.0"
+    id "com.diffplug.spotless" version "6.2.1"
     id "jacoco"
     id "org.sonarqube" version "3.3"
     id "org.springframework.boot" version "2.6.3"
@@ -28,7 +28,7 @@ plugins {
 
 ext {
     swagger_annotations_version = "1.6.4"
-    swagger_ui_version = "4.2.1"
+    swagger_ui_version = "4.4.1"
     resteasy_version = "3.6.3.Final"
     spring_boot_version = "2.6.3"
     jboss_jaxrs_api_version = "2.0.2.Final"

--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -59,6 +59,8 @@ public class StubRhsmApi extends RhsmApi {
     consumer1.getFacts().put("virt.is_guest", "True");
     consumer1.getFacts().put("ocm.units", "Sockets");
     consumer1.getFacts().put("ocm.billing_model", "standard");
+    consumer1.getFacts().put("distribution.name", "Red Hat Enterprise Linux Workstation");
+    consumer1.getFacts().put("distribution.version", "6.3");
     InstalledProducts product = new InstalledProducts();
     product.setProductId("72");
     consumer1.getInstalledProducts().add(product);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,12 @@ services:
       - "3030:3030"
       - "9092:9092"
       - "29092:29092"
+    expose:
+      - "9092"
   inventory:
     build:
       context: insights-host-inventory
       dockerfile: dev.dockerfile
+    environment:
+      - INVENTORY_DB_HOST=db
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -49,8 +49,6 @@ import lombok.Setter;
             @ColumnResult(name = "account"),
             @ColumnResult(name = "display_name"),
             @ColumnResult(name = "org_id"),
-            @ColumnResult(name = "cores"),
-            @ColumnResult(name = "sockets"),
             @ColumnResult(name = "products"),
             @ColumnResult(name = "sync_timestamp"),
             @ColumnResult(name = "system_profile_infrastructure_type"),
@@ -94,8 +92,6 @@ import lombok.Setter;
     query =
         "select h.id as inventory_id, h.modified_on, h.account, h.display_name, "
             + "h.facts->'rhsm'->>'orgId' as org_id, "
-            + "h.facts->'rhsm'->>'CPU_CORES' as cores, "
-            + "h.facts->'rhsm'->>'CPU_SOCKETS' as sockets, "
             + "h.facts->'rhsm'->>'IS_VIRTUAL' as is_virtual, "
             + "h.facts->'rhsm'->>'VM_HOST_UUID' as hypervisor_uuid, "
             + "h.facts->'satellite'->>'virtual_host_uuid' as satellite_hypervisor_uuid, "

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -37,8 +37,6 @@ public class InventoryHostFacts {
   private String account;
   private String displayName;
   private String orgId;
-  private Integer cores;
-  private Integer sockets;
   private String syncTimestamp;
   private Set<String> products;
   private String systemProfileInfrastructureType;
@@ -81,8 +79,6 @@ public class InventoryHostFacts {
       String account,
       String displayName,
       String orgId,
-      String cores,
-      String sockets,
       String products,
       String syncTimestamp,
       String systemProfileInfrastructureType,
@@ -114,8 +110,6 @@ public class InventoryHostFacts {
     this.account = account;
     this.displayName = displayName;
     this.orgId = orgId;
-    this.cores = asInt(cores);
-    this.sockets = asInt(sockets);
     this.products = asStringSet(products);
     this.qpcProducts = asStringSet(qpcProducts);
     this.qpcProductIds = asStringSet(qpcProductIds);
@@ -142,14 +136,6 @@ public class InventoryHostFacts {
     this.billingModel = billingModel;
     this.cloudProvider = cloudProvider;
     this.staleTimestamp = staleTimestamp;
-  }
-
-  public Integer getCores() {
-    return cores == null ? 0 : cores;
-  }
-
-  public Integer getSockets() {
-    return sockets == null ? 0 : sockets;
   }
 
   public void setProducts(String products) {

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -85,7 +85,9 @@ public class InventoryAccountUsageCollectorTest {
   public void hypervisorCountsIgnoredForNonRhelProduct() {
     String account = "A1";
 
-    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", NON_RHEL_PRODUCT_ID, 12, 3);
+    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", NON_RHEL_PRODUCT_ID);
+    hypervisor.setSystemProfileCoresPerSocket(4);
+    hypervisor.setSystemProfileSockets(3);
 
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(
@@ -111,7 +113,9 @@ public class InventoryAccountUsageCollectorTest {
   public void hypervisorTotalsForRHEL() {
     String account = "A1";
 
-    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID, 12, 3);
+    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID);
+    hypervisor.setSystemProfileCoresPerSocket(4);
+    hypervisor.setSystemProfileSockets(3);
 
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(
@@ -140,7 +144,7 @@ public class InventoryAccountUsageCollectorTest {
   public void guestWithKnownHypervisorNotAddedToTotalsForRHEL() {
     String account = "A1";
 
-    InventoryHostFacts guest = createGuest("hyper-1", "A1", "O1", TEST_PRODUCT_ID, 12, 3);
+    InventoryHostFacts guest = createGuest("hyper-1", "A1", "O1", TEST_PRODUCT_ID);
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(guest.getHypervisorUuid(), guest.getHypervisorUuid());
     mockReportedHypervisors(account, expectedHypervisorMap);
@@ -162,7 +166,9 @@ public class InventoryAccountUsageCollectorTest {
   @Test
   public void guestUnknownHypervisorTotalsForRHEL() {
     String account = "A1";
-    InventoryHostFacts guest = createGuest(null, "A1", "O1", TEST_PRODUCT_ID, 12, 3);
+    InventoryHostFacts guest = createGuest(null, "A1", "O1", TEST_PRODUCT_ID);
+    guest.setSystemProfileCoresPerSocket(4);
+    guest.setSystemProfileSockets(3);
 
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(guest.getHypervisorUuid(), null);
@@ -188,8 +194,9 @@ public class InventoryAccountUsageCollectorTest {
     String account = "A1";
     List<Integer> products = Arrays.asList(TEST_PRODUCT_ID);
 
-    InventoryHostFacts host = createRhsmHost("A1", "O1", products, 12, 3, "", OffsetDateTime.now());
-
+    InventoryHostFacts host = createRhsmHost("A1", "O1", products, "", OffsetDateTime.now());
+    host.setSystemProfileCoresPerSocket(4);
+    host.setSystemProfileSockets(3);
     mockReportedHypervisors(account, new HashMap<>());
 
     when(inventoryRepo.getFacts(eq(List.of(account)), anyInt()))
@@ -213,9 +220,17 @@ public class InventoryAccountUsageCollectorTest {
     List<String> accounts = List.of("A1", "A2");
     List<Integer> products = Arrays.asList(TEST_PRODUCT_ID);
 
-    InventoryHostFacts host1 = createRhsmHost("A1", "O1", products, 4, 4, "", OffsetDateTime.now());
-    InventoryHostFacts host2 = createRhsmHost("A1", "O1", products, 8, 4, "", OffsetDateTime.now());
-    InventoryHostFacts host3 = createRhsmHost("A2", "O2", products, 2, 6, "", OffsetDateTime.now());
+    InventoryHostFacts host1 = createRhsmHost("A1", "O1", products, "", OffsetDateTime.now());
+    host1.setSystemProfileCoresPerSocket(1);
+    host1.setSystemProfileSockets(4);
+
+    InventoryHostFacts host2 = createRhsmHost("A1", "O1", products, "", OffsetDateTime.now());
+    host2.setSystemProfileCoresPerSocket(2);
+    host2.setSystemProfileSockets(4);
+
+    InventoryHostFacts host3 = createRhsmHost("A2", "O2", products, "", OffsetDateTime.now());
+    host3.setSystemProfileCoresPerSocket(3);
+    host3.setSystemProfileSockets(2);
 
     mockReportedHypervisors(accounts, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of("A1")), anyInt())).thenReturn(Stream.of(host1, host2));
@@ -233,7 +248,7 @@ public class InventoryAccountUsageCollectorTest {
 
     AccountUsageCalculation a2Calc = calcs.get("A2");
     assertEquals(1, a2Calc.getProducts().size());
-    checkTotalsCalculation(a2Calc, "A2", "O2", TEST_PRODUCT, 2, 6, 1);
+    checkTotalsCalculation(a2Calc, "A2", "O2", TEST_PRODUCT, 6, 2, 1);
   }
 
   @Test
@@ -247,21 +262,16 @@ public class InventoryAccountUsageCollectorTest {
             "O1",
             TEST_PRODUCT_ID.toString(),
             ServiceLevel.STANDARD,
-            6,
-            6,
             "",
             OffsetDateTime.now());
+    host1.setSystemProfileCoresPerSocket(1);
+    host1.setSystemProfileSockets(6);
 
     InventoryHostFacts host2 =
         createRhsmHost(
-            "A1",
-            "O1",
-            TEST_PRODUCT_ID.toString(),
-            ServiceLevel.PREMIUM,
-            10,
-            10,
-            "",
-            OffsetDateTime.now());
+            "A1", "O1", TEST_PRODUCT_ID.toString(), ServiceLevel.PREMIUM, "", OffsetDateTime.now());
+    host2.setSystemProfileCoresPerSocket(1);
+    host2.setSystemProfileSockets(10);
 
     mockReportedHypervisors(account, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of(account)), anyInt()))
@@ -290,10 +300,10 @@ public class InventoryAccountUsageCollectorTest {
             TEST_PRODUCT_ID.toString(),
             ServiceLevel.EMPTY,
             Usage.DEVELOPMENT_TEST,
-            6,
-            6,
             "",
             OffsetDateTime.now());
+    host1.setSystemProfileCoresPerSocket(1);
+    host1.setSystemProfileSockets(6);
 
     InventoryHostFacts host2 =
         createRhsmHost(
@@ -302,10 +312,10 @@ public class InventoryAccountUsageCollectorTest {
             TEST_PRODUCT_ID.toString(),
             ServiceLevel.EMPTY,
             Usage.PRODUCTION,
-            10,
-            10,
             "",
             OffsetDateTime.now());
+    host2.setSystemProfileCoresPerSocket(1);
+    host2.setSystemProfileSockets(10);
 
     mockReportedHypervisors(account, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of(account)), anyInt()))
@@ -363,10 +373,14 @@ public class InventoryAccountUsageCollectorTest {
     String account = "A1";
 
     InventoryHostFacts h1 =
-        createRhsmHost(
-            "A1", "Owner1", Arrays.asList(TEST_PRODUCT_ID), 8, 12, "", OffsetDateTime.now());
+        createRhsmHost("A1", "Owner1", Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+    h1.setSystemProfileCoresPerSocket(4);
+    h1.setSystemProfileSockets(2);
+
     InventoryHostFacts h2 =
-        createRhsmHost("A1", "Owner1", Arrays.asList(32), 12, 14, "", OffsetDateTime.now());
+        createRhsmHost("A1", "Owner1", Arrays.asList(32), "", OffsetDateTime.now());
+    h2.setSystemProfileCoresPerSocket(12);
+    h2.setSystemProfileSockets(14);
 
     mockReportedHypervisors(account, new HashMap<>());
 
@@ -379,7 +393,7 @@ public class InventoryAccountUsageCollectorTest {
 
     AccountUsageCalculation accountCalc = calcs.get("A1");
     assertEquals(1, accountCalc.getProducts().size());
-    checkTotalsCalculation(accountCalc, "A1", "Owner1", TEST_PRODUCT, 8, 12, 1);
+    checkTotalsCalculation(accountCalc, "A1", "Owner1", TEST_PRODUCT, 8, 2, 1);
   }
 
   @Test
@@ -388,11 +402,12 @@ public class InventoryAccountUsageCollectorTest {
     String account = "A1";
 
     InventoryHostFacts h1 =
-        createRhsmHost(
-            "A1", "Owner1", Arrays.asList(TEST_PRODUCT_ID), 1, 2, "", OffsetDateTime.now());
+        createRhsmHost("A1", "Owner1", Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+    h1.setSystemProfileCoresPerSocket(1);
+    h1.setSystemProfileSockets(2);
+
     InventoryHostFacts h2 =
-        createRhsmHost(
-            "A1", "Owner2", Arrays.asList(TEST_PRODUCT_ID), 1, 2, "", OffsetDateTime.now());
+        createRhsmHost("A1", "Owner2", Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
 
     mockReportedHypervisors(account, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of(account)), anyInt()))
@@ -410,14 +425,22 @@ public class InventoryAccountUsageCollectorTest {
   public void testTallyCoresAndSocketsOfRhelForPhysicalSystems() {
     List<String> accounts = List.of("A1", "A2");
     InventoryHostFacts host1 =
-        createRhsmHost("A1", "O1", Arrays.asList(TEST_PRODUCT_ID), 4, 4, "", OffsetDateTime.now());
+        createRhsmHost("A1", "O1", Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+    host1.setSystemProfileCoresPerSocket(1);
+    host1.setSystemProfileSockets(4);
 
-    InventoryHostFacts host2 = createHypervisor("A1", "O1", TEST_PRODUCT_ID, 8, 4);
+    InventoryHostFacts host2 = createHypervisor("A1", "O1", TEST_PRODUCT_ID);
+    host2.setSystemProfileCoresPerSocket(2);
+    host2.setSystemProfileSockets(4);
 
     InventoryHostFacts host3 =
-        createRhsmHost("A2", "O2", Arrays.asList(TEST_PRODUCT_ID), 2, 6, "", OffsetDateTime.now());
+        createRhsmHost("A2", "O2", Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+    host3.setSystemProfileCoresPerSocket(5);
+    host3.setSystemProfileSockets(1);
 
-    InventoryHostFacts host4 = createHypervisor("A2", "O2", TEST_PRODUCT_ID, 3, 4);
+    InventoryHostFacts host4 = createHypervisor("A2", "O2", TEST_PRODUCT_ID);
+    host4.setSystemProfileCoresPerSocket(5);
+    host4.setSystemProfileSockets(1);
 
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(host2.getSubscriptionManagerId(), null);
@@ -440,22 +463,28 @@ public class InventoryAccountUsageCollectorTest {
 
     AccountUsageCalculation a2Calc = calcs.get("A2");
     assertEquals(1, a2Calc.getProducts().size());
-    checkTotalsCalculation(a2Calc, "A2", "O2", TEST_PRODUCT, 5, 10, 2);
-    checkPhysicalTotalsCalculation(a2Calc, "A2", "O2", TEST_PRODUCT, 5, 10, 2);
+    checkTotalsCalculation(a2Calc, "A2", "O2", TEST_PRODUCT, 10, 4, 2);
+    checkPhysicalTotalsCalculation(a2Calc, "A2", "O2", TEST_PRODUCT, 10, 4, 2);
   }
 
   @Test
   public void testHypervisorCalculationsWhenMapped() {
     String account = "A1";
 
-    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID, 12, 3);
+    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID);
+    hypervisor.setSystemProfileCoresPerSocket(4);
+    hypervisor.setSystemProfileSockets(3);
 
     // Guests should not end up in the total since only the hypervisor should be counted.
     InventoryHostFacts guest1 =
-        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID, 12, 3);
+        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID);
+    guest1.setSystemProfileCoresPerSocket(4);
+    guest1.setSystemProfileSockets(3);
 
     InventoryHostFacts guest2 =
-        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID, 8, 2);
+        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID);
+    guest2.setSystemProfileCoresPerSocket(4);
+    guest2.setSystemProfileSockets(2);
 
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(
@@ -481,14 +510,20 @@ public class InventoryAccountUsageCollectorTest {
   public void testHypervisorCalculationsWhenMappedWithNoProductsOnHypervisor() {
     String account = "A1";
 
-    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", null, 12, 3);
+    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", null);
+    hypervisor.setSystemProfileCoresPerSocket(4);
+    hypervisor.setSystemProfileSockets(3);
 
     // Guests should not end up in the total since only the hypervisor should be counted.
     InventoryHostFacts guest1 =
-        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID, 12, 3);
+        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID);
+    guest1.setSystemProfileCoresPerSocket(4);
+    guest1.setSystemProfileSockets(3);
 
     InventoryHostFacts guest2 =
-        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID, 8, 2);
+        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID);
+    guest2.setSystemProfileCoresPerSocket(4);
+    guest2.setSystemProfileSockets(3);
 
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(
@@ -515,14 +550,14 @@ public class InventoryAccountUsageCollectorTest {
   void testGuestCountIsTrackedOnHost() {
     String account = "A1";
 
-    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID, 12, 3);
+    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID);
 
     // Guests should not end up in the total since only the hypervisor should be counted.
     InventoryHostFacts guest1 =
-        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID, 12, 3);
+        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID);
 
     InventoryHostFacts guest2 =
-        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID, 8, 2);
+        createGuest(hypervisor.getSubscriptionManagerId(), "A1", "O1", TEST_PRODUCT_ID);
 
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(
@@ -569,7 +604,7 @@ public class InventoryAccountUsageCollectorTest {
     Counter counter = meterRegistry.counter("rhsm-subscriptions.tally.hbi_hosts");
     double initialCount = counter.count();
 
-    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID, 12, 3);
+    InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID);
 
     Map<String, String> expectedHypervisorMap = new HashMap<>();
     expectedHypervisorMap.put(
@@ -588,8 +623,9 @@ public class InventoryAccountUsageCollectorTest {
   void accountsWithNullInventoryIdFiltered() {
     String account = "A1";
     List<Integer> products = Arrays.asList(TEST_PRODUCT_ID);
-    InventoryHostFacts host =
-        createRhsmHost(account, "O1", products, 12, 3, "", OffsetDateTime.now());
+    InventoryHostFacts host = createRhsmHost(account, "O1", products, "", OffsetDateTime.now());
+    host.setSystemProfileCoresPerSocket(4);
+    host.setSystemProfileSockets(3);
 
     when(hostRepo.findByAccountNumber("A1"))
         .thenReturn(
@@ -619,9 +655,9 @@ public class InventoryAccountUsageCollectorTest {
   void removesDuplicateHostRecords() {
     String account = "A1";
     List<Integer> products = Arrays.asList(TEST_PRODUCT_ID);
-    InventoryHostFacts host =
-        createRhsmHost(account, "O1", products, 12, 3, "", OffsetDateTime.now());
-
+    InventoryHostFacts host = createRhsmHost(account, "O1", products, "", OffsetDateTime.now());
+    host.setSystemProfileCoresPerSocket(4);
+    host.setSystemProfileSockets(3);
     Host orig =
         new Host(
             host.getInventoryId().toString(),

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -35,28 +35,18 @@ public class InventoryHostFactTestHelper {
     throw new IllegalStateException("Utility class; should never be instantiated!");
   }
 
-  public static InventoryHostFacts createHypervisor(
-      String account, String orgId, Integer product, int cores, int sockets) {
+  public static InventoryHostFacts createHypervisor(String account, String orgId, Integer product) {
     InventoryHostFacts baseFacts = createBaseHost(account, orgId);
     if (product != null) {
       baseFacts.setProducts(product.toString());
     }
-    baseFacts.setCores(cores);
-    baseFacts.setSockets(sockets);
     return baseFacts;
   }
 
   public static InventoryHostFacts createGuest(
-      String hypervisorUUID,
-      String account,
-      String orgId,
-      Integer product,
-      int cores,
-      int sockets) {
+      String hypervisorUUID, String account, String orgId, Integer product) {
     InventoryHostFacts baseFacts = createBaseHost(account, orgId);
     baseFacts.setProducts(product.toString());
-    baseFacts.setCores(cores);
-    baseFacts.setSockets(sockets);
     baseFacts.setHypervisorUuid(hypervisorUUID);
     baseFacts.setGuestId(UUID.randomUUID().toString());
     baseFacts.setVirtual(true);
@@ -67,32 +57,22 @@ public class InventoryHostFactTestHelper {
       String account,
       String orgId,
       List<Integer> products,
-      Integer cores,
-      Integer sockets,
       String syspurposeRole,
       OffsetDateTime syncTimestamp) {
     return createRhsmHost(
         account,
         orgId,
         StringUtils.collectionToCommaDelimitedString(products),
-        cores,
-        sockets,
         syspurposeRole,
         syncTimestamp);
   }
 
   public static InventoryHostFacts createRhsmHost(
-      List<Integer> products,
-      Integer cores,
-      Integer sockets,
-      String syspurposeRole,
-      OffsetDateTime syncTimestamp) {
+      List<Integer> products, String syspurposeRole, OffsetDateTime syncTimestamp) {
     return createRhsmHost(
         "Account",
         "test_org",
         StringUtils.collectionToCommaDelimitedString(products),
-        cores,
-        sockets,
         syspurposeRole,
         syncTimestamp);
   }
@@ -101,19 +81,10 @@ public class InventoryHostFactTestHelper {
       String account,
       String orgId,
       String products,
-      Integer cores,
-      Integer sockets,
       String syspurposeRole,
       OffsetDateTime syncTimeStamp) {
     return createRhsmHost(
-        account,
-        orgId,
-        products,
-        ServiceLevel.EMPTY,
-        cores,
-        sockets,
-        syspurposeRole,
-        syncTimeStamp);
+        account, orgId, products, ServiceLevel.EMPTY, syspurposeRole, syncTimeStamp);
   }
 
   public static InventoryHostFacts createRhsmHost(
@@ -121,13 +92,11 @@ public class InventoryHostFactTestHelper {
       String orgId,
       String products,
       ServiceLevel sla,
-      Integer cores,
-      Integer sockets,
       String syspurposeRole,
       OffsetDateTime syncTimeStamp) {
 
     return createRhsmHost(
-        account, orgId, products, sla, Usage.EMPTY, cores, sockets, syspurposeRole, syncTimeStamp);
+        account, orgId, products, sla, Usage.EMPTY, syspurposeRole, syncTimeStamp);
   }
 
   public static InventoryHostFacts createRhsmHost(
@@ -136,15 +105,11 @@ public class InventoryHostFactTestHelper {
       String products,
       ServiceLevel sla,
       Usage usage,
-      Integer cores,
-      Integer sockets,
       String syspurposeRole,
       OffsetDateTime syncTimeStamp) {
 
     InventoryHostFacts baseFacts = createBaseHost(account, orgId);
     baseFacts.setProducts(products);
-    baseFacts.setCores(cores);
-    baseFacts.setSockets(sockets);
     baseFacts.setSyspurposeRole(syspurposeRole);
     baseFacts.setSyspurposeSla(sla.getValue());
     baseFacts.setSyspurposeUsage(usage.getValue());

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -120,7 +120,7 @@ public abstract class InventoryService {
   private SystemProfile createSystemProfile(ConduitFacts facts) {
     SystemProfile systemProfile = new SystemProfile();
     if (facts.getOsName() != null) {
-      systemProfile.setOperatingSystem(operatingSystemName(facts.getOsName()));
+      systemProfile.setOperatingSystem(operatingSystem(facts));
     }
     systemProfile.setOsRelease(facts.getOsVersion());
     systemProfile.setArch(facts.getArchitecture());
@@ -169,6 +169,14 @@ public abstract class InventoryService {
     return rhsmFactMap;
   }
 
+  private SystemProfileOperatingSystem operatingSystem(ConduitFacts facts) {
+    var operatingSystem = operatingSystemName(facts.getOsName());
+    if (facts.getOsVersion() != null) {
+      setOperatingSystemVersion(operatingSystem, facts.getOsVersion());
+    }
+    return operatingSystem;
+  }
+
   private SystemProfileOperatingSystem operatingSystemName(String operatingSystemName) {
     if (!operatingSystemName.toLowerCase().contains("red hat enterprise linux")) {
       return null;
@@ -176,6 +184,19 @@ public abstract class InventoryService {
     var operatingSystems = new SystemProfileOperatingSystem();
     operatingSystems.setName(SystemProfileOperatingSystem.NameEnum.RHEL);
     return operatingSystems;
+  }
+
+  private void setOperatingSystemVersion(
+      SystemProfileOperatingSystem operatingSystem, String operatingSystemVersion) {
+    var versions = operatingSystemVersion.split("\\.");
+    if (versions.length == 2) {
+      operatingSystem.setMajor(Integer.parseInt(versions[0]));
+      operatingSystem.setMinor(Integer.parseInt(versions[1]));
+    } else {
+      log.warn(
+          "Invalid OperatingSystemVersion: found \"{}\" but should be in format \"major.minor\"",
+          operatingSystemVersion);
+    }
   }
 
   private void addFact(Map<String, Object> factMap, String key, String value) {

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -117,6 +117,8 @@ class KafkaEnabledInventoryServiceTest {
     assertEquals("6.3", message.getData().getSystemProfile().getOsRelease());
     assertEquals(
         "RHEL", message.getData().getSystemProfile().getOperatingSystem().getName().getValue());
+    assertEquals(6, message.getData().getSystemProfile().getOperatingSystem().getMajor());
+    assertEquals(3, message.getData().getSystemProfile().getOperatingSystem().getMinor());
   }
 
   @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4598

Reads the distribution.version fact and sets the major and minor version numbers of the the operation system  for use in HBI.