### PR TITLE
Correct some annotations on our Hawtio customization

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -4,8 +4,16 @@ kind: Template
 metadata:
   name: rhsm
 parameters:
-  - name: HAWTIO_BASE_PATH
-    value: /hawtio
+  - name: SUBSCRIPTIONS_HAWTIO_BASE_PATH
+    value: /app/rhsm-subscriptions/hawtio
+  - name: MARKETPLACE_HAWTIO_BASE_PATH
+    value: /app/rhsm-marketplace/hawtio
+  - name: METRICS_WORKER_HAWTIO_BASE_PATH
+    value: /app/rhsm-metrics/hawtio
+  - name: CONDUIT_HAWTIO_BASE_PATH
+    value: /app/rhsm-conduit/hawtio
+  - name: CAPACITY_INGRESS_HAWTIO_BASE_PATH
+    value: /app/rhsm-capacity-ingress/hawtio
   - name: SERVER_MAX_HTTP_HEADER_SIZE
     value: '48000'
   - name: LOGGING_LEVEL_ROOT
@@ -285,8 +293,6 @@ objects:
               value: 'true'
             - name: SERVER_MAX_HTTP_HEADER_SIZE
               value: ${SERVER_MAX_HTTP_HEADER_SIZE}
-            - name: HAWTIO_BASE_PATH
-              value: ${HAWTIO_BASE_PATH}
             - name: LOG_FILE
               value: /logs/server.log
             - name: JAVA_MAX_MEM_RATIO
@@ -488,7 +494,7 @@ objects:
             - name: SERVER_MAX_HTTP_HEADER_SIZE
               value: ${SERVER_MAX_HTTP_HEADER_SIZE}
             - name: HAWTIO_BASE_PATH
-              value: ${HAWTIO_BASE_PATH}
+              value: ${SUBSCRIPTIONS_HAWTIO_BASE_PATH}
             - name: LOG_FILE
               value: /logs/server.log
             - name: JAVA_MAX_MEM_RATIO
@@ -694,7 +700,7 @@ objects:
             - name: SERVER_MAX_HTTP_HEADER_SIZE
               value: ${SERVER_MAX_HTTP_HEADER_SIZE}
             - name: HAWTIO_BASE_PATH
-              value: ${HAWTIO_BASE_PATH}
+              value: ${MARKETPLACE_HAWTIO_BASE_PATH}
             - name: LOG_FILE
               value: /logs/server.log
             - name: JAVA_MAX_MEM_RATIO
@@ -908,7 +914,7 @@ objects:
             - name: SERVER_MAX_HTTP_HEADER_SIZE
               value: ${SERVER_MAX_HTTP_HEADER_SIZE}
             - name: HAWTIO_BASE_PATH
-              value: ${HAWTIO_BASE_PATH}
+              value: ${METRICS_WORKER_HAWTIO_BASE_PATH}
             - name: LOG_FILE
               value: /logs/server.log
             - name: JAVA_MAX_MEM_RATIO
@@ -1111,7 +1117,7 @@ objects:
             - name: AB_JOLOKIA_OFF
               value: 'true'
             - name: HAWTIO_BASE_PATH
-              value: ${HAWTIO_BASE_PATH}
+              value: ${CONDUIT_HAWTIO_BASE_PATH}
             - name: LOG_FILE
               value: /logs/server.log
             - name: JAVA_MAX_MEM_RATIO
@@ -1284,7 +1290,7 @@ objects:
             - name: AB_JOLOKIA_OFF
               value: 'true'
             - name: HAWTIO_BASE_PATH
-              value: ${HAWTIO_BASE_PATH}
+              value: ${CAPACITY_INGRESS_HAWTIO_BASE_PATH}
             - name: LOG_FILE
               value: /logs/server.log
             - name: JAVA_MAX_MEM_RATIO

--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -26,6 +26,7 @@ import org.candlepin.subscriptions.rbac.RbacService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -73,6 +74,7 @@ public class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   @Autowired protected ObjectMapper mapper;
   @Autowired protected SecurityProperties secProps;
+  @Autowired protected ManagementServerProperties actuatorProps;
   @Autowired protected RbacProperties rbacProperties;
   @Autowired protected ConfigurableEnvironment env;
   @Autowired protected RbacService rbacService;
@@ -163,6 +165,12 @@ public class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
         .permitAll()
         // ingress security uses server settings (require ssl cert auth), so permit all here
         .antMatchers(String.format("/%s/ingress/**", apiPath))
+        .permitAll()
+        // Allow access to the Spring Actuator "root" which displays the available endpoints
+        .requestMatchers(
+            request ->
+                request.getServerPort() == actuatorProps.getPort()
+                    && request.getContextPath().equals(actuatorProps.getBasePath()))
         .permitAll()
         .requestMatchers(EndpointRequest.to("health", "info", "prometheus", "hawtio"))
         .permitAll()

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/util/HawtioConfiguration.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.util;
 
-import io.hawt.springboot.HawtioManagementConfiguration;
+import io.hawt.springboot.HawtioEndpoint;
 import io.hawt.web.filters.BaseTagHrefFilter;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -31,11 +31,12 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
-import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.actuate.autoconfigure.jolokia.JolokiaEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.util.StringUtils;
 
 /**
@@ -47,11 +48,12 @@ import org.springframework.util.StringUtils;
  * a browser URL of /rhsm-subscriptions/hawtio, then setting `rhsm-subscriptions.hawtioBasePath` to
  * /rhsm-subscriptions/hawtio forces the frontend to return the proper URLs for JavaScript/CSS.
  */
-@Configuration
-@ConditionalOnManagementPort(ManagementPortType.SAME)
-@AutoConfigureAfter(HawtioManagementConfiguration.class)
+@ManagementContextConfiguration
+@AutoConfigureAfter(JolokiaEndpointAutoConfiguration.class)
+@ConditionalOnBean(HawtioEndpoint.class)
 public class HawtioConfiguration {
   @Autowired
+  @DependsOn("baseTagHrefFilter")
   public void modifyBaseTagHrefFilter(
       @Qualifier("baseTagHrefFilter") FilterRegistrationBean<BaseTagHrefFilter> filter,
       ServletContext servletContext,

--- a/swatch-core/src/main/resources/META-INF/spring.factories
+++ b/swatch-core/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,4 @@
-org.springframework.boot.env.EnvironmentPostProcessor=org.candlepin.subscriptions.clowder.ClowderJsonEnvironmentPostProcessor
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.candlepin.subscriptions.clowder.ClowderJsonEnvironmentPostProcessor
+org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration=\
+  org.candlepin.subscriptions.util.HawtioConfiguration

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -81,6 +81,12 @@ management:
       enabled: true
     prometheus:
       enabled: true
+    # The liveness and readiness probes are enabled automatically when Spring Boot detects
+    # kubernetes environment variables.  This setting just enables them always so that we see them
+    # when running in a local deployment.
+    health:
+      probes:
+        enabled: true
 
 spring:
   jmx:


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4658

* When running Hawtio on a different management port, the order of bean initialization changed such that our 
  HawtioContextListener was being instantiated before the HawtioManagementConfiguration.  Since the former
  depended on a bean in the latter, this caused a start up failure.

  This PR changes the annotations on the HawtioContextListener so that it will load under the same circumstances the
  HawtioManagementConfiguration bean loads and the former is marked ashaving a dependency on the latter.

  Additionally, when management services (Spring Actuator) are run on a different port from the main application, the
  management services exist in a child context descended from the main context.  So that our configuration will exist
  in that same context, we annotate it with ManagementContextConfiguration and put a special entry in the
  META-INF/spring.factories file.

  See the ManagementContextAutoConfiguration class for details.
* Allow access to the Spring Actuator root context.  We allow access to the health, info, etc. actuators over the web but were not actually allowing access to the root context that a) gave a handy list of the web exposed actuators and b) was a useful test URL for hitting the app over `curl`
* Set the `HAWTIO_BASE_PATH` correctly for the relevant deployments in the ClowdApp.  ***Note that the testing instructions below do not actually test this fix***.  Instead the testing instructions demonstrate the `HAWTIO_BASE_PATH` environment variable needs to be set to the same string as what is used in the Turnpike route plus the suffix `hawtio`.  In other words, if I made a typo in the changes to `rhsm-clowdapp.yml`, the test instructions below wouldn't reveal it.  I have quadruple checked that I didn't, but please check again for me.  The routes that we use in Turnpike are in `data/services/insights/turnpike/deploy.yml` in the AppSRE repo.
---
Testing instructions

Reproducing the issue requires setting up [Turnpike](https://github.com/RedHatInsights/turnpike).

1. Make sure that you have **Docker** and **Docker Compose** installed.  I have not tested this with Podman/Podman-Compose and can not vouch for them.
    ```
    $ sudo dnf install moby-engine docker-compose
    ```
1. Build this branch and tag it into your Docker images.
    ```
    $ docker build -t rhsm-subscriptions .
    ```
1. Clone the turnpike repository and run the setup script.
    ```
    $ scripts/setup_devel_env
    ```
1. Apply the following patch to the `docker-compose.yml` file
    ```patch
    diff --git a/docker-compose.yml b/docker-compose.yml
    index a913cff..e3d7f75 100644
    --- a/docker-compose.yml
    +++ b/docker-compose.yml
    @@ -14,7 +14,7 @@ services:
         volumes:
           - ".:/usr/src/app/"
           - "./saml:/usr/src/app/turnpike/saml"
    -      - "./dev-backends.yml:/etc/turnpike/backends.yml"
    +      - "./dev-backends.yml:/etc/turnpike/backends.yml:z"
           - "./dev-config.py:/etc/turnpike/dev-config.py"
         networks:
           mynet:
    @@ -33,7 +33,7 @@ services:
         hostname: nginx
         volumes:
           - "./dev-backends.yml:/etc/turnpike/backends.yml"
    -      - "./nginx/certs:/etc/nginx/certs"
    +      - "./nginx/certs:/etc/nginx/certs:z"
         networks:
           mynet:
             aliases:
    @@ -42,6 +42,7 @@ services:
           NGINX_LISTEN: 8443 ssl
           NGINX_SERVER_NAME: ${SERVER_NAME}
           FLASK_SERVICE_URL: http://web.svc.cluster.local:5000
    +      TURNPIKE_NO_AUTH_ROUTES: '["public", "app"]'
           FLASK_SERVER_NAME: ${SERVER_NAME}
           NGINX_SSL_CONFIG: |
            ssl_certificate certs/cert.pem;
    @@ -71,5 +72,33 @@ services:
               - echo-server.svc.cluster.local
         environment:
           PORT: 8080
    +  rhsm-subscriptions:
    +    image: localhost/rhsm-subscriptions
    +    hostname: rhsm-subscriptions
    +    ports:
    +      - 8081:8081
    +      - 9000:9000
    +    expose:
    +      - "9000"
    +    networks:
    +      mynet:
    +        aliases:
    +          # Must use svc.cluster.local domain
    +          - rhsm-subscriptions.svc.cluster.local
    +    environment:
    +      RHSM_SUBSCRIPTIONS_DATASOURCE_PLATFORM: hsqldb
    +      RHSM_SUBSCRIPTIONS_DATASOURCE_DRIVER_CLASS_NAME: org.hsqldb.jdbc.JDBCDriver
    +      RHSM_SUBSCRIPTIONS_DATASOURCE_URL: jdbc:hsqldb:mem:testdb
    +      RHSM_SUBSCRIPTIONS_INVENTORY_SERVICE_DATASOURCE_PLATFORM: hsqldb
    +      RHSM_SUBSCRIPTIONS_INVENTORY_SERVICE_DATASOURCE_DRIVER_CLASS_NAME: org.hsqldb.jdbc.JDBCDriver
    +      RHSM_SUBSCRIPTIONS_INVENTORY_SERVICE_DATASOURCE_URL: jdbc:hsqldb:mem:testdb2
    +      SPRING_PROFILES_ACTIVE: api
    +      HAWTIO_BASE_PATH: /app/rhsm-subscriptions/hawtio
    +      DEV_MODE: 'true'
    +      JAVA_MAX_MEM_RATIO: 85
    +      GC_MAX_METASPACE_SIZE: 256
    +      RBAC_USE_STUB: 'true'
    +      SERVER_PORT: 8081
    +      AB_JOLOKIA_OFF: 'true'
     networks:
       mynet:
    ```

    A few notes on the patch:
    * The `:z` added to the volume mounts is to maintain proper SELinux contexts in the mount
    * The `TURNPIKE_NO_AUTH_ROUTES` environment valuable is a JSON list that defines the contexts that do not require authentication in Turnpike.  The default is just `["public"]`.  However, we don't want to go through setting up SAML just for testing that HawtIO loads properly (and in fact, I don't even know the steps to do that).
    * The `mynet` alias needs to end in `svc.cluster.local`.  Turnpike has an environment variable `ALLOWED_ORIGIN_DOMAINS` that your alias needs to end with.
    * I don't think the `expose` directive I have in the `rhsm-subscriptions` compose is actually required, but it was in the patch when I started writing this :).
    * `DEV_MODE` is set to true to dispense with our security header inspection that accessing HawtIO normally requires.
1. Apply the following patch to the `dev-backends.yml` file
    ```patch
    diff --git a/dev-backends.yml b/dev-backends.yml
    index 68af266..abdf5a8 100644
    --- a/dev-backends.yml
    +++ b/dev-backends.yml
    @@ -19,3 +19,6 @@
       origin: http://echo-server.svc.cluster.local:8080/
       source_ip:
         - 240.0.0.0/4
    +- name: rhsm-subscriptions
    +  route: /app/rhsm-subscriptions/
    +  origin: http://rhsm-subscriptions.svc.cluster.local:9000/
    ```
1. Run `docker-compose up` and wait for everything to start up (~ 40 seconds)
1. Visit https://turnpike.example.com/app/rhsm-subscriptions/hawtio
1. HawtIO should appear with all the CSS and JS loaded.
