### PR TITLE
ENT-4453: Allow unlimited capacity SKU's

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1753,6 +1753,9 @@ components:
           description: "The combined (physical and virtual) capacity for the offering."
           type: integer
           format: int32
+        has_infinite_quantity:
+          description: "Denotes unlimited capacity for the offering when true."
+          type: boolean
         uom:
           description: "The unit-of-measure for the capacity."
           $ref: "#/components/schemas/Uom"

--- a/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CandlepinPoolCapacityMapper.java
@@ -108,7 +108,8 @@ public class CandlepinPoolCapacityMapper {
                   && capacity.getPhysicalCores() == null
                   && capacity.getVirtualCores() == null
                   && capacity.getVirtualSockets() == null
-                  && !capacity.getHasUnlimitedGuestSockets()) {
+                  && (capacity.getHasUnlimitedUsage() == null
+                      || !capacity.getHasUnlimitedUsage())) {
 
                 log.warn(
                     "SKU {} appears to not provide any capacity. Bad SKU definition?",

--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -48,6 +48,7 @@ class UpstreamProductData {
   private static final String MSG_TEMPLATE =
       "offeringSku=\"%s\" already has field=%s original=\"%s\" so will ignore value=\"%s\".";
   private static final int CONVERSION_RATIO_IFL_TO_CORES = 4;
+  private static final String UNLIMITED_CORES_OR_SOCKETS = "Unlimited";
 
   /** List of opProd attribute codes used in the making of an Offering. */
   // Non-standard attribute codes are prefixed by "X_". They are not actually attribute codes
@@ -303,13 +304,27 @@ class UpstreamProductData {
       offering.setVirtualCores(cores);
       offering.setVirtualSockets(sockets);
     }
+    var hasUnlimitedCores =
+        Optional.ofNullable(attrs.get(Attr.CORES))
+            .map(UpstreamProductData::hasUnlimitedUsage)
+            .orElse(false);
+    var hasUnlimitedSockets =
+        Optional.ofNullable(attrs.get(Attr.SOCKET_LIMIT))
+            .map(UpstreamProductData::hasUnlimitedUsage)
+            .orElse(false);
+    offering.setHasUnlimitedUsage(hasUnlimitedCores || hasUnlimitedSockets);
   }
 
-  private static Integer nullOrInteger(String v) {
-    if (v == null) {
+  private static Integer nullOrInteger(String capacity) {
+    if (capacity == null || hasUnlimitedUsage(capacity)) {
       return null;
+    } else {
+      return Integer.valueOf(capacity);
     }
-    return Integer.valueOf(v);
+  }
+
+  private static boolean hasUnlimitedUsage(String capacity) {
+    return UNLIMITED_CORES_OR_SOCKETS.equalsIgnoreCase(capacity);
   }
 
   private static UpstreamProductData createFromProduct(OperationalProduct product) {

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -24,6 +24,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
@@ -201,6 +202,7 @@ public class CapacityResource implements CapacityApi {
     int cores = 0;
     int physicalCores = 0;
     int hypervisorCores = 0;
+    boolean hasInfiniteQuantity = false;
 
     for (SubscriptionCapacity capacity : matches) {
       if (capacity.getBeginDate().isBefore(date) && capacity.getEndDate().isAfter(date)) {
@@ -219,6 +221,8 @@ public class CapacityResource implements CapacityApi {
         int capacityVirtCores = sanitize(capacity.getVirtualCores());
         cores += capacityVirtCores;
         hypervisorCores += capacityVirtCores;
+
+        hasInfiniteQuantity = Optional.ofNullable(capacity.getHasUnlimitedUsage()).orElse(false);
       }
     }
 
@@ -230,7 +234,7 @@ public class CapacityResource implements CapacityApi {
         .cores(cores)
         .physicalCores(physicalCores)
         .hypervisorCores(hypervisorCores)
-        .hasInfiniteQuantity(false);
+        .hasInfiniteQuantity(hasInfiniteQuantity);
   }
 
   private int sanitize(Integer value) {

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -236,8 +236,12 @@ public class SubscriptionTableController {
       }
     }
 
+    boolean hasInfiniteQuantity =
+        Optional.ofNullable(subscriptionCapacityView.getHasUnlimitedUsage()).orElse(false);
+
     skuCapacity.setTotalCapacity(
         skuCapacity.getPhysicalCapacity() + skuCapacity.getVirtualCapacity());
+    skuCapacity.setHasInfiniteQuantity(hasInfiniteQuantity);
   }
 
   private static void sortCapacities(

--- a/src/main/resources/liquibase/202202041415-add-unlimited-usage-column-to-offering-table.xml
+++ b/src/main/resources/liquibase/202202041415-add-unlimited-usage-column-to-offering-table.xml
@@ -1,0 +1,21 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202202041415-1"  author="kflahert">
+    <comment>Add has_unlimited_usage column to offering table</comment>
+    <addColumn tableName="offering">
+      <column name="has_unlimited_usage" type="BOOLEAN" />
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202202041415-2"  author="kflahert">
+    <comment>Rename has_unlimited_guest_sockets column to has_unlimited_usage in subscription_capacity table</comment>
+    <renameColumn  newColumnName="has_unlimited_usage"
+                   oldColumnName="has_unlimited_guest_sockets"
+                   tableName="subscription_capacity"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -52,5 +52,6 @@
     <include file="liquibase/202110211313-add-rhosak-offering.xml" />
     <include file="liquibase/202110211314-add-description-column-to-offering.xml" />
     <include file="liquibase/202112171721-add-subscription-indexes.xml" />
+    <include file="liquibase/202202041415-add-unlimited-usage-column-to-offering-table.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/product-stub-data/tree-MW00210M1_attrs-true.json
+++ b/src/main/resources/product-stub-data/tree-MW00210M1_attrs-true.json
@@ -1,0 +1,28 @@
+{
+  "products": [
+    {
+      "sku": "MW00210MO",
+      "description": "Red Hat OpenShift Container Platform, Premium (1 vCPU, Monthly, On-Demand, Billing)",
+      "status": "ACTIVE",
+      "attributes": [
+        {
+          "code": "PRODUCT_FAMILY",
+          "value": "OpenShift Enterprise"
+        },
+        {
+          "code": "SOCKET_LIMIT",
+          "value": "Unlimited"
+        },
+        {
+          "code": "SERVICE_TYPE",
+          "value": "Standard"
+        },
+        {
+          "code": "PRODUCT_NAME",
+          "value": "Red Hat OpenShift Container Platform, Premium (1 vCPU, Monthly, On-Demand, Billing)"
+        }
+      ],
+      "roles": []
+    }
+  ]
+}

--- a/src/main/resources/product-stub-data/tree-MW00210MO_attrs-true.json
+++ b/src/main/resources/product-stub-data/tree-MW00210MO_attrs-true.json
@@ -1,0 +1,28 @@
+{
+  "products": [
+    {
+      "sku": "MW00210MO",
+      "description": "Red Hat OpenShift Container Platform, Premium (1 vCPU, Monthly, On-Demand, Billing)",
+      "status": "ACTIVE",
+      "attributes": [
+        {
+          "code": "PRODUCT_FAMILY",
+          "value": "OpenShift Enterprise"
+        },
+        {
+          "code": "CORES",
+          "value": "Unlimited"
+        },
+        {
+          "code": "SERVICE_TYPE",
+          "value": "Standard"
+        },
+        {
+          "code": "PRODUCT_NAME",
+          "value": "Red Hat OpenShift Container Platform, Premium (1 vCPU, Monthly, On-Demand, Billing)"
+        }
+      ],
+      "roles": []
+    }
+  ]
+}

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -79,7 +79,7 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("ownerId", capacity.getOwnerId());
     assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
-    assertFalse(capacity.getHasUnlimitedGuestSockets());
+    assertFalse(capacity.getHasUnlimitedUsage());
   }
 
   @Test
@@ -104,7 +104,7 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("ownerId", capacity.getOwnerId());
     assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
-    assertFalse(capacity.getHasUnlimitedGuestSockets());
+    assertFalse(capacity.getHasUnlimitedUsage());
   }
 
   @Test
@@ -129,7 +129,7 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("ownerId", capacity.getOwnerId());
     assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
-    assertFalse(capacity.getHasUnlimitedGuestSockets());
+    assertFalse(capacity.getHasUnlimitedUsage());
   }
 
   @Test
@@ -154,7 +154,7 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("ownerId", capacity.getOwnerId());
     assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
-    assertFalse(capacity.getHasUnlimitedGuestSockets());
+    assertFalse(capacity.getHasUnlimitedUsage());
   }
 
   @Test
@@ -374,7 +374,7 @@ class SubscriptionCapacityRepositoryTest {
     capacity.setSubscriptionId("subscription");
     capacity.setBeginDate(begin);
     capacity.setEndDate(end);
-    capacity.setHasUnlimitedGuestSockets(false);
+    capacity.setHasUnlimitedUsage(false);
     capacity.setOwnerId("ownerId");
     capacity.setPhysicalSockets(4);
     capacity.setVirtualSockets(20);

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepositoryTest.java
@@ -686,7 +686,7 @@ class SubscriptionCapacityViewRepositoryTest {
     capacity.setSubscriptionId(SUBSCRIPTION_ID);
     capacity.setBeginDate(begin);
     capacity.setEndDate(end);
-    capacity.setHasUnlimitedGuestSockets(false);
+    capacity.setHasUnlimitedUsage(false);
     capacity.setOwnerId(OWNER_ID);
     capacity.setPhysicalSockets(4);
     capacity.setVirtualSockets(20);

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingSyncControllerTest.java
@@ -148,6 +148,7 @@ class OfferingSyncControllerTest {
             408, 290, 473, 479, 240, 603, 604, 185, 546, 608, 69, 70, 610));
     persisted.setServiceLevel(ServiceLevel.PREMIUM);
     persisted.setUsage(Usage.EMPTY);
+    persisted.setHasUnlimitedUsage(false);
 
     when(repo.findById(anyString())).thenReturn(Optional.of(persisted));
 

--- a/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
@@ -50,6 +50,7 @@ class UpstreamProductDataTest {
     expected.setDescription("Red Hat OpenShift Container Platform (Hourly)");
     expected.setServiceLevel(ServiceLevel.PREMIUM);
     expected.setUsage(Usage.EMPTY);
+    expected.setHasUnlimitedUsage(false);
 
     // When getting the upstream Offering,
     var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
@@ -71,6 +72,7 @@ class UpstreamProductDataTest {
     expected.setDescription("Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)");
     expected.setServiceLevel(ServiceLevel.PREMIUM);
     expected.setUsage(Usage.EMPTY);
+    expected.setHasUnlimitedUsage(false);
 
     // When getting the upstream Offering,
     var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
@@ -117,6 +119,7 @@ class UpstreamProductDataTest {
     expected.setServiceLevel(ServiceLevel.PREMIUM);
     // (Usage ends up coming from derived SKU RH00618F5)
     expected.setUsage(Usage.PRODUCTION);
+    expected.setHasUnlimitedUsage(false);
 
     // When getting the upstream Offering,
     var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
@@ -148,6 +151,7 @@ class UpstreamProductDataTest {
             + "(Up to 4 guests) with Smart Management");
     expected.setServiceLevel(ServiceLevel.STANDARD);
     expected.setUsage(Usage.PRODUCTION);
+    expected.setHasUnlimitedUsage(false);
 
     // When getting the upstream Offering,
     var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
@@ -176,6 +180,7 @@ class UpstreamProductDataTest {
     expected.setDescription("Red Hat Enterprise Linux Developer Workstation, Enterprise");
     expected.setServiceLevel(ServiceLevel.EMPTY); // Because Dev-Enterprise isn't a ServiceLevel yet
     expected.setUsage(Usage.DEVELOPMENT_TEST);
+    expected.setHasUnlimitedUsage(false);
 
     // When getting the upstream Offering,
     var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
@@ -194,5 +199,29 @@ class UpstreamProductDataTest {
 
     // Then there is no resulting offering.
     assertTrue(actual.isEmpty(), "When a sku doesn't exist upstream, return an empty Optional.");
+  }
+
+  @Test
+  void testOfferingFromUpstreamOpenShiftUnlimitedCores() {
+    // Given an Openshift SKU that has unlimited cores,
+    var sku = "MW00210MO";
+
+    // When getting the upstream offering,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
+
+    // Then hasUnlimitedUsage should be true
+    assertEquals(true, actual.getHasUnlimitedUsage());
+  }
+
+  @Test
+  void testOfferingFromUpstreamOpenShiftUnlimitedSocketLimit() {
+    // Given an Openshift SKU that has unlimited cores,
+    var sku = "MW00210M1";
+
+    // When getting the upstream offering,
+    var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
+
+    // Then hasUnlimitedUsage should be true
+    assertEquals(true, actual.getHasUnlimitedUsage());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -298,4 +298,21 @@ class CapacityResourceTest {
     long expected = ChronoUnit.WEEKS.between(begin, end) + 1;
     assertEquals(expected, actual.size());
   }
+
+  @Test
+  void testShouldCalculateCapacityWithUnlimitedUsage() {
+    SubscriptionCapacity capacity = new SubscriptionCapacity();
+    capacity.setHasUnlimitedUsage(true);
+    capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
+    capacity.setEndDate(max);
+
+    when(repository.findByOwnerAndProductId("owner123456", RHEL.toString(), null, null, min, max))
+        .thenReturn(Arrays.asList(capacity));
+
+    CapacityReport report =
+        resource.getCapacityReport(RHEL, GranularityType.DAILY, min, max, null, null, null, null);
+
+    CapacitySnapshot capacitySnapshot = report.getData().get(0);
+    assertTrue(capacitySnapshot.getHasInfiniteQuantity());
+  }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -134,4 +134,13 @@ public class Offering implements Serializable {
   /** Syspurpose Usage for the offering */
   @Column(name = "usage")
   private Usage usage;
+
+  // Lombok would name the getter "isHasUnlimitedGuestSockets"
+  @Getter(AccessLevel.NONE)
+  @Column(name = "has_unlimited_usage")
+  private Boolean hasUnlimitedUsage;
+
+  public Boolean getHasUnlimitedUsage() {
+    return hasUnlimitedUsage;
+  }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
@@ -54,8 +54,8 @@ public class SubscriptionCapacity implements Serializable {
 
   // Lombok would name the getter "isHasUnlimitedGuestSockets"
   @Getter(AccessLevel.NONE)
-  @Column(name = "has_unlimited_guest_sockets")
-  private boolean hasUnlimitedGuestSockets;
+  @Column(name = "has_unlimited_usage")
+  private Boolean hasUnlimitedUsage;
 
   @Column(name = "begin_date")
   private OffsetDateTime beginDate;
@@ -100,8 +100,8 @@ public class SubscriptionCapacity implements Serializable {
     key.setOwnerId(ownerId);
   }
 
-  public boolean getHasUnlimitedGuestSockets() {
-    return hasUnlimitedGuestSockets;
+  public Boolean getHasUnlimitedUsage() {
+    return hasUnlimitedUsage;
   }
 
   public static SubscriptionCapacity from(
@@ -123,6 +123,7 @@ public class SubscriptionCapacity implements Serializable {
         .virtualSockets(totalCapacity(offering.getVirtualSockets(), subscription.getQuantity()))
         .virtualCores(totalCapacity(offering.getVirtualCores(), subscription.getQuantity()))
         .physicalCores(totalCapacity(offering.getPhysicalCores(), subscription.getQuantity()))
+        .hasUnlimitedUsage(offering.getHasUnlimitedUsage())
         .build();
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
@@ -47,7 +47,7 @@ import org.hibernate.annotations.Subselect;
         + "sc.end_date, \n"
         + "sc.begin_date, \n"
         + "sc.account_number, \n"
-        + "sc.has_unlimited_guest_sockets, \n"
+        + "sc.has_unlimited_usage, \n"
         + "s.quantity, \n"
         + "s.subscription_number, \n"
         + "o.description as product_name \n"
@@ -104,8 +104,8 @@ public class SubscriptionCapacityView {
   @Column(name = "account_number")
   private String accountNumber;
 
-  @Column(name = "has_unlimited_guest_sockets")
-  private boolean hasUnlimitedGuestSockets;
+  @Column(name = "has_unlimited_usage")
+  private Boolean hasUnlimitedUsage;
 
   public Integer getPhysicalSockets() {
     return Objects.isNull(physicalSockets) ? 0 : physicalSockets;


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4453

Fixes errors when consuming SKU's with "Unlimited" cores capacity.

Rename "has_unlimited_guest_sockets" column to "has_unlimited_usage" in subscription_capacity table

Test Steps:

- call syncOffering() method in OfferingJmxBean with sku 'MW00210MO' or other SKU with unlimited capacity. http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.product-OfferingJmxBean-offeringJmxBean
