### PR TITLE
ENT-4431: add total_capacity sort param to for subscription/products api

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1769,6 +1769,8 @@ components:
         - next_event_date
         - next_event_type
         - quantity
+        - total_capacity
+        - product_name
 
     SkuCapacityReport:
       properties:

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -273,6 +273,12 @@ public class SubscriptionTableController {
             case NEXT_EVENT_TYPE:
               diff = left.getNextEventType().compareTo(right.getNextEventType());
               break;
+            case TOTAL_CAPACITY:
+              diff = left.getTotalCapacity().compareTo(right.getTotalCapacity());
+              break;
+            case PRODUCT_NAME:
+              diff = left.getProductName().compareTo(right.getProductName());
+              break;
           }
           // If the two items are sorted by some other field than SKU and are equal, then break the
           // tie by sorting by SKU. No two SKUs in the list are equal.


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4431

Allows for sorting by the total capacity of virtual/physical sockets and cores.

Test Steps:

```
- curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform?sort=total_capacity&dir=asc' \
  -H 'accept: application/vnd.api+json'
```