### PR TITLE
ENT-4598 Add major and minor version attributes to operating system details of HBI messages

### DIFF
--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -59,6 +59,8 @@ public class StubRhsmApi extends RhsmApi {
     consumer1.getFacts().put("virt.is_guest", "True");
     consumer1.getFacts().put("ocm.units", "Sockets");
     consumer1.getFacts().put("ocm.billing_model", "standard");
+    consumer1.getFacts().put("distribution.name", "Red Hat Enterprise Linux Workstation");
+    consumer1.getFacts().put("distribution.version", "6.3");
     InstalledProducts product = new InstalledProducts();
     product.setProductId("72");
     consumer1.getInstalledProducts().add(product);

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -120,7 +120,7 @@ public abstract class InventoryService {
   private SystemProfile createSystemProfile(ConduitFacts facts) {
     SystemProfile systemProfile = new SystemProfile();
     if (facts.getOsName() != null) {
-      systemProfile.setOperatingSystem(operatingSystemName(facts.getOsName()));
+      systemProfile.setOperatingSystem(operatingSystem(facts));
     }
     systemProfile.setOsRelease(facts.getOsVersion());
     systemProfile.setArch(facts.getArchitecture());
@@ -169,6 +169,14 @@ public abstract class InventoryService {
     return rhsmFactMap;
   }
 
+  private SystemProfileOperatingSystem operatingSystem(ConduitFacts facts) {
+    var operatingSystem = operatingSystemName(facts.getOsName());
+    if (facts.getOsVersion() != null) {
+      setOperatingSystemVersion(operatingSystem, facts.getOsVersion());
+    }
+    return operatingSystem;
+  }
+
   private SystemProfileOperatingSystem operatingSystemName(String operatingSystemName) {
     if (!operatingSystemName.toLowerCase().contains("red hat enterprise linux")) {
       return null;
@@ -176,6 +184,19 @@ public abstract class InventoryService {
     var operatingSystems = new SystemProfileOperatingSystem();
     operatingSystems.setName(SystemProfileOperatingSystem.NameEnum.RHEL);
     return operatingSystems;
+  }
+
+  private void setOperatingSystemVersion(
+      SystemProfileOperatingSystem operatingSystem, String operatingSystemVersion) {
+    var versions = operatingSystemVersion.split("\\.");
+    if (versions.length == 2) {
+      operatingSystem.setMajor(Integer.parseInt(versions[0]));
+      operatingSystem.setMinor(Integer.parseInt(versions[1]));
+    } else {
+      log.warn(
+          "Invalid OperatingSystemVersion: found \"{}\" but should be in format \"major.minor\"",
+          operatingSystemVersion);
+    }
   }
 
   private void addFact(Map<String, Object> factMap, String key, String value) {

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -117,6 +117,8 @@ class KafkaEnabledInventoryServiceTest {
     assertEquals("6.3", message.getData().getSystemProfile().getOsRelease());
     assertEquals(
         "RHEL", message.getData().getSystemProfile().getOperatingSystem().getName().getValue());
+    assertEquals(6, message.getData().getSystemProfile().getOperatingSystem().getMajor());
+    assertEquals(3, message.getData().getSystemProfile().getOperatingSystem().getMinor());
   }
 
   @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4598

Reads the distribution.version fact and sets the major and minor version numbers of the the operation system for use in HBI.