### PR TITLE
Hot-fix ENT-4347: Remove remaining cores & sockets in Conduit

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -149,8 +149,6 @@ public abstract class InventoryService {
     Map<String, Object> rhsmFactMap = new HashMap<>();
     rhsmFactMap.put("orgId", conduitFacts.getOrgId());
 
-    addFact(rhsmFactMap, "CPU_SOCKETS", conduitFacts.getCpuSockets());
-    addFact(rhsmFactMap, "CPU_CORES", conduitFacts.getCpuCores());
     addFact(rhsmFactMap, "MEMORY", conduitFacts.getMemory());
     addFact(rhsmFactMap, "ARCHITECTURE", conduitFacts.getArchitecture());
     addFact(rhsmFactMap, "IS_VIRTUAL", conduitFacts.getIsVirtual());

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/DefaultInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/DefaultInventoryServiceTest.java
@@ -87,8 +87,6 @@ class DefaultInventoryServiceTest {
     DefaultInventoryService inventoryService = new DefaultInventoryService(api, props);
     inventoryService.sendHostUpdate(Collections.singletonList(createFullyPopulatedConduitFacts()));
     Map<String, Object> expectedFactMap = new HashMap<>();
-    expectedFactMap.put("CPU_SOCKETS", 4);
-    expectedFactMap.put("CPU_CORES", 8);
     expectedFactMap.put("MEMORY", 32757752L);
     expectedFactMap.put("ARCHITECTURE", "x86_64");
     expectedFactMap.put("IS_VIRTUAL", true);

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -107,8 +107,6 @@ class KafkaEnabledInventoryServiceTest {
 
     Map<String, Object> rhsmFacts = (Map<String, Object>) rhsm.getFacts();
     assertEquals(expectedFacts.getOrgId(), (String) rhsmFacts.get("orgId"));
-    assertEquals(expectedFacts.getCpuCores(), (Integer) rhsmFacts.get("CPU_CORES"));
-    assertEquals(expectedFacts.getCpuSockets(), (Integer) rhsmFacts.get("CPU_SOCKETS"));
 
     OffsetDateTime syncDate = (OffsetDateTime) rhsmFacts.get("SYNC_TIMESTAMP");
     assertNotNull(syncDate);


### PR DESCRIPTION
This hotfix is to address [ENT-4347](https://issues.redhat.com/browse/ENT-4347), as conduit was still emitting cores & sockets to HBI

Remove cores & sockets from InventoryService
Refactor test cases for KafkaEnabledInventoryServiceTest & DefaultInventoryServiceTest

Testing steps
1. Run Conduit with below Environment variables
```
DEV_MODE=true;RHSM_USE_STUB=true
```
2. Use the [API ](http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.conduit.jmx-RhsmConduitJmxBean-rhsmConduitJmxBean)to create an Event.
3. Verify that the message in Kafka UI host-ingress no longer contains cores & sockets in the facts data.