### PR TITLE
Update our modified clowd-env with new Kafka version

### DIFF
--- a/deploy/rhsm-eph-clowdenv.yaml
+++ b/deploy/rhsm-eph-clowdenv.yaml
@@ -64,7 +64,7 @@ objects:
         # disable tls/auth for now until core apps are ready
         enableLegacyStrimzi: true
         cluster:
-          version: "2.7.0"
+          version: "2.8.0"
           resources:
             limits:
               cpu: 500m
@@ -73,8 +73,8 @@ objects:
               cpu: 250m
               memory: 600Mi
         connect:
-          version: "2.7.0"
-          image: "quay.io/cloudservices/xjoin-kafka-connect-strimzi:182ab8b"
+          version: "2.8.0"
+          image: quay.io/cloudservices/xjoin-kafka-connect-strimzi:61cc1b8
       db:
         mode: local
         pvc: false


### PR DESCRIPTION
The Kafka version used by ephemeral-base changed so we need to update
our custom ClowdEnv accordingly.

To figure this out:
1. Export the base ClowdEnv with `bonfire process-env --namespace
   ephemeral-base`
2. Convert the exported JSON to YAML using an online converter or a CLI
   tool of your choice
3. Diff the ephemeral-base YAML against our custom ClowdEnv and make
   necessary changes