### PR TITLE
Update ClowdApp so api deployment honors DEV_MODE env var

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -392,6 +392,8 @@ objects:
               value: /pinhead/keystore.jks
             - name: RHSM_RBAC_USE_STUB
               value: ${RHSM_RBAC_USE_STUB}
+            - name: DEV_MODE
+              value: ${DEV_MODE}
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
The `rhsm-subscriptions-api` pod in openshift didn't list `DEV_MODE` in the Environment tab even though it was being set in the ClowdApp.  The `rhsm-subscriptions-api` deployment didn't list the env variable as a parameter.