### PR TITLE
Apply fixes to make testcontainers work in Jenkins

### DIFF
--- a/podman_run.sh
+++ b/podman_run.sh
@@ -1,1 +1,25 @@
-podman run --rm --user=root -e GRADLE_USER_HOME=/workspace/.gradle -w /workspace -v $(pwd):/workspace:Z registry.access.redhat.com/ubi8/openjdk-11 "$@"
+SOCKET=$(mktemp)
+export CONTAINER_HOST=unix://$SOCKET
+export DOCKER_HOST=$CONTAINER_HOST
+echo Running podman service at $CONTAINER_HOST
+podman system service -t 360 $CONTAINER_HOST&
+PODMAN_PID=$!
+echo Running command '`'$@'`' via podman
+# needs host network and selinux labeling disabled to support testcontainers
+podman run \
+  --net=host \
+  --security-opt label=disable \
+  --rm \
+  --user=root \
+  -e DOCKER_HOST=$CONTAINER_HOST \
+  -e GRADLE_USER_HOME=/workspace/.gradle \
+  -w /workspace \
+  -v $SOCKET:$SOCKET:Z \
+  -v $(pwd):/workspace:Z \
+  registry.access.redhat.com/ubi8/openjdk-11 \
+  "$@"
+RETURN_CODE=$?
+echo Stopping podman service at $CONTAINER_HOST
+kill $PODMAN_PID
+rm -f $SOCKET
+exit $RETURN_CODE

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -76,7 +76,11 @@ compileTestJava {
 
 test {
     useJUnitPlatform()
-    environment "DOCKER_HOST", "unix:///run/user/1000/podman/podman.sock"
+    if (System.getenv("DOCKER_HOST") == null) {
+        String UID = 'id -u'.execute().text.strip()
+        environment "DOCKER_HOST", "unix:///run/user/$UID/podman/podman.sock"
+    }
+    System.out.println "DOCKER_HOST: ${environment.DOCKER_HOST}"
     environment "TESTCONTAINERS_RYUK_DISABLED", "true"
 }
 


### PR DESCRIPTION
Needed to passthrough DOCKER_HOST env var, and updated the podman_run.sh script so that it starts a temporary socket/daemon, configures testcontainers to use it, and then cleans up afterwards.

Couple of interesting bits in the podman command:

1. Disable labeling to avoid selinux issues.
2. Use host networking so that testcontainers can talk to the containers it starts.