### PR TITLE
ent-4729: Setup Testcontainers for usage in tests

### DIFF
--- a/podman_run.sh
+++ b/podman_run.sh
@@ -1,1 +1,25 @@
-podman run --rm --user=root -e GRADLE_USER_HOME=/workspace/.gradle -w /workspace -v $(pwd):/workspace:Z registry.access.redhat.com/ubi8/openjdk-11 "$@"
+SOCKET=$(mktemp)
+export CONTAINER_HOST=unix://$SOCKET
+export DOCKER_HOST=$CONTAINER_HOST
+echo Running podman service at $CONTAINER_HOST
+podman system service -t 360 $CONTAINER_HOST&
+PODMAN_PID=$!
+echo Running command '`'$@'`' via podman
+# needs host network and selinux labeling disabled to support testcontainers
+podman run \
+  --net=host \
+  --security-opt label=disable \
+  --rm \
+  --user=root \
+  -e DOCKER_HOST=$CONTAINER_HOST \
+  -e GRADLE_USER_HOME=/workspace/.gradle \
+  -w /workspace \
+  -v $SOCKET:$SOCKET:Z \
+  -v $(pwd):/workspace:Z \
+  registry.access.redhat.com/ubi8/openjdk-11 \
+  "$@"
+RETURN_CODE=$?
+echo Stopping podman service at $CONTAINER_HOST
+kill $PODMAN_PID
+rm -f $SOCKET
+exit $RETURN_CODE

--- a/swatch-producer-aws/README.adoc
+++ b/swatch-producer-aws/README.adoc
@@ -111,3 +111,10 @@ curl --request POST \
 }'
 
 ----
+
+== Install Testcontainers podman dependencies
+[source,bash]
+----
+dnf install -y podman-docker
+
+----

--- a/swatch-producer-aws/README.adoc
+++ b/swatch-producer-aws/README.adoc
@@ -115,6 +115,6 @@ curl --request POST \
 == For running tests with Testcontainers you must first start podman service
 [source,bash]
 ----
-podman system service -t 360
+systemctl --user enable --now podman.socket
 
 ----

--- a/swatch-producer-aws/README.adoc
+++ b/swatch-producer-aws/README.adoc
@@ -112,9 +112,9 @@ curl --request POST \
 
 ----
 
-== Install Testcontainers podman dependencies
+== For running tests with Testcontainers you must first start podman service
 [source,bash]
 ----
-dnf install -y podman-docker
+podman system service -t 360
 
 ----

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -47,6 +47,12 @@ dependencies {
     implementation 'com.splunk.logging:splunk-library-javalogging:1.8.0'
     testImplementation 'io.quarkus:quarkus-junit5'
     compileOnly 'org.projectlombok:lombok:1.18.22'
+    testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
+    testImplementation "org.testcontainers:testcontainers:1.16.3"
+    testImplementation "org.testcontainers:junit-jupiter:1.16.3"
+    testImplementation "org.testcontainers:postgresql:1.16.3"
+    testImplementation "org.testcontainers:kafka:1.16.3"
+
 }
 
 group = 'com.redhat.swatch'
@@ -66,6 +72,12 @@ compileJava {
 
 compileTestJava {
     options.encoding = 'UTF-8'
+}
+
+test {
+    useJUnitPlatform()
+    environment "DOCKER_HOST", "unix:///run/user/1000/podman/podman.sock"
+    environment "TESTCONTAINERS_RYUK_DISABLED", "true"
 }
 
 openApiGenerate {

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -76,7 +76,11 @@ compileTestJava {
 
 test {
     useJUnitPlatform()
-    environment "DOCKER_HOST", "unix:///run/user/1000/podman/podman.sock"
+    if (System.getenv("DOCKER_HOST") == null) {
+        String UID = 'id -u'.execute().text.strip()
+        environment "DOCKER_HOST", "unix:///run/user/$UID/podman/podman.sock"
+    }
+    System.out.println "DOCKER_HOST: ${environment.DOCKER_HOST}"
     environment "TESTCONTAINERS_RYUK_DISABLED", "true"
 }
 

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/KafkaResource.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/KafkaResource.java
@@ -1,0 +1,28 @@
+package com.redhat.swatch;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.util.Collections;
+import java.util.Map;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class KafkaResource implements
+    QuarkusTestResourceLifecycleManager {
+
+  static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka"));
+
+
+  @Override
+  public Map<String, String> start() {
+    kafka.start();
+    return Collections.singletonMap(
+        "kafka.bootstrap.servers", kafka.getBootstrapServers()
+    );
+  }
+
+  @Override
+  public void stop() {
+    kafka.stop();
+  }
+}

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/PostgresResource.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/PostgresResource.java
@@ -1,0 +1,30 @@
+package com.redhat.swatch;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.util.Collections;
+import java.util.Map;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class PostgresResource implements
+    QuarkusTestResourceLifecycleManager {
+
+  static PostgreSQLContainer<?> db =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres"))
+          .withDatabaseName("rhsm-subscriptions")
+          .withUsername("rhsm-subscriptions")
+          .withPassword("rhsm-subscriptions");
+
+  @Override
+  public Map<String, String> start() {
+    db.start();
+    return Collections.singletonMap(
+        "quarkus.datasource.jdbc.url", db.getJdbcUrl()
+    );
+  }
+
+  @Override
+  public void stop() {
+    db.stop();
+  }
+}

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/TestContainerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/TestContainerTest.java
@@ -1,0 +1,18 @@
+package com.redhat.swatch;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+
+@QuarkusTest
+@QuarkusTestResource(PostgresResource.class)
+@QuarkusTestResource(KafkaResource.class)
+class TestContainerTest {
+
+  @Test
+  void testContainersStarting() {
+    Assert.assertTrue(true);
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4729
Introduce Testcontainers dependencies and rework podman_run.sh script to expose podman socket for running Podman in Podman on CI.