### PR TITLE
Switch to the nebula release plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id "jacoco"
     id "org.sonarqube" version "3.3"
     id "org.springframework.boot" version "2.6.4"
-    id "net.researchgate.release" version "2.8.1"
+    id "nebula.release" version "15.3.1"
     id "GitProperties"
     id 'com.adarshr.test-logger' version '3.0.0'
     // Only applied for the rhsm-subscriptions-kafka sub project; applied below.
@@ -167,19 +167,6 @@ springBoot {
                     'gitHash': "${project.git.hash ?: ''}",
             ]
         }
-    }
-}
-
-release {
-    // Use single quotes so the variables aren't interpreted in the build file itself!
-    tagTemplate = '${name}-${version}'
-    preTagCommitMessage = '[Subscriptions Release] - pre tag commit: '
-    tagCommitMessage = '[Subscriptions Release] - creating tag: '
-    newVersionCommitMessage = '[Subscriptions Release] - version bump: '
-    pushReleaseVersionBranch = 'main'
-    git {
-        requireBranch = /develop|hotfix.*|release/
-        pushToRemote = false
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 dependencies {
     implementation gradleApi()
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:5.3.1.201904271842-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.0.0.202111291000-r'
 }
 
 gradlePlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.0.88-SNAPSHOT
+nebula.release.features.replaceDevWithImmutableSnapshot=true


### PR DESCRIPTION
Note we can't use latest without updating gradle.

See https://github.com/nebula-plugins/nebula-release-plugin for additional config options.

I had to update our jgit dependency for this to work.

This would mean no more maintenance of the version in a file.

http://localhost:9000/info still works well.

Testing
-------
`git fetch` to make sure you pull down the v1.0.87 tag.

Run `./gradlew assemble`. Note the filename/versions of the built artifacts, e.g.

```
1.1.0-snapshot.202203011533.uncommitted+khowell.nebula.release.d3cb990
```

Which has the following components:

* semver compatible major, minor, patch version
* timestamp of build
* repo clean/dirty status
* branch name (normalized to replace certain characters
* git commit abbreviation

With this change, we can choose to not tag versions, and we'll still get many useful identifiers.