### PR TITLE
[R.C. hotfix] Remove remaining ingress secret references

### DIFF
--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -259,8 +259,6 @@ objects:
                   protocol: TCP
                   name: metrics-port
               volumeMounts:
-                - name: ingress
-                  mountPath: /ingress
                 - name: capacity-allowlist
                   mountPath: /capacity-allowlist
                 - name: logs
@@ -293,9 +291,6 @@ objects:
                   name: splunk
                   subPath: splunk.pem
           volumes:
-            - name: ingress
-              secret:
-                secretName: ingress
             - name: capacity-allowlist
               configMap:
                 name: capacity-allowlist


### PR DESCRIPTION
Fixes

```
MountVolume.SetUp failed for volume "ingress" : secret "ingress" not found
```