### PR TITLE
Use Spring's Resource abstraction to handle loading keystores

### DIFF
--- a/clients/rhsm-client/src/test/java/org/candlepin/subscriptions/conduit/rhsm/client/RhsmApiFactoryTest.java
+++ b/clients/rhsm-client/src/test/java/org/candlepin/subscriptions/conduit/rhsm/client/RhsmApiFactoryTest.java
@@ -31,7 +31,6 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.google.common.io.Resources;
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +39,9 @@ import javax.ws.rs.core.GenericType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.util.ResourceUtils;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 
 class RhsmApiFactoryTest {
   public static final char[] STORE_PASSWORD = "password".toCharArray();
@@ -48,6 +49,7 @@ class RhsmApiFactoryTest {
   private WireMockServer server;
   private RhsmApiProperties config;
   private RhsmApiFactory apiFactory;
+  private ResourceLoader rl = new DefaultResourceLoader();
 
   private MappingBuilder stubHelloWorld() {
     return get(urlPathEqualTo("/hello"))
@@ -64,6 +66,10 @@ class RhsmApiFactoryTest {
   @BeforeEach
   private void setUp() {
     config = new RhsmApiProperties();
+  }
+
+  private Resource getKeystoreResource(String f) {
+    return rl.getResource("file:" + f);
   }
 
   @Test
@@ -85,10 +91,10 @@ class RhsmApiFactoryTest {
     server.start();
     server.stubFor(stubHelloWorld());
 
-    config.setKeystore(new File(server.getOptions().httpsSettings().keyStorePath()));
+    config.setKeystore(getKeystoreResource(server.getOptions().httpsSettings().keyStorePath()));
     config.setKeystorePassword(STORE_PASSWORD);
 
-    config.setTruststore(ResourceUtils.getFile("classpath:test-ca.jks"));
+    config.setTruststore(rl.getResource("classpath:test-ca.jks"));
     config.setTruststorePassword(STORE_PASSWORD);
 
     RhsmApiFactory factory = new RhsmApiFactory(config);
@@ -104,7 +110,7 @@ class RhsmApiFactoryTest {
     server.start();
     server.stubFor(stubHelloWorld());
 
-    config.setTruststore(ResourceUtils.getFile("classpath:test-ca.jks"));
+    config.setTruststore(rl.getResource("classpath:test-ca.jks"));
     config.setTruststorePassword(STORE_PASSWORD);
 
     RhsmApiFactory factory = new RhsmApiFactory(config);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/actuator/CertInfoInquisitor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/actuator/CertInfoInquisitor.java
@@ -35,11 +35,17 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.xml.bind.DatatypeConverter;
+import org.springframework.core.io.Resource;
 
 /** Class to return basic information about an X509 certificate. */
 public class CertInfoInquisitor {
   private CertInfoInquisitor() {
     // Static methods only
+  }
+
+  public static Map<String, Map<String, String>> loadStoreInfo(Resource resource, char[] password)
+      throws GeneralSecurityException, IOException {
+    return CertInfoInquisitor.loadStoreInfo(resource.getInputStream(), password);
   }
 
   public static Map<String, Map<String, String>> loadStoreInfo(InputStream stream, char[] password)

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/actuator/CertInfoEndpoint.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/actuator/CertInfoEndpoint.java
@@ -51,8 +51,7 @@ public class CertInfoEndpoint {
     HttpClientProperties config = rhsmApiProperties;
 
     try {
-      return CertInfoInquisitor.loadStoreInfo(
-          config.getKeystoreStream(), config.getKeystorePassword());
+      return CertInfoInquisitor.loadStoreInfo(config.getKeystore(), config.getKeystorePassword());
     } catch (IOException | GeneralSecurityException e) {
       log.error(CERT_LOAD_ERR, e);
     }
@@ -65,7 +64,7 @@ public class CertInfoEndpoint {
 
     try {
       return CertInfoInquisitor.loadStoreInfo(
-          config.getTruststoreStream(), config.getTruststorePassword());
+          config.getTruststore(), config.getTruststorePassword());
     } catch (IOException | GeneralSecurityException e) {
       log.error(CERT_LOAD_ERR, e);
     }

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/actuator/CertInfoEndpointTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/actuator/CertInfoEndpointTest.java
@@ -23,13 +23,13 @@ package org.candlepin.subscriptions.conduit.actuator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.FileNotFoundException;
 import java.util.Map;
 import org.candlepin.subscriptions.conduit.rhsm.client.RhsmApiProperties;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.util.ResourceUtils;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ResourceLoader;
 
 class CertInfoEndpointTest {
   public static final char[] STORE_PASSWORD = "password".toCharArray();
@@ -37,11 +37,12 @@ class CertInfoEndpointTest {
   private RhsmApiProperties config;
 
   @BeforeEach
-  private void setUp() throws FileNotFoundException {
+  private void setUp() {
+    ResourceLoader rl = new DefaultResourceLoader();
     config = new RhsmApiProperties();
-    config.setKeystore(ResourceUtils.getFile("classpath:client.jks"));
+    config.setKeystore(rl.getResource("classpath:client.jks"));
     config.setKeystorePassword(STORE_PASSWORD);
-    config.setTruststore(ResourceUtils.getFile("classpath:test-ca.jks"));
+    config.setTruststore(rl.getResource("classpath:test-ca.jks"));
     config.setTruststorePassword(STORE_PASSWORD);
   }
 


### PR DESCRIPTION
Previously we had the keystore properties bound to a File field.  I was
seeing failures when the rhsm-conduit.rhsm.keystore property was set to
empty string which could happen during unit tests that run without a
full configuration.

Using the Spring Resource abstraction avoids this issue since Spring
isn't trying to immediately create a File object.  Instead it creates a
Resource object and we later check to make sure the Resource is valid
and readable.  As a bonus, Spring will handle opening the resource as a
stream for us so we can remove some boiler plate methods in
HttpClientProperties that were doing that.