### PR TITLE
Add github workflows to manage stage branch alias

### DIFF
--- a/.github/workflows/update-env-alias-on-push.yml
+++ b/.github/workflows/update-env-alias-on-push.yml
@@ -1,0 +1,19 @@
+name: Update environment alias branches on push
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  update_stage_alias:
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/stage',
+              sha: context.payload.after
+            })


### PR DESCRIPTION
Testing
-------

Apply to a fork of this repo's `main` branch.

Create a branch named `stage`. (This action updates the branch, but won't create it.

Try pushing to the `main` branch of your fork (be careful not to push to upstream `main`).

Also try opening a PR against your fork's `main` branch, and merge it. Observe that for this action also, the action is triggered.
