### PR TITLE
Fix permissions when podman_run.sh falls back to docker

### DIFF
--- a/podman_run.sh
+++ b/podman_run.sh
@@ -1,6 +1,7 @@
 if command -v podman; then
   export SOCKET=$(mktemp)
   export CONTAINER_HOST=unix://$SOCKET
+  export PODMAN_USERNS=keep-id
   echo Running podman service at $CONTAINER_HOST
   podman system service -t 360 $CONTAINER_HOST&
   export PODMAN_PID=$!
@@ -18,7 +19,7 @@ $podman_cmd run \
   --net=host \
   --security-opt label=disable \
   --rm \
-  --user=root \
+  --user=$UID \
   -e DOCKER_HOST=$CONTAINER_HOST \
   -e GRADLE_USER_HOME=/workspace/.gradle \
   -w /workspace \


### PR DESCRIPTION
We got into a state where the CI user can't cleanup the workspace because file permissions are off. This is addressed by having the effective UID of the container process be the same as the calling user. I found a consistent way to do this for both docker and podman is by using --user=$UID along with setting the USERNS setting for podman to `keep-id`, which can conveniently be done with an env var.