### PR TITLE
ENT-4765: Include unlimited usage capacities when UOM param is sent

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewSpecification.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewSpecification.java
@@ -65,12 +65,14 @@ public class SubscriptionCapacityViewSpecification
         && criteria.getOperation().equals(SearchOperation.IS_NOT_NULL)) {
       return builder.or(
           builder.isNotNull(expression.get(SubscriptionCapacityView_.VIRTUAL_SOCKETS)),
-          builder.isNotNull(expression.get(SubscriptionCapacityView_.PHYSICAL_SOCKETS)));
+          builder.isNotNull(expression.get(SubscriptionCapacityView_.PHYSICAL_SOCKETS)),
+          builder.isTrue(expression.get(SubscriptionCapacityView_.HAS_UNLIMITED_USAGE)));
     } else if (SubscriptionCapacityView_.PHYSICAL_CORES.equals(criteria.getKey())
         && criteria.getOperation().equals(SearchOperation.IS_NOT_NULL)) {
       return builder.or(
           builder.isNotNull(expression.get(SubscriptionCapacityView_.VIRTUAL_CORES)),
-          builder.isNotNull(expression.get(SubscriptionCapacityView_.PHYSICAL_CORES)));
+          builder.isNotNull(expression.get(SubscriptionCapacityView_.PHYSICAL_CORES)),
+          builder.isTrue(expression.get(SubscriptionCapacityView_.HAS_UNLIMITED_USAGE)));
     } else if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_EQUAL)) {
       return builder.greaterThanOrEqualTo(
           expression.get(criteria.getKey()), criteria.getValue().toString());


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4765

Test Steps:
- Add a subscription with unlimited usage to an account
- Sync capacity
- Use http://localhost:8000/api-docs/index.html#/subscriptions/getSkuCapacityReport endpoint with UOM param set to either cores or sockets
- The subscriptions with unlimited usage should be returned