### PR TITLE
Override bootJar mainClass in rhsm-conduit

### DIFF
--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -63,3 +63,7 @@ dependencies {
     runtime "org.jolokia:jolokia-core"
     runtime "org.jboss.resteasy:resteasy-jackson2-provider"
 }
+
+bootJar {
+    mainClass = "org.candlepin.subscriptions.SystemConduitApplication"
+}


### PR DESCRIPTION
Current R.C. is bad, because of an oversight in #783

Compare

```
podman run --rm quay.io/cloudservices/swatch-system-conduit:0c7aaf4
```

where you'll see

```
Exception in thread "main" java.lang.ClassNotFoundException: org.candlepin.subscriptions.BootApplication
```

to an image built by this PR:

```
podman build . -f swatch-system-conduit/Dockerfile -t bootjar_fix && podman run --rm bootjar_fix
```

where you won't.