### PR TITLE
[HOTFIX] conduit: Fix NPE when OS is not RHEL

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -169,7 +169,7 @@ public abstract class InventoryService {
 
   private SystemProfileOperatingSystem operatingSystem(ConduitFacts facts) {
     var operatingSystem = operatingSystemName(facts.getOsName());
-    if (facts.getOsVersion() != null) {
+    if (operatingSystem != null) { // we set operatingSystem null with non-RHEL
       setOperatingSystemVersion(operatingSystem, facts.getOsVersion());
     }
     return operatingSystem;

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/DefaultInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/DefaultInventoryServiceTest.java
@@ -189,6 +189,24 @@ class DefaultInventoryServiceTest {
     assertEquals(2, resultList.size());
   }
 
+  @Test
+  void noExceptionsWhenOperatingSystemIsNonRhel() throws ApiException {
+    InventoryServiceProperties props = new InventoryServiceProperties();
+    props.setApiHostUpdateBatchSize(1);
+
+    DefaultInventoryService inventoryService = new DefaultInventoryService(api, props);
+    ConduitFacts facts = createFullyPopulatedConduitFacts();
+    facts.setOsName("That other OS");
+    facts.setOsVersion("42.42");
+    inventoryService.sendHostUpdate(Collections.singletonList(facts));
+
+    ArgumentCaptor<List<CreateHostIn>> argument = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(api).apiHostAddHostList(argument.capture());
+
+    List<CreateHostIn> resultList = argument.getValue();
+    assertEquals(1, resultList.size());
+  }
+
   /**
    * Compare two CreateHostIn objects excepting the syncTimestamp fact since times will be slightly
    * different between an expected CreateHostIn that we create for a test and the one actually


### PR DESCRIPTION
Specifically, this occurs when osVersion is populated and osName is populated, but OS name does not match (case-insensitive) "red hat enterprise linux"

See #810