### PR TITLE
ENT-4828 Use file: uri for rhsm keystores

### DIFF
--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -7,11 +7,11 @@ rhsm-conduit:
   rhsm:
     use-stub: ${RHSM_USE_STUB:false}
     url: ${RHSM_URL:http://localhost:9090}
-    keystore: ${RHSM_KEYSTORE:}
+    keystore: file:${RHSM_KEYSTORE:}
     keystore-password: ${RHSM_KEYSTORE_PASSWORD:changeit}
     request-batch-size: ${RHSM_BATCH_SIZE:1000}
     max-connections: ${RHSM_MAX_CONNECTIONS:100}
-    truststore: ${RHSM_TRUSTSTORE:}
+    truststore: file:${RHSM_TRUSTSTORE:}
     truststore-password: ${RHSM_TRUSTSTORE_PASSWORD:changeit}
   inventory-service:
     use-stub: ${INVENTORY_USE_STUB:true}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4828

Without the file: URI, it gets interpreted as a path relative to the
servlet context.