### PR TITLE
ENT-4698 Add admin API endpoint to resend specific tally snapshots

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -41,7 +41,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/VersionInfo"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
   /opt-in:
     description: "Endpoint for opting into subscription watch."
     get:
@@ -74,13 +74,13 @@ paths:
                   account_number: 12345
                   org_id: 1111
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
     put:
       summary: "Create/Update an account's opt-in configuration. Account and Org ID are defined by the
                 identity header. If no parameters are specified, all everything will be enabled."
@@ -131,13 +131,13 @@ paths:
                   account_number: 12345
                   org_id: 1111
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
     delete:
       summary: "Delete an opt-in config for the associated account/org. The account number and org ID are
                 pulled from the identity header."
@@ -146,14 +146,13 @@ paths:
         '204':
           description: "Successfully deleted the opt-in configuration for the accociated account/org"
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
-
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
   /tally/products/{product_id}/{metric_id}:
     description: "Operations on a data set of a given tally report."
     parameters:
@@ -234,16 +233,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/TallyReportData"
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - tally
-
   /tally/products/{product_id}:
     description: "Operations for a tally report of a specific account and product."
     parameters:
@@ -365,13 +363,13 @@ paths:
                   service_level: Premium
                   usage: Production
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - tally
   /capacity/products/{product_id}:
@@ -475,13 +473,13 @@ paths:
                   granularity: Daily
                   service_level: Premium
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - capacity
   /hosts/products/{product_id}:
@@ -594,13 +592,13 @@ paths:
                   service_level: Premium
                   usage: Production
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - hosts
   /hosts/{hypervisor_uuid}/guests:
@@ -652,13 +650,13 @@ paths:
                 meta:
                   count: 10
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - hosts
   /instances/products/{product_id}:
@@ -868,41 +866,19 @@ paths:
                 meta:
                   count: 3
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
-          $ref: '#/components/responses/Forbidden'
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
         '404':
-          $ref: '#/components/responses/ResourceNotFound'
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - subscriptions
   /openapi.json:
-    get:
-      description: "Get the OpenAPI spec in JSON format."
-      operationId: getOpenApiJson
-      tags:
-        - root
-      responses:
-        '200':
-          description: "The request to get the OpenAPI JSON was successful."
-          content:
-            application/json:
-              schema:
-                type: string
+    $ref: "../spec/openapi-paths.yaml#/openapi-json"
   /openapi.yaml:
-    get:
-      description: "Get the OpenAPI spec in YAML format."
-      operationId: getOpenApiYaml
-      tags:
-        - root
-      responses:
-        '200':
-          description: "The request to get the OpenAPI YAML was successful."
-          content:
-            application/x-yaml:
-              schema:
-                type: string
+    $ref: "../spec/openapi-paths.yaml#/openapi-yaml"
 
 components:
   securitySchemes:
@@ -929,37 +905,7 @@ components:
         ```
         Encoded (via `base64 -w0`):
         `eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=`
-  responses:
-    InternalServerError:
-      description: "An internal server error has occurred and is not recoverable."
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: "#/components/schemas/Errors"
-    BadRequest:
-      description: "The server could could not process the current request."
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: "#/components/schemas/Errors"
-    Forbidden:
-      description: "The request was valid, but the request was refused by the server."
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: "#/components/schemas/Errors"
-    ResourceNotFound:
-      description: "The requested resource was not found."
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: "#/components/schemas/Errors"
-    ServiceUnavailable:
-      description: "The server is currently unavailable."
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: "#/components/schemas/Errors"
+
   schemas:
     # Schemas ending in "Type" are intentionally named to prevent naming conflicts with db model classes
     GranularityType:
@@ -1031,6 +977,12 @@ components:
               type: string
             group:
               type: string
+    MetaCount:
+      required:
+        - count
+      properties:
+        count:
+          type: integer
     OptInConfig:
       required:
         - meta
@@ -1436,12 +1388,7 @@ components:
         links:
           $ref: "#/components/schemas/PageLinks"
         meta:
-          type: object
-          properties:
-            count:
-              type: integer
-          required:
-            - count
+          $ref: "#/components/schemas/MetaCount"
     Host:
       required:
         - display_name
@@ -1642,28 +1589,6 @@ components:
     CandlepinProvidedProduct:
       properties:
         productId:
-          type: string
-    Errors:
-      required:
-        - errors
-      properties:
-        errors:
-          type: array
-          items:
-            $ref: "#/components/schemas/Error"
-    Error:
-      required:
-        - status
-        - code
-        - title
-      properties:
-        status:
-          type: string
-        code:
-          type: string
-        title:
-          type: string
-        detail:
           type: string
 
     SubscriptionType:

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id "nebula.release"
     id 'com.adarshr.test-logger'
     id 'jacoco'
+    id "org.openapi.generator"
 }
 
 group = "org.candlepin"
@@ -108,6 +109,68 @@ compileJava.dependsOn(processResources)
 project.tasks["sonarqube"].dependsOn "test"
 project.tasks["sonarqube"].dependsOn "jacocoTestReport"
 
+/* TODO - The directives below to generate the API classes are duplicates of the
+ * the directives we use for the api module.  We need to DRY this up but that is
+ * going to require a little Gradle-fu that I don't currently possess.
+ */
+ext {
+    api_spec_path = "${projectDir}/src/main/spec/internal-tally-api.yaml"
+}
+
+openApiGenerate {
+    generatorName = "jaxrs-spec"
+    inputSpec = api_spec_path
+    outputDir = "$buildDir/generated"
+    apiPackage = "org.candlepin.subscriptions.tally.admin.api"
+    modelPackage = "org.candlepin.subscriptions.tally.admin.api.model"
+    invokerPackage = "org.candlepin.subscriptions.tally.admin"
+    groupId = "org.candlepin"
+    configOptions = [
+            interfaceOnly: "true",
+            generatePom: "false",
+            dateLibrary: "java8",
+    ]
+}
+
+openApiValidate {
+    inputSpec = api_spec_path
+}
+
+task generateApiDocs(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+    generatorName = "html"
+    inputSpec = api_spec_path
+    outputDir = "$buildDir/docs"
+    generateApiDocumentation = true
+    generateModelDocumentation = true
+    generateModelTests = false
+    generateApiTests = false
+    withXml = false
+}
+
+task generateOpenApiJson(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+    generatorName = "openapi"
+    inputSpec = api_spec_path
+    outputDir = "$buildDir/generated/openapijson"
+    generateApiDocumentation = true
+    generateModelDocumentation = true
+    generateModelTests = false
+    generateApiTests = false
+    withXml = false
+}
+
+processResources {
+    from "$buildDir/generated/openapijson/openapi.json"
+    from api_spec_path
+    rename { String fileName ->
+        api_spec_path.endsWith(fileName) ? 'openapi.yaml' : fileName  // rename yaml to openapi.yaml
+    }
+}
+
+sourceSets.main.java.srcDirs += ["${buildDir}/generated/src/gen/java"]
+compileJava.dependsOn tasks.openApiGenerate
+processResources.dependsOn tasks.generateOpenApiJson
+processResources.dependsOn tasks.openApiGenerate
+
 project(":api") {
     apply plugin: "swatch.java-conventions"
     apply plugin: "swatch.spring-boot-dependencies-conventions"
@@ -174,7 +237,7 @@ project(":api") {
         implementation libraries["jackson-databind-nullable"]
     }
 
-    sourceSets.main.java.srcDirs = ["${buildDir}/generated/src/gen/java"]
+    sourceSets.main.java.srcDirs += ["${buildDir}/generated/src/gen/java"]
     compileJava.dependsOn tasks.openApiGenerate
     processResources.dependsOn tasks.generateOpenApiJson
     processResources.dependsOn tasks.openApiGenerate

--- a/spec/error-responses.yaml
+++ b/spec/error-responses.yaml
@@ -1,0 +1,55 @@
+$id: error-responses.yaml
+$schema: http://json-schema.org/draft-04/schema#
+$defs:
+  InternalServerError:
+    description: "An internal server error has occurred and is not recoverable."
+    content:
+      application/vnd.api+json:
+        schema:
+          $ref: "#/$defs/Errors"
+  BadRequest:
+    description: "The server could could not process the current request."
+    content:
+      application/vnd.api+json:
+        schema:
+          $ref: "#/$defs/Errors"
+  Forbidden:
+    description: "The request was valid, but the request was refused by the server."
+    content:
+      application/vnd.api+json:
+        schema:
+          $ref: "#/$defs/Errors"
+  ResourceNotFound:
+    description: "The requested resource was not found."
+    content:
+      application/vnd.api+json:
+        schema:
+          $ref: "#/$defs/Errors"
+  ServiceUnavailable:
+    description: "The server is currently unavailable."
+    content:
+      application/vnd.api+json:
+        schema:
+          $ref: "#/$defs/Errors"
+  Errors:
+    required:
+      - errors
+    properties:
+      errors:
+        type: array
+        items:
+          $ref: "#/$defs/Error"
+  Error:
+    required:
+      - status
+      - code
+      - title
+    properties:
+      status:
+        type: string
+      code:
+        type: string
+      title:
+        type: string
+      detail:
+        type: string

--- a/spec/openapi-paths.yaml
+++ b/spec/openapi-paths.yaml
@@ -1,0 +1,26 @@
+openapi-json:
+  get:
+    description: "Get the OpenAPI spec in JSON format."
+    operationId: getOpenApiJson
+    tags:
+      - root
+    responses:
+      '200':
+        description: "The request to get the OpenAPI JSON was successful."
+        content:
+          application/json:
+            schema:
+              type: string
+openapi-yaml:
+  get:
+    description: "Get the OpenAPI spec in YAML format."
+    operationId: getOpenApiYaml
+    tags:
+      - root
+    responses:
+      '200':
+        description: "The request to get the OpenAPI YAML was successful."
+        content:
+          application/x-yaml:
+            schema:
+              type: string

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -46,7 +46,7 @@ import org.candlepin.subscriptions.utilization.api.model.HostReport;
 import org.candlepin.subscriptions.utilization.api.model.HostReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 import org.candlepin.subscriptions.utilization.api.model.HypervisorGuestReport;
-import org.candlepin.subscriptions.utilization.api.model.HypervisorGuestReportMeta;
+import org.candlepin.subscriptions.utilization.api.model.MetaCount;
 import org.candlepin.subscriptions.utilization.api.model.PageLinks;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
@@ -262,7 +262,7 @@ public class HostsResource implements HostsApi {
 
     return new HypervisorGuestReport()
         .links(links)
-        .meta(new HypervisorGuestReportMeta().count((int) guests.getTotalElements()))
+        .meta(new MetaCount().count((int) guests.getTotalElements()))
         .data(guests.getContent().stream().map(Host::asApiHost).collect(Collectors.toList()));
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/security/InternalApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/InternalApiSecurityConfiguration.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.candlepin.subscriptions.rbac.RbacProperties;
+import org.candlepin.subscriptions.rbac.RbacService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.csrf.CsrfFilter;
+
+/**
+ * Security configuration for Internal APIs.
+ *
+ * <p>This security configuration will be loaded before the normal configuration.
+ */
+@Order(2)
+@Configuration
+public class InternalApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+  @Autowired private SecurityProperties secProps;
+  @Autowired private ConfigurableEnvironment env;
+  @Autowired private ObjectMapper mapper;
+  @Autowired private RbacProperties rbacProperties;
+  @Autowired private RbacService rbacService;
+
+  @Override
+  protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+    auth.authenticationProvider(
+        internalIdentityHeaderAuthenticationProvider(
+            internalIdentityHeaderAuthenticationDetailsService(
+                secProps, rbacProperties, rbacService)));
+  }
+
+  @Bean
+  public AuthenticationProvider internalIdentityHeaderAuthenticationProvider(
+      @Qualifier("internalIdentityHeaderAuthenticationDetailsService")
+          IdentityHeaderAuthenticationDetailsService detailsService) {
+    return new IdentityHeaderAuthenticationProvider(detailsService);
+  }
+
+  @Bean
+  public IdentityHeaderAuthenticationDetailsService
+      internalIdentityHeaderAuthenticationDetailsService(
+          SecurityProperties secProps, RbacProperties rbacProperties, RbacService rbacService) {
+    return new IdentityHeaderAuthenticationDetailsService(
+        secProps, rbacProperties, internalIdentityHeaderAuthoritiesMapper(), rbacService);
+  }
+
+  @Bean
+  public IdentityHeaderAuthoritiesMapper internalIdentityHeaderAuthoritiesMapper() {
+    return new IdentityHeaderAuthoritiesMapper();
+  }
+
+  // NOTE: intentionally *not* annotated with @Bean; @Bean causes an extra use as an application
+  // filter
+  public AntiCsrfFilter antiCsrfFilter(SecurityProperties secProps, ConfigurableEnvironment env) {
+    return new AntiCsrfFilter(secProps, env);
+  }
+
+  // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application
+  // filter
+  public IdentityHeaderAuthenticationFilter internalIdentityHeaderAuthenticationFilter()
+      throws Exception {
+    IdentityHeaderAuthenticationFilter filter = new IdentityHeaderAuthenticationFilter(mapper);
+    filter.setCheckForPrincipalChanges(true);
+    filter.setAuthenticationManager(authenticationManager());
+    filter.setAuthenticationFailureHandler(new IdentityHeaderAuthenticationFailureHandler(mapper));
+    filter.setContinueFilterChainOnUnsuccessfulAuthentication(false);
+    return filter;
+  }
+
+  // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application
+  // filter
+  public MdcFilter internalMdcFilter() {
+    return new MdcFilter();
+  }
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    // See
+    // https://docs.spring.io/spring-security/site/docs/current/reference/html5/#ns-custom-filters
+    // for list of filters and their order
+    http.requestMatchers(matchers -> matchers.antMatchers("/**/internal/**"))
+        .csrf()
+        .disable()
+        .addFilter(internalIdentityHeaderAuthenticationFilter())
+        .addFilterAfter(internalMdcFilter(), IdentityHeaderAuthenticationFilter.class)
+        .addFilterAt(antiCsrfFilter(secProps, env), CsrfFilter.class)
+        .authorizeRequests()
+        .anyRequest()
+        .authenticated();
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyController.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.validator.Uuid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@Validated
+public class MarketplaceResendTallyController {
+  private static final Logger log = LoggerFactory.getLogger(MarketplaceResendTallyController.class);
+  private final SnapshotSummaryProducer summaryProducer;
+  private final TallySnapshotRepository snapshotRepository;
+
+  public MarketplaceResendTallyController(
+      SnapshotSummaryProducer summaryProducer, TallySnapshotRepository snapshotRepository) {
+    this.summaryProducer = summaryProducer;
+    this.snapshotRepository = snapshotRepository;
+  }
+
+  /* Ideally we would have the Bean Validator annotation @Valid at the REST endpoint that calls this
+   * method.  It is possible to enable bean validation annotations in the OpenApi generator but
+   * it appears (documentation is non-existent) that the only annotations that you can apply are
+   * very basic ones like @Pattern or @Size (especially for the jaxrs-spec generator that we are
+   * currently using -- the Spring specific generators seem slightly more flexible).  In theory,
+   * the validations could be applied with a META-INF/validations.xml file (see
+   * https://guntherrotsch.github.io/blog_2020/openapi-bean-validation.html) but that seems even
+   * less desirable to me than applying the validation one layer down in the application.  I
+   * prefer having the annotations as they are visible in the code as opposed to tucked away in
+   * an XML file.
+   */
+  public int resendTallySnapshots(List<@Uuid String> uuids) {
+    var snapshotIds = uuids.stream().map(UUID::fromString).collect(Collectors.toList());
+    var snapshots = snapshotRepository.findAllById(snapshotIds);
+    log.info("Resending tally snapshots for {} messages", snapshots.size());
+    Map<String, List<TallySnapshot>> totalSnapshots =
+        snapshots.stream().collect(Collectors.groupingBy(TallySnapshot::getAccountNumber));
+    summaryProducer.produceTallySummaryMessages(totalSnapshots);
+    return snapshots.size();
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalResource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
+import org.candlepin.subscriptions.tally.admin.api.InternalApi;
+import org.candlepin.subscriptions.tally.admin.api.model.TallyResend;
+import org.candlepin.subscriptions.tally.admin.api.model.TallyResendData;
+import org.candlepin.subscriptions.tally.admin.api.model.UuidList;
+import org.springframework.stereotype.Component;
+
+/** This resource is for exposing administrator REST endpoints for Tally. */
+@Component
+public class InternalResource implements InternalApi {
+
+  private final MarketplaceResendTallyController resendTallyController;
+
+  public InternalResource(MarketplaceResendTallyController resendTallyController) {
+    this.resendTallyController = resendTallyController;
+  }
+
+  @Override
+  public TallyResend resendTally(UuidList uuidList) {
+    var tallies = resendTallyController.resendTallySnapshots(uuidList.getUuids());
+    return new TallyResend().data(new TallyResendData().talliesResent(tallies));
+  }
+}

--- a/src/main/spec/internal-tally-api.yaml
+++ b/src/main/spec/internal-tally-api.yaml
@@ -1,0 +1,58 @@
+openapi: "3.0.2"
+info:
+  title: "rhsm-subscriptions internal tally API"
+  version: 1.0.0
+
+paths:
+  /internal/tally/resend:
+    description: 'Operations to resend specific tally snapshots to marketplaces'
+    post:
+      operationId: resendTally
+      summary: "Resend specific tally snapshots"
+      requestBody:
+        $ref: '#/components/requestBodies/UuidListBody'
+      responses:
+        '200':
+          description: "The request for resending the tally snapshots was accepted"
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/TallyResend"
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags:
+        - internal
+  /openapi.json:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
+  /openapi.yaml:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
+components:
+  requestBodies:
+    UuidListBody:
+      description: "A list of UUIDs"
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UuidList"
+  schemas:
+    UuidList:
+      type: object
+      properties:
+        uuids:
+          type: array
+          items:
+            type: string
+    TallyResend:
+      properties:
+        data:
+          type: object
+          required:
+            - tallies_resent
+          properties:
+            tallies_resent:
+              type: integer

--- a/src/test/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyControllerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MarketplaceResendTallyControllerTest {
+
+  @Mock private SnapshotSummaryProducer summaryProducer;
+  @Mock private TallySnapshotRepository repository;
+
+  @Test
+  void resendTallySnapshots() {
+    var ids =
+        List.of(
+            "6bf2f254-0000-0000-0000-54e1ada886c3",
+            "deadbeef-0000-0000-0000-defaceace111",
+            "cafeface-0000-0000-0000-000000000000");
+    var t1 = new TallySnapshot();
+    t1.setAccountNumber("1");
+    var t2 = new TallySnapshot();
+    t2.setAccountNumber("1");
+    var t3 = new TallySnapshot();
+    t3.setAccountNumber("1");
+    var tallyList = List.of(t1, t2, t3);
+
+    when(repository.findAllById(Mockito.anyIterable())).thenReturn(tallyList);
+
+    var controller = new MarketplaceResendTallyController(summaryProducer, repository);
+    int count = controller.resendTallySnapshots(ids);
+    assertEquals(3, count);
+
+    var summaryMap = Map.of("1", tallyList);
+    verify(summaryProducer, times(1)).produceTallySummaryMessages(summaryMap);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/validator/UuidValidatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/validator/UuidValidatorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.validation.annotation.Validated;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class UuidValidatorTest {
+
+  @Autowired ValidatedThing validatedThing;
+
+  @TestConfiguration
+  static class UuidValidatorTestConfig {
+    @Bean
+    ValidatedThing validatedThing() {
+      return new ValidatedThing();
+    }
+  }
+
+  @Validated
+  static class ValidatedThing {
+
+    public boolean mySingleMethod(@Uuid String uuid) {
+      return true;
+    }
+
+    public boolean myCollectionMethod(List<@Uuid String> uuids) {
+      return true;
+    }
+  }
+
+  @Test
+  void testValidUuid() {
+    assertTrue(validatedThing.mySingleMethod("b682126b-88d8-40b7-ada6-212f0e65e30a"));
+    assertTrue(validatedThing.mySingleMethod("B682126B-88D8-40B7-ADA6-212F0E65E30A"));
+    assertTrue(
+        validatedThing.myCollectionMethod(
+            List.of(
+                "7ac9da96-d11d-44ca-b7dc-7480eab5e750",
+                "6c0c79d2-d1d4-4f2a-85e0-7631b5a58f7e",
+                "f909b5a8-a8de-4721-950d-5f48be84ee21",
+                "5922f04f-8398-49b7-a9dd-c2d04a9b7d16")));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "hellowor-ldhe-llow-worl-dhelloworldh",
+        "hellow&!-ld%%-llow-worl-dhellow*rldh",
+        "6c0c79d2-d1d4-4f2a-85e0-7631b5-a58f7e", // Valid but not in the 8-4-4-4-12 format
+        "190464649652423269416550308090595239059", // This is a UUID in decimal format
+        "b682126b88d840b7ada6212f0e65e30a",
+        "b682126b88d840b7ada6212f",
+        "192.168.2.8.4",
+        "redhat.com"
+      })
+  void testInvalidUuid(String s) {
+    var ex =
+        assertThrows(ConstraintViolationException.class, () -> validatedThing.mySingleMethod(s));
+    Set<ConstraintViolation<?>> constraintViolations = ex.getConstraintViolations();
+    assertEquals(1, constraintViolations.size());
+    var violation = constraintViolations.stream().findFirst().get();
+    String expected = String.format("%s is not a valid UUID", s);
+    assertEquals(expected, violation.getMessage());
+  }
+
+  @Test
+  void testEmptyStringAndNull() {
+    String expected = "Must be a valid UUID";
+    var ex =
+        assertThrows(ConstraintViolationException.class, () -> validatedThing.mySingleMethod(""));
+    Set<ConstraintViolation<?>> constraintViolations = ex.getConstraintViolations();
+    assertEquals(1, constraintViolations.size());
+    var violation = constraintViolations.stream().findFirst().get();
+    assertEquals(expected, violation.getMessage());
+
+    ex =
+        assertThrows(ConstraintViolationException.class, () -> validatedThing.mySingleMethod(null));
+    constraintViolations = ex.getConstraintViolations();
+    assertEquals(1, constraintViolations.size());
+    violation = constraintViolations.stream().findFirst().get();
+    assertEquals(expected, violation.getMessage());
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/validator/IpAddress.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/validator/IpAddress.java
@@ -20,17 +20,17 @@
  */
 package org.candlepin.subscriptions.validator;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import org.candlepin.subscriptions.validator.IpAddress.List;
 
 /**
  * Marks a field as needing V4/V6 IP validation. The annotation can be used on a String field or on
@@ -43,9 +43,8 @@ import org.candlepin.subscriptions.validator.IpAddress.List;
  * private List&lt;IpAddress String&gt; ipAddresses
  * </pre>
  */
-@Target({FIELD, TYPE_USE})
+@Target({FIELD, PARAMETER, ANNOTATION_TYPE, TYPE_USE})
 @Retention(RUNTIME)
-@Repeatable(List.class)
 @Documented
 @Constraint(validatedBy = {IpAddressValidator.class})
 public @interface IpAddress {
@@ -54,12 +53,4 @@ public @interface IpAddress {
   Class<?>[] groups() default {};
 
   Class<? extends Payload>[] payload() default {};
-
-  /** Inner annotation to support annotating type arguments of parameterized types. */
-  @Target({FIELD, TYPE_USE})
-  @Retention(RUNTIME)
-  @Documented
-  @interface List {
-    IpAddress[] value();
-  }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/validator/Iso8601.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/validator/Iso8601.java
@@ -20,21 +20,21 @@
  */
 package org.candlepin.subscriptions.validator;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import org.candlepin.subscriptions.validator.Iso8601.List;
 
 /** JSR-380 validation for ensuring that a value is in a particular ISO 8601 format. */
 @Target({FIELD, PARAMETER, ANNOTATION_TYPE, TYPE_USE})
 @Retention(RUNTIME)
-@Repeatable(List.class)
 @Documented
 @Constraint(validatedBy = {Iso8601Validator.class})
 public @interface Iso8601 {
@@ -46,12 +46,4 @@ public @interface Iso8601 {
   Class<? extends Payload>[] payload() default {};
 
   Iso8601Format value() default Iso8601Format.ISO_DATE_TIME;
-
-  /** Inner annotation to support annotating type arguments of parameterized types. */
-  @Target({FIELD, TYPE_USE})
-  @Retention(RUNTIME)
-  @Documented
-  @interface List {
-    Iso8601[] value();
-  }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/validator/Uuid.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/validator/Uuid.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Marks a field as needing UUID validation. The annotation can be used on a String field or on a
+ * String typed collection.
+ *
+ * <pre>
+ * {@literal @}Uuid
+ * private String uuid;
+ *
+ * private List&lt;{@literal @}Uuid String&gt; uuids
+ * </pre>
+ */
+@Target({FIELD, PARAMETER, TYPE_USE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {UuidValidator.class})
+public @interface Uuid {
+  String message() default "Must be a valid UUID";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/validator/UuidValidator.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/validator/UuidValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import java.util.UUID;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+
+/** A ConstraintValidator that ensures that a string is a valid Leach-Salz UUID */
+public class UuidValidator implements ConstraintValidator<Uuid, String> {
+
+  @Override
+  public void initialize(Uuid constraintAnnotation) {
+    /* intentionally empty */
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    // A null or empty value is considered invalid.
+    if (value == null || value.isEmpty()) {
+      return false;
+    }
+
+    try {
+      UUID.fromString(value);
+      return true;
+    } catch (IllegalArgumentException e) {
+      var hibernateContext = context.unwrap(HibernateConstraintValidatorContext.class);
+      hibernateContext
+          .addMessageParameter("uuid", value)
+          .buildConstraintViolationWithTemplate("{uuid} is not a valid UUID")
+          .addConstraintViolation()
+          .disableDefaultConstraintViolation();
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Exposing administrator REST endpoints. Unlike our other REST endpoints, this resource is meant to be deployed across all pods. With that being the case, we need to account for the contingency where a bean we depend on is not available (due to the Spring profile the pod is deployed with or for other architectural reasons). To account for this possibility, dependencies are injected as typed ObjectProviders. The provider then calls the `getIfAvailable` method with a dummy default provider.  The default provider implements or extends the dependency and has dummy implementations of the methods that
throw UnsupportedOperationExceptions.

This architecture has the potential to become very cumbersome if this resource begins to pull in a lot of dependencies. However, due to the current situation where we are using Spring deployment profiles to determine runtime functionality, any universal admin endpoint needs to be able to cope with missing beans.

---
## Testing (using [HTTPie](https://httpie.io/))

These instructions assume that you are either running locally (`./gradlew clean :bootRun --args="--spring.profiles.active=api,kafka-queue,worker,capacity-ingress"`) or that you are using `oc port-forward` to forward your `worker` pod to localhost and using the `bin/hawtio-proxy.sh` to get a hawtio console for the `api` pod.
```
$ bin/insert-mock-hosts --account account123 --num-physical 25 --product RHEL --hbi
# Run a tally for account123 using the Hawtio web console or via Jolokia REST request as seen below
$ http -v :9000/hawtio/jolokia type=exec mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean operation="tallyAccount(java.lang.String)" arguments:='["account123"]'
$ psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select id from tally_snapshots limit 1;"
$ http -v POST :8000/api/rhsm-subscriptions/v1/internal/tally/resend  x-rh-identity:$(echo -n '{"identity":{"account_number":"account123","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w 0) uuids:="[\"536e564f-19b7-476c-bf1d-882a97f385a1\"]"
```

But replace that UUID with a UUID from the `psql` command.