### PR TITLE
Remove jacoco from common gradle config and move to individual projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id "org.sonarqube"
     id "nebula.release"
     id 'com.adarshr.test-logger'
+    id 'jacoco'
 }
 
 group = "org.candlepin"
@@ -97,6 +98,11 @@ allprojects {
     }
 }
 
+jacocoTestReport {
+    reports {
+        xml.required = true
+    }
+}
 
 compileJava.dependsOn(processResources)
 project.tasks["sonarqube"].dependsOn "test"

--- a/buildSrc/src/main/groovy/swatch.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.java-conventions.gradle
@@ -1,7 +1,6 @@
 // gradle config common to all swatch java projects
 plugins {
     id "java"
-    id "jacoco"
     id "com.diffplug.spotless"
 }
 
@@ -62,10 +61,5 @@ test {
     }
     environment "TESTCONTAINERS_RYUK_DISABLED", "true"
     environment "TESTCONTAINERS_CHECKS_DISABLE", "true"
-}
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
 }

--- a/swatch-core/build.gradle
+++ b/swatch-core/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "swatch.spring-boot-dependencies-conventions"
     id 'java'
     id 'jsonschema2pojo'
+    id 'jacoco'
 }
 
 dependencies {
@@ -55,4 +56,10 @@ description = 'SWATCH Core Library'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+    }
 }

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "swatch.spring-boot-conventions"
     id "org.openapi.generator"
+    id "jacoco"
 }
 
 ext {
@@ -62,6 +63,12 @@ dependencies {
     runtimeOnly "org.hsqldb:hsqldb"
     runtimeOnly "org.jolokia:jolokia-core"
     runtimeOnly "org.jboss.resteasy:resteasy-jackson2-provider"
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+    }
 }
 
 bootJar {


### PR DESCRIPTION
swatch-producer-aws uses a QuarkusJacoco dependency that clashes with the Jacoco plugin so this PR moves the plugin from a common config to individual projects that need it.