### PR TITLE
Improve dependabot compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,8 +170,8 @@ project(":api") {
         implementation "javax.validation:validation-api"
         implementation "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec"
         implementation "io.swagger:swagger-annotations"
-        implementation "com.google.code.findbugs:jsr305:3.0.2"
-        implementation "org.openapitools:jackson-databind-nullable:0.2.2"
+        implementation libraries["jsr305"]
+        implementation libraries["jackson-databind-nullable"]
     }
 
     sourceSets.main.java.srcDirs = ["${buildDir}/generated/src/gen/java"]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,18 +1,20 @@
 // By keeping dependencies in this file, they get picked up by dependabot reliably
 // inspired by mockito's gradle structure, which dependabot uses as a test case
-ext {
-    libraries = [:]
-    plugins = [:]
-    versions = [:]
+
+// Repeating repositories here allows dependabot to use them to check for updates
+buildscript {
+  repositories {
+      mavenCentral()
+      maven { url "https://plugins.gradle.org/m2/" }
+      maven { url "https://packages.confluent.io/maven/" }
+      maven { url "https://splunk.jfrog.io/splunk/ext-releases-local" }
+  }
 }
 
-// versions is for things that are released together (deps that happen to be multi-module projects)
-// NOTE: you must use versions.$name syntax here instead of versions["$name"] for dependendabot to work correctly
-// See https://github.com/dependabot/dependabot-core/blob/1643cfac63878e378f0aa8fc812bf42318df5299/gradle/lib/dependabot/gradle/file_parser.rb#L23-L28
-// Hint: You can use dependabot-script to debug what gets picked up
-versions.quarkus = "2.7.1.Final"
-versions.resteasy = "3.6.3.Final"
-versions.testcontainers = "1.16.3"
+ext {
+    libraries = [:]
+    plugins = []
+}
 
 // these are the plugin artifact IDs, which can be found on plugins.gradle.org
 // buildSrc/build.gradle adds them to the gradle classpath
@@ -23,7 +25,7 @@ ext.plugins = [
         "com.github.davidmc24.gradle.plugin:gradle-avro-plugin:1.3.0",
         "com.netflix.nebula:nebula-release-plugin:16.0.0",
         "de.undercouch:gradle-download-task:5.0.2",
-        "io.quarkus:gradle-application-plugin:${versions.quarkus}",
+        "io.quarkus:gradle-application-plugin:2.7.1.Final",
         "io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE",
         "org.jsonschema2pojo:jsonschema2pojo-gradle-plugin:1.1.1",
         "org.openapitools:openapi-generator-gradle-plugin:5.4.0",
@@ -44,17 +46,13 @@ libraries["jsr305"] = "com.google.code.findbugs:jsr305:3.0.2"
 libraries["junit-jupiter"] = "org.junit.jupiter:junit-jupiter:5.8.2"
 libraries["kafka-avro-serializer"] = "io.confluent:kafka-avro-serializer:7.0.1"
 libraries["lombok"] = "org.projectlombok:lombok:1.18.22"
-libraries["org.testcontainers:junit-jupiter"] = "org.testcontainers:junit-jupiter:${versions.testcontainers}"
-libraries["org.testcontainers:kafka"] = "org.testcontainers:kafka:${versions.testcontainers}"
-libraries["org.testcontainers:postgresql"] = "org.testcontainers:postgresql:${versions.testcontainers}"
-libraries["org.testcontainers:testcontainers"] = "org.testcontainers:testcontainers:${versions.testcontainers}"
-libraries["quarkus-bom"] = "io.quarkus.platform:quarkus-bom:${versions.quarkus}"
+libraries["quarkus-bom"] = "io.quarkus.platform:quarkus-bom:2.7.1.Final"
 libraries["quarkus-logging-logback"] = "io.quarkiverse.logging.logback:quarkus-logging-logback:0.11.0"
-libraries["resteasy-client"] = "org.jboss.resteasy:resteasy-client:${versions.resteasy}"
-libraries["resteasy-jackson2-provider"] = "org.jboss.resteasy:resteasy-jackson2-provider:${versions.resteasy}"
-libraries["resteasy-multipart-provider"] = "org.jboss.resteasy:resteasy-multipart-provider:${versions.resteasy}"
+libraries["resteasy-client"] = "org.jboss.resteasy:resteasy-client:3.6.3.Final"
+libraries["resteasy-jackson2-provider"] = "org.jboss.resteasy:resteasy-jackson2-provider:3.6.3.Final"
+libraries["resteasy-multipart-provider"] = "org.jboss.resteasy:resteasy-multipart-provider:3.6.3.Final"
 libraries["resteasy-spring-boot-starter"] = "org.jboss.resteasy:resteasy-spring-boot-starter:3.9.1.Final"
-libraries["resteasy-validator-provider-11"] = "org.jboss.resteasy:resteasy-validator-provider-11:${versions.resteasy}"
+libraries["resteasy-validator-provider-11"] = "org.jboss.resteasy:resteasy-validator-provider-11:3.6.3.Final"
 libraries["splunk-library-javalogging"] = "com.splunk.logging:splunk-library-javalogging:1.11.4"
 libraries["spring-boot-dependencies"] = "org.springframework.boot:spring-boot-dependencies:2.6.5"
 libraries["swagger-annotations"] = "io.swagger:swagger-annotations:1.6.5"

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -40,10 +40,10 @@ dependencies {
     testImplementation 'io.quarkus:quarkus-junit5'
     compileOnly libraries["lombok"]
     testImplementation libraries["junit-jupiter"]
-    testImplementation libraries["org.testcontainers:testcontainers"]
-    testImplementation libraries["org.testcontainers:junit-jupiter"]
-    testImplementation libraries["org.testcontainers:postgresql"]
-    testImplementation libraries["org.testcontainers:kafka"]
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:kafka'
 
 }
 


### PR DESCRIPTION
By specifying repos in a central location - dependencies.gradle, dependabot knows to consult additional maven repos.

I also found that dependabot is a bit conservative with updating versions in properties; specifically, if those versions are used by more than one dep, it skips those deps. So it kind of defeats the purpose of having a versions object.

I found there is a good workaround though: using bom artifacts instead.

I checked the results against this branch by updating the dependabot-script `update-script.rb` with the following logic:

```rb
dependencies.each { |d|
  checker = Dependabot::Gradle::UpdateChecker.new(
    dependency: d,
    dependency_files: files,
    credentials: credentials,
  )

  if not checker.up_to_date?
    if checker.latest_resolvable_version.nil?
      puts "#{d.name}:#{d.version} not up to date, but unable to update; TODO figure out why"
      binding.irb
    else
      puts "#{d.name}: #{d.version} to #{checker.latest_resolvable_version}"
    end
  end
}

exit
```

This showed better results on the branch:

```
com.adarshr:gradle-test-logger-plugin: 3.0.0 to 3.2.0
com.commercehub.gradle.plugin:gradle-avro-plugin: 0.9.1 to 0.99.99
com.github.davidmc24.gradle.plugin:gradle-avro-plugin:1.3.0 not up to date, but unable to update; TODO figure out why
io.quarkus:gradle-application-plugin: 2.7.1.Final to 2.7.5.Final
com.redhat.cloud.common:clowder-quarkus-config-source: 0.5.3 to 1.0.0
io.quarkus.platform:quarkus-bom: 2.7.1.Final to 2.7.5.Final
org.jboss.resteasy:resteasy-bom: 3.6.3.Final to 6.0.0.Final
org.jboss.resteasy:resteasy-spring-boot-starter: 3.9.1.Final to 5.0.0.Final
com.github.tomakehurst:wiremock-jre8:2.32.0 not up to date, but unable to update; TODO figure out why
```

For the two com.github ones, I fired up a ruby debugger and noticed that they're trying to resolve against GitHub, rather than maven repos. I *suspect* this isn't an issue with dependabot the service, because we've had wiremock updated via dependabot in the past successfully, but at least this is a step in the right direction.