### PR TITLE
Remove obsolete gradle-avro-plugin

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,7 +20,6 @@ ext {
 // buildSrc/build.gradle adds them to the gradle classpath
 ext.plugins = [
         "com.adarshr:gradle-test-logger-plugin:3.0.0",
-        "com.commercehub.gradle.plugin:gradle-avro-plugin:0.9.1",
         "com.diffplug.spotless:spotless-plugin-gradle:6.4.0",
         "com.github.davidmc24.gradle.plugin:gradle-avro-plugin:1.3.0",
         "com.netflix.nebula:nebula-release-plugin:16.0.0",


### PR DESCRIPTION
Note we already weren't using it, it was just left in unintentionally.

Fixes #845.