### PR TITLE
ENT-4691: Filter out non RH Marketplace billing providers

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -33,6 +33,7 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.json.TallyMeasurement.Uom;
 import org.candlepin.subscriptions.json.TallySnapshot;
+import org.candlepin.subscriptions.json.TallySnapshot.BillingProvider;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.rhmarketplace.api.model.UsageEvent;
@@ -122,6 +123,13 @@ public class RhMarketplacePayloadMapper {
     return isSnapshotPAYGEligible;
   }
 
+  protected boolean isSnapshotRHMarketplaceEligible(TallySnapshot snapshot) {
+    return snapshot.getBillingProvider() == null
+        || snapshot.getBillingProvider().equals(BillingProvider.RED_HAT)
+        || snapshot.getBillingProvider().equals(BillingProvider.ANY)
+        || snapshot.getBillingProvider().equals(BillingProvider.__EMPTY__);
+  }
+
   /**
    * UsageRequest objects are made up of a list of UsageEvents.
    *
@@ -138,6 +146,7 @@ public class RhMarketplacePayloadMapper {
 
     var eligibleSnapshots =
         tallySummary.getTallySnapshots().stream()
+            .filter(this::isSnapshotRHMarketplaceEligible)
             .filter(this::isSnapshotPAYGEligible)
             .collect(Collectors.toList());
 

--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -92,6 +92,10 @@ public class SnapshotSummaryProducer {
         org.candlepin.subscriptions.json.TallySnapshot.Usage.fromValue(
             tallySnapshot.getUsage().getValue());
 
+    var billingProvider =
+        org.candlepin.subscriptions.json.TallySnapshot.BillingProvider.fromValue(
+            tallySnapshot.getBillingProvider().getValue());
+
     return new org.candlepin.subscriptions.json.TallySnapshot()
         .withGranularity(granularity)
         .withId(tallySnapshot.getId())
@@ -99,6 +103,7 @@ public class SnapshotSummaryProducer {
         .withSnapshotDate(tallySnapshot.getSnapshotDate())
         .withSla(sla)
         .withUsage(usage)
+        .withBillingProvider(billingProvider)
         .withTallyMeasurements(mapMeasurements(tallySnapshot.getTallyMeasurements()));
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -85,6 +86,7 @@ class SnapshotSummaryProducerTest {
                 Granularity.HOURLY,
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
+                BillingProvider.RED_HAT,
                 Uom.CORES,
                 20.4)));
     updateMap.put(
@@ -96,6 +98,7 @@ class SnapshotSummaryProducerTest {
                 Granularity.HOURLY,
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
+                BillingProvider.AWS,
                 Uom.CORES,
                 22.2)));
     producer.produceTallySummaryMessages(updateMap);
@@ -168,6 +171,7 @@ class SnapshotSummaryProducerTest {
                 Granularity.HOURLY,
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
+                BillingProvider.RED_HAT,
                 Uom.CORES,
                 20.4)));
     updateMap.get("a1").get(0).getTallyMeasurements().clear();
@@ -197,6 +201,7 @@ class SnapshotSummaryProducerTest {
       Granularity granularity,
       ServiceLevel sla,
       Usage usage,
+      BillingProvider billingProvider,
       Uom uom,
       double val) {
     Map<TallyMeasurementKey, Double> measurements = new HashMap<>();
@@ -210,6 +215,7 @@ class SnapshotSummaryProducerTest {
         .granularity(granularity)
         .serviceLevel(sla)
         .usage(usage)
+        .billingProvider(billingProvider)
         .build();
   }
 }

--- a/swatch-core/schemas/tally_summary.yaml
+++ b/swatch-core/schemas/tally_summary.yaml
@@ -48,6 +48,17 @@ properties:
             - Monthly
             - Quarterly
             - Yearly
+        billing_provider:
+          type: string
+          enum:
+            - ''
+            - Red hat
+            - Aws
+            - Gcp
+            - Azure
+            - Oracle
+            - _ANY
+          required: false
         tally_measurements:
           type: array
           items:


### PR DESCRIPTION
Filters out tallySnapshots by billingProvider so that RHMarketplaceProducer only consumes the appropriate snapshots.

https://issues.redhat.com/browse/ENT-4691