### PR TITLE
Default the gradle build to parallel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 nebula.release.features.replaceDevWithImmutableSnapshot=true
 org.gradle.jvmargs=-Xmx1024m "-XX:MaxMetaspaceSize=256m"
+org.gradle.parallel=true


### PR DESCRIPTION
Setting the build to parallel mode reduces the time required to build.
If something goes wrong with thee build process itself and you want to
run single threaded use the "--no-parallel" gradle flag to disable the
parallel build process.