### PR TITLE
Update security settings around Jolokia

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/JolokiaActuatorConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/JolokiaActuatorConfiguration.java
@@ -108,21 +108,14 @@ public class JolokiaActuatorConfiguration extends WebSecurityConfigurerAdapter {
     // See
     // https://docs.spring.io/spring-security/site/docs/current/reference/html5/#ns-custom-filters
     // for list of filters and their order
-    http.requestMatchers(
-            matchers -> matchers.antMatchers("/actuator/**/jolokia", "/actuator/**/jolokia/**"))
+    http.requestMatcher(EndpointRequest.to("jolokia"))
         .csrf()
         .disable()
         .addFilter(identityHeaderAuthenticationFilter())
         .addFilterAfter(mdcFilter(), IdentityHeaderAuthenticationFilter.class)
         .addFilterAt(getVerbIncludingAntiCsrfFilter(secProps, env), CsrfFilter.class)
         .authorizeRequests()
-        .requestMatchers(EndpointRequest.to("jolokia"))
-        .permitAll()
-        .and()
-        .anonymous() // Creates an anonymous user if no header is present at all. Prevents NPEs
-        .and()
-        .authorizeRequests()
         .anyRequest()
-        .permitAll();
+        .authenticated();
   }
 }


### PR DESCRIPTION
It looks like I overlooked updating these when we changed the actuator
endpoint prefix.  I modified them to use a reference to the actuator
itself rather than whatever URL it happens to be served under.