### PR TITLE
Remove external api spec download during build

### DIFF
--- a/clients/build.gradle
+++ b/clients/build.gradle
@@ -17,28 +17,11 @@ project(":clients:cloudigrade-internal-client") {
 project(":clients:insights-inventory-client") {
     apply plugin: "swatch.java-conventions"
     apply plugin: "org.openapi.generator"
-    apply plugin: "de.undercouch.download"
 
     ext {
-        api_spec_path = "${buildDir}/api.spec.yaml"
+        api_spec_path = "${projectDir}/api.spec.yaml"
         config_file = "${projectDir}/insights-inventory-client-config.json"
     }
-
-    // work around https://github.com/OpenAPITools/openapi-generator/issues/8255 by downloading the spec manually
-    task downloadSpec(type: Download) {
-        src 'https://raw.githubusercontent.com/RedHatInsights/insights-host-inventory/075f8e4433ecfb2e227e02108096847242e14e19/swagger/api.spec.yaml'
-        dest buildDir
-        overwrite false
-    }
-
-    task downloadSystemProfileSpec(type: Download) {
-        src 'https://raw.githubusercontent.com/RedHatInsights/insights-host-inventory/d479778d9ae72fea9a493429ea44142364648ec5/swagger/system_profile.spec.yaml'
-        dest buildDir
-        overwrite false
-    }
-
-    tasks.openApiGenerate.dependsOn downloadSpec
-    tasks.openApiGenerate.dependsOn downloadSystemProfileSpec
 
     dependencies {
         compileOnly 'org.springframework.boot:spring-boot'
@@ -76,21 +59,11 @@ project(":clients:prometheus-client") {
 project(":clients:rbac-client") {
     apply plugin: "swatch.java-conventions"
     apply plugin: "org.openapi.generator"
-    apply plugin: "de.undercouch.download"
 
     ext {
-        api_spec_path = "${buildDir}/openapi.json"
+        api_spec_path = "${projectDir}/openapi.json"
         config_file = "${projectDir}/rbac-client-config.json"
     }
-
-    // work around https://github.com/OpenAPITools/openapi-generator/issues/8255 by downloading the spec manually
-    task downloadSpec(type: Download) {
-        src 'https://raw.githubusercontent.com/RedHatInsights/insights-rbac/stable/docs/source/specs/openapi.json'
-        dest buildDir
-        overwrite false
-    }
-
-    tasks.openApiGenerate.dependsOn downloadSpec
 
     dependencies {
         compileOnly "org.springframework:spring-web"

--- a/clients/insights-inventory-client/api.spec.yaml
+++ b/clients/insights-inventory-client/api.spec.yaml
@@ -1,0 +1,1028 @@
+---
+openapi: 3.0.0
+info:
+  description: REST interface for the Insights Platform Host Inventory application.
+  version: 1.0.0
+  title: Insights Host Inventory REST Interface
+paths:
+  /hosts:
+    get:
+      operationId: api.host.get_host_list
+      tags:
+        - hosts
+      summary: Read the entire list of hosts
+      description: >-
+        Read the entire list of all hosts available to the account.
+        <br /><br />
+        Required permissions: inventory:hosts:read
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: query
+          name: display_name
+          schema:
+            type: string
+          description: A part of a searched host’s display name.
+          required: false
+        - in: query
+          name: fqdn
+          schema:
+            type: string
+          description: Filter by a host's FQDN
+          required: false
+        - in: query
+          name: hostname_or_id
+          schema:
+            type: string
+          description: 'Search for a host by display_name, fqdn, id'
+          required: false
+        - in: query
+          name: insights_id
+          schema:
+            type: string
+            format: uuid
+          description: Search for a host by insights_id
+          required: false
+        - $ref: '#/components/parameters/branchId'
+        - $ref: '#/components/parameters/perPageParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/orderByParam'
+        - $ref: '#/components/parameters/orderHowParam'
+        - $ref: '#/components/parameters/stalenessParam'
+        - $ref: '#/components/parameters/tagsParam'
+        - $ref: '#/components/parameters/registered_with'
+      responses:
+        '200':
+          description: Successfully read the hosts list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostQueryOutput'
+    post:
+      deprecated: true
+      operationId: api.host.add_host_list
+      tags:
+        - hosts
+      summary: Create/update multiple host and add them to the host list
+      description: >-
+        Create a new host and add it to the host list or update an existing
+        hosts. A host is updated if there is already one with the same
+        canonicals facts and belonging to the same account.
+        <br /><br />
+        Required permissions: inventory:hosts:write
+        <br /><br />
+        NOTICE: This operation is deprecated. The explicit creation of hosts is
+        no longer supported. Hosts are created automatically based on uploads
+        processed by the [payload ingress service](/docs/api/ingress#operations-default-post_upload) instead.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        description: A list of host objects to be added to the host list
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/CreateHostIn'
+      responses:
+        '207':
+          description: Successfully created a host.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkHostOut'
+              examples:
+                update:
+                  value:
+                    status: 200
+                    host: Host details
+                create:
+                  value:
+                    status: 201
+                    host: Host details
+                error:
+                  value:
+                    status: 400
+                    title: Invalid Request
+                    detail: Could not process request
+                    host: Input host data
+        '400':
+          description: Invalid request.
+  '/hosts/{host_id_list}':
+    get:
+      tags:
+        - hosts
+      summary: Find hosts by their IDs
+      description: >-
+        Find one or more hosts by their ID.
+        <br /><br />
+        Required permissions: inventory:hosts:read
+      operationId: api.host.get_host_by_id
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/branchId'
+        - $ref: '#/components/parameters/perPageParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/orderByParam'
+        - $ref: '#/components/parameters/orderHowParam'
+      responses:
+        '200':
+          description: Successfully searched for hosts.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostQueryOutput'
+        '400':
+          description: Invalid request.
+        '404':
+          description: Host not found.
+    delete:
+      tags:
+        - hosts
+      summary: Delete hosts by IDs
+      description: >-
+        Delete hosts by IDs
+        <br /><br />
+        Required permissions: inventory:hosts:write
+      operationId: api.host.delete_by_id
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/branchId'
+      responses:
+        '200':
+          description: Successfully deleted hosts.
+        '400':
+          description: Invalid request.
+        '404':
+          description: Host not found.
+    patch:
+      tags:
+        - hosts
+      summary: Update a host
+      description: >-
+        Update a host
+        <br /><br />
+        Required permissions: inventory:hosts:write
+      operationId: api.host.patch_by_id
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/branchId'
+      requestBody:
+        description: A group of fields to be updated on the host
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchHostIn'
+      responses:
+        '200':
+          description: Successfully updated the host.
+        '400':
+          description: Invalid request.
+        '404':
+          description: Host not found.
+  '/hosts/{host_id_list}/facts/{namespace}':
+    patch:
+      tags:
+        - hosts
+      summary: Merge facts under a namespace
+      description: >-
+        Merge one or multiple hosts facts under a namespace.
+        <br /><br />
+        Required permissions: inventory:hosts:write
+      operationId: api.host.merge_facts
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/factsNamespace'
+        - $ref: '#/components/parameters/branchId'
+      requestBody:
+        description: A dictionary with the new facts to merge with the original ones.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Facts'
+      responses:
+        '200':
+          description: Successfully merged facts.
+        '400':
+          description: Invalid request.
+        '404':
+          description: Host or namespace not found.
+    put:
+      tags:
+        - hosts
+      summary: Replace facts under a namespace
+      description: >-
+        Replace facts under a namespace
+        <br /><br />
+        Required permissions: inventory:hosts:write
+      security:
+        - ApiKeyAuth: []
+      operationId: api.host.replace_facts
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/factsNamespace'
+        - $ref: '#/components/parameters/branchId'
+      requestBody:
+        description: A dictionary with the new facts to replace the original ones.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Facts'
+      responses:
+        '200':
+          description: Successfully replaced facts.
+        '400':
+          description: Invalid request.
+        '404':
+          description: Host or namespace not found.
+  '/hosts/{host_id_list}/system_profile':
+    get:
+      tags:
+        - hosts
+      summary: Return one or more hosts system profile
+      description: >-
+        Find one or more hosts by their ID and return the id and system profile
+        <br /><br />
+        Required permissions: inventory:hosts:read
+      operationId: api.host.get_host_system_profile_by_id
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/perPageParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/orderByParam'
+        - $ref: '#/components/parameters/orderHowParam'
+        - $ref: '#/components/parameters/branchId'
+      responses:
+        '200':
+          description: Successfully searched for hosts.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemProfileByHostOut'
+        '400':
+          description: Invalid request.
+        '404':
+          description: Host not found.
+  '/hosts/{host_id_list}/tags':
+    get:
+      tags:
+        - hosts
+      summary: Get the tags on a host
+      description: >-
+        Get the tags on a host
+        <br /><br />
+        Required permissions: inventory:hosts:read
+      operationId: api.host.get_host_tags
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/perPageParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/orderByParam'
+        - $ref: '#/components/parameters/orderHowParam'
+        - $ref: '#/components/parameters/searchParam'
+      responses:
+        '200':
+          description: Successfully found tags.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagsOut'
+        '400':
+          description: Invalid request.
+  '/hosts/{host_id_list}/tags/count':
+    get:
+      tags:
+        - hosts
+      summary: Get the number of tags on a host
+      description: >-
+        Get the number of tags on a host
+        <br /><br />
+        Required permissions: inventory:hosts:read
+      operationId: api.host.get_host_tag_count
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/perPageParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/orderByParam'
+        - $ref: '#/components/parameters/orderHowParam'
+      responses:
+        '200':
+          description: Successfully found tag count.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagCountOut'
+        '400':
+          description: Invalid request.
+
+  /tags:
+    get:
+      tags:
+        - tags
+      summary: Get the active host tags for a given account
+      description: >-
+        Required permissions: inventory:hosts:read
+      operationId: api.tag.get_tags
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/tagsParam'
+        - $ref: '#/components/parameters/tagsOrderBy'
+        - $ref: '#/components/parameters/tagsOrderHow'
+        - $ref: '#/components/parameters/perPageParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/stalenessParam'
+        - $ref: '#/components/parameters/searchParam'
+        - $ref: '#/components/parameters/registered_with'
+      responses:
+        '200':
+            description: Tags
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ActiveTags'
+        '400':
+            description: Invalid request.
+        '404':
+          $ref: '#/components/responses/PageOutOfBounds'
+
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      x-bearerInfoFunc: app.auth.bearer_token_handler
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-rh-identity
+      description: >-
+        Base64-encoded JSON identity header provided by 3Scale. Contains an
+        account number of the user issuing the request. Format of the JSON:
+        {"identity": {"account_number": "12345678"}}
+      x-apikeyInfoFunc: app.auth.authentication_header_handler
+  parameters:
+    pageParam:
+      name: page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+      description: A page number of the items to return.
+    perPageParam:
+      name: per_page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 50
+      description: A number of items to return per page.
+    hostIdList:
+      in: path
+      name: host_id_list
+      description: A comma separated list of host IDs.
+      required: true
+      schema:
+        type: array
+        items:
+          type: string
+          format: uuid
+    branchId:
+      in: query
+      name: branch_id
+      schema:
+        type: string
+      description: Filter by branch_id
+      required: false
+    factsNamespace:
+      in: path
+      name: namespace
+      description: A namespace of the merged facts.
+      required: true
+      schema:
+        type: string
+    orderByParam:
+      name: order_by
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - display_name
+          - updated
+      description: Ordering field name
+    orderHowParam:
+      name: order_how
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - ASC
+          - DESC
+      description: >-
+        Direction of the ordering, defaults to ASC for display_name and to DESC for
+        updated
+    stalenessParam:
+      name: staleness
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+            - fresh
+            - stale
+            - stale_warning
+            - unknown
+        default:
+          - fresh
+          - stale
+          - unknown
+      description: "Culling states of the hosts. Default: fresh,stale,unknown"
+    tagsParam:
+      name: tags
+      in: query
+      description: filters out hosts not tagged by the given tags
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          pattern: '^([^=/]+/)?[^=/]+(=[^=/]+)?$'
+    tagsOrderBy:
+      in: query
+      name: order_by
+      required: false
+      schema:
+        type: string
+        default: tag
+        enum:
+          - tag
+          - count
+      description: Ordering field name
+    tagsOrderHow:
+      in: query
+      name: order_how
+      required: false
+      schema:
+        type: string
+        default: ASC
+        enum:
+          - ASC
+          - DESC
+      description: Direction of the ordering. Default to ASC
+    searchParam:
+      in: query
+      name: search
+      required: false
+      description: Only include tags that match the given search string. The value is matched against namespace, key and value.
+      schema:
+        type: string
+    registered_with:
+      in: query
+      name: registered_with
+      required: false
+      description: Filters out any host not registered with the specified service
+      schema:
+        type: string
+        enum:
+          - insights
+
+
+  schemas:
+    TagsOut:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of items in the "data" list.
+        count:
+          description: A number of entries on the current page.
+          type: integer
+        page:
+          description: A current page number.
+          type: integer
+        per_page:
+          description: A page size – a number of entries per single page.
+          type: integer
+        results:
+          description: The list of tags on the systems
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/StructuredTag'
+    StructuredTag:
+      type: object
+      properties:
+        namespace:
+          type: string
+          nullable: true
+        key:
+          type: string
+        value:
+          type: string
+          nullable: true
+    TagCountOut:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of items in the "data" list.
+        count:
+          description: A number of entries on the current page.
+          type: integer
+        page:
+          description: A current page number.
+          type: integer
+        per_page:
+          description: A page size – a number of entries per single page.
+          type: integer
+        results:
+          description: The list of tags on the systems
+          type: object
+          additionalProperties:
+            type: integer
+    BulkHostOut:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of items in the "data" list.
+        errors:
+          type: integer
+          description: Number of items in the "data" list that contain errors.
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkHostOutDetails'
+          description: 'List of hosts that were created, updated or failed to be processed.'
+    BulkHostOutDetails:
+      type: object
+      properties:
+        status:
+          type: integer
+          description: HTTP status code of the results of the host create/update process
+        host:
+          $ref: '#/components/schemas/CreateHostOut'
+        title:
+          type: string
+          description: Short description of why a host failed to be created or updated.
+        detail:
+          type: string
+          description: Details about why a host failed to be created or updated.
+    Facts:
+      title: Host facts
+      description: A set of string facts about a host.
+      type: object
+      example:
+        fact1: value1
+        fact2: value2
+    FactSet:
+      title: Host facts under a namespace
+      description: A set of string facts belonging to a single namespace.
+      properties:
+        namespace:
+          type: string
+          minLength: 1
+          description: A namespace the facts belong to.
+        facts:
+          type: object
+          description: The facts themselves.
+          example:
+            fact1: value1
+            fact2: value2
+      required:
+        - namespace
+        - facts
+    CreateHostIn:
+      title: Host data
+      description: >-
+        Data of a single host belonging to an account. Represents the hosts
+        without its Inventory metadata.
+      type: object
+      required:
+        - account
+        - stale_timestamp
+        - reporter
+      properties:
+        display_name:
+          description: >-
+            A host’s human-readable display name, e.g. in a form of a domain
+            name.
+          type: string
+          example: host1.mydomain.com
+        ansible_host:
+          description: >-
+            The ansible host name for remediations
+          type: string
+          example: host1.mydomain.com
+        account:
+          description: A Red Hat Account number that owns the host.
+          type: string
+          example: '000102'
+        insights_id:
+          description: >-
+            An ID defined in /etc/insights-client/machine-id. This field is
+            considered a canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+        rhel_machine_id:
+          description: >-
+            A Machine ID of a RHEL host.  This field is considered to be a
+            canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+        subscription_manager_id:
+          description: >-
+            A Red Hat Subcription Manager ID of a RHEL host.  This field is
+            considered to be a canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+        satellite_id:
+          description: >-
+            A Red Hat Satellite ID of a RHEL host.  This field is considered to
+            be a canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+        bios_uuid:
+          description: >-
+            A UUID of the host machine BIOS.  This field is considered to be a
+            canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+        ip_addresses:
+          description: >-
+            Host’s network IP addresses.  This field is considered to be a
+            canonical fact.
+          type: array
+          items:
+            type: string
+          example:
+            - 10.10.0.1
+            - 10.0.0.2
+        fqdn:
+          description: >-
+            A host’s Fully Qualified Domain Name.  This field is considered to
+            be a canonical fact.
+          type: string
+          example: my.host.example.com
+        mac_addresses:
+          description: >-
+            Host’s network interfaces MAC addresses.  This field is considered
+            to be a canonical fact.
+          type: array
+          items:
+            type: string
+          example:
+            - 'c2:00:d0:c8:61:01'
+        external_id:
+          description: >-
+            Host’s reference in the external source e.g. AWS EC2, Azure,
+            OpenStack, etc. This field is considered to be a canonical fact.
+          type: string
+          example: i-05d2313e6b9a42b16
+        facts:
+          description: A set of facts belonging to the host.
+          type: array
+          items:
+            $ref: '#/components/schemas/FactSet'
+        system_profile:
+          $ref: '#/components/schemas/SystemProfile'
+        stale_timestamp:
+          description: Timestamp from which the host is considered stale.
+          type: string
+          format: date-time
+        reporter:
+          description: Reporting source of the host. Used when updating the stale_timestamp.
+          type: string
+    CreateHostOut:
+      title: Create Host Out
+      description: >-
+        Data of a single host belonging to an account. Represents the hosts
+        without its Inventory metadata.
+      type: object
+      required:
+        - account
+      properties:
+        display_name:
+          description: >-
+            A host’s human-readable display name, e.g. in a form of a domain
+            name.
+          type: string
+          example: host1.mydomain.com
+          nullable: true
+        ansible_host:
+          description: >-
+            The ansible host name for remediations
+          type: string
+          example: host1.mydomain.com
+          nullable: true
+        account:
+          description: A Red Hat Account number that owns the host.
+          type: string
+          example: '000102'
+        insights_id:
+          description: >-
+            An ID defined in /etc/insights-client/machine-id. This field is
+            considered a canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        rhel_machine_id:
+          description: >-
+            A Machine ID of a RHEL host.  This field is considered to be a
+            canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        subscription_manager_id:
+          description: >-
+            A Red Hat Subcription Manager ID of a RHEL host.  This field is
+            considered to be a canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        satellite_id:
+          description: >-
+            A Red Hat Satellite ID of a RHEL host.  This field is considered to
+            be a canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        bios_uuid:
+          description: >-
+            A UUID of the host machine BIOS.  This field is considered to be a
+            canonical fact.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        ip_addresses:
+          description: >-
+            Host’s network IP addresses.  This field is considered to be a
+            canonical fact.
+          type: array
+          items:
+            type: string
+          nullable: true
+          example:
+            - 10.10.0.1
+            - 10.0.0.2
+        fqdn:
+          description: >-
+            A host’s Fully Qualified Domain Name.  This field is considered to
+            be a canonical fact.
+          type: string
+          example: my.host.example.com
+          nullable: true
+        mac_addresses:
+          description: >-
+            Host’s network interfaces MAC addresses.  This field is considered
+            to be a canonical fact.
+          type: array
+          items:
+            type: string
+          nullable: true
+          example:
+            - 'c2:00:d0:c8:61:01'
+        external_id:
+          description: >-
+            Host’s reference in the external source e.g. AWS EC2, Azure,
+            OpenStack, etc. This field is considered to be a canonical fact.
+          type: string
+          nullable: true
+          example: i-05d2313e6b9a42b16
+        id:
+          description: >-
+            A durable and reliable platform-wide host identifier. Applications
+            should use this identifier to reference hosts.
+          type: string
+          example: 3f01b55457674041b75e41829bcee1dc
+        created:
+          description: A timestamp when the entry was created.
+          type: string
+          format: date-time
+        updated:
+          description: A timestamp when the entry was last updated.
+          type: string
+          format: date-time
+        facts:
+          description: A set of facts belonging to the host.
+          type: array
+          items:
+            $ref: '#/components/schemas/FactSet'
+        stale_timestamp:
+          description: Timestamp from which the host is considered stale.
+          type: string
+          format: date-time
+          nullable: true
+        stale_warning_timestamp:
+          description: >-
+            Timestamp from which the host is considered too stale to be listed without an explicit
+            toggle.
+          type: string
+          format: date-time
+          nullable: true
+        culled_timestamp:
+          description: Timestamp from which the host is considered deleted.
+          type: string
+          format: date-time
+          nullable: true
+        reporter:
+          description: Reporting source of the host. Used when updating the stale_timestamp.
+          type: string
+          nullable: true
+    HostOut:
+      title: A Host Inventory entry
+      description: A database entry representing a single host with its Inventory metadata.
+      allOf:
+        - $ref: '#/components/schemas/CreateHostOut'
+        - type: object
+          properties:
+            facts:
+              description: A set of facts belonging to the host.
+              type: array
+              items:
+                $ref: '#/components/schemas/FactSet'
+    HostQueryOutput:
+      title: A Host Inventory query result
+      description: >-
+        A paginated host search query result with host entries and their
+        Inventory metadata.
+      type: object
+      required:
+        - count
+        - page
+        - per_page
+        - total
+        - results
+      properties:
+        count:
+          description: A number of entries on the current page.
+          type: integer
+        page:
+          description: A current page number.
+          type: integer
+        per_page:
+          description: A page size – a number of entries per single page.
+          type: integer
+        total:
+          description: A total count of the found entries.
+          type: integer
+        results:
+          description: Actual host search query result entries.
+          type: array
+          items:
+            $ref: '#/components/schemas/HostOut'
+    SystemProfileByHostOut:
+      title: A host system profile query result
+      description: Structure of the output of the host system profile query
+      type: object
+      required:
+        - count
+        - page
+        - per_page
+        - total
+        - results
+      properties:
+        count:
+          description: A number of entries on the current page.
+          type: integer
+        page:
+          description: A current page number.
+          type: integer
+        per_page:
+          description: A page size – a number of entries per single page.
+          type: integer
+        total:
+          description: A total count of the found entries.
+          type: integer
+        results:
+          description: Actual host search query result entries.
+          type: array
+          items:
+            $ref: '#/components/schemas/HostSystemProfileOut'
+    HostSystemProfileOut:
+      title: Structure of an individual host system profile output
+      description: Individual host record that contains only the host id and system profile
+      properties:
+        id:
+          type: string
+        system_profile:
+          $ref: '#/components/schemas/SystemProfile'
+    PatchHostIn:
+      title: Host data
+      description: >-
+        Data of a single host to be updated.
+      type: object
+      properties:
+        ansible_host:
+          description: >-
+            The ansible host name for remediations
+          type: string
+          example: host1.mydomain.com
+        display_name:
+          description: >-
+            A host’s human-readable display name, e.g. in a form of a domain
+            name.
+          type: string
+          example: host1.mydomain.com
+
+    ActiveTags:
+      title: Host data
+      type: object
+      required:
+        - total
+        - count
+        - page
+        - per_page
+        - results
+      properties:
+        total:
+          $ref: '#/components/schemas/Total'
+        count:
+          $ref: '#/components/schemas/Count'
+        page:
+          $ref: '#/components/schemas/Page'
+        per_page:
+          $ref: '#/components/schemas/PerPage'
+        results:
+          type: array
+          items:
+            title: ActiveTag
+            description: Information about a host tag
+            type: object
+            required:
+              - tag
+              - count
+            properties:
+              tag:
+                $ref: '#/components/schemas/StructuredTag'
+              count:
+                description: The number of hosts with the given tag. If the value is null this indicates that the count is unknown.
+                type: integer
+                nullable: true
+      example:
+        total: 3
+        count: 3
+        page: 1
+        per_page: 50
+        results:
+          - tag:
+              namespace: Sat
+              key: env
+              value: prod
+            count: 3
+          - tag:
+              namespace: aws
+              key: region
+              value: us-east-1
+            count: 1
+          - tag:
+              namespace: insights-client
+              key: web
+              value: null
+            count: -1
+    Total:
+      type: integer
+      description: Total number of items
+    Count:
+      type: integer
+      description: The number of items on the current page
+    Page:
+      type: integer
+      description: The page number
+    PerPage:
+      type: integer
+      description: The number of items to return per page
+    SystemProfile:
+      $ref: 'system_profile.spec.yaml#/$defs/SystemProfile'
+  responses:
+    PageOutOfBounds:
+      description: Requested page is outside of the range of available pages

--- a/clients/insights-inventory-client/system_profile.spec.yaml
+++ b/clients/insights-inventory-client/system_profile.spec.yaml
@@ -1,0 +1,314 @@
+---
+$id: system_profile.spec.yaml
+$schema: http://json-schema.org/draft-04/schema#
+$defs:
+  DiskDevice:
+    description: Representation of one mounted device
+    type: object
+    properties:
+      device:
+        example: "/dev/fdd0"
+        type: string
+        maxLength: 2048
+      label:
+        description: User-defined mount label
+        type: string
+        maxLength: 1024
+      options:
+        description: Mount options for nested object
+        example:
+          uid: "0"
+          ro: true
+        type: object
+      mount_point:
+        description: The mount point
+        example: "/mnt/remote_nfs_shares"
+        type: string
+        maxLength: 2048
+      type:
+        description: The mount type
+        example: "ext3"
+        type: string
+        maxLength: 256
+  YumRepo:
+    description: Representation of one yum repository
+    type: object
+    properties:
+      id:
+        type: string
+        maxLength: 256
+      name:
+        type: string
+        maxLength: 1024
+      gpgcheck:
+        type: boolean
+      enabled:
+        type: boolean
+      base_url:
+        type: string
+        format: uri
+        maxLength: 2048
+  DnfModule:
+    description: Representation of one DNF module
+    type: object
+    properties:
+      name:
+        type: string
+        maxLength: 128
+      stream:
+        type: string
+        maxLength: 2048
+  InstalledProduct:
+    description: Representation of one installed product
+    type: object
+    properties:
+      name:
+        type: string
+        maxLength: 512
+      id:
+        description: The product ID
+        example: "71"
+        type: string
+        maxLength: 64
+      status:
+        description: Subscription status for product
+        example: "Subscribed"
+        type: string
+        maxLength: 256
+  NetworkInterface:
+    description: Representation of one network interface
+    type: object
+    properties:
+      ipv4_addresses:
+        type: array
+        items:
+          description: The ipv4 address of the system
+          example: "123.456.789.012"
+          type: string
+          format: ipv4
+      ipv6_addresses:
+        type: array
+        items:
+          description: The ipv6 address of the system
+          example: "0123:4567:89ab:cdef:0123:4567:89ab:cdef"
+          type: string
+          format: ipv6
+      mtu:
+        description: MTU (Maximum transmission unit)
+        type: integer
+      mac_address:
+        description: MAC address (with or without colons)
+        example: "00:00:00:00:00:00"
+        type: string
+        maxLength: 59
+      name:
+        description: Name of interface
+        type: string
+        example: eth0
+        minLength: 1
+        maxLength: 50
+      state:
+        description: Interface state (UP, DOWN, UNKNOWN)
+        type: string
+        example: "UP"
+        maxLength: 25
+      type:
+        description: Interface type (ether, loopback)
+        type: string
+        example: "ether"
+        maxLength: 18
+  SystemProfile:
+    description: Representation of the system profile fields
+    type: object
+    properties:
+      owner_id:
+        description: A UUID associated with the host's RHSM certificate
+        type: string
+        pattern: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        maxLength: 36
+        example: 22cd8e39-13bb-4d02-8316-84b850dc5136
+      number_of_cpus:
+        type: integer
+      number_of_sockets:
+        type: integer
+      cores_per_socket:
+        type: integer
+      system_memory_bytes:
+        type: integer
+        format: int64
+      infrastructure_type:
+        type: string
+        maxLength: 100
+      infrastructure_vendor:
+        type: string
+        maxLength: 100
+      network_interfaces:
+        type: array  # techincally a set, ordering is not important
+        items:
+          $ref: '#/$defs/NetworkInterface'
+      disk_devices:
+        type: array  # techincally a set, ordering is not important
+        items:
+          $ref: '#/$defs/DiskDevice'
+      bios_vendor:
+        type: string
+        maxLength: 100
+      bios_version:
+        type: string
+        maxLength: 100
+      bios_release_date:
+        type: string
+        maxLength: 50
+      cpu_flags:
+        items:
+          type: string
+          maxLength: 30
+        type: array
+      operating_system:
+        type: object
+        properties:
+          major:
+            description: Major release of OS (aka the x version)
+            example: 6
+            type: integer
+            minimum: 0
+            maximum: 99
+          minor:
+            description: Minor release of OS (aka the y version)
+            example: 8
+            type: integer
+            minimum: 0
+            maximum: 99
+          name:
+            description: Name of the distro/os
+            example: "RHEL"
+            type: string
+            maxLength: 4
+            enum: [RHEL]
+      os_release:
+        type: string
+        maxLength: 100
+      os_kernel_version:
+        type: string
+        maxLength: 20
+        pattern: '^\d+\.\d+\.\d+(\.\d+)?$'
+        description: The kernel version represented with a three, optionally four, number scheme.
+        example: '3.10.0'
+      arch:
+        type: string
+        maxLength: 50
+      kernel_modules:
+        type: array
+        items:
+          type: string
+          maxLength: 255
+      last_boot_time:
+        type: string
+        format: date-time
+        maxLength: 50
+      running_processes:
+        type: array  # techincally a set, ordering is not important
+        items:
+          description: A single running process. This will be truncated to 1000 characters when saved.
+          type: string
+          maxLength: 1000
+      subscription_status:
+        type: string
+        maxLength: 100
+      subscription_auto_attach:
+        type: string
+        maxLength: 100
+      katello_agent_running:
+        type: boolean
+      satellite_managed:
+        type: boolean
+      cloud_provider:
+        type: string
+        maxLength: 100
+      yum_repos:
+        type: array  # technically a set, ordering is not important
+        items:
+          $ref: '#/$defs/YumRepo'
+      dnf_modules:
+        type: array # technically a set, ordering is not important
+        items:
+          $ref: '#/$defs/DnfModule'
+      installed_products:
+        type: array  # technically a set, ordering is not important
+        items:
+          $ref: '#/$defs/InstalledProduct'
+      insights_client_version:
+        type: string
+        maxLength: 50
+      insights_egg_version:
+        type: string
+        maxLength: 50
+      captured_date:
+        type: string
+        maxLength: 32
+      installed_packages:
+        type: array  # technically a set, ordering is not important
+        items:
+          description: A NEVRA string for a single installed package
+          example: "krb5-libs-0:-1.16.1-23.fc29.i686"
+          type: string
+          maxLength: 512
+      installed_packages_delta:
+        type: array # sorted list, rest of packages not in installed_packages
+        items:
+          description: A NEVRA string for a single installed package
+          example: "krb5-libs-0:-1.16.1-23.fc29.i686"
+          type: string
+          maxLength: 512
+      installed_services:
+        type: array
+        items:
+          type: string
+          maxLength: 512
+      enabled_services:
+        type: array
+        items:
+          type: string
+          maxLength: 512
+      sap_system:
+        type: boolean
+        description: Indicates if SAP is installed on the system
+      sap_sids:
+        type: array
+        description: List of SAP SIDs
+        uniqueItems: true
+        items:
+          description: The SAP system ID (SID)
+          type: string
+          example: "H2O"
+          maxLength: 3
+          pattern: '^[A-Z][A-Z0-9]{2}$'
+      sap_instance_number:
+        type: string
+        description: The instance number of the SAP HANA system
+        example: '42'
+        maxLength: 2
+        pattern: '^[0-9]{2}$'
+      sap_version:
+        type: string
+        description: The version of the SAP HANA lifecycle management program
+        example:  '1.00.122.04.1478575636'
+        maxLength: 22
+        pattern: '^[0-9].[0-9]{2}.[0-9]{3}.[0-9]{2}.[0-9]{10}$'
+      tuned_profile:
+        type: string
+        maxLength: 256
+        description: Current profile resulting from command tuned-adm active
+        example: 'desktop'
+      selinux_current_mode:
+        type: string
+        enum: [enforcing, permissive, disabled]
+        description: The current SELinux mode, either enforcing, permissive, or disabled
+        maxLength: 10
+        example: 'enforcing'
+      selinux_config_file:
+        type: string
+        enum: [enforcing, permissive, disabled]
+        description: The SELinux mode provided in the config file
+        maxLength: 10
+        example: 'permissive'

--- a/clients/rbac-client/openapi.json
+++ b/clients/rbac-client/openapi.json
@@ -1,0 +1,3175 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "The API for Role Based Access Control.",
+    "version": "1.0.0",
+    "title": "Role Based Access Control",
+    "license": {
+      "name": "AGPL-3.0",
+      "url": "https://opensource.org/licenses/AGPL-3.0"
+    }
+  },
+  "security": [
+    {
+      "basic_auth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Principal",
+      "description": "Operations about principals"
+    },
+    {
+      "name": "Group",
+      "description": "Operations about groups"
+    },
+    {
+      "name": "Role",
+      "description": "Operations about roles"
+    },
+    {
+      "name": "Policy",
+      "description": "Operations about policies"
+    },
+    {
+      "name": "Access",
+      "description": "Operations about access"
+    },
+    {
+      "name": "Status",
+      "description": "Operations about status"
+    }
+  ],
+  "paths": {
+    "/status/": {
+      "get": {
+        "tags": [
+          "Status"
+        ],
+        "summary": "Obtain server status",
+        "operationId": "getStatus",
+        "responses": {
+          "200": {
+            "description": "An object describing the server status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Status"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/principals/": {
+      "get": {
+        "tags": [
+          "Principal"
+        ],
+        "summary": "List the principals for a tenant",
+        "description": "By default, responses are sorted in ascending order by username",
+        "operationId": "listPrincipals",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "in": "query",
+            "name": "match_criteria",
+            "required": false,
+            "description": "Parameter for specifying the matching criteria for an object's name or email.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "partial",
+                "exact"
+              ],
+              "default": "exact"
+            }
+          },
+          {
+            "name": "usernames",
+            "in": "query",
+            "description": "Comma separated usernames of principals to get. If match_criteria is specified, only the first username will be picked up for search.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "userA,userB"
+            }
+          },
+
+          {
+            "name": "sort_order",
+            "in": "query",
+            "description": "The sort order of the query, either ascending or descending. Defaults to ascending.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["asc", "desc"]
+            }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "description": "E-mail address of principal to search for. Could be combined with match_criteria for searching.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Set the status of users to get back. Could not be used with: usernames, email, admin_only",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
+              "default": "enabled"
+            }
+          },
+          {
+            "name": "admin_only",
+            "in": "query",
+            "description": "Get only admin users within an account. Setting this would ignore the parameters: usernames, email",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "default": "false"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "description": "Parameter for ordering principals by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-username",
+            "schema": {
+              "type": "string",
+              "enum": ["username"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of principals",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrincipalPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to list principals",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/": {
+      "post": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Create a group in a tenant",
+        "operationId": "createGroup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Group"
+              }
+            }
+          },
+          "description": "Group to create in tenant",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "An object describing the group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to create group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "List the groups for a tenant",
+        "description": "By default, responses are sorted in ascending order by group name",
+        "operationId": "listGroups",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/NameFilter"
+          },
+          {
+            "$ref": "#/components/parameters/NameMatchCriteria"
+          },
+          {
+            "$ref": "#/components/parameters/ScopeFilter"
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "A username for a principal to filter for groups",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "uuid",
+            "in": "query",
+            "description": "A list of UUIDs to filter listed groups.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explode": false,
+            "style": "form"
+          },
+          {
+            "name": "role_names",
+            "in": "query",
+            "description": "List of role name to filter for groups. It is exact match but case-insensitive",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explode": false,
+            "style": "form"
+          },
+          {
+            "name": "role_discriminator",
+            "in": "query",
+            "description": "Discriminator that works with role_names to indicate matching all/any of the role names",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "any"]
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "description": "Parameter for ordering groups by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-name",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "modified",
+                "principalCount",
+                "policyCount"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of group objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to list groups",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{uuid}/": {
+      "get": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Get a group in the tenant",
+        "operationId": "getGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to get",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A Group object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupWithPrincipalsAndRoles"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to get group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Udate a group in the tenant",
+        "operationId": "updateGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Group"
+              }
+            }
+          },
+          "description": "Group to update in tenant",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Group updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to update group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Delete a group in the tenant",
+        "operationId": "deleteGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Group deleted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to delete group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{uuid}/principals/": {
+      "post": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Add a principal to a group in the tenant",
+        "operationId": "addPrincipalToGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/GroupPrincipalIn"
+        },
+        "responses": {
+          "200": {
+            "description": "Group updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupWithPrincipalsAndRoles"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to update principals in group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Get a list of principals from a group in the tenant",
+        "description": "By default, responses are sorted in ascending order by username",
+        "operationId": "getPrincipalsFromGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group from which to get principals",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "principal_username",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group principals by principal `username` using string contains search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "description": "Parameter for ordering principals by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-username",
+            "schema": {
+              "type": "string",
+              "enum": ["username"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of principals attached to group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrincipalPagination"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Remove a principal from a group in the tenant",
+        "operationId": "deletePrincipalFromGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "usernames",
+            "in": "query",
+            "description": "A comma separated list of usernames for principals to remove from the group",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Principals removed from group"
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to remove principals from group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{uuid}/roles/": {
+      "get": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "List the roles for a group in the tenant",
+        "description": "By default, responses are sorted in ascending order by role name",
+        "operationId": "listRolesForGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "exclude",
+            "in": "query",
+            "description": "If this is set to true, the result would be roles excluding the ones in the group",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "role_name",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group roles by role `name` using string contains search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "role_display_name",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group roles by role `display_name` using string contains search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "role_description",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for filtering group roles by role `description` using string contains search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "description": "Parameter for ordering roles by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-name",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "display_name",
+                "modified",
+                "policyCount"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of roles for a group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupRolesPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to list roles for group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Add a role to a group in the tenant",
+        "operationId": "addRoleToGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/GroupRoleIn"
+        },
+        "responses": {
+          "200": {
+            "description": "Group updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RoleOut"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to update roles for group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Remove a role from a group in the tenant",
+        "operationId": "deleteRoleFromGroup",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of group to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "roles",
+            "in": "query",
+            "description": "A comma separated list of role UUIDs for roles to remove from the group",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Roles removed from group"
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to remove roles from group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/roles/": {
+      "post": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "Create a roles for a tenant",
+        "operationId": "createRoles",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoleIn"
+              }
+            }
+          },
+          "description": "Role to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "An object describing the role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleWithAccess"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to create role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "List the roles for a tenant",
+        "description": "By default, responses are sorted in ascending order by role name",
+        "operationId": "listRoles",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/NameFilter"
+          },
+          {
+            "in": "query",
+            "name": "display_name",
+            "required": false,
+            "description": "Parameter for filtering resource by display_name using string contains search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/NameMatchCriteria"
+          },
+          {
+            "$ref": "#/components/parameters/ScopeFilter"
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "description": "Parameter for ordering roles by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-name",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "display_name",
+                "modified",
+                "policyCount"
+              ]
+            }
+          },
+          {
+            "name": "add_fields",
+            "in": "query",
+            "required": false,
+            "description": "Parameter for add list of fields to display for roles.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "groups_in",
+                  "groups_in_count"
+                ]
+              }
+            },
+            "explode": false,
+            "style": "form"
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "Unique username of the principal to obtain roles for (only available for admins, and if supplied, takes precedence over the identity header).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "application",
+            "in": "query",
+            "description": "The application name(s) to filter roles by, from permissions. This is an exact match. You may also use a comma-separated list to match on multiple applications.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "description": "The permission(s) to filter roles by. This is an exact match. You may also use a comma-separated list to match on multiple permissions.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of role objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RolePaginationDynamic"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to list roles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/roles/{uuid}/": {
+      "get": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "Get a role in the tenant",
+        "operationId": "getRole",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of role to get",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/ScopeFilter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A Role object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleWithAccess"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to get role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "Delete a role in the tenant",
+        "operationId": "deleteRole",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of role to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Role deleted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to delete role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "Update a Role in the tenant",
+        "operationId": "updateRole",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of role to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoleWithAccess"
+              }
+            }
+          },
+          "description": "Update to a Role",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Role updated"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to update role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "Patch a Role in the tenant",
+        "operationId": "patchRole",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of role to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RolePatch"
+              }
+            }
+          },
+          "description": "Patch to a Role"
+        },
+        "responses": {
+          "200": {
+            "description": "Role patched",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleWithAccess"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to patch role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/roles/{uuid}/access/": {
+      "get": {
+        "tags": [
+          "Role"
+        ],
+        "summary": "Get access for a role in the tenant",
+        "operationId": "getRoleAccess",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of the role",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of the access objects for a role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to get access for role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/": {
+      "post": {
+        "tags": [
+          "Policy"
+        ],
+        "summary": "Create a policy in a tenant",
+        "operationId": "createPolicies",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyIn"
+              }
+            }
+          },
+          "description": "Policy to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "An object describing the policy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyExtended"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Policy"
+        ],
+        "summary": "List the policies in the tenant",
+        "description": "By default, responses are sorted in ascending order by policy name",
+        "operationId": "listPolicies",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/NameFilter"
+          },
+          {
+            "$ref": "#/components/parameters/ScopeFilter"
+          },
+          {
+            "$ref": "#/components/parameters/GroupNameFilter"
+          },
+          {
+            "$ref": "#/components/parameters/GroupUUIDFilter"
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "description": "Parameter for ordering policies by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-name",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "modified"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of policy objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{uuid}/": {
+      "get": {
+        "tags": [
+          "Policy"
+        ],
+        "summary": "Get a policy in the tenant",
+        "operationId": "getPolicy",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of policy to get",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A Policy object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyExtended"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Policy"
+        ],
+        "summary": "Update a policy in the tenant",
+        "operationId": "updatePolicy",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of policy to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyIn"
+              }
+            }
+          },
+          "description": "Policy to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A Policy object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyExtended"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Policy"
+        ],
+        "summary": "Delete a policy in the tenant",
+        "operationId": "deletePolicy",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "ID of policy to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Policy deleted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/access/": {
+      "get": {
+        "tags": [
+          "Access"
+        ],
+        "summary": "Get the permitted access for a principal in the tenant (defaults to principal from the identity header)",
+        "description": "Access responses are sorted in ascending order by an ID internal to the database",
+        "operationId": "getPrincipalAccess",
+        "parameters": [
+          {
+            "name": "application",
+            "in": "query",
+            "description": "The application name(s) to obtain access for the principal. This is an exact match. When no application is supplied, all permissions for the principal are returned. You may also use a comma-separated list to match on multiple applications.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "Unique username of the principal to obtain access for (only available for admins, and if supplied, takes precedence over the identity header).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of access objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/permissions/": {
+      "get": {
+        "tags": [
+          "Permission"
+        ],
+        "summary": "List the permissions for a tenant",
+        "description": "By default, responses are sorted in ascending order by permission application.",
+        "operationId": "listPermissions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "description": "Parameter for ordering permissions by value. For inverse ordering, supply '-' before the param value, such as: ?order_by=-application",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application",
+                "resource_type",
+                "verb",
+                "permission"
+              ]
+            }
+          },
+          {
+            "name": "application",
+            "in": "query",
+            "description": "Exact match for the application name of a permission. You may also use a comma-separated list to match on multiple applications.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "resource_type",
+            "in": "query",
+            "description": "Exact match for the resource type name of a permission. You may also use a comma-separated list to match on multiple resource_types.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "verb",
+            "in": "query",
+            "description": "Exact match for the operation verb name of a permission You may also use a comma-separated list to match on multiple verbs.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "description": "Partial match for the aggregate permission value name of a permission object.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exclude_globals",
+            "in": "query",
+            "description": "If set to 'true', this will exclude any permission with a global allowance on either 'application', 'resource_type' or 'verb'. The default is 'false'.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "false",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of permission objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to list permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/permissions/options/": {
+      "get": {
+        "tags": [
+          "Permission"
+        ],
+        "summary": "List the available options for fields of permissions for a tenant",
+        "description": "By default, options of application is returned. And could be resource_type or verb on demand.",
+        "operationId": "listPermissionOptions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "name": "field",
+            "in": "query",
+            "description": "specify which fields of permission to display",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application",
+                "resource_type",
+                "verb"
+              ]
+            }
+          },
+          {
+            "name": "application",
+            "in": "query",
+            "description": "Filter returned options based on application. You may also use a comma-separated list to filter on multiple applications.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "resource_type",
+            "in": "query",
+            "description": "Filter returned options based on resource_type. You may also use a comma-separated list to filter on multiple resource_types.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "verb",
+            "in": "query",
+            "description": "Filter returned options based on verb. You may also use a comma-separated list to filter on multiple verbs.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of options for field of permission",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionOptionsPagination"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to list permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "/api/rbac/v1"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "QueryOffset": {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "description": "Parameter for selecting the offset of data.",
+        "schema": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0
+        }
+      },
+      "QueryLimit": {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "description": "Parameter for selecting the amount of data returned.",
+        "schema": {
+          "type": "integer",
+          "default": 10,
+          "minimum": 1,
+          "maximum": 1000
+        }
+      },
+      "NameFilter": {
+        "in": "query",
+        "name": "name",
+        "required": false,
+        "description": "Parameter for filtering resource by name using string contains search.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "GroupNameFilter": {
+        "in": "query",
+        "name": "group_name",
+        "required": false,
+        "description": "Parameter for filtering resource by group name using string contains search.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "GroupUUIDFilter": {
+        "in": "query",
+        "name": "group_uuid",
+        "required": false,
+        "description": "Parameter for filtering resource by group uuid using UUID exact match.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "ScopeFilter": {
+        "in": "query",
+        "name": "scope",
+        "required": false,
+        "description": "Parameter for filtering resource by scope.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "account",
+            "principal"
+          ],
+          "default": "account"
+        }
+      },
+      "NameMatchCriteria": {
+        "in": "query",
+        "name": "name_match",
+        "required": false,
+        "description": "Parameter for specifying the matching criteria for an object's name or display_name.",
+        "schema": {
+          "type": "string",
+          "enum": ["partial", "exact"]
+        }
+      }
+    },
+    "requestBodies": {
+      "GroupPrincipalIn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GroupPrincipalIn"
+            }
+          }
+        },
+        "description": "Principal to add to a group",
+        "required": true
+      },
+      "GroupRoleIn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GroupRoleIn"
+            }
+          }
+        },
+        "description": "Role to add to a group",
+        "required": true
+      }
+    },
+    "securitySchemes": {
+      "basic_auth": {
+        "type": "http",
+        "description": "The userid/password is needed when accessing this API externally",
+        "scheme": "basic"
+      }
+    },
+    "schemas": {
+      "Error": {
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "detail": {
+                  "type": "string",
+                  "example": "Not found."
+                },
+                "status": {
+                  "type": "string",
+                  "example": "403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Error403": {
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "detail": {
+                  "type": "string",
+                  "example": "You do not have permission to perform this action."
+                },
+                "source": {
+                  "type": "string",
+                  "example": "detail"
+                },
+                "status": {
+                  "type": "string",
+                  "example": "403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "UUID": {
+        "type": "object",
+        "required": [
+          "uuid"
+        ],
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "format": "uuid",
+            "example": "57e60f90-8c0c-4bd1-87a0-2143759aae1c"
+          }
+        }
+      },
+      "Timestamped": {
+        "type": "object",
+        "required": [
+          "created",
+          "modified"
+        ],
+        "properties": {
+          "created": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2019-01-21T17:32:28Z"
+          },
+          "modified": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2019-03-04T07:25:58Z"
+          }
+        }
+      },
+      "PaginationMeta": {
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "example": 30
+          }
+        }
+      },
+      "PaginationLinks": {
+        "properties": {
+          "first": {
+            "type": "string",
+            "format": "uri",
+            "example": "/api/v1/(resources)/?offset=0&limit=10"
+          },
+          "previous": {
+            "type": "string",
+            "format": "uri",
+            "example": "/api/v1/(resources)/?offset=20&limit=10"
+          },
+          "next": {
+            "type": "string",
+            "format": "uri",
+            "example": "/api/v1/(resources)/?offset=40&limit=10"
+          },
+          "last": {
+            "type": "string",
+            "format": "uri",
+            "example": "/api/v1/(resources)/?offset=90&limit=10"
+          }
+        }
+      },
+      "ListPagination": {
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "links": {
+            "$ref": "#/components/schemas/PaginationLinks"
+          }
+        }
+      },
+      "Principal": {
+        "required": [
+          "username",
+          "email"
+        ],
+        "properties": {
+          "username": {
+            "type": "string",
+            "example": "smithj"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "smithj@mytechco.com"
+          },
+          "first_name": {
+            "type": "string",
+            "example": "John"
+          },
+          "last_name": {
+            "type": "string",
+            "example": "Smith"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "is_org_admin": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PrincipalIn": {
+        "required": [
+          "username"
+        ],
+        "properties": {
+          "username": {
+            "type": "string",
+            "example": "smithj"
+          }
+        }
+      },
+      "PrincipalOut": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Principal"
+          },
+          {
+            "$ref": "#/components/schemas/UUID"
+          }
+        ]
+      },
+      "PrincipalPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Principal"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Group": {
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "GroupA"
+          },
+          "description": {
+            "type": "string",
+            "example": "A description of GroupA"
+          }
+        }
+      },
+      "AdditionalGroup": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "GroupA"
+          },
+          "description": {
+            "type": "string",
+            "example": "GroupA Description"
+          },
+          "uuid": {
+            "type": "string",
+            "example": "234df936-abb4-4238-a1c9-d91fc540c702"
+          }
+        }
+      },
+      "GroupOut": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Group"
+          },
+          {
+            "$ref": "#/components/schemas/UUID"
+          },
+          {
+            "$ref": "#/components/schemas/Timestamped"
+          },
+          {
+            "properties": {
+              "principalCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "roleCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "system": {
+                "type": "boolean",
+                "default": false
+              },
+              "platform_default": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          }
+        ]
+      },
+      "GroupPrincipalIn": {
+        "required": [
+          "principals"
+        ],
+        "properties": {
+          "principals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrincipalIn"
+            }
+          }
+        }
+      },
+      "GroupRoleIn": {
+        "required": [
+          "roles"
+        ],
+        "properties": {
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "example": "94846f2f-cced-474f-b7f3-47e2ec51dd11"
+            }
+          }
+        }
+      },
+      "GroupWithPrincipals": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Group"
+          },
+          {
+            "$ref": "#/components/schemas/UUID"
+          },
+          {
+            "$ref": "#/components/schemas/Timestamped"
+          },
+          {
+            "type": "object",
+            "required": [
+              "principals"
+            ],
+            "properties": {
+              "principals": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Principal"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GroupWithPrincipalsAndRoles": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Group"
+          },
+          {
+            "$ref": "#/components/schemas/UUID"
+          },
+          {
+            "$ref": "#/components/schemas/Timestamped"
+          },
+          {
+            "type": "object",
+            "required": [
+              "principals",
+              "roles"
+            ],
+            "properties": {
+              "principals": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Principal"
+                }
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RoleOut"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GroupRolesPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RoleOut"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GroupPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GroupOut"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ResourceDefinitionFilter": {
+        "required": [
+          "key",
+          "operation",
+          "value"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "example": "cost-management.aws.account"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "equal",
+              "in"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "example": "123456"
+          }
+        }
+      },
+      "ResourceDefinition": {
+        "required": [
+          "attributeFilter"
+        ],
+        "properties": {
+          "attributeFilter": {
+            "$ref": "#/components/schemas/ResourceDefinitionFilter"
+          }
+        }
+      },
+      "Access": {
+        "required": [
+          "permission",
+          "resourceDefinitions"
+        ],
+        "properties": {
+          "permission": {
+            "type": "string",
+            "example": "cost-management:*:read"
+          },
+          "resourceDefinitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceDefinition"
+            }
+          }
+        }
+      },
+      "Role": {
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "RoleA"
+          },
+          "display_name": {
+            "type": "string",
+            "example": "ARoleName"
+          },
+          "description": {
+            "type": "string",
+            "example": "A description of RoleA"
+          }
+        }
+      },
+      "RoleIn": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Role"
+          },
+          {
+            "type": "object",
+            "required": [
+              "access"
+            ],
+            "properties": {
+              "access": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Access"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "RolePagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RoleOut"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "RolePaginationDynamic": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RoleOutDynamic"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "RoleOut": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Role"
+          },
+          {
+            "$ref": "#/components/schemas/UUID"
+          },
+          {
+            "$ref": "#/components/schemas/Timestamped"
+          },
+          {
+            "properties": {
+              "policyCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "accessCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "applications": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "catalog"
+                }
+              },
+              "system": {
+                "type": "boolean",
+                "default": false
+              },
+              "platform_default": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          }
+        ]
+      },
+      "RoleOutDynamic": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Role"
+          },
+          {
+            "$ref": "#/components/schemas/UUID"
+          },
+          {
+            "$ref": "#/components/schemas/Timestamped"
+          },
+          {
+            "type": "object",
+            "required": [
+              "policyCount",
+              "accessCount",
+              "applications",
+              "system",
+              "platform_default"
+            ],
+            "properties": {
+              "policyCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "accessCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "applications": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "catalog"
+                }
+              },
+              "system": {
+                "type": "boolean",
+                "default": false
+              },
+              "platform_default": {
+                "type": "boolean",
+                "default": false
+              },
+              "groups_in_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "groups_in": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AdditionalGroup"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "RolePatch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "RoleA"
+          },
+          "display_name": {
+            "type": "string",
+            "example": "ARoleName"
+          },
+          "description": {
+            "type": "string",
+            "example": "A description of RoleA"
+          }
+        }
+      },
+      "RoleWithAccess": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoleOut"
+          },
+          {
+            "type": "object",
+            "required": [
+              "access"
+            ],
+            "properties": {
+              "access": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Access"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Policy": {
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "PolicyA"
+          },
+          "description": {
+            "type": "string",
+            "example": "A description of PolicyA"
+          }
+        }
+      },
+      "PolicyIn": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Policy"
+          },
+          {
+            "type": "object",
+            "required": [
+              "group",
+              "roles"
+            ],
+            "properties": {
+              "group": {
+                "type": "string",
+                "format": "uuid",
+                "example": "83ee048e-3c1d-43ef-b945-108225ae52f4"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid",
+                  "example": "94846f2f-cced-474f-b7f3-47e2ec51dd11"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "PolicyExtended": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Policy"
+          },
+          {
+            "$ref": "#/components/schemas/UUID"
+          },
+          {
+            "$ref": "#/components/schemas/Timestamped"
+          },
+          {
+            "type": "object",
+            "required": [
+              "group",
+              "roles"
+            ],
+            "properties": {
+              "group": {
+                "$ref": "#/components/schemas/GroupOut"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RoleOut"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "PolicyPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PolicyExtended"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "AccessPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Access"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Status": {
+        "required": [
+          "api_version"
+        ],
+        "properties": {
+          "api_version": {
+            "type": "integer",
+            "format": "int64",
+            "example": 1
+          },
+          "commit": {
+            "type": "string",
+            "example": "178d2ea"
+          },
+          "server_address": {
+            "type": "string",
+            "example": "127.0.0.1:8000"
+          },
+          "platform_info": {
+            "type": "object",
+            "example": {
+              "system": "Darwin",
+              "node": "node-1.example.com",
+              "release": "17.5.0",
+              "version": "Darwin Kernel Version 17.5.0",
+              "machine": "x86_64",
+              "processor": "i386"
+            }
+          },
+          "python_version": {
+            "type": "string",
+            "example": "3.6.1"
+          },
+          "modules": {
+            "type": "object",
+            "example": {
+              "coverage": "4.5.1",
+              "coverage.version": "4.5.1",
+              "coverage.xmlreport": "4.5.1",
+              "cryptography": "2.0.3",
+              "ctypes": "1.1.0",
+              "ctypes.macholib": "1.0",
+              "decimal": "1.70",
+              "django": "1.11.5",
+              "django.utils.six": "1.10.0",
+              "django_filters": "1.0.4",
+              "http.server": "0.6"
+            }
+          }
+        }
+      },
+      "Permission": {
+        "properties": {
+          "application": {
+            "type": "string",
+            "example": "rbac"
+          },
+          "resource_type": {
+            "type": "string",
+            "example": "group"
+          },
+          "verb": {
+            "type": "string",
+            "example": "read"
+          },
+          "permission": {
+            "type": "string",
+            "example": "rbac:group:read"
+          },
+          "description": {
+            "type": "string",
+            "example": "Describe the usage of permission."
+          }
+        }
+      },
+      "PermissionPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Permission"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "PermissionOptionsPagination": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ListPagination"
+          },
+          {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,7 +24,6 @@ ext.plugins = [
         "com.diffplug.spotless:spotless-plugin-gradle:6.4.1",
         "com.github.davidmc24.gradle.plugin:gradle-avro-plugin:1.3.0",
         "com.netflix.nebula:nebula-release-plugin:16.0.0",
-        "de.undercouch:gradle-download-task:5.0.4",
         "io.quarkus:gradle-application-plugin:2.7.5.Final",
         "io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE",
         "org.jsonschema2pojo:jsonschema2pojo-gradle-plugin:1.1.1",


### PR DESCRIPTION
Update the build to remove the download of an external API spec during
compilation. This speeds up the build and prevents the need to download
from an external repository for a source file during our compilation.
The upside is that if all the dependencies have been downloaded we
no longer make network calls during a regular build. In addition it
allows us to remove an external gradle plugin from our configuration.

This requires us to be more intentional about when we update clients
for the one of 3 updates that was pointing to the latest from a
repository instead of a particular git hash. It does bring consistency
so that now all of the API clients that we interact with are being built
in house.