### PR TITLE
ENT-4688: add billing provider to instance api

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -963,12 +963,19 @@ components:
   schemas:
     # Schemas ending in "Type" are intentionally named to prevent naming conflicts with db model classes
     GranularityType:
+      description: "Describes the significance of each date in the snapshot list. For example if the
+          granularity is set to 'weekly', the dates in the snapshot list will represent the start
+          of a seven day period."
       type: string
       enum: [ Hourly, Daily, Weekly, Monthly, Quarterly, Yearly ]
     ServiceLevelType:
+      description: "Describes the service level that the report was made against. Not set if it
+          wasn't specified as a query parameter."
       type: string
       enum: [ "", Premium, Standard, Self-Support, _ANY ]
     UsageType:
+      description: "Describes the usage that the report was made against. Not set if it wasn't
+          specified as a query parameter."
       type: string
       enum: [ "", Production, Development/Test, Disaster Recovery, _ANY ]
     BillingProviderType:
@@ -1009,6 +1016,7 @@ components:
         - virtual
         - cloud
     Uom:
+      description: "The unit-of-measure for the capacity."
       type: string
       enum:
         - cores
@@ -1189,17 +1197,10 @@ components:
               $ref: '#/components/schemas/ProductId'
             service_level:
               $ref: '#/components/schemas/ServiceLevelType'
-              description: "Describes the service level that the report was made against. Not set if it wasn't
-                specified as a query parameter."
             usage:
               $ref: '#/components/schemas/UsageType'
-              description: "Describes the usage that the report was made against. Not set if it wasn't
-                            specified as a query parameter."
             granularity:
               $ref: '#/components/schemas/GranularityType'
-              description: "Describes the significance of each date in the TallySnapshot list. For example if the
-                              granularity is set to 'weekly', the dates in the TallySnapshot list will represent the start of a
-                              seven day period."
           required:
             - count
             - product
@@ -1326,17 +1327,10 @@ components:
               $ref: '#/components/schemas/ProductId'
             granularity:
               $ref: '#/components/schemas/GranularityType'
-              description: "Describes the significance of each date in the CapacitySnapshot list. For example if the
-                granularity is set to 'weekly', the dates in the CapacitySnapshot list will represent the start of a
-                seven day period."
             service_level:
               $ref: '#/components/schemas/ServiceLevelType'
-              description: "Describes the service level that the report was made against. Not set if it wasn't
-                specified as a query parameter."
             usage:
               $ref: '#/components/schemas/UsageType'
-              description: "Describes the usages that the report was made against. Not set if it wasn't
-               specified as a query parameter."
           required:
             - count
             - product
@@ -1415,13 +1409,8 @@ components:
               $ref: '#/components/schemas/ProductId'
             service_level:
               $ref: '#/components/schemas/ServiceLevelType'
-              description: "Describes the service level that the report was made against. Not set if it wasn't
-                    specified as a query parameter."
-              type: string
             usage:
               $ref: '#/components/schemas/UsageType'
-              description: "Describes the usages that the report was made against. Not set if it wasn't
-                   specified as a query parameter."
             uom:
               $ref: '#/components/schemas/Uom'
           required:
@@ -1539,10 +1528,6 @@ components:
           $ref: '#/components/schemas/PageLinks'
         meta:
           $ref: '#/components/schemas/InstanceMeta'
-          properties:
-            count:
-              format: int32
-              type: integer
       example:
         data:
           - inventory_id: d6214a0b-b344-4778-831c-d53dcacb2da3
@@ -1673,6 +1658,7 @@ components:
         - Annual
 
     SubscriptionEventType:
+      description: "The most immediate subscription event, such as a subscription beginning or ending."
       type: string
       enum:
         - Subscription Start
@@ -1707,7 +1693,6 @@ components:
           type: string
           format: date-time
         next_event_type:
-          description: "The most immediate subscription event, such as a subscription beginning or ending."
           $ref: "#/components/schemas/SubscriptionEventType"
         quantity:
           description: "The summed subscription quantities across the active subscriptions for the offering."
@@ -1729,7 +1714,6 @@ components:
           description: "Denotes unlimited capacity for the offering when true."
           type: boolean
         uom:
-          description: "The unit-of-measure for the capacity."
           $ref: "#/components/schemas/Uom"
 
     SkuCapacityReportSort:
@@ -1761,11 +1745,8 @@ components:
               $ref: '#/components/schemas/ProductId'
             service_level:
               $ref: '#/components/schemas/ServiceLevelType'
-              description: "The service level that the report was made against. Not set if it wasn't specified as a query parameter."
-              type: string
             usage:
               $ref: '#/components/schemas/UsageType'
-              description: "The usage that the report was made against. Not set if it wasn't specified as a query parameter."
             uom:
               $ref: '#/components/schemas/Uom'
             subscription_type:

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -694,6 +694,11 @@ paths:
           schema:
             $ref: '#/components/schemas/UsageType'
           description: "Include only hosts for the specified usage level."
+        - name: billing_provider
+          in: query
+          schema:
+            $ref: '#/components/schemas/BillingProviderType'
+          description: "Include only hosts for the specified billing provider."
         - name: display_name_contains
           description: Include only hosts containing the specified display name. Passing an empty string behaves the same way as passing null
           schema:
@@ -1502,6 +1507,8 @@ components:
           $ref: '#/components/schemas/ServiceLevelType'
         usage:
           $ref: '#/components/schemas/UsageType'
+        billing_provider:
+          $ref: '#/components/schemas/BillingProviderType'
         measurements:
           type: array
           items:
@@ -1555,6 +1562,7 @@ components:
         - Instance-hours
         - Storage-gibibytes
         - Transfer-gibibytes
+        - billing_provider
     InstanceData:
       title: Root Type for Instance
       description: The representation of a product cluster data
@@ -1564,6 +1572,8 @@ components:
           type: string
         display_name:
           type: string
+        billing_provider:
+          $ref: '#/components/schemas/BillingProviderType'
         measurements:
           description: >-
             Must be in the same order as "measurements" in the meta. (i.e. in the example

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -190,6 +190,7 @@ public class HostsResource implements HostsApi {
               minSockets,
               month,
               referenceUom,
+              null,
               page);
       payload =
           ((Page<Host>) hosts)

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -22,12 +22,18 @@ package org.candlepin.subscriptions.resource;
 
 import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -35,7 +41,16 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
-import org.candlepin.subscriptions.utilization.api.model.*;
+import org.candlepin.subscriptions.utilization.api.model.BillingProviderType;
+import org.candlepin.subscriptions.utilization.api.model.InstanceData;
+import org.candlepin.subscriptions.utilization.api.model.InstanceMeta;
+import org.candlepin.subscriptions.utilization.api.model.InstanceReportSort;
+import org.candlepin.subscriptions.utilization.api.model.InstanceResponse;
+import org.candlepin.subscriptions.utilization.api.model.PageLinks;
+import org.candlepin.subscriptions.utilization.api.model.ProductId;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
+import org.candlepin.subscriptions.utilization.api.model.SortDirection;
+import org.candlepin.subscriptions.utilization.api.model.UsageType;
 import org.candlepin.subscriptions.utilization.api.resources.InstancesApi;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -55,6 +70,7 @@ public class InstancesResource implements InstancesApi {
       ImmutableMap.<InstanceReportSort, String>builder()
           .put(InstanceReportSort.DISPLAY_NAME, "displayName")
           .put(InstanceReportSort.LAST_SEEN, "lastSeen")
+          .put(InstanceReportSort.BILLING_PROVIDER, "billingProvider")
           .putAll(getUomSorts())
           .build();
 
@@ -78,6 +94,7 @@ public class InstancesResource implements InstancesApi {
       Integer limit,
       ServiceLevelType sla,
       UsageType usage,
+      BillingProviderType billingProviderType,
       String displayNameContains,
       OffsetDateTime beginning,
       OffsetDateTime ending,
@@ -96,6 +113,8 @@ public class InstancesResource implements InstancesApi {
     String accountNumber = ResourceUtils.getAccountNumber();
     ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
     Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
+    BillingProvider sanitizedBilling = ResourceUtils.sanitizeBillingProvider(billingProviderType);
+
     String sanitizedDisplayNameSubstring =
         Objects.nonNull(displayNameContains) ? displayNameContains : "";
 
@@ -133,6 +152,7 @@ public class InstancesResource implements InstancesApi {
             minSockets,
             month,
             referenceUom,
+            sanitizedBilling,
             page);
     payload =
         hosts.getContent().stream()
@@ -154,6 +174,7 @@ public class InstancesResource implements InstancesApi {
                 .product(productId)
                 .serviceLevel(sla)
                 .usage(usage)
+                .billingProvider(billingProviderType)
                 .measurements(measurements))
         .data(payload);
   }
@@ -173,6 +194,10 @@ public class InstancesResource implements InstancesApi {
     List<Double> measurementList = new ArrayList<>();
     instance.setId(host.getInstanceId());
     instance.setDisplayName(host.getDisplayName());
+
+    if (Objects.nonNull(host.getBillingProvider())) {
+      instance.setBillingProvider(host.getBillingProvider().asOpenApiEnum());
+    }
 
     for (String uom : measurements) {
       measurementList.add(host.getMonthlyTotal(monthId, Measurement.Uom.fromValue(uom)));

--- a/src/main/resources/liquibase/202203161423-add-billing-provider-column-to-host-table.xml
+++ b/src/main/resources/liquibase/202203161423-add-billing-provider-column-to-host-table.xml
@@ -1,0 +1,14 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202203161423-1"  author="mstead">
+    <comment>Add billing_provider column to host table</comment>
+    <addColumn tableName="hosts">
+      <column name="billing_provider" type="VARCHAR(255)"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -54,6 +54,7 @@
     <include file="liquibase/202112171721-add-subscription-indexes.xml" />
     <include file="liquibase/202202041415-add-unlimited-usage-column-to-offering-table.xml" />
     <include file="liquibase/202202211433-add-billing-provider-column-to-subscription-table.xml" />
+    <include file="liquibase/202203161423-add-billing-provider-column-to-host-table.xml" />
     <include file="liquibase/202203241102-add-billing-provider-column-to-tally-snapshots.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -394,6 +394,7 @@ class HostsResourceTest {
             1,
             june2019,
             null,
+            null,
             PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))))
         .thenReturn(page);
 

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -30,6 +30,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.json.Measurement;
@@ -63,14 +64,17 @@ class InstancesResourceTest {
 
   @Test
   void testShouldPopulateInstanceResponse() {
+    BillingProvider expectedBillingProvider = BillingProvider.AWS;
+
     var host = new Host();
     host.setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     host.setDisplayName("rhv.example.com");
+    host.setBillingProvider(expectedBillingProvider);
     host.setLastSeen(OffsetDateTime.now());
 
     Mockito.when(
             repository.findAllBy(
-                any(), any(), any(), any(), any(), anyInt(), anyInt(), any(), any(), any()))
+                any(), any(), any(), any(), any(), anyInt(), anyInt(), any(), any(), any(), any()))
         .thenReturn(new PageImpl<>(List.of(host)));
 
     var expectUom = List.of("Instance-hours", "Storage-gibibytes", "Transfer-gibibytes");
@@ -82,6 +86,7 @@ class InstancesResourceTest {
     var data = new InstanceData();
     data.setId(host.getInstanceId());
     data.setDisplayName(host.getDisplayName());
+    data.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
     data.setLastSeen(host.getLastSeen());
     data.setMeasurements(expectedMeasurement);
 
@@ -91,6 +96,7 @@ class InstancesResourceTest {
     meta.setServiceLevel(ServiceLevelType.PREMIUM);
     meta.setUsage(UsageType.PRODUCTION);
     meta.setMeasurements(expectUom);
+    meta.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
 
     var expected = new InstanceResponse();
     expected.setData(List.of(data));
@@ -103,6 +109,7 @@ class InstancesResourceTest {
             null,
             ServiceLevelType.PREMIUM,
             UsageType.PRODUCTION,
+            expectedBillingProvider.asOpenApiEnum(),
             null,
             null,
             null,

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -21,9 +21,11 @@
 package org.candlepin.subscriptions.db;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
+import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.HostBucketKey_;
 import org.candlepin.subscriptions.db.model.HostTallyBucket_;
@@ -128,6 +130,7 @@ public interface HostRepository
       @Param("minSockets") int minSockets,
       String month,
       Uom referenceUom,
+      BillingProvider billingProvider,
       Pageable pageable) {
 
     HostSpecification searchCriteria = new HostSpecification();
@@ -156,6 +159,11 @@ public interface HostRepository
                 new InstanceMonthlyTotalKey(month, effectiveUom),
                 SearchOperation.EQUAL));
       }
+    }
+
+    if (Objects.nonNull(billingProvider)) {
+      searchCriteria.add(
+          new SearchCriteria(Host_.BILLING_PROVIDER, billingProvider, SearchOperation.EQUAL));
     }
 
     return findAll(searchCriteria, pageable);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillingProvider.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillingProvider.java
@@ -25,6 +25,7 @@ import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 import org.candlepin.subscriptions.utilization.api.model.BillingProviderType;
 
+/** Billing provider associated with a host. */
 public enum BillingProvider implements StringValueEnum<BillingProviderType> {
   EMPTY("", BillingProviderType.EMPTY),
   RED_HAT("Red hat", BillingProviderType.RED_HAT),
@@ -55,6 +56,7 @@ public enum BillingProvider implements StringValueEnum<BillingProviderType> {
     return StringValueEnum.getValueOf(BillingProvider.class, VALUE_ENUM_MAP, value, EMPTY);
   }
 
+  @Override
   public String getValue() {
     return value;
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -150,6 +150,9 @@ public class Host implements Serializable {
   @Column(name = "instance_type")
   private String instanceType;
 
+  @Column(name = "billing_provider")
+  private BillingProvider billingProvider;
+
   public Host() {}
 
   public Host(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -149,7 +149,7 @@ public class ResourceUtils {
    * Uses BillingProvider.ANY for a null value, otherwise returns db model equivalent of
    * BillingProviderType generated enum
    *
-   * @param billingProvider string form of sla
+   * @param billingProvider string form of billing provider
    * @return BilligProvider enum
    */
   public static BillingProvider sanitizeBillingProvider(BillingProviderType billingProvider) {


### PR DESCRIPTION
Question: Do we want to set a default value and non-null constraint on the billing provider column in the hosts table like we did in the tally_snapshots table?  Currently, this code does not since that's the way @mstead had it in his branch.