### PR TITLE
ENT-4686: add aws payg subscription identifiers when syncing

### DIFF
--- a/clients/subscription-client/subscription-api-spec.yaml
+++ b/clients/subscription-client/subscription-api-spec.yaml
@@ -150,3 +150,9 @@ components:
           type: string
         subscriptionID:
           type: string
+        customerID:
+          type: string
+        productCode:
+          type: string
+        sellerAccount:
+          type: string

--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.subscription;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import org.candlepin.subscriptions.subscription.api.model.ExternalReference;
 import org.candlepin.subscriptions.subscription.api.model.Subscription;
 import org.candlepin.subscriptions.subscription.api.model.SubscriptionProduct;
 import org.candlepin.subscriptions.subscription.api.resources.SearchApi;
@@ -32,6 +33,9 @@ public class StubSearchApi extends SearchApi {
 
   @Override
   public Subscription getSubscriptionById(String id) throws ApiException {
+    if ("789".equals(id)) {
+      return createAwsBillingProviderData();
+    }
     return createData();
   }
 
@@ -53,6 +57,24 @@ public class StubSearchApi extends SearchApi {
         .subscriptionNumber("2253591")
         .effectiveStartDate(now.minusYears(10).toEpochSecond() * 1000L)
         .effectiveEndDate(now.plusYears(10).toEpochSecond() * 1000L)
+        .subscriptionProducts(List.of(new SubscriptionProduct().sku("sku")));
+  }
+
+  private Subscription createAwsBillingProviderData() {
+    var now = OffsetDateTime.now();
+    ExternalReference awsRef = new ExternalReference();
+    awsRef.setCustomerID("customer123");
+    awsRef.setProductCode("testProductCode123");
+    awsRef.setSellerAccount("testSellerAccount123");
+    return new Subscription()
+        .id(235252)
+        .quantity(1)
+        .webCustomerId(123)
+        .oracleAccountNumber(123)
+        .subscriptionNumber("4243626")
+        .effectiveStartDate(now.minusYears(10).toEpochSecond() * 1000L)
+        .effectiveEndDate(now.plusYears(10).toEpochSecond() * 1000L)
+        .putExternalReferencesItem("aws", awsRef)
         .subscriptionProducts(List.of(new SubscriptionProduct().sku("sku")));
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -143,7 +143,7 @@ public class SubscriptionSyncController {
                   .quantity(subscription.getQuantity())
                   .startDate(OffsetDateTime.now())
                   .endDate(clock.dateFromMilliseconds(subscription.getEffectiveEndDate()))
-                  .billingProviderId(SubscriptionDtoUtil.extractRhMarketplaceId(subscription))
+                  .billingProviderId(SubscriptionDtoUtil.extractBillingProviderId(subscription))
                   .subscriptionNumber(subscription.getSubscriptionNumber())
                   .billingProvider(SubscriptionDtoUtil.populateBillingProvider(subscription))
                   .build();
@@ -267,7 +267,7 @@ public class SubscriptionSyncController {
         .quantity(subscription.getQuantity())
         .startDate(clock.dateFromMilliseconds(subscription.getEffectiveStartDate()))
         .endDate(clock.dateFromMilliseconds(subscription.getEffectiveEndDate()))
-        .billingProviderId(SubscriptionDtoUtil.extractRhMarketplaceId(subscription))
+        .billingProviderId(SubscriptionDtoUtil.extractBillingProviderId(subscription))
         .billingProvider(SubscriptionDtoUtil.populateBillingProvider(subscription))
         .build();
   }

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepositoryTest.java
@@ -734,7 +734,7 @@ class SubscriptionCapacityViewRepositoryTest {
     subscription.setStartDate(startDate);
     subscription.setEndDate(endDate);
     subscription.setSubscriptionNumber(subId + "1");
-    subscription.setBillingProvider("Test_Marketplace");
+    subscription.setBillingProvider(BillingProvider.RED_HAT);
 
     return subscription;
   }

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.util.Random;
 import java.util.Set;
 import javax.transaction.Transactional;
+import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Subscription;
@@ -205,7 +206,7 @@ class SubscriptionRepositoryTest {
     subscription.setStartDate(startDate);
     subscription.setEndDate(endDate);
     subscription.setSubscriptionNumber(subId + "1");
-    subscription.setBillingProvider("Test_Marketplace");
+    subscription.setBillingProvider(BillingProvider.RED_HAT);
 
     return subscription;
   }

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtilTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtilTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.subscription.api.model.ExternalReference;
 import org.candlepin.subscriptions.subscription.api.model.SubscriptionProduct;
 import org.junit.jupiter.api.Test;
 
@@ -53,5 +55,49 @@ class SubscriptionDtoUtilTest {
     dto.setSubscriptionProducts(products);
 
     assertThrows(IllegalStateException.class, () -> SubscriptionDtoUtil.extractSku(dto));
+  }
+
+  @Test
+  void testExtractBillingProviderIdRHMarketplace() {
+    var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
+
+    ExternalReference extRef = new ExternalReference();
+    extRef.setSubscriptionID("test123");
+    dto.putExternalReferencesItem("ibmmarketplace", extRef);
+
+    assertEquals("test123", SubscriptionDtoUtil.extractBillingProviderId(dto));
+  }
+
+  @Test
+  void testExtractBillingProviderIdAWSMarketplace() {
+    var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
+
+    ExternalReference extRef = new ExternalReference();
+    extRef.setProductCode("testProduct456");
+    extRef.setCustomerID("testCustomer123");
+    extRef.setSellerAccount("testSellerAccount789");
+    dto.putExternalReferencesItem("aws", extRef);
+
+    assertEquals(
+        "testProduct456;testCustomer123;testSellerAccount789",
+        SubscriptionDtoUtil.extractBillingProviderId(dto));
+  }
+
+  @Test
+  void testExtractBillingProviderRHMarketplace() {
+    var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
+
+    dto.putExternalReferencesItem("ibmmarketplace", new ExternalReference());
+
+    assertEquals(BillingProvider.RED_HAT, SubscriptionDtoUtil.populateBillingProvider(dto));
+  }
+
+  @Test
+  void testExtractBillingProviderAWSMarketplace() {
+    var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
+
+    dto.putExternalReferencesItem("aws", new ExternalReference());
+
+    assertEquals(BillingProvider.AWS, SubscriptionDtoUtil.populateBillingProvider(dto));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -334,7 +334,7 @@ class SubscriptionSyncControllerTest {
         .quantity(subscription.getQuantity())
         .startDate(clock.dateFromMilliseconds(subscription.getEffectiveStartDate()))
         .endDate(clock.dateFromMilliseconds(subscription.getEffectiveEndDate()))
-        .billingProviderId(SubscriptionDtoUtil.extractRhMarketplaceId(subscription))
+        .billingProviderId(SubscriptionDtoUtil.extractBillingProviderId(subscription))
         .billingProvider(SubscriptionDtoUtil.populateBillingProvider(subscription))
         .build();
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -68,7 +68,7 @@ public class Subscription {
   private String accountNumber;
 
   @Column(name = "billing_provider")
-  private String billingProvider;
+  private BillingProvider billingProvider = BillingProvider.EMPTY;
 
   /** Composite ID class for Subscription entities. */
   @EqualsAndHashCode


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4686

Test Steps:

- Add test offering data:
 `INSERT INTO public.offering(
	sku, product_name, physical_cores, physical_sockets, virtual_cores, virtual_sockets, role, sla, usage, description)
	VALUES ('sku', 'OpenShift Streams for Apache Kafka', 0, 0, 0, 0, 'rhosak', 'Premium', 'Production', 'Red Hat OpenShift Streams for Apache Kafka (Hourly)');`

- Use syncSubscription method of subscriptionJmxBean passing in '789' as subscriptionId
http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.subscription-SubscriptionJmxBean-subscriptionJmxBean

- Check that subscription was created with Aws billingProvider and billingProviderId
