### PR TITLE
ENT-4709: retry tally summary messaging

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -118,6 +118,14 @@ parameters:
     value: 1s
   - name: USER_BACK_OFF_MULTIPLIER
     value: '2'
+  - name: TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS
+    value: '5'
+  - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL
+    value: 1m
+  - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER
+    value: '2'
   - name: ENV_NAME
     value: env-rhsm
 
@@ -377,6 +385,14 @@ objects:
               value: ${USER_BACK_OFF_INITIAL_INTERVAL}
             - name: USER_BACK_OFF_MULTIPLIER
               value: ${USER_BACK_OFF_MULTIPLIER}
+            - name: TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS
+              value: ${TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS}
+            - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL
+              value: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL}
+            - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL
+              value: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL}
+            - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER
+              value: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER}
             - name: RHSM_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySummaryProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySummaryProperties.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import java.time.Duration;
+import lombok.Data;
+
+@Data
+public class TallySummaryProperties {
+
+  /** How many attempts before giving up. */
+  private Integer maxAttempts;
+
+  /** Retry backoff interval. */
+  private Duration backOffInitialInterval;
+
+  /** Retry backoff interval. */
+  private Duration backOffMaxInterval;
+
+  /** Retry exponential backoff multiplier. */
+  private Double backOffMultiplier;
+}

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -2,6 +2,10 @@ CLOUDIGRADE_HOST: ${clowder.endpoints[?(@.app == 'cloudigrade')].hostname:localh
 CLOUDIGRADE_PORT: ${clowder.endpoints[?(@.app == 'cloudigrade')].port:8080}
 CLOUDIGRADE_INTERNAL_HOST: ${CLOUDIGRADE_HOST}
 CLOUDIGRADE_INTERNAL_PORT: ${CLOUDIGRADE_PORT}
+TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS: 5
+TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL: 1m
+TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL: 1s
+TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER: 2
 
 rhsm-subscriptions:
   jmx:
@@ -30,3 +34,8 @@ rhsm-subscriptions:
     internal:
       url: http://${CLOUDIGRADE_INTERNAL_HOST}:${CLOUDIGRADE_INTERNAL_PORT}/internal/api/cloudigrade/v1
       presharedKey: ${CLOUDIGRADE_PSK:}
+  tally-summary-producer:
+    back-off-initial-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL}
+    back-off-max-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL}
+    back-off-multiplier: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER}
+    max-attempts: ${TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS}

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -54,6 +54,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.retry.support.RetryTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class SnapshotSummaryProducerTest {
@@ -70,8 +71,8 @@ class SnapshotSummaryProducerTest {
   void setup() {
     props = new TaskQueueProperties();
     props.setTopic("summary-topic");
-
-    this.producer = new SnapshotSummaryProducer(kafka, props);
+    RetryTemplate retryTemplate = new RetryTemplate();
+    this.producer = new SnapshotSummaryProducer(kafka, retryTemplate, props);
   }
 
   @Test

--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -87,6 +87,14 @@ parameters:
     value: 'false'
   - name: ENABLE_ACCOUNT_RESET
     value: 'false'
+  - name: TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS
+    value: '5'
+  - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL
+    value: 1m
+  - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER
+    value: '2'
 
 objects:
   - apiVersion: v1
@@ -264,6 +272,14 @@ objects:
                   value: ${USER_BACK_OFF_INITIAL_INTERVAL}
                 - name: USER_BACK_OFF_MULTIPLIER
                   value: ${USER_BACK_OFF_MULTIPLIER}
+                - name: TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS
+                  value: ${TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS}
+                - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL
+                  value: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL}
+                - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL
+                  value: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL}
+                - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER
+                  value: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER}
                 - name: RHSM_KEYSTORE_PASSWORD
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4709

Test Steps:

- Insert Test Data: 
`INSERT INTO public.tally_snapshots(
    id, product_id, account_number, granularity, owner_id, instance_count, cores, snapshot_date, sockets, physical_cores, physical_sockets, physical_instance_count, hypervisor_cores, hypervisor_sockets, hypervisor_instance_count, sla, billing_provider)
    VALUES ('981c5ee6-1cee-4992-9e1e-437e4047efee', 'RHEL for x86', '6362381', 'DAILY', '13160362', 28, 599, '2021-04-16T00:00:00Z', 40, 12, 16, 4, 12, 4, 4,'Standard', '_ANY');`
`INSERT INTO public.tally_measurements(
    snapshot_id, measurement_type, uom, value)
    VALUES ('981c5ee6-1cee-4992-9e1e-437e4047efee', 'VIRTUAL', 'CORES', 2);`

- Stop kafka 
- Run: `curl -X 'POST' 'http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/resend' -H 'accept: application/vnd.api+json' -H 'Content-Type: application/json' -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' -d '{
  "uuids": [
    "981c5ee6-1cee-4992-9e1e-437e4047efee"
  ]
`
- Restart kafka and request should finish processing or throw error if not restarted in time.
