### PR TITLE
Update deployment configuration for PSK authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ RHSM_RBAC_USE_STUB=true ./gradlew bootRun
 * `CLOUDIGRADE_INTERNAL_PORT`: cloudigrade internal services port
 * `CLOUDIGRADE_MAX_CONNECTIONS`: max concurrent connections to cloudigrade service
 * `CLOUDIGRADE_PSK`: pre-shared key for cloudigrade authentication
-* `SWATCH_PSK`: pre-shared keys for internal service-to-service authentication
+* `SWATCH_*_PSK`: pre-shared keys for internal service-to-service authentication
+  where the `*` represents the name of an authorized service
 
 </details>
 

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -1393,11 +1393,11 @@ objects:
                   key: keystore_password
             - name: DEV_MODE
               value: ${DEV_MODE}
-            - name: SWATCH_PSKS
+            - name: SWATCH_SOURCE_PSK
               valueFrom:
                 secretKeyRef:
                   name: swatch-psks
-                  key: swatch-app-secret
+                  key: source
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -159,3 +159,6 @@ rhsm-subscriptions:
     tasks:
       topic: platform.rhsm-subscriptions.offering-sync
       kafka-group-id: offering-worker
+  auth:
+    swatchPsks:
+      source: ${SWATCH_SOURCE_PSK:dummy}

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -221,11 +221,11 @@ objects:
                     secretKeyRef:
                       name: tls
                       key: keystore_password
-                - name: SWATCH_PSKS
+                - name: SWATCH_SOURCE_PSK
                   valueFrom:
                     secretKeyRef:
                       name: swatch-psks
-                      key: swatch-app-secret
+                      key: source
               livenessProbe:
                 failureThreshold: 3
                 httpGet:


### PR DESCRIPTION
Previously, the PSKs were stored in a JSON blob assigned to one
configuration property.  The blob was then parsed at runtime to get the
PSKs for individual applications.  Spring Boot allows us to bind
configuration properties to a map so I simplified the code to use this
functionality instead of parsing JSON.

This patch makes the deployment changes necessitated by the conversion
to using configurations properties bound to a map.