### PR TITLE
Make quarkus choose a dynamic testing port

### DIFF
--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -31,6 +31,8 @@ AWS_MARKETPLACE_ENDPOINT_OVERRIDE=false
 %dev.quarkus.log.category."com.redhat.swatch".level=DEBUG
 
 quarkus.http.port=${SERVER_PORT}
+# make quarkus choose a dynamic port for testing to avoid port collisions w/ simultaneous tests
+quarkus.http.test-port=0
 
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=${DB_USER}


### PR DESCRIPTION
I've seen some tests fail with bind exceptions, and https://quarkus.io/guides/getting-started-testing#controlling-the-test-port suggests we can get a randomly assigned port which should prevent collisions when e.g. multiple PRs are being tested at once.