### PR TITLE
Remove Gradle renaming of our OpenAPI spec file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,7 @@
+import com.github.davidmc24.gradle.plugin.avro.GenerateAvroJavaTask
 import groovy.json.JsonOutput
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+import org.openapitools.generator.gradle.plugin.tasks.ValidateTask
 
 buildscript {
     // dependabot will parse dependencies.gradle by detecting the `apply from` below
@@ -122,7 +125,7 @@ ext {
     sub_sync_config_file = "${internal_spec_dir}/internal-subscriptions-sync-api-config.json"
 }
 
-tasks.register("buildApiTally", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+tasks.register("buildApiTally", GenerateTask) {
     generatorName = "jaxrs-spec"
     inputSpec = tally_api_spec_file
     configFile = tally_config_file
@@ -134,7 +137,7 @@ tasks.register("buildApiTally", org.openapitools.generator.gradle.plugin.tasks.G
     ]
 }
 
-tasks.register("buildApiSubSync", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+tasks.register("buildApiSubSync", GenerateTask) {
     generatorName = "jaxrs-spec"
     inputSpec = sub_sync_api_spec_file
     configFile = sub_sync_config_file
@@ -152,11 +155,11 @@ tasks.register("apiGenerate") {
     })
 }
 
-tasks.register("validateApiTally", org.openapitools.generator.gradle.plugin.tasks.ValidateTask) {
+tasks.register("validateApiTally", ValidateTask) {
     inputSpec = tally_api_spec_file
 }
 
-tasks.register("validateApiSubSync", org.openapitools.generator.gradle.plugin.tasks.ValidateTask) {
+tasks.register("validateApiSubSync", ValidateTask) {
     inputSpec = sub_sync_api_spec_file
 }
 
@@ -166,7 +169,7 @@ tasks.register("apiValidate") {
     })
 }
 
-tasks.register("generateApiDocsTally", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+tasks.register("generateApiDocsTally", GenerateTask) {
     generatorName = "html"
     inputSpec = tally_api_spec_file
     outputDir = "$buildDir/internal-tally-docs"
@@ -174,7 +177,7 @@ tasks.register("generateApiDocsTally", org.openapitools.generator.gradle.plugin.
     generateApiTests = false
 }
 
-tasks.register("generateApiDocsSubSync", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+tasks.register("generateApiDocsSubSync", GenerateTask) {
     generatorName = "html"
     inputSpec = sub_sync_api_spec_file
     outputDir = "$buildDir/internal-subscription-sync-docs"
@@ -182,7 +185,7 @@ tasks.register("generateApiDocsSubSync", org.openapitools.generator.gradle.plugi
     generateApiTests = false
 }
 
-tasks.register("generateOpenApiJsonTally", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+tasks.register("generateOpenApiJsonTally", GenerateTask) {
     generatorName = "openapi"
     inputSpec = tally_api_spec_file
     outputDir = "$buildDir/openapijson"
@@ -193,7 +196,7 @@ tasks.register("generateOpenApiJsonTally", org.openapitools.generator.gradle.plu
     ]
 }
 
-tasks.register("generateOpenApiJsonSubSync", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+tasks.register("generateOpenApiJsonSubSync", GenerateTask) {
     generatorName = "openapi"
     inputSpec = sub_sync_api_spec_file
     outputDir = "$buildDir/openapijson"
@@ -231,7 +234,7 @@ project(":api") {
         config_file = "${projectDir}/rhsm-subscriptions-api-config.json"
     }
 
-    tasks.register("apiGenerate", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+    tasks.register("apiGenerate", GenerateTask) {
         generatorName = "jaxrs-spec"
         inputSpec = api_spec_file
         configFile = config_file
@@ -243,11 +246,11 @@ project(":api") {
         ]
     }
 
-    tasks.register("validateApiSpec", org.openapitools.generator.gradle.plugin.tasks.ValidateTask) {
+    tasks.register("validateApiSpec", ValidateTask) {
         inputSpec = api_spec_file
     }
 
-    tasks.register("generateApiDocs", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+    tasks.register("generateApiDocs", GenerateTask) {
         generatorName = "html"
         inputSpec = api_spec_file
         outputDir = "$buildDir/docs"
@@ -255,7 +258,7 @@ project(":api") {
         generateApiTests = false
     }
 
-    tasks.register("generateOpenApiJson", org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+    tasks.register("generateOpenApiJson", GenerateTask) {
         generatorName = "openapi"
         inputSpec = api_spec_file
         outputDir = "$buildDir/openapijson"
@@ -291,7 +294,7 @@ project(":kafka-schema") {
         implementation "org.apache.avro:avro"
     }
 
-    task generateAvro(type: com.github.davidmc24.gradle.plugin.avro.GenerateAvroJavaTask) {
+    task generateAvro(type: GenerateAvroJavaTask) {
         // sub dir needed so that the plugin does not traverse into the build dir (if it exists).
         source("${projectDir}/avro")
         outputDir = file("${buildDir}/generated/avro/src/main/java")

--- a/build.gradle
+++ b/build.gradle
@@ -266,10 +266,6 @@ project(":api") {
     processResources {
         from tasks.generateOpenApiJson
         from api_spec_file
-        rename { String fileName ->
-            // rename yaml to openapi.yaml
-            api_spec_file.endsWith(fileName) ? 'openapi.yaml' : fileName
-        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ plugins {
     id "nebula.release"
     id 'com.adarshr.test-logger'
     id 'jacoco'
-    id "org.openapi.generator"
 }
 
 group = "org.candlepin"
@@ -149,7 +148,7 @@ tasks.register("buildApiSubSync", GenerateTask) {
     ]
 }
 
-tasks.register("apiGenerate") {
+tasks.register("openApiGenerate") {
     dependsOn(provider {
         tasks.findAll { task -> task.name.startsWith('buildApi') }
     })
@@ -234,7 +233,7 @@ project(":api") {
         config_file = "${projectDir}/rhsm-subscriptions-api-config.json"
     }
 
-    tasks.register("apiGenerate", GenerateTask) {
+    openApiGenerate {
         generatorName = "jaxrs-spec"
         inputSpec = api_spec_file
         configFile = config_file
@@ -282,7 +281,7 @@ project(":api") {
     }
 
     sourceSets.main.java.srcDirs += ["${buildDir}/generated/src/gen/java"]
-    compileJava.dependsOn tasks.apiGenerate
+    compileJava.dependsOn tasks.openApiGenerate
 }
 
 project(":kafka-schema") {

--- a/buildSrc/src/main/groovy/swatch.spring-boot-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-conventions.gradle
@@ -42,11 +42,8 @@ tasks.jar {
     enabled = false
 }
 
-tasks.bootJar {
-    mainClass.set "org.candlepin.subscriptions.BootApplication"
-}
-
 springBoot {
+    mainClass = "org.candlepin.subscriptions.BootApplication"
     buildInfo {
         properties {
             // Leave time empty: The default value is the instant at which the project is built. A

--- a/src/main/java/org/candlepin/subscriptions/resource/api/ApiSpecController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/ApiSpecController.java
@@ -38,7 +38,9 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ApiSpecController {
-  @Value("classpath:openapi.yaml")
+  // The name these files are served as is controlled by the corresponding Resource
+  // implementation (and ultimately in the openAPI spec itself)
+  @Value("classpath:rhsm-subscriptions-api-spec.yaml")
   private Resource openApiYaml;
 
   @Value("classpath:openapi.json")

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -1,5 +1,3 @@
-import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
-
 plugins {
     id 'swatch.java-conventions'
     id 'io.quarkus'
@@ -89,7 +87,7 @@ tasks.register('configureQuarkusBuild') {
   }
 }
 
-task wiremock(type: JavaExec) {
+tasks.register("wiremock", JavaExec) {
     description = "Run mock REST services for this service"
     classpath = sourceSets.test.runtimeClasspath
     mainClass = "com.redhat.swatch.wiremock.WiremockRunner"

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -71,6 +71,6 @@ jacocoTestReport {
     }
 }
 
-bootJar {
+springBoot {
     mainClass = "org.candlepin.subscriptions.SystemConduitApplication"
 }


### PR DESCRIPTION
The consoledot guidelines want the API spec to be served under
"openapi.yaml" which we can do by controlling the name of the endpoint
that serves the file in the specification itself.  There's no need to
rename the file with Gradle.