### PR TITLE
ENT-4838: sync awsAccountId for subscriptions

### DIFF
--- a/clients/subscription-client/subscription-api-spec.yaml
+++ b/clients/subscription-client/subscription-api-spec.yaml
@@ -156,3 +156,5 @@ components:
           type: string
         sellerAccount:
           type: string
+        customerAccountId:
+          type: string

--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -66,6 +66,7 @@ public class StubSearchApi extends SearchApi {
     awsRef.setCustomerID("customer123");
     awsRef.setProductCode("testProductCode123");
     awsRef.setSellerAccount("testSellerAccount123");
+    awsRef.setCustomerAccountId("1234567891234");
     return new Subscription()
         .id(235252)
         .quantity(1)

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtil.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtil.java
@@ -96,4 +96,12 @@ public class SubscriptionDtoUtil {
     }
     return null;
   }
+
+  public static String extractBillingAccountId(Subscription subscription) {
+    if (subscription.getExternalReferences() != null
+        && subscription.getExternalReferences().containsKey(AWS_MARKETPLACE)) {
+      return subscription.getExternalReferences().get(AWS_MARKETPLACE).getCustomerAccountId();
+    }
+    return null;
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -144,6 +144,7 @@ public class SubscriptionSyncController {
                   .startDate(OffsetDateTime.now())
                   .endDate(clock.dateFromMilliseconds(subscription.getEffectiveEndDate()))
                   .billingProviderId(SubscriptionDtoUtil.extractBillingProviderId(subscription))
+                  .billingAccountId(SubscriptionDtoUtil.extractBillingAccountId(subscription))
                   .subscriptionNumber(subscription.getSubscriptionNumber())
                   .billingProvider(SubscriptionDtoUtil.populateBillingProvider(subscription))
                   .build();
@@ -269,6 +270,7 @@ public class SubscriptionSyncController {
         .endDate(clock.dateFromMilliseconds(subscription.getEffectiveEndDate()))
         .billingProviderId(SubscriptionDtoUtil.extractBillingProviderId(subscription))
         .billingProvider(SubscriptionDtoUtil.populateBillingProvider(subscription))
+        .billingAccountId(SubscriptionDtoUtil.extractBillingAccountId(subscription))
         .build();
   }
 

--- a/src/main/resources/liquibase/202204081020-add-billing-account-id-column-to-subscriptions.xml
+++ b/src/main/resources/liquibase/202204081020-add-billing-account-id-column-to-subscriptions.xml
@@ -1,0 +1,14 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202204081020-1" author="kflahert">
+        <comment>Add column for billing account id to subscription table</comment>
+        <addColumn tableName="subscription">
+            <column name="billing_account_id" type="VARCHAR(255)" />
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -56,5 +56,6 @@
     <include file="liquibase/202202211433-add-billing-provider-column-to-subscription-table.xml" />
     <include file="liquibase/202203161423-add-billing-provider-column-to-host-table.xml" />
     <include file="liquibase/202203241102-add-billing-provider-column-to-tally-snapshots.xml" />
+    <include file="liquibase/202204081020-add-billing-account-id-column-to-subscriptions.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtilTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtilTest.java
@@ -100,4 +100,30 @@ class SubscriptionDtoUtilTest {
 
     assertEquals(BillingProvider.AWS, SubscriptionDtoUtil.populateBillingProvider(dto));
   }
+
+  @Test
+  void testExtractBillingAccountIdExternalReference() {
+    var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
+
+    ExternalReference extRef = new ExternalReference();
+    extRef.setCustomerAccountId("123456789123");
+    dto.putExternalReferencesItem("aws", extRef);
+    assertEquals("123456789123", SubscriptionDtoUtil.extractBillingAccountId(dto));
+  }
+
+  @Test
+  void testExtractBillingAccountNoAWSExternalReference() {
+    var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
+
+    dto.putExternalReferencesItem("ibmmarketplace", new ExternalReference());
+
+    assertEquals(null, SubscriptionDtoUtil.extractBillingAccountId(dto));
+  }
+
+  @Test
+  void testExtractBillingAccountNoExternalReferences() {
+    var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
+
+    assertEquals(null, SubscriptionDtoUtil.extractBillingAccountId(dto));
+  }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -64,6 +64,9 @@ public class Subscription {
   @Column(name = "billing_provider_id")
   private String billingProviderId;
 
+  @Column(name = "billing_account_id")
+  private String billingAccountId;
+
   @Column(name = "account_number")
   private String accountNumber;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4838
Test Steps:
- Add test offering data:
 `INSERT INTO public.offering(
	sku, product_name, physical_cores, physical_sockets, virtual_cores, virtual_sockets, role, sla, usage, description)
	VALUES ('sku', 'OpenShift Streams for Apache Kafka', 0, 0, 0, 0, 'rhosak', 'Premium', 'Production', 'Red Hat OpenShift Streams for Apache Kafka (Hourly)');`

- Use syncSubscription method of subscriptionJmxBean passing in '789' as subscriptionId
http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.subscription-SubscriptionJmxBean-subscriptionJmxBean

- Check that subscription was created with billingAccountId is populated