### PR TITLE
Express defaults directly in property value

### DIFF
--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -2,10 +2,6 @@ CLOUDIGRADE_HOST: ${clowder.endpoints[?(@.app == 'cloudigrade')].hostname:localh
 CLOUDIGRADE_PORT: ${clowder.endpoints[?(@.app == 'cloudigrade')].port:8080}
 CLOUDIGRADE_INTERNAL_HOST: ${CLOUDIGRADE_HOST}
 CLOUDIGRADE_INTERNAL_PORT: ${CLOUDIGRADE_PORT}
-TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS: 5
-TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL: 1m
-TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL: 1s
-TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER: 2
 
 rhsm-subscriptions:
   jmx:
@@ -35,7 +31,7 @@ rhsm-subscriptions:
       url: http://${CLOUDIGRADE_INTERNAL_HOST}:${CLOUDIGRADE_INTERNAL_PORT}/internal/api/cloudigrade/v1
       presharedKey: ${CLOUDIGRADE_PSK:}
   tally-summary-producer:
-    back-off-initial-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL}
-    back-off-max-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL}
-    back-off-multiplier: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER}
-    max-attempts: ${TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS}
+    back-off-initial-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL:1s}
+    back-off-max-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL:1m}
+    back-off-multiplier: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER:2}
+    max-attempts: ${TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS:5}


### PR DESCRIPTION
The reason to define an property that's meant to have the same name as
an environment variable is for when we would otherwise have to nest
expressions (e.g. we can't nest expressions like
${CLOUDIGRADE_INTERNAL_HOST:$CLOUDIGRADE_HOST}). That situation doesn't
apply to these properties, so we can define the defaults inline.