### PR TITLE
ENT-4878: Drop db libraries from swatch-producer-aws

### DIFF
--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -8,16 +8,11 @@ dependencies {
     compileOnly libraries["lombok"]
     implementation enforcedPlatform(libraries["quarkus-bom"])
     implementation platform(libraries["awssdk-bom"])
-    implementation 'io.quarkus:quarkus-agroal'
     implementation 'io.quarkus:quarkus-arc'
     implementation 'io.quarkus:quarkus-config-yaml'
-    implementation 'io.quarkus:quarkus-hibernate-orm-panache'
     implementation 'io.quarkus:quarkus-hibernate-validator'
     implementation 'io.quarkus:quarkus-jacoco'
-    implementation 'io.quarkus:quarkus-jdbc-h2'
-    implementation 'io.quarkus:quarkus-jdbc-postgresql'
     implementation 'io.quarkus:quarkus-jsonb'
-    implementation 'io.quarkus:quarkus-liquibase'
     implementation 'io.quarkus:quarkus-logging-json'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-openshift'

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -1,8 +1,3 @@
-DB_HOST=${clowder.database.hostname:localhost}
-DB_PORT=${clowder.database.port:5432}
-DB_NAME=${clowder.database.name:rhsm-subscriptions}
-DB_USER=${clowder.database.username:rhsm-subscriptions}
-DB_PASSWORD=${clowder.database.password:rhsm-subscriptions}
 SERVER_PORT=${clowder.endpoints.swatch-producer-aws.port:8000}
 #TODO ENT-4890
 SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://${clowder.endpoints.capacity-ingress.hostname}:${clowder.endpoints.capacity-ingress.port}
@@ -51,12 +46,6 @@ SPLUNK_HEC_INCLUDE_EX=false
 quarkus.http.port=${SERVER_PORT}
 # make quarkus choose a dynamic port for testing to avoid port collisions w/ simultaneous tests
 quarkus.http.test-port=0
-
-quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=${DB_USER}
-quarkus.datasource.password=${DB_PASSWORD}
-quarkus.datasource.jdbc.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
-quarkus.datasource.jdbc.max-size=16
 
 #clowder quarkus config takes care of setting these, no need to try to do clowder.kafka.brokers[0]
 

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/TestContainerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/TestContainerTest.java
@@ -23,8 +23,10 @@ package com.redhat.swatch;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.Assert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@Disabled("This placeholder test shows how to setup an integration test w/ DB & Kafka")
 @QuarkusTest
 @QuarkusTestResource(PostgresResource.class)
 @QuarkusTestResource(KafkaResource.class)


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4878

Testing
-------

`./gradlew swatch-producer-aws:quarkusDev` continues to work.

Also, create a mock clowder config at `/tmp/test.json`:

```json
{
  "endpoints": [
    {
      "app": "notifications",
      "hostname": "n-api.svc",
      "name": "api",
      "port": 8000
    },
    {
      "app": "notifications",
      "hostname": "n-gw.svc",
      "name": "gw",
      "port": 8000
    }
  ],
  "kafka": {
    "brokers": [
      {
        "hostname": "localhost",
        "port": 29092
      }
    ],
    "topics": [
      {
        "name": "platform-tmp-12345",
        "requestedName": "platform.notifications.ingress"
      },
      {
        "name": "platform-tmp-666",
        "requestedName": "platform.notifications.alerts"
      }
    ]
  },
  "metricsPath": "/metrics",
  "metricsPort": 9000,
  "privatePort": 10000,
  "publicPort": 8000,
  "webPort": 8000
}
```

(Note no `database` section exists, and then launch the app via
`ACG_CONFIG=/tmp/test.json ./gradlew swatch-producer-aws:quarkusDev`).
It still boots successfully.