### PR TITLE
ENT-4844: add billingAccountId to hosts table and Instance API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -697,6 +697,11 @@ paths:
           schema:
             $ref: '#/components/schemas/BillingProviderType'
           description: "Include only hosts for the specified billing provider."
+        - name: billing_account_id
+          description: Include only hosts containing the specified billing account ID.
+          schema:
+            type: string
+          in: query
         - name: display_name_contains
           description: Include only hosts containing the specified display name. Passing an empty string behaves the same way as passing null
           schema:
@@ -1521,6 +1526,8 @@ components:
           type: string
         billing_provider:
           $ref: '#/components/schemas/BillingProviderType'
+        billing_account_id:
+          type: string
         measurements:
           description: >-
             Must be in the same order as "measurements" in the meta. (i.e. in the example

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -191,6 +191,7 @@ public class HostsResource implements HostsApi {
               month,
               referenceUom,
               null,
+              null,
               page);
       payload =
           ((Page<Host>) hosts)

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -96,6 +96,7 @@ public class InstancesResource implements InstancesApi {
       ServiceLevelType sla,
       UsageType usage,
       BillingProviderType billingProviderType,
+      String billingAccountId,
       String displayNameContains,
       OffsetDateTime beginning,
       OffsetDateTime ending,
@@ -161,6 +162,7 @@ public class InstancesResource implements InstancesApi {
             month,
             referenceUom,
             billingProvider,
+            billingAccountId,
             page);
     payload =
         hosts.getContent().stream()
@@ -210,6 +212,7 @@ public class InstancesResource implements InstancesApi {
     for (String uom : measurements) {
       measurementList.add(host.getMonthlyTotal(monthId, Measurement.Uom.fromValue(uom)));
     }
+    instance.setBillingAccountId(host.getBillingAccountId());
     instance.setMeasurements(measurementList);
     instance.setLastSeen(host.getLastSeen());
 

--- a/src/main/resources/liquibase/202204131346-add-billing-account-id-column-to-hosts.xml
+++ b/src/main/resources/liquibase/202204131346-add-billing-account-id-column-to-hosts.xml
@@ -1,0 +1,14 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202204131346-1" author="kflahert">
+        <comment>Add column for billing account id to hosts table</comment>
+        <addColumn tableName="hosts">
+            <column name="billing_account_id" type="VARCHAR(255)" />
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -57,5 +57,6 @@
     <include file="liquibase/202203161423-add-billing-provider-column-to-host-table.xml" />
     <include file="liquibase/202203241102-add-billing-provider-column-to-tally-snapshots.xml" />
     <include file="liquibase/202204081020-add-billing-account-id-column-to-subscriptions.xml" />
+    <include file="liquibase/202204131346-add-billing-account-id-column-to-hosts.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -706,6 +706,7 @@ class HostRepositoryTest {
             "2021-01",
             referenceUom,
             null,
+            null,
             page);
 
     assertEquals(2, results.getTotalElements());
@@ -920,6 +921,7 @@ class HostRepositoryTest {
             null,
             null,
             BillingProvider.AWS,
+            null,
             page);
     assertEquals(1L, results.getTotalElements());
     assertEquals(BillingProvider.AWS, results.getContent().get(0).getBillingProvider());
@@ -933,6 +935,7 @@ class HostRepositoryTest {
             "",
             0,
             0,
+            null,
             null,
             null,
             null,
@@ -983,6 +986,7 @@ class HostRepositoryTest {
             "",
             0,
             0,
+            null,
             null,
             null,
             null,

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -395,6 +395,7 @@ class HostsResourceTest {
             june2019,
             null,
             null,
+            null,
             PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))))
         .thenReturn(page);
 

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -74,7 +74,8 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                any(), any(), any(), any(), any(), anyInt(), anyInt(), any(), any(), any(), any()))
+                any(), any(), any(), any(), any(), anyInt(), anyInt(), any(), any(), any(), any(),
+                any()))
         .thenReturn(new PageImpl<>(List.of(host)));
 
     var expectUom = List.of("Instance-hours", "Storage-gibibytes", "Transfer-gibibytes");
@@ -110,6 +111,7 @@ class InstancesResourceTest {
             ServiceLevelType.PREMIUM,
             UsageType.PRODUCTION,
             expectedBillingProvider.asOpenApiEnum(),
+            null,
             null,
             null,
             null,

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -131,6 +131,7 @@ public interface HostRepository
       String month,
       Uom referenceUom,
       BillingProvider billingProvider,
+      String billingAccountId,
       Pageable pageable) {
 
     HostSpecification searchCriteria = new HostSpecification();
@@ -164,6 +165,11 @@ public interface HostRepository
     if (Objects.nonNull(billingProvider)) {
       searchCriteria.add(
           new SearchCriteria(Host_.BILLING_PROVIDER, billingProvider, SearchOperation.EQUAL));
+    }
+
+    if (Objects.nonNull(billingAccountId)) {
+      searchCriteria.add(
+          new SearchCriteria(Host_.BILLING_ACCOUNT_ID, billingAccountId, SearchOperation.EQUAL));
     }
 
     return findAll(searchCriteria, pageable);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -153,6 +153,9 @@ public class Host implements Serializable {
   @Column(name = "billing_provider")
   private BillingProvider billingProvider;
 
+  @Column(name = "billing_account_id")
+  private String billingAccountId;
+
   public Host() {}
 
   public Host(
@@ -317,7 +320,8 @@ public class Host implements Serializable {
         && Objects.equals(lastSeen, host.lastSeen)
         && Objects.equals(buckets, host.buckets)
         && Objects.equals(cloudProvider, host.cloudProvider)
-        && Objects.equals(instanceId, host.instanceId);
+        && Objects.equals(instanceId, host.instanceId)
+        && Objects.equals(billingAccountId, host.billingAccountId);
   }
 
   @Override
@@ -342,7 +346,8 @@ public class Host implements Serializable {
         isHypervisor,
         cloudProvider,
         instanceId,
-        instanceType);
+        instanceType,
+        billingAccountId);
   }
 
   public org.candlepin.subscriptions.utilization.api.model.Host asTallyHostViewApiHost(


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4844

Test Steps:

- Add hosts using insert-mock-hosts.py script
- Edit some to have any billing_account_id
- Use `https://petstore.swagger.io/?url=https://raw.githubusercontent.com/RedHatInsights/rhsm-subscriptions/main/api/rhsm-subscriptions-api-spec.yaml#/instances/getInstancesByProduct ` with billing_account_id param and check results for billing_account_id