### PR TITLE
ENT-4837 Do not attempt to process Tally snapshots in batches

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.tally;
 
 import io.micrometer.core.annotation.Timed;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -58,25 +57,18 @@ public class CloudigradeAccountUsageCollector {
    * Add measurements from cloudigrade to usage calculations
    *
    * @param accountCalcs map of existing account to usage calculations
-   * @param accounts list of accounts to enrich calculations for
+   * @param account account to enrich calculations for
    * @throws ApiException if the cloudigrade service errs
    */
   @Timed("rhsm-subscriptions.snapshots.cloudigrade")
   public void enrichUsageWithCloudigradeData(
-      Map<String, AccountUsageCalculation> accountCalcs, Collection<String> accounts)
+      Map<String, AccountUsageCalculation> accountCalcs, String account)
       throws ApiException, org.candlepin.subscriptions.cloudigrade.internal.ApiException {
-
-    for (String account : accounts) {
-      log.trace("Cloudigrade checking for user {}", account);
-      if (cloudigradeService.cloudigradeUserExists(account)) {
-        log.trace("Cloudigrade found user {}", account);
-        enrichUsageWithCloudigradeData(accountCalcs, account);
-      }
+    log.trace("Cloudigrade checking for user {}", account);
+    if (!cloudigradeService.cloudigradeUserExists(account)) {
+      log.trace("Cloudigrade could not find user {}", account);
+      return;
     }
-  }
-
-  private void enrichUsageWithCloudigradeData(
-      Map<String, AccountUsageCalculation> accountCalcs, String account) throws ApiException {
     log.trace("Fetching cloudigrade data for {}", account);
     ConcurrencyReport cloudigradeUsage =
         cloudigradeService.listDailyConcurrentUsages(account, null, null, null, null);

--- a/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
@@ -153,7 +153,7 @@ public class CombiningRollupSnapshotStrategy {
 
     summaryProducer.produceTallySummaryMessages(totalSnapshots);
 
-    log.info("Finished producing finestGranularitySnapshots for all accounts.");
+    log.info("Finished producing finestGranularitySnapshots for account {}.", accountNumber);
   }
 
   private void catalogExistingSnapshots(
@@ -186,11 +186,7 @@ public class CombiningRollupSnapshotStrategy {
 
       var snapMap =
           getCurrentSnapshotsByAccount(
-              List.of(accountNumber),
-              swatchProductIds,
-              granularity,
-              effectiveStartTime,
-              effectiveEndTime);
+              accountNumber, swatchProductIds, granularity, effectiveStartTime, effectiveEndTime);
 
       List<TallySnapshot> existingSnapshots =
           snapMap.getOrDefault(accountNumber, Collections.emptyList());
@@ -214,14 +210,14 @@ public class CombiningRollupSnapshotStrategy {
 
   @SuppressWarnings("indentation")
   protected Map<String, List<TallySnapshot>> getCurrentSnapshotsByAccount(
-      Collection<String> accounts,
+      String account,
       Collection<String> products,
       Granularity granularity,
       OffsetDateTime begin,
       OffsetDateTime end) {
     try (Stream<TallySnapshot> snapStream =
-        tallyRepo.findByAccountNumberInAndProductIdInAndGranularityAndSnapshotDateBetween(
-            accounts, products, granularity, begin, end)) {
+        tallyRepo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+            account, products, granularity, begin, end)) {
       return snapStream.collect(Collectors.groupingBy(TallySnapshot::getAccountNumber));
     }
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/MaxSeenSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MaxSeenSnapshotStrategy.java
@@ -72,18 +72,18 @@ public class MaxSeenSnapshotStrategy {
   }
 
   @Transactional
-  public Map<String, List<TallySnapshot>> produceSnapshotsFromCalculations(
-      Collection<String> accounts, Collection<AccountUsageCalculation> accountCalcs) {
+  public List<TallySnapshot> produceSnapshotsFromCalculations(
+      String account, Collection<AccountUsageCalculation> accountCalcs) {
     Stream<BaseSnapshotRoller> rollers =
         Stream.of(
             hourlyRoller, dailyRoller, weeklyRoller, monthlyRoller, quarterlyRoller, yearlyRoller);
     var newAndUpdatedSnapshots =
         rollers
-            .map(roller -> roller.rollSnapshots(accounts, accountCalcs))
+            .map(roller -> roller.rollSnapshots(account, accountCalcs))
             .flatMap(Collection::stream)
-            .collect(Collectors.groupingBy(TallySnapshot::getAccountNumber));
-    summaryProducer.produceTallySummaryMessages(newAndUpdatedSnapshots);
-    log.info("Finished producing snapshots for all accounts.");
+            .collect(Collectors.toList());
+    summaryProducer.produceTallySummaryMessages(Map.of(account, newAndUpdatedSnapshots));
+    log.info("Finished producing snapshots for account {}", account);
     return newAndUpdatedSnapshots;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -67,12 +67,12 @@ public abstract class BaseSnapshotRoller {
   /**
    * Roll the snapshots for the given account.
    *
-   * @param accounts the accounts of the snapshots to roll.
+   * @param account the account of the snapshots to roll.
    * @param accountCalcs the current calculations from the host inventory.
    * @return collection of snapshots
    */
   public abstract Collection<TallySnapshot> rollSnapshots(
-      Collection<String> accounts, Collection<AccountUsageCalculation> accountCalcs);
+      String account, Collection<AccountUsageCalculation> accountCalcs);
 
   protected TallySnapshot createSnapshotFromProductUsageCalculation(
       String account, String owner, UsageCalculation productCalc, Granularity granularity) {
@@ -127,16 +127,16 @@ public abstract class BaseSnapshotRoller {
   }
 
   @SuppressWarnings("indentation")
-  protected Map<String, List<TallySnapshot>> getCurrentSnapshotsByAccount(
-      Collection<String> accounts,
+  protected List<TallySnapshot> getCurrentSnapshotsByAccount(
+      String account,
       Collection<String> products,
       Granularity granularity,
       OffsetDateTime begin,
       OffsetDateTime end) {
     try (Stream<TallySnapshot> snapStream =
-        tallyRepo.findByAccountNumberInAndProductIdInAndGranularityAndSnapshotDateBetween(
-            accounts, products, granularity, begin, end)) {
-      return snapStream.collect(Collectors.groupingBy(TallySnapshot::getAccountNumber));
+        tallyRepo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+            account, products, granularity, begin, end)) {
+      return snapStream.collect(Collectors.toList());
     }
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import static org.candlepin.subscriptions.db.model.Granularity.*;
+import static org.candlepin.subscriptions.db.model.Granularity.DAILY;
 
 import java.util.Collection;
 import java.util.List;
@@ -52,16 +52,18 @@ public class DailySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      Collection<String> accounts, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing daily snapshots for {} account(s).", accounts.size());
+      String account, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing daily snapshots for account {}.", account);
 
     Map<String, List<TallySnapshot>> existingSnapsForToday =
-        getCurrentSnapshotsByAccount(
-            accounts,
-            getApplicableProducts(accountCalcs, DAILY),
-            DAILY,
-            clock.startOfToday(),
-            clock.endOfToday());
+        Map.of(
+            account,
+            getCurrentSnapshotsByAccount(
+                account,
+                getApplicableProducts(accountCalcs, DAILY),
+                DAILY,
+                clock.startOfToday(),
+                clock.endOfToday()));
 
     return updateSnapshots(accountCalcs, existingSnapsForToday, DAILY);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRoller.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import static org.candlepin.subscriptions.db.model.Granularity.*;
+import static org.candlepin.subscriptions.db.model.Granularity.HOURLY;
 
 import java.util.Collection;
 import java.util.List;
@@ -51,16 +51,18 @@ public class HourlySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      Collection<String> accounts, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing hourly snapshots for {} account(s).", accounts.size());
+      String account, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing hourly snapshots for account {}.", account);
 
     Map<String, List<TallySnapshot>> existingSnapsForTheHour =
-        getCurrentSnapshotsByAccount(
-            accounts,
-            getApplicableProducts(accountCalcs, HOURLY),
-            HOURLY,
-            clock.startOfCurrentHour(),
-            clock.endOfCurrentHour());
+        Map.of(
+            account,
+            getCurrentSnapshotsByAccount(
+                account,
+                getApplicableProducts(accountCalcs, HOURLY),
+                HOURLY,
+                clock.startOfCurrentHour(),
+                clock.endOfCurrentHour()));
 
     return updateSnapshots(accountCalcs, existingSnapsForTheHour, HOURLY);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import static org.candlepin.subscriptions.db.model.Granularity.*;
+import static org.candlepin.subscriptions.db.model.Granularity.MONTHLY;
 
 import java.util.Collection;
 import java.util.List;
@@ -52,16 +52,18 @@ public class MonthlySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      Collection<String> accounts, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing monthly snapshots for {} account(s).", accounts.size());
+      String account, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing monthly snapshots for account {}.", account);
 
     Map<String, List<TallySnapshot>> currentMonthlySnaps =
-        getCurrentSnapshotsByAccount(
-            accounts,
-            getApplicableProducts(accountCalcs, MONTHLY),
-            MONTHLY,
-            clock.startOfCurrentMonth(),
-            clock.endOfCurrentMonth());
+        Map.of(
+            account,
+            getCurrentSnapshotsByAccount(
+                account,
+                getApplicableProducts(accountCalcs, MONTHLY),
+                MONTHLY,
+                clock.startOfCurrentMonth(),
+                clock.endOfCurrentMonth()));
 
     return updateSnapshots(accountCalcs, currentMonthlySnaps, MONTHLY);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import static org.candlepin.subscriptions.db.model.Granularity.*;
+import static org.candlepin.subscriptions.db.model.Granularity.QUARTERLY;
 
 import java.util.Collection;
 import java.util.List;
@@ -55,16 +55,18 @@ public class QuarterlySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      Collection<String> accounts, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing quarterly snapshots for {} account(s).", accounts.size());
+      String account, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing quarterly snapshots for account {}.", account);
 
     Map<String, List<TallySnapshot>> currentQuarterlySnaps =
-        getCurrentSnapshotsByAccount(
-            accounts,
-            getApplicableProducts(accountCalcs, QUARTERLY),
-            QUARTERLY,
-            clock.startOfCurrentQuarter(),
-            clock.endOfCurrentQuarter());
+        Map.of(
+            account,
+            getCurrentSnapshotsByAccount(
+                account,
+                getApplicableProducts(accountCalcs, QUARTERLY),
+                QUARTERLY,
+                clock.startOfCurrentQuarter(),
+                clock.endOfCurrentQuarter()));
 
     return updateSnapshots(accountCalcs, currentQuarterlySnaps, QUARTERLY);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import static org.candlepin.subscriptions.db.model.Granularity.*;
+import static org.candlepin.subscriptions.db.model.Granularity.WEEKLY;
 
 import java.util.Collection;
 import java.util.List;
@@ -52,16 +52,18 @@ public class WeeklySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      Collection<String> accounts, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing weekly snapshots for {} account(s).", accounts.size());
+      String account, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing weekly snapshots for account {}.", account);
 
     Map<String, List<TallySnapshot>> currentForWeek =
-        getCurrentSnapshotsByAccount(
-            accounts,
-            getApplicableProducts(accountCalcs, WEEKLY),
-            WEEKLY,
-            clock.startOfCurrentWeek(),
-            clock.endOfCurrentWeek());
+        Map.of(
+            account,
+            getCurrentSnapshotsByAccount(
+                account,
+                getApplicableProducts(accountCalcs, WEEKLY),
+                WEEKLY,
+                clock.startOfCurrentWeek(),
+                clock.endOfCurrentWeek()));
 
     return updateSnapshots(accountCalcs, currentForWeek, WEEKLY);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import static org.candlepin.subscriptions.db.model.Granularity.*;
+import static org.candlepin.subscriptions.db.model.Granularity.YEARLY;
 
 import java.util.Collection;
 import java.util.List;
@@ -52,16 +52,18 @@ public class YearlySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      Collection<String> accounts, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing yearly snapshots for {} account(s).", accounts.size());
+      String account, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing yearly snapshots for account {}.", account);
 
     Map<String, List<TallySnapshot>> currentYearlySnaps =
-        getCurrentSnapshotsByAccount(
-            accounts,
-            getApplicableProducts(accountCalcs, YEARLY),
-            YEARLY,
-            clock.startOfCurrentYear(),
-            clock.endOfCurrentYear());
+        Map.of(
+            account,
+            getCurrentSnapshotsByAccount(
+                account,
+                getApplicableProducts(accountCalcs, YEARLY),
+                YEARLY,
+                clock.startOfCurrentYear(),
+                clock.endOfCurrentYear()));
 
     return updateSnapshots(accountCalcs, currentYearlySnaps, YEARLY);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/tasks/UpdateAccountSnapshotsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/tasks/UpdateAccountSnapshotsTask.java
@@ -21,12 +21,15 @@
 package org.candlepin.subscriptions.tally.tasks;
 
 import java.util.List;
+import javax.validation.constraints.Size;
 import org.candlepin.subscriptions.tally.TallySnapshotController;
 import org.candlepin.subscriptions.task.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.validation.annotation.Validated;
 
 /** Updates the usage snapshots for a given account. */
+@Validated
 public class UpdateAccountSnapshotsTask implements Task {
   private static final Logger log = LoggerFactory.getLogger(UpdateAccountSnapshotsTask.class);
 
@@ -34,14 +37,16 @@ public class UpdateAccountSnapshotsTask implements Task {
   private final TallySnapshotController snapshotController;
 
   public UpdateAccountSnapshotsTask(
-      TallySnapshotController snapshotController, List<String> accountNumbers) {
+      TallySnapshotController snapshotController,
+      @Size(min = 1, max = 1) List<String> accountNumbers) {
     this.snapshotController = snapshotController;
     this.accountNumbers = accountNumbers;
   }
 
   @Override
   public void execute() {
-    log.info("Updating snapshots for {} accounts.", accountNumbers.size());
-    snapshotController.produceSnapshotsForAccounts(accountNumbers);
+    String account = accountNumbers.get(0);
+    log.info("Updating snapshots for account {}.", account);
+    snapshotController.produceSnapshotsForAccount(account);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -29,7 +29,13 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurement;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -160,39 +166,34 @@ public class TallySnapshotRepositoryTest {
         createUnpersisted("Account1", product1, Granularity.DAILY, 2, 3, 4, LONG_AGO);
     // Will be found.
     TallySnapshot t2 =
-        createUnpersisted("Account2", product1, Granularity.DAILY, 9, 10, 11, NOWISH);
-    // Will be found.
-    TallySnapshot t3 =
-        createUnpersisted("Account2", product2, Granularity.DAILY, 19, 20, 21, NOWISH);
+        createUnpersisted("Account1", product1, Granularity.DAILY, 9, 10, 11, NOWISH);
     // Will not be found, incorrect granularity
-    TallySnapshot t4 =
-        createUnpersisted("Account2", product2, Granularity.WEEKLY, 19, 20, 21, NOWISH);
+    TallySnapshot t3 =
+        createUnpersisted("Account1", product2, Granularity.WEEKLY, 19, 20, 21, NOWISH);
     // Will not be in result - Account not in query
-    TallySnapshot t5 =
-        createUnpersisted("Account3", product1, Granularity.DAILY, 99, 100, 101, FAR_FUTURE);
+    TallySnapshot t4 =
+        createUnpersisted("Account2", product1, Granularity.DAILY, 99, 100, 101, FAR_FUTURE);
     // Will not be found - incorrect granularity
-    TallySnapshot t6 =
-        createUnpersisted("Account2", product1, Granularity.WEEKLY, 20, 22, 23, NOWISH);
+    TallySnapshot t5 =
+        createUnpersisted("Account1", product1, Granularity.WEEKLY, 20, 22, 23, NOWISH);
 
-    repository.saveAll(Arrays.asList(t1, t2, t3, t4, t5, t6));
+    repository.saveAll(Arrays.asList(t1, t2, t3, t4, t5));
     repository.flush();
 
     OffsetDateTime min = OffsetDateTime.of(2019, 05, 23, 00, 00, 00, 00, ZoneOffset.UTC);
     OffsetDateTime max = OffsetDateTime.of(2019, 07, 23, 00, 00, 00, 00, ZoneOffset.UTC);
 
-    List<String> accounts = Arrays.asList("Account1", "Account2");
     List<String> products = Arrays.asList(product1, product2);
     List<TallySnapshot> found =
         repository
-            .findByAccountNumberInAndProductIdInAndGranularityAndSnapshotDateBetween(
-                accounts, products, Granularity.DAILY, min, max)
+            .findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+                "Account1", products, Granularity.DAILY, min, max)
             .collect(Collectors.toList());
-    // TODO Expect this to fail. Need to rebuild test result checking.
-    assertEquals(2, found.size());
+    assertEquals(1, found.size());
 
     TallySnapshot result = found.get(0);
 
-    assertEquals("Account2", result.getAccountNumber());
+    assertEquals("Account1", result.getAccountNumber());
     assertEquals(product1, result.getProductId());
 
     HardwareMeasurement total = result.getHardwareMeasurement(HardwareMeasurementType.TOTAL);
@@ -217,8 +218,8 @@ public class TallySnapshotRepositoryTest {
 
     List<TallySnapshot> found =
         repository
-            .findByAccountNumberInAndProductIdInAndGranularityAndSnapshotDateBetween(
-                Arrays.asList("Acme Inc."),
+            .findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+                "Acme Inc.",
                 Arrays.asList("rocket-skates"),
                 Granularity.DAILY,
                 LONG_AGO,

--- a/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
@@ -60,7 +60,7 @@ class CloudigradeAccountUsageCollectorTest {
   void testEnrichUsageWithCloudigradeDataHaltsWithBadUser() throws Exception {
     when(cloudigradeService.cloudigradeUserExists(ACCOUNT)).thenReturn(false);
     var calculations = new HashMap<String, AccountUsageCalculation>();
-    collector.enrichUsageWithCloudigradeData(calculations, Collections.singletonList(ACCOUNT));
+    collector.enrichUsageWithCloudigradeData(calculations, ACCOUNT);
     verify(cloudigradeService, never())
         .listDailyConcurrentUsages(any(), any(), any(), any(), any());
   }
@@ -79,7 +79,7 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.cloudigradeUserExists(ACCOUNT)).thenReturn(true);
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
-    collector.enrichUsageWithCloudigradeData(calculations, Collections.singletonList(ACCOUNT));
+    collector.enrichUsageWithCloudigradeData(calculations, ACCOUNT);
     assertEquals(1, calculations.size());
   }
 
@@ -98,8 +98,7 @@ class CloudigradeAccountUsageCollectorTest {
         .thenReturn(report);
 
     AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(
-        usageMapOf(ACCOUNT, accountUsage), Collections.singletonList(ACCOUNT));
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT);
     assertEquals(
         1,
         accountUsage
@@ -128,8 +127,7 @@ class CloudigradeAccountUsageCollectorTest {
         .thenReturn(report);
 
     AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(
-        usageMapOf(ACCOUNT, accountUsage), Collections.singletonList(ACCOUNT));
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT);
     assertEquals(0, accountUsage.getKeys().size());
   }
 
@@ -156,8 +154,7 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
     AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(
-        usageMapOf(ACCOUNT, accountUsage), Collections.singletonList(ACCOUNT));
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT);
     assertEquals(
         1,
         accountUsage
@@ -184,8 +181,7 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
     AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(
-        usageMapOf(ACCOUNT, accountUsage), Collections.singletonList(ACCOUNT));
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT);
     assertEquals(0, accountUsage.getKeys().size());
   }
 
@@ -203,8 +199,7 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
     AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(
-        usageMapOf(ACCOUNT, accountUsage), Collections.singletonList(ACCOUNT));
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT);
     assertEquals(0, accountUsage.getKeys().size());
   }
 
@@ -237,8 +232,7 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
     AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(
-        usageMapOf(ACCOUNT, accountUsage), Collections.singletonList(ACCOUNT));
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT);
     assertEquals(1, accountUsage.getKeys().size());
     Optional<UsageCalculation.Key> usageKey = accountUsage.getKeys().stream().findFirst();
     assertTrue(usageKey.isPresent());

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,13 +85,5 @@ class TallySnapshotControllerTest {
     props.setCloudigradeEnabled(false);
     controller.produceSnapshotsForAccount(ACCOUNT);
     verifyNoInteractions(cloudigradeCollector);
-  }
-
-  @Test
-  void testBatchesLargerThanConfigIgnored() {
-    controller.produceSnapshotsForAccounts(
-        Collections.nCopies(props.getAccountBatchSize() + 1, "foo"));
-    verifyNoInteractions(cloudigradeCollector);
-    verifyNoInteractions(inventoryCollector);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
@@ -29,7 +29,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
-import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurement;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.tally.AccountUsageCalculation;
 import org.candlepin.subscriptions.tally.UsageCalculation;
@@ -66,7 +72,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     String account = a1Calc.getAccount();
 
     UsageCalculation a1ProductCalc = a1Calc.getCalculation(createUsageKey(getTestProduct()));
-    roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
+    roller.rollSnapshots(account, Arrays.asList(a1Calc));
 
     List<TallySnapshot> currentSnaps =
         repository
@@ -93,7 +99,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
       OffsetDateTime endOfGranularPeriod) {
     AccountUsageCalculation a1Calc = createTestData();
     String account = a1Calc.getAccount();
-    roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
+    roller.rollSnapshots(account, Arrays.asList(a1Calc));
 
     List<TallySnapshot> currentSnaps =
         repository
@@ -117,7 +123,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     assertSnapshot(toBeUpdated, a1ProductCalc, granularity);
 
     a1ProductCalc.addPhysical(100, 200, 50);
-    roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1Calc));
+    roller.rollSnapshots(account, Arrays.asList(a1Calc));
 
     List<TallySnapshot> updatedSnaps =
         repository
@@ -163,7 +169,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     AccountUsageCalculation expectedCalc = expectMaxAccepted ? a1HighCalc : a1LowCalc;
 
     // Roll to the initial high values
-    roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1HighCalc));
+    roller.rollSnapshots(account, Arrays.asList(a1HighCalc));
 
     List<TallySnapshot> currentSnaps =
         repository
@@ -186,7 +192,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
         toUpdate, a1HighCalc.getCalculation(createUsageKey(getTestProduct())), granularity);
 
     // Roll again with the low values
-    roller.rollSnapshots(Arrays.asList(account), Arrays.asList(a1LowCalc));
+    roller.rollSnapshots(account, Arrays.asList(a1LowCalc));
 
     List<TallySnapshot> updatedSnaps =
         repository
@@ -219,7 +225,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
       OffsetDateTime endOfGranularPeriod) {
 
     AccountUsageCalculation calc = createAccountCalc("12345678", "O1", getTestProduct(), 0, 0, 0);
-    roller.rollSnapshots(Collections.singletonList("12345678"), Collections.singletonList(calc));
+    roller.rollSnapshots("12345678", Collections.singletonList(calc));
 
     List<TallySnapshot> currentSnaps =
         repository
@@ -285,7 +291,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     UsageCalculation a1ProductCalc = a1Calc.getCalculation(createUsageKey(getTestProduct()));
     assertNotNull(a1ProductCalc);
 
-    roller.rollSnapshots(List.of(account), List.of(a1Calc));
+    roller.rollSnapshots(account, List.of(a1Calc));
 
     List<TallySnapshot> updatedSnaps =
         repository

--- a/src/test/java/org/candlepin/subscriptions/tally/tasks/UpdateAccountSnapshotsTaskTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/tasks/UpdateAccountSnapshotsTaskTest.java
@@ -20,8 +20,6 @@
  */
 package org.candlepin.subscriptions.tally.tasks;
 
-import static org.mockito.BDDMockito.eq;
-
 import java.util.Arrays;
 import java.util.List;
 import org.candlepin.subscriptions.tally.TallySnapshotController;
@@ -38,9 +36,9 @@ class UpdateAccountSnapshotsTaskTest {
 
   @Test
   void testExecute() {
-    List<String> accounts = Arrays.asList("a1", "a2");
+    List<String> accounts = Arrays.asList("a1");
     UpdateAccountSnapshotsTask task = new UpdateAccountSnapshotsTask(snapshotController, accounts);
     task.execute();
-    Mockito.verify(snapshotController).produceSnapshotsForAccounts(eq(accounts));
+    Mockito.verify(snapshotController).produceSnapshotsForAccount("a1");
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -24,7 +24,11 @@ import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -53,8 +57,8 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
   void deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(
       String accountNumber, Granularity granularity, OffsetDateTime cutoffDate);
 
-  Stream<TallySnapshot> findByAccountNumberInAndProductIdInAndGranularityAndSnapshotDateBetween(
-      Collection<String> accountNumbers,
+  Stream<TallySnapshot> findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+      String accountNumber,
       Collection<String> productIds,
       Granularity granularity,
       OffsetDateTime beginning,


### PR DESCRIPTION
Running tallies in batches larger than size one causes errors:
specifically postgresql can't commit the transaction and says
"terminating connection due to conflict with recovery".  This issue
happened when our read query conflicts with an appending replication
change.  See ENT-2834.

Since there are no plans to start running tallies in batches any more,
we can go ahead and change the method signatures to reflect this
reality.  Additionally, this let's us log how long a tally takes on a
per-account basis which is useful for the performance team.