### PR TITLE
Make billing provider enums lowercase in openapi spec

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -931,7 +931,7 @@ components:
       enum: [ "", Production, Development/Test, Disaster Recovery, _ANY ]
     BillingProviderType:
       type: string
-      enum: [ "", Red Hat, Aws, Gcp, Azure, Oracle, _ANY ]
+      enum: [ "", red hat, aws, gcp, azure, oracle, _ANY ]
     ProductId:
       type: string
       enum:


### PR DESCRIPTION
For consistency; also we actually currently 500 response w/ the case as written.