### PR TITLE
ENT-4896: Sort infinite quantity subs along with quantity

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -265,6 +265,17 @@ public class SubscriptionTableController {
               diff = left.getUsage().compareTo(right.getUsage());
               break;
             case QUANTITY:
+              // unlimited quantity subscriptions are greater than non-unlimited
+              if (!Objects.equals(left.getHasInfiniteQuantity(), right.getHasInfiniteQuantity())) {
+                if (Boolean.TRUE.equals(left.getHasInfiniteQuantity())) {
+                  diff = 1;
+                  break;
+                }
+                if (Boolean.TRUE.equals(right.getHasInfiniteQuantity())) {
+                  diff = -1;
+                  break;
+                }
+              }
               diff = left.getQuantity().compareTo(right.getQuantity());
               break;
             case NEXT_EVENT_DATE:

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -265,18 +265,7 @@ public class SubscriptionTableController {
               diff = left.getUsage().compareTo(right.getUsage());
               break;
             case QUANTITY:
-              // unlimited quantity subscriptions are greater than non-unlimited
-              if (!Objects.equals(left.getHasInfiniteQuantity(), right.getHasInfiniteQuantity())) {
-                if (Boolean.TRUE.equals(left.getHasInfiniteQuantity())) {
-                  diff = 1;
-                  break;
-                }
-                if (Boolean.TRUE.equals(right.getHasInfiniteQuantity())) {
-                  diff = -1;
-                  break;
-                }
-              }
-              diff = left.getQuantity().compareTo(right.getQuantity());
+              diff = compareQuantity(left, right);
               break;
             case NEXT_EVENT_DATE:
               diff = left.getNextEventDate().compareTo(right.getNextEventDate());
@@ -299,5 +288,18 @@ public class SubscriptionTableController {
 
           return diff * sortDir;
         });
+  }
+
+  private static int compareQuantity(SkuCapacity left, SkuCapacity right) {
+    // unlimited quantity subscriptions are greater than non-unlimited
+    if (!Objects.equals(left.getHasInfiniteQuantity(), right.getHasInfiniteQuantity())) {
+      if (Boolean.TRUE.equals(left.getHasInfiniteQuantity())) {
+        return 1;
+      }
+      if (Boolean.TRUE.equals(right.getHasInfiniteQuantity())) {
+        return -1;
+      }
+    }
+    return left.getQuantity().compareTo(right.getQuantity());
   }
 }

--- a/src/main/resources/product-stub-data/tree-MW00210M1_attrs-true.json
+++ b/src/main/resources/product-stub-data/tree-MW00210M1_attrs-true.json
@@ -1,7 +1,7 @@
 {
   "products": [
     {
-      "sku": "MW00210MO",
+      "sku": "MW00210M1",
       "description": "Red Hat OpenShift Container Platform, Premium (1 vCPU, Monthly, On-Demand, Billing)",
       "status": "ACTIVE",
       "attributes": [


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4896

Testing
-------

Create an allowlist with a couple of SKUs on it:

```
echo -e 'MW00330\nMW00210MO\n' > /tmp/allowlist.txt
```

Run the app:

```
RHSM_RBAC_USE_STUB=true \
  DEV_MODE=true \
  PRODUCT_WHITELIST_RESOURCE_LOCATION=file:/tmp/allowlist.txt \
  ./gradlew :bootRun
```

Opt in account 123 / org 123:

```
curl   -H 'Content-Type: application/json'   -d '{
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean",
    "operation": "createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)",
    "arguments": [
      "123",
      "123",
      true,
      true,
      true
    ]
  }'   http://localhost:9000/hawtio/jolokia
```

Insert offerings into the DB manually:

```
curl   -H 'Content-Type: application/json'   -d "{
    \"type\": \"exec\",
    \"mbean\": \"org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean\",
    \"operation\": \"saveOfferings(java.lang.String,java.lang.String,java.lang.String,boolean)\",
    \"arguments\": [
        $(cat src/main/resources/product-stub-data/tree-*.json | jq -s),
        $(cat src/main/resources/product-stub-data/tree-*.json | jq -s),
        $(cat src/main/resources/product-stub-data/engprods-*.json | jq -s),
        false
    ]
  }"   http://localhost:9000/hawtio/jolokia
```

Insert a non-unlimited subscription:

```
curl   -H 'Content-Type: application/json'   -d '{
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean",
    "operation": "saveSubscriptions(java.lang.String,boolean)",
    "arguments": [
      "[{
         \"id\": 123456789,
         \"quantity\": 2,
         \"webCustomerId\": 123,
         \"effectiveStartDate\": 946702800000,
         \"effectiveEndDate\": 2524626000000,
         \"subscriptionProducts\": [
           {
             \"sku\": \"MW00330\"
           }
         ]
      }]",
      true
    ]
  }'   http://localhost:9000/hawtio/jolokia
```

Insert an infinite quantity sub:

```
curl   -H 'Content-Type: application/json'   -d '{
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean",
    "operation": "saveSubscriptions(java.lang.String,boolean)",
    "arguments": [
      "[{
         \"id\": 123456790,
         \"quantity\": 1,
         \"webCustomerId\": 123,
         \"effectiveStartDate\": 946702800000,
         \"effectiveEndDate\": 2524626000000,
         \"subscriptionProducts\": [
           {
             \"sku\": \"MW00210MO\"
           }
         ]
      }]",
      true
    ]
  }'   http://localhost:9000/hawtio/jolokia
```

Try the API for subscription table, sorting by quantity ascending:

```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform?sort=quantity&dir=asc' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMyIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjMifX19Cg==' | jq
```

(The unlimited sub will appear last).

Try the API for subscription table, sorting by quantity descending:

```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform?sort=quantity&dir=desc' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMyIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjMifX19Cg==' | jq
```

(The unlimited sub will appear first).

Clean up if desired (can just recreate DB instead if desired):

```
psql -h localhost -U rhsm-subscriptions -c 'truncate offering cascade;'
psql -h localhost -U rhsm-subscriptions -c 'truncate subscription cascade;'
psql -h localhost -U rhsm-subscriptions -c 'truncate subscription_capacity cascade;'
```