### PR TITLE
ENT-4895: Fix hasInfiniteQuantity population bug

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -222,7 +222,7 @@ public class CapacityResource implements CapacityApi {
         cores += capacityVirtCores;
         hypervisorCores += capacityVirtCores;
 
-        hasInfiniteQuantity = Optional.ofNullable(capacity.getHasUnlimitedUsage()).orElse(false);
+        hasInfiniteQuantity |= Optional.ofNullable(capacity.getHasUnlimitedUsage()).orElse(false);
       }
     }
 

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -315,4 +315,48 @@ class CapacityResourceTest {
     CapacitySnapshot capacitySnapshot = report.getData().get(0);
     assertTrue(capacitySnapshot.getHasInfiniteQuantity());
   }
+
+  @Test
+  void testShouldCalculateCapacityHavingUnlimitedUsageSeenFirst() {
+    SubscriptionCapacity limited = new SubscriptionCapacity();
+    limited.setHasUnlimitedUsage(false);
+    limited.setPhysicalCores(4);
+    limited.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
+    limited.setEndDate(max);
+    SubscriptionCapacity unlimited = new SubscriptionCapacity();
+    unlimited.setHasUnlimitedUsage(true);
+    unlimited.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
+    unlimited.setEndDate(max);
+
+    when(repository.findByOwnerAndProductId("owner123456", RHEL.toString(), null, null, min, max))
+        .thenReturn(Arrays.asList(unlimited, limited));
+
+    CapacityReport report =
+        resource.getCapacityReport(RHEL, GranularityType.DAILY, min, max, null, null, null, null);
+
+    CapacitySnapshot capacitySnapshot = report.getData().get(0);
+    assertTrue(capacitySnapshot.getHasInfiniteQuantity());
+  }
+
+  @Test
+  void testShouldCalculateCapacityHavingUnlimitedUsageSeenLast() {
+    SubscriptionCapacity limited = new SubscriptionCapacity();
+    limited.setHasUnlimitedUsage(false);
+    limited.setPhysicalCores(4);
+    limited.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
+    limited.setEndDate(max);
+    SubscriptionCapacity unlimited = new SubscriptionCapacity();
+    unlimited.setHasUnlimitedUsage(true);
+    unlimited.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
+    unlimited.setEndDate(max);
+
+    when(repository.findByOwnerAndProductId("owner123456", RHEL.toString(), null, null, min, max))
+        .thenReturn(Arrays.asList(limited, unlimited));
+
+    CapacityReport report =
+        resource.getCapacityReport(RHEL, GranularityType.DAILY, min, max, null, null, null, null);
+
+    CapacitySnapshot capacitySnapshot = report.getData().get(0);
+    assertTrue(capacitySnapshot.getHasInfiniteQuantity());
+  }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4895

Without this fix, when two subscriptions match the criteria, and one of them provides infinite quantity, the order they are processed in determined whether the flag got populated correctly or not.

Given the nature of the bug and the complexity of reproducing, I think unit testing should suffice.