### PR TITLE
Remove public modifiers from JUnit tests

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
@@ -43,13 +43,13 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
-public class AccountConfigRepositoryTest {
+class AccountConfigRepositoryTest {
 
   @Autowired private AccountConfigRepository repository;
   private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
 
   @Test
-  public void saveAndUpdate() {
+  void saveAndUpdate() {
     OffsetDateTime creation = clock.now();
     OffsetDateTime expectedUpdate = creation.plusDays(1);
 
@@ -80,7 +80,7 @@ public class AccountConfigRepositoryTest {
   }
 
   @Test
-  public void testDelete() {
+  void testDelete() {
     AccountConfig config = createConfig("an-account", true, true);
     repository.saveAndFlush(config);
 
@@ -93,7 +93,7 @@ public class AccountConfigRepositoryTest {
   }
 
   @Test
-  public void testFindAccountsWithEnabledSync() {
+  void testFindAccountsWithEnabledSync() {
     repository.saveAll(
         Arrays.asList(
             createConfig("A1", true, true),
@@ -109,7 +109,7 @@ public class AccountConfigRepositoryTest {
   }
 
   @Test
-  public void testIsReportingEnabled() {
+  void testIsReportingEnabled() {
     repository.saveAll(
         Arrays.asList(
             createConfig("A1", true, true),

--- a/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
@@ -44,7 +44,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
-public class OrgConfigRepositoryTest {
+class OrgConfigRepositoryTest {
 
   @Autowired private OrgConfigRepository repository;
   private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
@@ -55,7 +55,7 @@ public class OrgConfigRepositoryTest {
   }
 
   @Test
-  public void saveAndUpdate() {
+  void saveAndUpdate() {
     OffsetDateTime creation = clock.now();
     OffsetDateTime expectedUpdate = creation.plusDays(1);
 
@@ -83,7 +83,7 @@ public class OrgConfigRepositoryTest {
   }
 
   @Test
-  public void testDelete() {
+  void testDelete() {
     OrgConfig config = createConfig("an-org", true);
     repository.saveAndFlush(config);
 
@@ -96,7 +96,7 @@ public class OrgConfigRepositoryTest {
   }
 
   @Test
-  public void testFindOrgsWithEnabledSync() {
+  void testFindOrgsWithEnabledSync() {
     repository.saveAll(
         Arrays.asList(
             createConfig("A1", true),

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -83,7 +83,7 @@ class SubscriptionCapacityRepositoryTest {
   }
 
   @Test
-  public void testShouldFindGivenSubscriptionStartingBeforeRangeAndEndingAfterRange() {
+  void testShouldFindGivenSubscriptionStartingBeforeRangeAndEndingAfterRange() {
     SubscriptionCapacity c = createUnpersisted(NOWISH.minusDays(1), FAR_FUTURE.plusDays(1));
 
     repository.save(c);

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -29,7 +29,13 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurement;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +48,7 @@ import org.springframework.transaction.annotation.Transactional;
 // The transactional annotation will rollback the transaction at the end of every test.
 @Transactional
 @ActiveProfiles("test")
-public class TallySnapshotRepositoryTest {
+class TallySnapshotRepositoryTest {
   private static final OffsetDateTime LONG_AGO =
       OffsetDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault());
   private static final OffsetDateTime NOWISH =
@@ -53,7 +59,7 @@ public class TallySnapshotRepositoryTest {
   @Autowired private TallySnapshotRepository repository;
 
   @Test
-  public void testSave() {
+  void testSave() {
     TallySnapshot t =
         createUnpersisted("Hello", "World", Granularity.DAILY, 2, 3, 4, OffsetDateTime.now());
     TallySnapshot saved = repository.saveAndFlush(t);
@@ -62,7 +68,7 @@ public class TallySnapshotRepositoryTest {
 
   @SuppressWarnings("linelength")
   @Test
-  public void findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsage() {
+  void findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsage() {
     TallySnapshot t1 = createUnpersisted("Hello", "World", Granularity.DAILY, 2, 3, 4, NOWISH);
     TallySnapshot t2 = createUnpersisted("Bugs", "Bunny", Granularity.DAILY, 9999, 999, 99, NOWISH);
     TallySnapshot t3 =
@@ -109,7 +115,7 @@ public class TallySnapshotRepositoryTest {
 
   @SuppressWarnings("linelength")
   @Test
-  public void testFindByEmptyServiceLevelAndUsage() {
+  void testFindByEmptyServiceLevelAndUsage() {
     TallySnapshot t1 =
         createUnpersisted(
             "A1",
@@ -152,7 +158,7 @@ public class TallySnapshotRepositoryTest {
   }
 
   @Test
-  public void testFindByAccountNumberInAndProductIdInAndGranularityAndSnapshotDateBetween() {
+  void testFindByAccountNumberInAndProductIdInAndGranularityAndSnapshotDateBetween() {
     String product1 = "Product1";
     String product2 = "Product2";
     // Will not be found - out of date range.
@@ -202,7 +208,7 @@ public class TallySnapshotRepositoryTest {
   }
 
   @Test
-  public void testPersistsHardwareMeasurements() {
+  void testPersistsHardwareMeasurements() {
     TallySnapshot snap =
         createUnpersisted("Acme Inc.", "rocket-skates", Granularity.DAILY, 1, 2, 3, NOWISH);
 

--- a/src/test/java/org/candlepin/subscriptions/db/model/HardwareMeasurementTypeTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HardwareMeasurementTypeTest.java
@@ -20,38 +20,37 @@
  */
 package org.candlepin.subscriptions.db.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-public class HardwareMeasurementTypeTest {
+class HardwareMeasurementTypeTest {
 
   @Test
-  public void testIsCloudProviderTypeCaseInsensitive() {
+  void testIsCloudProviderTypeCaseInsensitive() {
     assertTrue(HardwareMeasurementType.isSupportedCloudProvider("aws"));
     assertTrue(HardwareMeasurementType.isSupportedCloudProvider("AWS"));
   }
 
   @Test
-  public void testEmptyCloudProviderNotSupported() {
+  void testEmptyCloudProviderNotSupported() {
     assertFalse(HardwareMeasurementType.isSupportedCloudProvider(null));
     assertFalse(HardwareMeasurementType.isSupportedCloudProvider(""));
   }
 
   @Test
-  public void testUnsupportedIfNotInList() {
+  void testUnsupportedIfNotInList() {
     assertFalse(HardwareMeasurementType.isSupportedCloudProvider("unknown_type"));
   }
 
   @Test
-  public void testUnsupportedIfHardwareTypeButNotInList() {
+  void testUnsupportedIfHardwareTypeButNotInList() {
     assertFalse(
         HardwareMeasurementType.isSupportedCloudProvider(HardwareMeasurementType.PHYSICAL.name()));
   }
 
   @Test
-  public void ensureAllCloudProviderTypesAreConsideredSupported() {
+  void ensureAllCloudProviderTypesAreConsideredSupported() {
     HardwareMeasurementType.getCloudProviderTypes()
         .forEach(
             type -> {

--- a/src/test/java/org/candlepin/subscriptions/files/FileAccountSyncListSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/FileAccountSyncListSourceTest.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.files;
 
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
@@ -31,10 +31,10 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.FileSystemResourceLoader;
 
-public class FileAccountSyncListSourceTest {
+class FileAccountSyncListSourceTest {
 
   @Test
-  public void ensureResourcePathComesFromApplicationProperty() throws Exception {
+  void ensureResourcePathComesFromApplicationProperty() throws Exception {
     ApplicationProperties props = new ApplicationProperties();
     props.setAccountListResourceLocation("classpath:account_list.txt");
 

--- a/src/test/java/org/candlepin/subscriptions/files/PerLineFileResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/PerLineFileResourceTest.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.files;
 
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Clock;
@@ -31,20 +31,20 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.FileSystemResourceLoader;
 
-public class PerLineFileResourceTest {
+class PerLineFileResourceTest {
 
   @Test
-  public void ensureOneProductPerLine() throws Exception {
+  void ensureOneProductPerLine() throws Exception {
     assertListFile("item_per_line.txt", Arrays.asList("I1", "I2", "I3"));
   }
 
   @Test
-  public void ensureEmptyLinesAreIgnored() throws Exception {
+  void ensureEmptyLinesAreIgnored() throws Exception {
     assertListFile("item_per_line_with_empty_lines.txt", Arrays.asList("I10", "I20", "I30"));
   }
 
   @Test
-  public void ensureExceptionWhenResourceNotFound() {
+  void ensureExceptionWhenResourceNotFound() {
     RuntimeException rte =
         assertThrows(
             RuntimeException.class,

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -252,7 +252,7 @@ class CapacityResourceTest {
 
   @Test
   @WithMockRedHatPrincipal("1111")
-  public void testAccessDeniedWhenAccountIsNotWhitelisted() {
+  void testAccessDeniedWhenAccountIsNotWhitelisted() {
     assertThrows(
         AccessDeniedException.class,
         () -> {
@@ -264,7 +264,7 @@ class CapacityResourceTest {
   @WithMockRedHatPrincipal(
       value = "123456",
       roles = {})
-  public void testAccessDeniedWhenUserIsNotAnAdmin() {
+  void testAccessDeniedWhenUserIsNotAnAdmin() {
     assertThrows(
         AccessDeniedException.class,
         () -> {

--- a/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
@@ -44,7 +44,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles({"api", "test"})
 @WithMockRedHatPrincipal("123456")
-public class OptInResourceTest {
+class OptInResourceTest {
 
   private ApplicationClock clock;
 
@@ -61,19 +61,19 @@ public class OptInResourceTest {
   }
 
   @Test
-  public void testDeleteOptInConfig() {
+  void testDeleteOptInConfig() {
     resource.deleteOptInConfig();
     Mockito.verify(controller).optOut(eq("account123456"), eq("owner123456"));
   }
 
   @Test
-  public void testGet() {
+  void testGet() {
     resource.getOptInConfig();
     Mockito.verify(controller).getOptInConfig(eq("account123456"), eq("owner123456"));
   }
 
   @Test
-  public void testPut() {
+  void testPut() {
     resource.putOptInConfig(false, false, false);
     Mockito.verify(controller)
         .optIn(
@@ -86,7 +86,7 @@ public class OptInResourceTest {
   }
 
   @Test
-  public void testPutDefaultsToTrue() {
+  void testPutDefaultsToTrue() {
     resource.putOptInConfig(null, null, null);
     Mockito.verify(controller)
         .optIn(
@@ -100,13 +100,13 @@ public class OptInResourceTest {
 
   @Test
   @WithMockRedHatPrincipal(value = "123456", nullifyOwner = true)
-  public void testMissingOrgOnDelete() {
+  void testMissingOrgOnDelete() {
     assertThrows(BadRequestException.class, () -> resource.deleteOptInConfig());
   }
 
   @Test
   @WithMockRedHatPrincipal(value = "123456", nullifyAccount = true)
-  public void testMissingAccountOnDelete() {
+  void testMissingAccountOnDelete() {
     assertThrows(BadRequestException.class, () -> resource.deleteOptInConfig());
   }
 
@@ -114,19 +114,19 @@ public class OptInResourceTest {
   @WithMockRedHatPrincipal(
       value = "123456",
       roles = {})
-  public void testAccessDeniedForDeleteAccountConfigWhenUserIsNotAnAdmin() {
+  void testAccessDeniedForDeleteAccountConfigWhenUserIsNotAnAdmin() {
     assertThrows(AccessDeniedException.class, () -> resource.deleteOptInConfig());
   }
 
   @Test
   @WithMockRedHatPrincipal(value = "123456", nullifyOwner = true)
-  public void testMissingOrgOnGet() {
+  void testMissingOrgOnGet() {
     assertThrows(BadRequestException.class, () -> resource.getOptInConfig());
   }
 
   @Test
   @WithMockRedHatPrincipal(value = "123456", nullifyAccount = true)
-  public void testMissingAccountOnGet() {
+  void testMissingAccountOnGet() {
     assertThrows(BadRequestException.class, () -> resource.getOptInConfig());
   }
 
@@ -134,19 +134,19 @@ public class OptInResourceTest {
   @WithMockRedHatPrincipal(
       value = "123456",
       roles = {})
-  public void testAccessDeniedForGetAccountConfigWhenUserIsNotAnAdmin() {
+  void testAccessDeniedForGetAccountConfigWhenUserIsNotAnAdmin() {
     assertThrows(AccessDeniedException.class, () -> resource.getOptInConfig());
   }
 
   @Test
   @WithMockRedHatPrincipal(value = "123456", nullifyOwner = true)
-  public void testMissingOrgOnPut() {
+  void testMissingOrgOnPut() {
     assertThrows(BadRequestException.class, () -> resource.putOptInConfig(true, true, true));
   }
 
   @Test
   @WithMockRedHatPrincipal(value = "123456", nullifyAccount = true)
-  public void testMissingAccountOnPut() {
+  void testMissingAccountOnPut() {
     assertThrows(BadRequestException.class, () -> resource.putOptInConfig(true, true, true));
   }
 
@@ -154,7 +154,7 @@ public class OptInResourceTest {
   @WithMockRedHatPrincipal(
       value = "123456",
       roles = {})
-  public void testAccessDeniedForOptInWhenUserIsNotAnAdmin() {
+  void testAccessDeniedForOptInWhenUserIsNotAnAdmin() {
     assertThrows(AccessDeniedException.class, () -> resource.putOptInConfig(true, true, true));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -37,7 +37,13 @@ import javax.ws.rs.core.Response;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
-import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurement;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.json.Measurement.Uom;
@@ -76,7 +82,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles({"api", "test"})
 @WithMockRedHatPrincipal("123456")
 @Import(FixedClockConfiguration.class)
-public class TallyResourceTest {
+class TallyResourceTest {
 
   public static final ProductId RHEL_PRODUCT_ID = ProductId.RHEL;
   public static final String INVALID_PRODUCT_ID_VALUE = "bad_product";
@@ -110,10 +116,8 @@ public class TallyResourceTest {
   }
 
   @Test
-  public void testNullSlaQueryParameter() {
-
+  void testNullSlaQueryParameter() {
     TallySnapshot snap = new TallySnapshot();
-
     Mockito.when(
             repository
                 .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndBillingProviderAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -182,10 +186,8 @@ public class TallyResourceTest {
   }
 
   @Test
-  public void testNullUsageQueryParameter() {
-
+  void testNullUsageQueryParameter() {
     TallySnapshot snap = new TallySnapshot();
-
     Mockito.when(
             repository
                 .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndBillingProviderAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -237,9 +239,8 @@ public class TallyResourceTest {
 
   @Test
   @SuppressWarnings({"linelength", "indentation"})
-  public void testUnsetSlaQueryParameter() {
+  void testUnsetSlaQueryParameter() {
     TallySnapshot snap = new TallySnapshot();
-
     Mockito.when(
             repository
                 .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndBillingProviderAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -291,9 +292,8 @@ public class TallyResourceTest {
   }
 
   @Test
-  public void testUnsetUsageQueryParameter() {
+  void testUnsetUsageQueryParameter() {
     TallySnapshot snap = new TallySnapshot();
-
     Mockito.when(
             repository
                 .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndBillingProviderAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -345,9 +345,8 @@ public class TallyResourceTest {
   }
 
   @Test
-  public void testSetSlaAndUsageQueryParameters() {
+  void testSetSlaAndUsageQueryParameters() {
     TallySnapshot snap = new TallySnapshot();
-
     Mockito.when(
             repository
                 .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndBillingProviderAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -456,9 +455,8 @@ public class TallyResourceTest {
   }
 
   @Test
-  public void testShouldUseQueryBasedOnHeaderAndParameters() throws Exception {
+  void testShouldUseQueryBasedOnHeaderAndParameters() throws Exception {
     TallySnapshot snap = new TallySnapshot();
-
     Mockito.when(
             repository
                 .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndBillingProviderAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -548,7 +546,7 @@ public class TallyResourceTest {
   }
 
   @Test
-  public void testShouldThrowExceptionOnBadOffset() throws IOException {
+  void testShouldThrowExceptionOnBadOffset() throws IOException {
     SubscriptionsException e =
         assertThrows(
             SubscriptionsException.class,
@@ -567,7 +565,7 @@ public class TallyResourceTest {
   }
 
   @Test
-  public void reportDataShouldGetFilledWhenPagingParametersAreNotPassed() {
+  void reportDataShouldGetFilledWhenPagingParametersAreNotPassed() {
     Mockito.when(
             repository
                 .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndBillingProviderAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -613,7 +611,7 @@ public class TallyResourceTest {
   @WithMockRedHatPrincipal(
       value = "123456",
       roles = {"ROLE_" + RoleProvider.SWATCH_ADMIN_ROLE})
-  public void canReportWithOnlyReportingRole() {
+  void canReportWithOnlyReportingRole() {
     Mockito.when(
             repository
                 .findByAccountNumberAndProductIdAndGranularityAndServiceLevelAndUsageAndBillingProviderAndSnapshotDateBetweenOrderBySnapshotDate(
@@ -636,7 +634,7 @@ public class TallyResourceTest {
 
   @Test
   @WithMockRedHatPrincipal("1111")
-  public void testAccessDeniedWhenAccountIsNotWhitelisted() {
+  void testAccessDeniedWhenAccountIsNotWhitelisted() {
     assertThrows(
         AccessDeniedException.class,
         () -> {
@@ -649,7 +647,7 @@ public class TallyResourceTest {
   @WithMockRedHatPrincipal(
       value = "123456",
       roles = {})
-  public void testAccessDeniedWhenUserIsNotAnAdmin() {
+  void testAccessDeniedWhenUserIsNotAnAdmin() {
     assertThrows(
         AccessDeniedException.class,
         () -> {

--- a/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/VersionResourceTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles({"api", "test"})
-public class VersionResourceTest {
+class VersionResourceTest {
   @MockBean BuildProperties buildProperties;
 
   @Autowired VersionResource versionResource;

--- a/src/test/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequiredTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/auth/ReportingAccessRequiredTest.java
@@ -40,7 +40,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles("test")
 @Import(StubResourceConfiguration.class)
-public class ReportingAccessRequiredTest {
+class ReportingAccessRequiredTest {
 
   @Autowired ApplicationContext context;
 

--- a/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/AccountUsageCalculationTest.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -28,10 +28,10 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-public class AccountUsageCalculationTest {
+class AccountUsageCalculationTest {
 
   @Test
-  public void testGetCalculation() {
+  void testGetCalculation() {
     String p1 = "Product1";
     AccountUsageCalculation calc = new AccountUsageCalculation("Account1");
     UsageCalculation prodCalc = new UsageCalculation(createUsageKey(p1));
@@ -42,7 +42,7 @@ public class AccountUsageCalculationTest {
   }
 
   @Test
-  public void testContainsCalculation() {
+  void testContainsCalculation() {
     String p1 = "Product1";
     AccountUsageCalculation calc = new AccountUsageCalculation("Account1");
     UsageCalculation prodCalc = new UsageCalculation(createUsageKey(p1));
@@ -54,7 +54,7 @@ public class AccountUsageCalculationTest {
   }
 
   @Test
-  public void testGetProducts() {
+  void testGetProducts() {
     String p1 = "Product1";
     String p2 = "Product2";
     String p3 = "Product3";

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -20,9 +20,14 @@
  */
 package org.candlepin.subscriptions.tally;
 
-import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.*;
-import static org.candlepin.subscriptions.tally.collector.Assertions.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createGuest;
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createHypervisor;
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createRhsmHost;
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createSystemProfileHost;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertHypervisorTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertPhysicalTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertTotalsCalculation;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -64,7 +69,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles({"worker", "test"})
-public class InventoryAccountUsageCollectorTest {
+class InventoryAccountUsageCollectorTest {
 
   private static final String TEST_PRODUCT = "RHEL";
   public static final Integer TEST_PRODUCT_ID = 1;
@@ -82,7 +87,7 @@ public class InventoryAccountUsageCollectorTest {
   @Autowired private MeterRegistry meterRegistry;
 
   @Test
-  public void hypervisorCountsIgnoredForNonRhelProduct() {
+  void hypervisorCountsIgnoredForNonRhelProduct() {
     String account = "A1";
 
     InventoryHostFacts hypervisor = createHypervisor("A1", "O1", NON_RHEL_PRODUCT_ID);
@@ -110,7 +115,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void hypervisorTotalsForRHEL() {
+  void hypervisorTotalsForRHEL() {
     String account = "A1";
 
     InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID);
@@ -141,7 +146,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void guestWithKnownHypervisorNotAddedToTotalsForRHEL() {
+  void guestWithKnownHypervisorNotAddedToTotalsForRHEL() {
     String account = "A1";
 
     InventoryHostFacts guest = createGuest("hyper-1", "A1", "O1", TEST_PRODUCT_ID);
@@ -164,7 +169,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void guestUnknownHypervisorTotalsForRHEL() {
+  void guestUnknownHypervisorTotalsForRHEL() {
     String account = "A1";
     InventoryHostFacts guest = createGuest(null, "A1", "O1", TEST_PRODUCT_ID);
     guest.setSystemProfileCoresPerSocket(4);
@@ -190,7 +195,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void physicalSystemTotalsForRHEL() {
+  void physicalSystemTotalsForRHEL() {
     String account = "A1";
     List<Integer> products = Arrays.asList(TEST_PRODUCT_ID);
 
@@ -216,7 +221,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void testTallyCoresAndSocketsOfRhelWhenInventoryFoundForAccount() throws Exception {
+  void testTallyCoresAndSocketsOfRhelWhenInventoryFoundForAccount() throws Exception {
     List<String> accounts = List.of("A1", "A2");
     List<Integer> products = Arrays.asList(TEST_PRODUCT_ID);
 
@@ -369,7 +374,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void testCalculationDoesNotIncludeHostWhenProductDoesntMatch() throws IOException {
+  void testCalculationDoesNotIncludeHostWhenProductDoesntMatch() throws IOException {
     String account = "A1";
 
     InventoryHostFacts h1 =
@@ -397,7 +402,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void throwsISEOnAttemptToCalculateFactsBelongingToADifferentOwnerForSameAccount()
+  void throwsISEOnAttemptToCalculateFactsBelongingToADifferentOwnerForSameAccount()
       throws IOException {
     String account = "A1";
 
@@ -422,7 +427,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void testTallyCoresAndSocketsOfRhelForPhysicalSystems() {
+  void testTallyCoresAndSocketsOfRhelForPhysicalSystems() {
     List<String> accounts = List.of("A1", "A2");
     InventoryHostFacts host1 =
         createRhsmHost("A1", "O1", Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
@@ -468,7 +473,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void testHypervisorCalculationsWhenMapped() {
+  void testHypervisorCalculationsWhenMapped() {
     String account = "A1";
 
     InventoryHostFacts hypervisor = createHypervisor("A1", "O1", TEST_PRODUCT_ID);
@@ -507,7 +512,7 @@ public class InventoryAccountUsageCollectorTest {
   }
 
   @Test
-  public void testHypervisorCalculationsWhenMappedWithNoProductsOnHypervisor() {
+  void testHypervisorCalculationsWhenMappedWithNoProductsOnHypervisor() {
     String account = "A1";
 
     InventoryHostFacts hypervisor = createHypervisor("A1", "O1", null);

--- a/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
@@ -20,7 +20,8 @@
  */
 package org.candlepin.subscriptions.tally;
 
-import static org.candlepin.subscriptions.tally.collector.Assertions.*;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertHardwareMeasurementTotals;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertNullExcept;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.stream.IntStream;
@@ -29,10 +30,10 @@ import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.junit.jupiter.api.Test;
 
-public class UsageCalculationTest {
+class UsageCalculationTest {
 
   @Test
-  public void testDefaults() {
+  void testDefaults() {
     UsageCalculation calculation = new UsageCalculation(createUsageKey("Test Product"));
     assertEquals("Test Product", calculation.getProductId());
 
@@ -42,7 +43,7 @@ public class UsageCalculationTest {
   }
 
   @Test
-  public void testAddToTotal() {
+  void testAddToTotal() {
     UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
     IntStream.rangeClosed(0, 4).forEach(i -> calculation.addToTotal(i + 2, i + 1, i));
 
@@ -51,7 +52,7 @@ public class UsageCalculationTest {
   }
 
   @Test
-  public void testPhysicalSystemTotal() {
+  void testPhysicalSystemTotal() {
     UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
     IntStream.rangeClosed(0, 4).forEach(i -> calculation.addPhysical(i + 2, i + 1, i));
 
@@ -65,7 +66,7 @@ public class UsageCalculationTest {
   }
 
   @Test
-  public void testHypervisorTotal() {
+  void testHypervisorTotal() {
     UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
     IntStream.rangeClosed(0, 4).forEach(i -> calculation.addHypervisor(i + 2, i + 1, i));
 
@@ -75,22 +76,22 @@ public class UsageCalculationTest {
   }
 
   @Test
-  public void testAWSTotal() {
+  void testAWSTotal() {
     checkCloudProvider(HardwareMeasurementType.AWS);
   }
 
   @Test
-  public void testAlibabaTotal() {
+  void testAlibabaTotal() {
     checkCloudProvider(HardwareMeasurementType.ALIBABA);
   }
 
   @Test
-  public void testGoogleTotal() {
+  void testGoogleTotal() {
     checkCloudProvider(HardwareMeasurementType.GOOGLE);
   }
 
   @Test
-  public void testAzureTotal() {
+  void testAzureTotal() {
     checkCloudProvider(HardwareMeasurementType.AZURE);
   }
 
@@ -128,7 +129,7 @@ public class UsageCalculationTest {
   }
 
   @Test
-  public void invalidCloudTypeThrowsExcpection() {
+  void invalidCloudTypeThrowsExcpection() {
     UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
     assertThrows(
         IllegalArgumentException.class,

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -20,8 +20,14 @@
  */
 package org.candlepin.subscriptions.tally.collector;
 
-import static org.candlepin.subscriptions.tally.collector.Assertions.*;
-import static org.candlepin.subscriptions.tally.collector.TestHelper.*;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertHardwareMeasurementTotals;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertNullExcept;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertPhysicalTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.TestHelper.cloudMachineFacts;
+import static org.candlepin.subscriptions.tally.collector.TestHelper.guestFacts;
+import static org.candlepin.subscriptions.tally.collector.TestHelper.hypervisorFacts;
+import static org.candlepin.subscriptions.tally.collector.TestHelper.physicalNonHypervisor;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -32,7 +38,7 @@ import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 import org.junit.jupiter.api.Test;
 
-public class DefaultProductUsageCollectorTest {
+class DefaultProductUsageCollectorTest {
 
   private DefaultProductUsageCollector collector;
 
@@ -41,7 +47,7 @@ public class DefaultProductUsageCollectorTest {
   }
 
   @Test
-  public void testCountsForHypervisor() {
+  void testCountsForHypervisor() {
     // By default hypervisors are not tracked at all and therefor
     // it is considered to be a physical machine.
     NormalizedFacts facts = hypervisorFacts(4, 12);
@@ -54,7 +60,7 @@ public class DefaultProductUsageCollectorTest {
   }
 
   @Test
-  public void testCountsForGuestWithUnknownHypervisor() {
+  void testCountsForGuestWithUnknownHypervisor() {
     NormalizedFacts facts = guestFacts(3, 12, false);
 
     UsageCalculation calc = new UsageCalculation(createUsageKey());
@@ -67,7 +73,7 @@ public class DefaultProductUsageCollectorTest {
   }
 
   @Test
-  public void testCountsForGuestWithKnownHypervisor() {
+  void testCountsForGuestWithKnownHypervisor() {
     NormalizedFacts facts = guestFacts(3, 12, true);
 
     UsageCalculation calc = new UsageCalculation(createUsageKey());
@@ -80,7 +86,7 @@ public class DefaultProductUsageCollectorTest {
   }
 
   @Test
-  public void testCountsForPhysicalSystem() {
+  void testCountsForPhysicalSystem() {
     NormalizedFacts facts = physicalNonHypervisor(4, 12);
 
     UsageCalculation calc = new UsageCalculation(createUsageKey());
@@ -92,7 +98,7 @@ public class DefaultProductUsageCollectorTest {
   }
 
   @Test
-  public void testCountsForCloudProvider() {
+  void testCountsForCloudProvider() {
     // Cloud provider host should contribute to the matched supported cloud provider,
     // as well as the overall total. A cloud host should only ever contribute 1 socket
     // along with its cores.

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -20,8 +20,15 @@
  */
 package org.candlepin.subscriptions.tally.collector;
 
-import static org.candlepin.subscriptions.tally.collector.Assertions.*;
-import static org.candlepin.subscriptions.tally.collector.TestHelper.*;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertHardwareMeasurementTotals;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertHypervisorTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertNullExcept;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertPhysicalTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.TestHelper.cloudMachineFacts;
+import static org.candlepin.subscriptions.tally.collector.TestHelper.guestFacts;
+import static org.candlepin.subscriptions.tally.collector.TestHelper.hypervisorFacts;
+import static org.candlepin.subscriptions.tally.collector.TestHelper.physicalNonHypervisor;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.LinkedList;
@@ -35,7 +42,7 @@ import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 import org.junit.jupiter.api.Test;
 
-public class RHELProductUsageCollectorTest {
+class RHELProductUsageCollectorTest {
 
   private RHELProductUsageCollector collector;
 

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/NormalizedFactsTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/NormalizedFactsTest.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.facts;
 
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Map;
@@ -28,10 +28,10 @@ import java.util.Set;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-public class NormalizedFactsTest {
+class NormalizedFactsTest {
 
   @Test
-  public void testToInventoryPayload() {
+  void testToInventoryPayload() {
     NormalizedFacts facts = new NormalizedFacts();
     facts.addProduct("RHEL");
     facts.setCores(12);
@@ -47,7 +47,7 @@ public class NormalizedFactsTest {
   }
 
   @Test
-  public void testEmptyInventoryPayload() {
+  void testEmptyInventoryPayload() {
     NormalizedFacts facts = new NormalizedFacts();
 
     Map<String, Object> payload = facts.toInventoryPayload();

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.tally.filler;
 
 import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -33,7 +33,7 @@ import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.junit.jupiter.api.Test;
 
-public class DailyReportFillerTest {
+class DailyReportFillerTest {
 
   private ApplicationClock clock;
   private ReportFiller filler;
@@ -44,7 +44,7 @@ public class DailyReportFillerTest {
   }
 
   @Test
-  public void noExistingSnapsShouldfillWithDailyGranularity() {
+  void noExistingSnapsShouldfillWithDailyGranularity() {
     OffsetDateTime start = clock.now();
     OffsetDateTime end = start.plusDays(3);
 
@@ -60,7 +60,7 @@ public class DailyReportFillerTest {
   }
 
   @Test
-  public void shouldFillGapsBasedOnExistingSnapshotsForDailyGranularity() {
+  void shouldFillGapsBasedOnExistingSnapshotsForDailyGranularity() {
     OffsetDateTime start = clock.now();
     OffsetDateTime snap1Date = start.plusDays(1);
     OffsetDateTime end = start.plusDays(3);
@@ -95,7 +95,7 @@ public class DailyReportFillerTest {
   }
 
   @Test
-  public void testSnapshotsIgnoredWhenNoDatesSet() {
+  void testSnapshotsIgnoredWhenNoDatesSet() {
     OffsetDateTime start = clock.startOfToday();
     OffsetDateTime end = start.plusDays(3);
 

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.tally.filler;
 
 import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -33,7 +33,7 @@ import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.junit.jupiter.api.Test;
 
-public class MonthlyReportFillerTest {
+class MonthlyReportFillerTest {
 
   private ApplicationClock clock;
   private ReportFiller filler;
@@ -44,7 +44,7 @@ public class MonthlyReportFillerTest {
   }
 
   @Test
-  public void noExistingSnapsShouldFillWithMonthlyGranularity() {
+  void noExistingSnapsShouldFillWithMonthlyGranularity() {
     OffsetDateTime start = clock.startOfCurrentMonth();
     OffsetDateTime end = start.plusMonths(3);
 
@@ -60,7 +60,7 @@ public class MonthlyReportFillerTest {
   }
 
   @Test
-  public void startAndEndDatesForMonthlyAreResetWhenDateIsMidMonth() {
+  void startAndEndDatesForMonthlyAreResetWhenDateIsMidMonth() {
     // Mid month start
     OffsetDateTime start = clock.now();
     // Mid month end
@@ -81,7 +81,7 @@ public class MonthlyReportFillerTest {
   }
 
   @Test
-  public void testSnapshotsIgnoredWhenNoDatesSet() {
+  void testSnapshotsIgnoredWhenNoDatesSet() {
     OffsetDateTime start = clock.startOfCurrentMonth();
     OffsetDateTime end = start.plusMonths(3);
 
@@ -101,7 +101,7 @@ public class MonthlyReportFillerTest {
   }
 
   @Test
-  public void shouldFillGapsBasedOnExistingSnapshotsForMonthlyGranularity() {
+  void shouldFillGapsBasedOnExistingSnapshotsForMonthlyGranularity() {
     OffsetDateTime start = clock.startOfCurrentMonth();
     OffsetDateTime snap1Date = start.plusMonths(1);
     OffsetDateTime end = start.plusMonths(3);

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.tally.filler;
 
 import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -33,7 +33,7 @@ import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.junit.jupiter.api.Test;
 
-public class QuarterlyReportFillerTest {
+class QuarterlyReportFillerTest {
 
   private ApplicationClock clock;
   private ReportFiller filler;
@@ -44,7 +44,7 @@ public class QuarterlyReportFillerTest {
   }
 
   @Test
-  public void noExistingSnapsShouldFillWithQuarterlyGranularity() {
+  void noExistingSnapsShouldFillWithQuarterlyGranularity() {
     OffsetDateTime start = clock.startOfCurrentQuarter();
     OffsetDateTime end = start.plusYears(1);
     TallyReport report = new TallyReport();
@@ -60,7 +60,7 @@ public class QuarterlyReportFillerTest {
   }
 
   @Test
-  public void startAndEndDatesForQuarterlyAreResetWhenDateIsMidQuarter() {
+  void startAndEndDatesForQuarterlyAreResetWhenDateIsMidQuarter() {
     // Mid year start
     OffsetDateTime start = clock.now();
     // Mid year end
@@ -81,7 +81,7 @@ public class QuarterlyReportFillerTest {
   }
 
   @Test
-  public void testSnapshotsIgnoredWhenNoDatesSet() {
+  void testSnapshotsIgnoredWhenNoDatesSet() {
     OffsetDateTime start = clock.startOfCurrentQuarter();
     OffsetDateTime end = start.plusYears(1);
 
@@ -102,7 +102,7 @@ public class QuarterlyReportFillerTest {
   }
 
   @Test
-  public void shouldFillGapsBasedOnExistingSnapshotsForQuarterlyGranularity() {
+  void shouldFillGapsBasedOnExistingSnapshotsForQuarterlyGranularity() {
     OffsetDateTime start = clock.startOfCurrentQuarter();
     OffsetDateTime snap1Date = start.plusMonths(3);
     OffsetDateTime end = start.plusYears(1);

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.tally.filler;
 
 import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -33,7 +33,7 @@ import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.junit.jupiter.api.Test;
 
-public class WeeklyReportFillerTest {
+class WeeklyReportFillerTest {
 
   private ApplicationClock clock;
   private ReportFiller filler;
@@ -44,7 +44,7 @@ public class WeeklyReportFillerTest {
   }
 
   @Test
-  public void noExistingSnapsShouldFillWithWeeklyGranularity() {
+  void noExistingSnapsShouldFillWithWeeklyGranularity() {
     OffsetDateTime start = clock.startOfCurrentWeek();
     OffsetDateTime end = start.plusWeeks(3);
 
@@ -60,7 +60,7 @@ public class WeeklyReportFillerTest {
   }
 
   @Test
-  public void startAndEndDatesForWeeklyAreResetWhenDateIsMidWeek() {
+  void startAndEndDatesForWeeklyAreResetWhenDateIsMidWeek() {
     // Mid week start
     OffsetDateTime start = clock.now();
     // Mid week end
@@ -81,7 +81,7 @@ public class WeeklyReportFillerTest {
   }
 
   @Test
-  public void testSnapshotsIgnoredWhenNoDatesSet() {
+  void testSnapshotsIgnoredWhenNoDatesSet() {
     OffsetDateTime start = clock.startOfCurrentWeek();
     OffsetDateTime end = start.plusWeeks(3);
 
@@ -101,7 +101,7 @@ public class WeeklyReportFillerTest {
   }
 
   @Test
-  public void shouldFillGapsBasedOnExistingSnapshotsForWeeklyGranularity() {
+  void shouldFillGapsBasedOnExistingSnapshotsForWeeklyGranularity() {
     OffsetDateTime start = clock.startOfCurrentWeek();
     OffsetDateTime snap1Date = start.plusWeeks(1);
     OffsetDateTime end = start.plusWeeks(3);

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.tally.filler;
 
 import static org.candlepin.subscriptions.tally.filler.Assertions.assertSnapshot;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -33,7 +33,7 @@ import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 import org.junit.jupiter.api.Test;
 
-public class YearlyReportFillerTest {
+class YearlyReportFillerTest {
 
   private ApplicationClock clock;
   private ReportFiller filler;
@@ -44,7 +44,7 @@ public class YearlyReportFillerTest {
   }
 
   @Test
-  public void noExistingSnapsShouldFillWithYearlyGranularity() {
+  void noExistingSnapsShouldFillWithYearlyGranularity() {
     OffsetDateTime start = clock.startOfCurrentYear();
     OffsetDateTime end = start.plusYears(3);
     TallyReport report = new TallyReport();
@@ -59,7 +59,7 @@ public class YearlyReportFillerTest {
   }
 
   @Test
-  public void startAndEndDatesForYearlyAreResetWhenDateIsMidYear() {
+  void startAndEndDatesForYearlyAreResetWhenDateIsMidYear() {
     // Mid year start
     OffsetDateTime start = clock.now();
     // Mid year end
@@ -79,7 +79,7 @@ public class YearlyReportFillerTest {
   }
 
   @Test
-  public void testSnapshotsIgnoredWhenNoDatesSet() {
+  void testSnapshotsIgnoredWhenNoDatesSet() {
     OffsetDateTime start = clock.startOfCurrentYear();
     OffsetDateTime end = start.plusYears(3);
 
@@ -99,7 +99,7 @@ public class YearlyReportFillerTest {
   }
 
   @Test
-  public void shouldFillGapsBasedOnExistingSnapshotsForYearlyGranularity() {
+  void shouldFillGapsBasedOnExistingSnapshotsForYearlyGranularity() {
     OffsetDateTime start = clock.startOfCurrentYear();
     OffsetDateTime snap1Date = start.plusYears(1);
     OffsetDateTime end = start.plusYears(3);

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
-public class DailySnapshotRollerTest {
+class DailySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
 
@@ -51,7 +51,7 @@ public class DailySnapshotRollerTest {
   private SnapshotRollerTester<DailySnapshotRoller> tester;
 
   @BeforeAll
-  public void setupAllTests() throws IOException {
+  void setupAllTests() throws IOException {
     this.clock = new FixedClockConfiguration().fixedClock();
     this.tester =
         new SnapshotRollerTester<>(
@@ -60,28 +60,27 @@ public class DailySnapshotRollerTest {
 
   @SuppressWarnings("indentation")
   @Test
-  public void testDailySnapshotProducer() {
+  void testDailySnapshotProducer() {
     this.tester.performBasicSnapshotRollerTest(
         Granularity.DAILY, clock.startOfToday(), clock.endOfToday());
   }
 
   @SuppressWarnings("indentation")
   @Test
-  public void testDailySnapIsUpdatedWhenItAlreadyExists() {
+  void testDailySnapIsUpdatedWhenItAlreadyExists() {
     this.tester.performSnapshotUpdateTest(
         Granularity.DAILY, clock.startOfToday(), clock.endOfToday());
   }
 
   @Test
-  public void
-      ensureCurrentDailyUpdatedRegardlessOfWhetherIncomingCalculationsAreLessThanTheExisting() {
+  void ensureCurrentDailyUpdatedRegardlessOfWhetherIncomingCalculationsAreLessThanTheExisting() {
     tester.performUpdateWithLesserValueTest(
         Granularity.DAILY, clock.startOfToday(), clock.endOfToday(), false);
   }
 
   @Test
   @SuppressWarnings("java:S2699") /* NOTE(khowell): have no idea why sonar thinks no assertions */
-  public void testEmptySnapshotsNotPersisted() {
+  void testEmptySnapshotsNotPersisted() {
     tester.performDoesNotPersistEmptySnapshots(
         Granularity.DAILY, clock.startOfToday(), clock.endOfToday());
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
@@ -75,7 +75,7 @@ class HourlySnapshotRollerTest {
   }
 
   @BeforeEach
-  public void setupAllTests() throws Exception {
+  void setupAllTests() throws Exception {
     this.tester =
         new SnapshotRollerTester<>(
             repository, new HourlySnapshotRoller(repository, clock, testProfile));

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
-public class MonthlySnapshotRollerTest {
+class MonthlySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
 
@@ -51,7 +51,7 @@ public class MonthlySnapshotRollerTest {
   private SnapshotRollerTester<MonthlySnapshotRoller> tester;
 
   @BeforeAll
-  public void setupAllTests() throws IOException {
+  void setupAllTests() throws IOException {
     this.clock = new FixedClockConfiguration().fixedClock();
     this.tester =
         new SnapshotRollerTester<>(
@@ -60,20 +60,20 @@ public class MonthlySnapshotRollerTest {
 
   @SuppressWarnings("indentation")
   @Test
-  public void testMonthlySnapshotProducer() {
+  void testMonthlySnapshotProducer() {
     tester.performBasicSnapshotRollerTest(
         Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
   }
 
   @SuppressWarnings("indentation")
   @Test
-  public void testMonthlySnapIsUpdatedWhenItAlreadyExists() {
+  void testMonthlySnapIsUpdatedWhenItAlreadyExists() {
     tester.performSnapshotUpdateTest(
         Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth());
   }
 
   @Test
-  public void ensureCurrentMonthlyIsNotUpdatedWhenIncomingCalculationsAreLessThanTheExisting() {
+  void ensureCurrentMonthlyIsNotUpdatedWhenIncomingCalculationsAreLessThanTheExisting() {
     tester.performUpdateWithLesserValueTest(
         Granularity.MONTHLY, clock.startOfCurrentMonth(), clock.endOfCurrentMonth(), true);
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
-public class QuarterlySnapshotRollerTest {
+class QuarterlySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
 
@@ -51,7 +51,7 @@ public class QuarterlySnapshotRollerTest {
   private SnapshotRollerTester<QuarterlySnapshotRoller> tester;
 
   @BeforeEach
-  public void setupTest() throws IOException {
+  void setupTest() throws IOException {
     this.clock = new FixedClockConfiguration().fixedClock();
     this.tester =
         new SnapshotRollerTester<>(
@@ -59,19 +59,19 @@ public class QuarterlySnapshotRollerTest {
   }
 
   @Test
-  public void testQuarterlySnapshotProduction() {
+  void testQuarterlySnapshotProduction() {
     this.tester.performBasicSnapshotRollerTest(
         Granularity.QUARTERLY, clock.startOfCurrentQuarter(), clock.endOfCurrentQuarter());
   }
 
   @Test
-  public void testQuarterlySnapIsUpdatedWhenItAlreadyExists() {
+  void testQuarterlySnapIsUpdatedWhenItAlreadyExists() {
     this.tester.performSnapshotUpdateTest(
         Granularity.QUARTERLY, clock.startOfCurrentQuarter(), clock.endOfCurrentQuarter());
   }
 
   @Test
-  public void ensureCurrentQuarterlyIsNotUpdatedWhenIncomingCalculationsAreLessThanTheExisting() {
+  void ensureCurrentQuarterlyIsNotUpdatedWhenIncomingCalculationsAreLessThanTheExisting() {
     this.tester.performUpdateWithLesserValueTest(
         Granularity.QUARTERLY, clock.startOfCurrentQuarter(), clock.endOfCurrentQuarter(), true);
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
-public class WeeklySnapshotRollerTest {
+class WeeklySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
 
@@ -51,7 +51,7 @@ public class WeeklySnapshotRollerTest {
   private SnapshotRollerTester<WeeklySnapshotRoller> tester;
 
   @BeforeAll
-  public void setupAllTests() throws IOException {
+  void setupAllTests() throws IOException {
     this.clock = new FixedClockConfiguration().fixedClock();
     this.tester =
         new SnapshotRollerTester<>(
@@ -59,19 +59,19 @@ public class WeeklySnapshotRollerTest {
   }
 
   @Test
-  public void testWeeklySnapshotProduction() {
+  void testWeeklySnapshotProduction() {
     this.tester.performBasicSnapshotRollerTest(
         Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
   }
 
   @Test
-  public void testWeeklySnapIsUpdatedWhenItAlreadyExists() {
+  void testWeeklySnapIsUpdatedWhenItAlreadyExists() {
     this.tester.performSnapshotUpdateTest(
         Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek());
   }
 
   @Test
-  public void ensureCurrentWeeklyIsNotUpdatedWhenIncomingCalculationsAreLessThanTheExisting() {
+  void ensureCurrentWeeklyIsNotUpdatedWhenIncomingCalculationsAreLessThanTheExisting() {
     this.tester.performUpdateWithLesserValueTest(
         Granularity.WEEKLY, clock.startOfCurrentWeek(), clock.endOfCurrentWeek(), true);
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -40,7 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
-public class YearlySnapshotRollerTest {
+class YearlySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
 
@@ -51,7 +51,7 @@ public class YearlySnapshotRollerTest {
   private SnapshotRollerTester<YearlySnapshotRoller> tester;
 
   @BeforeEach
-  public void setupTest() throws IOException {
+  void setupTest() throws IOException {
     this.clock = new FixedClockConfiguration().fixedClock();
     this.tester =
         new SnapshotRollerTester<>(
@@ -59,19 +59,19 @@ public class YearlySnapshotRollerTest {
   }
 
   @Test
-  public void testYearlySnapshotProduction() {
+  void testYearlySnapshotProduction() {
     this.tester.performBasicSnapshotRollerTest(
         Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear());
   }
 
   @Test
-  public void testYearlySnapIsUpdatedWhenItAlreadyExists() {
+  void testYearlySnapIsUpdatedWhenItAlreadyExists() {
     this.tester.performSnapshotUpdateTest(
         Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear());
   }
 
   @Test
-  public void ensureCurrentYearlyIsNotUpdatedWhenIncomingCalculationsAreLessThanTheExisting() {
+  void ensureCurrentYearlyIsNotUpdatedWhenIncomingCalculationsAreLessThanTheExisting() {
     this.tester.performUpdateWithLesserValueTest(
         Granularity.YEARLY, clock.startOfCurrentYear(), clock.endOfCurrentYear(), true);
   }

--- a/src/test/java/org/candlepin/subscriptions/task/TaskDescriptorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskDescriptorTest.java
@@ -21,8 +21,7 @@
 package org.candlepin.subscriptions.task;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,10 +29,10 @@ import java.util.Map;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-public class TaskDescriptorTest {
+class TaskDescriptorTest {
 
   @Test
-  public void testCreation() {
+  void testCreation() {
     String expectedGroupId = "my-group";
     TaskType expectedTaskType = TaskType.UPDATE_SNAPSHOTS;
     String expectedArgKey = "arg1";
@@ -54,7 +53,7 @@ public class TaskDescriptorTest {
   }
 
   @Test
-  public void testEquality() {
+  void testEquality() {
     TaskDescriptor d1 =
         TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group1")
             .setSingleValuedArg("a1", "a1v")

--- a/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/TaskWorkerTest.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.task;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.doThrow;
 import static org.mockito.BDDMockito.verify;
@@ -40,7 +40,7 @@ class TaskWorkerTest {
   @Mock private Task mockTask;
 
   @Test
-  public void testExecuteTask() throws Exception {
+  void testExecuteTask() throws Exception {
     TaskWorker worker = new TaskWorker(factory);
     when(factory.build(any(TaskDescriptor.class))).thenReturn(mockTask);
     worker.executeTask(TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "group").build());
@@ -48,7 +48,7 @@ class TaskWorkerTest {
   }
 
   @Test
-  public void testThrowsTaskExecutionExceptionOnTaskFailure() throws Exception {
+  void testThrowsTaskExecutionExceptionOnTaskFailure() throws Exception {
     TaskWorker worker = new TaskWorker(factory);
     when(factory.build(any(TaskDescriptor.class))).thenReturn(mockTask);
     doThrow(RuntimeException.class).when(mockTask).execute();

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroDeserializerTest.java
@@ -20,9 +20,8 @@
  */
 package org.candlepin.subscriptions.task.queue.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
 import org.apache.kafka.common.errors.SerializationException;
@@ -35,7 +34,7 @@ import org.junit.jupiter.api.Test;
  * AvroMessageSerializationTest} since both the serialization and deserialization will be tested
  * together.
  */
-public class AvroDeserializerTest {
+class AvroDeserializerTest {
 
   private AvroDeserializer<TaskMessage> deserializer;
 
@@ -45,7 +44,7 @@ public class AvroDeserializerTest {
   }
 
   @Test
-  public void testThrowsSerializationExceptionOnError() {
+  void testThrowsSerializationExceptionOnError() {
     HashMap<String, Object> configs = new HashMap<>();
     configs.put(AvroDeserializer.TARGET_TYPE_CLASS, TaskMessage.class);
     deserializer.configure(configs, false);
@@ -60,7 +59,7 @@ public class AvroDeserializerTest {
   }
 
   @Test
-  public void canConfigureTargetClassWithStringOrClassObject() {
+  void canConfigureTargetClassWithStringOrClassObject() {
     // Will throw an exception if invalid.
     HashMap<String, Object> configs = new HashMap<>();
 
@@ -78,7 +77,7 @@ public class AvroDeserializerTest {
   }
 
   @Test
-  public void throwsExceptionOnDeserializationWhenNotConfigured() {
+  void throwsExceptionOnDeserializationWhenNotConfigured() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -87,7 +86,7 @@ public class AvroDeserializerTest {
   }
 
   @Test
-  public void testMissingTargetClassConfiguration() {
+  void testMissingTargetClassConfiguration() {
     assertThrows(
         IllegalStateException.class,
         () -> {
@@ -96,7 +95,7 @@ public class AvroDeserializerTest {
   }
 
   @Test
-  public void testTargetClassNotFound() {
+  void testTargetClassNotFound() {
     HashMap<String, Object> configs = new HashMap<>();
     configs.put(AvroDeserializer.TARGET_TYPE_CLASS, "not.found.Message");
 

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroMessageSerializationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroMessageSerializationTest.java
@@ -20,8 +20,7 @@
  */
 package org.candlepin.subscriptions.task.queue.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,10 +28,10 @@ import java.util.List;
 import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
 import org.junit.jupiter.api.Test;
 
-public class AvroMessageSerializationTest {
+class AvroMessageSerializationTest {
 
   @Test
-  public void testMessageCanBeSerializedAndThenDeserialized() {
+  void testMessageCanBeSerializedAndThenDeserialized() {
     AvroSerializer<TaskMessage> serializer = new AvroSerializer<>();
     AvroDeserializer<TaskMessage> deserializer = new AvroDeserializer<>();
 

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/AvroSerializerTest.java
@@ -20,9 +20,8 @@
  */
 package org.candlepin.subscriptions.task.queue.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.candlepin.subscriptions.task.queue.kafka.message.TaskMessage;
@@ -34,17 +33,17 @@ import org.junit.jupiter.api.Test;
  * AvroMessageSerializationTest} since both the serialization and deserialization will be tested
  * together.
  */
-public class AvroSerializerTest {
+class AvroSerializerTest {
 
   private AvroSerializer<TaskMessage> serializer;
 
   @BeforeEach
-  public void setupTest() {
+  void setupTest() {
     serializer = new AvroSerializer<TaskMessage>();
   }
 
   @Test
-  public void testThrowsSerializationException() {
+  void testThrowsSerializationException() {
     TaskMessage mockMessage = mock(TaskMessage.class);
     when(mockMessage.getSchema()).thenThrow(new RuntimeException("forced"));
     assertThrows(

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -20,7 +20,14 @@
  */
 package org.candlepin.subscriptions.util;
 
-import static org.candlepin.subscriptions.FixedClockConfiguration.*;
+import static org.candlepin.subscriptions.FixedClockConfiguration.SPRING_EPOCH_EDT;
+import static org.candlepin.subscriptions.FixedClockConfiguration.SPRING_EPOCH_UTC;
+import static org.candlepin.subscriptions.FixedClockConfiguration.SPRING_TIME_EDT;
+import static org.candlepin.subscriptions.FixedClockConfiguration.SPRING_TIME_UTC;
+import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_EPOCH_EST;
+import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_EPOCH_UTC;
+import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_TIME_EST;
+import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_TIME_UTC;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
@@ -87,104 +94,104 @@ class ApplicationClockTest {
   }
 
   @Test
-  public void testNow() {
+  void testNow() {
     assertDate(2019, 5, 24, 12, 35, 0, 0, clock.now());
   }
 
   @Test
-  public void testStartOfToday() {
+  void testStartOfToday() {
     assertStartOfDay(2019, 5, 24, clock.startOfToday());
   }
 
   @Test
-  public void testStartOfDay() {
+  void testStartOfDay() {
     assertStartOfDay(2019, 5, 25, clock.startOfDay(clock.now().plusDays(1)));
   }
 
   @Test
-  public void testEndOfToday() {
+  void testEndOfToday() {
     assertEndOfDay(2019, 5, 24, clock.endOfToday());
   }
 
   @Test
-  public void testEndOfDay() {
+  void testEndOfDay() {
     assertEndOfDay(2019, 5, 25, clock.endOfDay(clock.now().plusDays(1)));
   }
 
   @Test
-  public void testStartOfCurrentWeek() {
+  void testStartOfCurrentWeek() {
     assertStartOfDay(2019, 5, 19, clock.startOfCurrentWeek());
   }
 
   @Test
-  public void testStartOfWeek() {
+  void testStartOfWeek() {
     assertStartOfDay(2019, 4, 28, clock.startOfWeek(clock.now().minusWeeks(3)));
   }
 
   @Test
-  public void testStartOfWeekWhenDateIsTheStartOfTheWeek() {
+  void testStartOfWeekWhenDateIsTheStartOfTheWeek() {
     OffsetDateTime startOfWeek = clock.now().withYear(2019).withMonth(5).withDayOfMonth(12);
     assertStartOfDay(2019, 5, 12, clock.startOfWeek(startOfWeek));
   }
 
   @Test
-  public void testEndOfCurrentWeek() {
+  void testEndOfCurrentWeek() {
     assertEndOfDay(2019, 5, 25, clock.endOfCurrentWeek());
   }
 
   @Test
-  public void testEndOfWeek() {
+  void testEndOfWeek() {
     assertEndOfDay(2019, 5, 4, clock.endOfWeek(clock.now().minusWeeks(3)));
   }
 
   @Test
-  public void testEndOfWeekWhenDateIsTheEndOfTheWeek() {
+  void testEndOfWeekWhenDateIsTheEndOfTheWeek() {
     OffsetDateTime endOfWeek = clock.now().withYear(2019).withMonth(5).withDayOfMonth(18);
     assertEndOfDay(2019, 5, 18, clock.endOfWeek(endOfWeek));
   }
 
   @Test
-  public void testStartOfCurrentMonth() {
+  void testStartOfCurrentMonth() {
     assertStartOfDay(2019, 5, 1, clock.startOfCurrentMonth());
   }
 
   @Test
-  public void testStartOfMonth() {
+  void testStartOfMonth() {
     assertStartOfDay(2019, 4, 1, clock.startOfMonth(clock.now().minusMonths(1)));
   }
 
   @Test
-  public void testEndOfCurrentMonth() {
+  void testEndOfCurrentMonth() {
     assertEndOfDay(2019, 5, 31, clock.endOfCurrentMonth());
   }
 
   @Test
-  public void testEndOfMonth() {
+  void testEndOfMonth() {
     assertEndOfDay(2019, 2, 28, clock.endOfMonth(clock.now().minusMonths(3)));
   }
 
   @Test
-  public void testStartOfCurrentYear() {
+  void testStartOfCurrentYear() {
     assertStartOfDay(2019, 1, 1, clock.startOfCurrentYear());
   }
 
   @Test
-  public void testStartOfYear() {
+  void testStartOfYear() {
     assertStartOfDay(2018, 1, 1, clock.startOfYear(clock.now().minusYears(1)));
   }
 
   @Test
-  public void testEndOfCurrentYear() {
+  void testEndOfCurrentYear() {
     assertEndOfDay(2019, 12, 31, clock.endOfCurrentYear());
   }
 
   @Test
-  public void testEndOfYear() {
+  void testEndOfYear() {
     assertEndOfDay(2018, 12, 31, clock.endOfYear(clock.now().minusYears(1)));
   }
 
   @Test
-  public void startOfQuarter() {
+  void startOfQuarter() {
     assertStartOfDay(2019, 1, 1, clock.startOfQuarter(clock.startOfCurrentYear()));
     assertStartOfDay(2019, 4, 1, clock.startOfQuarter(clock.startOfCurrentYear().plusMonths(3)));
     assertStartOfDay(2019, 7, 1, clock.startOfQuarter(clock.startOfCurrentYear().plusMonths(6)));
@@ -192,7 +199,7 @@ class ApplicationClockTest {
   }
 
   @Test
-  public void endOfQuarter() {
+  void endOfQuarter() {
     assertEndOfDay(2019, 3, 31, clock.endOfQuarter(clock.startOfCurrentYear()));
     assertEndOfDay(2019, 6, 30, clock.endOfQuarter(clock.startOfCurrentYear().plusMonths(3)));
     assertEndOfDay(2019, 9, 30, clock.endOfQuarter(clock.startOfCurrentYear().plusMonths(6)));
@@ -200,12 +207,12 @@ class ApplicationClockTest {
   }
 
   @Test
-  public void testStartCurrentQuarter() {
+  void testStartCurrentQuarter() {
     assertStartOfDay(2019, 4, 1, clock.startOfCurrentQuarter());
   }
 
   @Test
-  public void testEndOfCurrentQuarter() {
+  void testEndOfCurrentQuarter() {
     assertEndOfDay(2019, 6, 30, clock.endOfCurrentQuarter());
   }
 


### PR DESCRIPTION
SonarLint complains about this so we might as well clean up all the
legacy violations.