### PR TITLE
ENT-4912: Pass HAWTIO_BASE_PATH to the capacity-ingress pod

### DIFF
--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -9,6 +9,8 @@ metadata:
   name: rhsm-subscriptions-capacity-ingress
 
 parameters:
+  - name: CAPACITY_INGRESS_HAWTIO_BASE_PATH
+    value: /app/rhsm-capacity-ingress/hawtio
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL
@@ -130,6 +132,8 @@ objects:
                 # turn off built-in jolokia, so that the spring boot jolokia actuator will work
                 - name: AB_JOLOKIA_OFF
                   value: 'true'
+                - name: HAWTIO_BASE_PATH
+                  value: ${CAPACITY_INGRESS_HAWTIO_BASE_PATH}
                 - name: LOG_FILE
                   value: /logs/server.log
                 - name: SPRING_PROFILES_ACTIVE


### PR DESCRIPTION
The HAWTIO_BASE_PATH env var is defined in the ClowdApp template, but missing from the stage/prod OS templates.  Not sure how or why that went missing, but adding it back.