### PR TITLE
ENT-4695: Adjust usage latency to meet AWS SLA

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -103,7 +103,7 @@ public class ApplicationProperties {
    * Offsets the range to look at metrics to account for delay in prometheus having metrics
    * available
    */
-  private Duration prometheusLatencyDuration = Duration.ofHours(4L);
+  private Duration prometheusLatencyDuration = Duration.ofHours(0L);
 
   /**
    * Amount of time from current timestamp to start looking for metrics during a tally, independent

--- a/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
@@ -108,11 +108,8 @@ public class MeteringJmxBean {
     Object principal = ResourceUtils.getPrincipal();
     log.info("Metering for all accounts triggered via JMX by {}", principal);
 
-    OffsetDateTime end = getDate(null);
-    OffsetDateTime start = getStartDate(end, metricProperties.getRangeInMinutes());
-
     try {
-      tasks.updateMetricsForAllAccounts(productTag, start, end);
+      tasks.updateMetricsForAllAccounts(productTag, metricProperties.getRangeInMinutes());
     } catch (Exception e) {
       log.error("Error triggering {} metering for all accounts via JMX.", productTag, e);
     }

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.subscriptions.metering.profile;
 
-import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.jobs.JobProperties;
 import org.candlepin.subscriptions.metering.job.MeteringJob;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
@@ -30,7 +29,6 @@ import org.candlepin.subscriptions.metering.task.MeteringTasksConfiguration;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.spring.JobRunner;
 import org.candlepin.subscriptions.task.queue.TaskProducerConfiguration;
-import org.candlepin.subscriptions.util.ApplicationClock;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -70,12 +68,10 @@ public class MeteringJobProfile {
   @Bean
   MeteringJob meteringJob(
       PrometheusMetricsTaskManager tasks,
-      ApplicationClock clock,
       TagProfile tagProfile,
       MetricProperties metricProperties,
-      ApplicationProperties appProps,
       @Qualifier("meteringJobRetryTemplate") RetryTemplate retryTemplate) {
-    return new MeteringJob(tasks, clock, tagProfile, metricProperties, appProps, retryTemplate);
+    return new MeteringJob(tasks, tagProfile, metricProperties, retryTemplate);
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.metering.task;
 
+import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
@@ -33,6 +34,7 @@ import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.queue.TaskConsumer;
 import org.candlepin.subscriptions.task.queue.TaskConsumerFactory;
 import org.candlepin.subscriptions.task.queue.TaskQueue;
+import org.candlepin.subscriptions.util.ApplicationClock;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -72,8 +74,11 @@ public class MeteringTasksConfiguration {
       TaskQueue queue,
       @Qualifier("meteringTaskQueueProperties") TaskQueueProperties queueProps,
       PrometheusAccountSource accountSource,
-      TagProfile tagProfile) {
-    return new PrometheusMetricsTaskManager(queue, queueProps, accountSource, tagProfile);
+      TagProfile tagProfile,
+      ApplicationClock clock,
+      ApplicationProperties appProps) {
+    return new PrometheusMetricsTaskManager(
+        queue, queueProps, accountSource, tagProfile, clock, appProps);
   }
 
   // The following beans are defined for the worker profile only allowing

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,7 +45,7 @@ rhsm-subscriptions:
     capture-hourly-snapshot-schedule: ${CAPTURE_HOURLY_SNAPSHOT_SCHEDULE:0 0 * * * ?}
     capture-snapshot-schedule: ${CAPTURE_SNAPSHOT_SCHEDULE:0 0 1 * * ?}
     purge-snapshot-schedule: ${PURGE_SNAPSHOT_SCHEDULE:0 0 1 * * ?}
-    metering-schedule: ${METERING_SCHEDULE:0 0 1 * * ?}
+    metering-schedule: ${METERING_SCHEDULE:0 30 * * * ?}
     subscription-sync-schedule: ${SUBSCRIPTION_SYNC_SCHEDULE:0 0 10 * * ?}
     offering-sync-schedule: ${OFFERING_SYNC_SCHEDULE:0 0 2 * * ?}
   account-batch-size: ${ACCOUNT_BATCH_SIZE:1}
@@ -70,8 +70,8 @@ rhsm-subscriptions:
       kafka-group-id: ${METERING_TASK_GROUP_ID:metering-task-processor}
       seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
       seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
-  prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:4h}
-  hourly-tally-offset: ${HOURLY_TALLY_OFFSET:120m}
+  prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:0h}
+  hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:1h}
   subscription-sync-enabled: ${SUBSCRIPTION_SYNC_ENABLED:false}
   subscription:

--- a/src/test/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBeanTest.java
@@ -109,7 +109,7 @@ class MeteringJmxBeanTest {
 
     jmx.performMetering(PRODUCT_PROFILE_ID);
 
-    verify(tasks).updateMetricsForAllAccounts(PRODUCT_PROFILE_ID, startDate, endDate);
+    verify(tasks).updateMetricsForAllAccounts(PRODUCT_PROFILE_ID, 60);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
@@ -61,7 +61,7 @@ class MeteringJobTest {
     appProps.setPrometheusLatencyDuration(Duration.ofHours(6L));
 
     clock = new FixedClockConfiguration().fixedClock();
-    job = new MeteringJob(tasks, clock, tagProfile, metricProps, appProps, retryTemplate);
+    job = new MeteringJob(tasks, tagProfile, metricProps, retryTemplate);
 
     when(tagProfile.getTagsWithPrometheusEnabledLookup()).thenReturn(Set.of("OpenShift-metrics"));
   }
@@ -79,7 +79,6 @@ class MeteringJobTest {
             expStartDate.plusMinutes(range).truncatedTo(ChronoUnit.HOURS).minusMinutes(1));
     job.run();
 
-    verify(tasks)
-        .updateMetricsForAllAccounts("OpenShift-metrics", expStartDate, expEndDate, retryTemplate);
+    verify(tasks).updateMetricsForAllAccounts("OpenShift-metrics", range, retryTemplate);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
 import java.util.Set;
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource;
 import org.candlepin.subscriptions.registry.TagProfile;
@@ -35,6 +37,7 @@ import org.candlepin.subscriptions.task.TaskDescriptor;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.TaskType;
 import org.candlepin.subscriptions.task.queue.TaskQueue;
+import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,7 +64,10 @@ class PrometheusMetricsTaskManagerTest {
   void setupTest() {
     when(queueProperties.getTopic()).thenReturn(TASK_TOPIC);
     when(tagProfile.getSupportedMetricsForProduct(any())).thenReturn(Set.of(Uom.CORES));
-    manager = new PrometheusMetricsTaskManager(queue, queueProperties, accountSource, tagProfile);
+    ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+    manager =
+        new PrometheusMetricsTaskManager(
+            queue, queueProperties, accountSource, tagProfile, clock, new ApplicationProperties());
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
@@ -173,11 +173,9 @@ class CaptureSnapshotsTaskManagerTest {
                   TaskDescriptor.builder(
                           TaskType.UPDATE_HOURLY_SNAPSHOTS, taskQueueProperties.getTopic())
                       .setSingleValuedArg("accountNumber", accountNumber)
-                      // 2019-05-24T12:35Z truncated to top of the hour - 4 hours prometheus latency
-                      // - 1 hour
-                      // tally latency - 1 hour metric range
-                      .setSingleValuedArg("startDateTime", "2019-05-24T05:00:00Z")
-                      .setSingleValuedArg("endDateTime", "2019-05-24T06:00:00Z")
+                      // 2019-05-24T12:35Z truncated to top of the hour - 1 hour tally range
+                      .setSingleValuedArg("startDateTime", "2019-05-24T10:00:00Z")
+                      .setSingleValuedArg("endDateTime", "2019-05-24T11:00:00Z")
                       .build());
         });
   }

--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -24,7 +24,7 @@ parameters:
   - name: SUBSCRIPTION_SYNC_SCHEDULE
     value: 0 10 * * *
   - name: METERING_SCHEDULE
-    value: 0 * * * *
+    value: 30 * * * *
   - name: OFFERING_SYNC_SCHEDULE
     value: 0 2 * * *
   - name: EVENT_RECORD_RETENTION
@@ -56,7 +56,7 @@ parameters:
   - name: SPLUNK_FORWARDER_CPU_LIMIT
     value: 100m
   - name: HOURLY_TALLY_OFFSET
-    value: 120m
+    value: 60m
   - name: TOKEN_REFRESHER_IMAGE
     value: quay.io/observatorium/token-refresher:master-2021-02-05-5da9663
   - name: TOKEN_REFRESHER_CPU_REQUEST


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4695

Usage metering now occurs every hour on the half hour
and is delayed by only 30 minutes relative to when the job
is run. This means that if the metering job runs at 2:30PM,
metrics will be gathered for 1pm (the 1pm - 2pm range).

**NOTE:** When the metrics query is run, it is run against the
2pm - 2:59:59.99999pm range since the query does a 1h look back
and the data actually represents usage for 1pm.

The hourly tally schedule has been updated to run with a
1h delay, relative to when the job is run. This give the
metrics tasks 30m to complete and to have events populated.

## Testing
The metering job should be offset by only 1h based on when the job was run. It does not matter at what point in the current hour the job is run, the result will be the same. For example, if you run the job at 2:15pm, metrics should be gathered for 2pm-2:59:59.9999pm. This would be the same for 2:45pm.

**REMEBER: The resulting metric would be for 1pm due to the PromQL query look back.**

Manually run the MetricsJob and verify the resulting metering range in the logs.
```
# Current time 14:47UTC
PROM_URL="http://localhost:8888/api/metrics/v1/telemeter/api/v1" SPRING_PROFILES_ACTIVE=metering-job,kafka-queue ./gradlew :bootRun
```
```
2022-04-26 14:47:31,695 [thread=restartedMain] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager] - Queuing rhosak metric updates for range: 2022-04-26T14:00Z -> 2022-04-26T14:59:59.999999
```

Run the hourly job at any point. The tally range should be offset by only 1h.
```
# Current time: 14:49
$ SPRING_PROFILES_ACTIVE=capture-hourly-snapshots,kafka-queue ./gradlew :bootRun
```
```
2022-04-26 14:49:47,061 [thread=restartedMain] [INFO ] [org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager] - Queuing hourly snapshot production for accountNumber 941133 between 2022-04-26T12:00:00Z and 2022-04-26T13:00:00Z
```

**NOTE**: With this configuration, metrics will be gathered every hour on the 1/2 hour, and the tally will occur at the top of the next hour.

Metrics for 1pm are gathered @ 2:30pm and these hourly metrics are tallied at 3pm.