### PR TITLE
ENT-4693: Add filter for logging user requests to admin APIs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -148,6 +148,10 @@ public class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
     return new MdcFilter();
   }
 
+  public LogPrincipalFilter logPrincipalFilter() {
+    return new LogPrincipalFilter();
+  }
+
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     String apiPath =
@@ -155,6 +159,7 @@ public class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
             "rhsm-subscriptions.package_uri_mappings.org.candlepin.subscriptions.resteasy");
     http.addFilter(identityHeaderAuthenticationFilter())
         .addFilterAfter(mdcFilter(), IdentityHeaderAuthenticationFilter.class)
+        .addFilterAfter(logPrincipalFilter(), MdcFilter.class)
         .addFilterAt(antiCsrfFilter(secProps, env), CsrfFilter.class)
         .csrf()
         .disable()

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/LogPrincipalFilter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/LogPrincipalFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/** Filter to log authenticated user for internal/admin endpoints. */
+public class LogPrincipalFilter extends OncePerRequestFilter {
+
+  private static final Logger log = LoggerFactory.getLogger(LogPrincipalFilter.class);
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null) {
+      log.info(
+          "Internal API: {} requested by user: {}",
+          request.getRequestURI(),
+          authentication.getName());
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String path = request.getRequestURI();
+    return !path.contains("/internal/");
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4693

Test Steps:
- Start app with default profiles
- Run against an internal endpoint and check server logs for message with path and user
`curl -X 'PUT'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123' -H 'x-rh-swatch-psk: dummy'`

- Run non internal endpoint and check that same log message does not come up
`curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`
