### PR TITLE
Add SWATCH_SELF_PSK to swatch-producer-aws clowdapp

### DIFF
--- a/deploy/clowder.md
+++ b/deploy/clowder.md
@@ -17,7 +17,7 @@
   bonfire config write-default
 
   cat <<BONFIRE >>  ~/.config/bonfire/config.yaml
-  - name: rhsm-subscriptions
+  - name: rhsm
     components:
       - name: capacity-allowlist
         host: gitlab
@@ -33,6 +33,12 @@
             RH_MARKETPLACE_MANUAL_SUBMISSION_ENABLED: 'true'
             DEV_MODE: 'true'
             ENABLE_ACCOUNT_RESET: 'true'
+      - name: swatch-producer-aws
+        host: local
+        repo: $(pwd)
+        path: swatch-producer-aws/deploy/clowdapp.yaml
+        parameters:
+          AWS_MANUAL_SUBMISSION_ENABLED: 'true'
 
   BONFIRE
   ```

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -153,3 +153,10 @@ objects:
             - name: pinhead
               secret:
                 secretName: pinhead
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: swatch-psks
+  data:
+    self: ZHVtbXk=

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -137,6 +137,11 @@ objects:
                   key: credentials
             - name: AWS_MARKETPLACE_ENDPOINT_URL
               value: ${AWS_MARKETPLACE_ENDPOINT_URL}
+            - name: SWATCH_SELF_PSK
+              valueFrom:
+                secretKeyRef:
+                  name: swatch-psks
+                  key: self
           volumeMounts:
             - name: logs
               mountPath: /logs

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -75,7 +75,7 @@ objects:
               path: /q/health/live
               port: 8000
               scheme: HTTP
-            initialDelaySeconds: 300
+            initialDelaySeconds: 20
             periodSeconds: 20
             successThreshold: 1
             timeoutSeconds: 5
@@ -85,7 +85,7 @@ objects:
               path: /q/health/ready
               port: 8000
               scheme: HTTP
-            initialDelaySeconds: 300
+            initialDelaySeconds: 20
             periodSeconds: 20
             successThreshold: 1
             timeoutSeconds: 5


### PR DESCRIPTION
In order to fix pod restarts due to:

```
Failed to load config value of type class java.lang.String for: SWATCH_SELF_PSK
```

Reduced initial probe delays to a more reasonable value for quicker deployment.

Updated bonfire config in clowder README. Bonfire now checks app-interface for the components and expects the same "app name" as the saas-file name in app-interface, so had to update accordingly.

Testing
------

Regenerate your bonfire config per the updated README.

```
bonfire deploy -C swatch-producer-aws -f rhsm -i quay.io/cloudservices/swatch-producer-aws=9897ac3
```
*latest doesn't work as the image tag - it'll pull an old version - above is at the time of writing the latest hash.

Observe that it deploys correctly to ephemeral. Optionally, go look at the logs in the ephemeral namespace as well.