### PR TITLE
ENT-4950: Serialize ISO-8601 dates in SnapshotSummaryProducer

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotProducerJsonSerializationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotProducerJsonSerializationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.candlepin.subscriptions.json.TallySnapshot;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"worker", "kafka-queue", "test"})
+class SnapshotProducerJsonSerializationTest {
+  @Autowired KafkaTemplate<String, TallySummary> kafkaTemplate;
+
+  @Test
+  void testSerializesDatesToIso8601Format() {
+    assertNotNull(kafkaTemplate.getProducerFactory().getValueSerializer());
+    byte[] serialized =
+        kafkaTemplate
+            .getProducerFactory()
+            .getValueSerializer()
+            .serialize(
+                "foobar",
+                new TallySummary()
+                    .withTallySnapshots(
+                        List.of(
+                            new TallySnapshot()
+                                .withSnapshotDate(OffsetDateTime.parse("2022-04-29T00:00:00Z")))));
+    assertEquals(
+        "{\"tally_snapshots\":[{\"snapshot_date\":\"2022-04-29T00:00:00Z\"}]}",
+        new String(serialized, StandardCharsets.UTF_8));
+  }
+}

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -41,6 +41,8 @@ parameters:
     value: http://localhost:8101/subscriptions/
   - name: AWS_MARKETPLACE_ENDPOINT_URL
     value: 'http://localhost:8101/aws-marketplace/'
+  - name: TALLY_IN_FAIL_ON_DESER_FAILURE
+    value: 'true'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -142,6 +144,8 @@ objects:
                 secretKeyRef:
                   name: swatch-psks
                   key: self
+            - name: TALLY_IN_FAIL_ON_DESER_FAILURE
+              value: ${TALLY_IN_FAIL_ON_DESER_FAILURE}
           volumeMounts:
             - name: logs
               mountPath: /logs

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/TallyTopicProcessor.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/TallyTopicProcessor.java
@@ -78,6 +78,10 @@ public class TallyTopicProcessor {
     if (log.isDebugEnabled()) {
       log.debug("Picked up tally message {} to process", tallySummary);
     }
+    if (tallySummary == null) {
+      log.warn("Skipping null tally summary: deserialization failure?");
+      return;
+    }
     for (TallySummaryTallySnapshots tallySnapshot : tallySummary.getTallySnapshots()) {
       if (!isSnapshotApplicable(tallySnapshot)) {
         continue;

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 SERVER_PORT=${clowder.endpoints.swatch-producer-aws.port:8000}
-#TODO ENT-4890
 SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://${clowder.endpoints.capacity-ingress.hostname}:${clowder.endpoints.capacity-ingress.port}
 AWS_REGION=us-east-1
 AWS_MANUAL_SUBMISSION_ENABLED=false
@@ -14,6 +13,7 @@ SPLUNK_HEC_BATCH_SIZE=10
 SPLUNK_HEC_BATCH_INTERVAL=10S
 SPLUNK_HEC_RETRY_COUNT=3
 SPLUNK_HEC_INCLUDE_EX=false
+TALLY_IN_FAIL_ON_DESER_FAILURE=true
 
 # dev-specific defaults; these can still be overridden by env var
 %dev.AWS_CREDENTIALS_JSON=[{"accessKeyId":"accessKey","secretAccessKey":"placeholder","sellerAccount":"awsSellerAccountId"}]
@@ -54,6 +54,7 @@ kafka.bootstrap.servers=localhost:9092
 quarkus.reactive-messaging.kafka.serializer-generation.enabled=false
 
 # Consumer settings
+mp.messaging.incoming.tally-in.fail-on-deserialization-failure=${TALLY_IN_FAIL_ON_DESER_FAILURE}
 mp.messaging.incoming.tally-in.connector=smallrye-kafka
 mp.messaging.incoming.tally-in.topic=platform.rhsm-subscriptions.tally
 # Go back to the first records, if it's our first access


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4950

JSON-B (which we are using in swatch-producer-aws), does not parse dates entered as a String with the timestamp in milliseconds, such as "1649019600.000000000". We had not applied our ObjectMapper
configuration to TallySnapshot messages, otherwise they would have been omitted in ISO-8601 format, as we use:

```
objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
objectMapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
```

This changes the TallySnapshotSummaryProducer to use our configured ObjectMapper, and adds an environment variable to swatch-producer-aws we can set temporarily to skip failures.

Testing
-------

To get into this state, it is necessary to get messages with the problematic serialization into Kafka. To do so, run the service from `develop`:

```
DEV_MODE=true \
    SPRING_PROFILES_ACTIVE=worker \
    ./gradlew :bootRun
```

Import some event data:

```
bin/import-events.py --file bin/events.csv
```

Then, trigger an hourly tally, producing tally summary messages:

```
curl http://localhost:9000/hawtio/jolokia \
  -H 'Content-Type: application/json' \
  -d '{
    "mbean": "org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
    "arguments":
    [
      "account123",
      "2021-10-18T00:00:00Z",
      "2021-10-18T22:00:00Z"
    ],
    "type": "exec",
    "operation": "tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)"
  }'
```

Stop the worker component, switch back to this branch.

Then run the swatch-producer-aws component, and observe it shows bad health:

```
./gradlew swatch-producer-aws:quarkusDev
```

Liveness probe shows "DOWN":

```
curl http://localhost:8000/q/health/live
```

Now, run the swatch-producer-aws component set to ignore deserialization errors:

```
TALLY_IN_FAIL_ON_DESER_FAILURE=false \
  ./gradlew swatch-producer-aws:quarkusDev
```

Confirm liveness is UP:

```
curl http://localhost:8000/q/health/live
```

Stop the swatch-producer-aws component, and restart without the failure var overwritten:

```
./gradlew swatch-producer-aws:quarkusDev
```

Next, repeat the hourly tally (this time from this branch), and observe that the swatch-producer-aws component is able to process the messages this time without warnings.