### PR TITLE
ENT-4896: Apply infinite quantity sort logic to totalCapacity

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -265,7 +265,7 @@ public class SubscriptionTableController {
               diff = left.getUsage().compareTo(right.getUsage());
               break;
             case QUANTITY:
-              diff = compareQuantity(left, right);
+              diff = left.getQuantity().compareTo(right.getQuantity());
               break;
             case NEXT_EVENT_DATE:
               diff = left.getNextEventDate().compareTo(right.getNextEventDate());
@@ -274,7 +274,7 @@ public class SubscriptionTableController {
               diff = left.getNextEventType().compareTo(right.getNextEventType());
               break;
             case TOTAL_CAPACITY:
-              diff = left.getTotalCapacity().compareTo(right.getTotalCapacity());
+              diff = compareTotalCapacity(left, right);
               break;
             case PRODUCT_NAME:
               diff = left.getProductName().compareTo(right.getProductName());
@@ -290,8 +290,8 @@ public class SubscriptionTableController {
         });
   }
 
-  private static int compareQuantity(SkuCapacity left, SkuCapacity right) {
-    // unlimited quantity subscriptions are greater than non-unlimited
+  private static int compareTotalCapacity(SkuCapacity left, SkuCapacity right) {
+    // unlimited capacity subscriptions are greater than non-unlimited
     if (!Objects.equals(left.getHasInfiniteQuantity(), right.getHasInfiniteQuantity())) {
       if (Boolean.TRUE.equals(left.getHasInfiniteQuantity())) {
         return 1;
@@ -300,6 +300,6 @@ public class SubscriptionTableController {
         return -1;
       }
     }
-    return left.getQuantity().compareTo(right.getQuantity());
+    return left.getTotalCapacity().compareTo(right.getTotalCapacity());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -613,7 +613,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for the eng product, sorted by quantity
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            productId, null, null, null, null, null, SkuCapacityReportSort.QUANTITY, null);
+            productId, null, null, null, null, null, SkuCapacityReportSort.TOTAL_CAPACITY, null);
 
     // Then the report contains two inventory items containing a sub with appropriate
     // quantity and capacities, and RH00604F5 is listed first.
@@ -659,7 +659,7 @@ class SubscriptionTableControllerTest {
             null,
             null,
             null,
-            SkuCapacityReportSort.QUANTITY,
+            SkuCapacityReportSort.TOTAL_CAPACITY,
             SortDirection.DESC);
 
     // Then the report contains two inventory items containing a sub with appropriate


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4896

This is a second take (a lot of repeat from #907). In the initial solution, I made a mistake, we should put this logic against `total_capacity` sort value (instead of `quantity`).

Testing
-------

Create an allowlist with a couple of SKUs on it:

```
echo -e 'MW00330\nMW00210MO\n' > /tmp/allowlist.txt
```

Run the app:

```
RHSM_RBAC_USE_STUB=true \
  DEV_MODE=true \
  PRODUCT_WHITELIST_RESOURCE_LOCATION=file:/tmp/allowlist.txt \
  ./gradlew :bootRun
```

Opt in account 123 / org 123:

```
curl   -H 'Content-Type: application/json'   -d '{
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean",
    "operation": "createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)",
    "arguments": [
      "123",
      "123",
      true,
      true,
      true
    ]
  }'   http://localhost:9000/hawtio/jolokia
```

Insert offerings into the DB manually:

```
curl   -H 'Content-Type: application/json'   -d "{
    \"type\": \"exec\",
    \"mbean\": \"org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean\",
    \"operation\": \"saveOfferings(java.lang.String,java.lang.String,java.lang.String,boolean)\",
    \"arguments\": [
        $(cat src/main/resources/product-stub-data/tree-*.json | jq -s),
        $(cat src/main/resources/product-stub-data/tree-*.json | jq -s),
        $(cat src/main/resources/product-stub-data/engprods-*.json | jq -s),
        false
    ]
  }"   http://localhost:9000/hawtio/jolokia
```

Insert a non-unlimited subscription:

```
curl   -H 'Content-Type: application/json'   -d '{
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean",
    "operation": "saveSubscriptions(java.lang.String,boolean)",
    "arguments": [
      "[{
         \"id\": 123456789,
         \"quantity\": 2,
         \"webCustomerId\": 123,
         \"effectiveStartDate\": 946702800000,
         \"effectiveEndDate\": 2524626000000,
         \"subscriptionProducts\": [
           {
             \"sku\": \"MW00330\"
           }
         ]
      }]",
      true
    ]
  }'   http://localhost:9000/hawtio/jolokia
```

Insert an infinite capacity sub:

```
curl   -H 'Content-Type: application/json'   -d '{
    "type": "exec",
    "mbean": "org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean",
    "operation": "saveSubscriptions(java.lang.String,boolean)",
    "arguments": [
      "[{
         \"id\": 123456790,
         \"quantity\": 1,
         \"webCustomerId\": 123,
         \"effectiveStartDate\": 946702800000,
         \"effectiveEndDate\": 2524626000000,
         \"subscriptionProducts\": [
           {
             \"sku\": \"MW00210MO\"
           }
         ]
      }]",
      true
    ]
  }'   http://localhost:9000/hawtio/jolokia
```

Try the API for subscription table, sorting by total_capacity ascending:

```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform?sort=total_capacity&dir=asc' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMyIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjMifX19Cg==' | jq
```

(The unlimited sub will appear last).

Try the API for subscription table, sorting by capacity descending:

```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform?sort=total_capacity&dir=desc' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMyIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjMifX19Cg==' | jq
```

(The unlimited sub will appear first).

Clean up if desired (can just recreate DB instead if desired):

```
psql -h localhost -U rhsm-subscriptions -c 'truncate offering cascade;'
psql -h localhost -U rhsm-subscriptions -c 'truncate subscription cascade;'
psql -h localhost -U rhsm-subscriptions -c 'truncate subscription_capacity cascade;'
```