### PR TITLE
[DRAFT] Uncouple rhsm ClowdApp deploy from cloudigrade

### DIFF
--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -160,3 +160,9 @@ objects:
     name: swatch-psks
   data:
     self: ZHVtbXk=
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: cloudigrade-psk
+  data:
+    psk: ZHVtbXk=


### PR DESCRIPTION
In an attempt to be able to deploy the rhsm ClowdApp to ephemeral environments as clean as possible, I added a dummy cloudigrade psk to our ClowdApp definition.  Without it, we need to deploy the optional dependency, cloudigrade, just because it creates that secret.  Otherwise, rhsm pods fail to start up because it's missing a secret.

```
bonfire deploy --no-remove-resources=all \
--optional-deps-method=none \
-i quay.io/cloudservices/rhsm-subscriptions=latest \
-p rhsm-subscriptions/IMAGE=quay.io/cloudservices/rhsm-subscriptions \
-i quay.io/cloudservices/swatch-system-conduit=latest \
-p rhsm-subscriptions/IMAGE=quay.io/cloudservices/swatch-system-conduit \
-i quay.io/cloudservices/swatch-producer-aws=latest \
-p rhsm-subscriptions/IMAGE=quay.io/cloudservices/swatch-producer-aws \
rhsm host-inventory
```