### PR TITLE
ENT-4842: Add accountBillingId to Events

### DIFF
--- a/clients/prometheus-client/prometheus-api-spec.yaml
+++ b/clients/prometheus-client/prometheus-api-spec.yaml
@@ -7,7 +7,7 @@ info:
   version: 1.0.0
 
 paths:
-  /query/:
+  /query:
     description: "Evaluates an instant query at a single point in time"
     parameters:
       - name: query
@@ -41,7 +41,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/QueryResult'
 
-  /query_range/:
+  /query_range:
     description: " Evaluates an expression query over a range of time"
     parameters:
       - name: query

--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -71,6 +71,7 @@ public class MeteringEventFactory {
       OffsetDateTime expired,
       String serviceType,
       String billingProvider,
+      String billingAccountId,
       Uom measuredMetric,
       Double measuredValue) {
     Event event = new Event();
@@ -86,6 +87,7 @@ public class MeteringEventFactory {
         expired,
         serviceType,
         billingProvider,
+        billingAccountId,
         measuredMetric,
         measuredValue);
     return event;
@@ -104,6 +106,7 @@ public class MeteringEventFactory {
       OffsetDateTime expired,
       String serviceType,
       String billingProvider,
+      String billingAccountId,
       Uom measuredMetric,
       Double measuredValue) {
     toUpdate
@@ -118,6 +121,7 @@ public class MeteringEventFactory {
         .withSla(getSla(serviceLevel, accountNumber, instanceId))
         .withUsage(getUsage(usage, accountNumber, instanceId))
         .withBillingProvider(getBillingProvider(billingProvider, accountNumber, instanceId))
+        .withBillingAccountId(Optional.ofNullable(billingAccountId))
         .withMeasurements(
             List.of(new Measurement().withUom(measuredMetric).withValue(measuredValue)))
         .withRole(getRole(role, accountNumber, instanceId));

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -159,6 +159,7 @@ public class PrometheusMeteringController {
               //       tag profile. For openshift, the values will be 'ocp' or 'osd'.
               String role = labels.get("product");
               String billingProvider = labels.get("billing_provider");
+              String billingAccountId = labels.get("billing_marketplace_account");
 
               // For the openshift metrics, we expect our results to be a 'matrix'
               // vector [(instant_time,value), ...] so we only look at the result's getValues()
@@ -186,6 +187,7 @@ public class PrometheusMeteringController {
                         eventTermDate,
                         tagMetaData.get().getServiceType(),
                         billingProvider,
+                        billingAccountId,
                         tagMetric.get().getUom(),
                         value);
                 events.putIfAbsent(EventKey.fromEvent(event), event);
@@ -235,6 +237,7 @@ public class PrometheusMeteringController {
       OffsetDateTime expired,
       String serviceType,
       String billingProvider,
+      String billingAccountId,
       Uom metric,
       BigDecimal value) {
     EventKey lookupKey =
@@ -260,6 +263,7 @@ public class PrometheusMeteringController {
         expired,
         serviceType,
         billingProvider,
+        billingAccountId,
         metric,
         value.doubleValue());
     return event;

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.metering;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;
@@ -62,6 +63,7 @@ class MeteringEventFactoryTest {
             expiry,
             serviceType,
             billingProvider,
+            null,
             uom,
             measuredValue);
 
@@ -95,6 +97,7 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "red hat",
+            null,
             Uom.CORES,
             12.5);
     assertNull(event.getSla());
@@ -114,6 +117,7 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "red hat",
+            "null",
             Uom.CORES,
             12.5);
     assertEquals(Sla.__EMPTY__, event.getSla());
@@ -133,6 +137,7 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "red hat",
+            null,
             Uom.CORES,
             12.5);
     assertNull(event.getSla());
@@ -152,6 +157,7 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "red hat",
+            null,
             Uom.CORES,
             12.5);
     assertNull(event.getUsage());
@@ -171,6 +177,7 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "red hat",
+            null,
             Uom.CORES,
             12.5);
     assertNull(event.getUsage());
@@ -190,6 +197,7 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "red hat",
+            null,
             Uom.CORES,
             12.5);
     assertNull(event.getRole());
@@ -209,13 +217,14 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "red hat",
+            null,
             Uom.CORES,
             12.5);
     assertNull(event.getRole());
   }
 
   @Test
-  void testOpenShiftClusterCoresHandlesValidBillingProvider() throws Exception {
+  void testHandlesValidBillingData() throws Exception {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
@@ -228,13 +237,16 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "aws",
+            "aws_account_123",
             Uom.CORES,
             12.5);
     assertEquals(BillingProvider.AWS, event.getBillingProvider());
+    assertTrue(event.getBillingAccountId().isPresent());
+    assertEquals("aws_account_123", event.getBillingAccountId().get());
   }
 
   @Test
-  void testOpenShiftClusterCoresHandlesNullBillingProvider() throws Exception {
+  void testHandlesNullBillingData() throws Exception {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
@@ -247,14 +259,15 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             null,
+            null,
             Uom.CORES,
             12.5);
     assertNull(event.getBillingProvider());
+    assertTrue(event.getBillingAccountId().isEmpty());
   }
 
   @Test
-  void testOpenShiftClusterCoresBillingProviderSetToEmptyForBillingProviderValueNone()
-      throws Exception {
+  void testBillingProviderSetToEmptyForBillingProviderValueNone() throws Exception {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
@@ -267,13 +280,14 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "",
+            null,
             Uom.CORES,
             12.5);
     assertEquals(BillingProvider.__EMPTY__, event.getBillingProvider());
   }
 
   @Test
-  void testOpenShiftClusterCoresInvalidBillingProviderWillNotBeSetOnEvent() throws Exception {
+  void testInvalidBillingProviderWillNotBeSetOnEvent() throws Exception {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
@@ -286,6 +300,7 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "invalid provider",
+            null,
             Uom.CORES,
             12.5);
     assertNull(event.getBillingProvider());
@@ -305,6 +320,7 @@ class MeteringEventFactoryTest {
             OffsetDateTime.now(),
             "service_type",
             "red hat",
+            null,
             Uom.CORES,
             12.5);
     assertEquals("snapshot_metric-id", event.getEventType());

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -99,6 +99,7 @@ class PrometheusMeteringControllerTest {
   private final String expectedRole = "ocm";
   private final String expectedServiceType = "OpenShift Cluster";
   private final String expectedBillingProvider = "red hat";
+  private final String expectedBillingAccountId = "mktp-account";
   private final Uom expectedUom = Uom.CORES;
 
   private PrometheusMeteringController controller;
@@ -134,6 +135,7 @@ class PrometheusMeteringControllerTest {
             expectedSla,
             expectedUsage,
             expectedBillingProvider,
+            expectedBillingAccountId,
             List.of(List.of(new BigDecimal(12312.345), new BigDecimal(24))));
 
     when(service.runRangeQuery(anyString(), any(), any(), any(), any()))
@@ -157,6 +159,7 @@ class PrometheusMeteringControllerTest {
             expectedSla,
             expectedUsage,
             expectedBillingProvider,
+            expectedBillingAccountId,
             List.of(List.of(new BigDecimal(12312.345), new BigDecimal(24))));
     when(service.runRangeQuery(anyString(), any(), any(), any(), any())).thenReturn(data);
 
@@ -181,6 +184,7 @@ class PrometheusMeteringControllerTest {
             expectedSla,
             expectedUsage,
             expectedBillingProvider,
+            expectedBillingAccountId,
             List.of(List.of(new BigDecimal(12312.345), new BigDecimal(24))));
     when(service.runRangeQuery(anyString(), any(), any(), any(), any())).thenReturn(data);
 
@@ -211,6 +215,7 @@ class PrometheusMeteringControllerTest {
             expectedSla,
             expectedUsage,
             expectedBillingProvider,
+            expectedBillingAccountId,
             List.of(List.of(time1, val1), List.of(time2, val2)));
     when(service.runRangeQuery(
             eq(queries.expectedQuery("OpenShift-metrics", expectedAccount)),
@@ -236,6 +241,7 @@ class PrometheusMeteringControllerTest {
                 clock.dateFromUnix(time1),
                 expectedServiceType,
                 expectedBillingProvider,
+                expectedBillingAccountId,
                 expectedUom,
                 val1.doubleValue()),
             MeteringEventFactory.createMetricEvent(
@@ -249,6 +255,7 @@ class PrometheusMeteringControllerTest {
                 clock.dateFromUnix(time2),
                 expectedServiceType,
                 expectedBillingProvider,
+                expectedBillingAccountId,
                 expectedUom,
                 val2.doubleValue()));
 
@@ -287,6 +294,7 @@ class PrometheusMeteringControllerTest {
             expectedSla,
             expectedUsage,
             expectedBillingProvider,
+            expectedBillingAccountId,
             List.of(List.of(time1, val1), List.of(time2, val2)));
     when(service.runRangeQuery(
             eq(queries.expectedQuery("OpenShift-metrics", expectedAccount)),
@@ -311,6 +319,7 @@ class PrometheusMeteringControllerTest {
             clock.dateFromUnix(time1),
             expectedServiceType,
             expectedBillingProvider,
+            expectedBillingAccountId,
             expectedUom,
             val1.doubleValue());
 
@@ -328,6 +337,7 @@ class PrometheusMeteringControllerTest {
                 clock.dateFromUnix(time2),
                 expectedServiceType,
                 expectedBillingProvider,
+                expectedBillingAccountId,
                 expectedUom,
                 val2.doubleValue()));
 
@@ -343,6 +353,7 @@ class PrometheusMeteringControllerTest {
             clock.dateFromUnix(time1),
             expectedServiceType,
             expectedBillingProvider,
+            expectedBillingAccountId,
             expectedUom,
             val1.doubleValue());
 
@@ -360,6 +371,7 @@ class PrometheusMeteringControllerTest {
                 updatedEvent.getExpiration().get(),
                 expectedServiceType,
                 expectedBillingProvider,
+                expectedBillingAccountId,
                 expectedUom,
                 144.4),
             // This event should get purged because prometheus did not report this cluster.
@@ -410,6 +422,7 @@ class PrometheusMeteringControllerTest {
             .putMetricItem("role", "osd")
             .putMetricItem("ebs_account", expectedAccount)
             .putMetricItem("billing_provider", "red hat")
+            .putMetricItem("billing_marketplace_account", expectedBillingAccountId)
             .addValuesItem(List.of(BigDecimal.valueOf(1616787308L), BigDecimal.valueOf(4.0)));
     QueryResultDataResult premiumResultItem =
         new QueryResultDataResult()
@@ -419,6 +432,7 @@ class PrometheusMeteringControllerTest {
             .putMetricItem("role", "osd")
             .putMetricItem("ebs_account", expectedAccount)
             .putMetricItem("billing_provider", "red hat")
+            .putMetricItem("billing_marketplace_account", expectedBillingAccountId)
             .addValuesItem(List.of(BigDecimal.valueOf(1616787308L), BigDecimal.valueOf(4.0)));
     QueryResultData queryResultData =
         new QueryResultData().addResultItem(standardResultItem).addResultItem(premiumResultItem);
@@ -447,6 +461,7 @@ class PrometheusMeteringControllerTest {
             clock.dateFromUnix(1616787308L),
             expectedServiceType,
             expectedBillingProvider,
+            expectedBillingAccountId,
             expectedUom,
             4.0);
 
@@ -467,6 +482,7 @@ class PrometheusMeteringControllerTest {
             updatedEvent.getExpiration().get(),
             expectedServiceType,
             expectedBillingProvider,
+            expectedBillingAccountId,
             expectedUom,
             144.4);
     existingEvent.setEventId(eventId);
@@ -510,6 +526,7 @@ class PrometheusMeteringControllerTest {
       String sla,
       String usage,
       String billingProvider,
+      String billingAccountId,
       List<List<BigDecimal>> timeValueTuples) {
     QueryResultDataResult dataResult =
         new QueryResultDataResult()
@@ -517,7 +534,8 @@ class PrometheusMeteringControllerTest {
             .putMetricItem("support", sla)
             .putMetricItem("usage", usage)
             .putMetricItem("ebs_account", account)
-            .putMetricItem("billing_provider", billingProvider);
+            .putMetricItem("billing_provider", billingProvider)
+            .putMetricItem("billing_marketplace_account", billingAccountId);
 
     // NOTE: A tuple is [unix_time,value]
     timeValueTuples.forEach(tuple -> dataResult.addValuesItem(tuple));

--- a/swatch-core/schemas/event.yaml
+++ b/swatch-core/schemas/event.yaml
@@ -155,7 +155,7 @@ properties:
       - Sockets
     required: false
   billing_provider:
-    description: Billing provider of the service.
+    description: Billing provider used for billing.
     type: string
     enum:
       - ''  # UNSPECIFIED
@@ -164,4 +164,9 @@ properties:
       - gcp
       - azure
       - oracle
+    required: false
+  billing_account_id:
+    description: The account ID used for billing.
+    type: string
+    existingJavaType: java.util.Optional<String>
     required: false


### PR DESCRIPTION
**Add billing_marketplace_account metric label to Event data**

When metrics are read from prometheus, the billing_marketplace_account
label is read from the metrics and is stored in the resulting Event
object.

To be consistent, the label value is stored in the Event as
billingAccountId.

**Remove trailling / from prometheus API paths**

The trailing / causes a / before query parameters are defined in the URL,
which trips up some web servers ( /?parameter=foo ).


# Testing
Because the billing_marketplace_account is not yet available in our Observatorium environments, we will have to stub the data when testing: [Generating Prometheus Metric Data](https://docs.engineering.redhat.com/display/ENT/Generating+Prometheus+Metric+Data)

As in the doc, after generating the data, run the MeteringJob and then launch the application to have the task picked up and metrics gathered. Once the metrics are gathered, you should be able to find the new data in the Event record in the DB.

```bash
# Run the metering job
$ PROM_URL="http://localhost:9090/api/v1/" SPRING_PROFILES_ACTIVE=metering-job,kafka-queue ./gradlew :bootRun
 
# Run the swatch services.
$ SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true DEV_MODE=true PROM_URL="http://localhost:9090/api/v1/" ./gradlew :bootRun

```
```sql
select timestamp, data from events order by timestamp ASC;

 2022-05-02 13:00:00+00 | {"sla": "Premium", "role": "rhosak", "event_id": "a6f158a2-4d1e-4b51-bd25-a53712a39533", "timestamp": "2022-05-02T13:00:00Z", "event_type": "snapshot_redhat.com:rhosak:storage_gb", "expiration": "2022-05-02T14:0
0:00Z", "instance_id": "test01", "display_name": "test01", "event_source": "prometheus", "measurements": [{"uom": "Storage-gibibytes", "value": 25.56847361034478}], "service_type": "Kafka Cluster", "account_number": "account123", "billin
g_provider": "aws", "billing_account_id": "mktp-123"}
```