### PR TITLE
ENT-4720: Use annotation instead of antMatcher for internal role check

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -31,6 +31,7 @@ import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Subscription;
 import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.security.auth.InternalRoleRequired;
 import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.UsageCalculation.Key;
@@ -55,12 +56,14 @@ public class InternalSubscriptionResource implements InternalApi {
     this.subscriptionSyncController = subscriptionSyncController;
   }
 
+  @InternalRoleRequired
   @Override
   public String forceSyncSubscriptionsForOrg(String orgId) {
     subscriptionSyncController.forceSyncSubscriptionsForOrg(orgId);
     return SUCCESS_STATUS;
   }
 
+  @InternalRoleRequired
   @Override
   public AwsUsageContext getAwsUsageContext(
       String accountNumber, OffsetDateTime date, String productId, String sla, String usage) {

--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -196,8 +196,6 @@ public class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
         .antMatchers("/metrics")
         .permitAll()
-        .antMatchers("/**/internal/**")
-        .access("hasRole('ROLE_INTERNAL')")
         .antMatchers("/**/capacity/**", "/**/tally/**", "/**/hosts/**")
         .access("@optInChecker.checkAccess(authentication)")
         .anyRequest()

--- a/src/main/java/org/candlepin/subscriptions/security/auth/InternalRoleRequired.java
+++ b/src/main/java/org/candlepin/subscriptions/security/auth/InternalRoleRequired.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.candlepin.subscriptions.security.RoleProvider;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Must have the ROLE_INTERNAL role.
+ *
+ * @see RoleProvider
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('" + RoleProvider.ROLE_INTERNAL + "')")
+public @interface InternalRoleRequired {}

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.admin;
 
+import org.candlepin.subscriptions.security.auth.InternalRoleRequired;
 import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
 import org.candlepin.subscriptions.tally.admin.api.InternalApi;
 import org.candlepin.subscriptions.tally.admin.api.model.TallyResend;
@@ -37,6 +38,7 @@ public class InternalTallyResource implements InternalApi {
     this.resendTallyController = resendTallyController;
   }
 
+  @InternalRoleRequired
   @Override
   public TallyResend resendTally(UuidList uuidList) {
     var tallies = resendTallyController.resendTallySnapshots(uuidList.getUuids());


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4720

Use of antMatcher/access might possibly be causing the UnsupportedOperation exception happening in stage so I'm removing it to see if it helps with the issue.

Test Steps (Regression):

- Start capacity-ingress profile
- Run with incorrect role and should get unauthorized message: `curl -X 'PUT'  'http://localhost:8000/api/rhsm-subscriptieyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`
- Run with correct PSK and it should now work: `curl -X 'PUT'  'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123' -H 'x-rh-swatch-psk: dummy'`