### PR TITLE
Rename swatch-producer-aws clowdapp deployment service

### DIFF
--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -59,7 +59,7 @@ objects:
       name: ${IMAGE_PULL_SECRET}
 
     deployments:
-      - name: swatch-producer-aws
+      - name: service
         minReplicas: 1
         webServices:
           public:


### PR DESCRIPTION
The k8s deployment name is generated by clowder as `$clowdapp-$deploymentName`, so it was being set to `swatch-producer-aws-swatch-producer-aws`; With this change it'll get set instead to `swatch-producer-aws-service`, which is much less redundant.