### PR TITLE
ENT-4954: Make openapi and swagger-ui paths turnpike friendly

### DIFF
--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -46,6 +46,10 @@ TALLY_IN_FAIL_ON_DESER_FAILURE=true
 quarkus.http.port=${SERVER_PORT}
 # make quarkus choose a dynamic port for testing to avoid port collisions w/ simultaneous tests
 quarkus.http.test-port=0
+# expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
+quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/openapi
+quarkus.swagger-ui.always-include=true
+quarkus.swagger-ui.path=/api/${quarkus.application.name}/swagger-ui
 
 #clowder quarkus config takes care of setting these, no need to try to do clowder.kafka.brokers[0]
 

--- a/swatch-producer-aws/src/main/resources/openapi.yaml
+++ b/swatch-producer-aws/src/main/resources/openapi.yaml
@@ -7,7 +7,7 @@ info:
   contact:
     url: https://github.com/RedHatInsights/rhsm-subscriptions
 paths:
-  /internal/aws/tally_summary:
+  /api/swatch-producer-aws/internal/aws/tally_summary:
     post:
       summary: Send `TallySummary` usage data to AWS.
       requestBody:


### PR DESCRIPTION
In order to allow us to create a route that can be used in turnpike config.

Create a nginx configuration that mimics the turnpike config (the key is that only `/api/swatch-producer-aws` is routed to our app):

```
cat <<EOF > nginx.conf
events {}

http {
  server {
    listen 8080;
    location /api/swatch-producer-aws/ {
      proxy_pass http://localhost:8000;
    }
  }
}
EOF
```

Run nginx:

```
podman run \
    --network=host \
     -v $(pwd)/nginx.conf:/etc/nginx/nginx.conf:Z \
     --rm \
     -ti \
     docker.io/library/nginx
```

Run the application *in production mode* (to verify swagger-ui
accessible in prod):

```
./gradlew swatch-producer-aws:quarkusBuild
QUARKUS_LOG_CONSOLE_JSON=false \
    ENABLE_SPLUNK_HEC=false \
    SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8080/ \
    SWATCH_SELF_PSK=dummy \
    AWS_MARKETPLACE_ENDPOINT_URL=http://localhost/foo \
    AWS_CREDENTIALS_JSON='[]' \
    java -jar swatch-producer-aws/build/quarkus-app/quarkus-run.jar
```

Observe that you can browse and hit the api from http://localhost:8080/api/swatch-producer-aws/swagger-ui/