### PR TITLE
ENT-4951 Add range support for hourly tally by all accounts

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -97,10 +97,12 @@ public class TallyJmxBean {
               + " the job was run).")
   @ManagedOperationParameter(
       name = "start",
-      description = "The start date for the tally. Must be specified along with the end parameter.")
+      description =
+          "The start date for the tally (e.g. 22-05-03T10:00:00Z). Must be specified along with the end parameter.")
   @ManagedOperationParameter(
       name = "end",
-      description = "The end date for the tally. Must be specified along with the start parameter.")
+      description =
+          "The end date for the tally (e.g. 22-05-03T16:00:00Z). Must be specified along with the start parameter.")
   public void tallyAllAccountsByHourly(String start, String end) throws IllegalArgumentException {
 
     DateRange range = null;

--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.jmx;
 
+import java.util.Optional;
 import javax.validation.constraints.NotNull;
 import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
@@ -31,6 +32,7 @@ import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedOperationParameter;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
 /** Exposes the ability to trigger a tally for an account from JMX. */
@@ -87,11 +89,37 @@ public class TallyJmxBean {
     tasks.tallyAccountByHourly(accountNumber, tallyRange);
   }
 
-  @ManagedOperation(description = "Trigger hourly tally for all configured accounts")
-  public void tallyAllAccountsByHourly() {
-    log.info(
-        "Hourly tally for all accounts triggered over JMX by {}", ResourceUtils.getPrincipal());
+  @ManagedOperation(
+      description =
+          "Trigger hourly tally for all configured accounts for the specified range. The 'start' and "
+              + "'end' parameters MUST be specified as a pair to complete a range. If they are left empty, "
+              + "a date range is used based on NOW with the configured offsets applied (identical to if "
+              + " the job was run).")
+  @ManagedOperationParameter(
+      name = "start",
+      description = "The start date for the tally. Must be specified along with the end parameter.")
+  @ManagedOperationParameter(
+      name = "end",
+      description = "The end date for the tally. Must be specified along with the start parameter.")
+  public void tallyAllAccountsByHourly(String start, String end) throws IllegalArgumentException {
 
-    tasks.updateHourlySnapshotsForAllAccounts();
+    DateRange range = null;
+    if (StringUtils.hasText(start) || StringUtils.hasText(end)) {
+      try {
+        range = DateRange.fromStrings(start, end);
+        log.info(
+            "Hourly tally for all accounts triggered for range {} over JMX by {}",
+            range,
+            ResourceUtils.getPrincipal());
+      } catch (Exception e) {
+        throw new IllegalArgumentException(
+            "Both startDateTime and endDateTime must be set to " + "valid date Strings.");
+      }
+    } else {
+      log.info(
+          "Hourly tally for all accounts triggered over JMX by {}", ResourceUtils.getPrincipal());
+    }
+
+    tasks.updateHourlySnapshotsForAllAccounts(Optional.ofNullable(range));
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/job/CaptureHourlySnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/CaptureHourlySnapshotsJob.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.job;
 
+import java.util.Optional;
 import org.candlepin.subscriptions.exception.JobFailureException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -40,7 +41,7 @@ public class CaptureHourlySnapshotsJob implements Runnable {
   @Scheduled(cron = "${rhsm-subscriptions.jobs.capture-hourly-snapshot-schedule}")
   public void run() {
     try {
-      tasks.updateHourlySnapshotsForAllAccounts();
+      tasks.updateHourlySnapshotsForAllAccounts(Optional.empty());
     } catch (Exception e) {
       throw new JobFailureException("Failed to run CaptureHourlySnapshotsJob.", e);
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountListSource;
@@ -39,6 +40,7 @@ import org.candlepin.subscriptions.task.TaskType;
 import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskQueue;
 import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskQueueConsumerFactory;
 import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.util.DateRange;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -164,7 +166,7 @@ class CaptureSnapshotsTaskManagerTest {
             prometheusLatencyDuration);
     OffsetDateTime startDateTime = endDateTime.minus(metricRange);
 
-    manager.updateHourlySnapshotsForAllAccounts();
+    manager.updateHourlySnapshotsForAllAccounts(Optional.empty());
 
     expectedAccounts.forEach(
         accountNumber -> {
@@ -176,6 +178,31 @@ class CaptureSnapshotsTaskManagerTest {
                       // 2019-05-24T12:35Z truncated to top of the hour - 1 hour tally range
                       .setSingleValuedArg("startDateTime", "2019-05-24T10:00:00Z")
                       .setSingleValuedArg("endDateTime", "2019-05-24T11:00:00Z")
+                      .build());
+        });
+  }
+
+  @Test
+  void testHourlySnapshotForAllAccountsForDateRange() throws Exception {
+    List<String> expectedAccounts = Arrays.asList("a1", "a2");
+    when(accountListSource.syncableAccounts()).thenReturn(expectedAccounts.stream());
+
+    DateRange range =
+        new DateRange(applicationClock.now().minusDays(10L), applicationClock.now().minusDays(5L));
+
+    manager.updateHourlySnapshotsForAllAccounts(Optional.of(range));
+
+    expectedAccounts.forEach(
+        accountNumber -> {
+          verify(queue, times(1))
+              .enqueue(
+                  TaskDescriptor.builder(
+                          TaskType.UPDATE_HOURLY_SNAPSHOTS, taskQueueProperties.getTopic())
+                      .setSingleValuedArg("accountNumber", accountNumber)
+                      // 10 days less than the test clock at the top of the hour.
+                      .setSingleValuedArg("startDateTime", "2019-05-14T12:00:00Z")
+                      // 5 days less than the test clock at the top of the hour.
+                      .setSingleValuedArg("endDateTime", "2019-05-19T12:00:00Z")
                       .build());
         });
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4951

TallyJmxBean.tallyAllAccountsByHourly now supports a date range.
When no range is specified, the default is run based on NOW with
offsets applied.


# Testing

When testing, monitor the logs to check the resulting dates of the Tally.

NOTES:
* Must have Events in the DB and a matching opted in account.

Hitting the JMX endpoint with null or empty start/end values will default to the same behaviour as the CaptureHourlySnapshotJob, where the start/end dates are based on NOW with the configured offsets applied. For example, running at 18:41:05pm UTC, you should expect to see:

> 2022-05-03 18:41:05,087 [thread=rhsm-subscriptions-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.TallySnapshotController] - Producing hourly snapshots for account 941133 for service type Kafka Cluster between startDateTime 2022-05-03T16:00:00Z and endDateTime 2022-05-03T17:00:00Z


```bash
$ curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)","arguments":[null, null]}'
```


Hitting the JMX endpoint with a start/end date set, results in the tally being run against that exact range with the start/end dates truncated to the start of the hour.

```bash
$ curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)","arguments":["2022-05-01T16:12:20Z", "2022-05-03T16:20:00Z"]}'
```
> 2022-05-03 18:43:30,114 [thread=rhsm-subscriptions-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.TallySnapshotController] - Producing hourly snapshots for account account123 for service type Kafka Cluster between startDateTime 2022-05-01T16:00:00Z and endDateTime 2022-05-03T16:00:00Z

**NOTE:** You may notice in the logs that the date range might get automatically adjusted because a re-tally might need to be done if there are currently other snapshots that may also need to be re-tallied during this time. Even so, you will still see the log above before this happens.

BOTH the start and end date must be specified when being run and must be valid dates.

```bash
$ curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)","arguments":[null, "2022-05-03T16:20:00Z"]}'

{"request":{"mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","arguments":[null,"2022-05-03T16:20:00Z"],"type":"exec","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)"},"error_type":"java.lang.IllegalArgumentException","error":"java.lang.IllegalArgumentException : Both startDateTime and endDateTime must be set to valid date Strings.","status":500}
```
```bash
$ curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)","arguments":["2022-05-01T16:12:20Z", null]}'

{"request":{"mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","arguments":["2022-05-01T16:12:20Z",null],"type":"exec","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)"},"error_type":"java.lang.IllegalArgumentException","error":"java.lang.IllegalArgumentException : Both startDateTime and endDateTime must be set to valid date Strings.","status":500}
```
```bash
$ curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)","arguments":["2022-05-01T16:12:20Z", ""]}'

{"request":{"mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","arguments":["2022-05-01T16:12:20Z",""],"type":"exec","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)"},"error_type":"java.lang.IllegalArgumentException","error":"java.lang.IllegalArgumentException : Both startDateTime and endDateTime must be set to valid date Strings.","status":500}
```
```bash
$ curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)","arguments":["", "2022-05-03T16:20:00Z"]}'

{"request":{"mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","arguments":["","2022-05-03T16:20:00Z"],"type":"exec","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)"},"error_type":"java.lang.IllegalArgumentException","error":"java.lang.IllegalArgumentException : Both startDateTime and endDateTime must be set to valid date Strings.","status":500}
```