### PR TITLE
Realign and simplify range handling w/ metrics

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
@@ -90,10 +90,16 @@ public class MeteringJmxBean {
       String accountNumber, String productTag, String endDate, Integer rangeInMinutes)
       throws IllegalArgumentException {
     Object principal = ResourceUtils.getPrincipal();
-    log.info("{} metering for {} triggered via JMX by {}", productTag, accountNumber, principal);
 
     OffsetDateTime end = getDate(endDate);
     OffsetDateTime start = getStartDate(end, rangeInMinutes);
+    log.info(
+        "{} metering for {} against range [{}, {}) triggered via JMX by {}",
+        productTag,
+        accountNumber,
+        start,
+        end,
+        principal);
 
     try {
       tasks.updateMetricsForAccount(accountNumber, productTag, start, end);
@@ -128,10 +134,14 @@ public class MeteringJmxBean {
   public void performCustomMetering(String productTag, String endDate, Integer rangeInMinutes)
       throws IllegalArgumentException {
     Object principal = ResourceUtils.getPrincipal();
-    log.info("Metering for all accounts triggered via JMX by {}", principal);
 
     OffsetDateTime end = getDate(endDate);
     OffsetDateTime start = getStartDate(end, rangeInMinutes);
+    log.info(
+        "Metering for all accounts against range [{}, {}) triggered via JMX by {}",
+        start,
+        end,
+        principal);
 
     try {
       tasks.updateMetricsForAllAccounts(productTag, start, end);
@@ -168,6 +178,13 @@ public class MeteringJmxBean {
       throw new IllegalArgumentException("Invalid value specified (Must be >= 0): rangeInMinutes");
     }
 
-    return endDate.minusMinutes(rangeInMinutes);
+    OffsetDateTime result = endDate.minusMinutes(rangeInMinutes);
+    if (!result.isEqual(clock.startOfHour(result))) {
+      throw new IllegalArgumentException(
+          String.format(
+              "endDate %s - range %s produces time not at top of the hour: %s",
+              endDate, rangeInMinutes, result));
+    }
+    return result;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -108,13 +108,14 @@ public class PrometheusMeteringController {
           String.format("Unable to determine service type for tag %s.", tagMetric.get().getTag()));
     }
 
-    // Reset the start/end dates to ensure they span a complete hour.
-    // NOTE: If the prometheus query step changes, we will need to adjust this.
-    OffsetDateTime startDate = clock.startOfHour(start);
-    // Subtract 1 minute off the end date so that the date is guaranteed to never be
-    // at the top of an hour. Otherwise we would get an extra hour added onto the date
-    // when we moved it to the end of the hour.
-    OffsetDateTime endDate = clock.endOfHour(end.minusMinutes(1));
+    /* Adjust the range for the prometheus range query API. Range query returns a data point at the
+    startDate, and then an additional data point for each increment of `step` that is <= endDate.
+    Because our prometheus queries use a range vector (look back) of 1h, we need to add an hour to
+    the start of our range to get datapoints which represents the time range we're gathering data
+    for. We also ensure that the start of the range is on an hourly boundary (defensive programming
+    - it should already be)
+     */
+    OffsetDateTime startDate = clock.startOfHour(start).plusHours(1);
     log.debug("Ensuring marketplace account {} has been set up for syncing/reporting.", account);
     ensureOptIn(account);
     openshiftRetry.execute(
@@ -126,7 +127,7 @@ public class PrometheusMeteringController {
                 prometheusService.runRangeQuery(
                     buildPromQLForMetering(account, tagMetric.get()),
                     startDate,
-                    endDate,
+                    end,
                     metricProperties.getStep(),
                     metricProperties.getQueryTimeout());
 
@@ -145,7 +146,12 @@ public class PrometheusMeteringController {
                     // shift in the event start date when it is created. See note about eventDate
                     // below.
                     startDate.minusSeconds(metricProperties.getStep()),
-                    endDate.minusSeconds(metricProperties.getStep()));
+                    end);
+
+            log.debug(
+                "Looking for events in range [{}, {})",
+                startDate.minusSeconds(metricProperties.getStep()),
+                end);
             log.debug("Found {} existing events.", existing.size());
 
             Map<EventKey, Event> events = new HashMap<>();

--- a/src/test/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBeanTest.java
@@ -71,13 +71,27 @@ class MeteringJmxBeanTest {
   @Test
   void testCustomMeteringForAccount() {
     String expectedAccount = "test-account";
-    int rangeInMins = 20;
+    int rangeInMins = 60;
     OffsetDateTime endDate = clock.startOfCurrentHour();
     OffsetDateTime startDate = endDate.minusMinutes(rangeInMins);
     jmx.performCustomMeteringForAccount(
         expectedAccount, PRODUCT_PROFILE_ID, clock.startOfCurrentHour().toString(), rangeInMins);
 
     verify(tasks).updateMetricsForAccount(expectedAccount, PRODUCT_PROFILE_ID, startDate, endDate);
+  }
+
+  @Test
+  void testBadRangeThrowsException() {
+    String expectedAccount = "test-account";
+    int rangeInMins = 20;
+    OffsetDateTime endDate = clock.startOfCurrentHour();
+    String startDate = endDate.minusMinutes(rangeInMins).toString();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          jmx.performCustomMeteringForAccount(
+              expectedAccount, PRODUCT_PROFILE_ID, startDate, rangeInMins);
+        });
   }
 
   @Test
@@ -114,7 +128,7 @@ class MeteringJmxBeanTest {
 
   @Test
   void testPerformCustomMeteringForAllAccounts() {
-    int rangeInMins = 20;
+    int rangeInMins = 60;
     OffsetDateTime endDate = clock.startOfCurrentHour();
     OffsetDateTime startDate = endDate.minusMinutes(rangeInMins);
     jmx.performCustomMetering(

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
@@ -85,17 +85,22 @@ class PrometheusAccountSourceTest {
   @Test
   void buildsPromQLByAccountLookupTemplateKey() {
     OffsetDateTime expectedDate = OffsetDateTime.now();
-    when(service.runQuery(
+    when(service.runRangeQuery(
             queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag)),
             expectedDate,
+            expectedDate,
+            3600,
             metricProperties.getQueryTimeout()))
         .thenReturn(buildAccountQueryResult(List.of("A1")));
 
-    accountSource.getMarketplaceAccounts(TEST_PROD_TAG, Uom.CORES, expectedDate);
+    accountSource.getMarketplaceAccounts(
+        TEST_PROD_TAG, Uom.CORES, expectedDate.minusHours(1), expectedDate);
     verify(service)
-        .runQuery(
+        .runRangeQuery(
             queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag)),
             expectedDate,
+            expectedDate,
+            3600,
             metricProperties.getQueryTimeout());
   }
 
@@ -110,14 +115,17 @@ class PrometheusAccountSourceTest {
     accountList.add("");
     accountList.add(expectedAccount);
 
-    when(service.runQuery(
+    when(service.runRangeQuery(
             queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag)),
             expectedDate,
+            expectedDate,
+            3600,
             metricProperties.getQueryTimeout()))
         .thenReturn(buildAccountQueryResult(accountList));
 
     Set<String> accounts =
-        accountSource.getMarketplaceAccounts(TEST_PROD_TAG, Uom.CORES, expectedDate);
+        accountSource.getMarketplaceAccounts(
+            TEST_PROD_TAG, Uom.CORES, expectedDate.minusHours(1), expectedDate);
     assertEquals(1, accounts.size());
     assertTrue(accounts.contains(expectedAccount));
   }
@@ -127,14 +135,17 @@ class PrometheusAccountSourceTest {
     List<String> expectedAccounts = List.of("A1", "A2");
     OffsetDateTime expectedDate = OffsetDateTime.now();
 
-    when(service.runQuery(
+    when(service.runRangeQuery(
             queryBuilder.buildAccountLookupQuery(new QueryDescriptor(tag)),
             expectedDate,
+            expectedDate,
+            3600,
             metricProperties.getQueryTimeout()))
         .thenReturn(buildAccountQueryResult(expectedAccounts));
 
     Set<String> accounts =
-        accountSource.getMarketplaceAccounts(TEST_PROD_TAG, Uom.CORES, expectedDate);
+        accountSource.getMarketplaceAccounts(
+            TEST_PROD_TAG, Uom.CORES, expectedDate.minusHours(1), expectedDate);
     assertEquals(2, accounts.size());
     assertTrue(accounts.containsAll(expectedAccounts));
   }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -167,15 +167,15 @@ class PrometheusMeteringControllerTest {
     verify(service)
         .runRangeQuery(
             queries.expectedQuery("OpenShift-metrics", expectedAccount),
-            clock.startOfHour(start),
-            clock.endOfHour(end),
+            clock.startOfHour(start).plusHours(1),
+            end,
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());
   }
 
   @Test
   void accountGetsOptedInWhenReportingMetrics() {
-    OffsetDateTime start = clock.now();
+    OffsetDateTime start = clock.startOfCurrentHour();
     OffsetDateTime end = start.plusHours(4);
     QueryResult data =
         buildOpenShiftClusterQueryResult(
@@ -192,8 +192,8 @@ class PrometheusMeteringControllerTest {
     verify(service)
         .runRangeQuery(
             queries.expectedQuery("OpenShift-metrics", expectedAccount),
-            clock.startOfHour(start),
-            clock.endOfHour(end),
+            start.plusHours(1),
+            end,
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());
     verify(optInController)
@@ -226,7 +226,7 @@ class PrometheusMeteringControllerTest {
         .thenReturn(data);
 
     OffsetDateTime start = clock.startOfCurrentHour();
-    OffsetDateTime end = clock.endOfHour(start.plusDays(1));
+    OffsetDateTime end = start.plusDays(1);
 
     List<Event> expectedEvents =
         List.of(
@@ -267,7 +267,7 @@ class PrometheusMeteringControllerTest {
     verify(service)
         .runRangeQuery(
             queries.expectedQuery("OpenShift-metrics", expectedAccount),
-            start,
+            start.plusHours(1),
             end,
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());
@@ -305,7 +305,7 @@ class PrometheusMeteringControllerTest {
         .thenReturn(data);
 
     OffsetDateTime start = clock.startOfCurrentHour();
-    OffsetDateTime end = clock.endOfHour(start.plusDays(1));
+    OffsetDateTime end = start.plusDays(1);
 
     Event updatedEvent =
         MeteringEventFactory.createMetricEvent(
@@ -380,8 +380,8 @@ class PrometheusMeteringControllerTest {
             expectedAccount,
             MeteringEventFactory.EVENT_SOURCE,
             MeteringEventFactory.getEventType(expectedMetricId),
-            start.minusSeconds(metricProperties.getStep()),
-            end.minusSeconds(metricProperties.getStep())))
+            start,
+            end))
         .thenReturn(
             existingEvents.stream()
                 .collect(Collectors.toMap(EventKey::fromEvent, Function.identity())));
@@ -397,7 +397,7 @@ class PrometheusMeteringControllerTest {
     verify(service)
         .runRangeQuery(
             queries.expectedQuery("OpenShift-metrics", expectedAccount),
-            start,
+            start.plusHours(1),
             end,
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());
@@ -494,8 +494,8 @@ class PrometheusMeteringControllerTest {
             expectedAccount,
             MeteringEventFactory.EVENT_SOURCE,
             MeteringEventFactory.getEventType(expectedMetricId),
-            start.minusSeconds(metricProperties.getStep()),
-            end.minusSeconds(metricProperties.getStep())))
+            start,
+            end))
         .thenReturn(
             existingEvents.stream()
                 .collect(Collectors.toMap(EventKey::fromEvent, Function.identity())));
@@ -508,7 +508,7 @@ class PrometheusMeteringControllerTest {
     verify(service)
         .runRangeQuery(
             queries.expectedQuery("OpenShift-metrics", expectedAccount),
-            start,
+            start.plusHours(1),
             end,
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -93,7 +93,7 @@ class PrometheusMetricsTaskManagerTest {
     OffsetDateTime end = OffsetDateTime.now();
     OffsetDateTime start = end.minusDays(1);
 
-    when(accountSource.getMarketplaceAccounts(eq(TEST_PROFILE_ID), eq(Uom.CORES), any()))
+    when(accountSource.getMarketplaceAccounts(eq(TEST_PROFILE_ID), eq(Uom.CORES), any(), any()))
         .thenReturn(Set.of("a1", "a2"));
     TaskDescriptor account1Task =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, TASK_TOPIC)


### PR DESCRIPTION
During verification of #953, I noticed that the way the metrics ranges are handled was a bit inconsistent. Specifically, when we
persist metrics, we treat the data point timestamp as the "end" of the range and then calculate back to the beginning of the range by subtracting an hour. For a data point that represents 12pm-1pm, we record `timestamp` as `12pm` and `expiration` as `1pm`, but the handling of the active account query and task interpretation of ranges were different.

I also noticed that the JMX operation `performCustomMetering` was not functioning properly when given a range longer than 1 hour, which I addressed.

These changes make the entry points to metrics gathering also follow this convention - the start of the range and end of the range for 12pm to 1pm are consistently represented across the data flow.

Testing
-------
Follow instructions in [Generating Prometheus Metric Data](https://docs.engineering.redhat.com/display/ENT/Generating+Prometheus+Metric+Data)

Run the metering job with debug logging to see the range queried:

```
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_METERING=DEBUG \
    PROM_URL="http://localhost:9090/api/v1/" \
    SPRING_PROFILES_ACTIVE=metering-job,kafka-queue \
    ./gradlew :bootRun
```

Note the log messages reflect that the time range of interest is the previous hour:

```
2022-05-05 14:02:09,958 [thread=restartedMain] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Fetching metrics from prometheus: 2022-05-05T14:00Z -> 2022-05-05T14:00Z [Step: 3600]
...
2022-05-05 14:02:09,965 [thread=restartedMain] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource] - Querying for active accounts for range [2022-05-05T13:00Z, 2022-05-05T14:00Z)
...
2022-05-05 14:02:09,966 [thread=restartedMain] [INFO ] [org.candlepin.subscriptions.task.queue.kafka.KafkaTaskQueue] - Queuing task: TaskDescriptor[groupId: platform.rhsm-subscriptions.metering-tasks, taskType: METRICS_COLLECTION, args: [metric: [Transfer-gibibytes], productTag: [rhosak], start: [2022-05-05T13:00Z], end: [2022-05-05T14:00Z], account: [account123]]]
```

Note 14:00 in the above example is the appropriate timestamp given our `[1h]` range vector look back.

Run the metrics worker to pick up the queued tasks:

```
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_METERING=DEBUG \
    SUBSCRIPTION_USE_STUB=true \
    USER_USE_STUB=true \
    DEV_MODE=true \
    PROM_URL="http://localhost:9090/api/v1/" \
    ./gradlew :bootRun
```

Observe that start and end time reflect *only* the previous hour, and that the DB query lines up with the time range (the `[1h]`
range vector is important here too):

```
2022-05-05 14:03:58,611 [thread=metering-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Fetching metrics from prometheus: 2022-05-05T14:00Z -> 2022-05-05T14:00Z [Step: 3600]
2022-05-05 14:03:58,611 [thread=metering-task-processor-0-C-1] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Running prometheus range query: Start: 1651759200 End: 1651759200 Step: 3600, Query: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes%20*%20on(_id)%20group_right%20min_over_time(subscription_labels%7Bproduct=%22rhosak%22,%20ebs_account=%22account123%22,%20billing_model=%22marketplace%22,%20support=~%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D)
2022-05-05 14:03:58,616 [thread=metering-task-processor-0-C-1] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Looking for events in range [2022-05-05T13:00Z, 2022-05-05T14:00Z)
```

Verify the behavior of the MeterJmxBean changes. Specifically, note I added some input validation on rangeInMinutes.

Running `performCustomMetering` with 60 minutes queries for active accounts across a 1 hour range, and 120 minutes looks for active accounts across a two-hour range.

Running `performCustomMeteringForAccount` directly queues tasks with the proper ranges.

Entering something not on the hourly boundary for `rangeInMinutes` (e.g. `61`) causes an exception.