### PR TITLE
ENT-4912: Protect subscription sync against failures due to invalid org/acct id

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -99,10 +99,14 @@ parameters:
     value: https://subscription.qa.api.redhat.com/svcrest/subscription/v5
   - name: SUBSCRIPTION_MAX_CONNECTIONS
     value: '100'
-  - name: SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL
-    value: 1s
   - name: SUBSCRIPTION_MAX_RETRY_ATTEMPTS
     value: '4'
+  - name: SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL
+    value: 1s
+  - name: SUBSCRIPTION_BACK_OFF_MAX_INTERVAL
+    value: 64s
+  - name: SUBSCRIPTION_BACK_OFF_MULTIPLIER
+    value: '2'
   - name: SUBSCRIPTION_PAGE_SIZE
     value: '500'
   - name: USER_HOST
@@ -805,6 +809,10 @@ objects:
               value: ${SUBSCRIPTION_MAX_CONNECTIONS}
             - name: SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL
               value: ${SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL}
+            - name: SUBSCRIPTION_BACK_OFF_MAX_INTERVAL
+              value: ${SUBSCRIPTION_BACK_OFF_MAX_INTERVAL}
+            - name: SUBSCRIPTION_BACK_OFF_MULTIPLIER
+              value: ${SUBSCRIPTION_BACK_OFF_MULTIPLIER}
             - name: SUBSCRIPTION_MAX_RETRY_ATTEMPTS
               value: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS}
             - name: SUBSCRIPTION_PAGE_SIZE

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionService.java
@@ -42,6 +42,8 @@ public class SubscriptionService {
 
   private static final String ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG =
       "Error during attempt to request subscription info";
+  public static final String API_EXCEPTION_FROM_SUBSCRIPTION_SERVICE =
+      "Api exception from subscription service: {}";
   private final SearchApi searchApi;
   private final RetryTemplate subscriptionServiceRetryTemplate;
   private final SubscriptionServiceProperties properties;
@@ -67,7 +69,7 @@ public class SubscriptionService {
           try {
             return searchApi.getSubscriptionById(id);
           } catch (ApiException e) {
-            log.error("Api exception from subscription service: {}", e.getMessage());
+            log.error(API_EXCEPTION_FROM_SUBSCRIPTION_SERVICE, e.getMessage());
             throw new ExternalServiceException(
                 ErrorCode.REQUEST_PROCESSING_ERROR,
                 ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG,
@@ -121,7 +123,7 @@ public class SubscriptionService {
           try {
             return searchApi.searchSubscriptionsByAccountNumber(accountNumber, index, pageSize);
           } catch (ApiException e) {
-            log.error("Api exception from subscription service: {}", e.getResponseBody());
+            log.error(API_EXCEPTION_FROM_SUBSCRIPTION_SERVICE, e.getResponseBody());
 
             if (e.getResponseBody().contains("NumberFormatException")) {
               throw new UnretryableException(
@@ -173,7 +175,7 @@ public class SubscriptionService {
           try {
             return searchApi.searchSubscriptionsByOrgId(orgId, index, pageSize);
           } catch (ApiException e) {
-            log.error("Api exception from subscription service: {}", e.getResponseBody());
+            log.error(API_EXCEPTION_FROM_SUBSCRIPTION_SERVICE, e.getResponseBody());
 
             if (e.getResponseBody().contains("NumberFormatException")) {
               throw new UnretryableException(

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionService.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
+import org.candlepin.subscriptions.exception.UnretryableExternalServiceException;
 import org.candlepin.subscriptions.subscription.api.model.Subscription;
 import org.candlepin.subscriptions.subscription.api.resources.SearchApi;
 import org.springframework.retry.support.RetryTemplate;
@@ -119,6 +120,15 @@ public class SubscriptionService {
           try {
             return searchApi.searchSubscriptionsByAccountNumber(accountNumber, index, pageSize);
           } catch (ApiException e) {
+            log.error("Api exception from subscription service: {}", e.getResponseBody());
+
+            if (e.getResponseBody().contains("NumberFormatException")) {
+              throw new UnretryableExternalServiceException(
+                  ErrorCode.REQUEST_PROCESSING_ERROR,
+                  ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG,
+                  e);
+            }
+
             throw new ExternalServiceException(
                 ErrorCode.REQUEST_PROCESSING_ERROR,
                 ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG,
@@ -161,6 +171,15 @@ public class SubscriptionService {
           try {
             return searchApi.searchSubscriptionsByOrgId(orgId, index, pageSize);
           } catch (ApiException e) {
+            log.error("Api exception from subscription service: {}", e.getResponseBody());
+
+            if (e.getResponseBody().contains("NumberFormatException")) {
+              throw new UnretryableExternalServiceException(
+                  ErrorCode.REQUEST_PROCESSING_ERROR,
+                  ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG,
+                  e);
+            }
+
             throw new ExternalServiceException(
                 ErrorCode.REQUEST_PROCESSING_ERROR,
                 ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG,

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionService.java
@@ -25,10 +25,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
+import javax.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
-import org.candlepin.subscriptions.exception.UnretryableExternalServiceException;
+import org.candlepin.subscriptions.exception.UnretryableException;
 import org.candlepin.subscriptions.subscription.api.model.Subscription;
 import org.candlepin.subscriptions.subscription.api.resources.SearchApi;
 import org.springframework.retry.support.RetryTemplate;
@@ -123,8 +124,9 @@ public class SubscriptionService {
             log.error("Api exception from subscription service: {}", e.getResponseBody());
 
             if (e.getResponseBody().contains("NumberFormatException")) {
-              throw new UnretryableExternalServiceException(
+              throw new UnretryableException(
                   ErrorCode.REQUEST_PROCESSING_ERROR,
+                  Response.Status.INTERNAL_SERVER_ERROR,
                   ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG,
                   e);
             }
@@ -174,8 +176,9 @@ public class SubscriptionService {
             log.error("Api exception from subscription service: {}", e.getResponseBody());
 
             if (e.getResponseBody().contains("NumberFormatException")) {
-              throw new UnretryableExternalServiceException(
+              throw new UnretryableException(
                   ErrorCode.REQUEST_PROCESSING_ERROR,
+                  Response.Status.INTERNAL_SERVER_ERROR,
                   ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG,
                   e);
             }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
@@ -23,7 +23,7 @@ package org.candlepin.subscriptions.subscription;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.capacity.CapacityReconciliationConfiguration;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
-import org.candlepin.subscriptions.exception.UnretryableExternalServiceException;
+import org.candlepin.subscriptions.exception.UnretryableException;
 import org.candlepin.subscriptions.registry.RegistryConfiguration;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
@@ -75,7 +75,7 @@ public class SubscriptionServiceConfiguration {
             applicationProperties.getSubscription().getBackOffInitialInterval().toMillis(),
             applicationProperties.getSubscription().getBackOffMultiplier(),
             applicationProperties.getSubscription().getBackOffMaxInterval().toMillis())
-        .notRetryOn(UnretryableExternalServiceException.class)
+        .notRetryOn(UnretryableException.class)
         .build();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.subscription;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.capacity.CapacityReconciliationConfiguration;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
+import org.candlepin.subscriptions.exception.UnretryableExternalServiceException;
 import org.candlepin.subscriptions.registry.RegistryConfiguration;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
@@ -32,9 +33,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
-import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.retry.support.RetryTemplateBuilder;
 
 /** Configuration class for subscription package. */
 @Configuration
@@ -69,16 +69,13 @@ public class SubscriptionServiceConfiguration {
   public RetryTemplate subscriptionServiceRetryTemplate(
       ApplicationProperties applicationProperties) {
 
-    SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
-    retryPolicy.setMaxAttempts(applicationProperties.getSubscription().getMaxRetryAttempts());
-
-    ExponentialRandomBackOffPolicy backOffPolicy = new ExponentialRandomBackOffPolicy();
-    backOffPolicy.setInitialInterval(
-        applicationProperties.getSubscription().getBackOffInitialInterval().toMillis());
-
-    RetryTemplate retryTemplate = new RetryTemplate();
-    retryTemplate.setRetryPolicy(retryPolicy);
-    retryTemplate.setBackOffPolicy(backOffPolicy);
-    return retryTemplate;
+    return new RetryTemplateBuilder()
+        .maxAttempts(applicationProperties.getSubscription().getMaxRetryAttempts())
+        .exponentialBackoff(
+            applicationProperties.getSubscription().getBackOffInitialInterval().toMillis(),
+            applicationProperties.getSubscription().getBackOffMultiplier(),
+            applicationProperties.getSubscription().getBackOffMaxInterval().toMillis())
+        .notRetryOn(UnretryableExternalServiceException.class)
+        .build();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceProperties.java
@@ -38,6 +38,18 @@ public class SubscriptionServiceProperties extends HttpClientProperties {
    */
   private int maxRetryAttempts = 4;
 
+  /**
+   * The initial sleep interval between retries when retrying fetching info from the Subscription
+   * Service
+   */
+  private Duration backOffInitialInterval = Duration.ofSeconds(1L);
+
+  /** Retry backoff interval. */
+  private Duration backOffMaxInterval;
+
+  /** Retry exponential backoff multiplier. */
+  private Double backOffMultiplier;
+
   /** Page size for subscription queries */
   private int pageSize = 1000;
 
@@ -46,10 +58,4 @@ public class SubscriptionServiceProperties extends HttpClientProperties {
 
   /** Do not sync any subs starting later than this much in the future from now. */
   private Period ignoreStartingLaterThan = Period.ofMonths(2);
-
-  /**
-   * The initial sleep interval between retries when retrying fetching info from the Subscription
-   * Service
-   */
-  private Duration backOffInitialInterval = Duration.ofSeconds(1L);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,12 +76,14 @@ rhsm-subscriptions:
   subscription-sync-enabled: ${SUBSCRIPTION_SYNC_ENABLED:false}
   subscription:
     use-stub: ${SUBSCRIPTION_USE_STUB:false}
-    url: ${SUBSCRIPTION_URL:https://subscription.qa.api.redhat.com/svcrest/subscription/v5}
+    url: ${SUBSCRIPTION_URL:https://subscription.stage.api.redhat.com/svcrest/subscription/v5}
     keystore: file:${SUBSCRIPTION_KEYSTORE:}
     keystore-password: ${SUBSCRIPTION_KEYSTORE_PASSWORD:changeit}
     max-connections: ${SUBSCRIPTION_MAX_CONNECTIONS:100}
-    back-off-initial-interval: ${SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL:1s}
     max-retry-attempts: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS:4}
+    back-off-max-interval: ${SUBSCRIPTION_BACK_OFF_MAX_INTERVAL:64s}
+    back-off-initial-interval: ${SUBSCRIPTION_BACK_OFF_INITIAL_INTERVAL:1s}
+    back-off-multiplier: ${SUBSCRIPTION_BACK_OFF_MULTIPLIER:2}
     page-size: ${SUBSCRIPTION_PAGE_SIZE:1000}
     ignore-expired-older-than: ${SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN:2m}
     ignore-starting-later-than: ${SUBSCRIPTION_IGNORE_STARTING_LATER_THAN:2m}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/SubscriptionsException.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/SubscriptionsException.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.exception;
 
 import javax.ws.rs.core.Response.Status;
+import lombok.Getter;
 import org.candlepin.subscriptions.utilization.api.model.Error;
 
 /**
@@ -29,8 +30,8 @@ import org.candlepin.subscriptions.utilization.api.model.Error;
  */
 public class SubscriptionsException extends RuntimeException {
 
-  private final Status status;
-  private final String detail;
+  @Getter private final Status status;
+  @Getter private final String detail;
   private final ErrorCode code;
 
   public SubscriptionsException(ErrorCode code, Status status, String message, String detail) {
@@ -47,14 +48,6 @@ public class SubscriptionsException extends RuntimeException {
     this.code = code;
     this.status = status;
     this.detail = detail;
-  }
-
-  public ErrorCode getCode() {
-    return this.code;
-  }
-
-  public Status getStatus() {
-    return this.status;
   }
 
   public Error error() {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/UnretryableException.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/UnretryableException.java
@@ -20,9 +20,11 @@
  */
 package org.candlepin.subscriptions.exception;
 
-public class UnretryableExternalServiceException extends ExternalServiceException {
+import javax.ws.rs.core.Response.Status;
 
-  public UnretryableExternalServiceException(ErrorCode code, String message, Throwable e) {
-    super(code, message, e);
+public class UnretryableException extends SubscriptionsException {
+
+  public UnretryableException(ErrorCode code, Status status, String message, Throwable e) {
+    super(code, status, message, e);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/UnretryableExternalServiceException.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/UnretryableExternalServiceException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.exception;
+
+public class UnretryableExternalServiceException extends ExternalServiceException {
+
+  public UnretryableExternalServiceException(ErrorCode code, String message, Throwable e) {
+    super(code, message, e);
+  }
+}

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -63,6 +63,16 @@ parameters:
     value: 2m
   - name: PRODUCT_URL
     value: https://product.qa.api.redhat.com/svcrest/product/v3
+  - name: SUBSCRIPTION_MAX_CONNECTIONS
+    value: '100'
+  - name: SUBSCRIPTION_MAX_RETRY_ATTEMPTS
+    value: '4'
+  - name: SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL
+    value: 1s
+  - name: SUBSCRIPTION_BACK_OFF_MAX_INTERVAL
+    value: 64s
+  - name: SUBSCRIPTION_BACK_OFF_MULTIPLIER
+    value: '2'
 
 objects:
   - apiVersion: v1
@@ -218,6 +228,16 @@ objects:
                   value: /service-certs/keystore.jks
                 - name: SUBSCRIPTION_URL
                   value: ${SUBSCRIPTION_URL}
+                - name: SUBSCRIPTION_MAX_CONNECTIONS
+                  value: ${SUBSCRIPTION_MAX_CONNECTIONS}
+                - name: SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL
+                  value: ${SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL}
+                - name: SUBSCRIPTION_BACK_OFF_MAX_INTERVAL
+                  value: ${SUBSCRIPTION_BACK_OFF_MAX_INTERVAL}
+                - name: SUBSCRIPTION_BACK_OFF_MULTIPLIER
+                  value: ${SUBSCRIPTION_BACK_OFF_MULTIPLIER}
+                - name: SUBSCRIPTION_MAX_RETRY_ATTEMPTS
+                  value: ${SUBSCRIPTION_MAX_RETRY_ATTEMPTS}
                 - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN
                   value: ${SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN}
                 - name: SUBSCRIPTION_IGNORE_STARTING_LATER_THAN


### PR DESCRIPTION
I traced back the remaining kafka exceptions in stage to an ApiException from the subscription service.  This was happening because there's an orgId in stage - `lsjel`.  This happens when subscription sync cron job runs, which is why it's buried in a kafka exception.


# Reproducing on develop

The easiest/fastest way to produce locally though is to use the `syncSubscriptionsForOrg` jolokia endpoint.

Set environment variables to point to the stage subscription service.  Keystore and password can be found in vault.  You might want to turn on some http logging.  You can do this with `LOGGING_LEVEL_ORG_APACHE_HTTP_WIRE=debug`.
  
```
SUBSCRIPTION_URL=https://subscription.stage.api.redhat.com/svcrest/subscription/v5
SUBSCRIPTION_KEYSTORE=<redacted>
SUBSCRIPTION_KEYSTORE_PASSWORD=<redacted>
SPRING_PROFILES_ACTIVE =api,worker,capacity-ingress
```

Start the service `./gradlew :bootRun`

Kick off a syncSubscriptionsForOrg request
```
curl 'http://localhost:9000/hawtio/jolokia/?maxDepth=7&maxCollectionSize=50000&ignoreErrors=true&canonicalNaming=false' \
  -H 'Accept: application/json, text/javascript, */*; q=0.01' \
  -H 'Content-Type: text/json' \
  --data-raw '{"type":"exec","mbean":"org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean","operation":"syncSubscriptionsForOrg(java.lang.String)","arguments":["lsjel"]}' \
  --compressed
```

If you have http logging on, you'll notice in the console some 500 errors and that it's retrying the request a few times.  Eventually when the function exits, you'll get this response from your curl request:

```
{"request":{"mbean":"org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean","arguments":["lsjel"],"type":"exec","operation":"syncSubscriptionsForOrg(java.lang.String)"},"error_type":"org.candlepin.subscriptions.exception.ExternalServiceException","error":"org.candlepin.subscriptions.exception.ExternalServiceException : Error during attempt to request subscription info","status":500}
```
For anyone who is curious, this is the example of the response body that the subscription service returns:
```
{"msgName":"com.redhat.services.util.rest.ExceptionMessage","type":["java.lang.NumberFormatException"],"message":["For input string: \"lsjel\""],"serialized":null}
```

# "The Fix"
There isn't a need to keep retrying the rest request if we know it's caused by an invalid orgId.  I updated the subscription sync retry template to /not/ do that.

Also added a log.error to print out the response body when an ApiException happens.

# "TODO"
- [ ] locally reproduce the nasty kafka stack trace that i fished up out of the stage console logs 

```
... 11 common frames omitted
Caused by: org.candlepin.subscriptions.subscription.ApiException: <HTML><HEAD><TITLE>Error</TITLE></HEAD><BODY>
An error occurred while processing your request.<p>
Reference&#32;&#35;30&#46;5efe3017&#46;1651156484&#46;323bf55c
</BODY></HTML>
```