### PR TITLE
ENT-4720: Fetch all subscriptions at once from db for force sync

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -57,7 +57,9 @@ public class InternalSubscriptionResource implements InternalApi {
 
   @Override
   public String forceSyncSubscriptionsForOrg(String orgId) {
+    log.info("Starting force sync for orgId: {}", orgId);
     subscriptionSyncController.forceSyncSubscriptionsForOrg(orgId);
+    log.info("Finished force sync for orgId: {}", orgId);
     return SUCCESS_STATUS;
   }
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -323,10 +323,10 @@ class SubscriptionSyncControllerTest {
     var subList = Arrays.asList(dto1, dto2);
     var subDaoList = Arrays.asList(convertDto(dto1), convertDto(dto2));
     Mockito.when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(subList);
-    Mockito.when(subscriptionRepository.findByOwnerIdAndEndDateAfter("123", any()))
+    Mockito.when(subscriptionRepository.findByOwnerIdAndEndDateAfter(eq("123"), any()))
         .thenReturn(subDaoList);
     subscriptionSyncController.forceSyncSubscriptionsForOrg("123");
-    verify(subscriptionRepository).findByOwnerIdAndEndDateAfter("123", any());
+    verify(subscriptionRepository).findByOwnerIdAndEndDateAfter(eq("123"), any());
     verify(subscriptionRepository, never()).findActiveSubscription(any());
   }
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -377,7 +377,7 @@ class SubscriptionSyncControllerTest {
   }
 
   @Test
-  void memorizesSubscriptionId() {
+  void memoizesSubscriptionId() {
     UsageCalculation.Key key = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage.PRODUCTION);
     Subscription s = new Subscription();
     s.setStartDate(OffsetDateTime.now().minusDays(7));

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -158,7 +159,7 @@ class SubscriptionSyncControllerTest {
     var dto = createDto("456", 10);
     Mockito.when(subscriptionService.getSubscriptionById("456")).thenReturn(dto);
     subscriptionSyncController.syncSubscription(dto.getId().toString());
-    verifyNoInteractions(subscriptionRepository);
+    verify(subscriptionRepository, never()).save(any());
   }
 
   @Test
@@ -167,7 +168,7 @@ class SubscriptionSyncControllerTest {
     var dto = createDto("456", 10);
     Mockito.when(subscriptionService.getSubscriptionById("456")).thenReturn(dto);
     subscriptionSyncController.syncSubscription(dto.getId().toString());
-    verifyNoInteractions(subscriptionRepository);
+    verify(subscriptionRepository, never()).save(any());
   }
 
   @Test
@@ -316,6 +317,19 @@ class SubscriptionSyncControllerTest {
   }
 
   @Test
+  void shouldForceSubscriptionSyncForOrgWithExistingSubs() {
+    var dto1 = createDto("234", 3);
+    var dto2 = createDto("345", 3);
+    var subList = Arrays.asList(dto1, dto2);
+    var subDaoList = Arrays.asList(convertDto(dto1), convertDto(dto2));
+    Mockito.when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(subList);
+    Mockito.when(subscriptionRepository.findActiveByOwnerId("123")).thenReturn(subDaoList);
+    subscriptionSyncController.forceSyncSubscriptionsForOrg("123");
+    verify(subscriptionRepository).findActiveByOwnerId("123");
+    verify(subscriptionRepository, never()).findActiveSubscription(any());
+  }
+
+  @Test
   void doesNotAllowReservedValuesInKey() {
     UsageCalculation.Key key1 = new Key(String.valueOf(1), ServiceLevel._ANY, Usage.PRODUCTION);
     UsageCalculation.Key key2 = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage._ANY);
@@ -363,7 +377,7 @@ class SubscriptionSyncControllerTest {
   }
 
   @Test
-  void memoizesSubscriptionId() {
+  void memorizesSubscriptionId() {
     UsageCalculation.Key key = new Key(String.valueOf(1), ServiceLevel.STANDARD, Usage.PRODUCTION);
     Subscription s = new Subscription();
     s.setStartDate(OffsetDateTime.now().minusDays(7));

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -323,9 +323,10 @@ class SubscriptionSyncControllerTest {
     var subList = Arrays.asList(dto1, dto2);
     var subDaoList = Arrays.asList(convertDto(dto1), convertDto(dto2));
     Mockito.when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(subList);
-    Mockito.when(subscriptionRepository.findActiveByOwnerId("123")).thenReturn(subDaoList);
+    Mockito.when(subscriptionRepository.findByOwnerIdAndEndDateAfter("123", any()))
+        .thenReturn(subDaoList);
     subscriptionSyncController.forceSyncSubscriptionsForOrg("123");
-    verify(subscriptionRepository).findActiveByOwnerId("123");
+    verify(subscriptionRepository).findByOwnerIdAndEndDateAfter("123", any());
     verify(subscriptionRepository, never()).findActiveSubscription(any());
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -63,6 +63,11 @@ public interface SubscriptionRepository
 
   Stream<Subscription> findByOwnerId(String ownerId);
 
+  @Query(
+      "SELECT s FROM Subscription s where s.endDate > CURRENT_TIMESTAMP "
+          + "AND s.ownerId = :ownerId")
+  List<Subscription> findActiveByOwnerId(String ownerId);
+
   void deleteBySubscriptionId(String subscriptionId);
 
   void deleteByAccountNumber(String accountNumber);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -63,10 +63,7 @@ public interface SubscriptionRepository
 
   Stream<Subscription> findByOwnerId(String ownerId);
 
-  @Query(
-      "SELECT s FROM Subscription s where s.endDate > CURRENT_TIMESTAMP "
-          + "AND s.ownerId = :ownerId")
-  List<Subscription> findActiveByOwnerId(String ownerId);
+  List<Subscription> findByOwnerIdAndEndDateAfter(String ownerId, OffsetDateTime date);
 
   void deleteBySubscriptionId(String subscriptionId);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4720

Test Steps:
- Add rhosak offering to db: 
`INSERT INTO public.offering(
    sku, product_name, product_family, sla, description, has_unlimited_usage)
    VALUES ('MW01882', 'OpenShift Streams for Apache Kafka', 'JBoss', 'Premium', 'Red Hat OpenShift Streams for Apache Kafka (Hourly)', false);`
- Run capacity-ingress
- `curl -X 'PUT'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123' -H 'x-rh-swatch-psk: dummy'`
- Check subscriptions table that subscription with subscription_id="235252" and change quantity of that record from 1 to 2.
`UPDATE public.subscription
	SET quantity=2
	WHERE subscription_id = '235252';`
- Run curl again  `curl -X 'PUT'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123' -H 'x-rh-swatch-psk: dummy'` 
- Check db for  subscription_id="235252"  and quantity should be back to 1


