### PR TITLE
Optimize force sync subscriptions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,7 +34,7 @@ ext.plugins = [
 
 libraries["annotation-api"] = "javax.annotation:javax.annotation-api:1.3.2"
 libraries["avro"] = "org.apache.avro:avro:1.11.0"
-libraries["awssdk-bom"] = "software.amazon.awssdk:bom:2.17.186"
+libraries["awssdk-bom"] = "software.amazon.awssdk:bom:2.17.190"
 libraries["clowder-quarkus-config-source"] = "com.redhat.cloud.common:clowder-quarkus-config-source:1.0.0"
 libraries["guava"] = "com.google.guava:guava:31.1-jre"
 libraries["hawtio-springboot"] = "io.hawt:hawtio-springboot:2.14.5"

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 /**
  * Configuration for the "capacity-ingress" profile.
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration
 @Profile("capacity-ingress")
+@EnableAsync
 @Import({ResteasyConfiguration.class, RhsmSubscriptionsDataSourceConfiguration.class})
 @ComponentScan(
     basePackages = {"org.candlepin.subscriptions.capacity", "org.candlepin.subscriptions.product"})

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -57,10 +57,8 @@ public class InternalSubscriptionResource implements InternalApi {
 
   @Override
   public String forceSyncSubscriptionsForOrg(String orgId) {
-    log.info("Starting force sync for orgId: {}", orgId);
-    subscriptionSyncController.forceSyncSubscriptionsForOrg(orgId);
-    log.info("Finished force sync for orgId: {}", orgId);
-    return SUCCESS_STATUS;
+    subscriptionSyncController.forceSyncSubscriptionsForOrgAsync(orgId);
+    return "Sync started.";
   }
 
   @Override

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -361,7 +361,7 @@ public class SubscriptionSyncController {
           boolean doesContain = knownOfferings.contains(sku);
 
           if (!doesContain) {
-            continue;
+            return;
           }
 
           syncSubscription(

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -53,7 +53,6 @@ import org.candlepin.subscriptions.tally.UsageCalculation.Key;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.user.AccountService;
 import org.candlepin.subscriptions.util.ApplicationClock;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -358,17 +357,17 @@ public class SubscriptionSyncController {
     var knownOfferings = offeringRepository.findAllKnownOfferingSkus();
     subscriptions.forEach(
         subscription -> {
-
           var sku = sku(subscription);
           boolean doesContain = knownOfferings.contains(sku);
 
-          if(!doesContain){
+          if (!doesContain) {
             continue;
           }
 
           syncSubscription(
               subscription,
-              Optional.ofNullable(subscriptionMap.get(String.valueOf(subscription.getId()))));});
+              Optional.ofNullable(subscriptionMap.get(String.valueOf(subscription.getId()))));
+        });
 
     log.info("Finished force sync for orgId: {}", orgId);
   }

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -41,13 +41,13 @@ paths:
       tags:
         - internalSubscriptions
       responses:
-        '200':
-          description: "The request for syncing organization's subscription was successful."
+        '202':
+          description: "The request for syncing organization's subscription is processing."
           content:
             text/plain:
               schema:
                 type: string
-                example: Success
+                example: Sync started.
         '400':
           $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
         '403':

--- a/src/test/java/org/candlepin/subscriptions/capacity/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/InternalSubscriptionResourceTest.java
@@ -42,6 +42,6 @@ class InternalSubscriptionResourceTest {
 
   @Test
   void forceSyncForOrgShouldReturnSuccess() {
-    assertEquals("Success", resource.forceSyncSubscriptionsForOrg("123"));
+    assertEquals("Sync started.", resource.forceSyncSubscriptionsForOrg("123"));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -311,7 +311,7 @@ class SubscriptionSyncControllerTest {
     var dto1 = createDto("234", 3);
     var dto2 = createDto("345", 3);
     var subList = Arrays.asList(dto1, dto2);
-    Mockito.when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(subList);
+    when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(subList);
     subscriptionSyncController.forceSyncSubscriptionsForOrg("123");
     verify(subscriptionService).getSubscriptionsByOrgId("123");
   }
@@ -322,8 +322,8 @@ class SubscriptionSyncControllerTest {
     var dto2 = createDto("345", 3);
     var subList = Arrays.asList(dto1, dto2);
     var subDaoList = Arrays.asList(convertDto(dto1), convertDto(dto2));
-    Mockito.when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(subList);
-    Mockito.when(subscriptionRepository.findByOwnerIdAndEndDateAfter(eq("123"), any()))
+    when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(subList);
+    when(subscriptionRepository.findByOwnerIdAndEndDateAfter(eq("123"), any()))
         .thenReturn(subDaoList);
     subscriptionSyncController.forceSyncSubscriptionsForOrg("123");
     verify(subscriptionRepository).findByOwnerIdAndEndDateAfter(eq("123"), any());

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
@@ -21,18 +21,12 @@
 package org.candlepin.subscriptions.db;
 
 import java.util.List;
-import java.util.stream.Stream;
-import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.Offering;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 /** Repository interface for the Offering entity */
 public interface OfferingRepository extends JpaRepository<Offering, String> {
-  @Query(
-      "select distinct o.sku from Offering o")
+  @Query("select distinct o.sku from Offering o")
   List<String> findAllKnownOfferingSkus();
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
@@ -20,10 +20,19 @@
  */
 package org.candlepin.subscriptions.db;
 
+import java.util.List;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.Offering;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Repository interface for the Offering entity */
 public interface OfferingRepository extends JpaRepository<Offering, String> {
-  /* Intentionally left blank */
+  @Query(
+      "select distinct o.sku from Offering o")
+  List<String> findAllKnownOfferingSkus();
 }


### PR DESCRIPTION
The problem on develop is hard to reproduce locally if you just have the default three values in the offering table.  I was able to reproduce slowness by grabbing the subscriptions/offering tables from s3, and importing that data locally.

A lot of time was being spent checking if the sku from the service exists in our offering table (https://github.com/RedHatInsights/rhsm-subscriptions/blob/develop/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java#L138)

Made some changes where we query the offering table up front for the list of skus, .filter the subscriptions (coming from the service), and then perform sync after filtering out unknowns.

Will probably have to make similar changes so that the rest of subscription sync (ie other than the force api) still works.