### PR TITLE
ENT-4978 Add BillingProducer to worker component

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -49,7 +49,8 @@ public class SnapshotSummaryProducer {
 
   @Autowired
   protected SnapshotSummaryProducer(
-      KafkaTemplate<String, TallySummary> tallySummaryKafkaTemplate,
+      @Qualifier("tallySummaryKafkaTemplate")
+          KafkaTemplate<String, TallySummary> tallySummaryKafkaTemplate,
       @Qualifier("tallySummaryKafkaRetryTemplate") RetryTemplate kafkaRetryTemplate,
       @Qualifier("rhMarketplaceTasks") TaskQueueProperties props) {
     this.tallySummaryTopic = props.getTopic();

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -35,6 +35,7 @@ import org.candlepin.subscriptions.jmx.JmxBeansConfiguration;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.product.ProductConfiguration;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.tally.billing.BillingProducerConfiguration;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.queue.TaskConsumer;
@@ -71,6 +72,7 @@ import org.springframework.retry.support.RetryTemplateBuilder;
 @Import({
   TallyTaskQueueConfiguration.class,
   TaskConsumerConfiguration.class,
+  BillingProducerConfiguration.class,
   InventoryDataSourceConfiguration.class,
   ProductConfiguration.class,
   CloudigradeClientConfiguration.class,

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Component that produces billing usage messages based on TallySnapshots.
+ *
+ * <p>NOTE: We are currently just forwarding TallySummary messages, but will transition to sending
+ * BillingUsage.
+ */
+@Service
+@Slf4j
+public class BillingProducer {
+
+  private KafkaTemplate<String, TallySummary> billingUsageKafkaTemplate;
+  private String billingUsageTopic;
+
+  @Autowired
+  public BillingProducer(
+      @Qualifier("billingUsageTopicProperties") TaskQueueProperties billingUsageTopicProperties,
+      @Qualifier("billingUsageKafkaTemplate")
+          KafkaTemplate<String, TallySummary> billingUsageKafkaTemplate) {
+    this.billingUsageKafkaTemplate = billingUsageKafkaTemplate;
+    this.billingUsageTopic = billingUsageTopicProperties.getTopic();
+  }
+
+  public void produce(TallySummary tallySummary) {
+    log.debug(
+        "Forwarding summary {} to topic {}",
+        tallySummary.getAccountNumber(),
+        this.billingUsageTopic);
+    billingUsageKafkaTemplate.send(this.billingUsageTopic, tallySummary);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.tally.billing;
 
 import lombok.extern.slf4j.Slf4j;
-import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -38,19 +38,19 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class BillingProducer {
 
-  private KafkaTemplate<String, TallySummary> billableUsageKafkaTemplate;
+  private KafkaTemplate<String, BillableUsage> billableUsageKafkaTemplate;
   private String billableUsageTopic;
 
   @Autowired
   public BillingProducer(
       @Qualifier("billableUsageTopicProperties") TaskQueueProperties billableUsageTopicProperties,
       @Qualifier("billableUsageKafkaTemplate")
-          KafkaTemplate<String, TallySummary> billableUsageKafkaTemplate) {
+          KafkaTemplate<String, BillableUsage> billableUsageKafkaTemplate) {
     this.billableUsageKafkaTemplate = billableUsageKafkaTemplate;
     this.billableUsageTopic = billableUsageTopicProperties.getTopic();
   }
 
-  public void produce(TallySummary tallySummary) {
+  public void produce(BillableUsage tallySummary) {
     log.debug(
         "Forwarding summary {} to topic {}",
         tallySummary.getAccountNumber(),

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
@@ -29,32 +29,32 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 /**
- * Component that produces billing usage messages based on TallySnapshots.
+ * Component that produces BillableUsage messages based on TallySnapshots.
  *
  * <p>NOTE: We are currently just forwarding TallySummary messages, but will transition to sending
- * BillingUsage.
+ * BillableUsage.
  */
 @Service
 @Slf4j
 public class BillingProducer {
 
-  private KafkaTemplate<String, TallySummary> billingUsageKafkaTemplate;
-  private String billingUsageTopic;
+  private KafkaTemplate<String, TallySummary> billableUsageKafkaTemplate;
+  private String billableUsageTopic;
 
   @Autowired
   public BillingProducer(
-      @Qualifier("billingUsageTopicProperties") TaskQueueProperties billingUsageTopicProperties,
-      @Qualifier("billingUsageKafkaTemplate")
-          KafkaTemplate<String, TallySummary> billingUsageKafkaTemplate) {
-    this.billingUsageKafkaTemplate = billingUsageKafkaTemplate;
-    this.billingUsageTopic = billingUsageTopicProperties.getTopic();
+      @Qualifier("billableUsageTopicProperties") TaskQueueProperties billableUsageTopicProperties,
+      @Qualifier("billableUsageKafkaTemplate")
+          KafkaTemplate<String, TallySummary> billableUsageKafkaTemplate) {
+    this.billableUsageKafkaTemplate = billableUsageKafkaTemplate;
+    this.billableUsageTopic = billableUsageTopicProperties.getTopic();
   }
 
   public void produce(TallySummary tallySummary) {
     log.debug(
         "Forwarding summary {} to topic {}",
         tallySummary.getAccountNumber(),
-        this.billingUsageTopic);
-    billingUsageKafkaTemplate.send(this.billingUsageTopic, tallySummary);
+        this.billableUsageTopic);
+    billableUsageKafkaTemplate.send(this.billableUsageTopic, tallySummary);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
@@ -18,34 +18,49 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.rhmarketplace;
+package org.candlepin.subscriptions.tally.billing;
 
+import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.candlepin.subscriptions.json.TallySummary;
-import org.candlepin.subscriptions.subscription.SubscriptionServiceConfiguration;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.retry.support.RetryTemplateBuilder;
 
-/** Configuration for the Marketplace integration worker. */
-@Profile("rh-marketplace")
-@ComponentScan(basePackages = "org.candlepin.subscriptions.rhmarketplace")
-@Import(SubscriptionServiceConfiguration.class)
-public class RhMarketplaceWorkerConfiguration {
+@Configuration
+public class BillingProducerConfiguration {
+
   @Bean
-  @Qualifier("rhMarketplaceRetryTemplate")
-  public RetryTemplate marketplaceRetryTemplate(RhMarketplaceProperties properties) {
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.billing-producer")
+  public BillingProducerProperties billingProducerProperties() {
+    return new BillingProducerProperties();
+  }
+
+  @Bean
+  @Qualifier("billingProducerTallySummaryTopicProperties")
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.billing-producer.messaging.tally-summary")
+  public TaskQueueProperties billingProducerTallySummaryTopicProperties() {
+    return new TaskQueueProperties();
+  }
+
+  @Bean(name = "billingProducerKafkaRetryTemplate")
+  public RetryTemplate billingProducerKafkaRetryTemplate(BillingProducerProperties properties) {
     return new RetryTemplateBuilder()
         .maxAttempts(properties.getMaxAttempts())
         .exponentialBackoff(
@@ -56,8 +71,8 @@ public class RhMarketplaceWorkerConfiguration {
   }
 
   @Bean
-  @Qualifier("rhMarketplaceTallySummaryConsumerFactory")
-  ConsumerFactory<String, TallySummary> tallySummaryConsumerFactory(
+  @Qualifier("billingProducerTallySummaryConsumerFactory")
+  ConsumerFactory<String, TallySummary> billingProducerTallySummaryConsumerFactory(
       KafkaProperties kafkaProperties) {
     return new DefaultKafkaConsumerFactory<>(
         kafkaProperties.buildConsumerProperties(),
@@ -66,15 +81,9 @@ public class RhMarketplaceWorkerConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean
-  KafkaConsumerRegistry kafkaConsumerRegistry() {
-    return new KafkaConsumerRegistry();
-  }
-
-  @Bean
   ConcurrentKafkaListenerContainerFactory<String, TallySummary>
-      kafkaTallySummaryListenerContainerFactory(
-          @Qualifier("rhMarketplaceTallySummaryConsumerFactory")
+      billingProducerKafkaTallySummaryListenerContainerFactory(
+          @Qualifier("billingProducerTallySummaryConsumerFactory")
               ConsumerFactory<String, TallySummary> consumerFactory,
           KafkaProperties kafkaProperties,
           KafkaConsumerRegistry registry) {
@@ -93,15 +102,29 @@ public class RhMarketplaceWorkerConfiguration {
     return factory;
   }
 
-  /**
-   * Build the BeanFactory implementation ourselves since the docs say "Implementations are not
-   * supposed to rely on annotation-driven injection or other reflective facilities."
-   *
-   * @param properties containing the RhMarketplaceProperties needed by the factory
-   * @return a configured RhMarketplaceApiFactory
-   */
   @Bean
-  public RhMarketplaceApiFactory marketplaceApiFactory(RhMarketplaceProperties properties) {
-    return new RhMarketplaceApiFactory(properties);
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.billing-producer.messaging.billable-usage")
+  public TaskQueueProperties billingUsageTopicProperties() {
+    return new TaskQueueProperties();
+  }
+
+  @Bean
+  public ProducerFactory<String, TallySummary> billingUsageProducerFactory(
+      KafkaProperties kafkaProperties, ObjectMapper objectMapper) {
+    DefaultKafkaProducerFactory<String, TallySummary> factory =
+        new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+    /*
+    Use our customized ObjectMapper. Notably, the spring-kafka default ObjectMapper writes dates as
+    timestamps, which produces messages not compatible with JSON-B deserialization.
+     */
+    factory.setValueSerializer(new JsonSerializer<>(objectMapper));
+    return factory;
+  }
+
+  @Bean
+  public KafkaTemplate<String, TallySummary> billingUsageKafkaTemplate(
+      @Qualifier("billingUsageProducerFactory")
+          ProducerFactory<String, TallySummary> billingUsageProducerFactory) {
+    return new KafkaTemplate<>(billingUsageProducerFactory);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
@@ -104,12 +104,12 @@ public class BillingProducerConfiguration {
 
   @Bean
   @ConfigurationProperties(prefix = "rhsm-subscriptions.billing-producer.messaging.billable-usage")
-  public TaskQueueProperties billingUsageTopicProperties() {
+  public TaskQueueProperties billableUsageTopicProperties() {
     return new TaskQueueProperties();
   }
 
   @Bean
-  public ProducerFactory<String, TallySummary> billingUsageProducerFactory(
+  public ProducerFactory<String, TallySummary> billableUsageProducerFactory(
       KafkaProperties kafkaProperties, ObjectMapper objectMapper) {
     DefaultKafkaProducerFactory<String, TallySummary> factory =
         new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
@@ -122,9 +122,9 @@ public class BillingProducerConfiguration {
   }
 
   @Bean
-  public KafkaTemplate<String, TallySummary> billingUsageKafkaTemplate(
-      @Qualifier("billingUsageProducerFactory")
-          ProducerFactory<String, TallySummary> billingUsageProducerFactory) {
-    return new KafkaTemplate<>(billingUsageProducerFactory);
+  public KafkaTemplate<String, TallySummary> billableUsageKafkaTemplate(
+      @Qualifier("billableUsageProducerFactory")
+          ProducerFactory<String, TallySummary> billableUsageProducerFactory) {
+    return new KafkaTemplate<>(billableUsageProducerFactory);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
@@ -24,6 +24,7 @@ import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConf
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
@@ -109,9 +110,9 @@ public class BillingProducerConfiguration {
   }
 
   @Bean
-  public ProducerFactory<String, TallySummary> billableUsageProducerFactory(
+  public ProducerFactory<String, BillableUsage> billableUsageProducerFactory(
       KafkaProperties kafkaProperties, ObjectMapper objectMapper) {
-    DefaultKafkaProducerFactory<String, TallySummary> factory =
+    DefaultKafkaProducerFactory<String, BillableUsage> factory =
         new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
     /*
     Use our customized ObjectMapper. Notably, the spring-kafka default ObjectMapper writes dates as
@@ -122,9 +123,9 @@ public class BillingProducerConfiguration {
   }
 
   @Bean
-  public KafkaTemplate<String, TallySummary> billableUsageKafkaTemplate(
+  public KafkaTemplate<String, BillableUsage> billableUsageKafkaTemplate(
       @Qualifier("billableUsageProducerFactory")
-          ProducerFactory<String, TallySummary> billableUsageProducerFactory) {
+          ProducerFactory<String, BillableUsage> billableUsageProducerFactory) {
     return new KafkaTemplate<>(billableUsageProducerFactory);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
@@ -54,7 +54,7 @@ public class BillingProducerConfiguration {
 
   @Bean
   @Qualifier("billingProducerTallySummaryTopicProperties")
-  @ConfigurationProperties(prefix = "rhsm-subscriptions.billing-producer.messaging.tally-summary")
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.billing-producer.incoming")
   public TaskQueueProperties billingProducerTallySummaryTopicProperties() {
     return new TaskQueueProperties();
   }
@@ -103,7 +103,7 @@ public class BillingProducerConfiguration {
   }
 
   @Bean
-  @ConfigurationProperties(prefix = "rhsm-subscriptions.billing-producer.messaging.billable-usage")
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.billing-producer.outgoing")
   public TaskQueueProperties billableUsageTopicProperties() {
     return new TaskQueueProperties();
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import java.time.Duration;
+import lombok.Data;
+
+@Data
+public class BillingProducerProperties {
+  /** How many attempts before giving up. */
+  private Integer maxAttempts;
+
+  /** Retry backoff interval. */
+  private Duration backOffInitialInterval;
+
+  /** Retry backoff interval. */
+  private Duration backOffMaxInterval;
+
+  /** Retry exponential backoff multiplier. */
+  private Double backOffMultiplier;
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/TallySummaryMessageConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/TallySummaryMessageConsumer.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.tally.billing;
 
 import io.micrometer.core.annotation.Timed;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
@@ -57,6 +58,10 @@ public class TallySummaryMessageConsumer extends SeekableKafkaConsumer {
       containerFactory = "billingProducerKafkaTallySummaryListenerContainerFactory")
   public void receive(TallySummary tallySummary) {
     log.debug("Tally Summary recieved. Producing billable usage.}");
-    this.billingProducer.produce(tallySummary);
+    BillableUsage usage =
+        new BillableUsage()
+            .withAccountNumber(tallySummary.getAccountNumber())
+            .withBillableTallySnapshots(tallySummary.getTallySnapshots());
+    this.billingProducer.produce(usage);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/TallySummaryMessageConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/TallySummaryMessageConsumer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import io.micrometer.core.annotation.Timed;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+/*
+ * Processes messages on the TallySummary topic and delegates to the BillingProducer for processing.
+ */
+@Service
+@Slf4j
+public class TallySummaryMessageConsumer extends SeekableKafkaConsumer {
+
+  private BillingProducer billingProducer;
+
+  @Autowired
+  public TallySummaryMessageConsumer(
+      BillingProducer billingProducer,
+      @Qualifier("billingProducerTallySummaryTopicProperties")
+          TaskQueueProperties tallySummaryTopicProperties,
+      KafkaConsumerRegistry kafkaConsumerRegistry) {
+    super(tallySummaryTopicProperties, kafkaConsumerRegistry);
+    this.billingProducer = billingProducer;
+  }
+
+  @Timed("rhsm-subscriptions.billing-producer.tally-summary")
+  @KafkaListener(
+      id = "#{__listener.groupId}",
+      topics = "#{__listener.topic}",
+      containerFactory = "billingProducerKafkaTallySummaryListenerContainerFactory")
+  public void receive(TallySummary tallySummary) {
+    log.debug("Tally Summary recieved. Producing billable usage.}");
+    this.billingProducer.produce(tallySummary);
+  }
+}

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -40,9 +40,10 @@ rhsm-subscriptions:
     back-off-max-interval: ${BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL:1m}
     back-off-multiplier: ${BILLING_PRODUCER_BACK_OFF_MULTIPLIER:2}
     max-attempts: ${BILLING_PRODUCER_MAX_ATTEMPTS:1}
-    messaging:
-      tally-summary:
+    incoming:
         topic: platform.rhsm-subscriptions.tally
-        kafka-group-id: billing-producer-tally-summary-consumers
+        kafka-group-id: swatch-producer-billing
         seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
         seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+    outgoing:
+      topic: platform.rhsm-subscriptions.billable-usage

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -41,9 +41,9 @@ rhsm-subscriptions:
     back-off-multiplier: ${BILLING_PRODUCER_BACK_OFF_MULTIPLIER:2}
     max-attempts: ${BILLING_PRODUCER_MAX_ATTEMPTS:1}
     incoming:
-        topic: platform.rhsm-subscriptions.tally
-        kafka-group-id: swatch-producer-billing
-        seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
-        seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+      topic: platform.rhsm-subscriptions.tally
+      kafka-group-id: swatch-producer-billing
+      seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
+      seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
     outgoing:
       topic: platform.rhsm-subscriptions.billable-usage

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -35,3 +35,14 @@ rhsm-subscriptions:
     back-off-max-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL:1m}
     back-off-multiplier: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER:2}
     max-attempts: ${TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS:5}
+  billing-producer:
+    back-off-initial-interval: ${BILLING_PRODUCER_BACK_OFF_INITIAL_INTERVAL:1s}
+    back-off-max-interval: ${BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL:1m}
+    back-off-multiplier: ${BILLING_PRODUCER_BACK_OFF_MULTIPLIER:2}
+    max-attempts: ${BILLING_PRODUCER_MAX_ATTEMPTS:1}
+    messaging:
+      tally-summary:
+        topic: platform.rhsm-subscriptions.tally
+        kafka-group-id: billing-producer-tally-summary-consumers
+        seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
+        seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,3 +113,10 @@ rhsm-subscriptions:
     kafka-group-id: rh-marketplace-worker
     seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
     seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+  billing-producer:
+    messaging:
+      billable-usage:
+        topic: platform.rhsm-subscriptions.billable-usage
+        kafka-group-id: billable-usage-consumer
+        seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
+        seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,10 +113,3 @@ rhsm-subscriptions:
     kafka-group-id: rh-marketplace-worker
     seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
     seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
-  billing-producer:
-    messaging:
-      billable-usage:
-        topic: platform.rhsm-subscriptions.billable-usage
-        kafka-group-id: billable-usage-consumer
-        seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
-        seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotProducerJsonSerializationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotProducerJsonSerializationTest.java
@@ -30,6 +30,7 @@ import org.candlepin.subscriptions.json.TallySnapshot;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -37,7 +38,9 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles({"worker", "kafka-queue", "test"})
 class SnapshotProducerJsonSerializationTest {
-  @Autowired KafkaTemplate<String, TallySummary> kafkaTemplate;
+  @Autowired
+  @Qualifier("tallySummaryKafkaTemplate")
+  KafkaTemplate<String, TallySummary> kafkaTemplate;
 
   @Test
   void testSerializesDatesToIso8601Format() {

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillingProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillingProducerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import static org.mockito.Mockito.verify;
+
+import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class BillingProducerTest {
+
+  @Mock private KafkaTemplate<String, TallySummary> kafka;
+
+  private TaskQueueProperties billableUsageTopicProps;
+  private BillingProducer producer;
+
+  @BeforeEach
+  void setupTest() {
+    billableUsageTopicProps = new TaskQueueProperties();
+    billableUsageTopicProps.setTopic("billable-usage");
+
+    this.producer = new BillingProducer(billableUsageTopicProps, kafka);
+  }
+
+  @Test
+  void testTallySummaryPassThrough() {
+    TallySummary summary = new TallySummary();
+    producer.produce(summary);
+    verify(kafka).send(billableUsageTopicProps.getTopic(), summary);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillingProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillingProducerTest.java
@@ -22,7 +22,7 @@ package org.candlepin.subscriptions.tally.billing;
 
 import static org.mockito.Mockito.verify;
 
-import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 @ExtendWith(MockitoExtension.class)
 class BillingProducerTest {
 
-  @Mock private KafkaTemplate<String, TallySummary> kafka;
+  @Mock private KafkaTemplate<String, BillableUsage> kafka;
 
   private TaskQueueProperties billableUsageTopicProps;
   private BillingProducer producer;
@@ -49,8 +49,8 @@ class BillingProducerTest {
 
   @Test
   void testTallySummaryPassThrough() {
-    TallySummary summary = new TallySummary();
-    producer.produce(summary);
-    verify(kafka).send(billableUsageTopicProps.getTopic(), summary);
+    BillableUsage usage = new BillableUsage();
+    producer.produce(usage);
+    verify(kafka).send(billableUsageTopicProps.getTopic(), usage);
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4978

* Add secondary listener to tally summary topic.
* Implemented a bare bones BillingProducer class that listens
  to the TallySummary topic and logs that a message was recieved
  and then forwards to new billable usage topic:
     platform.rhsm-subscriptions.billable-usage

## Testing
1. Ensure you have some Events in the DB and take not of the message counts for each topic.
2. Start the app as follows:
```bash
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_TALLY_BILLING=DEBUG SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true DEV_MODE=true  ./gradlew :bootRun
```
3. Run the hourly tally. BE SURE YOU TALLY AROUND THE RANGE THAT HAS EVENTS. The example below should cover any Events in may and force a fresh re-tally.
```bash
curl 'http://localhost:8080/actuator/hawtio/jolokia/' \
-H 'Content-Type: application/json' \
-d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)","arguments":["account123", "2022-05-01T00:00Z", "2022-05-30T00:00Z"]}'
```
4. Verify that you see logs from the RhMarketplaceMapper which means we are still getting TallySummary messages to the RHM consumer (likely subscription not found type messages).
```bash
2022-05-13 16:55:30,704 [thread=rh-marketplace-worker-0-C-1] [ERROR] [org.candlepin.subscriptions.rhmarketplace.RhMarketplacePayloadMapper] - SUBSCRIPTIONS3001: Could not find marketplace subscription id
```

5. Verify that you see DEBUG logs stating that we are getting messages to the secondary TallySummary consumer
```bash
2022-05-13 16:55:30,595 [thread=billing-producer-tally-summary-consumers-0-C-1] [DEBUG] [org.candlepin.subscriptions.tally.billing.TallySummaryMessageConsumer] - Tally Summary recieved. Producing billable usage.}
2022-05-13 16:55:30,595 [thread=billing-producer-tally-summary-consumers-0-C-1] [DEBUG] [org.candlepin.subscriptions.tally.billing.BillingProducer] - Forwarding summary account123 to topic platform.rhsm-subscriptions.billable-usage
```
8. Verify the  platform.rhsm-subscriptions.billable-usage topic exists and has messages waiting to be consumed.