### PR TITLE
Change to /health/liveness for tally livenessProbe

### DIFF
--- a/templates/rhsm-subscriptions-worker.yml
+++ b/templates/rhsm-subscriptions-worker.yml
@@ -294,7 +294,7 @@ objects:
               livenessProbe:
                 failureThreshold: 3
                 httpGet:
-                  path: /health
+                  path: /health/liveness
                   port: 9000
                   scheme: HTTP
                 initialDelaySeconds: 90


### PR DESCRIPTION
In order to hopefully stop crashlooping when the DB is too busy.

Related to troubleshooting a production issue.