### PR TITLE
Add BillableUsage schema to swatch-core and add configuration changes.

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -188,6 +188,16 @@ parameters:
     value: '1'
   - name: SPLUNK_HEC_TERMINATION_TIMEOUT
     value: '2000'
+  - name: BILLING_PRODUCER_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL
+    value: 1m
+  - name: BILLING_PRODUCER_BACK_OFF_MULTIPLIER
+    value: '2'
+  - name: BILLING_PRODUCER_MAX_ATTEMPTS
+    value: '1'
+  - name: ENABLE_TALLY_SUMMARY_LISTENER
+    value: 'true'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -215,7 +225,9 @@ objects:
       - replicas: 3
         partitions: 3
         topicName: platform.rhsm-subscriptions.subscription-sync
-
+      - replicas: 3
+        partitions: 3
+        topicName: platform.rhsm-subscriptions.billable-usage
     # Creates a database if local mode, or uses RDS in production
     database:
       # Must specify both a name and a major postgres version
@@ -824,6 +836,16 @@ objects:
               value: /pinhead/keystore.jks
             - name: DEV_MODE
               value: ${DEV_MODE}
+            - name: BILLING_PRODUCER_BACK_OFF_INITIAL_INTERVAL
+              value: ${BILLING_PRODUCER_BACK_OFF_INITIAL_INTERVAL}
+            - name: BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL
+              value: ${BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL}
+            - name: BILLING_PRODUCER_BACK_OFF_MULTIPLIER
+              value: ${BILLING_PRODUCER_BACK_OFF_MULTIPLIER}
+            - name: BILLING_PRODUCER_MAX_ATTEMPTS
+              value: ${BILLING_PRODUCER_MAX_ATTEMPTS}
+            - name: ENABLE_TALLY_SUMMARY_LISTENER
+              value: ${ENABLE_TALLY_SUMMARY_LISTENER}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -1,12 +1,12 @@
 $schema: http://json-schema.org/draft-07/schema#
-title: TallySummary
+title: BillableUsage
 required:
   - account_number
 properties:
   account_number:
     description: Account identifier for the relevant account.
     type: string
-  tally_snapshots:
+  billable_tally_snapshots:
     description: List of tally snapshots produced in the range.
     type: array
     items:

--- a/swatch-core/schemas/tally_snapshot.yaml
+++ b/swatch-core/schemas/tally_snapshot.yaml
@@ -1,0 +1,71 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: TallySnapshot
+properties:
+  id:
+    type: string
+    format: uuid
+  billing_provider:
+    type: string
+    enum:
+      - ''
+      - red hat
+      - aws
+      - gcp
+      - azure
+      - oracle
+      - _ANY
+  snapshot_date:
+    type: string
+    format: date-time
+  product_id:
+    type: string
+  sla:
+    description: Service level for the subject.
+    type: string
+    enum:
+      - ''  # UNSPECIFIED
+      - Premium
+      - Standard
+      - Self-Support
+      - _ANY
+  usage:
+    description: Intended usage for the subject.
+    type: string
+    enum:
+      - ''  # UNSPECIFIED
+      - Production
+      - Development/Test
+      - Disaster Recovery
+      - _ANY
+  granularity:
+    type: string
+    enum:
+      - Hourly
+      - Daily
+      - Weekly
+      - Monthly
+      - Quarterly
+      - Yearly
+  tally_measurements:
+    type: array
+    items:
+      type: object
+      required:
+        - hardware_measurement_type
+        - value
+      properties:
+        hardware_measurement_type:
+          type: string
+        uom:
+          description: Preferred unit of measure for the subject (for products with multiple possible UOM).
+          type: string
+          enum:
+            - ''  # UNSPECIFIED
+            - Cores
+            - Sockets
+            - Instance-hours
+            - Storage-gibibytes
+            - Transfer-gibibytes
+        value:
+          description: Measurement value.
+          type: number

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/com/redhat/swatch/processors/TallyTopicProcessorTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/com/redhat/swatch/processors/TallyTopicProcessorTest.java
@@ -31,12 +31,12 @@ import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiE
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi;
 import com.redhat.swatch.exception.AwsUsageContextLookupException;
 import com.redhat.swatch.files.TagProfile;
+import com.redhat.swatch.openapi.model.TallySnapshot;
+import com.redhat.swatch.openapi.model.TallySnapshot.BillingProviderEnum;
+import com.redhat.swatch.openapi.model.TallySnapshot.GranularityEnum;
+import com.redhat.swatch.openapi.model.TallySnapshotTallyMeasurements;
+import com.redhat.swatch.openapi.model.TallySnapshotTallyMeasurements.UomEnum;
 import com.redhat.swatch.openapi.model.TallySummary;
-import com.redhat.swatch.openapi.model.TallySummaryTallyMeasurements;
-import com.redhat.swatch.openapi.model.TallySummaryTallyMeasurements.UomEnum;
-import com.redhat.swatch.openapi.model.TallySummaryTallySnapshots;
-import com.redhat.swatch.openapi.model.TallySummaryTallySnapshots.BillingProviderEnum;
-import com.redhat.swatch.openapi.model.TallySummaryTallySnapshots.GranularityEnum;
 import com.redhat.swatch.processors.AwsMarketplaceMeteringClientFactory;
 import com.redhat.swatch.processors.TallyTopicProcessor;
 import io.micrometer.core.instrument.Counter;
@@ -65,14 +65,14 @@ class TallyTopicProcessorTest {
       new TallySummary()
           .tallySnapshots(
               List.of(
-                  new TallySummaryTallySnapshots()
+                  new TallySnapshot()
                       .productId("rhosak")
                       .granularity(GranularityEnum.DAILY)
                       .snapshotDate(OffsetDateTime.MAX)
                       .billingProvider(BillingProviderEnum.AWS)
                       .tallyMeasurements(
                           List.of(
-                              new TallySummaryTallyMeasurements()
+                              new TallySnapshotTallyMeasurements()
                                   .uom(UomEnum.INSTANCE_HOURS)
                                   .value(new BigDecimal("42.0"))))));
 
@@ -118,8 +118,7 @@ class TallyTopicProcessorTest {
   void shouldSkipNonDailySnapshots() {
     TallySummary summary =
         new TallySummary()
-            .tallySnapshots(
-                List.of(new TallySummaryTallySnapshots().granularity(GranularityEnum.YEARLY)));
+            .tallySnapshots(List.of(new TallySnapshot().granularity(GranularityEnum.YEARLY)));
     processor.process(summary);
     verifyNoInteractions(internalSubscriptionsApi, clientFactory);
   }
@@ -129,8 +128,7 @@ class TallyTopicProcessorTest {
     TallySummary summary =
         new TallySummary()
             .tallySnapshots(
-                List.of(
-                    new TallySummaryTallySnapshots().billingProvider(BillingProviderEnum.RED_HAT)));
+                List.of(new TallySnapshot().billingProvider(BillingProviderEnum.RED_HAT)));
     processor.process(summary);
     verifyNoInteractions(internalSubscriptionsApi, clientFactory);
   }
@@ -158,7 +156,7 @@ class TallyTopicProcessorTest {
         new TallySummary()
             .tallySnapshots(
                 List.of(
-                    new TallySummaryTallySnapshots()
+                    new TallySnapshot()
                         .granularity(GranularityEnum.DAILY)
                         .billingProvider(BillingProviderEnum.AWS)));
     when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/files/TagProfileTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/files/TagProfileTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.redhat.swatch.exception.AwsDimensionNotConfiguredException;
-import com.redhat.swatch.openapi.model.TallySummaryTallyMeasurements.UomEnum;
+import com.redhat.swatch.openapi.model.TallySnapshotTallyMeasurements.UomEnum;
 import org.junit.jupiter.api.Test;
 
 class TagProfileTest {

--- a/templates/swatch-billing-provider-rh-marketplace.yml
+++ b/templates/swatch-billing-provider-rh-marketplace.yml
@@ -95,7 +95,16 @@ parameters:
     value: 1s
   - name: USER_BACK_OFF_MULTIPLIER
     value: '2'
-
+  - name: BILLING_PRODUCER_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL
+    value: 1m
+  - name: BILLING_PRODUCER_BACK_OFF_MULTIPLIER
+    value: '2'
+  - name: BILLING_PRODUCER_MAX_ATTEMPTS
+    value: '1'
+  - name: ENABLE_TALLY_SUMMARY_LISTENER
+    value: 'true'
 objects:
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
@@ -283,6 +292,16 @@ objects:
                       key: keystore_password
                 - name: RHSM_KEYSTORE
                   value: /pinhead/keystore.jks
+                - name: BILLING_PRODUCER_BACK_OFF_INITIAL_INTERVAL
+                  value: ${BILLING_PRODUCER_BACK_OFF_INITIAL_INTERVAL}
+                - name: BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL
+                  value: ${BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL}
+                - name: BILLING_PRODUCER_BACK_OFF_MULTIPLIER
+                  value: ${BILLING_PRODUCER_BACK_OFF_MULTIPLIER}
+                - name: BILLING_PRODUCER_MAX_ATTEMPTS
+                  value: ${BILLING_PRODUCER_MAX_ATTEMPTS}
+                - name: ENABLE_TALLY_SUMMARY_LISTENER
+                  value: ${ENABLE_TALLY_SUMMARY_LISTENER}
               livenessProbe:
                 failureThreshold: 3
                 httpGet:


### PR DESCRIPTION
I broke apart the schema files in order to minimize change
and to avoid class name conflicts with sub classes that were
being generated for TallySnapshots.

It also makes the class names a little nicer in swatch-producer-aws.

New billable-usage topic and relevant settings were added to clowdapp.

New billable-usage topic related settings rh-marketplace deploy template.
