### PR TITLE
ENT-4894: Update RH Marketplace Task Lag panel to include kafka group id in query

### DIFF
--- a/dashboards/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/dashboards/grafana-dashboard-subscription-watch.configmap.yaml
@@ -59,7 +59,7 @@ data:
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
       "id": null,
-      "iteration": 1652708932734,
+      "iteration": 1652723048193,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -2760,7 +2760,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.tally\"}) by (group, partition)",
+              "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.tally\", group=\"rh-marketplace-worker\"}) by (group, partition)",
               "format": "time_series",
               "instant": false,
               "interval": "",


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4894

Resolves a issue with the graph in grafana looking like it's climbing steadily because we made changes to the kafka consumer group id