### PR TITLE
ENT-4994: Disable RHM tally summary listener when flag false

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplaceWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplaceWorker.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.rhmarketplace;
 
 import io.micrometer.core.annotation.Timed;
 import java.util.Optional;
+import lombok.Getter;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
@@ -37,6 +38,7 @@ public class RhMarketplaceWorker extends SeekableKafkaConsumer {
 
   private final RhMarketplaceProducer producer;
   private final RhMarketplacePayloadMapper rhMarketplacePayloadMapper;
+  @Getter private final boolean enabled;
 
   @Autowired
   public RhMarketplaceWorker(
@@ -47,11 +49,13 @@ public class RhMarketplaceWorker extends SeekableKafkaConsumer {
     super(taskQueueProperties, kafkaConsumerRegistry);
     this.producer = producer;
     this.rhMarketplacePayloadMapper = rhMarketplacePayloadMapper;
+    this.enabled = taskQueueProperties.isEnabled();
   }
 
   @Timed("rhsm-subscriptions.marketplace.tally-summary")
   @KafkaListener(
       id = "#{__listener.groupId}",
+      autoStartup = "#{__listener.enabled}",
       topics = "#{__listener.topic}",
       containerFactory = "kafkaTallySummaryListenerContainerFactory")
   public void receive(TallySummary tallySummary) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,3 +113,4 @@ rhsm-subscriptions:
     kafka-group-id: rh-marketplace-worker
     seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
     seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+    enabled: ${ENABLE_TALLY_SUMMARY_LISTENER:true}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
@@ -36,4 +36,6 @@ public class TaskQueueProperties {
   private OffsetDateTime seekOverrideTimestamp = null;
 
   private boolean seekOverrideEnd = false;
+
+  private boolean enabled = true;
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4994

Testing
-------

Run the app without setting `ENABLE_TALLY_SUMMARY_LISTENER`:

```
./gradlew :bootRun
```

Using a kafka producer, emit a message to the tally summary topic
(platform.rhsm-subscriptions.tally). (I used IntelliJ Big Data Tools
with message `{f}` (contents don't matter). Observe listener is active
and attempts to process the message.

Then run with the flag, and repeat, observing no activity:

```
ENABLE_TALLY_SUMMARY_LISTENER=false ./gradlew :bootRun
```