### PR TITLE
Set maxHeapSize for gradle tests

### DIFF
--- a/buildSrc/src/main/groovy/swatch.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.java-conventions.gradle
@@ -62,4 +62,6 @@ test {
     environment "TESTCONTAINERS_RYUK_DISABLED", "true"
     environment "TESTCONTAINERS_CHECKS_DISABLE", "true"
 
+    maxHeapSize = "1024m"
+
 }


### PR DESCRIPTION
Set maxHeapSize for gradle tests

tests don't honor gradle.properties because forked JVM