### PR TITLE
Add billingProvider and billingAccountId to TallySnapshotNaturalKey

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
@@ -293,6 +293,8 @@ public class CombiningRollupSnapshotStrategy {
                     granularity,
                     usageKey.getSla(),
                     usageKey.getUsage(),
+                    usageKey.getBillingProvider(),
+                    usageKey.getBillingAccountId(),
                     offset);
 
             TallySnapshot existing = affectedSnaps.remove(snapshotKey);
@@ -417,6 +419,8 @@ public class CombiningRollupSnapshotStrategy {
                   granularity,
                   usageKey.getSla(),
                   usageKey.getUsage(),
+                  usageKey.getBillingProvider(),
+                  usageKey.getBillingAccountId(),
                   snapshotDate);
           TallySnapshot existing = existingSnapshotLookup.get(snapshotKey);
           TallySnapshot snapshot = Objects.requireNonNullElseGet(existing, TallySnapshot::new);

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotNaturalKey.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotNaturalKey.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.tally;
 import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
@@ -38,6 +39,8 @@ public class TallySnapshotNaturalKey {
   private Granularity granularity;
   private ServiceLevel serviceLevel;
   private Usage usage;
+  private BillingProvider billingProvider;
+  private String billingAccountId;
   private OffsetDateTime referenceDate;
 
   public TallySnapshotNaturalKey(TallySnapshot snapshot) {
@@ -46,6 +49,8 @@ public class TallySnapshotNaturalKey {
     this.granularity = snapshot.getGranularity();
     this.serviceLevel = snapshot.getServiceLevel();
     this.usage = snapshot.getUsage();
+    this.billingProvider = snapshot.getBillingProvider();
     this.referenceDate = snapshot.getSnapshotDate();
+    this.billingAccountId = snapshot.getBillingAccountId();
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5037

The TallySnapshotNaturalKey is used to help group snapshots for
update and delete during rollups. We missed adding the billing
provider and billing account ID, which in turn caused snapshots
to be missed when determining if they should be deleted.

## Testing

1. Start with a fresh tally_snapshots table.
2. Ensure that you have some Events in your DB.
3. Run the hourly tally for the account and ensure that there were new snapshots inserted into the database. Take note of the count.
4. Re-run the hourly tally for the same time period and the total snapshot count will rise.

**NOTE:** When this patch is applied, after the re-tally, the snapshot count should remain the same as the first run.