### PR TITLE
ENT-4684: Refactor filter logic for Billing Provider

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -146,7 +146,12 @@ public class TallyResource implements TallyApi {
     report.getMeta().setMetricId(metricId.toString());
     report.getMeta().setServiceLevel(sla);
     report.getMeta().setUsage(usageType == null ? null : reportCriteria.getUsage().asOpenApiEnum());
-    report.getMeta().setBillingProvider(billingProviderType);
+    report
+        .getMeta()
+        .setBillingProvider(
+            billingProviderType == null
+                ? null
+                : reportCriteria.getBillingProvider().asOpenApiEnum());
     report.getMeta().setBillingAcountId(billingAcctId);
 
     // NOTE: rather than keep a separate monthly rollup, in order to avoid unnecessary storage and
@@ -274,10 +279,12 @@ public class TallyResource implements TallyApi {
       pageable = ResourceUtils.getPageable(offset, limit);
     }
 
+    // Sanitize null value as _ANY for optional fields to filter through snapshot table.
     ServiceLevel serviceLevel = ResourceUtils.sanitizeServiceLevel(sla);
     Usage effectiveUsage = ResourceUtils.sanitizeUsage(usageType);
     Granularity granularityFromValue = Granularity.fromString(granularityType.toString());
     BillingProvider providerType = ResourceUtils.sanitizeBillingProvider(billingProviderType);
+    String sanitizedBillingAcctId = ResourceUtils.sanitizeBillingAccountId(billingAccountId);
 
     try {
       /* Throw an error if we are asked to return reports at a finer grain than what is supported by
@@ -299,7 +306,7 @@ public class TallyResource implements TallyApi {
         .serviceLevel(serviceLevel)
         .usage(effectiveUsage)
         .billingProvider(providerType)
-        .billingAccountId(billingAccountId)
+        .billingAccountId(sanitizedBillingAcctId)
         .pageable(pageable)
         .beginning(beginning)
         .ending(ending)

--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -110,6 +110,7 @@ public class SnapshotSummaryProducer {
         .withSla(sla)
         .withUsage(usage)
         .withBillingProvider(billingProvider)
+        .withBillingAccountId(tallySnapshot.getBillingAccountId())
         .withTallyMeasurements(mapMeasurements(tallySnapshot.getTallyMeasurements()));
   }
 

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -38,6 +38,7 @@ import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.json.Measurement.Uom;
@@ -45,16 +46,7 @@ import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.RoleProvider;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
-import org.candlepin.subscriptions.utilization.api.model.GranularityType;
-import org.candlepin.subscriptions.utilization.api.model.MetricId;
-import org.candlepin.subscriptions.utilization.api.model.ProductId;
-import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
-import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
-import org.candlepin.subscriptions.utilization.api.model.TallyReport;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportData;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportMeta;
-import org.candlepin.subscriptions.utilization.api.model.UsageType;
+import org.candlepin.subscriptions.utilization.api.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -121,7 +113,7 @@ class TallyResourceTest {
                 Mockito.eq(ServiceLevel._ANY),
                 Mockito.eq(Usage.PRODUCTION),
                 Mockito.eq(BillingProvider._ANY),
-                Mockito.eq(null),
+                Mockito.eq("_ANY"),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -149,7 +141,7 @@ class TallyResourceTest {
             ServiceLevel._ANY,
             Usage.PRODUCTION,
             BillingProvider._ANY,
-            null,
+            "_ANY",
             min,
             max,
             expectedPageable);
@@ -193,7 +185,7 @@ class TallyResourceTest {
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage._ANY),
                 Mockito.eq(BillingProvider._ANY),
-                Mockito.eq(null),
+                Mockito.eq("_ANY"),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -220,7 +212,7 @@ class TallyResourceTest {
             ServiceLevel.PREMIUM,
             Usage._ANY,
             BillingProvider._ANY,
-            null,
+            "_ANY",
             min,
             max,
             expectedPageable);
@@ -248,7 +240,7 @@ class TallyResourceTest {
                 Mockito.eq(ServiceLevel.EMPTY),
                 Mockito.eq(Usage.PRODUCTION),
                 Mockito.eq(BillingProvider._ANY),
-                Mockito.eq(null),
+                Mockito.eq("_ANY"),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -276,7 +268,7 @@ class TallyResourceTest {
             ServiceLevel.EMPTY,
             Usage.PRODUCTION,
             BillingProvider._ANY,
-            null,
+            "_ANY",
             min,
             max,
             expectedPageable);
@@ -303,7 +295,7 @@ class TallyResourceTest {
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.EMPTY),
                 Mockito.eq(BillingProvider._ANY),
-                Mockito.eq(null),
+                Mockito.eq("_ANY"),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -331,7 +323,7 @@ class TallyResourceTest {
             ServiceLevel.PREMIUM,
             Usage.EMPTY,
             BillingProvider._ANY,
-            null,
+            "_ANY",
             min,
             max,
             expectedPageable);
@@ -358,7 +350,7 @@ class TallyResourceTest {
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
                 Mockito.eq(BillingProvider._ANY),
-                Mockito.eq(null),
+                Mockito.eq("_ANY"),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -386,7 +378,7 @@ class TallyResourceTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             BillingProvider._ANY,
-            null,
+            "_ANY",
             min,
             max,
             expectedPageable);
@@ -424,7 +416,7 @@ class TallyResourceTest {
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
                 BillingProvider._ANY,
-                null,
+                "_ANY",
                 OffsetDateTime.parse("2019-05-01T00:00Z"),
                 OffsetDateTime.parse("2019-05-31T11:59:59.999Z"),
                 null))
@@ -470,7 +462,7 @@ class TallyResourceTest {
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
                 Mockito.eq(BillingProvider._ANY),
-                Mockito.eq(null),
+                Mockito.eq("_ANY"),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -498,7 +490,7 @@ class TallyResourceTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             BillingProvider._ANY,
-            null,
+            "_ANY",
             min,
             max,
             expectedPageable);
@@ -517,7 +509,7 @@ class TallyResourceTest {
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
                 Mockito.eq(BillingProvider._ANY),
-                Mockito.eq(null),
+                Mockito.eq("_ANY"),
                 Mockito.eq(min),
                 Mockito.eq(max),
                 Mockito.any(Pageable.class)))
@@ -546,7 +538,7 @@ class TallyResourceTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             BillingProvider._ANY,
-            null,
+            "_ANY",
             min,
             max,
             expectedPageable);
@@ -581,7 +573,7 @@ class TallyResourceTest {
                 ServiceLevel._ANY,
                 Usage._ANY,
                 BillingProvider._ANY,
-                null,
+                "_ANY",
                 min,
                 max,
                 null))
@@ -627,7 +619,7 @@ class TallyResourceTest {
                 ServiceLevel._ANY,
                 Usage._ANY,
                 BillingProvider._ANY,
-                null,
+                "_ANY",
                 min,
                 max,
                 null))
@@ -1058,5 +1050,43 @@ class TallyResourceTest {
             .value(7.0)
             .hasData(true);
     assertEquals(expectedTotalMonthly, response.getMeta().getTotalMonthly());
+  }
+
+  @Test
+  void testTallyReportTotalMonthlyPopulatedWithBillingProvider() {
+    TallySnapshot snapshot1 = new TallySnapshot();
+    snapshot1.setSnapshotDate(OffsetDateTime.parse("2021-11-02T00:00Z"));
+    snapshot1.setGranularity(Granularity.DAILY);
+    snapshot1.setBillingProvider(BillingProvider.RED_HAT);
+    snapshot1.setMeasurement(HardwareMeasurementType.TOTAL, Uom.CORES, 4.0);
+    TallySnapshot snapshot2 = new TallySnapshot();
+    snapshot2.setSnapshotDate(OffsetDateTime.parse("2021-11-03T00:00Z"));
+    snapshot2.setGranularity(Granularity.DAILY);
+    snapshot2.setBillingProvider(BillingProvider.RED_HAT);
+    snapshot2.setMeasurement(HardwareMeasurementType.TOTAL, Uom.CORES, 3.0);
+    when(repository.findSnapshot(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new PageImpl<>(List.of(snapshot1, snapshot2)));
+    TallyReportData response =
+        resource.getTallyReportData(
+            ProductId.RHEL,
+            MetricId.CORES,
+            GranularityType.DAILY,
+            OffsetDateTime.parse("2021-11-01T00:00Z"),
+            OffsetDateTime.parse("2021-11-30T23:59:59.999Z"),
+            null,
+            null,
+            null,
+            BillingProviderType.RED_HAT,
+            null,
+            null,
+            null);
+    TallyReportDataPoint expectedTotalMonthly =
+        new TallyReportDataPoint()
+            .date(OffsetDateTime.parse("2021-11-03T00:00Z"))
+            .value(7.0)
+            .hasData(true);
+    assertEquals(expectedTotalMonthly, response.getMeta().getTotalMonthly());
+    assertEquals(BillingProviderType.RED_HAT, response.getMeta().getBillingProvider());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -261,17 +261,19 @@ class MetricUsageCollectorTest {
                         sla -> {
                           for (BillingProvider billingProvider :
                               Set.of(BillingProvider._ANY, BillingProvider.RED_HAT)) {
-                            HostBucketKey key = new HostBucketKey();
-                            key.setProductId(RHEL);
-                            key.setSla(sla);
-                            key.setBillingProvider(billingProvider);
-                            key.setBillingAccountId("sellerAcctId");
-                            key.setUsage(usage);
-                            key.setAsHypervisor(false);
-                            HostTallyBucket bucket = new HostTallyBucket();
-                            bucket.setKey(key);
-                            bucket.setHost(instance);
-                            expected.add(bucket);
+                            for (String billingAcctId : Set.of("sellerAcctId", "_ANY")) {
+                              HostBucketKey key = new HostBucketKey();
+                              key.setProductId(RHEL);
+                              key.setSla(sla);
+                              key.setBillingProvider(billingProvider);
+                              key.setBillingAccountId(billingAcctId);
+                              key.setUsage(usage);
+                              key.setAsHypervisor(false);
+                              HostTallyBucket bucket = new HostTallyBucket();
+                              bucket.setKey(key);
+                              bucket.setHost(instance);
+                              expected.add(bucket);
+                            }
                           }
                         }));
     assertEquals(expected, new HashSet<>(instance.getBuckets()));

--- a/swatch-core/schemas/tally_snapshot.yaml
+++ b/swatch-core/schemas/tally_snapshot.yaml
@@ -14,6 +14,8 @@ properties:
       - azure
       - oracle
       - _ANY
+  billing_account_id:
+    type: string
   snapshot_date:
     type: string
     format: date-time


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4684

Refactor implementation slightly to handle filtering logic for Tally
Add new test case to test filtering by billingProvider

## Testing Steps
```
1. Start app with `DEV_MODE=DEV_MODE=true;SPRING_PROFILES_ACTIVE=worker,api

2. Insert mock events from the bin folder in your directory:
- ./import-events.py --file events.csv

3. Start tally event with the following parameters for your mock events
 "acount123" , ''2021-10-01T00:00Z", "2021-10-31T00:00Z":
 http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.jmx-TallyJmxBean-tallyJmxBean 

4. Use the get Tally data to show the response populate with the Instance-Hours metric:
 http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/rhosak/Instance-hours?granularity=Daily&billing_provider=red%20hat&beginning=2021-10-18T00%3A00Z&ending=2021-10-31T00%3A00Z.

```
