### PR TITLE
ENT-4995 Update swatch-producer-aws to consume BillableUsage messages

### DIFF
--- a/swatch-producer-aws/README.adoc
+++ b/swatch-producer-aws/README.adoc
@@ -107,11 +107,11 @@ oc port-forward $(oc -n ephemeral-itjulc get -o name pod | grep fruit) 8000
 [source,bash]
 ----
 curl --request POST \
-  --url http://localhost:8000/tally_summary \
+  --url http://localhost:8000/api/swatch-producer-aws/internal/aws/billable_usage \
   --header 'content-type: application/json' \
   --data '{
   "account_number": "string",
-  "tally_snapshots": [
+  "billable_tally_snapshots": [
     {
       "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "snapshot_date": "2022-02-16T15:44:16.793Z",

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -70,8 +70,8 @@ processResources {
     }
 }
 
-// Let gradle know that if tally_summary.yaml changes, openApiGenerate should run
-tasks.openApiGenerate.inputs.file("../swatch-core/schemas/tally_summary.yaml")
+// Let gradle know that if billable_usage.yaml changes, openApiGenerate should run
+tasks.openApiGenerate.inputs.file("../swatch-core/schemas/billable_usage.yaml")
 
 sourceSets.main.java.srcDirs += ["${buildDir}/generated/src/gen/java"]
 

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/kafka/BillableUsageDeserializer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/kafka/BillableUsageDeserializer.java
@@ -18,27 +18,15 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.processors;
+package com.redhat.swatch.kafka;
 
-import com.redhat.swatch.openapi.model.TallySummary;
-import javax.enterprise.context.ApplicationScoped;
-import lombok.extern.slf4j.Slf4j;
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
+import com.redhat.swatch.openapi.model.BillableUsage;
+import io.quarkus.kafka.client.serialization.JsonbDeserializer;
 
-@Slf4j
-@ApplicationScoped
-public class TallySummaryProducer {
+/** Provides quarkus a hint that we want to use JSON-B to deserialize BillableUsage objects */
+public class BillableUsageDeserializer extends JsonbDeserializer<BillableUsage> {
 
-  private final Emitter<TallySummary> emitter;
-
-  public TallySummaryProducer(@Channel("tally-out") Emitter<TallySummary> emitter) {
-    this.emitter = emitter;
-  }
-
-  public void queueTallySummary(TallySummary tallySummary) {
-    emitter.send(tallySummary);
-
-    log.info("Queued up a TallySummary object to the tally topic");
+  public BillableUsageDeserializer() {
+    super(BillableUsage.class);
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/kafka/BillableUsageSerializer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/kafka/BillableUsageSerializer.java
@@ -20,8 +20,8 @@
  */
 package com.redhat.swatch.kafka;
 
-import com.redhat.swatch.openapi.model.TallySummary;
+import com.redhat.swatch.openapi.model.BillableUsage;
 import io.quarkus.kafka.client.serialization.JsonbSerializer;
 
-/** Provides quarkus a hint that we want to use JSON-B to serialize TallySummary objects */
-public class TallySummarySerializer extends JsonbSerializer<TallySummary> {}
+/** Provides quarkus a hint that we want to use JSON-B to serialize BillableUsage objects */
+public class BillableUsageSerializer extends JsonbSerializer<BillableUsage> {}

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/BillableUsageProducer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/BillableUsageProducer.java
@@ -18,15 +18,27 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.kafka;
+package com.redhat.swatch.processors;
 
-import com.redhat.swatch.openapi.model.TallySummary;
-import io.quarkus.kafka.client.serialization.JsonbDeserializer;
+import com.redhat.swatch.openapi.model.BillableUsage;
+import javax.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
 
-/** Provides quarkus a hint that we want to use JSON-B to deserialize TallySummary objects */
-public class TallySummaryDeserializer extends JsonbDeserializer<TallySummary> {
+@Slf4j
+@ApplicationScoped
+public class BillableUsageProducer {
 
-  public TallySummaryDeserializer() {
-    super(TallySummary.class);
+  private final Emitter<BillableUsage> emitter;
+
+  public BillableUsageProducer(@Channel("tally-out") Emitter<BillableUsage> emitter) {
+    this.emitter = emitter;
+  }
+
+  public void queueBillableUsage(BillableUsage billableUsage) {
+    emitter.send(billableUsage);
+
+    log.info("Queued up a BillableUsage object to the billable-usage topic");
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/resource/BillableUsageResource.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/resource/BillableUsageResource.java
@@ -21,31 +21,31 @@
 package com.redhat.swatch.resource;
 
 import com.redhat.swatch.exception.AwsManualSubmissionDisabledException;
-import com.redhat.swatch.openapi.model.TallySummary;
+import com.redhat.swatch.openapi.model.BillableUsage;
 import com.redhat.swatch.openapi.resource.DefaultApi;
-import com.redhat.swatch.processors.TallySummaryProducer;
+import com.redhat.swatch.processors.BillableUsageProducer;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Slf4j
-public class TallySummaryResource implements DefaultApi {
-  private final TallySummaryProducer tallySummaryProducer;
+public class BillableUsageResource implements DefaultApi {
+  private final BillableUsageProducer tallySummaryProducer;
   private final boolean manualSubmissionEnabled;
 
-  TallySummaryResource(
-      TallySummaryProducer tallySummaryProducer,
+  BillableUsageResource(
+      BillableUsageProducer tallySummaryProducer,
       @ConfigProperty(name = "AWS_MANUAL_SUBMISSION_ENABLED") boolean manualSubmissionEnabled) {
     this.tallySummaryProducer = tallySummaryProducer;
     this.manualSubmissionEnabled = manualSubmissionEnabled;
   }
 
   @Override
-  public void submitTallySummary(TallySummary tallySummary) {
+  public void submitBillableUsage(BillableUsage billableUsage) {
     if (!manualSubmissionEnabled) {
       throw new AwsManualSubmissionDisabledException();
     }
-    log.info("{}", tallySummary);
+    log.info("{}", billableUsage);
 
-    tallySummaryProducer.queueTallySummary(tallySummary);
+    tallySummaryProducer.queueBillableUsage(billableUsage);
   }
 }

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -60,13 +60,13 @@ quarkus.reactive-messaging.kafka.serializer-generation.enabled=false
 # Consumer settings
 mp.messaging.incoming.tally-in.fail-on-deserialization-failure=${TALLY_IN_FAIL_ON_DESER_FAILURE}
 mp.messaging.incoming.tally-in.connector=smallrye-kafka
-mp.messaging.incoming.tally-in.topic=platform.rhsm-subscriptions.tally
+mp.messaging.incoming.tally-in.topic=platform.rhsm-subscriptions.billable-usage
 # Go back to the first records, if it's our first access
 mp.messaging.incoming.tally-in.auto.offset.reset = earliest
 
 # Producer settings
 mp.messaging.outgoing.tally-out.connector=smallrye-kafka
-mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.tally
+mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.billable-usage
 
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.rest.SwatchPskHeaderFilter

--- a/swatch-producer-aws/src/main/resources/openapi.yaml
+++ b/swatch-producer-aws/src/main/resources/openapi.yaml
@@ -3,23 +3,23 @@ openapi: 3.0.2
 info:
   title: SWatch Producer AWS Internal API
   version: 1.0.0
-  description: "Provides AWS with billing details based on TallySummary"
+  description: "Provides AWS with billing details based on BillableUsage"
   contact:
     url: https://github.com/RedHatInsights/rhsm-subscriptions
 paths:
-  /api/swatch-producer-aws/internal/aws/tally_summary:
+  /api/swatch-producer-aws/internal/aws/billable_usage:
     post:
-      summary: Send `TallySummary` usage data to AWS.
+      summary: Send `BillableUsage` usage data to AWS.
       requestBody:
-        description: A given `TallySummary` to have usage data forwarded to AWS.
+        description: A given `BillableUsage` to have usage data forwarded to AWS.
         content:
           application/json:
             schema:
-              $ref: '../../../../swatch-core/schemas/tally_summary.yaml'
+              $ref: '../../../../swatch-core/schemas/billable_usage.yaml'
         required: false
       responses:
         '202':
-          description: "TallySummary queued for sending to AWS."
+          description: "BillableUsage queued for sending to AWS."
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -28,7 +28,7 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-      operationId: submitTallySummary
+      operationId: submitBillableUsage
       description: Only available when `AWS_MANUAL_SUBMISSION_ENABLED=true`
 components:
   responses:


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4995

The swatch-producer-aws producer was updated to allow sending
BillableUsage messages instead of TallySummary messages.

The swatch-producer-aws processor was updated to listen for
BillableUsage messages instead of TallySummary messages.

The admin API was updated to reflect billable usage and accepts
a BillableUsage payload.

## Testing

1. Run `./gradlew swatch-producer-aws:wiremock` in a terminal
2. Run `./gradlew swatch-producer-aws:quarkusDev` in another (`quarkus dev` from the subdirectory works instead too).
3. Send a BillableUsage message to the topic
```bash
$ curl -X 'POST'   'http://localhost:8000/api/swatch-producer-aws/internal/aws/billable_usage'   -H 'accept: */*'   -H 'Content-Type: application/json'   -d '{
  "account_number": "account123",
  "billable_tally_snapshots": [
    {
      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
      "billing_provider": "aws",
      "snapshot_date": "2022-04-04T21:06:41.425Z",
      "product_id": "rhosak",
      "granularity": "Daily",
      "tally_measurements": [
        {
          "hardware_measurement_type": "string",
          "uom": "Instance-hours",
          "value": 42.0
        }
      ]
    }
  ]
}'
```
4. Verify it is queued and picked up by the application in the logs.
**NOTE:** Because of wiremock, the reported UsageRecordResult contains data that does not represent what was sent in as part of the message.
```
2022-05-26 14:33:33,314 INFO  [com.red.swa.pro.BillableUsageProducer] (executor-thread-0) Queued up a BillableUsage object to the billable-usage topic
2022-05-26 14:33:33,357 DEBUG [com.red.swa.pro.BillableUsageProcessor] (vert.x-worker-thread-0) BatchMeterUsageResponse(Results=[UsageRecordResult(UsageRecord=UsageRecord(Timestamp=2022-04-04T00:00:00Z, CustomerIdentifier=customer123, Dimension=units), MeteringRecordId=record1, Status=Success)])
2022-05-26 14:33:33,358 INFO  [com.red.swa.pro.BillableUsageProcessor] (vert.x-worker-thread-0) awsMeteringRecordId=record1 for dimension=units and customerId=customer123
     2022-05-26 14:33:43,979 INFO  [com.red.swa.res.BillableUsageResource] (executor-thread-0) class BillableUsage {
    accountNumber: account123
    billableTallySnapshots: [class TallySnapshot {
        id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
        billingProvider: aws
        billingAccountId: null
        snapshotDate: 2022-04-04T21:06:41.425Z
        productId: rhosak
        sla: null
        usage: null
        granularity: Daily
        tallyMeasurements: [class TallySnapshotTallyMeasurements {
            hardwareMeasurementType: string
            uom: Instance-hours
            value: 42.0
        }]
    }]
}
2022-05-26 14:33:43,980 INFO  [com.red.swa.pro.BillableUsageProducer] (executor-thread-0) Queued up a BillableUsage object to the billable-usage topic
2022-05-26 14:33:43,984 DEBUG [com.red.swa.pro.BillableUsageProcessor] (vert.x-worker-thread-0) Picked up billable usage message class BillableUsage {
    accountNumber: account123
    billableTallySnapshots: [class TallySnapshot {
        id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
        billingProvider: aws
        billingAccountId: null
        snapshotDate: 2022-04-04T21:06:41.425Z
        productId: rhosak
        sla: null
        usage: null
        granularity: Daily
        tallyMeasurements: [class TallySnapshotTallyMeasurements {
            hardwareMeasurementType: string
            uom: Instance-hours
            value: 42.0
        }]
    }]
} to process
2022-05-26 14:33:43,999 DEBUG [com.red.swa.pro.BillableUsageProcessor] (vert.x-worker-thread-0) BatchMeterUsageResponse(Results=[UsageRecordResult(UsageRecord=UsageRecord(Timestamp=2022-04-04T00:00:00Z, CustomerIdentifier=customer123, Dimension=units), MeteringRecordId=record1, Status=Success)])
2022-05-26 14:33:44,000 INFO  [com.red.swa.pro.BillableUsageProcessor] (vert.x-worker-thread-0) awsMeteringRecordId=record1 for dimension=units and customerId=customer123


```