### PR TITLE
ENT-5012: Refactor Metric ID to the rhMarketplaceMetricId

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -236,7 +236,8 @@ public class RhMarketplacePayloadMapper {
                     measurement.getHardwareMeasurementType()))
         .forEach(
             measurement -> {
-              String metricId = tagProfile.metricIdForTagAndUom(productId, measurement.getUom());
+              String rhmMarketplaceMetricId =
+                  tagProfile.rhmMetricIdForTagAndUom(productId, measurement.getUom());
               Double value = measurement.getValue();
 
               // RHM is expecting counts of 4 vCPU-hour blocks, but currently does not have a way
@@ -246,7 +247,7 @@ public class RhMarketplacePayloadMapper {
               // definition
               // itself so that we are not hard coding this type of value in our code. This will do
               // for now.
-              if (OPENSHIFT_DEDICATED_4_CPU_HOUR.equalsIgnoreCase(metricId)
+              if (OPENSHIFT_DEDICATED_4_CPU_HOUR.equalsIgnoreCase(rhmMarketplaceMetricId)
                   && !Objects.isNull(value)
                   && Uom.CORES.equals(measurement.getUom())) {
                 value = value / 4;
@@ -258,7 +259,7 @@ public class RhMarketplacePayloadMapper {
 
               UsageMeasurement usageMeasurement = new UsageMeasurement();
               usageMeasurement.setValue(value);
-              usageMeasurement.setMetricId(metricId);
+              usageMeasurement.setMetricId(rhmMarketplaceMetricId);
               usageMeasurements.add(usageMeasurement);
             });
     return usageMeasurements;

--- a/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
@@ -64,6 +64,7 @@ class RhosakTagProfileTest {
             TagMetric.builder()
                 .tag("rhosak")
                 .metricId("redhat.com:rhosak:storage_gb")
+                .rhmMetricId("redhat.com:rhosak:storage_gb")
                 .awsDimension("redhat.com:rhosak:storage_gb")
                 .uom(Uom.STORAGE_GIBIBYTES)
                 .queryKey("default")
@@ -81,6 +82,7 @@ class RhosakTagProfileTest {
             TagMetric.builder()
                 .tag("rhosak")
                 .metricId("redhat.com:rhosak:transfer_gb")
+                .rhmMetricId("redhat.com:rhosak:transfer_gb")
                 .awsDimension("redhat.com:rhosak:transfer_gb")
                 .uom(Uom.TRANSFER_GIBIBYTES)
                 .queryKey("default")
@@ -100,6 +102,7 @@ class RhosakTagProfileTest {
             TagMetric.builder()
                 .tag("rhosak")
                 .metricId("redhat.com:rhosak:cluster_hour")
+                .rhmMetricId("redhat.com:rhosak:cluster_hour")
                 .awsDimension("redhat.com:rhosak:cluster_hour")
                 .uom(Uom.INSTANCE_HOURS)
                 .queryKey("default")
@@ -138,7 +141,7 @@ class RhosakTagProfileTest {
   @MethodSource("promethuesEnabledLookupArgs")
   void testPrometueusEnabledMeasurements(String tag, TallyMeasurement.Uom uom, String exMetricId) {
     assertTrue(tagProfile.getTagsWithPrometheusEnabledLookup().contains(tag));
-    assertEquals(exMetricId, tagProfile.metricIdForTagAndUom(tag, uom));
+    assertEquals(exMetricId, tagProfile.rhmMetricIdForTagAndUom(tag, uom));
   }
 
   static Stream<Arguments> promethuesEnabledLookupArgs() {

--- a/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
@@ -70,7 +70,7 @@ class TagProfileFactoryTest {
   @Test
   void testCanLookupMetricIdByTagAndUom() {
     assertNotNull(
-        tagProfile.metricIdForTagAndUom(ProductId.OPENSHIFT_METRICS.toString(), Uom.CORES));
+        tagProfile.rhmMetricIdForTagAndUom(ProductId.OPENSHIFT_METRICS.toString(), Uom.CORES));
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
@@ -74,11 +74,11 @@ class RhMarketplacePayloadMapperTest {
   void init() {
     // Tell Mockito not to complain if some of these mocks aren't used in a particular test
     lenient()
-        .when(tagProfile.metricIdForTagAndUom(OPENSHIFT_METRICS.toString(), Uom.CORES))
+        .when(tagProfile.rhmMetricIdForTagAndUom(OPENSHIFT_METRICS.toString(), Uom.CORES))
         .thenReturn("redhat.com:openshift:cpu_hour");
 
     lenient()
-        .when(tagProfile.metricIdForTagAndUom(OPENSHIFT_DEDICATED_METRICS.toString(), Uom.CORES))
+        .when(tagProfile.rhmMetricIdForTagAndUom(OPENSHIFT_DEDICATED_METRICS.toString(), Uom.CORES))
         .thenReturn(RhMarketplacePayloadMapper.OPENSHIFT_DEDICATED_4_CPU_HOUR);
 
     lenient()

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagMetric.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagMetric.java
@@ -42,6 +42,7 @@ import org.candlepin.subscriptions.json.Measurement.Uom;
 public class TagMetric {
   private String tag;
   private String metricId;
+  private String rhmMetricId;
   private String awsDimension;
   private Uom uom;
   @Default private String queryKey = "default";

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagProfile.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagProfile.java
@@ -60,7 +60,7 @@ public class TagProfile {
   @Getter private Set<String> serviceTypes;
 
   private Map<String, Set<String>> tagToEngProductsLookup;
-  private Map<ProductUom, String> productUomToMetricIdLookup;
+  private Map<ProductUom, String> productUomToRhmMetricIdLookup;
   @Getter private Set<String> tagsWithPrometheusEnabledLookup;
   private Map<String, Set<Uom>> measurementsByTagLookup;
   private Map<String, String> offeringProductNameToTagLookup;
@@ -75,7 +75,7 @@ public class TagProfile {
   @PostConstruct
   public void initLookups() {
     tagToEngProductsLookup = new HashMap<>();
-    productUomToMetricIdLookup = new HashMap<>();
+    productUomToRhmMetricIdLookup = new HashMap<>();
     tagsWithPrometheusEnabledLookup = new HashSet<>();
     measurementsByTagLookup = new HashMap<>();
     offeringProductNameToTagLookup = new HashMap<>();
@@ -123,8 +123,8 @@ public class TagProfile {
 
   private void handleTagMetric(TagMetric tagMetric) {
     tagsWithPrometheusEnabledLookup.add(tagMetric.getTag());
-    productUomToMetricIdLookup.put(
-        new ProductUom(tagMetric.getTag(), tagMetric.getUom().value()), tagMetric.getMetricId());
+    productUomToRhmMetricIdLookup.put(
+        new ProductUom(tagMetric.getTag(), tagMetric.getUom().value()), tagMetric.getRhmMetricId());
     measurementsByTagLookup
         .computeIfAbsent(tagMetric.getTag(), k -> new HashSet<>())
         .add(tagMetric.getUom());
@@ -157,8 +157,8 @@ public class TagProfile {
     return granularity.compareTo(finestGranularityLookup.get(tag)) < 1;
   }
 
-  public String metricIdForTagAndUom(String tag, TallyMeasurement.Uom uom) {
-    return productUomToMetricIdLookup.get(new ProductUom(tag, uom.value()));
+  public String rhmMetricIdForTagAndUom(String tag, TallyMeasurement.Uom uom) {
+    return productUomToRhmMetricIdLookup.get(new ProductUom(tag, uom.value()));
   }
 
   public String tagForOfferingProductName(String offeringProductName) {

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -170,6 +170,7 @@ tagMetrics:
   # OCP metrics
   - tag: OpenShift-metrics
     metricId: redhat.com:openshift_container_platform:cpu_hour
+    rhmMetricId: redhat.com:openshift_container_platform:cpu_hour
     uom: CORES
     queryKey: 5mSamples
     queryParams:
@@ -180,6 +181,7 @@ tagMetrics:
   # OSD metrics
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:4cpu_hour
+    rhmMetricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
     queryKey: 5mSamples
     queryParams:
@@ -188,6 +190,7 @@ tagMetrics:
       prometheusMetadataMetric: subscription_labels
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
+    rhmMetricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
     queryKey: 5mSamples
     queryParams:
@@ -198,6 +201,7 @@ tagMetrics:
   # RHOSAK metrics
   - tag: rhosak
     metricId: redhat.com:rhosak:storage_gb
+    rhmMetricId: redhat.com:rhosak:storage_gb
     awsDimension: redhat.com:rhosak:storage_gb
     uom: STORAGE_GIBIBYTES
     queryParams:
@@ -207,6 +211,7 @@ tagMetrics:
   - tag: rhosak
     # when we update this metricId to not mirror RHM ids, make sure GiB is reflected
     metricId: redhat.com:rhosak:transfer_gb
+    rhmMetricId: redhat.com:rhosak:transfer_gb
     awsDimension: redhat.com:rhosak:transfer_gb
     uom: TRANSFER_GIBIBYTES
     queryParams:
@@ -215,6 +220,7 @@ tagMetrics:
       prometheusMetadataMetric: subscription_labels
   - tag: rhosak
     metricId: redhat.com:rhosak:cluster_hour
+    rhmMetricId: redhat.com:rhosak:cluster_hour
     awsDimension: redhat.com:rhosak:cluster_hour
     uom: INSTANCE_HOURS
     queryParams:


### PR DESCRIPTION
This PR is to address sub task: https://issues.redhat.com/browse/ENT-5012 

Rename metric id to rhMarketplaceMetricId in tag_profile.yaml.
Update implementing Unit tests
