### PR TITLE
ENT-5011 Add BillingWindow configuration

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
@@ -32,6 +32,7 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.json.TallyMeasurement;
+import org.candlepin.subscriptions.registry.BillingWindow;
 import org.candlepin.subscriptions.registry.TagMetaData;
 import org.candlepin.subscriptions.registry.TagMetric;
 import org.candlepin.subscriptions.registry.TagProfile;
@@ -67,6 +68,7 @@ class RhosakTagProfileTest {
                 .rhmMetricId("redhat.com:rhosak:storage_gb")
                 .awsDimension("redhat.com:rhosak:storage_gb")
                 .uom(Uom.STORAGE_GIBIBYTES)
+                .billingWindow(BillingWindow.HOURLY)
                 .queryKey("default")
                 .accountQueryKey("default")
                 .queryParams(
@@ -85,6 +87,7 @@ class RhosakTagProfileTest {
                 .rhmMetricId("redhat.com:rhosak:transfer_gb")
                 .awsDimension("redhat.com:rhosak:transfer_gb")
                 .uom(Uom.TRANSFER_GIBIBYTES)
+                .billingWindow(BillingWindow.HOURLY)
                 .queryKey("default")
                 .accountQueryKey("default")
                 .queryParams(
@@ -106,6 +109,7 @@ class RhosakTagProfileTest {
                 .awsDimension("redhat.com:rhosak:cluster_hour")
                 .uom(Uom.INSTANCE_HOURS)
                 .queryKey("default")
+                .billingWindow(BillingWindow.HOURLY)
                 .accountQueryKey("default")
                 .queryParams(
                     Map.of(

--- a/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.registry;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.json.TallyMeasurement.Uom;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.junit.jupiter.api.Test;
@@ -106,5 +108,12 @@ class TagProfileFactoryTest {
   @Test
   void lookupMetaDataByTagWhenNotFound() {
     assertTrue(tagProfile.getTagMetaDataByTag("UNKNOWN").isEmpty());
+  }
+
+  @Test
+  void billingFrequencyIsSet() {
+    Optional<TagMetric> metric =
+        tagProfile.getTagMetric(ProductId.OPENSHIFT_METRICS.toString(), Measurement.Uom.CORES);
+    assertEquals(BillingWindow.HOURLY, metric.get().getBillingWindow());
   }
 }

--- a/src/test/resources/test_tag_profile.yaml
+++ b/src/test/resources/test_tag_profile.yaml
@@ -148,6 +148,7 @@ tagMetrics:
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
+    billingWindow: HOURLY
     queryKey: 5mSamples
     queryParams:
       product: osd
@@ -156,6 +157,7 @@ tagMetrics:
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
+    billingWindow: HOURLY
     queryKey: 5mSamples
     queryParams:
       product: osd
@@ -166,6 +168,7 @@ tagMetrics:
   - tag: rhosak
     metricId: redhat.com:rhosak:storage_gb
     uom: STORAGE_GIBIBYTES
+    billingWindow: HOURLY
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
@@ -174,6 +177,7 @@ tagMetrics:
     # when we update this metricId to not mirror RHM ids, make sure GiB is reflected
     metricId: redhat.com:rhosak:transfer_gb
     uom: TRANSFER_GIBIBYTES
+    billingWindow: HOURLY
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
@@ -181,6 +185,7 @@ tagMetrics:
   - tag: rhosak
     metricId: redhat.com:rhosak:cluster_hour
     uom: INSTANCE_HOURS
+    billingWindow: HOURLY
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:strimzi_resource_state:max_over_time1h

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/registry/BillingWindow.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/registry/BillingWindow.java
@@ -20,33 +20,7 @@
  */
 package org.candlepin.subscriptions.registry;
 
-import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Builder.Default;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.candlepin.subscriptions.json.Measurement.Uom;
-
-/** A composite class for tag profiles. Describes tag metric information. */
-@AllArgsConstructor
-@Builder
-@EqualsAndHashCode
-@Getter
-@NoArgsConstructor
-@Setter
-@ToString
-public class TagMetric {
-  private String tag;
-  private String metricId;
-  private String rhmMetricId;
-  private String awsDimension;
-  private Uom uom;
-  @Default private BillingWindow billingWindow = BillingWindow.MONTHLY;
-  @Default private String queryKey = "default";
-  @Default private String accountQueryKey = "default";
-  private Map<String, String> queryParams;
+public enum BillingWindow {
+  HOURLY,
+  MONTHLY
 }

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -172,6 +172,7 @@ tagMetrics:
     metricId: redhat.com:openshift_container_platform:cpu_hour
     rhmMetricId: redhat.com:openshift_container_platform:cpu_hour
     uom: CORES
+    billingWindow: HOURLY
     queryKey: 5mSamples
     queryParams:
       product: ocp
@@ -183,6 +184,7 @@ tagMetrics:
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     rhmMetricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
+    billingWindow: HOURLY
     queryKey: 5mSamples
     queryParams:
       product: osd
@@ -192,6 +194,7 @@ tagMetrics:
     metricId: redhat.com:openshift_dedicated:cluster_hour
     rhmMetricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
+    billingWindow: HOURLY
     queryKey: 5mSamples
     queryParams:
       product: osd
@@ -204,6 +207,7 @@ tagMetrics:
     rhmMetricId: redhat.com:rhosak:storage_gb
     awsDimension: redhat.com:rhosak:storage_gb
     uom: STORAGE_GIBIBYTES
+    billingWindow: HOURLY
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
@@ -214,6 +218,7 @@ tagMetrics:
     rhmMetricId: redhat.com:rhosak:transfer_gb
     awsDimension: redhat.com:rhosak:transfer_gb
     uom: TRANSFER_GIBIBYTES
+    billingWindow: HOURLY
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
@@ -223,6 +228,7 @@ tagMetrics:
     rhmMetricId: redhat.com:rhosak:cluster_hour
     awsDimension: redhat.com:rhosak:cluster_hour
     uom: INSTANCE_HOURS
+    billingWindow: HOURLY
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:strimzi_resource_state:max_over_time1h


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5011

BillingWindow is the window in which billable usage
will be sent to the marketplace instances. By default,
we send MONTHLY usage.

All existing metrics are configured to send usage in
an HOURLY billing window.