### PR TITLE
ENT-5013: Update RHM Payload Mapper for unconfigured rhMarketplaceMetricId

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -212,7 +212,7 @@ public class RhMarketplacePayloadMapper {
 
   /**
    * UsageEvents include a list of usage measurements. This data includes unit of measure (UOM), the
-   * value for the uom, and the metricId (RHM terminology) which is a configuration value of the
+   * value for the uom, and the rhmMetricId (RHM terminology) which is a configuration value of the
    * product the uom is for.
    *
    * @param snapshot TallySnapshot
@@ -257,10 +257,12 @@ public class RhMarketplacePayloadMapper {
                     value);
               }
 
-              UsageMeasurement usageMeasurement = new UsageMeasurement();
-              usageMeasurement.setValue(value);
-              usageMeasurement.setMetricId(rhmMarketplaceMetricId);
-              usageMeasurements.add(usageMeasurement);
+              if (rhmMarketplaceMetricId != null) {
+                UsageMeasurement usageMeasurement = new UsageMeasurement();
+                usageMeasurement.setValue(value);
+                usageMeasurement.setMetricId(rhmMarketplaceMetricId);
+                usageMeasurements.add(usageMeasurement);
+              }
             });
     return usageMeasurements;
   }

--- a/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
@@ -111,6 +111,30 @@ class RhMarketplacePayloadMapperTest {
     assertEquals(expected, actual);
   }
 
+  @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
+  @MethodSource("generateHardwareMeasurementPermutations")
+  void testProductUnconfiguredUsageMeasurements(
+      ProductId productId,
+      List<TallyMeasurement> tallyMeasurements,
+      List<UsageMeasurement> expected) {
+
+    var snapshot =
+        new TallySnapshot()
+            .withId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
+            .withProductId(productId.toString())
+            .withSnapshotDate(OffsetDateTime.now())
+            .withUsage(Usage.PRODUCTION)
+            .withTallyMeasurements(tallyMeasurements)
+            .withSla(Sla.PREMIUM)
+            .withBillingProvider(TallySnapshot.BillingProvider.RED_HAT)
+            .withGranularity(HOURLY);
+
+    var actual = rhMarketplacePayloadMapper.produceUsageMeasurements(snapshot, "Unknown");
+
+    assertNotEquals(expected, actual);
+    assertEquals(0, actual.size());
+  }
+
   @SuppressWarnings("linelength")
   static Stream<Arguments> generateHardwareMeasurementPermutations() {
     double value = 36.0;


### PR DESCRIPTION
Add logic to ignore Usage metric for undefined rhmMetricId.
Update Unit test for ignoring undefined rhmMetricId.