### PR TITLE
ENT-5014: Update aws producer to ignore metrics without awsDimension

### DIFF
--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/files/TagProfile.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/files/TagProfile.java
@@ -62,6 +62,10 @@ public class TagProfile {
     return awsDimension;
   }
 
+  public boolean isAwsConfigured(String product, String metric) {
+    return awsDimensionLookup.containsKey(new AwsDimensionLookupKey(product, metric));
+  }
+
   @Data
   @AllArgsConstructor
   private static class AwsDimensionLookupKey {

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/BillableUsageProcessor.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/BillableUsageProcessor.java
@@ -125,6 +125,12 @@ public class BillableUsageProcessor {
       log.debug("Snapshot not applicable because billingProvider is not AWS");
       applicable = false;
     }
+    if (!tagProfile.isAwsConfigured(
+        tallySnapshot.getProductId(),
+        tallySnapshot.getTallyMeasurements().get(0).getUom().name())) {
+      log.debug("Snapshot not applicable because productId and/or uom is not configured for AWS");
+      applicable = false;
+    }
     return applicable;
   }
 

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/com/redhat/swatch/processors/BillableUsageProcessorTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/com/redhat/swatch/processors/BillableUsageProcessorTest.java
@@ -119,7 +119,14 @@ class BillableUsageProcessorTest {
     BillableUsage usage =
         new BillableUsage()
             .billableTallySnapshots(
-                List.of(new TallySnapshot().granularity(GranularityEnum.YEARLY)));
+                List.of(
+                    new TallySnapshot()
+                        .granularity(GranularityEnum.YEARLY)
+                        .tallyMeasurements(
+                            List.of(
+                                new TallySnapshotTallyMeasurements()
+                                    .uom(UomEnum.INSTANCE_HOURS)
+                                    .value(new BigDecimal("42.0"))))));
     processor.process(usage);
     verifyNoInteractions(internalSubscriptionsApi, clientFactory);
   }
@@ -129,7 +136,14 @@ class BillableUsageProcessorTest {
     BillableUsage usage =
         new BillableUsage()
             .billableTallySnapshots(
-                List.of(new TallySnapshot().billingProvider(BillingProviderEnum.RED_HAT)));
+                List.of(
+                    new TallySnapshot()
+                        .billingProvider(BillingProviderEnum.RED_HAT)
+                        .tallyMeasurements(
+                            List.of(
+                                new TallySnapshotTallyMeasurements()
+                                    .uom(UomEnum.INSTANCE_HOURS)
+                                    .value(new BigDecimal("42.0"))))));
     processor.process(usage);
     verifyNoInteractions(internalSubscriptionsApi, clientFactory);
   }
@@ -158,12 +172,37 @@ class BillableUsageProcessorTest {
             .billableTallySnapshots(
                 List.of(
                     new TallySnapshot()
+                        .productId("rhosak")
                         .granularity(GranularityEnum.DAILY)
-                        .billingProvider(BillingProviderEnum.AWS)));
+                        .billingProvider(BillingProviderEnum.AWS)
+                        .tallyMeasurements(
+                            List.of(
+                                new TallySnapshotTallyMeasurements()
+                                    .uom(UomEnum.INSTANCE_HOURS)
+                                    .value(new BigDecimal("42.0"))))));
     when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))
         .thenThrow(AwsUsageContextLookupException.class);
     processor.process(usage);
     verifyNoInteractions(meteringClient);
+  }
+
+  @Test
+  void shouldSkipMessageIfUnknownAwsDimensionCannotBeLookedUp() {
+    BillableUsage usage =
+        new BillableUsage()
+            .billableTallySnapshots(
+                List.of(
+                    new TallySnapshot()
+                        .productId("OpenShift-dedicated-metrics")
+                        .granularity(GranularityEnum.DAILY)
+                        .billingProvider(BillingProviderEnum.AWS)
+                        .tallyMeasurements(
+                            List.of(
+                                new TallySnapshotTallyMeasurements()
+                                    .uom(UomEnum.INSTANCE_HOURS)
+                                    .value(new BigDecimal("42.0"))))));
+    processor.process(usage);
+    verifyNoInteractions(internalSubscriptionsApi, meteringClient);
   }
 
   @Test


### PR DESCRIPTION
Add logic to isSnapshotApplicable method to skip unconfigured dimensions
Update Unit test for BillableUsageProcessor for skipping unknown dimension.
Add new method to TagProfile.