### PR TITLE
Remove calls to deprecated Spring Data method getById

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
@@ -37,7 +37,6 @@ import org.candlepin.subscriptions.capacity.files.ProductWhitelist;
 import org.candlepin.subscriptions.db.OfferingRepository;
 import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
 import org.candlepin.subscriptions.db.SubscriptionRepository;
-import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.db.model.Subscription;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityKey;
@@ -123,8 +122,12 @@ public class CapacityReconciliationController {
   }
 
   private Collection<SubscriptionCapacity> mapSubscriptionToCapacities(Subscription subscription) {
+    var optionalOffering = offeringRepository.findById(subscription.getSku());
+    if (optionalOffering.isEmpty()) {
+      return Collections.emptyList();
+    }
 
-    Offering offering = offeringRepository.getById(subscription.getSku());
+    var offering = optionalOffering.get();
     Set<String> products = productExtractor.getProducts(offering);
     return products.stream()
         .map(product -> from(subscription, offering, product))

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
@@ -20,11 +20,16 @@
  */
 package org.candlepin.subscriptions.capacity;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.OffsetDateTime;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.capacity.files.ProductWhitelist;
 import org.candlepin.subscriptions.db.OfferingRepository;
@@ -93,7 +98,7 @@ class CapacityReconciliationControllerTest {
 
     when(whitelist.productIdMatches(any())).thenReturn(true);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(new HashSet<>(productIds));
-    when(offeringRepository.getById("MCT3718")).thenReturn(offering);
+    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(offering));
     when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
             "123", Collections.singletonList("456")))
         .thenReturn(Collections.emptyList());
@@ -150,7 +155,7 @@ class CapacityReconciliationControllerTest {
 
     when(whitelist.productIdMatches(any())).thenReturn(true);
     when(capacityProductExtractor.getProducts(updatedOffering)).thenReturn(productIds);
-    when(offeringRepository.getById("MCT3718")).thenReturn(updatedOffering);
+    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(updatedOffering));
     when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
             "123", Collections.singletonList("456")))
         .thenReturn(existingCapacities);
@@ -193,7 +198,7 @@ class CapacityReconciliationControllerTest {
     when(whitelist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(offering))
         .thenReturn(Set.of("RHEL", "RHEL Workstation"));
-    when(offeringRepository.getById("MCT3718")).thenReturn(offering);
+    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(offering));
     when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
             "123", Collections.singletonList("456")))
         .thenReturn(existingCapacities);
@@ -213,7 +218,7 @@ class CapacityReconciliationControllerTest {
 
     when(whitelist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(Set.of("RHEL1", "RHEL2"));
-    when(offeringRepository.getById("MCT3718")).thenReturn(offering);
+    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(offering));
     when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
             "123", Collections.singletonList("456")))
         .thenReturn(Collections.emptyList());
@@ -257,7 +262,7 @@ class CapacityReconciliationControllerTest {
 
     when(whitelist.productIdMatches(any())).thenReturn(true);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(productIds);
-    when(offeringRepository.getById("MCT3718")).thenReturn(offering);
+    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(offering));
     when(subscriptionCapacityRepository.findByKeyOwnerIdAndKeySubscriptionIdIn(
             "123", Collections.singletonList("456")))
         .thenReturn(staleCapacities);


### PR DESCRIPTION
Spring Data deprecated getById because it didn't do what people thought
it did.  Rather than fetching the entity, getById returned a JPA proxy
object.  The method has been replaced with the more accurately named
getReferenceById.  In the case of the code this commit patches, it
appears that the original author wanted the semantics associated with
findById and got tripped up by the confusing naming.

See https://github.com/spring-projects/spring-data-jpa/issues/2232