### PR TITLE
Support integer billing for MONTHLY billing window

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageCalculation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import java.time.OffsetDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+class BillableUsageCalculation {
+  private double remittedValue;
+  private double billableValue;
+  private OffsetDateTime remittanceDate;
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.registry.BillingWindow;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+public class BillableUsageController {
+
+  private final ApplicationClock clock;
+  private final BillingProducer billingProducer;
+  private final BillableUsageRemittanceRepository billableUsageRemittanceRepository;
+  private final TallySnapshotRepository snapshotRepository;
+
+  public BillableUsageController(
+      ApplicationClock clock,
+      BillingProducer billingProducer,
+      BillableUsageRemittanceRepository billableUsageRemittanceRepository,
+      TallySnapshotRepository snapshotRepository) {
+    this.clock = clock;
+    this.billingProducer = billingProducer;
+    this.billableUsageRemittanceRepository = billableUsageRemittanceRepository;
+    this.snapshotRepository = snapshotRepository;
+  }
+
+  public void submitBillableUsage(BillingWindow billingWindow, BillableUsage usage) {
+    switch (billingWindow) {
+      case HOURLY:
+        produceHourlyBillable(usage);
+        break;
+      case MONTHLY:
+        produceMonthlyBillable(usage);
+        break;
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported billing window specified when producing billable usage: " + billingWindow);
+    }
+  }
+
+  private BillableUsageRemittanceEntity getLatestRemittance(BillableUsage billableUsage) {
+    BillableUsageRemittanceEntityPK key =
+        BillableUsageRemittanceEntityPK.builder()
+            .usage(billableUsage.getUsage().value())
+            .accountNumber(billableUsage.getAccountNumber())
+            .billingProvider(billableUsage.getBillingProvider().value())
+            .billingAccountId(billableUsage.getBillingAccountId())
+            .productId(billableUsage.getProductId())
+            .sla(billableUsage.getSla().value())
+            .metricId(billableUsage.getUom().value())
+            .accumulationPeriod(getAccumulationPeriod(billableUsage.getSnapshotDate()))
+            .build();
+
+    return billableUsageRemittanceRepository
+        .findById(key)
+        .orElse(BillableUsageRemittanceEntity.builder().key(key).remittedValue(0.0).build());
+  }
+
+  private BillableUsageCalculation calculateBillableUsage(
+      double measuredTotal, double currentRemittedValue) {
+    double adjustedMeasuredTotal = Math.ceil(measuredTotal);
+    double billableValue = adjustedMeasuredTotal - currentRemittedValue;
+    if (billableValue < 0) {
+      // Message could have been received out of order via another process,
+      // or on re-tally we have already billed for this usage and using
+      // credit. There's nothing to bill in this case.
+      billableValue = 0.0;
+    }
+    double remittedValue = currentRemittedValue + billableValue;
+
+    return BillableUsageCalculation.builder()
+        .billableValue(billableValue)
+        .remittedValue(remittedValue)
+        .remittanceDate(clock.now())
+        .build();
+  }
+
+  private void produceHourlyBillable(BillableUsage usage) {
+    log.debug("Processing hourly billable usage {}", usage);
+    billingProducer.produce(usage);
+  }
+
+  private void produceMonthlyBillable(BillableUsage usage) {
+    log.debug("Processing monthly billable usage {}", usage);
+    Double currentMontlyTotal =
+        getCurrentlyMeasuredTotal(
+            usage, clock.startOfMonth(usage.getSnapshotDate()), usage.getSnapshotDate());
+    BillableUsageRemittanceEntity remittance = getLatestRemittance(usage);
+    BillableUsageCalculation usageCalc =
+        calculateBillableUsage(currentMontlyTotal, remittance.getRemittedValue());
+
+    log.debug("Current montly total: {}", currentMontlyTotal);
+    log.debug("Current remittance: {}", remittance);
+    log.debug("New billable usage calculation: {}", usageCalc);
+
+    // Update the reported usage value to the newly calculated one.
+    usage.setValue(usageCalc.getBillableValue());
+
+    // The orgId might not have been available when remittance
+    // was originally created, so we attempt to set here.
+    if (updateRemittance(
+        remittance,
+        usage.getOrgId(),
+        usageCalc.getRemittedValue(),
+        usageCalc.getRemittanceDate())) {
+      // Only send the update if we need to.
+      log.debug("Updating remittance: {}", remittance);
+      billableUsageRemittanceRepository.save(remittance);
+    }
+
+    // Send the message last to ensure that remittance has been updated.
+    // If the message fails to send, it will roll back the transaction.
+    billingProducer.produce(usage);
+  }
+
+  private String getAccumulationPeriod(OffsetDateTime reference) {
+    return InstanceMonthlyTotalKey.formatMonthId(reference);
+  }
+
+  private boolean updateRemittance(
+      BillableUsageRemittanceEntity remittance,
+      String orgId,
+      Double remittedValue,
+      OffsetDateTime remittedDate) {
+    boolean updated = false;
+    if (!Objects.equals(remittance.getRemittanceDate(), remittedDate)) {
+      remittance.setRemittanceDate(remittedDate);
+      updated = true;
+    }
+    if (!Objects.equals(remittance.getOrgId(), orgId) && StringUtils.hasText(orgId)) {
+      remittance.setOrgId(orgId);
+      updated = true;
+    }
+    if (!Objects.equals(remittance.getRemittedValue(), remittedValue)) {
+      remittance.setRemittedValue(remittedValue);
+      updated = true;
+    }
+    return updated;
+  }
+
+  private Double getCurrentlyMeasuredTotal(
+      BillableUsage usage, OffsetDateTime beginning, OffsetDateTime ending) {
+    // NOTE: We are filtering billable usage to PHYSICAL hardware as that's the only
+    //       hardware type set when metering.
+    TallyMeasurementKey measurementKey =
+        new TallyMeasurementKey(
+            HardwareMeasurementType.PHYSICAL, Uom.fromValue(usage.getUom().value()));
+    return snapshotRepository.sumMeasurementValueForPeriod(
+        usage.getAccountNumber(),
+        usage.getProductId(),
+        // Billable usage has already been filtered to HOURLY only.
+        Granularity.HOURLY,
+        ServiceLevel.fromString(usage.getSla().value()),
+        Usage.fromString(usage.getUsage().value()),
+        BillingProvider.fromString(usage.getBillingProvider().value()),
+        usage.getBillingAccountId(),
+        beginning,
+        ending,
+        measurementKey);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
@@ -50,11 +50,8 @@ public class BillingProducer {
     this.billableUsageTopic = billableUsageTopicProperties.getTopic();
   }
 
-  public void produce(BillableUsage tallySummary) {
-    log.debug(
-        "Forwarding summary {} to topic {}",
-        tallySummary.getAccountNumber(),
-        this.billableUsageTopic);
-    billableUsageKafkaTemplate.send(this.billableUsageTopic, tallySummary);
+  public void produce(BillableUsage usage) {
+    log.debug("Sending billable usage {} to topic {}", usage, billableUsageTopic);
+    billableUsageKafkaTemplate.send(billableUsageTopic, usage);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/TallySummaryMessageConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/TallySummaryMessageConsumer.java
@@ -87,10 +87,12 @@ public class TallySummaryMessageConsumer extends SeekableKafkaConsumer {
                         usage.getProductId(), uom));
               }
 
-              retry.execute(context -> {
-                billableUsageController.submitBillableUsage(tagMetric.get().getBillingWindow(), usage);
-                return null;
-              });
+              retry.execute(
+                  context -> {
+                    billableUsageController.submitBillableUsage(
+                        tagMetric.get().getBillingWindow(), usage);
+                    return null;
+                  });
             });
   }
 }

--- a/src/main/resources/liquibase/202206021315-add-version-to-billable-usage-tracking-table.xml
+++ b/src/main/resources/liquibase/202206021315-add-version-to-billable-usage-tracking-table.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202206021315" author="khowell">
+    <comment>Add version column to billable_usage_remittance tracking table for optimistic locking</comment>
+
+    <addColumn tableName="billable_usage_remittance">
+      <column name="version" type="INT"/>
+    </addColumn>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -64,5 +64,6 @@
     <include file="liquibase/202205161446-update-index-on-host-tally-bucket.xml"/>
     <include file="liquibase/202205171157-update-billing-account-and-billing-provider-columns-in-snapshot-and-host-tally-bucket-tables.xml"/>
     <include file="liquibase/202205231334-create-billable-usage-tracking-table.xml"/>
+    <include file="liquibase/202206021315-add-version-to-billable-usage-tracking-table.xml"/>
 </databaseChangeLog>
   <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import java.util.List;
+import lombok.Data;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+import org.junit.jupiter.api.Test;
+
+public class BillableUsageControllerTest {
+
+  private static final String ACCOUNT_NUMBER = "acct123";
+
+  BillableUsageRemittanceEntity createBillableUsageRemittanceEntity() {
+    //    return BillableUsageRemittanceEntity.builder()
+    //        .usage(Usage.ANY.value())
+    //        .accountNumber(ACCOUNT_NUMBER)
+    //        .billingProvider(BillingProvider.ANY.value())
+    //        .billingAccountId(tallySnapshot.getBillingAccountId())
+    //        .granularity(tallySnapshot.getGranularity().toString())
+    //        .productId(tallySnapshot.getProductId())
+    //        .sla(tallySnapshot.getSla().toString())
+    //        .snapshotDate(tallySnapshot.getSnapshotDate())
+    //        .metricId(tallyMeasurement.getUom().toString())
+    //        .month("2022-05") // TODO
+    //        .remittanceDate(OffsetDateTime.now())
+    //        .remittedValue(tallyMeasurement.getValue())
+    //        .build();
+    return null;
+  }
+
+  void testBillingProviderEmpty() {}
+
+  void testBillingProviderRedHat() {
+    /*
+    If the Billing Provider is Red Hat, we create BillableUsage with all the same values
+    as they were sent to us in TallySummary
+     */
+
+  }
+
+  void testBillingProviderAWS() {
+
+    /*
+    If the BillingProvider is AWS, we need to find the monthly total usage
+     */
+
+  }
+
+  void testBillingProviderGCP() {}
+
+  void testBillingProviderAzure() {}
+
+  void testBillingProviderOracle() {}
+
+  @Test
+  void testBillingProvider_ANY() {
+
+    List<Person> people = List.of(new Person("John", "male"), new Person("Lindsey", "female"));
+
+    // Declarative/Functional Programming
+
+  }
+
+  @Data
+  class Person {
+    private final String name;
+    private final String gender;
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -25,7 +25,7 @@ import lombok.Data;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 import org.junit.jupiter.api.Test;
 
-public class BillableUsageControllerTest {
+class BillableUsageControllerTest {
 
   private static final String ACCOUNT_NUMBER = "acct123";
 

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillingProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillingProducerTest.java
@@ -38,6 +38,7 @@ class BillingProducerTest {
 
   private TaskQueueProperties billableUsageTopicProps;
   private BillingProducer producer;
+  private BillableUsageController billableUsageEvaluator;
 
   @BeforeEach
   void setupTest() {

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillingProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillingProducerTest.java
@@ -49,7 +49,7 @@ class BillingProducerTest {
   }
 
   @Test
-  void testTallySummaryPassThrough() {
+  void testBillableUsageIsSentToTopic() {
     BillableUsage usage = new BillableUsage();
     producer.produce(usage);
     verify(kafka).send(billableUsageTopicProps.getTopic(), usage);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -79,6 +79,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
 
   void deleteByAccountNumber(String accountNumber);
 
+  @SuppressWarnings("java:S107") // repository method has a lot of params, deal with it
   @Query(
       "select coalesce(sum(VALUE(m)), 0.0) from TallySnapshot s "
           + "left join s.tallyMeasurements m on key(m) = :measurementKey "

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.springframework.data.domain.Page;
@@ -77,4 +78,27 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
       OffsetDateTime ending);
 
   void deleteByAccountNumber(String accountNumber);
+
+  @Query(
+      "select coalesce(sum(VALUE(m)), 0.0) from TallySnapshot s "
+          + "left join s.tallyMeasurements m on key(m) = :measurementKey "
+          + "where s.accountNumber = :accountNumber and "
+          + "s.productId = :productId and "
+          + "s.granularity = :granularity and "
+          + "s.serviceLevel = :serviceLevel and "
+          + "s.usage = :usage and "
+          + "s.billingProvider = :billingProvider and "
+          + "s.billingAccountId = :billingAcctId and "
+          + "s.snapshotDate >= :beginning and s.snapshotDate <= :ending")
+  Double sumMeasurementValueForPeriod(
+      @Param("accountNumber") String accountNumber,
+      @Param("productId") String productId,
+      @Param("granularity") Granularity granularity,
+      @Param("serviceLevel") ServiceLevel serviceLevel,
+      @Param("usage") Usage usage,
+      @Param("billingProvider") BillingProvider billingProvider,
+      @Param("billingAcctId") String billingAccountId,
+      @Param("beginning") OffsetDateTime beginning,
+      @Param("ending") OffsetDateTime ending,
+      @Param("measurementKey") TallyMeasurementKey measurementKey);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
@@ -26,6 +26,7 @@ import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import javax.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -54,4 +55,9 @@ public class BillableUsageRemittanceEntity {
   @Basic
   @Column(name = "org_id", nullable = true)
   private String orgId;
+
+  // Version to enable optimistic locking
+  @Version
+  @Column
+  private Integer version;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
@@ -57,7 +57,5 @@ public class BillableUsageRemittanceEntity {
   private String orgId;
 
   // Version to enable optimistic locking
-  @Version
-  @Column
-  private Integer version;
+  @Version @Column private Integer version;
 }


### PR DESCRIPTION
When a metered product's billing window is configured as MONTHLY,
the ceiling of the total monthly usage up to a snapshot's date is
compared with the currently remitted montly usage and the difference
is sent as the billable amount.

billing_value = ceil(montly_total_up_to_snapshot_date) - currently_remitted

Example:

Snapshot 1:  2022-03-31T23:00
  value: 0.2
  monthly total: 0.2
  currently remitted: 0.0

After processing:
  billed value: 1.0 GB-month
  remitted: 1.0 GB-month

Snapshot 2:  2022-04-01T00:00
  value: 0.1200
  monthly total: 0.1200
  currently remitted: 0.0

After Processing:
  billed value: 1.0 GB-month
  remitted: 1.0 GB-month

Snapshot 3:  2022-04-01T01:00
  value: 0.3000
  monthly total: 0.4200
  currently remitted: 1.0

After processing:
  billed value: 0.0 GB-month
  remitted: 1.0 GB-month

Snapshot 4:  2022-04-01T02:00
  value: 1.5
  monthly total: 1.92
  currently remitted: 1.0

After processing:
  billed value: 1.0 GB-month
  remitted: 2.0 GB-month

## TODO
- Optimistic locking on remittance entity
- Support retry on failure (per BillableUsage)
- Add unit tests (severely under tested at the moment)

## Testing
1. Copy the following contents into a file.
```
--
-- PostgreSQL database dump
--

-- Dumped from database version 13.4
-- Dumped by pg_dump version 13.4

SET statement_timeout = 0;
SET lock_timeout = 0;
SET idle_in_transaction_session_timeout = 0;
SET client_encoding = 'UTF8';
SET standard_conforming_strings = on;
SELECT pg_catalog.set_config('search_path', '', false);
SET check_function_bodies = false;
SET xmloption = content;
SET client_min_messages = warning;
SET row_security = off;

SET default_tablespace = '';

SET default_table_access_method = heap;

--
-- Name: events; Type: TABLE; Schema: public; Owner: rhsm-subscriptions
--
DROP TABLE IF EXISTS public.events;
CREATE TABLE public.events (
    id uuid NOT NULL,
    account_number character varying(255),
    "timestamp" timestamp with time zone,
    data jsonb,
    event_type character varying(60),
    event_source character varying(60),
    instance_id character varying(60)
);


ALTER TABLE public.events OWNER TO "rhsm-subscriptions";

--
-- Data for Name: events; Type: TABLE DATA; Schema: public; Owner: rhsm-subscriptions
--

COPY public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id) FROM stdin;
7e4e46dc-6c27-45a9-a038-6f3f9ed72722	account123	2022-04-01 02:00:00+00	{"sla": "Premium", "role": "rhosak", "event_id": "7e4e46dc-6c27-45a9-a038-6f3f9ed72722", "timestamp": "2022-04-01T02:00:00Z", "event_type": "snapshot_redhat.com:rhosak:storage_gb", "expiration": "2022-04-01T03:00:00Z", "instance_id": "test01", "display_name": "test01", "event_source": "prometheus", "measurements": [{"uom": "Storage-gibibytes", "value": 2.9428093690226356}], "service_type": "Kafka Cluster", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}	snapshot_redhat.com:rhosak:storage_gb	prometheus	test01
c1203191-61f1-47f1-903b-b594f02a3d7a	account123	2022-04-01 01:00:00+00	{"sla": "Premium", "role": "rhosak", "event_id": "c1203191-61f1-47f1-903b-b594f02a3d7a", "timestamp": "2022-04-01T01:00:00Z", "event_type": "snapshot_redhat.com:rhosak:storage_gb", "expiration": "2022-04-01T02:00:00Z", "instance_id": "test01", "display_name": "test01", "event_source": "prometheus", "measurements": [{"uom": "Storage-gibibytes", "value": 1.9516074570521695}], "service_type": "Kafka Cluster", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}	snapshot_redhat.com:rhosak:storage_gb	prometheus	test01
7ac50524-2951-4274-b56b-b586f6598c44	account123	2022-03-31 23:00:00+00	{"sla": "Premium", "role": "rhosak", "event_id": "7ac50524-2951-4274-b56b-b586f6598c44", "timestamp": "2022-03-31T23:00:00Z", "event_type": "snapshot_redhat.com:rhosak:storage_gb", "expiration": "2022-04-01T00:00:00Z", "instance_id": "test01", "display_name": "test01", "event_source": "prometheus", "measurements": [{"uom": "Storage-gibibytes", "value": 0.04106220395445278}], "service_type": "Kafka Cluster", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}	snapshot_redhat.com:rhosak:storage_gb	prometheus	test01
46583690-873c-4a82-99d2-5b1bf27b148a	account123	2022-04-01 00:00:00+00	{"sla": "Premium", "role": "rhosak", "event_id": "46583690-873c-4a82-99d2-5b1bf27b148a", "timestamp": "2022-04-01T00:00:00Z", "event_type": "snapshot_redhat.com:rhosak:storage_gb", "expiration": "2022-04-01T01:00:00Z", "instance_id": "test01", "display_name": "test01", "event_source": "prometheus", "measurements": [{"uom": "Storage-gibibytes", "value": 1.1496455033644466}], "service_type": "Kafka Cluster", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}	snapshot_redhat.com:rhosak:storage_gb	prometheus	test01
\.


--
-- Name: events events_event_type_event_source_instance_id_account_number_t_key; Type: CONSTRAINT; Schema: public; Owner: rhsm-subscriptions
--

ALTER TABLE ONLY public.events
    ADD CONSTRAINT events_event_type_event_source_instance_id_account_number_t_key UNIQUE (event_type, event_source, instance_id, account_number, "timestamp");


--
-- Name: events events_pk; Type: CONSTRAINT; Schema: public; Owner: rhsm-subscriptions
--

ALTER TABLE ONLY public.events
    ADD CONSTRAINT events_pk PRIMARY KEY (id);


--
-- Name: events_account_timestamp_idx; Type: INDEX; Schema: public; Owner: rhsm-subscriptions
--

CREATE INDEX events_account_timestamp_idx ON public.events USING btree (account_number, "timestamp");


--
-- Name: events_event_type_idx; Type: INDEX; Schema: public; Owner: rhsm-subscriptions
--

CREATE INDEX events_event_type_idx ON public.events USING btree (account_number, event_type, "timestamp");


--
-- PostgreSQL database dump complete
--

```
2. Drop and load the events test data
```
psql -U rhsm-subscriptions rhsm-subscriptions < YOUR_EVENTS_FILE_FROM_ABOVE
```
3. Update the billingWindow configuration for rhosak redhat.com:rhosak:storage_gb metric to MONTHLY
```
  - tag: rhosak
    metricId: redhat.com:rhosak:storage_gb
    rhmMetricId: redhat.com:rhosak:storage_gb
    awsDimension: redhat.com:rhosak:storage_gb
    uom: STORAGE_GIBIBYTES
    billingWindow: MONTHLY
    queryParams:
      product: rhosak
      prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
      prometheusMetadataMetric: subscription_labels

```
6. Deploy
```
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_TALLY_BILLING=DEBUG SPRING_PROFILES_ACTIVE="api,worker"  SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true DEV_MODE=true ./gradlew :bootRun
```
8. Run hourly tally:
  - account: account123
  - startDate: 2022-03-01T00:00Z
  - end: 2022-04-02T00:00Z

When complete:
1. Check the billable_usage_remittance table to make sure the remittance data is correct based on the events in the DB.
2. Check the billable usage topic to make sure that the correct billable values have been sent.
