### PR TITLE
ENT-5048: add missing order by to tally snapshot query

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -52,7 +52,8 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
           + "t.usage = :usage and "
           + "t.billingProvider = :billingProvider and "
           + "t.billingAccountId = :billingAcctId and "
-          + "t.snapshotDate between :beginning and :ending")
+          + "t.snapshotDate between :beginning and :ending "
+          + "order by t.snapshotDate")
   Page<TallySnapshot> findSnapshot( // NOSONAR
       @Param("accountNumber") String accountNumber,
       @Param("productId") String productId,


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5048

Missing orderby was causing the fill in dates to get duplicated.