### PR TITLE
ENT-5081 Clean up remitted table on account cleanup

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.tally;
 
 import javax.transaction.Transactional;
 import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
@@ -39,6 +40,7 @@ public class AccountResetService {
   private final AccountServiceInventoryRepository accountServiceInventoryRepository;
   private final SubscriptionCapacityRepository subscriptionCapacityRepository;
   private final SubscriptionRepository subscriptionRepository;
+  private final BillableUsageRemittanceRepository remittanceRepository;
 
   @Autowired
   public AccountResetService(
@@ -47,13 +49,15 @@ public class AccountResetService {
       TallySnapshotRepository tallySnapshotRepository,
       AccountServiceInventoryRepository accountServiceInventoryRepository,
       SubscriptionCapacityRepository subscriptionCapacityRepository,
-      SubscriptionRepository subscriptionRepository) {
+      SubscriptionRepository subscriptionRepository,
+      BillableUsageRemittanceRepository remittanceRepository) {
     this.eventRecordRepo = eventRecordRepo;
     this.hostRepo = hostRepo;
     this.tallySnapshotRepository = tallySnapshotRepository;
     this.accountServiceInventoryRepository = accountServiceInventoryRepository;
     this.subscriptionCapacityRepository = subscriptionCapacityRepository;
     this.subscriptionRepository = subscriptionRepository;
+    this.remittanceRepository = remittanceRepository;
   }
 
   @Transactional
@@ -65,5 +69,6 @@ public class AccountResetService {
     tallySnapshotRepository.deleteByAccountNumber(accountNumber);
     subscriptionRepository.deleteByAccountNumber(accountNumber);
     subscriptionCapacityRepository.deleteByAccountNumber(accountNumber);
+    remittanceRepository.deleteByKeyAccountNumber(accountNumber);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.json.BillableUsage.BillingProvider;
+import org.candlepin.subscriptions.json.BillableUsage.Sla;
+import org.candlepin.subscriptions.json.BillableUsage.Uom;
+import org.candlepin.subscriptions.json.BillableUsage.Usage;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureTestDatabase
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class BillableUsageRemittanceRepositoryTest {
+
+  @Autowired private BillableUsageRemittanceRepository repository;
+  private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+
+  @Test
+  void saveAndFetch() {
+    BillableUsageRemittanceEntity remittance =
+        remittance("account123", "product1", 12.0, clock.startOfCurrentMonth());
+    repository.saveAndFlush(remittance);
+    Optional<BillableUsageRemittanceEntity> fetched = repository.findById(remittance.getKey());
+    assertTrue(fetched.isPresent());
+    assertEquals(remittance, fetched.get());
+  }
+
+  @Test
+  void deleteByAccount() {
+    BillableUsageRemittanceEntity remittance1 =
+        remittance("account123", "product1", 12.0, clock.startOfCurrentMonth());
+    BillableUsageRemittanceEntity remittance2 =
+        remittance("account555", "product1", 12.0, clock.startOfCurrentMonth());
+
+    List<BillableUsageRemittanceEntity> toSave = List.of(remittance1, remittance2);
+    repository.saveAllAndFlush(toSave);
+
+    repository.deleteByKeyAccountNumber("account123");
+    repository.flush();
+    assertTrue(repository.findById(remittance1.getKey()).isEmpty());
+    Optional<BillableUsageRemittanceEntity> found = repository.findById(remittance2.getKey());
+    assertTrue(found.isPresent());
+    assertEquals(remittance2, found.get());
+  }
+
+  private BillableUsageRemittanceEntity remittance(
+      String accountNumber, String productId, Double value, OffsetDateTime remittanceDate) {
+    BillableUsageRemittanceEntityPK key =
+        BillableUsageRemittanceEntityPK.builder()
+            .usage(Usage.PRODUCTION.value())
+            .accountNumber(accountNumber)
+            .billingProvider(BillingProvider.AWS.value())
+            .billingAccountId(accountNumber + "_ba")
+            .productId(productId)
+            .sla(Sla.PREMIUM.value())
+            .metricId(Uom.CORES.value())
+            .accumulationPeriod(InstanceMonthlyTotalKey.formatMonthId(remittanceDate))
+            .build();
+    return BillableUsageRemittanceEntity.builder()
+        .key(key)
+        .remittanceDate(remittanceDate)
+        .remittedValue(value)
+        .build();
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
@@ -23,6 +23,11 @@ package org.candlepin.subscriptions.db;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BillableUsageRemittanceRepository
-    extends JpaRepository<BillableUsageRemittanceEntity, BillableUsageRemittanceEntityPK> {}
+    extends JpaRepository<BillableUsageRemittanceEntity, BillableUsageRemittanceEntityPK> {
+
+  @Query
+  void deleteByKeyAccountNumber(String accountNumber);
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5081

## Testing

1. Copy the sql below and paste into a file.
2. Import the data. **NOTE**: Will wipe the billable_usage_remittance table and import records.
```
$ psql -U rhsm-subscriptions rhsm-subscriptions < YOUR_FILE
```

3. Make sure there are records in the table: billable_usage_remittance
```bash
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select account_number, accumulation_period from billable_usage_remittance"
 account_number | accumulation_period 
----------------+---------------------
 account123     | 2022-03
 account123     | 2022-04
 account234     | 2022-04
(3 rows)
```

4. Run the application:
```
SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true DEV_MODE=true ./gradlew :bootRun
```
5. Run the JMX endpoint to clean out account data.
```
curl 'http://localhost:9000/hawtio/jolokia/' -X POST -H 'Content-Type: text/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=accountResetJmxBean,type=AccountResetJmxBean","operation":"deleteDataAssociatedWithAccount(java.lang.String)","arguments":["account123"]}'
```
6. Ensure that remittance has been cleaned up for the account.
```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select account_number, accumulation_period from billable_usage_remittance"
 account_number | accumulation_period 
----------------+---------------------
 account234     | 2022-04
(1 row)
```

**SQL SCRIPT**
```
--
-- PostgreSQL database dump
--

-- Dumped from database version 13.4
-- Dumped by pg_dump version 13.4

SET statement_timeout = 0;
SET lock_timeout = 0;
SET idle_in_transaction_session_timeout = 0;
SET client_encoding = 'UTF8';
SET standard_conforming_strings = on;
SELECT pg_catalog.set_config('search_path', '', false);
SET check_function_bodies = false;
SET xmloption = content;
SET client_min_messages = warning;
SET row_security = off;

SET default_tablespace = '';

SET default_table_access_method = heap;

--
-- Name: billable_usage_remittance; Type: TABLE; Schema: public; Owner: rhsm-subscriptions
--

DROP TABLE IF EXISTS public.billable_usage_remittance;
CREATE TABLE public.billable_usage_remittance (
    account_number character varying(32) NOT NULL,
    org_id character varying(32),
    product_id character varying(32) NOT NULL,
    metric_id character varying(255) NOT NULL,
    accumulation_period character varying(255) NOT NULL,
    sla character varying(255) NOT NULL,
    usage character varying(255) NOT NULL,
    billing_provider character varying(255) NOT NULL,
    billing_account_id character varying(255) NOT NULL,
    remitted_value double precision,
    remittance_date timestamp with time zone,
    version integer
);


ALTER TABLE public.billable_usage_remittance OWNER TO "rhsm-subscriptions";

--
-- Data for Name: billable_usage_remittance; Type: TABLE DATA; Schema: public; Owner: rhsm-subscriptions
--

COPY public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_value, remittance_date, version) FROM stdin;
account123	\N	rhosak	Storage-gibibyte-months	2022-03	Premium	Production	aws	mktp-123	1	2022-06-06 19:23:28.48574+00	0
account123	\N	rhosak	Storage-gibibyte-months	2022-04	Premium	Production	aws	mktp-123	7	2022-06-06 19:23:28.502726+00	2
account234	\N	rhosak	Storage-gibibyte-months	2022-04	Premium	Production	aws	mktp-123	7	2022-06-06 19:23:28.502726+00	2
\.


--
-- Name: billable_usage_remittance billable_usage_remittance_pkey; Type: CONSTRAINT; Schema: public; Owner: rhsm-subscriptions
--

ALTER TABLE ONLY public.billable_usage_remittance
    ADD CONSTRAINT billable_usage_remittance_pkey PRIMARY KEY (account_number, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id);


--
-- PostgreSQL database dump complete
--


```
