### PR TITLE
ENT-5087: Do not default Subscription.billingProvider

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -51,19 +51,17 @@ public class StubSearchApi extends SearchApi {
   }
 
   private Subscription createData() {
-    var now = OffsetDateTime.now();
     return new Subscription()
         .subscriptionNumber("2253591")
         .webCustomerId(123)
         .oracleAccountNumber(123)
         .quantity(1)
-        .effectiveStartDate(now.minusYears(10).toEpochSecond() * 1000L)
-        .effectiveEndDate(now.plusYears(10).toEpochSecond() * 1000L)
+        .effectiveStartDate(OffsetDateTime.parse("2011-01-01T01:02:33Z").toEpochSecond() * 1000L)
+        .effectiveEndDate(OffsetDateTime.parse("2031-01-01T01:02:33Z").toEpochSecond() * 1000L)
         .subscriptionProducts(List.of(new SubscriptionProduct().sku("sku")));
   }
 
   private Subscription createAwsBillingProviderData() {
-    var now = OffsetDateTime.now();
     ExternalReference awsRef = new ExternalReference();
     awsRef.setCustomerID("customer123");
     awsRef.setProductCode("testProductCode123");
@@ -75,8 +73,8 @@ public class StubSearchApi extends SearchApi {
         .webCustomerId(123)
         .oracleAccountNumber(123)
         .subscriptionNumber("4243626")
-        .effectiveStartDate(now.minusYears(10).toEpochSecond() * 1000L)
-        .effectiveEndDate(now.plusYears(10).toEpochSecond() * 1000L)
+        .effectiveStartDate(OffsetDateTime.parse("2011-01-01T01:02:33Z").toEpochSecond() * 1000L)
+        .effectiveEndDate(OffsetDateTime.parse("2031-01-01T01:02:33Z").toEpochSecond() * 1000L)
         .putExternalReferencesItem("aws", awsRef)
         .subscriptionProducts(List.of(new SubscriptionProduct().sku("MW01882")));
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -70,9 +70,8 @@ public class Subscription {
   @Column(name = "account_number")
   private String accountNumber;
 
-  @Builder.Default
   @Column(name = "billing_provider")
-  private BillingProvider billingProvider = BillingProvider.EMPTY;
+  private BillingProvider billingProvider;
 
   /** Composite ID class for Subscription entities. */
   @EqualsAndHashCode


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5087
    
This was causing every subscription to be treated as needing updating, as it'd end up with BillingProvider.EMPTY when the column was null.

```
2022-06-07T20:05:39.637+0000 [thread=swatch-producer-rh-marketplace-10-C-1] [level=DEBUG] [category=org.candlepin.subscriptions.subscription.SubscriptionSyncController]  - Existing subscription in DB=Subscription(subscriptionId=123456, subscriptionNumber=7890, sku=MCT2735, ownerId=123456, quantity=1, startDate=2021-06-10T04:00Z, endDate=2022-06-09T04:00Z, billingProviderId=null, billingAccountId=null, accountNumber=123456, billingProvider=EMPTY)
```

vs.

```
2022-06-07T20:06:37.436+0000 [thread=subscription-worker-2-C-1] [level=DEBUG] [category=org.candlepin.subscriptions.subscription.SubscriptionSyncController]  - New subscription that will need to be saved=Subscription(subscriptionId=123456, subscriptionNumber=7890, sku=MCT2735, ownerId=123456, quantity=1, startDate=2021-06-10T04:00Z, endDate=2022-06-09T04:00Z, billingProviderId=null, billingAccountId=null, accountNumber=123456, billingProvider=null)
```

This resulted in a lot of DB contention and even some deadlocks such as:

```
Caused by: org.postgresql.util.PSQLException: ERROR: deadlock detected
```

Testing
-------

First try the commit that only updates the stub. Then try this branch.

Run as

```
SUBSCRIPTION_USE_STUB=true \
  ./gradlew :bootRun \
  --args='--logging.level.org.hibernate.SQL=DEBUG'
```

Sync the orgId `123` several times:
    
```
http -b :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean \
  operation='syncSubscriptionsForOrg(java.lang.String)'\
  arguments:='["123"]'
```

Observe with the old code, it issues updates, with the new code, it doesn't.