### PR TITLE
ENT-5091: Make awsUsageContext lookup use billingAccountId

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -70,14 +70,19 @@ public class InternalSubscriptionResource implements InternalApi {
 
   @Override
   public AwsUsageContext getAwsUsageContext(
-      String accountNumber, OffsetDateTime date, String productId, String sla, String usage) {
+      String accountNumber,
+      OffsetDateTime date,
+      String productId,
+      String sla,
+      String usage,
+      String billingAccountId) {
     UsageCalculation.Key usageKey =
         new Key(
             productId,
             ServiceLevel.fromString(sla),
             Usage.fromString(usage),
             BillingProvider.AWS,
-            "_ANY");
+            billingAccountId);
     List<Subscription> subscriptions =
         subscriptionSyncController.findSubscriptionsAndSyncIfNeeded(
             accountNumber, Optional.empty(), usageKey, date, date);

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -84,6 +84,10 @@ paths:
         in: query
         schema:
           type: string
+      - name: awsAccountId
+        in: query
+        schema:
+          type: string
     get:
       summary: "Lookup necessary info to submit a usage record to AWS"
       operationId: getAwsUsageContext

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -88,7 +88,7 @@ class InternalSubscriptionResourceTest {
         NotFoundException.class,
         () ->
             resource.getAwsUsageContext(
-                "account123", OffsetDateTime.MIN, "rhosak", "Premium", "Production"));
+                "account123", OffsetDateTime.MIN, "rhosak", "Premium", "Production", "123"));
     Counter counter = meterRegistry.counter("swatch_missing_aws_subscription");
     assertEquals(1.0, counter.count());
   }
@@ -106,7 +106,7 @@ class InternalSubscriptionResourceTest {
         .thenReturn(List.of(sub1, sub2));
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
-            "account123", OffsetDateTime.MIN, "rhosak", "Premium", "Production");
+            "account123", OffsetDateTime.MIN, "rhosak", "Premium", "Production", "123");
     Counter counter = meterRegistry.counter("swatch_ambiguous_aws_subscription");
     assertEquals(1.0, counter.count());
     assertEquals("foo1", awsUsageContext.getProductCode());

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/BillableUsageProcessor.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/BillableUsageProcessor.java
@@ -133,7 +133,8 @@ public class BillableUsageProcessor {
           billableUsage.getSnapshotDate(),
           billableUsage.getProductId(),
           Optional.ofNullable(billableUsage.getSla()).map(SlaEnum::value).orElse(null),
-          Optional.ofNullable(billableUsage.getUsage()).map(UsageEnum::value).orElse(null));
+          Optional.ofNullable(billableUsage.getUsage()).map(UsageEnum::value).orElse(null),
+          Optional.ofNullable(billableUsage.getBillingAccountId()).orElse("_ANY"));
     } catch (ApiException e) {
       throw new AwsUsageContextLookupException(e);
     }

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -20,7 +20,7 @@ TALLY_IN_FAIL_ON_DESER_FAILURE=true
 # dev-specific defaults; these can still be overridden by env var
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
 %dev.AWS_CREDENTIALS_JSON=[{"accessKeyId":"accessKey","secretAccessKey":"placeholder","sellerAccount":"awsSellerAccountId"}]
-%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101/subscriptions/
+%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101/api/rhsm-subscriptions/v1
 %dev.AWS_MARKETPLACE_ENDPOINT_URL=http://localhost:8101/aws-marketplace/
 %dev.AWS_MARKETPLACE_ENDPOINT_OVERRIDE=true
 %dev.AWS_MANUAL_SUBMISSION_ENABLED=true

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/com/redhat/swatch/processors/BillableUsageProcessorTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/com/redhat/swatch/processors/BillableUsageProcessorTest.java
@@ -120,15 +120,15 @@ class BillableUsageProcessorTest {
 
   @Test
   void shouldLookupAwsContextOnApplicableSnapshot() throws ApiException {
-    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))
+    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(new AwsUsageContext());
     processor.process(RHOSAK_INSTANCE_HOURS_RECORD);
-    verify(internalSubscriptionsApi).getAwsUsageContext(any(), any(), any(), any(), any());
+    verify(internalSubscriptionsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any());
   }
 
   @Test
   void shouldSendUsageForApplicableSnapshot() throws ApiException {
-    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))
+    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     processor.process(RHOSAK_INSTANCE_HOURS_RECORD);
@@ -143,7 +143,7 @@ class BillableUsageProcessorTest {
             .billingProvider(BillingProviderEnum.AWS)
             .uom(UomEnum.INSTANCE_HOURS)
             .value(new BigDecimal("42.0"));
-    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))
+    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenThrow(AwsUsageContextLookupException.class);
     processor.process(usage);
     verifyNoInteractions(meteringClient);
@@ -163,15 +163,15 @@ class BillableUsageProcessorTest {
 
   @Test
   void shouldFindStorageAwsDimension() throws ApiException {
-    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))
+    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(new AwsUsageContext());
     processor.process(RHOSAK_STORAGE_GIB_MONTHS_RECORD);
-    verify(internalSubscriptionsApi).getAwsUsageContext(any(), any(), any(), any(), any());
+    verify(internalSubscriptionsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any());
   }
 
   @Test
   void shouldIncrementAcceptedCounterIfSuccessful() throws ApiException {
-    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))
+    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
@@ -182,7 +182,7 @@ class BillableUsageProcessorTest {
 
   @Test
   void shouldIncrementFailureCounterIfUnprocessed() throws ApiException {
-    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))
+    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
@@ -196,7 +196,7 @@ class BillableUsageProcessorTest {
 
   @Test
   void shouldIncrementFailureCounterOnError() throws ApiException {
-    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any()))
+    when(internalSubscriptionsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/wiremock/WiremockRunner.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/wiremock/WiremockRunner.java
@@ -62,7 +62,7 @@ public class WiremockRunner {
         Optional.ofNullable(System.getenv("WIREMOCK_AWS_PRODUCT_CODE")).orElse("productCode");
     Jsonb jsonb = JsonbBuilder.create();
     wireMockServer.stubFor(
-        any(urlMatching("/subscriptions/?.*"))
+        any(urlMatching("/api/rhsm-subscriptions/v1/?.*"))
             .withQueryParam("accountNumber", equalTo("account123"))
             .willReturn(
                 aResponse()
@@ -76,7 +76,7 @@ public class WiremockRunner {
                                 .rhSubscriptionId("rhSubscriptionId")
                                 .subscriptionStartDate(OffsetDateTime.now().minusDays(1))))));
     wireMockServer.stubFor(
-        any(urlMatching("/subscriptions/?.*"))
+        any(urlMatching("/api/rhsm-subscriptions/v1/?.*"))
             .withQueryParam("accountNumber", equalTo("unconfigured"))
             .willReturn(
                 aResponse()
@@ -92,7 +92,7 @@ public class WiremockRunner {
     // last stub has highest prio, so this effectively short-circuits any request without the header
     // at 401
     wireMockServer.stubFor(
-        any(urlMatching("/subscriptions/?.*"))
+        any(urlMatching("/api/rhsm-subscriptions/v1/?.*"))
             .withHeader("x-rh-swatch-psk", notMatching("dummy"))
             .willReturn(aResponse().withStatus(401)));
   }


### PR DESCRIPTION
Testing
-------

Insert a subscription record that matches billingAccountId "123" and one
that doesn't:

```
cat <<EOF | psql -h localhost -U rhsm-subscriptions
INSERT INTO offering(
    sku, product_name, product_family, sla, usage, description, has_unlimited_usage)
    VALUES ('MW01882', 'OpenShift Streams for Apache Kafka', 'JBoss', 'Premium', 'Production', 'Red Hat OpenShift Streams for Apache Kafka (Hourly)', false);

INSERT INTO subscription(
	sku, owner_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id)
	VALUES ('MW01882', 'org123', '12351256', '1', '2012-05-13 16:32:00+00', '2032-05-13 16:32:00+00', 'testProductCode123;customer123;sellerAccount123', 'account123', '1235153', 'aws', '123');

INSERT INTO public.subscription(
	sku, owner_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id)
	VALUES ('MW01882', 'org123', '12351257', '1', '2012-05-13 16:32:00+00', '2032-05-13 16:32:00+00', 'testProductCode123;customer123;sellerAccount123', 'account123', '1235153', 'aws', '456');
EOF
```

Run the capacity-ingress service on port 8101:

```
SERVER_PORT=8101 ./gradlew :bootRun
```

```
./gradlew swatch-producer-aws:quarkusDev
```

Then, send a fake billable usage message containing billingAccountId:

```
curl -X 'POST' \
  'http://localhost:8000/api/swatch-producer-aws/internal/aws/billable_usage' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '{
  "account_number": "account123",
  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "billing_provider": "aws",
  "billing_account_id": "123",
  "snapshot_date": "2022-06-09T17:36:54.567Z",
  "product_id": "rhosak",
  "sla": "Premium",
  "usage": "Production",
  "uom": "Instance-hours",
  "value": 0
}'
```

Observe that the aws usage context is returned with no warnings:

You'll observe another error, but this is okay:

```
2022-06-09 13:59:41,114 ERROR [com.red.swa.pro.BillableUsageProcessor] (vert.x-worker-thread-0) Error sending usage for account=account123 rhSubscriptionId=12351256 tallySnapshotId=3fa85f64-5717-4562-b3fc-2c963f66afa6 awsCustomerId=customer123 awsProductCode=testProductCode123: com.redhat.swatch.exception.AwsMissingCredentialsException: SWATCHAWS1003: AWS credentials missing: sellerAccount=sellerAccount123
```

FYI, I also tweaked the wiremock config and dev profile config to line up,
to make it easier to switch between mock and real service.