### PR TITLE
Optionally disable AWS usage send

### DIFF
--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -53,6 +53,8 @@ parameters:
     value: 'false'
   - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
     value: ''
+  - name: ENABLE_AWS_DRY_RUN
+    value: 'false'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -166,6 +168,8 @@ objects:
               value: ${KAFKA_SEEK_OVERRIDE_END}
             - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
               value: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP}
+            - name: ENABLE_AWS_DRY_RUN
+              value: ${ENABLE_AWS_DRY_RUN}
           volumeMounts:
             - name: logs
               mountPath: /logs


### PR DESCRIPTION
Setting env var ENABLE_AWS_DRY_RUN=true will skip sending
usage to AWS and instead log the request.

## Testing
1. Ensure you have events with AWS billing provider in the DB.
2. Start the proxy in a terminal: ```./gradlew :swatch-producer-aws:wiremock```
3. Run the app in another terminal: ```ENABLE_AWS_DRY_RUN=true ./gradlew :swatch-producer-aws:quarkusDev```
4. Each validated message will producer a log message as follows, and will not attempt to send to AWS Marketplace:
```
2022-06-09 15:17:10,514 INFO  [com.red.swa.pro.BillableUsageProcessor] (vert.x-worker-thread-0) [DRY RUN] Sending usage request to AWS: BatchMeterUsageRequest(UsageRecords=[UsageRecord(Timestamp=2022-06-08T18:16:49.569407Z, CustomerIdentifier=customer123, Dimension=storage_gb, Quantity=0)], ProductCode=productCode)
```