### PR TITLE
Do not retry Account Service if account is simply not found

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/user/AccountService.java
+++ b/src/main/java/org/candlepin/subscriptions/user/AccountService.java
@@ -65,7 +65,7 @@ public class AccountService {
         MDC.put("ACCOUNT_LOOKUP_FAILED", Boolean.TRUE.toString());
         throw new SubscriptionsException(
             ErrorCode.ACCOUNT_SERVICE_LOOKUP_ERROR,
-            Status.NOT_FOUND,
+            Status.NO_CONTENT,
             String.format("Account number %s not found", accountNumber),
             (String) null);
       }
@@ -94,7 +94,7 @@ public class AccountService {
         MDC.put("ACCOUNT_LOOKUP_FAILED", Boolean.TRUE.toString());
         throw new SubscriptionsException(
             ErrorCode.ACCOUNT_SERVICE_LOOKUP_ERROR,
-            Status.NOT_FOUND,
+            Status.NO_CONTENT,
             String.format("Account w/ orgId %s not found", orgId),
             (String) null);
       }

--- a/src/main/java/org/candlepin/subscriptions/user/NotFoundSubscriptionsExceptionClassifier.java
+++ b/src/main/java/org/candlepin/subscriptions/user/NotFoundSubscriptionsExceptionClassifier.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.user;
+
+import javax.ws.rs.core.Response.Status;
+import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.springframework.classify.Classifier;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.policy.NeverRetryPolicy;
+
+/**
+ * This is a {@link Classifier} that examines a Throwable and returns a RetryPolicy to use based on
+ * that Throwable. The purpose of this class is to introspect SubscriptionsExceptions that are
+ * thrown by {@link AccountService}. SubscriptionsExceptions are thrown in two circumstances: if an
+ * account is non-found or if there was some request or server error. For an account that is not
+ * found, the server returns a 204 No Content, If the account isn't found, then we don't want to
+ * retry. This Classifier looks at the HTTP response status in the exception and if the status is
+ * 204, it returns a NeverRetryPolicy. Otherwise, it returns a default that is set during
+ * construction.
+ */
+public class NotFoundSubscriptionsExceptionClassifier
+    implements Classifier<Throwable, RetryPolicy> {
+  private final RetryPolicy defaultPolicy;
+
+  public NotFoundSubscriptionsExceptionClassifier(RetryPolicy defaultPolicy) {
+    this.defaultPolicy = defaultPolicy;
+  }
+
+  @Override
+  public RetryPolicy classify(Throwable classifiable) {
+    if (classifiable instanceof SubscriptionsException) {
+      var subscriptionsException = (SubscriptionsException) classifiable;
+      if (Status.NO_CONTENT.equals(subscriptionsException.getStatus())) {
+        return new NeverRetryPolicy();
+      }
+    }
+
+    return defaultPolicy;
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/user/NotFoundSubscriptionsExceptionClassifierTest.java
+++ b/src/test/java/org/candlepin/subscriptions/user/NotFoundSubscriptionsExceptionClassifierTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.user;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.core.Response.Status;
+import org.candlepin.subscriptions.exception.ErrorCode;
+import org.candlepin.subscriptions.exception.SubscriptionsException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.classify.Classifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.policy.ExceptionClassifierRetryPolicy;
+import org.springframework.retry.policy.MaxAttemptsRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.retry.support.RetryTemplateBuilder;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NotFoundSubscriptionsExceptionClassifierTest {
+
+  @TestConfiguration
+  public static class RetryTestConfig {
+    @Bean
+    public RetryPolicy testDefaultPolicy() {
+      // The number of attempts includes the initial try.
+      return new MaxAttemptsRetryPolicy(3);
+    }
+
+    @Bean
+    public Classifier<Throwable, RetryPolicy> testClassifier(RetryPolicy testDefaultPolicy) {
+      return new NotFoundSubscriptionsExceptionClassifier(testDefaultPolicy);
+    }
+
+    @Bean
+    public RetryPolicy testRetryPolicy(Classifier<Throwable, RetryPolicy> testClassifier) {
+      ExceptionClassifierRetryPolicy exceptionClassifierRetryPolicy =
+          new ExceptionClassifierRetryPolicy();
+      exceptionClassifierRetryPolicy.setExceptionClassifier(testClassifier);
+      return exceptionClassifierRetryPolicy;
+    }
+
+    @Bean
+    @Qualifier("testRetry")
+    public RetryTemplate testRetry(RetryPolicy testRetryPolicy) {
+      return new RetryTemplateBuilder()
+          .fixedBackoff(10) // 10 ms
+          .customPolicy(testRetryPolicy)
+          .build();
+    }
+
+    @Bean
+    public RetryingThing retryingThing(RetryTemplate testRetry) {
+      return new RetryingThing(testRetry);
+    }
+  }
+
+  public static class RetryingThing {
+    private final RetryTemplate template;
+    private AtomicInteger noContentTries = new AtomicInteger(0);
+    private AtomicInteger serverErrorTries = new AtomicInteger(0);
+
+    public RetryingThing(RetryTemplate template) {
+      this.template = template;
+    }
+
+    public void noContentStatus() {
+      template.execute(
+          ctx -> {
+            noContentTries.incrementAndGet();
+            throw new SubscriptionsException(
+                ErrorCode.ACCOUNT_SERVICE_LOOKUP_ERROR,
+                Status.NO_CONTENT,
+                String.format("No Content"),
+                "");
+          });
+    }
+
+    public void serverErrorStatus() {
+      template.execute(
+          ctx -> {
+            serverErrorTries.incrementAndGet();
+            throw new SubscriptionsException(
+                ErrorCode.ACCOUNT_SERVICE_LOOKUP_ERROR,
+                Status.INTERNAL_SERVER_ERROR,
+                String.format("No Content"),
+                "");
+          });
+    }
+
+    public AtomicInteger getNoContentTries() {
+      return noContentTries;
+    }
+
+    public AtomicInteger getServerErrorTries() {
+      return serverErrorTries;
+    }
+  }
+
+  @Autowired RetryingThing retryingThing;
+
+  @Test
+  void testDoesNotRetryOn204() {
+    assertThrows(SubscriptionsException.class, () -> retryingThing.noContentStatus());
+    assertEquals(1, retryingThing.getNoContentTries().get());
+  }
+
+  @Test
+  void testDoesRetryOnServerError() {
+    assertThrows(SubscriptionsException.class, () -> retryingThing.serverErrorStatus());
+    assertEquals(3, retryingThing.getServerErrorTries().get());
+  }
+}


### PR DESCRIPTION
A custom RetryPolicy allows us to limit our retries to the case where
this is a legitimate service failure instead of an account simply not
existing.