### PR TITLE
Add Storage-gibibyte-months sortable UOM enum

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1539,6 +1539,7 @@ components:
         - Core-seconds
         - Instance-hours
         - Storage-gibibytes
+        - Storage-gibibyte-months
         - Transfer-gibibytes
         - billing_provider
     InstanceData:


### PR DESCRIPTION
Add Storage-gibibyte-months to our list of units of measure in order to enable sorting in the GUI.