### PR TITLE
ENT-5089: add Storage-gibibyte-months sort param to instance api

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1542,6 +1542,7 @@ components:
         - Storage-gibibyte-months
         - Transfer-gibibytes
         - billing_provider
+        - Storage-gibibyte-months
     InstanceData:
       title: Root Type for Instance
       description: The representation of a product cluster data


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5098

Test Steps:

- Generate hosts: `./bin/insert-mock-hosts --num-aws 2 --billing-provider aws --billing-account-id 123`
- Insert records for each host in instance_monthly_total with current month and UOM = 'STORAGE_GIBIBYTE_MONTHS' with different Value's for each row.
- Start app with: `RHSM_RBAC_USE_STUB=true ./gradlew :bootRun`
- Run: `curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/rhosak?sort=Storage-gibibyte-months&dir=desc' \
  -H 'accept: application/json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJhY2NvdW50X251bWJlciI6ICI2Mzk3OTQ0IiwKICAgICAgICAidHlwZSI6ICJVc2VyIiwKICAgICAgICAidXNlciIgOiB7CiAgICAgICAgICAgICJpc19vcmdfYWRtaW4iOiB0cnVlCiAgICAgICAgfSwKICAgICAgICAiaW50ZXJuYWwiIDogewogICAgICAgICAgICAib3JnX2lkIjogIm9yZzEyMyIKICAgICAgICB9CiAgICB9Cn0='`
- Hosts should be sorted by Storage-gibibyte-months