### PR TITLE
ENT-5094: Retry billable-usage-producer transient errors

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/util/KafkaTransientDataAccessErrorHandler.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/util/KafkaTransientDataAccessErrorHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.KafkaException.Level;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.listener.SeekUtils;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * Spring kafka error handler that logs at warning level and retries until successful.
+ *
+ * <p>Intended to be used with {@link org.springframework.dao.TransientDataAccessException}
+ */
+@Slf4j
+public class KafkaTransientDataAccessErrorHandler extends DefaultErrorHandler {
+
+  public KafkaTransientDataAccessErrorHandler() {
+    super(new FixedBackOff());
+  }
+
+  @Override
+  public void handleRemaining(
+      @NotNull Exception thrownException,
+      @NotNull List<ConsumerRecord<?, ?>> records,
+      @NotNull Consumer<?, ?> consumer,
+      @NotNull MessageListenerContainer container) {
+    Throwable rootCause;
+    if (thrownException instanceof KafkaException) {
+      rootCause = thrownException.getCause();
+    } else {
+      rootCause = thrownException;
+    }
+    log.warn("Encountered {}. Will retry.", rootCause.toString());
+    SeekUtils.seekOrRecover(
+        thrownException,
+        records,
+        consumer,
+        container,
+        isCommitRecovered(),
+        getRecoveryStrategy(records, consumer, thrownException),
+        this.logger,
+        Level.DEBUG);
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5094

With warning messages rather than verbose error messages with stack traces. Note that this will retry indefinitely...

Note that it was already retrying 10 times by default, but without backoff, and I verified that it failed even with retries a couple
of times in stage environment. By retrying indefinitely (for transient errors only), we'll eventually work past transient issues.
kafka topic lag will detect if we ever get into a situation where this causes issues.

Testing
-------

Run as

```
SPRING_PROFILES_ACTIVE=worker ./gradlew :bootRun
```

Simulate a transient error by replacing the logic in `TallySummaryMessageConsumer#receive` with:

```
throw new ObjectOptimisticLockingFailureException("test", "test");
```

Then use the kafka producer in intellij to queue up a message to `platform.rhsm-subscriptions.tally` with value `{}`.

You can also simulate other errors if desired to see that the retry remains unchanged for other exception types.