### PR TITLE
ENT-4690: Update grafana dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,13 @@ Essentially:
 2. Export the dashboard, choosing to "export for sharing externally", save JSON to a file.
 3. Rename the file to `subscription-watch.json`.
 
+OR
+
+1. Edit the dashboard on the stage grafana instance.
+2. Navigate to Dashboard Settings (cogwheel top right of page)
+3. Navigate to JSON Model (left nav)
+4. Save contents of the JSON Model into a file named `subscription-watch.json`.
+
 Use the following command to update the configmap YAML:
 
 ```
@@ -427,11 +434,14 @@ cat << EOF >> ./grafana-dashboard-subscription-watch.configmap.yaml
 EOF
 ```
 
+
 Possibly useful, to extract the JSON from the k8s configmap file:
 
 ```
 oc extract -f dashboards/grafana-dashboard-subscription-watch.configmap.yaml --confirm
 ```
+
+Once you extract it from the .yaml that's checked into this repo, you can import it into the stage instance of grafana by going to Create -> Import from the left nav.
 
 ## License
 

--- a/dashboards/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/dashboards/grafana-dashboard-subscription-watch.configmap.yaml
@@ -2,45 +2,14 @@ apiVersion: v1
 data:
   subscription-watch.json: |-
     {
-      "__inputs": [],
-      "__elements": [],
-      "__requires": [
-        {
-          "type": "datasource",
-          "id": "cloudwatch",
-          "name": "CloudWatch",
-          "version": "1.0.0"
-        },
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "8.4.1"
-        },
-        {
-          "type": "panel",
-          "id": "graph",
-          "name": "Graph (old)",
-          "version": ""
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "1.0.0"
-        },
-        {
-          "type": "panel",
-          "id": "stat",
-          "name": "Stat",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
             "builtIn": 1,
-            "datasource": "-- Grafana --",
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
             "enable": true,
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
@@ -58,13 +27,17 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": null,
-      "iteration": 1652723048193,
+      "id": 57,
+      "iteration": 1655409955025,
       "links": [],
       "liveNow": false,
       "panels": [
         {
           "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tuHy3WB7z"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -597,6 +570,10 @@ data:
         },
         {
           "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tuHy3WB7z"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1293,6 +1270,10 @@ data:
         },
         {
           "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tuHy3WB7z"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1749,6 +1730,10 @@ data:
         },
         {
           "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tuHy3WB7z"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -2222,6 +2207,10 @@ data:
         },
         {
           "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tuHy3WB7z"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -2514,6 +2503,10 @@ data:
         },
         {
           "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tuHy3WB7z"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -2522,7 +2515,7 @@ data:
           },
           "id": 74,
           "panels": [],
-          "title": "Red Hat Marketplace Integration",
+          "title": "Billing Provider Integration",
           "type": "row"
         },
         {
@@ -2562,7 +2555,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.1",
+          "pluginVersion": "8.5.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2653,7 +2646,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.1",
+          "pluginVersion": "8.5.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2713,9 +2706,10 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$datasource"
           },
-          "description": "⬇️ SWatch pushes usage info into RH Marketplace ⬇️ \n\n(TIP: if this isn't working, the \"pending bill\" will never be updated on customer accounts)",
+          "description": "rhsm-subscriptions-worker service produces TallySummary messages for consumption by Billing Usage service",
           "fieldConfig": {
             "defaults": {
               "unit": "none"
@@ -2749,7 +2743,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.1",
+          "pluginVersion": "8.5.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2760,7 +2754,11 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.tally\", group=\"rh-marketplace-worker\"}) by (group, partition)",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "skSy3ZB7k"
+              },
+              "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.tally\", group=\"swatch-producer-billing\"}) by (group, partition)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -2771,7 +2769,209 @@ data:
           ],
           "thresholds": [],
           "timeRegions": [],
-          "title": "RH Marketplace Task Lag",
+          "title": "Tally to Billable Usage Lag",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:332",
+              "format": "none",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:333",
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Billable Usage service emits messages with usage data for swatch billing provider services to consume.  This widget monitors the consumer group connected to the swatch-producer-aws service)",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 83,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeatDirection": "h",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "skSy3ZB7k"
+              },
+              "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.billable-usage\", group=\"swatch-producer-aws\"}) by (group, partition)",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "partition {{ partition }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "AWS Billable Usage Lag",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:332",
+              "format": "none",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:333",
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Billable Usage service emits messages with usage data for swatch billing provider services to consume.  This widget monitors the rh-marketplace-worker consumer group (consumed by the swatch-billing-provider-rh-marketplace service)",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 6,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 84,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeatDirection": "h",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "skSy3ZB7k"
+              },
+              "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.billable-usage\", group=\"swatch-producer-rh-marketplace\"}) by (group, partition)",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "partition {{ partition }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "RH Marketplace Billable Usage Lag",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2861,8 +3061,8 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 18,
-            "y": 6
+            "x": 0,
+            "y": 24
           },
           "id": 82,
           "links": [],
@@ -2881,7 +3081,7 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.4.1",
+          "pluginVersion": "8.5.2",
           "targets": [
             {
               "expr": "sum(increase(rhsm_subscriptions_rh_marketplace_batch_accepted_total[$__range]))",
@@ -2911,16 +3111,16 @@ data:
         }
       ],
       "refresh": false,
-      "schemaVersion": 35,
+      "schemaVersion": 36,
       "style": "dark",
       "tags": [],
       "templating": {
         "list": [
           {
             "current": {
-              "selected": true,
-              "text": "crcp01ue1-prometheus",
-              "value": "crcp01ue1-prometheus"
+              "selected": false,
+              "text": "crcs02ue1-prometheus",
+              "value": "crcs02ue1-prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -2937,8 +3137,8 @@ data:
           {
             "current": {
               "selected": false,
-              "text": "AWS insights-prod",
-              "value": "AWS insights-prod"
+              "text": "AWS insights-stage",
+              "value": "AWS insights-stage"
             },
             "hide": 0,
             "includeAll": false,

--- a/dashboards/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/dashboards/grafana-dashboard-subscription-watch.configmap.yaml
@@ -36,7 +36,7 @@ data:
           "collapsed": true,
           "datasource": {
             "type": "prometheus",
-            "uid": "tuHy3WB7z"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -52,7 +52,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$rdsdatasource"
+                "uid": "${rdsdatasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -171,7 +171,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$rdsdatasource"
+                "uid": "${rdsdatasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -299,7 +299,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$rdsdatasource"
+                "uid": "${rdsdatasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -452,7 +452,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$rdsdatasource"
+                "uid": "${rdsdatasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -572,7 +572,7 @@ data:
           "collapsed": true,
           "datasource": {
             "type": "prometheus",
-            "uid": "tuHy3WB7z"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -584,7 +584,7 @@ data:
           "panels": [
             {
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -647,7 +647,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "decimals": 3,
               "fieldConfig": {
@@ -773,7 +773,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "description": "",
               "fieldConfig": {
@@ -868,7 +868,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -960,7 +960,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -1086,7 +1086,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -1178,7 +1178,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -1272,7 +1272,7 @@ data:
           "collapsed": true,
           "datasource": {
             "type": "prometheus",
-            "uid": "tuHy3WB7z"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -1288,7 +1288,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "decimals": 3,
               "fieldConfig": {
@@ -1414,7 +1414,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "decimals": 3,
               "fieldConfig": {
@@ -1540,7 +1540,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -1638,7 +1638,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -1732,7 +1732,7 @@ data:
           "collapsed": true,
           "datasource": {
             "type": "prometheus",
-            "uid": "tuHy3WB7z"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -1748,7 +1748,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -1841,7 +1841,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -1931,7 +1931,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -2023,7 +2023,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -2115,7 +2115,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -2209,7 +2209,7 @@ data:
           "collapsed": true,
           "datasource": {
             "type": "prometheus",
-            "uid": "tuHy3WB7z"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -2225,7 +2225,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -2318,7 +2318,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -2411,7 +2411,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": {
-                "uid": "$datasource"
+                "uid": "${datasource}"
               },
               "fieldConfig": {
                 "defaults": {
@@ -2505,7 +2505,7 @@ data:
           "collapsed": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "tuHy3WB7z"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -2524,7 +2524,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
           "description": "⬇️ OCM provides usage metrics that are read by the metering collector job ⬇️\n\n(TIP: if this isn't working, data will not land in swatch DB at all)",
           "fill": 1,
@@ -2615,7 +2615,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
           "description": "⬇️ Sampled metrics stored in DB are \"collapsed\" into summary metrics ⬇️\n\n(TIP: Summary metrics are displayed in web UI)",
           "fill": 1,
@@ -2707,7 +2707,7 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
           "description": "rhsm-subscriptions-worker service produces TallySummary messages for consumption by Billing Usage service",
           "fieldConfig": {
@@ -2756,7 +2756,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "skSy3ZB7k"
+                "uid": "${datasource}"
               },
               "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.tally\", group=\"swatch-producer-billing\"}) by (group, partition)",
               "format": "time_series",
@@ -2808,7 +2808,7 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
           "description": "Billable Usage service emits messages with usage data for swatch billing provider services to consume.  This widget monitors the consumer group connected to the swatch-producer-aws service)",
           "fieldConfig": {
@@ -2857,7 +2857,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "skSy3ZB7k"
+                "uid": "${datasource}"
               },
               "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.billable-usage\", group=\"swatch-producer-aws\"}) by (group, partition)",
               "format": "time_series",
@@ -2909,7 +2909,7 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
           "description": "Billable Usage service emits messages with usage data for swatch billing provider services to consume.  This widget monitors the rh-marketplace-worker consumer group (consumed by the swatch-billing-provider-rh-marketplace service)",
           "fieldConfig": {
@@ -2958,7 +2958,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "skSy3ZB7k"
+                "uid": "${datasource}"
               },
               "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.rhsm-subscriptions.billable-usage\", group=\"swatch-producer-rh-marketplace\"}) by (group, partition)",
               "format": "time_series",
@@ -3005,7 +3005,7 @@ data:
         },
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {


### PR DESCRIPTION
Needs updating to coincide with multi marketplace changes

Repurpose RH Marketplace Task Lag to Tally to Billable Usage Lag
Widget for RH Marketplace Billable Usage Lag
Widget for AWS Billable Usage Lag

Testing
- Log into stage grafana: https://grafana.stage.devshift.net/?orgId=1
- Left Nav -> Create -> Import
- Paste/Upload the json and click "Load"
- If you get an error about there already being a panel, change the name of the dashboard and UID, then click Import again
- After checking out the dashboard changes, clean up after yourself and delete the dashboard.

Note: Might need to make sure you're trying to import under "General" category and not the Insights folder.