### PR TITLE
Enable DEVTEST_EVENT_EDITING in capacity ingress template

### DIFF
--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -207,6 +207,8 @@ objects:
                   value: ${DATABASE_MAX_POOL_SIZE}
                 - name: SUBSCRIPTION_SYNC_ENABLED
                   value: ${SUBSCRIPTION_SYNC_ENABLED}
+                - name: DEVTEST_EVENT_EDITING_ENABLED
+                  value: ${DEVTEST_EVENT_EDITING_ENABLED}
                 - name: SUBSCRIPTION_PAGE_SIZE
                   value: ${SUBSCRIPTION_PAGE_SIZE}
                 - name: INVENTORY_DATABASE_HOST

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -55,6 +55,8 @@ parameters:
     value: '500'
   - name: DEVTEST_SUBSCRIPTION_EDITING_ENABLED
     value: 'false'
+  - name: DEVTEST_EVENT_EDITING_ENABLED
+    value: 'false'
   - name: SUBSCRIPTION_URL
     value: https://subscription.qa.api.redhat.com/svcrest/subscription/v5
   - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN


### PR DESCRIPTION
Add DEVTEST_EVENT_EDITING =false in the capacity ingress template. It allows QE to test the new internal termination API mentioned in ENT-4932.