### PR TITLE
Correct bad AWS references in Subscription client

### DIFF
--- a/clients/subscription-client/subscription-api-spec.yaml
+++ b/clients/subscription-client/subscription-api-spec.yaml
@@ -179,5 +179,5 @@ components:
           type: string
         sellerAccount:
           type: string
-        customerAccountId:
+        customerAccountID:
           type: string

--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -72,7 +72,7 @@ public class StubSearchApi extends SearchApi {
     awsRef.setCustomerID("customer123");
     awsRef.setProductCode("testProductCode123");
     awsRef.setSellerAccount("awsSellerAccountId");
-    awsRef.setCustomerAccountId("1234567891234");
+    awsRef.setCustomerAccountID("1234567891234");
     return new Subscription()
         .id(235252)
         .quantity(1)

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtil.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtil.java
@@ -33,7 +33,7 @@ import org.springframework.util.StringUtils;
 /** Utility class to assist in pulling nested data out of the Subscription DTO. */
 public class SubscriptionDtoUtil {
   public static final String IBMMARKETPLACE = "ibmmarketplace";
-  public static final String AWS_MARKETPLACE = "aws";
+  public static final String AWS_MARKETPLACE = "awsMarketplace";
 
   private SubscriptionDtoUtil() {
     // Utility methods only
@@ -100,7 +100,7 @@ public class SubscriptionDtoUtil {
   public static String extractBillingAccountId(Subscription subscription) {
     if (subscription.getExternalReferences() != null
         && subscription.getExternalReferences().containsKey(AWS_MARKETPLACE)) {
-      return subscription.getExternalReferences().get(AWS_MARKETPLACE).getCustomerAccountId();
+      return subscription.getExternalReferences().get(AWS_MARKETPLACE).getCustomerAccountID();
     }
     return null;
   }

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtilTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionDtoUtilTest.java
@@ -76,7 +76,7 @@ class SubscriptionDtoUtilTest {
     extRef.setProductCode("testProduct456");
     extRef.setCustomerID("testCustomer123");
     extRef.setSellerAccount("testSellerAccount789");
-    dto.putExternalReferencesItem("aws", extRef);
+    dto.putExternalReferencesItem(SubscriptionDtoUtil.AWS_MARKETPLACE, extRef);
 
     assertEquals(
         "testProduct456;testCustomer123;testSellerAccount789",
@@ -96,7 +96,7 @@ class SubscriptionDtoUtilTest {
   void testExtractBillingProviderAWSMarketplace() {
     var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
 
-    dto.putExternalReferencesItem("aws", new ExternalReference());
+    dto.putExternalReferencesItem(SubscriptionDtoUtil.AWS_MARKETPLACE, new ExternalReference());
 
     assertEquals(BillingProvider.AWS, SubscriptionDtoUtil.populateBillingProvider(dto));
   }
@@ -106,8 +106,8 @@ class SubscriptionDtoUtilTest {
     var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
 
     ExternalReference extRef = new ExternalReference();
-    extRef.setCustomerAccountId("123456789123");
-    dto.putExternalReferencesItem("aws", extRef);
+    extRef.setCustomerAccountID("123456789123");
+    dto.putExternalReferencesItem(SubscriptionDtoUtil.AWS_MARKETPLACE, extRef);
     assertEquals("123456789123", SubscriptionDtoUtil.extractBillingAccountId(dto));
   }
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -526,7 +526,7 @@ class SubscriptionSyncControllerTest {
         Map.of(
             SubscriptionDtoUtil.AWS_MARKETPLACE,
             new ExternalReference()
-                .customerAccountId("billingAccountId")
+                .customerAccountID("billingAccountId")
                 .productCode("p")
                 .customerID("c")
                 .sellerAccount("s")));


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5120

There were two mistakes:

1. `awsMarketplace` needed instead of `aws`.
2. `customerAccountID` needed instead of `customerAccountId`.

Testing
-------

Deploy the app using non-prod keystore (replace FIXME below)

```
DEV_MODE=true \
  SUBSCRIPTION_URL=https://subscription.stage.api.redhat.com/svcrest/subscription/v5 \
  SUBSCRIPTION_KEYSTORE=$(pwd)/config/certs/keystore.jks \
  SUBSCRIPTION_KEYSTORE_PASSWORD=FIXME \
  ./gradlew :bootRun
```

Then invoke a sync of a test account in stage:

```
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean \
  operation='syncSubscriptionsForOrg(java.lang.String)' \
  arguments:='["6592901"]'
```

Then verify that the records have billing_provider_id, billing_provider, and billing_account_id:

```
psql -h localhost -U rhsm-subscriptions <<EOF
select * from subscription where owner_id='6592901' and start_date > '2022-06-01'
EOF
```

Filter on `start_date` is used to filter out old test data.