### PR TITLE
ENT-5120: Update billing fields if they change

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -194,7 +194,7 @@ public class SubscriptionSyncController {
                 .build();
         subscriptionRepository.save(newSub);
       } else {
-        updateSubscriptionEndDate(newOrUpdated, existingSubscription);
+        updateSubscription(newOrUpdated, existingSubscription);
         subscriptionRepository.save(existingSubscription);
       }
       capacityReconciliationController.reconcileCapacityForSubscription(newOrUpdated);
@@ -388,12 +388,16 @@ public class SubscriptionSyncController {
         .build();
   }
 
-  protected void updateSubscriptionEndDate(
+  /** Update all subscription fields that we allow to change */
+  protected void updateSubscription(
       org.candlepin.subscriptions.db.model.Subscription newOrUpdated,
       org.candlepin.subscriptions.db.model.Subscription entity) {
     if (newOrUpdated.getEndDate() != null) {
       entity.setEndDate(newOrUpdated.getEndDate());
     }
+    entity.setBillingProvider(newOrUpdated.getBillingProvider());
+    entity.setBillingAccountId(newOrUpdated.getBillingAccountId());
+    entity.setBillingProviderId(newOrUpdated.getBillingProviderId());
   }
 
   public void saveSubscriptions(String subscriptionsJson, boolean reconcileCapacity) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5120

Any subscriptions processed before #1143 went in would end up without the proper values for the fields, and weren't updated. With this change, we ensure they always get updated.

Testing
-------

Follow steps in #1143, then null out the billing fields, and then sync again. Note that on develop, they don't get populated, but with this change they do.