### PR TITLE
Add file: prefix to UMB keystore/truststore

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -1496,14 +1496,14 @@ objects:
             - name: SPRING_ACTIVEMQ_BROKER_URL
               value: ${SPRING_ACTIVEMQ_BROKER_URL}
             - name: UMB_KEYSTORE
-              value: /pinhead/keystore.jks
+              value: file:/pinhead/keystore.jks
             - name: UMB_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: tls
                   key: keystore_password
             - name: UMB_TRUSTSTORE
-              value: /pinhead/truststore.jks
+              value: file:/pinhead/truststore.jks
             - name: UMB_TRUSTSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/templates/rhsm-subscriptions-capacity-ingress.yml
+++ b/templates/rhsm-subscriptions-capacity-ingress.yml
@@ -298,14 +298,14 @@ objects:
                 - name: SPRING_ACTIVEMQ_BROKER_URL
                   value: ${SPRING_ACTIVEMQ_BROKER_URL}
                 - name: UMB_KEYSTORE
-                  value: /service-certs/keystore.jks
+                  value: file:/service-certs/keystore.jks
                 - name: UMB_KEYSTORE_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: tls
                       key: keystore_password
                 - name: UMB_TRUSTSTORE
-                  value: /service-certs/truststore.jks
+                  value: file:/service-certs/truststore.jks
                 - name: UMB_TRUSTSTORE_PASSWORD
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Because we're using Spring Resource as the datatype, it treats a path without the file: prefix as relative to the webapp root. Doh!

Testing
---------
Try locally with and without `file:` prefix, and note in logging without the prefix:

```
UMB config requires keystore and truststore - not provided or not valid.
```