### PR TITLE
ENT-5130: Ignore Usage value on PAYG subs for now

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -541,7 +541,9 @@ public class SubscriptionSyncController {
             .accountNumber(accountNumber)
             .productNames(productNames)
             .serviceLevel(usageKey.getSla())
-            .usage(usageKey.getUsage())
+            // NOTE(khowell) due to an oversight PAYG SKUs don't currently have a usage set -
+            // at some point we should use usageKey.getUsage() instead of "_ANY"
+            .usage(Usage._ANY)
             .billingProvider(usageKey.getBillingProvider())
             .billingAccountId(usageKey.getBillingAccountId())
             .payg(true)


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5130

Testing
-------

Deploy locally, using nonprod keystore (replace FIXME below).

```
DEV_MODE=true \
  SUBSCRIPTION_URL=https://subscription.stage.api.redhat.com/svcrest/subscription/v5 \
  USER_HOST=user.stage.api.redhat.com \
  SUBSCRIPTION_KEYSTORE=$(pwd)/config/certs/keystore.jks \
  SUBSCRIPTION_KEYSTORE_PASSWORD=FIXME \
  ./gradlew :bootRun
```

Clear the usage column in offerings:

```
psql -h localhost -U rhsm-subscriptions <<EOF
update offering set usage=null;
EOF
```

Test the getAwsUsage endpoint (replace FIXME with values from the Jira
issue):

```
http :8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext \
  accept:application/json \
  x-rh-swatch-psk:dummy \
  accountNumber==FIXME \
  date==2022-06-21T00:00Z \
  productId==rhosak \
  sla==Premium \
  usage==Production \
  awsAccountId==FIXME
```

Without this change, you'll get 404, with it, you'll an object back.