### PR TITLE
Fix ID parsing for UMB messages

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/umb/Identifiers.java
+++ b/src/main/java/org/candlepin/subscriptions/umb/Identifiers.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.umb;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Identifiers {
+  @JsonProperty("Identifier")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  private Reference[] ids;
+
+  @JsonProperty("Reference")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  private Reference[] references;
+}

--- a/src/main/java/org/candlepin/subscriptions/umb/UmbSubscription.java
+++ b/src/main/java/org/candlepin/subscriptions/umb/UmbSubscription.java
@@ -42,7 +42,7 @@ import lombok.NoArgsConstructor;
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
 public class UmbSubscription {
   private static final ZoneId RALEIGH_TIME_ZONE = ZoneId.of("America/New_York");
-  private Reference[] identifiers;
+  private Identifiers identifiers;
   private SubscriptionStatus status;
   private Integer quantity;
 
@@ -57,10 +57,22 @@ public class UmbSubscription {
   private SubscriptionProduct[] products;
 
   private Optional<String> getReference(String system, String entityName, String qualifier) {
-    if (identifiers == null) {
+    if (identifiers == null || identifiers.getReferences() == null) {
       return Optional.empty();
     }
-    return Arrays.stream(identifiers)
+    return Arrays.stream(identifiers.getReferences())
+        .filter(reference -> system.equals(reference.getSystem()))
+        .filter(reference -> entityName.equals(reference.getEntityName()))
+        .filter(reference -> qualifier.equals(reference.getQualifier()))
+        .map(Reference::getValue)
+        .findFirst();
+  }
+
+  private Optional<String> getIdentifier(String system, String entityName, String qualifier) {
+    if (identifiers == null || identifiers.getIds() == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(identifiers.getIds())
         .filter(reference -> system.equals(reference.getSystem()))
         .filter(reference -> entityName.equals(reference.getEntityName()))
         .filter(reference -> qualifier.equals(reference.getQualifier()))
@@ -69,7 +81,7 @@ public class UmbSubscription {
   }
 
   public String getSubscriptionNumber() {
-    return getReference("SUBSCRIPTION", "Subscription", "number").orElseThrow();
+    return getIdentifier("SUBSCRIPTION", "Subscription", "number").orElseThrow();
   }
 
   public String getWebCustomerId() {

--- a/src/test/java/org/candlepin/subscriptions/umb/SubscriptionMessageTests.java
+++ b/src/test/java/org/candlepin/subscriptions/umb/SubscriptionMessageTests.java
@@ -44,26 +44,32 @@ class SubscriptionMessageTests {
                             .subscription(
                                 UmbSubscription.builder()
                                     .identifiers(
-                                        new Reference[] {
-                                          Reference.builder()
-                                              .system("EBS")
-                                              .entityName("Account")
-                                              .qualifier("number")
-                                              .value("account123")
-                                              .build(),
-                                          Reference.builder()
-                                              .system("WEB")
-                                              .entityName("Customer")
-                                              .qualifier("id")
-                                              .value("org123_ICUST")
-                                              .build(),
-                                          Reference.builder()
-                                              .system("SUBSCRIPTION")
-                                              .entityName("Subscription")
-                                              .qualifier("number")
-                                              .value("1234")
-                                              .build()
-                                        })
+                                        Identifiers.builder()
+                                            .references(
+                                                new Reference[] {
+                                                  Reference.builder()
+                                                      .system("EBS")
+                                                      .entityName("Account")
+                                                      .qualifier("number")
+                                                      .value("account123")
+                                                      .build(),
+                                                  Reference.builder()
+                                                      .system("WEB")
+                                                      .entityName("Customer")
+                                                      .qualifier("id")
+                                                      .value("org123_ICUST")
+                                                      .build(),
+                                                })
+                                            .ids(
+                                                new Reference[] {
+                                                  Reference.builder()
+                                                      .system("SUBSCRIPTION")
+                                                      .entityName("Subscription")
+                                                      .qualifier("number")
+                                                      .value("1234")
+                                                      .build()
+                                                })
+                                            .build())
                                     .status(
                                         SubscriptionStatus.builder()
                                             .startDate(

--- a/src/test/resources/mocked-subscription-message.xml
+++ b/src/test/resources/mocked-subscription-message.xml
@@ -4,9 +4,13 @@
     <Sync>
       <Subscription>
         <Identifiers>
+          <!--NOTE: UMB messages have a lot more fields we don't care about, the following helps to
+          test that we're properly ignoring extra elements
+           -->
+          <DummyElementThatShouldBeIgnored>FooBar</DummyElementThatShouldBeIgnored>
           <Reference system="EBS" entity-name="Account" qualifier="number">account123</Reference>
           <Reference system="WEB" entity-name="Customer" qualifier="id">org123_ICUST</Reference>
-          <Reference system="SUBSCRIPTION" entity-name="Subscription" qualifier="number">1234</Reference>
+          <Identifier system="SUBSCRIPTION" entity-name="Subscription" qualifier="number">1234</Identifier>
         </Identifiers>
         <Status>
           <State>Active</State>


### PR DESCRIPTION
There were a few things wrong with the mocked message:

1. `Identifiers` can have additional elements.
2. `Subscription number` is written in an `Identifier` element.

This updates the mocked message and code appropriately.

Testing
-------

Testing via `mocked-subscription-message.xml`/unit tests.