### PR TITLE
DRAFT: Add billing provider/account to response payload of subscriptions api

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -836,6 +836,8 @@ paths:
                 data:
                   - sku: RH00011
                     product_name: "Red Hat Enterprise Linux Server, Premium (Physical and 4 Virtual Nodes)(L3 Only)"
+                    billing_provider: "some provider goes here"
+                    billing_account_id: "some account id goes here"
                     service_level: Premium
                     usage: Production
                     subscriptions:
@@ -1644,6 +1646,11 @@ components:
       properties:
         sku:
           description: "The identifier for the offering."
+          type: string
+        billing_provider:
+          $ref: '#/components/schemas/BillingProviderType'
+        billing_account_id:
+          description: "The billing account id."
           type: string
         product_name:
           description: "The offering name."

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -293,6 +293,15 @@ public class SubscriptionTableController {
       skuCapacity.setNextEventDate(nearestEventDate);
       skuCapacity.setNextEventType(SubscriptionEventType.END);
     }
+
+    //TODO
+    subscription.getBillingAccountId();
+    subscription.getBillingProvider();
+    subscription.getBillingProviderId();
+
+    skuCapacity.setBillingAccountId(null);
+    skuCapacity.setBillingProvider(null);
+
   }
 
   public void addSubscriptionInformation(

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -294,11 +294,7 @@ public class SubscriptionTableController {
       skuCapacity.setNextEventType(SubscriptionEventType.END);
     }
 
-    //TODO
-    subscription.getBillingAccountId();
-    subscription.getBillingProvider();
-    subscription.getBillingProviderId();
-
+    //Populate as part of ENT-5123
     skuCapacity.setBillingAccountId(null);
     skuCapacity.setBillingProvider(null);
 


### PR DESCRIPTION
Part of ENT-5123.  Got this far before the story was moved back to the backlog.  billing_provider and billing_account_id will always return null from this API for now, but at least they're there and exist for the UI that is expecting them.

Need to figure out what data to get in here in order to test via curl command


