### PR TITLE
Only set remittance date when remittance has changed

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -138,12 +138,7 @@ public class BillableUsageController {
 
     // The orgId might not have been available when remittance
     // was originally created, so we attempt to set here.
-    if (updateRemittance(
-        remittance,
-        usage.getOrgId(),
-        usageCalc.getRemittedValue(),
-        usageCalc.getRemittanceDate())) {
-      // Only send the update if we need to.
+    if (updateRemittance(remittance, usage.getOrgId(), usageCalc)) {
       log.debug("Updating remittance: {}", remittance);
       billableUsageRemittanceRepository.save(remittance);
     }
@@ -158,22 +153,20 @@ public class BillableUsageController {
   }
 
   private boolean updateRemittance(
-      BillableUsageRemittanceEntity remittance,
-      String orgId,
-      Double remittedValue,
-      OffsetDateTime remittedDate) {
+      BillableUsageRemittanceEntity remittance, String orgId, BillableUsageCalculation usageCalc) {
     boolean updated = false;
-    if (!Objects.equals(remittance.getRemittanceDate(), remittedDate)) {
-      remittance.setRemittanceDate(remittedDate);
-      updated = true;
-    }
     if (!Objects.equals(remittance.getOrgId(), orgId) && StringUtils.hasText(orgId)) {
       remittance.setOrgId(orgId);
       updated = true;
     }
-    if (!Objects.equals(remittance.getRemittedValue(), remittedValue)) {
-      remittance.setRemittedValue(remittedValue);
+    if (!Objects.equals(remittance.getRemittedValue(), usageCalc.getRemittedValue())) {
+      remittance.setRemittedValue(usageCalc.getRemittedValue());
       updated = true;
+    }
+
+    // Only update the date if the remittance was updated.
+    if (updated) {
+      remittance.setRemittanceDate(usageCalc.getRemittanceDate());
     }
     return updated;
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -93,7 +93,8 @@ class BillableUsageControllerTest {
   @Test
   void monthlyWindowWithRemittanceUpdate() {
     BillableUsage usage = billable(clock.startOfCurrentMonth(), 2.3);
-    BillableUsageRemittanceEntity currentRemittance = remittance(usage, clock.now(), 3.0);
+    BillableUsageRemittanceEntity currentRemittance =
+        remittance(usage, clock.now().minusHours(1), 3.0);
     when(remittanceRepo.findById(keyFrom(usage))).thenReturn(Optional.of(currentRemittance));
     mockCurrentSnapshotMeasurementTotal(usage, 4.4); // from multiple snapshots (2.1, 2.3)
     controller.submitBillableUsage(BillingWindow.MONTHLY, usage);


### PR DESCRIPTION
No need to always update the date becuase often times that is
the only thing that would be updated. This causes a version
update which increases the likelyhood of an OptimisticLockException.

## Testing
1. Import event
```
insert into events (id, account_number, "timestamp", data, event_type, event_source, instance_id) values ('6d5bb984-7c20-460a-bbb2-962e358e405d', 'account123', '2022-06-03 13:00:00+00', '{"sla": "Premium", "role": "rhosak", "event_id": "6d5bb984-7c20-460a-bbb2-962e358e405d", "timestamp": "2022-06-03T13:00:00Z", "event_type": "snapshot_redhat.com:rhosak:cluster_hour", "expiration": "2022-06-03T14:00:00Z", "instance_id": "44107058-48de-4ea2-a393-390a663b7c11", "display_name": "automation_rhosak_cluster_44107058-48de-4ea2-a393-390a663b7c11", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 9.31}], "service_type": "Kafka Cluster", "account_number": "account123", "billing_provider": "red hat"}', 'snapshot_redhat.com:rhosak:cluster_hour', 'prometheus', '44107058-48de-4ea2-a393-390a663b7c11');
```

2. Deploy the **develop** branch.
```
SPRING_PROFILES_ACTIVE="worker,api,kafka-queue" DEV_MODE=true ./gradlew clean :bootRun
```

3. Ensure that account 6389164 has been opted in.
```
curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["account123", "org123", true, true, true]}'
```

4. Run hourly tally.
```
curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)","arguments":["2022-06-01T00:00Z", "2022-07-01T00:00Z"]}'
```

5. Check remittance:
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance;"
 account_number | org_id | product_id |   metric_id    | accumulation_period |   sla   |   usage    | billing_provider | billing_account_id | remitted_value |        remittance_date        | version 
----------------+--------+------------+----------------+---------------------+---------+------------+------------------+--------------------+----------------+-------------------------------+---------
 account123     |        | rhosak     | Instance-hours | 2022-06             | Premium | Production | red hat          |                    |             10 | 2022-06-23 18:16:54.470818+00 |       0
(1 row)

```

6. Run the tally again.

7. Note the version number of the remittance entry has **has** incremented.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance;"
 account_number | org_id | product_id |   metric_id    | accumulation_period |   sla   |   usage    | billing_provider | billing_account_id | remitted_value |        remittance_date        | version 
----------------+--------+------------+----------------+---------------------+---------+------------+------------------+--------------------+----------------+-------------------------------+---------
 account123     |        | rhosak     | Instance-hours | 2022-06             | Premium | Production | red hat          |                    |             10 | 2022-06-23 18:20:34.204261+00 |       1
(1 row)

```

8. Check out the branch for this PR and deploy.
9. Run the tally again.
10. Check the remittance table again. Note that the version has not incremented.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance;"
 account_number | org_id | product_id |   metric_id    | accumulation_period |   sla   |   usage    | billing_provider | billing_account_id | remitted_value |        remittance_date        | version 
----------------+--------+------------+----------------+---------------------+---------+------------+------------------+--------------------+----------------+-------------------------------+---------
 account123     |        | rhosak     | Instance-hours | 2022-06             | Premium | Production | red hat          |                    |             10 | 2022-06-23 18:20:34.204261+00 |       1
(1 row)
```