### PR TITLE
ENT-4931: Log when subscription recently terminated for awsContextLookup API

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -49,6 +49,10 @@ public enum ErrorCode {
   /** The client's request was denied because opt-in has not yet occurred. */
   OPT_IN_REQUIRED(1004, "Request was denied since opt-in has not yet occurred."),
 
+  /** No active subscriptions were found but a subscription was recently termindated. */
+  SUBSCRIPTION_RECENTLY_TERMINATED(
+      1005, "Subscription recently terminated. No active subscriptions."),
+
   /** An unexpected exception was thrown by the inventory service client. */
   INVENTORY_SERVICE_ERROR(2000, "Inventory Service Error"),
 

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/exception/DefaultApiException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/exception/DefaultApiException.java
@@ -20,29 +20,20 @@
  */
 package com.redhat.swatch.exception;
 
-import lombok.Getter;
+import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
+import com.redhat.swatch.openapi.model.Errors;
+import javax.ws.rs.core.Response;
 
-public enum ErrorCode {
-  AWS_UNPROCESSED_RECORDS_ERROR(1000, "Some AWS UsageRecords were not processed"),
-  AWS_DIMENSION_NOT_CONFIGURED(1001, "Aws Dimension not configured"),
-  AWS_REQUEST_ERROR(1002, "AWS request failed"),
-  AWS_MISSING_CREDENTIALS_ERROR(1003, "AWS credentials missing"),
-  AWS_USAGE_CONTEXT_LOOKUP_ERROR(1004, "Error looking up AWS usage context"),
-  AWS_MANUAL_SUBMISSION_DISABLED(1005, "Manual submission disabled."),
-  SUBSCRIPTION_RECENTLY_TERMINATED(1006, "Subscription recently terminated");
+public class DefaultApiException extends ApiException {
 
-  private static final String CODE_PREFIX = "SWATCHAWS";
+  private final transient Errors errors;
 
-  @Getter private final String code;
-  @Getter private final String description;
-
-  ErrorCode(int intCode, String description) {
-    this.code = CODE_PREFIX + intCode;
-    this.description = description;
+  public DefaultApiException(Response response, Errors errors) {
+    super(response);
+    this.errors = errors;
   }
 
-  @Override
-  public String toString() {
-    return String.format("%s: %s", code, description);
+  public Errors getErrors() {
+    return this.errors;
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/exception/SubscriptionRecentlyTerminatedException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/exception/SubscriptionRecentlyTerminatedException.java
@@ -20,29 +20,9 @@
  */
 package com.redhat.swatch.exception;
 
-import lombok.Getter;
+public class SubscriptionRecentlyTerminatedException extends AwsProducerException {
 
-public enum ErrorCode {
-  AWS_UNPROCESSED_RECORDS_ERROR(1000, "Some AWS UsageRecords were not processed"),
-  AWS_DIMENSION_NOT_CONFIGURED(1001, "Aws Dimension not configured"),
-  AWS_REQUEST_ERROR(1002, "AWS request failed"),
-  AWS_MISSING_CREDENTIALS_ERROR(1003, "AWS credentials missing"),
-  AWS_USAGE_CONTEXT_LOOKUP_ERROR(1004, "Error looking up AWS usage context"),
-  AWS_MANUAL_SUBMISSION_DISABLED(1005, "Manual submission disabled."),
-  SUBSCRIPTION_RECENTLY_TERMINATED(1006, "Subscription recently terminated");
-
-  private static final String CODE_PREFIX = "SWATCHAWS";
-
-  @Getter private final String code;
-  @Getter private final String description;
-
-  ErrorCode(int intCode, String description) {
-    this.code = CODE_PREFIX + intCode;
-    this.description = description;
-  }
-
-  @Override
-  public String toString() {
-    return String.format("%s: %s", code, description);
+  public SubscriptionRecentlyTerminatedException(Exception e) {
+    super(ErrorCode.SUBSCRIPTION_RECENTLY_TERMINATED, e);
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/resource/DefaultApiExceptionMapper.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/resource/DefaultApiExceptionMapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.resource;
+
+import com.redhat.swatch.exception.DefaultApiException;
+import com.redhat.swatch.openapi.model.Errors;
+import javax.annotation.Priority;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+@Provider
+@Slf4j
+@Priority(-1)
+public class DefaultApiExceptionMapper implements ResponseExceptionMapper<DefaultApiException> {
+
+  @Override
+  public boolean handles(int status, MultivaluedMap<String, Object> headers) {
+    return status >= 400;
+  }
+
+  @Override
+  public DefaultApiException toThrowable(Response response) {
+    return new DefaultApiException(response, parseErrors(response));
+  }
+
+  private Errors parseErrors(Response response) {
+    try {
+      return response.readEntity(Errors.class);
+    } catch (Exception e) {
+      log.debug("Failed to create Errors from response.", e);
+      return null;
+    }
+  }
+}

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -73,7 +73,7 @@ mp.messaging.outgoing.tally-out.connector=smallrye-kafka
 mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.billable-usage
 
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.rest.SwatchPskHeaderFilter
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.rest.SwatchPskHeaderFilter, com.redhat.swatch.resource.DefaultApiExceptionMapper
 com.redhat.swatch.processors.BillableUsageProcessor/lookupAwsUsageContext/Retry/maxRetries=${AWS_USAGE_CONTEXT_LOOKUP_RETRIES}
 com.redhat.swatch.processors.BillableUsageProcessor/send/Retry/maxRetries=${AWS_SEND_RETRIES}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4931
Test Steps:

- Start capacity-ingress on Server port 8101: `DEV_MODE=true SERVER_PORT=8101 ./gradlew :bootRun`
- Start swatch-producer-aws: `./gradlew  quarkusDev`
- Put following billing_usage json onto topic platform.rhsm-subscriptions.billable-usage: `{"account_number":"123","org_id":"123","id":null,"billing_provider":"aws","billing_account_id":"1234567891234","snapshot_date":"2031-01-01T01:10:28Z","product_id":"rhosak","sla":"Premium","usage":null,"uom":"Storage-gibibyte-months","value":42.0}`
- Check swatch-producer-aws logs for 'Subscription recently terminated for account={} tallySnapshotId={}'
