### PR TITLE
ENT-5098 Support remittance syncing and update metrics to HOURLY billing window

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.json.TallyMeasurement;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TallySummaryMapper {
+
+  public TallySummary mapSnapshots(String account, List<TallySnapshot> snapshots) {
+    return createTallySummary(account, snapshots);
+  }
+
+  private TallySummary createTallySummary(
+      String accountNumber, List<TallySnapshot> tallySnapshots) {
+    var mappedSnapshots =
+        tallySnapshots.stream().map(this::mapTallySnapshot).collect(Collectors.toList());
+    return new TallySummary().withAccountNumber(accountNumber).withTallySnapshots(mappedSnapshots);
+  }
+
+  private org.candlepin.subscriptions.json.TallySnapshot mapTallySnapshot(
+      TallySnapshot tallySnapshot) {
+
+    var granularity =
+        org.candlepin.subscriptions.json.TallySnapshot.Granularity.fromValue(
+            tallySnapshot.getGranularity().getValue());
+
+    var sla =
+        org.candlepin.subscriptions.json.TallySnapshot.Sla.fromValue(
+            tallySnapshot.getServiceLevel().getValue());
+
+    var usage =
+        org.candlepin.subscriptions.json.TallySnapshot.Usage.fromValue(
+            tallySnapshot.getUsage().getValue());
+
+    var billingProvider =
+        org.candlepin.subscriptions.json.TallySnapshot.BillingProvider.fromValue(
+            tallySnapshot.getBillingProvider().getValue());
+
+    return new org.candlepin.subscriptions.json.TallySnapshot()
+        .withGranularity(granularity)
+        .withId(tallySnapshot.getId())
+        .withProductId(tallySnapshot.getProductId())
+        .withSnapshotDate(tallySnapshot.getSnapshotDate())
+        .withSla(sla)
+        .withUsage(usage)
+        .withBillingProvider(billingProvider)
+        .withBillingAccountId(tallySnapshot.getBillingAccountId())
+        .withTallyMeasurements(mapMeasurements(tallySnapshot.getTallyMeasurements()));
+  }
+
+  private List<TallyMeasurement> mapMeasurements(
+      Map<TallyMeasurementKey, Double> tallyMeasurements) {
+    return tallyMeasurements.entrySet().stream()
+        .map(
+            entry ->
+                new TallyMeasurement()
+                    .withHardwareMeasurementType(entry.getKey().getMeasurementType().toString())
+                    .withUom(TallyMeasurement.Uom.fromValue(entry.getKey().getUom().value()))
+                    .withValue(entry.getValue()))
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -25,6 +25,7 @@ import org.candlepin.subscriptions.tally.admin.api.InternalApi;
 import org.candlepin.subscriptions.tally.admin.api.model.TallyResend;
 import org.candlepin.subscriptions.tally.admin.api.model.TallyResendData;
 import org.candlepin.subscriptions.tally.admin.api.model.UuidList;
+import org.candlepin.subscriptions.tally.billing.RemittanceController;
 import org.springframework.stereotype.Component;
 
 /** This resource is for exposing administrator REST endpoints for Tally. */
@@ -32,14 +33,23 @@ import org.springframework.stereotype.Component;
 public class InternalTallyResource implements InternalApi {
 
   private final MarketplaceResendTallyController resendTallyController;
+  private final RemittanceController remittanceController;
 
-  public InternalTallyResource(MarketplaceResendTallyController resendTallyController) {
+  public InternalTallyResource(
+      MarketplaceResendTallyController resendTallyController,
+      RemittanceController remittanceController) {
     this.resendTallyController = resendTallyController;
+    this.remittanceController = remittanceController;
   }
 
   @Override
   public TallyResend resendTally(UuidList uuidList) {
     var tallies = resendTallyController.resendTallySnapshots(uuidList.getUuids());
     return new TallyResend().data(new TallyResendData().talliesResent(tallies));
+  }
+
+  @Override
+  public void syncRemittance() {
+    remittanceController.syncRemittance();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceController.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.registry.BillingWindow;
+import org.candlepin.subscriptions.registry.TagMetric;
+import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.tally.TallySummaryMapper;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+public class RemittanceController {
+
+  private ApplicationClock clock;
+  private final TagProfile tagProfile;
+  private final BillableUsageRemittanceRepository remittanceRepository;
+  private final TallySnapshotRepository snapshotRepository;
+  private final TallySummaryMapper summaryMapper;
+  private final BillableUsageMapper billableUsageMapper;
+  private final BillableUsageController billableUsageController;
+
+  public RemittanceController(
+      ApplicationClock clock,
+      TagProfile tagProfile,
+      BillableUsageRemittanceRepository remittanceRepository,
+      TallySnapshotRepository snapshotRepository,
+      TallySummaryMapper summaryMapper,
+      BillableUsageMapper billableUsageMapper,
+      BillableUsageController billableUsageController) {
+    this.clock = clock;
+    this.tagProfile = tagProfile;
+    this.remittanceRepository = remittanceRepository;
+    this.snapshotRepository = snapshotRepository;
+    this.summaryMapper = summaryMapper;
+    this.billableUsageMapper = billableUsageMapper;
+    this.billableUsageController = billableUsageController;
+  }
+
+  @Transactional
+  public void syncRemittance() {
+    log.info("Syncing remittance!");
+
+    snapshotRepository
+        .findLatestBillablesForMonth(clock.now().getMonthValue())
+        .map(s -> summaryMapper.mapSnapshots(s.getAccountNumber(), List.of(s)))
+        .forEach(
+            summary ->
+                billableUsageMapper
+                    .fromTallySummary(summary)
+                    .filter(
+                        billable -> {
+                          Optional<TagMetric> metricOptional =
+                              tagProfile.getTagMetric(
+                                  billable.getProductId(),
+                                  Uom.fromValue(billable.getUom().value()));
+                          return metricOptional.isPresent()
+                              && BillingWindow.MONTHLY.equals(
+                                  metricOptional.get().getBillingWindow());
+                        })
+                    .forEach(
+                        billable -> {
+                          if (remittanceExists(billable)) {
+                            log.debug(
+                                "Remittance already exists! Will not align remittance! {}",
+                                billable);
+                          } else {
+                            log.info("Creating new remittance! {}", billable);
+                            billableUsageController.processBillableUsage(
+                                BillingWindow.MONTHLY, billable);
+                          }
+                        }));
+  }
+
+  private boolean remittanceExists(BillableUsage billableUsage) {
+    return remittanceRepository.existsById(BillableUsageRemittanceEntityPK.keyFrom(billableUsage));
+  }
+}

--- a/src/main/spec/internal-tally-api-spec.yaml
+++ b/src/main/spec/internal-tally-api-spec.yaml
@@ -26,6 +26,20 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalTally
+  /internal/tally/sync-remittance:
+    description: 'Operations to sync remittance with existing tally snapshots.'
+    post:
+      operationId: syncRemittance
+      summary: "Sync remittance with existing tally snapshots for all metrics configured with MONTHLY billing window."
+      responses:
+        '200':
+          description: "The request for syncing remittance was successful."
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
   /internal-tally-openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
   /internal-tally-openapi.yaml:

--- a/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
@@ -113,7 +113,7 @@ class TagProfileFactoryTest {
   @Test
   void billingFrequencyIsSet() {
     Optional<TagMetric> metric =
-        tagProfile.getTagMetric(ProductId.OPENSHIFT_METRICS.toString(), Measurement.Uom.CORES);
+        tagProfile.getTagMetric(ProductId.RHOSAK.toString(), Measurement.Uom.STORAGE_GIBIBYTES);
     assertEquals(BillingWindow.HOURLY, metric.get().getBillingWindow());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -72,7 +72,8 @@ class SnapshotSummaryProducerTest {
     props = new TaskQueueProperties();
     props.setTopic("summary-topic");
     RetryTemplate retryTemplate = new RetryTemplate();
-    this.producer = new SnapshotSummaryProducer(kafka, retryTemplate, props);
+    this.producer =
+        new SnapshotSummaryProducer(kafka, retryTemplate, props, new TallySummaryMapper());
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.registry.BillingWindow;
+import org.candlepin.subscriptions.registry.TagMapping;
+import org.candlepin.subscriptions.registry.TagMetaData;
+import org.candlepin.subscriptions.registry.TagMetric;
+import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.tally.TallySummaryMapper;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class RemittanceControllerTest {
+
+  @Mock private BillableUsageRemittanceRepository remittanceRepo;
+  @Mock private TallySnapshotRepository snapshotRepo;
+  @Mock private KafkaTemplate<String, BillableUsage> billableTemplate;
+
+  private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+
+  private TagProfile tagProfile;
+
+  private RemittanceController controller;
+
+  @BeforeEach
+  public void setup() {
+    tagProfile = initTagProfile();
+    BillingProducer billingProducer =
+        new BillingProducer(new TaskQueueProperties(), billableTemplate);
+    BillableUsageController usageController =
+        new BillableUsageController(clock, billingProducer, remittanceRepo, snapshotRepo);
+    controller =
+        new RemittanceController(
+            clock,
+            tagProfile,
+            remittanceRepo,
+            snapshotRepo,
+            new TallySummaryMapper(),
+            new BillableUsageMapper(tagProfile),
+            usageController);
+  }
+
+  @Test
+  void syncRemittance() {
+    List<TallySnapshot> snaps = new ArrayList<>();
+    TallySnapshot expectedSnapshot1 =
+        buildSnapshot(
+            "account123",
+            "rhosak",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            15.25,
+            clock.startOfCurrentHour());
+    snaps.add(expectedSnapshot1);
+
+    TallySnapshot expectedSnapshot2 =
+        buildSnapshot(
+            "account345",
+            "rhosak",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            15.5,
+            clock.startOfCurrentHour());
+    snaps.add(expectedSnapshot2);
+    when(snapshotRepo.findLatestBillablesForMonth(clock.now().getMonthValue()))
+        .thenReturn(snaps.stream());
+
+    BillableUsageRemittanceEntity expectedRemittance1 =
+        createRemittanceAndMockMeasurementValue(expectedSnapshot1, 46.0);
+    BillableUsageRemittanceEntity expectedRemittance2 =
+        createRemittanceAndMockMeasurementValue(expectedSnapshot2, 16.0);
+
+    ArgumentCaptor<BillableUsageRemittanceEntity> savedRemittance =
+        ArgumentCaptor.forClass(BillableUsageRemittanceEntity.class);
+
+    controller.syncRemittance();
+    verify(remittanceRepo, times(2)).save(savedRemittance.capture());
+    assertEquals(2, savedRemittance.getAllValues().size());
+    assertTrue(
+        savedRemittance
+            .getAllValues()
+            .containsAll(List.of(expectedRemittance1, expectedRemittance2)));
+  }
+
+  @Test
+  void syncRemittanceSkipsSnapshotWhenBillingWindowIsNotMonthly() {
+    List<TallySnapshot> snaps = new ArrayList<>();
+    TallySnapshot snapshot =
+        buildSnapshot(
+            "account123",
+            "my-product",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            15.25,
+            clock.startOfCurrentHour());
+    snaps.add(snapshot);
+
+    when(snapshotRepo.findLatestBillablesForMonth(clock.now().getMonthValue()))
+        .thenReturn(snaps.stream());
+
+    controller.syncRemittance();
+    verifyNoInteractions(remittanceRepo);
+  }
+
+  @Test
+  void syncRemittanceSkipsSnapshotWhenRemittanceExists() {
+    List<TallySnapshot> snaps = new ArrayList<>();
+    TallySnapshot snapshot =
+        buildSnapshot(
+            "account123",
+            "rhosak",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            15.25,
+            clock.startOfCurrentHour());
+    snaps.add(snapshot);
+
+    when(snapshotRepo.findLatestBillablesForMonth(clock.now().getMonthValue()))
+        .thenReturn(snaps.stream());
+
+    BillableUsageRemittanceEntity remittance = createRemittance(snapshot, 46.0);
+    when(remittanceRepo.existsById(remittance.getKey())).thenReturn(true);
+
+    controller.syncRemittance();
+    // Should not save remittance.
+    verifyNoMoreInteractions(remittanceRepo);
+  }
+
+  private BillableUsageRemittanceEntity createRemittance(
+      TallySnapshot snapshot, double remittedValue) {
+    return BillableUsageRemittanceEntity.builder()
+        .key(
+            BillableUsageRemittanceEntityPK.builder()
+                .accountNumber(snapshot.getAccountNumber())
+                .accumulationPeriod(
+                    BillableUsageRemittanceEntityPK.getAccumulationPeriod(
+                        snapshot.getSnapshotDate()))
+                .billingAccountId(snapshot.getBillingAccountId())
+                .billingProvider(snapshot.getBillingProvider().getValue())
+                .metricId(Uom.STORAGE_GIBIBYTE_MONTHS.value())
+                .productId(snapshot.getProductId())
+                .sla(snapshot.getServiceLevel().getValue())
+                .usage(snapshot.getUsage().getValue())
+                .build())
+        .orgId(snapshot.getOwnerId())
+        // NOTE: We are mocking the repository's sum call, so this value doesn't have to match the
+        // snapshot.
+        .remittedValue(remittedValue)
+        .remittanceDate(clock.now())
+        .build();
+  }
+
+  private BillableUsageRemittanceEntity createRemittanceAndMockMeasurementValue(
+      TallySnapshot snapshot, double remittedValue) {
+    BillableUsageRemittanceEntity remittance = createRemittance(snapshot, remittedValue);
+
+    when(snapshotRepo.sumMeasurementValueForPeriod(
+            snapshot.getAccountNumber(),
+            snapshot.getProductId(),
+            snapshot.getGranularity(),
+            snapshot.getServiceLevel(),
+            snapshot.getUsage(),
+            snapshot.getBillingProvider(),
+            snapshot.getBillingAccountId(),
+            clock.startOfMonth(snapshot.getSnapshotDate()),
+            snapshot.getSnapshotDate(),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(remittance.getRemittedValue());
+
+    return remittance;
+  }
+
+  private TallySnapshot buildSnapshot(
+      String account,
+      String productId,
+      Granularity granularity,
+      ServiceLevel sla,
+      Usage usage,
+      BillingProvider billingProvider,
+      Uom uom,
+      double val,
+      OffsetDateTime snapshotDate) {
+    Map<TallyMeasurementKey, Double> measurements = new HashMap<>();
+    measurements.put(new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, uom), val);
+    measurements.put(new TallyMeasurementKey(HardwareMeasurementType.TOTAL, uom), val);
+    return TallySnapshot.builder()
+        .accountNumber(account)
+        .productId(productId)
+        .snapshotDate(snapshotDate)
+        .tallyMeasurements(measurements)
+        .granularity(granularity)
+        .serviceLevel(sla)
+        .usage(usage)
+        .billingProvider(billingProvider)
+        .billingAccountId("billing-account")
+        .build();
+  }
+
+  private TagProfile initTagProfile() {
+    List<TagMetric> tagMetrics = new LinkedList<>();
+    tagMetrics.add(
+        TagMetric.builder()
+            .tag("rhosak")
+            .uom(Uom.STORAGE_GIBIBYTE_MONTHS)
+            .metricId("redhat.com:rhosak:storage_gib_months")
+            .billingWindow(BillingWindow.MONTHLY)
+            .build());
+    tagMetrics.add(
+        TagMetric.builder()
+            .tag("my-product")
+            .uom(Uom.STORAGE_GIBIBYTE_MONTHS)
+            .metricId("redhat.com:rhosak:storage_gib_months")
+            .billingWindow(BillingWindow.HOURLY)
+            .build());
+
+    List<TagMetaData> metaData =
+        List.of(
+            TagMetaData.builder().tags(Set.of("rhosak")).billingModel("PAYG").build(),
+            TagMetaData.builder().tags(Set.of("my-product")).billingModel("PAYG").build());
+
+    TagProfile tagProfile =
+        TagProfile.builder()
+            .tagMappings(
+                List.of(
+                    TagMapping.builder()
+                        .tags(Set.of("rhosak"))
+                        .valueType("role")
+                        .value("rhosak")
+                        .build()))
+            .tagMetrics(tagMetrics)
+            .tagMetaData(metaData)
+            .build();
+
+    // Manually invoke @PostConstruct so that the class is properly initialized.
+    tagProfile.initLookups();
+    return tagProfile;
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
@@ -21,12 +21,14 @@
 package org.candlepin.subscriptions.db.model;
 
 import java.io.Serializable;
+import java.time.OffsetDateTime;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.candlepin.subscriptions.json.BillableUsage;
 
 @Data
 @Embeddable
@@ -58,4 +60,21 @@ public class BillableUsageRemittanceEntityPK implements Serializable {
 
   @Column(name = "billing_account_id", nullable = false, length = 255)
   private String billingAccountId;
+
+  public static BillableUsageRemittanceEntityPK keyFrom(BillableUsage billableUsage) {
+    return BillableUsageRemittanceEntityPK.builder()
+        .usage(billableUsage.getUsage().value())
+        .accountNumber(billableUsage.getAccountNumber())
+        .billingProvider(billableUsage.getBillingProvider().value())
+        .billingAccountId(billableUsage.getBillingAccountId())
+        .productId(billableUsage.getProductId())
+        .sla(billableUsage.getSla().value())
+        .metricId(billableUsage.getUom().value())
+        .accumulationPeriod(getAccumulationPeriod(billableUsage.getSnapshotDate()))
+        .build();
+  }
+
+  public static String getAccumulationPeriod(OffsetDateTime reference) {
+    return InstanceMonthlyTotalKey.formatMonthId(reference);
+  }
 }

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -172,7 +172,7 @@ tagMetrics:
     metricId: redhat.com:openshift_container_platform:cpu_hour
     rhmMetricId: redhat.com:openshift_container_platform:cpu_hour
     uom: CORES
-    billingWindow: HOURLY
+    billingWindow: MONTHLY
     queryKey: 5mSamples
     queryParams:
       product: ocp
@@ -184,7 +184,7 @@ tagMetrics:
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     rhmMetricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
-    billingWindow: HOURLY
+    billingWindow: MONTHLY
     queryKey: 5mSamples
     queryParams:
       product: osd
@@ -194,7 +194,7 @@ tagMetrics:
     metricId: redhat.com:openshift_dedicated:cluster_hour
     rhmMetricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
-    billingWindow: HOURLY
+    billingWindow: MONTHLY
     queryKey: 5mSamples
     queryParams:
       product: osd


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5098

**Add endpoint to sync remittance**
The endpoint will fetch all of the latest snapshots for each
metric for an account, filter them based on the configured
billing window and billing validity, and run them through the
remittance process.

If remittance already exists for a metric, a new remittance
value will not be calculated as the metric has already been
billed.

When remittance is synced, the new remittance value is calculated
and no billable usage will be sent as we consider this usage already
billed for.

**Configured metrics to use integer billing (monthly billing window)**

**NOTE:** rhosak - Storage-gibibytes remains as HOURLY billing window due to existing
subscription constraints.


## How To Test

1. Clean out the applicable data so we can start fresh
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "delete from events; delete from tally_snapshots; delete from instance_monthly_totals; delete from instance_measurements; delete from billable_usage_remittance;"
```
2. Load events into the DB. Make sure that it includes Events for the metrics that we are switching over (Reach out for sql script to load events if you need some. I pulled the data from stage and imported it.)

```
psql -U rhsm-subscriptions rhsm-subscriptions < ~/event_data.sql
```

3. Check out the develop branch and deploy the application
```
SPRING_PROFILES_ACTIVE="worker,api,kafka-queue" DEV_MODE=true ./gradlew :bootRun
```
4. Opt in all accounts from the events.
```
for var in 6 6043640 6266656 6305667;  do curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d "{\"type\":\"exec\",\"mbean\":\"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean\",\"operation\":\"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)\",\"arguments\":[\"$var\", \"org"$var"\", true, true, true]}"; done;
```

5. Do an hourly tally for all accounts.
```
curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAllAccountsByHourly(java.lang.String,java.lang.String)","arguments":["2022-06-01T00:00Z", "2022-07-01T00:00Z"]}'
```
6. Capture the remittance table after the hourly tally.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance order by account_number, product_id, metric_id, billing_provider;" > remittance_snap; cat remittance_snap
```
7. Check out the branch for this PR and deploy the application again.

8. Run the sync remittance API.
```
curl -X POST -H "x-rh-swatch-psk: dummy" http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/sync-remittance
```
1. Compare the old remittance with the updated remittance.
	* Old remmitance values should be the same.
	* New remittance values should exist for the metrics we have switched over to integer billing.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance order by account_number, product_id, metric_id, billing_provider;"; cat remittance_snap
```
1. Check the remitted value against the instance_montly_totals. Easiest to do this by account. **NOTE: The remitted values are rounded up**. Spot check a few.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select distinct(uom), sum(value) from hosts h inner join instance_monthly_totals t on h.id = t.instance_id where month='2022-06' and account_number = '6305667' group by uom;"
      uom       |        sum         
----------------+--------------------
 CORES          | 240.46153846153848
 INSTANCE_HOURS |  60.38461538461539
(2 rows)
```

```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select product_id, metric_id, remitted_value from billable_usage_remittance where accumulation_period='2022-06' and account_number = '6305667';"
         product_id          |   metric_id    | remitted_value 
-----------------------------+----------------+----------------
 OpenShift-dedicated-metrics | Cores          |            241
 OpenShift-dedicated-metrics | Instance-hours |             61
(2 rows)

```