### PR TITLE
ENT-5096: Add Internal Billing API to get remittances data.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,9 @@ ext {
 
     sub_sync_api_spec_file = "${internal_spec_dir}/internal-subscriptions-sync-api-spec.yaml"
     sub_sync_config_file = "${internal_spec_dir}/internal-subscriptions-sync-api-config.json"
+
+    billing_api_spec_file = "${internal_spec_dir}/internal-billing-api-spec.yaml"
+    billing_config_file = "${internal_spec_dir}/internal-billing-api-config.json"
 }
 
 tasks.register("buildApiTally", GenerateTask) {
@@ -148,6 +151,18 @@ tasks.register("buildApiSubSync", GenerateTask) {
     ]
 }
 
+tasks.register("buildApiBilling", GenerateTask) {
+    generatorName = "jaxrs-spec"
+    inputSpec = billing_api_spec_file
+    configFile = billing_config_file
+    outputDir = "$buildDir/generated/billing"
+    configOptions = [
+            interfaceOnly: "true",
+            generatePom: "false",
+            dateLibrary: "java8",
+    ]
+}
+
 tasks.register("openApiGenerate") {
     dependsOn(provider {
         tasks.findAll { task -> task.name.startsWith('buildApi') }
@@ -160,6 +175,10 @@ tasks.register("validateApiTally", ValidateTask) {
 
 tasks.register("validateApiSubSync", ValidateTask) {
     inputSpec = sub_sync_api_spec_file
+}
+
+tasks.register("validateApiBilling", ValidateTask) {
+    inputSpec = billing_api_spec_file
 }
 
 tasks.register("apiValidate") {
@@ -180,6 +199,14 @@ tasks.register("generateApiDocsSubSync", GenerateTask) {
     generatorName = "html"
     inputSpec = sub_sync_api_spec_file
     outputDir = "$buildDir/internal-subscription-sync-docs"
+    generateModelTests = false
+    generateApiTests = false
+}
+
+tasks.register("generateApiDocsBilling", GenerateTask) {
+    generatorName = "html"
+    inputSpec = billing_api_spec_file
+    outputDir = "$buildDir/internal-billing-docs"
     generateModelTests = false
     generateApiTests = false
 }
@@ -206,14 +233,26 @@ tasks.register("generateOpenApiJsonSubSync", GenerateTask) {
     ]
 }
 
+tasks.register("generateOpenApiJsonBilling", GenerateTask) {
+    generatorName = "openapi"
+    inputSpec = billing_api_spec_file
+    outputDir = "$buildDir/openapijson"
+    generateModelTests = false
+    generateApiTests = false
+    configOptions = [
+            outputFileName: "internal-billing-openapi.json"
+    ]
+}
+
 processResources {
-    from tasks.generateOpenApiJsonTally, tasks.generateOpenApiJsonSubSync
-    from tally_api_spec_file, sub_sync_api_spec_file
+    from tasks.generateOpenApiJsonTally, tasks.generateOpenApiJsonSubSync, tasks.generateOpenApiJsonBilling
+    from tally_api_spec_file, sub_sync_api_spec_file, billing_api_spec_file
 }
 
 sourceSets.main.java.srcDirs += [
     "${buildDir}/generated/tally/src/gen/java",
-    "${buildDir}/generated/sub-sync/src/gen/java"
+    "${buildDir}/generated/sub-sync/src/gen/java",
+    "${buildDir}/generated/billing/src/gen/java"
 ]
 
 compileJava {

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingController.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing.admin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.billing.admin.api.model.MonthlyRemittance;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class InternalBillingController {
+  private final BillableUsageRemittanceRepository remittanceRepository;
+
+  public InternalBillingController(BillableUsageRemittanceRepository remittanceRepository) {
+    this.remittanceRepository = remittanceRepository;
+  }
+
+  public List<MonthlyRemittance> process(
+      String accountNumber, String productId, String orgId, String metricId) {
+    if (accountNumber == null && orgId == null) {
+      log.debug("Must provide either accountNumber or orgId in query");
+      return Collections.emptyList();
+    }
+    MonthlyRemittance emptyRemittance =
+        new MonthlyRemittance()
+            .accountNumber(accountNumber)
+            .orgId(orgId)
+            .productId(productId)
+            .metricId(metricId)
+            .remittedValue(0.0);
+    var remittances = findUsageRemittance(accountNumber, productId, metricId, orgId);
+    List<MonthlyRemittance> accountRemittanceList = transformUsageToMonthlyRemittance(remittances);
+    if (accountRemittanceList.isEmpty()) {
+      log.debug("This Account Remittance could not be found.");
+      return List.of(emptyRemittance);
+    }
+    log.debug(
+        "Found {} matches for Account Number: {}", accountRemittanceList.size(), accountNumber);
+    return accountRemittanceList;
+  }
+
+  private List<BillableUsageRemittanceEntity> findUsageRemittance(
+      String accountNumber, String productId, String metricId, String orgId) {
+    if (orgId != null) {
+      if (metricId == null) {
+        return remittanceRepository.findAllRemittancesByOrgId(orgId, productId);
+      }
+      return remittanceRepository.findAllByOrgIdAndKey_ProductIdAndKey_MetricId(
+          orgId, productId, metricId);
+    } else if (metricId == null) {
+      return remittanceRepository.findAllRemittancesByAccountNumber(accountNumber, productId);
+    }
+    return remittanceRepository.findAllByKey_AccountNumberAndKey_ProductIdAndKey_MetricId(
+        accountNumber, productId, metricId);
+  }
+
+  private List<MonthlyRemittance> transformUsageToMonthlyRemittance(
+      List<BillableUsageRemittanceEntity> billableUsageRemittanceEntities) {
+    List<MonthlyRemittance> remittances = new ArrayList<>();
+    if (billableUsageRemittanceEntities.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    for (BillableUsageRemittanceEntity entity : billableUsageRemittanceEntities) {
+      MonthlyRemittance accountRemittance =
+          new MonthlyRemittance()
+              .accountNumber(entity.getKey().getAccountNumber())
+              .orgId(entity.getOrgId())
+              .productId(entity.getKey().getProductId())
+              .metricId(entity.getKey().getMetricId())
+              .remittedValue(entity.getRemittedValue())
+              .remittanceDate(entity.getRemittanceDate())
+              .accumulationPeriod(entity.getKey().getAccumulationPeriod());
+      remittances.add(accountRemittance);
+    }
+    log.debug("Found {} remittances for this account", remittances.size());
+    return remittances;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing.admin;
+
+import java.util.List;
+import org.candlepin.subscriptions.billing.admin.api.InternalApi;
+import org.candlepin.subscriptions.billing.admin.api.model.MonthlyRemittance;
+import org.springframework.stereotype.Component;
+
+/** This resource is for exposing administrator REST endpoints for Remittance. */
+@Component
+public class InternalBillingResource implements InternalApi {
+
+  private final InternalBillingController billingController;
+
+  public InternalBillingResource(InternalBillingController billingController) {
+    this.billingController = billingController;
+  }
+
+  @Override
+  public List<MonthlyRemittance> getRemittances(
+      String accountNumber, String productId, String orgId, String metricId) {
+    return billingController.process(accountNumber, productId, orgId, metricId);
+  }
+}

--- a/src/main/spec/internal-billing-api-config.json
+++ b/src/main/spec/internal-billing-api-config.json
@@ -1,0 +1,6 @@
+{
+  "invokerPackage": "org.candlepin.subscriptions.billing.admin",
+  "apiPackage": "org.candlepin.subscriptions.billing.admin.api",
+  "modelPackage": "org.candlepin.subscriptions.billing.admin.api.model",
+  "groupId": "org.candlepin"
+}

--- a/src/main/spec/internal-billing-api-spec.yaml
+++ b/src/main/spec/internal-billing-api-spec.yaml
@@ -1,0 +1,77 @@
+openapi: "3.0.2"
+info:
+  title: "rhsm-subscriptions internal billing API"
+  version: 1.0.0
+
+paths:
+  /internal/remittance/accountRemittances:
+    description: 'Operations to get specific account remittances'
+    parameters:
+      - name: accountNumber
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: productId
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: orgId
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: metricId
+        in: query
+        required: false
+        schema:
+          type: string
+    get:
+      operationId: getRemittances
+      summary: "Get all monthly remittances for an account"
+      responses:
+        '200':
+          description: "Found Account Remittances."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountRemittances"
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags:
+        - internalBilling
+  /internal-billing-openapi.json:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
+  /internal-billing-openapi.yaml:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
+
+components:
+  schemas:
+    AccountRemittances:
+      type: array
+      items:
+        $ref: "#/components/schemas/MonthlyRemittance"
+    MonthlyRemittance:
+      description: Encapsulates all Monthly remittance
+      properties:
+        accountNumber:
+          type: string
+        orgId:
+          type: string
+        productId:
+          type: string
+        metricId:
+          type: string
+        remittedValue:
+          type: number
+          format: double
+        accumulationPeriod:
+          type: string
+        remittanceDate:
+          type: string
+          format: date-time

--- a/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
@@ -20,8 +20,7 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -77,6 +76,21 @@ class BillableUsageRemittanceRepositoryTest {
     Optional<BillableUsageRemittanceEntity> found = repository.findById(remittance2.getKey());
     assertTrue(found.isPresent());
     assertEquals(remittance2, found.get());
+  }
+
+  @Test
+  void findByAccount() {
+    BillableUsageRemittanceEntity remittance1 =
+        remittance("account123", "product1", 12.0, clock.startOfCurrentMonth());
+    BillableUsageRemittanceEntity remittance2 =
+        remittance("account123", "product1", 12.0, clock.endOfCurrentQuarter());
+    var accountMonthlyList = List.of(remittance1, remittance2);
+    repository.saveAllAndFlush(accountMonthlyList);
+    List<BillableUsageRemittanceEntity> found =
+        repository.findAllRemittancesByAccountNumber(
+            remittance1.getKey().getAccountNumber(), "product1");
+    assertFalse(found.isEmpty());
+    assertEquals(accountMonthlyList, found);
   }
 
   private BillableUsageRemittanceEntity remittance(

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingControllerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing.admin;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+@Transactional
+class InternalBillingControllerTest {
+
+  @Autowired BillableUsageRemittanceRepository remittanceRepo;
+
+  private final ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+
+  InternalBillingController controller;
+
+  @BeforeEach
+  void setup() {
+    controller = new InternalBillingController(remittanceRepo);
+
+    BillableUsageRemittanceEntity remittance1 =
+        remittance("111", "product1", 24.0, clock.startOfCurrentMonth());
+    remittance1.setOrgId("orgId");
+    BillableUsageRemittanceEntity remittance2 =
+        remittance("account123", "product1", 12.0, clock.endOfCurrentQuarter());
+    remittance2.setOrgId("orgId");
+    BillableUsageRemittanceEntity remittance3 =
+        remittance("account123", "product1", 12.0, clock.startOfCurrentMonth());
+    remittance3.getKey().setMetricId(BillableUsage.Uom.TRANSFER_GIBIBYTES.value());
+    remittanceRepo.saveAllAndFlush(List.of(remittance1, remittance2, remittance3));
+  }
+
+  @Test
+  void ifAccountNotFoundDisplayEmptyAccountRemittance() {
+    var response = controller.process("", "product1", null, null);
+    assertFalse(response.isEmpty());
+    assertEquals(0.0, response.get(0).getRemittedValue());
+  }
+
+  @Test
+  void testFilterByOrgId() {
+    var response = controller.process("", "product1", "orgId", null);
+    assertFalse(response.isEmpty());
+    assertEquals(24.0, response.get(0).getRemittedValue());
+    assertEquals(BillableUsage.Uom.INSTANCE_HOURS.value(), response.get(0).getMetricId());
+  }
+
+  @Test
+  void testFilterByAccountAndProduct() {
+    var response = controller.process("account123", "product1", null, null);
+    assertFalse(response.isEmpty());
+    assertEquals(2, response.size());
+    assertEquals(24.0, response.get(0).getRemittedValue() + response.get(1).getRemittedValue());
+  }
+
+  @Test
+  void testFilterByAccountAndProductAndMetricId() {
+    var response =
+        controller.process(
+            "account123", "product1", null, BillableUsage.Uom.TRANSFER_GIBIBYTES.value());
+    assertFalse(response.isEmpty());
+    assertEquals(1, response.size());
+    assertEquals(12.0, response.get(0).getRemittedValue());
+    assertEquals(BillableUsage.Uom.TRANSFER_GIBIBYTES.value(), response.get(0).getMetricId());
+  }
+
+  @Test
+  void testFilterByOrgIdAndProductAndMetricId() {
+    var response =
+        controller.process(
+            "account123", "product1", "orgId", BillableUsage.Uom.INSTANCE_HOURS.value());
+    assertFalse(response.isEmpty());
+    assertEquals(2, response.size());
+    assertEquals(36.0, response.get(0).getRemittedValue() + response.get(1).getRemittedValue());
+    assertEquals(BillableUsage.Uom.INSTANCE_HOURS.value(), response.get(0).getMetricId());
+  }
+
+  @Test
+  void testAccountAndOrgIdShouldReturnEmpty() {
+    var response =
+        controller.process(null, "product1", null, BillableUsage.Uom.INSTANCE_HOURS.value());
+    assertTrue(response.isEmpty());
+  }
+
+  private BillableUsageRemittanceEntity remittance(
+      String accountNumber, String productId, Double value, OffsetDateTime remittanceDate) {
+    BillableUsageRemittanceEntityPK key =
+        BillableUsageRemittanceEntityPK.builder()
+            .usage(BillableUsage.Usage.PRODUCTION.value())
+            .accountNumber(accountNumber)
+            .billingProvider(BillableUsage.BillingProvider.AWS.value())
+            .billingAccountId(accountNumber + "_ba")
+            .productId(productId)
+            .sla(BillableUsage.Sla.PREMIUM.value())
+            .metricId(BillableUsage.Uom.INSTANCE_HOURS.value())
+            .accumulationPeriod(InstanceMonthlyTotalKey.formatMonthId(remittanceDate))
+            .build();
+    return BillableUsageRemittanceEntity.builder()
+        .key(key)
+        .remittanceDate(remittanceDate)
+        .remittedValue(value)
+        .build();
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
@@ -20,14 +20,39 @@
  */
 package org.candlepin.subscriptions.db;
 
+import java.util.List;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BillableUsageRemittanceRepository
     extends JpaRepository<BillableUsageRemittanceEntity, BillableUsageRemittanceEntityPK> {
 
   @Query
   void deleteByKeyAccountNumber(String accountNumber);
+
+  @Query
+  List<BillableUsageRemittanceEntity> findAllByOrgIdAndKey_ProductIdAndKey_MetricId( // NOSONAR
+      String orgId, String productId, String metricId);
+
+  @Query
+  List<BillableUsageRemittanceEntity>
+      findAllByKey_AccountNumberAndKey_ProductIdAndKey_MetricId( // NOSONAR
+      String accountNumber, String productId, String metricId);
+
+  @Query(
+      "SELECT b FROM BillableUsageRemittanceEntity b where "
+          + "b.key.accountNumber = :accountNumber and "
+          + "b.key.productId = :productId")
+  List<BillableUsageRemittanceEntity> findAllRemittancesByAccountNumber(
+      @Param("accountNumber") String accountNumber, @Param("productId") String productId);
+
+  @Query(
+      "SELECT b FROM BillableUsageRemittanceEntity b where "
+          + "b.orgId = :orgId and "
+          + "b.key.productId = :productId")
+  List<BillableUsageRemittanceEntity> findAllRemittancesByOrgId(
+      @Param("orgId") String orgId, @Param("productId") String productId);
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5096

Testing Steps:
1. Insert data into local database
```
insert into public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_value, remittance_date, version) values ('account123', null, 'rhosak', 'Instance-Hours', '2022-07', '_ANY', '_ANY', 'redhat', 'dummy', 10, '2022-07-27 13:04:51.977000 +00:00', 1);
insert into public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_value, remittance_date, version) values ('account123', null, 'rhosak', 'Instance-Monthly', '2022-06', '_ANY', '_ANY', 'redhat', 'dummy', 10, '2022-06-27 13:01:26.048000 +00:00', 1);
```
2. Run Application and hit Internal Billing API using curl. :
```
curl --request GET \
  --url 'http://localhost:8000/api/rhsm-subscriptions/v1/internal/remittance/accountRemittances?accountNumber=account123&productId=rhosak' \
  --header 'accept: application/vnd.api+json' \
  --header 'content-type: application/json' \
  --header 'x-rh-swatch-psk: dummy' \
  --data '{}'
```
3. Should return a list of Monthly Remittance. If you want you can get more specific, but make sure you add an `org Id `in the database. The current implementation of the internal billing API `org Id` will take precedent over `accountNumber` in the query of the remittance table.

