### PR TITLE
Add number_of_guests to instance API response

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1519,10 +1519,12 @@ components:
             display_name: guest01.example.com
             subscription_manager_id: adafd9d5-5b00-42fa-a6c9-75801d45cc6d
             last_seen: '2020-01-01T00:00:00Z'
+            number_of_guests: 4
           - inventory_id: 9358e312-1c9f-42f4-8910-dcef6e970852
             display_name: guest02.example.com
             subscription_manager_id: b101a72f-1859-4489-acb8-d6d31c2578c4
             last_seen: '2020-01-01T00:00:00Z'
+            number_of_guests: 1
         links:
           first: string
           last: string
@@ -1567,6 +1569,8 @@ components:
         last_seen:
           format: date-time
           type: string
+        number_of_guests:
+          type: integer
       example:
         id: d6214a0b-b344-4778-831c-d53dcacb2da3
         display_name: rhv.example.com
@@ -1575,6 +1579,7 @@ components:
           - null
           - 1
         last_seen: '2020-01-01T00:00:00Z'
+        number_of_guests: 4
     CandlepinPool:
       description: Subset of Candlepin pool data that rhsm-subscriptions understands.
       properties:

--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -238,14 +238,14 @@ for i in range(args.num_accounts):
     for i in range(args.num_aws):
         generate_host(account_number=account, hardware_type='VIRTUALIZED', measurement_type='AWS',
                       product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
-                      is_hbi=args.is_hbi,
+                      is_hbi=args.is_hbi, num_of_guests=args.num_guests,
                       cloud_provider='AWS', is_marketplace=args.is_marketplace, host_type=args.host_type,
                       billing_provider=args.billing_provider, billing_account_id=args.billing_account_id)
 
     for i in range(args.num_physical):
         generate_host(account_number=account, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
                       product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
-                      is_hbi=args.is_hbi,
+                      is_hbi=args.is_hbi, num_of_guests=args.num_guests,
                       is_marketplace=args.is_marketplace,
                       host_type=args.host_type,
                       billing_provider=args.billing_provider, billing_account_id=args.billing_account_id)

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -199,7 +199,6 @@ public class InstancesResource implements InstancesApi {
     List<Double> measurementList = new ArrayList<>();
     instance.setId(host.getInstanceId());
     instance.setDisplayName(host.getDisplayName());
-
     if (Objects.nonNull(host.getBillingProvider())) {
       instance.setBillingProvider(host.getBillingProvider().asOpenApiEnum());
     }
@@ -212,6 +211,7 @@ public class InstancesResource implements InstancesApi {
     instance.setBillingAccountId(host.getBillingAccountId());
     instance.setMeasurements(measurementList);
     instance.setLastSeen(host.getLastSeen());
+    instance.setNumberOfGuests(host.getNumOfGuests());
 
     return instance;
   }

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -70,6 +70,7 @@ class InstancesResourceTest {
     host.setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     host.setDisplayName("rhv.example.com");
     host.setBillingProvider(expectedBillingProvider);
+    host.setNumOfGuests(3);
     host.setLastSeen(OffsetDateTime.now());
 
     Mockito.when(
@@ -94,6 +95,7 @@ class InstancesResourceTest {
     data.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
     data.setLastSeen(host.getLastSeen());
     data.setMeasurements(expectedMeasurement);
+    data.setNumberOfGuests(host.getNumOfGuests());
 
     var meta = new InstanceMeta();
     meta.setCount(1);


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4580

Test Steps:

- Add mock host data: `./bin/insert-mock-hosts --num-physical 2 --billing-provider 'red hat' --billing-account-id 1232 --num-guests 3`
- Call endpoint: 
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?billing_provider=red%20hat&billing_account_id=1232' \
  -H 'accept: application/json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
- Should see number_of_guests in response