### PR TITLE
ENT-5204: Filter out snapshot message duplicates 

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
@@ -41,6 +41,7 @@ import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.util.DateRange;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -59,6 +60,8 @@ class CombiningRollupSnapshotStrategyTest {
   @MockBean TallySnapshotRepository repo;
 
   @MockBean SnapshotSummaryProducer producer;
+
+  @Captor private ArgumentCaptor<Map<String, List<TallySnapshot>>> producerCaptor;
 
   @Test
   void testConsecutiveHoursAddedTogether() {
@@ -435,6 +438,49 @@ class CombiningRollupSnapshotStrategyTest {
         talliesSaved,
         containsInAnyOrder(
             expectedHourly1, expectedHourly2, expectedHourly3, expectedDaily1, expectedDaily2));
+  }
+
+  @Test
+  void testFinestGranularitySnapshotFilteredByDateRange() {
+    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+            any(), any(), any(), any(), any()))
+        .then(invocation -> Stream.empty());
+    UsageCalculation.Key usageKey =
+        new UsageCalculation.Key(
+            OPEN_SHIFT_HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "_ANY");
+    when(repo.save(any())).then(invocation -> invocation.getArgument(0));
+    AccountUsageCalculation noonUsage = createAccountUsageCalculation(usageKey, 4.0);
+    AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
+    combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
+        "account123",
+        new DateRange(
+            OffsetDateTime.parse("2021-02-25T13:00:00Z"),
+            OffsetDateTime.parse("2021-02-25T14:00:00Z")),
+        tagProfile.getTagsWithPrometheusEnabledLookup(),
+        Map.of(
+            OffsetDateTime.parse("2021-02-25T12:00:00Z"),
+            noonUsage,
+            OffsetDateTime.parse("2021-02-25T13:00:00Z"),
+            afternoonUsage),
+        Granularity.HOURLY,
+        Double::sum);
+
+    TallySnapshot noonSnapshot =
+        createTallySnapshot(Granularity.HOURLY, "2021-02-25T12:00:00Z", 4.0);
+    TallySnapshot afternoonSnapshot =
+        createTallySnapshot(Granularity.HOURLY, "2021-02-25T13:00:00Z", 3.0);
+    TallySnapshot dailySnapshot =
+        createTallySnapshot(Granularity.DAILY, "2021-02-25T00:00:00Z", 7.0);
+
+    verify(producer, times(1)).produceTallySummaryMessages(producerCaptor.capture());
+    List<TallySnapshot> talliesSent = producerCaptor.getAllValues().get(0).get("account123");
+
+    assertEquals(2, talliesSent.size());
+    assertThat(talliesSent, containsInAnyOrder(afternoonSnapshot, dailySnapshot));
   }
 
   private AccountUsageCalculation createAccountUsageCalculation(


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5204
Test Steps:
- Add subscription for account:
```
INSERT INTO public.subscription(
	sku, owner_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id)
	VALUES ('MW01882', '123', '11381020', 1, '2022-06-29 04:00:00+00', '2022-07-29 04:00:00+00', 'testProductCode123;customer123;awsSellerAccountId', '123','11381177','aws', '719247844304');
```
- Create events (I have csv file I can share)
- Start swatch: `DEV_MODE=true SERVER_PORT=8101 SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true ./gradlew :bootRun`
- Start producer-aws: `ENABLE_AWS_DRY_RUN=true ./gradlew quarkusDev`
- Run hawtio endpoint for first hour where accountNumber = 123, startDateTime = 2022-07-01T01:00:00+00:00 and endDateTime= 2022-07-01T02:00:00+00:00: `http://localhost:9000/hawtio/jolokia/exec/org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean/tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)`
- Run hawtio endpoint for second hour where accountNumber = 123, startDateTime = 2022-07-01T02:00:00+00:00 and endDateTime= 2022-07-01T03:00:00+00:00: `http://localhost:9000/hawtio/jolokia/exec/org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean/tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)`
- Only one Dry Run log should be produced in the swatch-aws-producer logs