### PR TITLE
ENT-4384: Create new API for Capacity with metric ID

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -377,6 +377,127 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - tally
+  /capacity/products/{product_id}/{metric_id}:
+    description: 'Operations for capacity report for a given account and product'
+    parameters:
+      - name: product_id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/ProductId'
+        description: "The ID for the product we wish to query"
+      - name: metric_id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/MetricId'
+        description: "The metric ID for the product we wish to query"
+      - name: category
+        in: query
+        schema:
+          $ref: '#/components/schemas/ReportCategory'
+        description: 'The category to fetch graph data for (optional)'
+      - name: offset
+        in: query
+        schema:
+          type: integer
+        description: "The number of items to skip before starting to collect the result set"
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+        description: "The numbers of items to return"
+    get:
+      summary: "Fetch a capacity report for an account and product."
+      operationId: getCapacityReportByMetricId
+      parameters:
+        - name: granularity
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/GranularityType'
+          description: "The level of granularity to return."
+        - name: sla
+          in: query
+          schema:
+            $ref: '#/components/schemas/ServiceLevelType'
+          description: "Include only capacity for the specified service level."
+        - name: usage
+          in: query
+          schema:
+            $ref: '#/components/schemas/UsageType'
+          description: "Include only capacity for the specified usage level."
+        - name: beginning
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the start of the report period. Dates should be provided in ISO 8601
+            format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z"
+        - name: ending
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the end of the report period.  Defaults to the current time. Dates should
+            be provided in UTC."
+      responses:
+        '200':
+          description: 'The request for a capacity report was successful.'
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/CapacityReport"
+              example:
+                data:
+                  - date: '2017-08-04T17:32:05Z'
+                    sockets: 0
+                    physical_sockets: 0
+                    hypervisor_sockets: 0
+                    has_infinite_quantity: false
+                  - date: '2017-08-05T17:31:04Z'
+                    sockets: 0
+                    physical_sockets: 0
+                    hypervisor_sockets: 0
+                    has_infinite_quantity: false
+                  - date: '2017-08-06T17:32:03Z'
+                    sockets: 10
+                    physical_sockets: 5
+                    hypervisor_sockets: 5
+                    has_infinite_quantity: false
+                  - date: '2017-08-07T17:34:02Z'
+                    sockets: null
+                    physical_sockets: null
+                    hypervisor_sockets: null
+                    has_infinite_quantity: true
+                  - date: '2017-08-08T17:32:01Z'
+                    sockets: 10
+                    physical_sockets: 5
+                    hypervisor_sockets: 5
+                    has_infinite_quantity: true
+                links:
+                  first: '/api/rhsm-subscriptions/v1/capacity/RHEL?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
+                  last: '/api/rhsm-subscriptions/v1/capacity/RHEL?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  previous: null
+                  next: '/api/rhsm-subscriptions/v1/capacity/RHEL?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                meta:
+                  count: 10
+                  product: RHEL
+                  granularity: Daily
+                  service_level: Premium
+        '400':
+          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags:
+        - capacity
   /capacity/products/{product_id}:
     description: 'Operations for capacity report for a given account and product'
     parameters:
@@ -398,6 +519,7 @@ paths:
           minimum: 1
         description: "The numbers of items to return"
     get:
+      deprecated: true
       summary: "Fetch a capacity report for an account and product."
       operationId: getCapacityReport
       parameters:

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions.db;
 
+import static org.candlepin.subscriptions.utilization.api.model.MetricId.CORES;
+import static org.candlepin.subscriptions.utilization.api.model.MetricId.SOCKETS;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Instant;
@@ -31,6 +33,7 @@ import java.util.List;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -365,6 +368,542 @@ class SubscriptionCapacityRepositoryTest {
         repository.findByOwnerAndProductId(
             "ownerId", "product", ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
     assertEquals(3, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdShouldFindGivenSubscriptionStartingBeforeRangeAndEndingDuringRange() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.minusDays(1), FAR_FUTURE.minusDays(1));
+
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
+    assertEquals(1, found.size());
+    SubscriptionCapacity capacity = found.get(0);
+    assertEquals("account", capacity.getAccountNumber());
+    assertEquals("product", capacity.getProductId());
+    assertEquals("subscription", capacity.getSubscriptionId());
+    assertEquals(4, capacity.getPhysicalSockets().intValue());
+    assertEquals(20, capacity.getVirtualSockets().intValue());
+    assertEquals(8, capacity.getPhysicalCores().intValue());
+    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals("ownerId", capacity.getOwnerId());
+    assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
+    assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
+    assertFalse(capacity.getHasUnlimitedUsage());
+  }
+
+  @Test
+  void testFindByMetricIdShouldFindGivenSubscriptionStartingBeforeRangeAndEndingAfterRange() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.minusDays(1), FAR_FUTURE.plusDays(1));
+
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
+    assertEquals(1, found.size());
+    SubscriptionCapacity capacity = found.get(0);
+    assertEquals("account", capacity.getAccountNumber());
+    assertEquals("product", capacity.getProductId());
+    assertEquals("subscription", capacity.getSubscriptionId());
+    assertEquals(4, capacity.getPhysicalSockets().intValue());
+    assertEquals(20, capacity.getVirtualSockets().intValue());
+    assertEquals(8, capacity.getPhysicalCores().intValue());
+    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals("ownerId", capacity.getOwnerId());
+    assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
+    assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
+    assertFalse(capacity.getHasUnlimitedUsage());
+  }
+
+  @Test
+  void testFindByMetricIdShouldFindGivenSubscriptionStartingDuringRangeAndEndingDuringRange() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.minusDays(1));
+
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
+    assertEquals(1, found.size());
+    SubscriptionCapacity capacity = found.get(0);
+    assertEquals("account", capacity.getAccountNumber());
+    assertEquals("product", capacity.getProductId());
+    assertEquals("subscription", capacity.getSubscriptionId());
+    assertEquals(4, capacity.getPhysicalSockets().intValue());
+    assertEquals(20, capacity.getVirtualSockets().intValue());
+    assertEquals(8, capacity.getPhysicalCores().intValue());
+    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals("ownerId", capacity.getOwnerId());
+    assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
+    assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
+    assertFalse(capacity.getHasUnlimitedUsage());
+  }
+
+  @Test
+  void testFindByMetricIdShouldFindGivenSubscriptionStartingDuringRangeAndEndingAfterRange() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
+    assertEquals(1, found.size());
+    SubscriptionCapacity capacity = found.get(0);
+    assertEquals("account", capacity.getAccountNumber());
+    assertEquals("product", capacity.getProductId());
+    assertEquals("subscription", capacity.getSubscriptionId());
+    assertEquals(4, capacity.getPhysicalSockets().intValue());
+    assertEquals(20, capacity.getVirtualSockets().intValue());
+    assertEquals(8, capacity.getPhysicalCores().intValue());
+    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals("ownerId", capacity.getOwnerId());
+    assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
+    assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
+    assertFalse(capacity.getHasUnlimitedUsage());
+  }
+
+  @Test
+  void testFindByMetricIdShouldNotFindGivenSubscriptionBeforeWindow() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.minusDays(7), NOWISH.minusDays(1));
+
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
+    assertEquals(0, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdShouldNotFindGivenSubscriptionAfterWindow() {
+    SubscriptionCapacity c = createUnpersisted(FAR_FUTURE.plusDays(1), FAR_FUTURE.plusDays(7));
+
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
+    assertEquals(0, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdAllowsNullAccountNumber() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    c.setAccountNumber(null);
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
+    assertEquals(1, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdShouldFilterOutSlaIfDifferent() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            null,
+            ServiceLevel.STANDARD,
+            Usage._ANY,
+            NOWISH,
+            FAR_FUTURE);
+    assertEquals(0, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdShouldFilterOutUsageIfDifferent() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            null,
+            ServiceLevel._ANY,
+            Usage.DEVELOPMENT_TEST,
+            NOWISH,
+            FAR_FUTURE);
+    assertEquals(0, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdShouldMatchSlaIfSame() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            null,
+            ServiceLevel.PREMIUM,
+            Usage._ANY,
+            NOWISH,
+            FAR_FUTURE);
+
+    assertEquals(1, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdShouldMatchUsageIfSame() {
+    SubscriptionCapacity c = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    repository.save(c);
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            null,
+            ServiceLevel._ANY,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+    assertEquals(1, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdCanQueryBySlaNull() {
+    SubscriptionCapacity premium = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity standard = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    premium.setSubscriptionId("premium");
+    premium.setServiceLevel(ServiceLevel.PREMIUM);
+    standard.setSubscriptionId("standard");
+    standard.setServiceLevel(ServiceLevel.STANDARD);
+    unset.setSubscriptionId("unset");
+    unset.setServiceLevel(ServiceLevel.EMPTY);
+    repository.saveAll(Arrays.asList(premium, standard, unset));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, null, Usage.PRODUCTION, NOWISH, FAR_FUTURE);
+    assertEquals(3, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdCanQueryBySlaUnspecified() {
+    SubscriptionCapacity premium = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity standard = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    premium.setSubscriptionId("premium");
+    premium.setServiceLevel(ServiceLevel.PREMIUM);
+    standard.setSubscriptionId("standard");
+    standard.setServiceLevel(ServiceLevel.STANDARD);
+    unset.setSubscriptionId("unset");
+    unset.setServiceLevel(ServiceLevel.EMPTY);
+    repository.saveAll(Arrays.asList(premium, standard, unset));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            null,
+            ServiceLevel.EMPTY,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+    assertEquals(1, found.size());
+    assertEquals(ServiceLevel.EMPTY, found.get(0).getServiceLevel());
+  }
+
+  @Test
+  void testFindByMetricIdCanQueryBySlaAny() {
+    SubscriptionCapacity premium = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity standard = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    premium.setSubscriptionId("premium");
+    premium.setServiceLevel(ServiceLevel.PREMIUM);
+    standard.setSubscriptionId("standard");
+    standard.setServiceLevel(ServiceLevel.STANDARD);
+    unset.setSubscriptionId("unset");
+    unset.setServiceLevel(ServiceLevel.EMPTY);
+    repository.saveAll(Arrays.asList(premium, standard, unset));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            null,
+            ServiceLevel._ANY,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+    assertEquals(3, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdCanQueryByUsageNull() {
+    SubscriptionCapacity production = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity dr = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    production.setSubscriptionId("production");
+    production.setUsage(Usage.PRODUCTION);
+    dr.setSubscriptionId("dr");
+    dr.setUsage(Usage.DISASTER_RECOVERY);
+    unset.setSubscriptionId("unset");
+    unset.setUsage(Usage.EMPTY);
+    repository.saveAll(Arrays.asList(production, dr, unset));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, null, NOWISH, FAR_FUTURE);
+    assertEquals(3, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdCanQueryByUsageUnspecified() {
+    SubscriptionCapacity production = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity dr = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    production.setSubscriptionId("production");
+    production.setUsage(Usage.PRODUCTION);
+    dr.setSubscriptionId("dr");
+    dr.setUsage(Usage.DISASTER_RECOVERY);
+    unset.setSubscriptionId("unset");
+    unset.setUsage(Usage.EMPTY);
+    repository.saveAll(Arrays.asList(production, dr, unset));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage.EMPTY, NOWISH, FAR_FUTURE);
+    assertEquals(1, found.size());
+    assertEquals(Usage.EMPTY, found.get(0).getUsage());
+  }
+
+  @Test
+  void testFindByMetricIdCanQueryByUsageAny() {
+    SubscriptionCapacity production = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity dr = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity unset = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    production.setSubscriptionId("production");
+    production.setUsage(Usage.PRODUCTION);
+    dr.setSubscriptionId("dr");
+    dr.setUsage(Usage.DISASTER_RECOVERY);
+    unset.setSubscriptionId("unset");
+    unset.setUsage(Usage.EMPTY);
+    repository.saveAll(Arrays.asList(production, dr, unset));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId", "product", CORES, null, ServiceLevel._ANY, Usage._ANY, NOWISH, FAR_FUTURE);
+    assertEquals(3, found.size());
+  }
+
+  @Test
+  void testFindByMetricIdOnlyRetrieveCoresCapacity() {
+    SubscriptionCapacity cores = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity sockets = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    cores.setVirtualSockets(0);
+    cores.setPhysicalSockets(0);
+    cores.setSubscriptionId("cores");
+    sockets.setPhysicalCores(0);
+    sockets.setVirtualCores(0);
+    sockets.setSubscriptionId("sockets");
+    repository.saveAll(Arrays.asList(cores, sockets));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            null,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+    assertEquals(1, found.size());
+    assertEquals(8, found.get(0).getPhysicalCores());
+    assertEquals(40, found.get(0).getVirtualCores());
+  }
+
+  @Test
+  void testFindByMetricIdOnlyRetrieveVirtualCoresCapacity() {
+    SubscriptionCapacity virtualCores =
+        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity physicalCores =
+        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    virtualCores.setVirtualSockets(0);
+    virtualCores.setPhysicalSockets(0);
+    virtualCores.setPhysicalCores(0);
+    virtualCores.setSubscriptionId("virtualCores");
+    physicalCores.setPhysicalSockets(0);
+    physicalCores.setVirtualSockets(0);
+    physicalCores.setVirtualCores(0);
+    physicalCores.setSubscriptionId("physicalCores");
+    repository.saveAll(Arrays.asList(virtualCores, physicalCores));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            ReportCategory.VIRTUAL,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+
+    assertEquals(1, found.size());
+    assertEquals(40, found.get(0).getVirtualCores());
+  }
+
+  @Test
+  void testFindByMetricIdOnlyRetrievePhysicalCoresCapacity() {
+    SubscriptionCapacity virtualCores =
+        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity physicalCores =
+        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    virtualCores.setVirtualSockets(0);
+    virtualCores.setPhysicalSockets(0);
+    virtualCores.setPhysicalCores(0);
+    virtualCores.setSubscriptionId("virtualCores");
+    physicalCores.setPhysicalSockets(0);
+    physicalCores.setVirtualSockets(0);
+    physicalCores.setVirtualCores(0);
+    physicalCores.setSubscriptionId("physicalCores");
+    repository.saveAll(Arrays.asList(virtualCores, physicalCores));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            CORES,
+            ReportCategory.PHYSICAL,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+
+    assertEquals(1, found.size());
+    assertEquals(8, found.get(0).getPhysicalCores());
+  }
+
+  @Test
+  void testFindByMetricIdOnlyRetrieveSocketsCapacity() {
+    SubscriptionCapacity cores = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity sockets = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    cores.setVirtualSockets(0);
+    cores.setPhysicalSockets(0);
+    cores.setSubscriptionId("cores");
+    sockets.setPhysicalCores(0);
+    sockets.setVirtualCores(0);
+    sockets.setSubscriptionId("sockets");
+    repository.saveAll(Arrays.asList(cores, sockets));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            SOCKETS,
+            null,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+    assertEquals(1, found.size());
+    assertEquals(4, found.get(0).getPhysicalSockets());
+    assertEquals(20, found.get(0).getVirtualSockets());
+  }
+
+  @Test
+  void testFindByMetricIdOnlyRetrieveVirtualSocketsCapacity() {
+    SubscriptionCapacity virtualSockets =
+        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity physicalSockets =
+        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    virtualSockets.setVirtualCores(0);
+    virtualSockets.setPhysicalSockets(0);
+    virtualSockets.setPhysicalCores(0);
+    virtualSockets.setSubscriptionId("virtualSockets");
+    physicalSockets.setPhysicalCores(0);
+    physicalSockets.setVirtualSockets(0);
+    physicalSockets.setVirtualCores(0);
+    physicalSockets.setSubscriptionId("physicalSockets");
+    repository.saveAll(Arrays.asList(virtualSockets, physicalSockets));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            SOCKETS,
+            ReportCategory.VIRTUAL,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+
+    assertEquals(1, found.size());
+    assertEquals(20, found.get(0).getVirtualSockets());
+  }
+
+  @Test
+  void testFindByMetricIdOnlyRetrievePhysicalSocketsCapacity() {
+    SubscriptionCapacity virtualSockets =
+        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    SubscriptionCapacity physicalSockets =
+        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    virtualSockets.setVirtualCores(0);
+    virtualSockets.setPhysicalSockets(0);
+    virtualSockets.setPhysicalCores(0);
+    virtualSockets.setSubscriptionId("virtualSockets");
+    physicalSockets.setPhysicalCores(0);
+    physicalSockets.setVirtualSockets(0);
+    physicalSockets.setVirtualCores(0);
+    physicalSockets.setSubscriptionId("physicalSockets");
+    repository.saveAll(Arrays.asList(virtualSockets, physicalSockets));
+    repository.flush();
+
+    List<SubscriptionCapacity> found =
+        repository.findByOwnerAndProductIdAndMetricId(
+            "ownerId",
+            "product",
+            SOCKETS,
+            ReportCategory.PHYSICAL,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            NOWISH,
+            FAR_FUTURE);
+
+    assertEquals(1, found.size());
+    assertEquals(4, found.get(0).getPhysicalSockets());
   }
 
   private SubscriptionCapacity createUnpersisted(OffsetDateTime begin, OffsetDateTime end) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepository.java
@@ -25,6 +25,8 @@ import java.util.List;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacity;
 import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.utilization.api.model.MetricId;
+import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -35,10 +37,23 @@ import org.springframework.transaction.annotation.Transactional;
  * https://docs.spring.io/spring-data/jpa/docs/2.3.0.RELEASE/reference/html/#repositories.custom-implementations
  */
 public interface CustomizedSubscriptionCapacityRepository {
+
   @Transactional
   List<SubscriptionCapacity> findByOwnerAndProductId(
       String ownerId,
       String productId,
+      ServiceLevel serviceLevel,
+      Usage usage,
+      OffsetDateTime reportBegin,
+      OffsetDateTime reportEnd);
+
+  @Transactional
+  @SuppressWarnings("java:S107")
+  List<SubscriptionCapacity> findByOwnerAndProductIdAndMetricId(
+      String ownerId,
+      String productId,
+      MetricId metricId,
+      ReportCategory reportCategory,
       ServiceLevel serviceLevel,
       Usage usage,
       OffsetDateTime reportBegin,


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-4384

Test Steps:

- Insert test data: 
```
INSERT INTO public.subscription_capacity VALUES ('account123', 'RHEL', '7025101', 'org123', 20, NULL, false, '2022-06-12 04:00:00+00', '2023-06-11 04:00:00+00', NULL, NULL, 'RH00004', 'Standard', 'Production');
INSERT INTO public.subscription_capacity VALUES ('account123', 'RHEL', '7028601', 'org123', NULL, 2, false, '2022-06-17 04:00:00+00', '2023-06-16 04:00:00+00', NULL, NULL, 'RH00004', 'Standard', 'Production');
INSERT INTO public.subscription_capacity VALUES ('account123', 'RHEL Server', '7025101', 'org123', 20, NULL, false, '2022-06-12 04:00:00+00', '2023-06-11 04:00:00+00', NULL, NULL, 'RH00004', 'Standard', 'Production');
INSERT INTO public.subscription_capacity VALUES ('account123', 'RHEL for x86', '7025101', 'org123', 0, NULL, false, '2022-06-12 04:00:00+00', '2023-06-11 04:00:00+00', 3, NULL, 'RH00004', 'Standard', 'Production');
INSERT INTO public.subscription_capacity VALUES ('account123', 'RHEL for x86', '7028601', 'org123', 0, NULL, false, '2022-06-17 04:00:00+00', '2023-06-16 04:00:00+00', NULL, 30, 'RH00004', 'Standard', 'Production');
INSERT INTO public.subscription_capacity VALUES ('account123', 'RHEL Server', '7028601', 'org123', 0, NULL, false, '2022-06-17 04:00:00+00', '2023-06-16 04:00:00+00', 2, NULL, 'RH00004', 'Standard', 'Production');
```
- Start app: `DEV_MODE=true \ ./gradlew `
- Test endpoint: `
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/capacity/products/RHEL/Sockets?granularity=Daily&beginning=2022-07-21T17%3A32%3A28Z&ending=2022-07-21T17%3A32%3A28Z&category=virtual' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`
  - Should only get 2 Virtual sockets and no physical in response.