### PR TITLE
ENT-5096: Fix Mismatch position.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
@@ -37,7 +37,7 @@ public class InternalBillingResource implements InternalApi {
 
   @Override
   public List<MonthlyRemittance> getRemittances(
-      String accountNumber, String productId, String orgId, String metricId) {
+      String productId, String accountNumber, String orgId, String metricId) {
     return billingController.process(accountNumber, productId, orgId, metricId);
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENT-5096

This is to resolve a mismatch as the super class generated the parameters in a different order.