### PR TITLE
SWATCH-137 Tolerate missing account number in auth header

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInController.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 /**
  * Responsible for all opt-in functionality logic. Provides a means to tie both account and org
@@ -149,10 +150,16 @@ public class OptInController {
 
   @Transactional
   public OptInConfig getOptInConfig(String accountNumber, String orgId) {
+    Optional<AccountConfig> accountConfig =
+        StringUtils.hasText(accountNumber)
+            ? accountConfigRepository.findById(accountNumber)
+            : Optional.empty();
+    Optional<OrgConfig> orgConfig =
+        StringUtils.hasText(orgId) ? orgConfigRepository.findById(orgId) : Optional.empty();
     return buildDto(
         buildMeta(accountNumber, orgId),
-        buildOptInAccountDTO(accountConfigRepository.findById(accountNumber)),
-        buildOptInOrgDTO(orgConfigRepository.findById(orgId)));
+        buildOptInAccountDTO(accountConfig),
+        buildOptInOrgDTO(orgConfig));
   }
 
   @Transactional

--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProviderTest.java
@@ -64,15 +64,6 @@ class IdentityHeaderAuthenticationProviderTest {
   }
 
   @Test
-  void testMissingAccountNumber() {
-    Authentication auth = token("123", null);
-    AuthenticationException e =
-        assertThrows(AuthenticationException.class, () -> manager.authenticate(auth));
-    assertEquals(
-        "x-rh-identity contains no account number for the principal", e.getCause().getMessage());
-  }
-
-  @Test
   void validPrincipalIsAuthenticated() {
     when(detailsService.loadUserDetails(any()))
         .thenReturn(new User("N/A", "N/A", Collections.emptyList()));

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProvider.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationProvider.java
@@ -153,9 +153,6 @@ public class IdentityHeaderAuthenticationProvider implements AuthenticationProvi
           authentication.getPrincipal(), "No pre-authenticated principal found in request.");
       Assert.hasText(
           principal.getOwnerId(), RH_IDENTITY_HEADER + " contains no owner ID for the principal");
-      Assert.hasText(
-          principal.getAccountNumber(),
-          RH_IDENTITY_HEADER + " contains no account number for the principal");
       Assert.notNull(authentication.getDetails(), RH_IDENTITY_HEADER + "contains no roles");
     } catch (IllegalArgumentException e) {
       throw new PreAuthenticatedCredentialsNotFoundException(


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-137

Removed account check in auth provider and ensured that
an account/org config lookup was not made with null IDs
allowing OptIn check to report the error and not the
repository.


## Testing
Deploy the app from the develop branch
```
DEV_MODE=true ./gradlew clean :bootRun
```

OptIn with an account and org
```
curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["account123", "org123", true, true, true]}'
```

Generate the required rh-auth headers for testing:
```
# Includes account
$ echo -n '{"identity":{"account_number":"account123", "internal":{"org_id":"org123"}}}' | base64 -w 0

eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQ==

# Does not include account
$ echo -n '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w 0

eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19
```

**NOTE: You can check the contents of the identity string if you need to.**
```
$ echo eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19 | base64 -d
{"identity":{"internal":{"org_id":"org123"}}}
```

Test a couple of APIs to see where the auth provider ensures that the account number was provided in the auth header.

```
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/opt-in" | jq

{
  "errors": [
    {
      "status": "401",
      "code": "SUBSCRIPTIONS1001",
      "title": "Could not authenticate the user.",
      "detail": "x-rh-identity is missing required data"
    }
  ]
}
```

```
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-19T00:00:00.000Z&ending=2019-07-19T23:59:59.999Z" | jq

{
  "errors": [
    {
      "status": "401",
      "code": "SUBSCRIPTIONS1001",
      "title": "Could not authenticate the user.",
      "detail": "x-rh-identity is missing required data"
    }
  ]
}
```

Deploy the branch for this PR and re-run the curl commands above and ensure that the auth error is no longer due to the header, and is now do to a failed OptIn check.

```
# OptInResource is now failing due to missing account number.
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/opt-in" | jq

{
  "errors": [
    {
      "status": "400",
      "code": "SUBSCRIPTIONS1001",
      "title": "Must specify an account number."
    }
  ]
}
```

```
# TallyResource is now preventing the request due to the missing account when looking up the OptInAccountConfig.
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-19T00:00:00.000Z&ending=2019-07-19T23:59:59.999Z" | jq

{
  "errors": [
    {
      "status": "403",
      "code": "SUBSCRIPTIONS1004",
      "title": "Access Denied",
      "detail": "Opt-in required."
    }
  ]
}

```

Verify that when the auth header is complete, the requests are still possible.
```
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQ==" "http://localhost:8000/api/rhsm-subscriptions/v1/opt-in" | jq

{
  "meta": {
    "account_number": "account123",
    "org_id": "org123"
  },
  "data": {
    "opt_in_complete": true,
    "account": {
      "account_number": "account123",
      "tally_sync_enabled": true,
      "tally_reporting_enabled": true,
      "opt_in_type": "JMX",
      "created": "2022-07-05T18:34:07.465038Z",
      "last_updated": "2022-07-20T14:02:40.523596Z"
    },
    "org": {
      "org_id": "org123",
      "conduit_sync_enabled": true,
      "opt_in_type": "JMX",
      "created": "2022-07-20T14:02:05.802394Z",
      "last_updated": "2022-07-20T14:02:40.523596Z"
    }
  }
}
```

```
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQ==" "http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T01:59:59.999Z" | jq

{
  "data": [
    {
      "date": "2019-06-19T00:00:00Z",
      "instance_count": 0,
      "cores": 0,
      "core_hours": 0.0,
      "instance_hours": 0.0,
      "sockets": 0,
      "physical_instance_count": 0,
      "physical_cores": 0,
      "physical_sockets": 0,
      "hypervisor_instance_count": 0,
      "hypervisor_cores": 0,
      "hypervisor_sockets": 0,
      "cloud_instance_count": 0,
      "cloud_cores": 0,
      "cloud_sockets": 0,
      "has_data": false,
      "has_cloudigrade_data": false,
      "has_cloudigrade_mismatch": false
    }
  ],
  "meta": {
    "count": 1,
    "total_core_hours": 0.0,
    "total_instance_hours": 0.0,
    "product": "RHEL",
    "granularity": "Daily"
  }
}

```