### PR TITLE
SWATCH-214 Capture org_id from metrics and store on events.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -62,6 +62,7 @@ public class MeteringEventFactory {
   @SuppressWarnings("java:S107")
   public static Event createMetricEvent(
       String accountNumber,
+      String orgId,
       String metricId,
       String instanceId,
       String serviceLevel,
@@ -78,6 +79,7 @@ public class MeteringEventFactory {
     updateMetricEvent(
         event,
         accountNumber,
+        orgId,
         metricId,
         instanceId,
         serviceLevel,
@@ -97,6 +99,7 @@ public class MeteringEventFactory {
   public static void updateMetricEvent(
       Event toUpdate,
       String accountNumber,
+      String orgId,
       String metricId,
       String instanceId,
       String serviceLevel,
@@ -114,6 +117,7 @@ public class MeteringEventFactory {
         .withEventType(getEventType(metricId))
         .withServiceType(serviceType)
         .withAccountNumber(accountNumber)
+        .withOrgId(orgId)
         .withInstanceId(instanceId)
         .withTimestamp(measuredTime)
         .withExpiration(Optional.of(expired))

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -166,6 +166,7 @@ public class PrometheusMeteringController {
               String role = labels.get("product");
               String billingProvider = labels.get("billing_marketplace");
               String billingAccountId = labels.get("billing_marketplace_account");
+              String orgId = labels.get("external_organization");
 
               // For the openshift metrics, we expect our results to be a 'matrix'
               // vector [(instant_time,value), ...] so we only look at the result's getValues()
@@ -184,6 +185,7 @@ public class PrometheusMeteringController {
                     createOrUpdateEvent(
                         existing,
                         account,
+                        orgId,
                         tagMetric.get().getMetricId(),
                         clusterId,
                         sla,
@@ -234,6 +236,7 @@ public class PrometheusMeteringController {
   private Event createOrUpdateEvent(
       Map<EventKey, Event> existing,
       String account,
+      String orgId,
       String metricId,
       String instanceId,
       String sla,
@@ -260,6 +263,7 @@ public class PrometheusMeteringController {
     MeteringEventFactory.updateMetricEvent(
         event,
         account,
+        orgId,
         metricId,
         instanceId,
         sla,

--- a/src/main/resources/liquibase/202207201200-add-org-id-to-event-table.xml
+++ b/src/main/resources/liquibase/202207201200-add-org-id-to-event-table.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202207201200" author="mstead">
+    <comment>Add orgId to events table</comment>
+
+    <addColumn tableName="events">
+      <column name="org_id" type="varchar(32)"/>
+    </addColumn>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -65,5 +65,6 @@
     <include file="liquibase/202205171157-update-billing-account-and-billing-provider-columns-in-snapshot-and-host-tally-bucket-tables.xml"/>
     <include file="liquibase/202205231334-create-billable-usage-tracking-table.xml"/>
     <include file="liquibase/202206021315-add-version-to-billable-usage-tracking-table.xml"/>
+    <include file="liquibase/202207201200-add-org-id-to-event-table.xml"/>
 </databaseChangeLog>
   <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -51,6 +51,7 @@ class EventRecordRepositoryTest {
   void saveAndUpdate() {
     Event event = new Event();
     event.setAccountNumber("account123");
+    event.setOrgId("org123");
     event.setTimestamp(OffsetDateTime.now(CLOCK));
     event.setInstanceId("instanceId");
     event.setServiceType("RHEL System");
@@ -73,9 +74,14 @@ class EventRecordRepositoryTest {
   void testFindBeginInclusive() {
     Event oldEvent =
         event(
-            "account123", "SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK).minusSeconds(1));
+            "account123",
+            "org123",
+            "SOURCE",
+            "TYPE",
+            "INSTANCE",
+            OffsetDateTime.now(CLOCK).minusSeconds(1));
     Event currentEvent =
-        event("account123", "SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK));
+        event("account123", "org123", "SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK));
 
     repository.saveAll(Arrays.asList(new EventRecord(oldEvent), new EventRecord(currentEvent)));
     repository.flush();
@@ -94,12 +100,13 @@ class EventRecordRepositoryTest {
   void testFindEndExclusive() {
     EventRecord futureEvent =
         new EventRecord(
-            event("account123", "SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK)));
+            event("account123", "org123", "SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK)));
 
     EventRecord currentEvent =
         new EventRecord(
             event(
                 "account123",
+                "org123",
                 "SOURCE",
                 "TYPE",
                 "INSTANCE",
@@ -123,21 +130,34 @@ class EventRecordRepositoryTest {
   void findBySourceAndType() {
     EventRecord e1 =
         new EventRecord(
-            event("account123", "SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK)));
+            event("account123", "org123", "SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK)));
     EventRecord e2 =
         new EventRecord(
             event(
                 "account123",
+                "org123",
                 "ANOTHER_SOURCE",
                 "ANOTHER_TYPE",
                 "INSTANCE",
                 OffsetDateTime.now(CLOCK).minusSeconds(1)));
     EventRecord e3 =
         new EventRecord(
-            event("account123", "SOURCE", "ANOTHER_TYPE", "INSTANCE", OffsetDateTime.now(CLOCK)));
+            event(
+                "account123",
+                "org123",
+                "SOURCE",
+                "ANOTHER_TYPE",
+                "INSTANCE",
+                OffsetDateTime.now(CLOCK)));
     EventRecord e4 =
         new EventRecord(
-            event("account123", "ANOTHER_SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK)));
+            event(
+                "account123",
+                "org123",
+                "ANOTHER_SOURCE",
+                "TYPE",
+                "INSTANCE",
+                OffsetDateTime.now(CLOCK)));
 
     repository.saveAll(List.of(e1, e2, e3, e4));
     repository.flush();
@@ -160,13 +180,25 @@ class EventRecordRepositoryTest {
   void testUniqueConstraints() {
     EventRecord e1 =
         new EventRecord(
-            event("account123", "ANOTHER_SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK)));
+            event(
+                "account123",
+                "org123",
+                "ANOTHER_SOURCE",
+                "TYPE",
+                "INSTANCE",
+                OffsetDateTime.now(CLOCK)));
 
     repository.saveAndFlush(e1);
 
     EventRecord e2 =
         new EventRecord(
-            event("account123", "ANOTHER_SOURCE", "TYPE", "INSTANCE", OffsetDateTime.now(CLOCK)));
+            event(
+                "account123",
+                "org123",
+                "ANOTHER_SOURCE",
+                "TYPE",
+                "INSTANCE",
+                OffsetDateTime.now(CLOCK)));
 
     assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(e2));
   }
@@ -198,11 +230,17 @@ class EventRecordRepositoryTest {
   }
 
   private Event event(
-      String account, String source, String type, String instanceId, OffsetDateTime time) {
+      String account,
+      String orgId,
+      String source,
+      String type,
+      String instanceId,
+      OffsetDateTime time) {
     UUID eventId = UUID.randomUUID();
     Event event = new Event();
     event.setEventId(eventId);
     event.setAccountNumber(account);
+    event.setOrgId(orgId);
     event.setTimestamp(time);
     event.setInstanceId(instanceId);
     event.setEventSource(source);

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -39,6 +39,7 @@ class MeteringEventFactoryTest {
   @Test
   void testOpenShiftClusterCoresEventCreation() throws Exception {
     String account = "my-account";
+    String orgId = "my-org";
     String clusterId = "my-cluster";
     String sla = "Premium";
     String usage = "Production";
@@ -54,6 +55,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             account,
+            orgId,
             metricId,
             clusterId,
             sla,
@@ -68,6 +70,7 @@ class MeteringEventFactoryTest {
             measuredValue);
 
     assertEquals(account, event.getAccountNumber());
+    assertEquals(orgId, event.getOrgId());
     assertEquals(measuredTime, event.getTimestamp());
     assertEquals(expiry, event.getExpiration().get());
     assertEquals(clusterId, event.getInstanceId());
@@ -88,6 +91,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             null,
@@ -108,6 +112,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "None",
@@ -128,6 +133,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "UNKNOWN_SLA",
@@ -148,6 +154,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",
@@ -168,6 +175,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",
@@ -188,6 +196,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",
@@ -208,6 +217,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",
@@ -228,6 +238,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",
@@ -250,6 +261,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",
@@ -271,6 +283,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",
@@ -291,6 +304,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",
@@ -311,6 +325,7 @@ class MeteringEventFactoryTest {
     Event event =
         MeteringEventFactory.createMetricEvent(
             "my-account",
+            "my-org",
             "metric-id",
             "cluster-id",
             "Premium",

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -92,6 +92,7 @@ class PrometheusMeteringControllerTest {
   private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
 
   private final String expectedAccount = "my-test-account";
+  private final String expectedOrgId = "my-test-org";
   private final String expectedMetricId = "redhat.com:openshift_container_platform:cpu_hour";
   private final String expectedClusterId = "C1";
   private final String expectedSla = "Premium";
@@ -131,6 +132,7 @@ class PrometheusMeteringControllerTest {
     QueryResult good =
         buildOpenShiftClusterQueryResult(
             expectedAccount,
+            expectedOrgId,
             expectedClusterId,
             expectedSla,
             expectedUsage,
@@ -155,6 +157,7 @@ class PrometheusMeteringControllerTest {
     QueryResult data =
         buildOpenShiftClusterQueryResult(
             expectedAccount,
+            expectedOrgId,
             expectedClusterId,
             expectedSla,
             expectedUsage,
@@ -180,6 +183,7 @@ class PrometheusMeteringControllerTest {
     QueryResult data =
         buildOpenShiftClusterQueryResult(
             expectedAccount,
+            expectedOrgId,
             expectedClusterId,
             expectedSla,
             expectedUsage,
@@ -211,6 +215,7 @@ class PrometheusMeteringControllerTest {
     QueryResult data =
         buildOpenShiftClusterQueryResult(
             expectedAccount,
+            expectedOrgId,
             expectedClusterId,
             expectedSla,
             expectedUsage,
@@ -232,6 +237,7 @@ class PrometheusMeteringControllerTest {
         List.of(
             MeteringEventFactory.createMetricEvent(
                 expectedAccount,
+                expectedOrgId,
                 expectedMetricId,
                 expectedClusterId,
                 expectedSla,
@@ -246,6 +252,7 @@ class PrometheusMeteringControllerTest {
                 val1.doubleValue()),
             MeteringEventFactory.createMetricEvent(
                 expectedAccount,
+                expectedOrgId,
                 expectedMetricId,
                 expectedClusterId,
                 expectedSla,
@@ -290,6 +297,7 @@ class PrometheusMeteringControllerTest {
     QueryResult data =
         buildOpenShiftClusterQueryResult(
             expectedAccount,
+            expectedOrgId,
             expectedClusterId,
             expectedSla,
             expectedUsage,
@@ -310,6 +318,7 @@ class PrometheusMeteringControllerTest {
     Event updatedEvent =
         MeteringEventFactory.createMetricEvent(
             expectedAccount,
+            expectedOrgId,
             expectedMetricId,
             expectedClusterId,
             expectedSla,
@@ -328,6 +337,7 @@ class PrometheusMeteringControllerTest {
             updatedEvent,
             MeteringEventFactory.createMetricEvent(
                 expectedAccount,
+                expectedOrgId,
                 expectedMetricId,
                 expectedClusterId,
                 expectedSla,
@@ -344,6 +354,7 @@ class PrometheusMeteringControllerTest {
     Event purgedEvent =
         MeteringEventFactory.createMetricEvent(
             expectedAccount,
+            expectedOrgId,
             expectedMetricId,
             "CLUSTER_NO_LONGER_EXISTS",
             expectedSla,
@@ -362,6 +373,7 @@ class PrometheusMeteringControllerTest {
             // This event will get updated by the incoming data from prometheus.
             MeteringEventFactory.createMetricEvent(
                 expectedAccount,
+                expectedOrgId,
                 expectedMetricId,
                 expectedClusterId,
                 expectedSla,
@@ -421,6 +433,7 @@ class PrometheusMeteringControllerTest {
             .putMetricItem("usage", "Production")
             .putMetricItem("role", "osd")
             .putMetricItem("ebs_account", expectedAccount)
+            .putMetricItem("external_organization", expectedOrgId)
             .putMetricItem("billing_marketplace", "red hat")
             .putMetricItem("billing_marketplace_account", expectedBillingAccountId)
             .addValuesItem(List.of(BigDecimal.valueOf(1616787308L), BigDecimal.valueOf(4.0)));
@@ -431,6 +444,7 @@ class PrometheusMeteringControllerTest {
             .putMetricItem("usage", "Production")
             .putMetricItem("role", "osd")
             .putMetricItem("ebs_account", expectedAccount)
+            .putMetricItem("external_organization", expectedOrgId)
             .putMetricItem("billing_marketplace", "red hat")
             .putMetricItem("billing_marketplace_account", expectedBillingAccountId)
             .addValuesItem(List.of(BigDecimal.valueOf(1616787308L), BigDecimal.valueOf(4.0)));
@@ -452,6 +466,7 @@ class PrometheusMeteringControllerTest {
     Event updatedEvent =
         MeteringEventFactory.createMetricEvent(
             expectedAccount,
+            expectedOrgId,
             expectedMetricId,
             expectedClusterId,
             "Standard",
@@ -473,6 +488,7 @@ class PrometheusMeteringControllerTest {
     var existingEvent =
         MeteringEventFactory.createMetricEvent(
             expectedAccount,
+            expectedOrgId,
             expectedMetricId,
             expectedClusterId,
             expectedSla,
@@ -522,6 +538,7 @@ class PrometheusMeteringControllerTest {
 
   private QueryResult buildOpenShiftClusterQueryResult(
       String account,
+      String orgId,
       String clusterId,
       String sla,
       String usage,
@@ -534,6 +551,7 @@ class PrometheusMeteringControllerTest {
             .putMetricItem("support", sla)
             .putMetricItem("usage", usage)
             .putMetricItem("ebs_account", account)
+            .putMetricItem("external_organization", orgId)
             .putMetricItem("billing_marketplace", billingProvider)
             .putMetricItem("billing_marketplace_account", billingAccountId);
 

--- a/swatch-core/schemas/event.yaml
+++ b/swatch-core/schemas/event.yaml
@@ -19,6 +19,10 @@ properties:
     description: Account identifier for the relevant account.
     type: string
     required: true
+  org_id:
+    description: Organization identifier associated with this event.
+    type: string
+    required: false
   service_type:
     description: Identifier for the type of service being measured. (E.g. RHEL System, OpenShift Cluster)
     type: string

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
@@ -67,6 +67,7 @@ public class EventRecord {
     this.id = event.getEventId();
     this.event = event;
     this.accountNumber = event.getAccountNumber();
+    this.orgId = event.getOrgId();
     this.eventType = event.getEventType();
     this.eventSource = event.getEventSource();
     this.instanceId = event.getInstanceId();
@@ -77,6 +78,9 @@ public class EventRecord {
 
   @Column(name = "account_number")
   private String accountNumber;
+
+  @Column(name = "org_id")
+  private String orgId;
 
   @Column(name = "event_type")
   private String eventType;
@@ -104,6 +108,7 @@ public class EventRecord {
     }
     EventRecord that = (EventRecord) o;
     return Objects.equals(accountNumber, that.accountNumber)
+        && Objects.equals(orgId, that.getOrgId())
         && Objects.equals(eventType, that.eventType)
         && Objects.equals(eventSource, that.eventSource)
         && Objects.equals(instanceId, that.instanceId)
@@ -112,6 +117,6 @@ public class EventRecord {
 
   @Override
   public int hashCode() {
-    return Objects.hash(accountNumber, eventType, eventSource, instanceId, timestamp);
+    return Objects.hash(accountNumber, orgId, eventType, eventSource, instanceId, timestamp);
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-214

* Add org_id column to events table
* Add org_id field to JSON event schema
* Collect external_organization label value from metrics
  and store on Event record.

## Testing
Get connected to the testing telemeter instance (see: [Connecting To Observatorium](https://docs.engineering.redhat.com/display/ENT/Connecting+to+Observatorium+to+Fetch+Prometheus+Metrics) )

Start the application.
```
PROM_URL="http://localhost:8888/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean :bootRun
```

Pull down metrics for test account 10666718
```
curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performMeteringForAccount(java.lang.String,java.lang.String)","arguments":["10666718", "rhosak"]}'
```

Verify that the newly created Events were persisted with the org_id data.
```
select org_id, data->>'org_id' as data_org_id from events where account_number='10666718';
```

Pull the metrics again to ensure that the metrics are not duplicated.
```
# Pull the metrics again
curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean","operation":"performMeteringForAccount(java.lang.String,java.lang.String)","arguments":["10666718", "rhosak"]}'
```

```
# Verify the metrics for the account remain the same.
select org_id, data->>'org_id' as data_org_id from events where account_number='10666718';
```