### PR TITLE
SWATCH-288: Update Jenkins pipeline to use containers as nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,75 +1,84 @@
 pipeline {
-    options { buildDiscarder(logRotator(numToKeepStr: '50')) }
     agent {
-        label 'rhsm'
+        kubernetes {
+            label 'bananas'
+            // all your pods will be named with this prefix, followed by a unique id
+            idleMinutes 5  // how long the pod will live after no jobs have run on it
+            containerTemplate {
+                name 'openjdk11'
+                image 'registry.access.redhat.com/ubi8/openjdk-11'
+                command 'sleep'
+                args '99d'
+                resourceRequestCpu '4'
+                resourceLimitCpu '6'
+                resourceRequestMemory '4Gi'
+                resourceLimitMemory '6Gi'
+            }
+
+            defaultContainer 'openjdk11'
+            // define a default container if more than a few stages use it, will default to jnlp container
+        }
     }
     stages {
-        stage('Clean') {
-            steps {
-                sh "./podman_run.sh ./gradlew --no-daemon clean"
+        stage('Test Java Version') {
+            steps {  // no container directive is needed as the maven container is the default
+                sh "java -version"
             }
         }
-        stage('Build') {
+        stage('Test') {
             steps {
-                sh "./podman_run.sh ./gradlew --no-daemon assemble"
+                sh "./gradlew test"
             }
         }
-        stage('Unit tests') {
-            steps {
-                sh "./podman_run.sh ./gradlew --no-daemon test"
-            }
-        }
-        stage('Spotless') {
-            steps {
-                sh "./podman_run.sh ./gradlew --no-daemon spotlessCheck"
-            }
-        }
-        stage('Upload PR to SonarQube') {
-            when {
-                changeRequest()
-            }
-            steps {
-                withSonarQubeEnv('sonarcloud.io') {
-                    sh "./podman_run.sh ./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
-                }
-            }
-        }
-        stage('Upload Branch to SonarQube') {
-            when {
-                not {
-                    changeRequest()
-                }
-            }
-            steps {
-                withSonarQubeEnv('sonarcloud.io') {
-                    sh "./podman_run.sh ./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
-                }
-            }
-        }
-        stage('SonarQube Quality Gate') {
-            steps {
-                withSonarQubeEnv('sonarcloud.io') {
-                    echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
-                }
-                retry(4) {
-                    script {
-                        try {
-                            timeout(time: 5, unit: 'MINUTES') {
-                                waitForQualityGate abortPipeline: true
-                            }
-                        }
-                        catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
-                            // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
-                            if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
-                                error("Timeout waiting for SonarQube results")
-                            }
-                        }
-                    }
-                }
-            }
-        }
+//        stage('Clean') {
+//            steps {
+//                sh "./gradlew --no-daemon clean"
+//            }
+//        }
+//        stage('Build') {
+//            steps {
+//                sh "./gradlew --no-daemon build"
+//            }
+//        }
+//
+//        stage('Spotless') {
+//            steps {
+//                sh "./gradlew --no-daemon spotlessCheck"
+//            }
+//        }
+//
+//        stage('Upload PR to SonarQube') {
+//            when {
+//                changeRequest()
+//            }
+//            steps {
+//                withSonarQubeEnv('sonarcloud.io') {
+//                    sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+//                }
+//            }
+//        }
+//        stage('SonarQube Quality Gate') {
+//            steps {
+//                withSonarQubeEnv('sonarcloud.io') {
+//                    echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
+//                }
+//                retry(4) {
+//                    script {
+//                        try {
+//                            timeout(time: 5, unit: 'MINUTES') {
+//                                waitForQualityGate abortPipeline: true
+//                            }
+//                        } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+//                            // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
+//                            if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
+//                                error("Timeout waiting for SonarQube results")
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
     }
-
     post {
         always {
             junit '**/build/test-results/test/*.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         kubernetes {
-            label 'bananas'
+            label 'rhsm'
             // all your pods will be named with this prefix, followed by a unique id
             idleMinutes 5  // how long the pod will live after no jobs have run on it
             containerTemplate {
@@ -20,64 +20,43 @@ pipeline {
         }
     }
     stages {
-        stage('Test Java Version') {
-            steps {  // no container directive is needed as the maven container is the default
-                sh "java -version"
-            }
-        }
-        stage('Test') {
-            steps {
-                sh "./gradlew test"
-            }
-        }
-//        stage('Clean') {
-//            steps {
-//                sh "./gradlew --no-daemon clean"
-//            }
-//        }
-//        stage('Build') {
-//            steps {
-//                sh "./gradlew --no-daemon build"
-//            }
-//        }
-//
-//        stage('Spotless') {
-//            steps {
-//                sh "./gradlew --no-daemon spotlessCheck"
-//            }
-//        }
-//
-//        stage('Upload PR to SonarQube') {
-//            when {
-//                changeRequest()
-//            }
-//            steps {
-//                withSonarQubeEnv('sonarcloud.io') {
-//                    sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
-//                }
-//            }
-//        }
-//        stage('SonarQube Quality Gate') {
-//            steps {
-//                withSonarQubeEnv('sonarcloud.io') {
-//                    echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
-//                }
-//                retry(4) {
-//                    script {
-//                        try {
-//                            timeout(time: 5, unit: 'MINUTES') {
-//                                waitForQualityGate abortPipeline: true
-//                            }
-//                        } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
-//                            // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
-//                            if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
-//                                error("Timeout waiting for SonarQube results")
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//        }
+       stage('Build') {
+           steps {
+               sh "./gradlew --no-daemon build"
+           }
+       }
+
+       stage('Upload PR to SonarQube') {
+           when {
+               changeRequest()
+           }
+           steps {
+               withSonarQubeEnv('sonarcloud.io') {
+                   sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+               }
+           }
+       }
+       stage('SonarQube Quality Gate') {
+           steps {
+               withSonarQubeEnv('sonarcloud.io') {
+                   echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
+               }
+               retry(4) {
+                   script {
+                       try {
+                           timeout(time: 5, unit: 'MINUTES') {
+                               waitForQualityGate abortPipeline: true
+                           }
+                       } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+                           // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
+                           if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
+                               error("Timeout waiting for SonarQube results")
+                           }
+                       }
+                   }
+               }
+           }
+       }
     }
     post {
         always {

--- a/Jenkinsfile-lburnett
+++ b/Jenkinsfile-lburnett
@@ -1,0 +1,27 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'bananas'  // all your pods will be named with this prefix, followed by a unique id
+      idleMinutes 5  // how long the pod will live after no jobs have run on it
+      yamlFile 'build-pod.yaml'  // path to the pod definition relative to the root of our project
+      defaultContainer 'openjdk11'  // define a default container if more than a few stages use it, will default to jnlp container
+    }
+  }
+  stages {
+    stage('Test Java Version') {
+      steps {  // no container directive is needed as the maven container is the default
+        sh "java -version"
+      }
+    }
+   stage('Clean') {
+       steps {
+           sh "./gradlew --no-daemon clean"
+       }
+   }
+   stage('Assemble') {
+       steps {
+           sh "./gradlew --no-daemon --skip-validate-spec assemble"
+       }
+   }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 nebula.release.features.replaceDevWithImmutableSnapshot=true
-org.gradle.jvmargs=-Xmx2048m "-XX:MaxMetaspaceSize=256m"
 org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.daemon=false
+org.gradle.jvmargs=-Xmx2048m "-XX:MaxMetaspaceSize=1024m"


### PR DESCRIPTION
Instead of using "fedora" or "fedora35" node on the SMQE jenkins instance for our **continuous-integration/jenkins/pr-merge** check for each PR, have jenkins spin up a new container to use as a build node.

"Testing"/Verification

If you click "Details" in the checks section of this PR, and then navigate to the Jenkins instance[0]  (top right corner....icon that kind of looks like logout), and then open the console output and View Full Log....you'll be able to see near the top that an agent was provisioned based on a pod spec yaml. 

If the job has been ran recently, you can actually click into the linked agent name that got spun up and see some details within Jenkins.  You can also take that name and search for it in the openshift console [1], where you can view the node and access the terminal.

[0] https://stage-jenkins-csb-smqe.apps.ocp4.prod.psi.redhat.com/job/Subscriptions%20PR%20Check/
[1] https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/topology/ns/jenkins-csb-smqe?view=graph

