### PR TITLE
SWATCH-265 Set org_id on Hosts from Events

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -229,6 +229,7 @@ public class MetricUsageCollector {
       Event event, Host instance, Optional<TagMetaData> serviceTypeMeta) {
     // fields that we expect to always be present
     instance.setAccountNumber(event.getAccountNumber());
+    instance.setOrgId(event.getOrgId());
     instance.setInstanceType(event.getServiceType());
     instance.setInstanceId(event.getInstanceId());
     instance.setDisplayName(event.getInstanceId()); // may be overridden later


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-265

When an hourly tally is run, the org_id is pulled from the relevant Event objects and is set on the applicable Hosts when they are created/updated.

**Testing**
Copy the following to a file and Import some Events into the DB.
```
--
-- PostgreSQL database dump
--

-- Dumped from database version 13.4
-- Dumped by pg_dump version 13.4

SET statement_timeout = 0;
SET lock_timeout = 0;
SET idle_in_transaction_session_timeout = 0;
SET client_encoding = 'UTF8';
SET standard_conforming_strings = on;
SELECT pg_catalog.set_config('search_path', '', false);
SET check_function_bodies = false;
SET xmloption = content;
SET client_min_messages = warning;
SET row_security = off;

--
-- Data for Name: events; Type: TABLE DATA; Schema: public; Owner: rhsm-subscriptions
--

COPY public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) FROM stdin;
9903f3b2-f33d-4c21-b30c-bf68d17c9821	10666718	2022-07-26 16:00:00+00	{"sla": "Premium", "role": "rhosak", "org_id": "16141408", "event_id": "9903f3b2-f33d-4c21-b30c-bf68d17c9821", "timestamp": "2022-07-26T16:00:00Z", "event_type": "snapshot_redhat.com:rhosak:storage_gb", "expiration": "2022-07-26T17:00:00Z", "instance_id": "cbbs6icj729q1s7araeg", "display_name": "cbbs6icj729q1s7araeg", "event_source": "prometheus", "measurements": [{"uom": "Storage-gibibytes", "value": 6.399570465087891}], "service_type": "Kafka Cluster", "account_number": "10666718", "billing_provider": "aws", "billing_account_id": "320233444008"}	snapshot_redhat.com:rhosak:storage_gb	prometheus	cbbs6icj729q1s7araeg	16141408
0ce09a64-b403-45bb-9fd3-97805c5cd84f	10666718	2022-07-26 16:00:00+00	{"sla": "Premium", "role": "rhosak", "org_id": "16141408", "event_id": "0ce09a64-b403-45bb-9fd3-97805c5cd84f", "timestamp": "2022-07-26T16:00:00Z", "event_type": "snapshot_redhat.com:rhosak:transfer_gb", "expiration": "2022-07-26T17:00:00Z", "instance_id": "cbbs6icj729q1s7araeg", "display_name": "cbbs6icj729q1s7araeg", "event_source": "prometheus", "measurements": [{"uom": "Transfer-gibibytes", "value": 0.008900763402508421}], "service_type": "Kafka Cluster", "account_number": "10666718", "billing_provider": "aws", "billing_account_id": "320233444008"}	snapshot_redhat.com:rhosak:transfer_gb	prometheus	cbbs6icj729q1s7araeg	16141408
6c08a3e7-6f39-4fca-ba73-22105e8fd3c6	10666718	2022-07-26 16:00:00+00	{"sla": "Premium", "role": "rhosak", "org_id": "16141408", "event_id": "6c08a3e7-6f39-4fca-ba73-22105e8fd3c6", "timestamp": "2022-07-26T16:00:00Z", "event_type": "snapshot_redhat.com:rhosak:cluster_hour", "expiration": "2022-07-26T17:00:00Z", "instance_id": "cbbs6icj729q1s7araeg", "display_name": "cbbs6icj729q1s7araeg", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "Kafka Cluster", "account_number": "10666718", "billing_provider": "aws", "billing_account_id": "320233444008"}	snapshot_redhat.com:rhosak:cluster_hour	prometheus	cbbs6icj729q1s7araeg	16141408
26850544-dfdb-4f6c-9d17-fdd434ab86ee	10666718	2022-07-26 16:00:00+00	{"sla": "Premium", "role": "rhosak", "org_id": "16141408", "event_id": "26850544-dfdb-4f6c-9d17-fdd434ab86ee", "timestamp": "2022-07-26T16:00:00Z", "event_type": "snapshot_redhat.com:rhosak:storage_gib_months", "expiration": "2022-07-26T17:00:00Z", "instance_id": "cbbs6icj729q1s7araeg", "display_name": "cbbs6icj729q1s7araeg", "event_source": "prometheus", "measurements": [{"uom": "Storage-gibibyte-months", "value": 0.008601573205763293}], "service_type": "Kafka Cluster", "account_number": "10666718", "billing_provider": "aws", "billing_account_id": "320233444008"}	snapshot_redhat.com:rhosak:storage_gib_months	prometheus	cbbs6icj729q1s7araeg	16141408
\.


--
-- PostgreSQL database dump complete
--

```
```
psql -U rhsm-subscriptions rhsm-subscriptions < PATH_TO_YOUR_FILE
```

Start from the **develop** branch and launch the App
```
DEV_MODE=true ./gradlew clean :bootRun
```

Run the hourly tally for the account associated with the Events.
```
curl 'http://localhost:9000/hawtio/jolokia'   -H 'Content-Type: text/json'   -d '{
    "type":"exec",
    "mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean",
    "operation":"tallyAccountByHourly(java.lang.String,java.lang.String,java.lang.String)",
    "arguments":["10666718", "2022-07-26T00:00Z", "2022-07-27T00:00Z"]
  }'
```

Check the hosts table to see that the org_id was not populated.
```
select org_id from hosts where account_number='10666718';
```

Deploy this PR's branch and re-run the hourly tally. When you check the hosts table, the org_id should be populated.
