### PR TITLE
SWATCH-288: Update Jenkins pipeline to use containers as nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
+    options { buildDiscarder(logRotator(numToKeepStr: '50')) }
     agent {
         kubernetes {
-            label 'swatch'
-            // all your pods will be named with this prefix, followed by a unique id
+            label 'swatch' // this value + unique identifier becomes the label
             idleMinutes 5  // how long the pod will live after no jobs have run on it
             containerTemplate {
                 name 'openjdk11'
@@ -10,13 +10,12 @@ pipeline {
                 command 'sleep'
                 args '99d'
                 resourceRequestCpu '2'
-                resourceLimitCpu '2'
-                resourceRequestMemory '4Gi'
+                resourceLimitCpu '6'
+                resourceRequestMemory '2Gi'
                 resourceLimitMemory '6Gi'
             }
 
             defaultContainer 'openjdk11'
-            // define a default container if more than a few stages use it, will default to jnlp container
         }
     }
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,75 +1,63 @@
 pipeline {
-    options { buildDiscarder(logRotator(numToKeepStr: '50')) }
     agent {
-        label 'rhsm'
+        kubernetes {
+            label 'swatch'
+            // all your pods will be named with this prefix, followed by a unique id
+            idleMinutes 5  // how long the pod will live after no jobs have run on it
+            containerTemplate {
+                name 'openjdk11'
+                image 'registry.access.redhat.com/ubi8/openjdk-11'
+                command 'sleep'
+                args '99d'
+                resourceRequestCpu '2'
+                resourceLimitCpu '2'
+                resourceRequestMemory '4Gi'
+                resourceLimitMemory '6Gi'
+            }
+
+            defaultContainer 'openjdk11'
+            // define a default container if more than a few stages use it, will default to jnlp container
+        }
     }
     stages {
-        stage('Clean') {
-            steps {
-                sh "./podman_run.sh ./gradlew --no-daemon clean"
-            }
-        }
-        stage('Build') {
-            steps {
-                sh "./podman_run.sh ./gradlew --no-daemon assemble"
-            }
-        }
-        stage('Unit tests') {
-            steps {
-                sh "./podman_run.sh ./gradlew --no-daemon test"
-            }
-        }
-        stage('Spotless') {
-            steps {
-                sh "./podman_run.sh ./gradlew --no-daemon spotlessCheck"
-            }
-        }
-        stage('Upload PR to SonarQube') {
-            when {
-                changeRequest()
-            }
-            steps {
-                withSonarQubeEnv('sonarcloud.io') {
-                    sh "./podman_run.sh ./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
-                }
-            }
-        }
-        stage('Upload Branch to SonarQube') {
-            when {
-                not {
-                    changeRequest()
-                }
-            }
-            steps {
-                withSonarQubeEnv('sonarcloud.io') {
-                    sh "./podman_run.sh ./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
-                }
-            }
-        }
-        stage('SonarQube Quality Gate') {
-            steps {
-                withSonarQubeEnv('sonarcloud.io') {
-                    echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
-                }
-                retry(4) {
-                    script {
-                        try {
-                            timeout(time: 5, unit: 'MINUTES') {
-                                waitForQualityGate abortPipeline: true
-                            }
-                        }
-                        catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
-                            // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
-                            if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
-                                error("Timeout waiting for SonarQube results")
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+       stage('Build') {
+           steps {
+               sh "./gradlew build"
+           }
+       }
 
+       stage('Upload PR to SonarQube') {
+           when {
+               changeRequest()
+           }
+           steps {
+               withSonarQubeEnv('sonarcloud.io') {
+                   sh "./gradlew sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+               }
+           }
+       }
+       stage('SonarQube Quality Gate') {
+           steps {
+               withSonarQubeEnv('sonarcloud.io') {
+                   echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
+               }
+               retry(4) {
+                   script {
+                       try {
+                           timeout(time: 5, unit: 'MINUTES') {
+                               waitForQualityGate abortPipeline: true
+                           }
+                       } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+                           // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
+                           if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
+                               error("Timeout waiting for SonarQube results")
+                           }
+                       }
+                   }
+               }
+           }
+       }
+    }
     post {
         always {
             junit '**/build/test-results/test/*.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     stages {
        stage('Build') {
            steps {
-               sh "./gradlew build"
+               sh "./gradlew  --no-daemon  build"
            }
        }
 
@@ -31,7 +31,7 @@ pipeline {
            }
            steps {
                withSonarQubeEnv('sonarcloud.io') {
-                   sh "./gradlew sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                   sh "./gradlew  --no-daemon  sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
                }
            }
        }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 nebula.release.features.replaceDevWithImmutableSnapshot=true
-org.gradle.jvmargs=-Xmx2048m "-XX:MaxMetaspaceSize=256m"
 org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2048m "-XX:MaxMetaspaceSize=1024m"


### PR DESCRIPTION
Instead of using "fedora" or "fedora35" node on the SMQE jenkins instance for our **continuous-integration/jenkins/pr-merge** check for each PR, have jenkins spin up a new container to use as a build node.

"Testing"/Verification

If you click "Details" in the checks section of this PR, and then navigate to the Jenkins instance[0]  (top right corner....icon that kind of looks like logout), and then open the console output and View Full Log....you'll be able to see near the top that an agent was provisioned based on a pod spec yaml. 

If the job has been ran recently, you can actually click into the linked agent name that got spun up and see some details within Jenkins.  You can also take that name and search for it in the openshift console [1], where you can view the node and access the terminal.

[0] https://stage-jenkins-csb-smqe.apps.ocp4.prod.psi.redhat.com/job/Subscriptions%20PR%20Check/
[1] https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/topology/ns/jenkins-csb-smqe?view=graph