### PR TITLE
SWATCH-257: Tolerate missing accountnumber

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -4,6 +4,8 @@ kind: Template
 metadata:
   name: rhsm
 parameters:
+  - name: TOLERATE_MISSING_ACCOUNT_NUMBER
+    value: 'false'
   - name: SUBSCRIPTIONS_HAWTIO_BASE_PATH
     value: /app/rhsm-subscriptions/hawtio
   - name: RH_MARKETPLACE_HAWTIO_BASE_PATH
@@ -1188,6 +1190,8 @@ objects:
                 secretKeyRef:
                   name: splunk-hec-external
                   key: token
+            - name: TOLERATE_MISSING_ACCOUNT_NUMBER
+              value: ${TOLERATE_MISSING_ACCOUNT_NUMBER}
             - name: SPLUNK_SOURCE
               value: ${SPLUNK_SOURCE}
             - name: SPLUNK_SOURCE_TYPE

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -114,8 +114,7 @@ public class InventoryController {
   private Timer transformHostTimer;
   private Timer validateHostTimer;
 
-  @Autowired
-  private InventoryServiceProperties serviceProperties;
+  @Autowired private InventoryServiceProperties serviceProperties;
 
   @Autowired
   public InventoryController(
@@ -519,25 +518,26 @@ public class InventoryController {
       org.candlepin.subscriptions.conduit.rhsm.client.model.OrgInventory feedPage)
       throws MissingAccountNumberException {
 
-      if (feedPage.getBody().isEmpty()) {
-          return Stream.empty();
-      }
+    if (feedPage.getBody().isEmpty()) {
+      return Stream.empty();
+    }
 
-      // If the missing account number is false then
-      // Peek at the first consumer.  If it is missing an account number, that means they all are.
-      // Abort and return an empty stream.  No sense in wasting time looping through everything.
-      try {
-          if (!serviceProperties.isTolerateMissingAccountNumber() && !StringUtils.hasText(feedPage.getBody().get(0).getAccountNumber())) {
-              throw new MissingAccountNumberException();
-          }
-      } catch (NoSuchElementException e) {
-          throw new MissingAccountNumberException();
+    // If the missing account number is false then
+    // Peek at the first consumer.  If it is missing an account number, that means they all are.
+    // Abort and return an empty stream.  No sense in wasting time looping through everything.
+    try {
+      if (!serviceProperties.isTolerateMissingAccountNumber()
+          && !StringUtils.hasText(feedPage.getBody().get(0).getAccountNumber())) {
+        throw new MissingAccountNumberException();
       }
+    } catch (NoSuchElementException e) {
+      throw new MissingAccountNumberException();
+    }
 
-      return feedPage.getBody().stream()
-              .map(this::validateConsumer)
-              .filter(Optional::isPresent)
-              .map(Optional::get);
+    return feedPage.getBody().stream()
+        .map(this::validateConsumer)
+        .filter(Optional::isPresent)
+        .map(Optional::get);
   }
 
   @SuppressWarnings("indentation")

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryServiceProperties.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryServiceProperties.java
@@ -37,6 +37,7 @@ public class InventoryServiceProperties {
   private String kafkaHostIngressTopic = "platform.inventory.host-ingress";
   private int apiHostUpdateBatchSize = 50;
   private int staleHostOffsetInDays = 0;
+  private boolean tolerateMissingAccountNumber;
 
   @DurationUnit(ChronoUnit.HOURS)
   private Duration hostLastSyncThreshold = Duration.ofHours(24);

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -21,6 +21,7 @@ rhsm-conduit:
     # FIXME: misnamed, it's actually in hours
     stale-host-offset-in-days: ${INVENTORY_STALE_HOST_OFFSET_HOURS:48}
     kafka-host-ingress-topic: ${INVENTORY_HOST_INGRESS_TOPIC:platform.inventory.host-ingress}
+    tolerate-missing-account-number: ${TOLERATE_MISSING_ACCOUNT_NUMBER:false}
   tasks:
     topic: ${CONDUIT_KAFKA_TOPIC:platform.rhsm-conduit.tasks}
     kafka-group-id: ${CONDUIT_KAFKA_GROUP_ID:rhsm-conduit-task-processor}

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -219,7 +219,7 @@ class InventoryControllerTest {
 
   @Test
   void testWhenTolerateMissingAccountNumberEnabled_DoNotThrowMissingAccountNumberException()
-          throws ApiException, MissingAccountNumberException {
+      throws ApiException{
     Consumer consumer1 = new Consumer();
     consumer1.setOrgId("123");
     consumer1.setUuid(UUID.randomUUID().toString());
@@ -229,9 +229,8 @@ class InventoryControllerTest {
 
     when(inventoryServiceProperties.isTolerateMissingAccountNumber()).thenReturn(true);
     when(rhsmService.getPageOfConsumers(eq("123"), nullable(String.class), anyString()))
-            .thenReturn(pageOf(consumer1, consumer2));
-    assertDoesNotThrow(
-             () -> controller.updateInventoryForOrg("123"));
+        .thenReturn(pageOf(consumer1, consumer2));
+    assertDoesNotThrow(() -> controller.updateInventoryForOrg("123"));
     verify(inventoryService, times(0)).scheduleHostUpdate(any(ConduitFacts.class));
   }
 

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -219,7 +219,7 @@ class InventoryControllerTest {
 
   @Test
   void testWhenTolerateMissingAccountNumberEnabled_DoNotThrowMissingAccountNumberException()
-      throws ApiException{
+      throws ApiException {
     Consumer consumer1 = new Consumer();
     consumer1.setOrgId("123");
     consumer1.setUuid(UUID.randomUUID().toString());

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -200,7 +200,7 @@ class InventoryControllerTest {
   }
 
   @Test
-  void testShortCircuitsOnMissingAccountNumbers()
+  void testWhenTolerateMissingAccountNumberDisabled_ShortCircuitsOnMissingAccountNumbers()
       throws ApiException, MissingAccountNumberException {
     Consumer consumer1 = new Consumer();
     consumer1.setOrgId("123");
@@ -209,10 +209,29 @@ class InventoryControllerTest {
     consumer1.setOrgId("123");
     consumer2.setUuid(UUID.randomUUID().toString());
 
+    when(inventoryServiceProperties.isTolerateMissingAccountNumber()).thenReturn(false);
     when(rhsmService.getPageOfConsumers(eq("123"), nullable(String.class), anyString()))
         .thenReturn(pageOf(consumer1, consumer2));
     assertThrows(
         MissingAccountNumberException.class, () -> controller.updateInventoryForOrg("123"));
+    verify(inventoryService, times(0)).scheduleHostUpdate(any(ConduitFacts.class));
+  }
+
+  @Test
+  void testWhenTolerateMissingAccountNumberEnabled_DoNotThrowMissingAccountNumberException()
+          throws ApiException, MissingAccountNumberException {
+    Consumer consumer1 = new Consumer();
+    consumer1.setOrgId("123");
+    consumer1.setUuid(UUID.randomUUID().toString());
+    Consumer consumer2 = new Consumer();
+    consumer1.setOrgId("123");
+    consumer2.setUuid(UUID.randomUUID().toString());
+
+    when(inventoryServiceProperties.isTolerateMissingAccountNumber()).thenReturn(true);
+    when(rhsmService.getPageOfConsumers(eq("123"), nullable(String.class), anyString()))
+            .thenReturn(pageOf(consumer1, consumer2));
+    assertDoesNotThrow(
+             () -> controller.updateInventoryForOrg("123"));
     verify(inventoryService, times(0)).scheduleHostUpdate(any(ConduitFacts.class));
   }
 

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -73,6 +73,8 @@ parameters:
     value: 350m
   - name: CURL_CRON_CPU_LIMIT
     value: 500m
+  - name: TOLERATE_MISSING_ACCOUNT_NUMBER
+    value: 'false'
 
 objects:
 - apiVersion: v1
@@ -134,6 +136,8 @@ objects:
                 value: ${DATABASE_CONNECTION_TIMEOUT_MS}
               - name: DATABASE_MAX_POOL_SIZE
                 value: ${DATABASE_MAX_POOL_SIZE}
+              - name: TOLERATE_MISSING_ACCOUNT_NUMBER
+                value: ${TOLERATE_MISSING_ACCOUNT_NUMBER}
             resources:
               requests:
                 cpu: ${CPU_REQUEST}


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-257

1. **Description**:

- Currently, tolerate-missing-account-number has default value as false. It is set in stage as true and in prod it is set as false. This is defined in app-interface.

App-interface PR: ```https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/44020```

2. **Test Steps**:

- The flag is defined in swatch-system-conduit/src/main/resources/application.yaml

- Change the Stub: StubRhsmApi

- Comment out the account number to test the above flag locally.

 For false it will throw error and for true it will tolerate the missing account number.

-Run: `RHSM_USE_STUB=true DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun`

Another terminal execute:
`curl -X 'POST'  'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg' -H 'accept: application/vnd.api+json' -H 'x-rh-swatch-psk: dummy' -H 'Content-Type: application/json' -d '{ "org_id": "org123" }'`