### PR TITLE
SWATCH-174 Tolerate missing account number for opt-in checks

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInController.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.security;
 
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.Optional;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
@@ -179,7 +180,7 @@ public class OptInController {
             new OptInConfigData()
                 .account(accountData)
                 .org(orgData)
-                .optInComplete(accountData != null && orgData != null))
+                .optInComplete(Objects.nonNull(orgData)))
         .meta(meta);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
@@ -99,15 +99,24 @@ class OrgConfigRepositoryTest {
   void testFindOrgsWithEnabledSync() {
     repository.saveAll(
         Arrays.asList(
-            createConfig("A1", true),
-            createConfig("A2", true),
-            createConfig("A3", false),
-            createConfig("A4", false)));
+            createConfig("Org1", true),
+            createConfig("Org2", true),
+            createConfig("Org3", false),
+            createConfig("Org4", false)));
     repository.flush();
 
     List<String> orgsWithSync = repository.findSyncEnabledOrgs().collect(Collectors.toList());
     assertEquals(2, orgsWithSync.size());
-    assertTrue(orgsWithSync.containsAll(Arrays.asList("A1", "A2")));
+    assertTrue(orgsWithSync.containsAll(Arrays.asList("Org1", "Org2")));
+  }
+
+  @Test
+  void existsByOrgId() {
+    repository.saveAll(Arrays.asList(createConfig("Org1", true)));
+    repository.flush();
+    assertTrue(repository.existsByOrgId("Org1"));
+    assertFalse(repository.existsByOrgId("Not_Found"));
+    assertFalse(repository.existsByOrgId(null));
   }
 
   private OrgConfig createConfig(String org, boolean canSync) {

--- a/src/test/java/org/candlepin/subscriptions/security/OptInControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/OptInControllerTest.java
@@ -401,7 +401,7 @@ class OptInControllerTest {
   }
 
   @Test
-  void optInConfigNotCompleteWhenOnlyOrgConfigExists() {
+  void optInConfigIsCompleteWhenOnlyOrgConfigExists() {
     String expectedAccountNumber = "TEST_ACCOUNT309";
     String expectedOrgId = "TEST_OWNER310";
 
@@ -411,7 +411,7 @@ class OptInControllerTest {
     OptInConfig dto = controller.getOptInConfig(expectedAccountNumber, expectedOrgId);
     assertNull(dto.getData().getAccount());
     assertNotNull(dto.getData().getOrg());
-    assertFalse(dto.getData().getOptInComplete());
+    assertTrue(dto.getData().getOptInComplete());
   }
 
   private AccountConfig setupExistingAccountConfig(String account) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
@@ -46,4 +46,7 @@ public interface OrgConfigRepository extends JpaRepository<OrgConfig, String> {
     orgConfig.setUpdated(current);
     return Optional.of(save(orgConfig));
   }
+
+  @Query
+  Boolean existsByOrgId(String orgId);
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-174

When opt-in is checked, only the OrgConfig related to
principal is checked (opt-in considered complete).

The ReportingAccessService also needed to be updated to
account for a missing account number to allow the requests
to succeed. Since the reportingEnabled flag is associated
with the account config only, if the account was not specified
during the request, we allow reporting if the org was opted in.

**Testing**
Deploy the app from the develop branch
```
DEV_MODE=true ./gradlew clean :bootRun
```

Generate the required rh-auth tokens for testing:
```
# Includes account
$ echo -n '{"identity":{"account_number":"account123", "internal":{"org_id":"org123"}}}' | base64 -w 0

eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQ==

# Does not include account
$ echo -n '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w 0

eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19
```

Test the Opt-In API and successfully opt-in the org.
```
# Must contain the account number in the header
$ curl -X PUT -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/opt-in" | jq

{
  "errors": [
    {
      "status": "400",
      "code": "SUBSCRIPTIONS1001",
      "title": "Must specify an account number."
    }
  ]
}
```
```
# Always need the org_id in the header
$ curl -X PUT -H "x-rh-identity: eyJhY2NvdW50X251bWJlciI6ImExIiwgImlkZW50aXR5Ijp7ImludGVybmFsIjp7fX19" "http://localhost:8000/api/rhsm-subscriptions/v1/opt-in" | jq

{
  "errors": [
    {
      "status": "401",
      "code": "SUBSCRIPTIONS1001",
      "title": "Could not authenticate the user.",
      "detail": "x-rh-identity is missing required data"
    }
  ]
}
```

```
# Opt-in the account and org.
$ curl -X PUT -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQ==" "http://localhost:8000/api/rhsm-subscriptions/v1/opt-in" | jq

{
  "meta": {
    "account_number": "account123",
    "org_id": "org123"
  },
  "data": {
    "opt_in_complete": true,
    "account": {
      "account_number": "account123",
      "tally_sync_enabled": true,
      "tally_reporting_enabled": true,
      "opt_in_type": "API",
      "created": "2022-07-28T14:20:31.931572Z",
      "last_updated": "2022-07-28T14:20:31.931572Z"
    },
    "org": {
      "org_id": "org123",
      "conduit_sync_enabled": true,
      "opt_in_type": "API",
      "created": "2022-07-28T14:20:31.931572Z",
      "last_updated": "2022-07-28T14:20:31.931572Z"
    }
  }
}

```

Try and run a tally for the org (no account number in the header)

```
# NOTE: No data required since we are just testing access is denied
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T01:59:59.999Z" | jq
{
  "errors": [
    {
      "status": "403",
      "code": "SUBSCRIPTIONS1004",
      "title": "Access Denied",
      "detail": "Opt-in required."
    }
  ]
}
```

Next deploy the app from this PRs branch and retest everything above. The opt-in API should still be protected, however, the tally API will allow accesss to the report as long as the org has been opted in.

```
$ curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-19T00:00:00.000Z&ending=2019-06-19T01:59:59.999Z" | jq

{
  "data": [
    {
      "date": "2019-06-19T00:00:00Z",
      "instance_count": 0,
      "cores": 0,
      "core_hours": 0.0,
      "instance_hours": 0.0,
      "sockets": 0,
      "physical_instance_count": 0,
      "physical_cores": 0,
      "physical_sockets": 0,
      "hypervisor_instance_count": 0,
      "hypervisor_cores": 0,
      "hypervisor_sockets": 0,
      "cloud_instance_count": 0,
      "cloud_cores": 0,
      "cloud_sockets": 0,
      "has_data": false,
      "has_cloudigrade_data": false,
      "has_cloudigrade_mismatch": false
    }
  ],
  "meta": {
    "count": 1,
    "total_core_hours": 0.0,
    "total_instance_hours": 0.0,
    "product": "RHEL",
    "granularity": "Daily"
  }
}
```
