### PR TITLE
[bugfix for SWATCH-288] Add Upload Branch to SonarQube stage back to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,45 +19,57 @@ pipeline {
         }
     }
     stages {
-       stage('Build/Test/Lint') {
-           steps {
-               // The build task includes check, test, and assemble.  Linting happens during the check
-               // task and uses the spotless gradle plugin.
-               sh "./gradlew --no-daemon build"
-           }
-       }
+        stage('Build/Test/Lint') {
+            steps {
+                // The build task includes check, test, and assemble.  Linting happens during the check
+                // task and uses the spotless gradle plugin.
+                sh "./gradlew --no-daemon build"
+            }
+        }
 
-       stage('Upload PR to SonarQube') {
-           when {
-               changeRequest()
-           }
-           steps {
-               withSonarQubeEnv('sonarcloud.io') {
-                   sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
-               }
-           }
-       }
-       stage('SonarQube Quality Gate') {
-           steps {
-               withSonarQubeEnv('sonarcloud.io') {
-                   echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
-               }
-               retry(4) {
-                   script {
-                       try {
-                           timeout(time: 5, unit: 'MINUTES') {
-                               waitForQualityGate abortPipeline: true
-                           }
-                       } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
-                           // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
-                           if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
-                               error("Timeout waiting for SonarQube results")
-                           }
-                       }
-                   }
-               }
-           }
-       }
+        stage('Upload PR to SonarQube') {
+            when {
+                changeRequest()
+            }
+            steps {
+                withSonarQubeEnv('sonarcloud.io') {
+                    sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                }
+            }
+        }
+        stage('Upload Branch to SonarQube') {
+            when {
+                not {
+                    changeRequest()
+                }
+            }
+            steps {
+                withSonarQubeEnv('sonarcloud.io') {
+                    sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                }
+            }
+        }
+        stage('SonarQube Quality Gate') {
+            steps {
+                withSonarQubeEnv('sonarcloud.io') {
+                    echo "SonarQube scan results will be visible at: ${SONAR_HOST_URL}/dashboard?id=rhsm-subscriptions"
+                }
+                retry(4) {
+                    script {
+                        try {
+                            timeout(time: 5, unit: 'MINUTES') {
+                                waitForQualityGate abortPipeline: true
+                            }
+                        } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+                            // "rethrow" as something retry will actually retry, see https://issues.jenkins-ci.org/browse/JENKINS-51454
+                            if (e.causes.find { it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout } != null) {
+                                error("Timeout waiting for SonarQube results")
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
     post {
         always {


### PR DESCRIPTION
Fixes issue with https://github.com/RedHatInsights/rhsm-subscriptions/pull/1257 

When working on [SWATCH-288](https://issues.redhat.com/browse/SWATCH-288), I left out one of the stages that allowed the develop/main branch jenkins jobs to upload to sonar.  That Jenkins job doesn't trigger until something lands in the develop branch, so to verify this fix will have to wait until its been merged.