### PR TITLE
Fix incorrect liquibase references to instance_id

### DIFF
--- a/src/main/resources/liquibase/202207051557-transition-deprecated-columns.xml
+++ b/src/main/resources/liquibase/202207051557-transition-deprecated-columns.xml
@@ -14,13 +14,13 @@
         if (new.uom = 'CORES') then
           update hosts
           set cores=new.value
-          where instance_id = new.instance_id::text
+          where id = new.instance_id
             and cores is null
              or cores != new.value;
         elsif (new.uom = 'SOCKETS') then
           update hosts
           set sockets=new.value
-          where instance_id = new.instance_id::text
+          where id = new.instance_id
             and sockets is null
              or sockets != new.value;
         end if;

--- a/src/main/resources/liquibase/202207061021-migrate-cores-sockets-data.xml
+++ b/src/main/resources/liquibase/202207061021-migrate-cores-sockets-data.xml
@@ -10,7 +10,7 @@
     <comment>Copy data from hosts.cores to instance_measurements.</comment>
     <sql>
       insert into instance_measurements(instance_id, uom, value)
-      select instance_id::uuid, 'CORES', cores
+      select id, 'CORES', cores
       from hosts
       where cores is not null on conflict(instance_id, uom) do
       update set value =excluded.value;
@@ -20,7 +20,7 @@
     <comment>Copy data from hosts.sockets to instance_measurements.</comment>
     <sql>
       insert into instance_measurements(instance_id, uom, value)
-      select instance_id::uuid, 'SOCKETS', sockets
+      select id, 'SOCKETS', sockets
       from hosts
       where sockets is not null
       on conflict(instance_id, uom) do update set value=excluded.value;


### PR DESCRIPTION
Confusingly, we have a column named `instance_id` on the `hosts` table;
we also have a column named `instance_id` on `instance_measurements`.
However, the `instance_id` on `instance_measurements` references
`hosts.id` and NOT `hosts.instance_id`.

Testing
-------

Try the following sql for testing the trigger change:

```sql
insert into account_services(account_number, service_type) values ('a123', 'HBI_HOST');
insert into hosts(id, instance_id, display_name, account_number, org_id, cores, sockets)
values ('0cfbdd0e-8f5d-4152-9945-f8fd452c2b2d', 'foobar', 'foo', 'a123', 'org123', 4, null);
select * from instance_measurements;
```

The original testing instructions used the same value for both `id` and
`instance_id`, which is possibly why this wasn't caught sooner.

Note that given the changesets involved were modified, I added
`runOnChange=true` to simplify re-running against deployments where it's
already run.