### PR TITLE
SWATCH-157 Verify Org ID Exists in Sync List - API Implementation

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/admin/InternalOrganizationSyncResource.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/admin/InternalOrganizationSyncResource.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.conduit.InventoryController;
 import org.candlepin.subscriptions.conduit.job.OrgSyncTaskManager;
 import org.candlepin.subscriptions.conduit.rhsm.client.ApiException;
+import org.candlepin.subscriptions.db.model.OrgConfigRepository;
 import org.candlepin.subscriptions.exception.MissingAccountNumberException;
 import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.utilization.api.model.DefaultResponse;
@@ -41,10 +42,13 @@ public class InternalOrganizationSyncResource implements InternalOrganizationsAp
 
   private final InventoryController controller;
   private final OrgSyncTaskManager tasks;
+  private final OrgConfigRepository repo;
 
-  InternalOrganizationSyncResource(InventoryController controller, OrgSyncTaskManager tasks) {
+  InternalOrganizationSyncResource(
+      InventoryController controller, OrgSyncTaskManager tasks, OrgConfigRepository repo) {
     this.controller = controller;
     this.tasks = tasks;
+    this.repo = repo;
   }
 
   @Override
@@ -59,7 +63,10 @@ public class InternalOrganizationSyncResource implements InternalOrganizationsAp
 
   @Override
   public OrgExistsResponse hasOrgInSyncList(String orgId) {
-    throw new UnsupportedOperationException();
+    OrgExistsResponse response = new OrgExistsResponse();
+    boolean exists = repo.existsById(orgId);
+    response.setExistsInList(exists);
+    return response;
   }
 
   @Override
@@ -69,7 +76,6 @@ public class InternalOrganizationSyncResource implements InternalOrganizationsAp
 
   @Override
   public DefaultResponse syncFullOrgList() {
-
     log.info(
         "Starting sync for all configured orgs, initiated by {}", ResourceUtils.getPrincipal());
     tasks.syncFullOrgList();

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/admin/InternalOrganizationSyncResourceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/admin/InternalOrganizationSyncResourceTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.util.AssertionErrors.assertFalse;
+import static org.springframework.test.util.AssertionErrors.assertTrue;
 
 import org.candlepin.subscriptions.conduit.InventoryController;
 import org.candlepin.subscriptions.conduit.job.OrgSyncTaskManager;
@@ -67,5 +69,21 @@ class InternalOrganizationSyncResourceTest {
   @Test
   void syncAllOrgsShouldReturnSuccess() {
     assertEquals("Success", resource.syncFullOrgList().getStatus());
+  }
+
+  @Test
+  void hasOrgInSyncListShouldReturnTrue() {
+    when(repo.existsById("123")).thenReturn(true);
+    assertTrue(
+        "Org ID expected to exist but does not",
+        resource.hasOrgInSyncList("123").getExistsInList());
+  }
+
+  @Test
+  void hasOrgInSyncListShouldReturnFalse() {
+    when(repo.existsById("123")).thenReturn(false);
+    assertFalse(
+        "Org ID expected to not exist but does",
+        resource.hasOrgInSyncList("123").getExistsInList());
   }
 }


### PR DESCRIPTION
This implements the REST API for checking if an Org ID exists in the sync list in accordance with API spec.

https://issues.redhat.com/browse/SWATCH-157

Tested using test file and manually using endpoint.