### PR TITLE
Manage base-images w/ dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+  - package-ecosystem: "docker"
+    directory: "swatch-producer-aws/src/main/docker"
+    schedule:
+      interval: "daily"
+    target-branch: "main"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
 USER root
 WORKDIR /tmp/src
 ADD . /tmp/src
 RUN ./gradlew :assemble
 
-FROM registry.access.redhat.com/ubi8/openjdk-11
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
 COPY --from=0 /tmp/src/build/libs/* /deployments/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
 USER root
 WORKDIR /tmp/src
 ADD . /tmp/src

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/swatch-producer-aws/src/main/docker/Dockerfile.legacy-jar
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/swatch-producer-aws/src/main/docker/Dockerfile.native
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
Also updated the base images to the latest versions for swatch-producer-aws. To see the effect this has, see [my fork](https://github.com/kahowell/rhsm-subscriptions/pulls).