### PR TITLE
Update HBI-based tallies to populate orgId from HBI org_id column

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -27,11 +27,12 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
             'id': inventory_id,
             'account': account,
             'display_name': display_name or insights_id,
+            'org_id': org_id or f'org_{account}',
             'created_on': last_seen or '1993-03-26',
             'modified_on': last_seen or '1993-03-26',
             'facts': json.dumps({
                 'rhsm': {
-                    'orgId': f'org_{account}',
+                    'orgId': org_id or f'org_{account}',
                     'VM_HOST_UUID': str(hypervisor_uuid) if hypervisor_uuid else None,
                     'IS_VIRTUAL': is_guest,
                 },

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -90,8 +90,7 @@ import lombok.Setter;
 @NamedNativeQuery(
     name = "InventoryHost.getFacts",
     query =
-        "select h.id as inventory_id, h.modified_on, h.account, h.display_name, "
-            + "h.facts->'rhsm'->>'orgId' as org_id, "
+        "select h.id as inventory_id, h.org_id, h.modified_on, h.account, h.display_name, "
             + "h.facts->'rhsm'->>'IS_VIRTUAL' as is_virtual, "
             + "h.facts->'rhsm'->>'VM_HOST_UUID' as hypervisor_uuid, "
             + "h.facts->'satellite'->>'virtual_host_uuid' as satellite_hypervisor_uuid, "
@@ -145,6 +144,9 @@ public class InventoryHost implements Serializable {
   @Id private UUID id;
 
   private String account;
+
+  @Column(name = "org_id")
+  private String orgId;
 
   @Column(name = "display_name")
   private String displayName;


### PR DESCRIPTION
Refactor the orgId from facts query to host.
https://issues.redhat.com/browse/SWATCH-97

Testing Steps

1. Make sure podman creates the inventory db or else get a Host doesn't exist error in the logs.
2. Create mock host using script for insights db
```
INSERT INTO public.hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id) VALUES ('ad080589-fa8b-4d4b-8e16-0b6f4a3bf239', 'account123', 'physical_ncnmydit.example.com', '2022-08-02 15:02:24.347000 +00:00', '2022-08-02 00:00:00.000000 +00:00', '""', '""', '""', '""', '""', '2022-08-10 15:02:49.813000 +00:00', 'conduit', '{}', '13465533');
```
3. Make sure to create account service in the rhsm db:
```
INSERT INTO public.account_services (account_number, service_type) VALUES ('account123', 'HBI_HOST');
```
3. After creating mock hosts, run Tally and it should run as usual.
```bash
curl 'http://localhost:9000/hawtio/jolokia/?maxDepth=7&maxCollectionSize=50000&ignoreErrors=true&canonicalNaming=false' \
  -H 'Accept: application/json, text/javascript, */*; q=0.01' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: text/json' \
  --data-raw '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyAccount(java.lang.String)","arguments":["account123"]}' \
  --compressed
```
4. No error should happen and you get a tally of zero as the scripts don't have any values.