### PR TITLE
SWATCH-178: Define token-refresher env vars on the swatch-metrics pod

### DIFF
--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -160,6 +160,26 @@ objects:
                     cpu: ${CPU_LIMIT}
                     memory: ${MEMORY_LIMIT}
             env:
+              - name: CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher
+                    key: CLIENT_ID
+              - name: CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher
+                    key: CLIENT_SECRET
+              - name: ISSUER_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher
+                    key: ISSUER_URL
+              - name: URL
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher
+                    key: URL
               - name: ENABLE_SPLUNK_HEC
                 value: ${ENABLE_SPLUNK_HEC}
               - name: SPLUNKMETA_namespace


### PR DESCRIPTION
The ClowdApp operator is taking care of setting the args, image, and resources of the token-refresher sidecar.

Theoretically, if we provide the env vars necessary for the args, it'll magically start working

```
--oidc.audience=observatorium-telemeter --oidc.client-id=$(CLIENT_ID) --oidc.client-secret=$(CLIENT_SECRET) --oidc.issuer-url=$(ISSUER_URL) --url=$(URL) --web.listen=:8082
```