### PR TITLE
pr_check.sh: Set template ref for all clowdapps

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -41,6 +41,10 @@ OPTIONAL_DEPS_METHOD=none
 
 #each gets appended with --component
 export COMPONENTS_W_RESOURCES="rhsm swatch-producer-aws swatch-producer-red-hat-marketplace swatch-metrics"
+# NOTE: this ensures that all of the other services end up deployed with the latest template
+for EXTRA_COMPONENT_NAME in $COMPONENTS_W_RESOURCES; do
+  export EXTRA_DEPLOY_ARGS="${EXTRA_DEPLOY_ARGS} --set-template-ref ${EXTRA_COMPONENT_NAME}=${GIT_COMMIT}"
+done
 # Deploy to an ephemeral namespace for testing
 source $CICD_ROOT/deploy_ephemeral_env.sh
 


### PR DESCRIPTION
bonfire cicd boilerplate assumes a single clowdapp in the repo, so it
simply uses the templates from `main` branch for all other clowdapps in
a repo. This works around by manually adding args for
`--set-template-ref`