### PR TITLE
SWATCH-241 Set orgId on TallySummary when mapping snapshots

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -63,7 +63,13 @@ public class SnapshotSummaryProducer {
     newAndUpdatedSnapshots.forEach(
         (account, snapshots) ->
             snapshots.stream()
-                .map(snapshot -> summaryMapper.mapSnapshots(account, List.of(snapshot)))
+                // NOTE: The orgId should be passed in the same way as the account. When the APIs
+                // are changed to require an orgID, this should be updated to not take the orgId
+                // from the snapshot when they are mapped to a summary.
+                .map(
+                    snapshot ->
+                        summaryMapper.mapSnapshots(
+                            account, snapshot.getOwnerId(), List.of(snapshot)))
                 .forEach(
                     summary -> {
                       if (validateTallySummary(summary)) {

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
@@ -32,15 +32,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class TallySummaryMapper {
 
-  public TallySummary mapSnapshots(String account, List<TallySnapshot> snapshots) {
-    return createTallySummary(account, snapshots);
+  public TallySummary mapSnapshots(String account, String orgId, List<TallySnapshot> snapshots) {
+    return createTallySummary(account, orgId, snapshots);
   }
 
   private TallySummary createTallySummary(
-      String accountNumber, List<TallySnapshot> tallySnapshots) {
+      String accountNumber, String orgId, List<TallySnapshot> tallySnapshots) {
     var mappedSnapshots =
         tallySnapshots.stream().map(this::mapTallySnapshot).collect(Collectors.toList());
-    return new TallySummary().withAccountNumber(accountNumber).withTallySnapshots(mappedSnapshots);
+    return new TallySummary()
+        .withAccountNumber(accountNumber)
+        .withOrgId(orgId)
+        .withTallySnapshots(mappedSnapshots);
   }
 
   private org.candlepin.subscriptions.json.TallySnapshot mapTallySnapshot(

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceController.java
@@ -71,7 +71,7 @@ public class RemittanceController {
 
     snapshotRepository
         .findLatestBillablesForMonth(clock.now().getMonthValue())
-        .map(s -> summaryMapper.mapSnapshots(s.getAccountNumber(), List.of(s)))
+        .map(s -> summaryMapper.mapSnapshots(s.getAccountNumber(), s.getOwnerId(), List.of(s)))
         .forEach(
             summary ->
                 billableUsageMapper

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -84,6 +84,7 @@ class SnapshotSummaryProducerTest {
         List.of(
             buildSnapshot(
                 "a1",
+                "org1",
                 "OSD",
                 Granularity.HOURLY,
                 ServiceLevel.PREMIUM,
@@ -96,6 +97,7 @@ class SnapshotSummaryProducerTest {
         List.of(
             buildSnapshot(
                 "a2",
+                "org2",
                 "OCP",
                 Granularity.HOURLY,
                 ServiceLevel.PREMIUM,
@@ -113,6 +115,7 @@ class SnapshotSummaryProducerTest {
     assertSummary(
         results,
         "a1",
+        "org1",
         "OSD",
         Granularity.HOURLY,
         ServiceLevel.PREMIUM,
@@ -122,6 +125,7 @@ class SnapshotSummaryProducerTest {
     assertSummary(
         results,
         "a2",
+        "org2",
         "OCP",
         Granularity.HOURLY,
         ServiceLevel.PREMIUM,
@@ -133,6 +137,7 @@ class SnapshotSummaryProducerTest {
   void assertSummary(
       Map<String, List<TallySummary>> results,
       String account,
+      String orgId,
       String product,
       Granularity granularity,
       ServiceLevel sla,
@@ -144,6 +149,7 @@ class SnapshotSummaryProducerTest {
     assertEquals(1, accountSummaries.size());
     TallySummary expectedSummary = accountSummaries.get(0);
     assertEquals(account, expectedSummary.getAccountNumber());
+    assertEquals(orgId, expectedSummary.getOrgId());
 
     assertEquals(1, expectedSummary.getTallySnapshots().size());
     org.candlepin.subscriptions.json.TallySnapshot snapshot =
@@ -169,6 +175,7 @@ class SnapshotSummaryProducerTest {
         List.of(
             buildSnapshot(
                 "a1",
+                "org_1",
                 "OSD",
                 Granularity.HOURLY,
                 ServiceLevel.PREMIUM,
@@ -199,6 +206,7 @@ class SnapshotSummaryProducerTest {
 
   TallySnapshot buildSnapshot(
       String account,
+      String orgId,
       String productId,
       Granularity granularity,
       ServiceLevel sla,
@@ -211,6 +219,7 @@ class SnapshotSummaryProducerTest {
     measurements.put(new TallyMeasurementKey(HardwareMeasurementType.TOTAL, uom), val);
     return TallySnapshot.builder()
         .accountNumber(account)
+        .ownerId(orgId)
         .productId(productId)
         .snapshotDate(OffsetDateTime.now())
         .tallyMeasurements(measurements)

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySummaryMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySummaryMapperTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.json.TallySummary;
+import org.junit.jupiter.api.Test;
+
+public class TallySummaryMapperTest {
+
+  @Test
+  void testMapSnapshots() {
+    String account = "A1";
+    String org = "O1";
+    TallySnapshot rhosak =
+        buildSnapshot(
+            account,
+            org,
+            "RHOSAK",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            2);
+    TallySnapshot rhel =
+        buildSnapshot(
+            account,
+            org,
+            "RHEL",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.RED_HAT,
+            Uom.SOCKETS,
+            24);
+
+    var snapshots = List.of(rhosak, rhel);
+
+    TallySummaryMapper mapper = new TallySummaryMapper();
+    TallySummary summary = mapper.mapSnapshots(account, org, snapshots);
+    assertEquals(account, summary.getAccountNumber());
+    assertEquals(org, summary.getOrgId());
+    List<org.candlepin.subscriptions.json.TallySnapshot> summarySnaps = summary.getTallySnapshots();
+    assertEquals(snapshots.size(), summarySnaps.size());
+
+    var mappedRhosakOptional = findSnapshot(summary, "RHOSAK");
+    assertTrue(mappedRhosakOptional.isPresent());
+    assertMappedSnapshot(rhosak, mappedRhosakOptional.get());
+
+    var mappedRhelOptional = findSnapshot(summary, "RHEL");
+    assertTrue(mappedRhelOptional.isPresent());
+    assertMappedSnapshot(rhel, mappedRhelOptional.get());
+  }
+
+  void assertMappedSnapshot(
+      TallySnapshot expected, org.candlepin.subscriptions.json.TallySnapshot mapped) {
+    assertEquals(expected.getId(), mapped.getId());
+    assertEquals(expected.getBillingAccountId(), mapped.getBillingAccountId());
+    assertEquals(expected.getBillingProvider().getValue(), mapped.getBillingProvider().value());
+    assertEquals(expected.getGranularity().getValue(), mapped.getGranularity().value());
+    assertEquals(expected.getProductId(), mapped.getProductId());
+    assertEquals(expected.getSnapshotDate(), mapped.getSnapshotDate());
+    assertEquals(expected.getServiceLevel().getValue(), mapped.getSla().value());
+    assertEquals(expected.getUsage().getValue(), mapped.getUsage().value());
+
+    var expectedMeasurements = expected.getTallyMeasurements();
+    var mappedMeasurements = mapped.getTallyMeasurements();
+    assertEquals(expectedMeasurements.size(), mappedMeasurements.size());
+
+    mappedMeasurements.forEach(
+        m -> {
+          HardwareMeasurementType type =
+              HardwareMeasurementType.valueOf(m.getHardwareMeasurementType());
+          Uom uom = Uom.fromValue(m.getUom().value());
+          TallyMeasurementKey key = new TallyMeasurementKey(type, uom);
+          assertTrue(expectedMeasurements.containsKey(key));
+          Double expectedValue = expectedMeasurements.get(key);
+          assertEquals(expectedValue, m.getValue());
+        });
+  }
+
+  TallySnapshot buildSnapshot(
+      String account,
+      String orgId,
+      String productId,
+      Granularity granularity,
+      ServiceLevel sla,
+      Usage usage,
+      BillingProvider billingProvider,
+      Uom uom,
+      double val) {
+    Map<TallyMeasurementKey, Double> measurements = new HashMap<>();
+    measurements.put(new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, uom), val);
+    measurements.put(new TallyMeasurementKey(HardwareMeasurementType.TOTAL, uom), val);
+
+    return TallySnapshot.builder()
+        .accountNumber(account)
+        .ownerId(orgId)
+        .productId(productId)
+        .snapshotDate(OffsetDateTime.now())
+        .tallyMeasurements(measurements)
+        .granularity(granularity)
+        .serviceLevel(sla)
+        .usage(usage)
+        .billingProvider(billingProvider)
+        .build();
+  }
+
+  Optional<org.candlepin.subscriptions.json.TallySnapshot> findSnapshot(
+      TallySummary summary, String product) {
+    return summary.getTallySnapshots().stream()
+        .filter(s -> product.equalsIgnoreCase(s.getProductId()))
+        .findFirst();
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySummaryMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySummaryMapperTest.java
@@ -39,7 +39,7 @@ import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.junit.jupiter.api.Test;
 
-public class TallySummaryMapperTest {
+class TallySummaryMapperTest {
 
   @Test
   void testMapSnapshots() {

--- a/swatch-core/schemas/tally_summary.yaml
+++ b/swatch-core/schemas/tally_summary.yaml
@@ -2,9 +2,13 @@ $schema: http://json-schema.org/draft-07/schema#
 title: TallySummary
 required:
   - account_number
+  - org_id
 properties:
   account_number:
     description: Account identifier for the relevant account.
+    type: string
+  org_id:
+    description: The identifier for the relevant organization.
     type: string
   tally_snapshots:
     description: List of tally snapshots produced in the range.


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-241

* Add org_id field to TallySummary definition.
* Set orgId on TallySummary when snapshots are mapped to the summary.

**Testing Notes**
At the moment we are not really able to manually test that the orgId will be set on the TallySummary since the orgId is currently coming from the snapshots. The best we can do at the moment is to ensure that the setting of the orgId is unit tested appropriately.

**TallySnapshot.orgId will be populated by the following:**
- https://issues.redhat.com/browse/SWATCH-97
- https://issues.redhat.com/browse/SWATCH-459
