### PR TITLE
Only define capacity-allowlist ConfigMap once

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -126,6 +126,10 @@ objects:
     spec:
       envName: ${ENV_NAME}
 
+# Needs to stay commented out until there's an rhsm ClowdApp deployed in stage/prod
+#      dependencies:
+#        - rhsm
+
       kafkaTopics:
         - replicas: 1
           partitions: 1
@@ -716,11 +720,3 @@ objects:
       name: swatch-psks
     data:
       self: ZHVtbXk=
-
-  - apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: capacity-allowlist
-    data:
-      product-allowlist.txt: |-
-        PLACEHOLDER


### PR DESCRIPTION
https://ansible.slack.com/archives/C01F7QFNATC/p1660736722070339?thread_ts=1660675926.497599&cid=C01F7QFNATC

The rhsm-clowdapp.yaml template was creating the capacity-allowlist ConfigMap with values, but then the swatch-subscription-sync was recreating the ConfigMap with a placeholder