### PR TITLE
Add cronjob to cleanup databasechangeloglock

### DIFF
--- a/templates/rhsm-subscriptions-scheduler.yml
+++ b/templates/rhsm-subscriptions-scheduler.yml
@@ -49,6 +49,14 @@ parameters:
     value: 100m
   - name: HOURLY_TALLY_OFFSET
     value: 60m
+  - name: EGRESS_IMAGE_TAG
+    value: fec6dc2
+  - name: DB_CHANGELOG_CLEANUP_SCHEDULE
+    value: 00 15 19 08 *
+  - name: DB_CHANGELOG_CLEANUP_SUSPEND
+    value: 'true'
+  - name: DB_CHANGELOG_CLEANUP_SQL
+    value: delete from databasechangeloglock
 
 objects:
   - apiVersion: batch/v1beta1
@@ -412,3 +420,53 @@ objects:
                     secretName: splunk
                 - name: logs
                   emptyDir:
+  - apiVersion: batch/v1beta1
+    kind: CronJob
+    metadata:
+      name: db-changelog-cleanup
+    spec:
+      schedule: ${DB_CHANGELOG_CLEANUP_SCHEDULE}
+      jobTemplate:
+        spec:
+          activeDeadlineSeconds: 60
+          suspend:  ${{DB_CHANGELOG_CLEANUP_SUSPEND}}
+          template:
+            spec:
+              restartPolicy: Never
+              imagePullSecrets:
+                - name: quay-cloudservices-pull
+              containers:
+              - image: quay.io/cloudservices/rhsm-subscriptions-egress:${EGRESS_IMAGE_TAG}
+                imagePullPolicy: Always
+                name: db-changelog-cleanup
+                command: ["/bin/sh", "-c"]
+                args:
+                - psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER $POSTGRESQL_DATABASE -c "$DB_CHANGELOG_CLEANUP_SQL"
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                  limits:
+                    cpu: 500m
+                    memory: 256Mi
+                env:
+                - name: POSTGRESQL_SERVICE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.host
+                - name: POSTGRESQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.user
+                - name: POSTGRESQL_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.name
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.password


### PR DESCRIPTION
It's a hack, but the idea is that we unsuspend by setting `DB_CHANGELOG_CLEANUP_SUSPEND: false` and then also adjust the schedule to be in the near future. (e.g. `DB_CHANGELOG_CLEANUP_SCHEDULE: 30 15 19 08 *`).

It's suspended by default so that when we roll the cronjob to prod it'll be a no-op, until we manually toggle it on.

I tested locally via creating a rhsm-db secret as follows:

```
cat <<EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: rhsm-db
data:
  db.host: bG9jYWxob3N0  # localhost
  db.user: cGxhY2Vob2xkZXI=  # placeholder
  db.name: cGxhY2Vob2xkZXI=  # placeholder
  db.password: cGxhY2Vob2xkZXI=  # placeholder
EOF
```

in an ephemeral namespace, and then running:

```
oc process -p DB_CHANGELOG_CLEANUP_SUSPEND=false DB_CHANGELOG_CLEANUP_SCHEDULE='03 15 19 08 *' -p KAFKA_BOOTSTRAP_HOST=localhost -f templates/rhsm-subscriptions-scheduler.yml | oc apply -f -
```

(and then verified the pod attempted to run psql command against localhost).

(Adjust schedule as needed).