### PR TITLE
SWATCH-489 Add Job and ClowdJobInvocation to run account_config org_id migration

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -87,6 +87,7 @@ parameters:
     value: 1s
   - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER
     value: '2'
+
   - name: PURGE_SNAPSHOT_SCHEDULE
     value: 0 3 * * *
   - name: CAPTURE_SNAPSHOT_SCHEDULE
@@ -121,6 +122,29 @@ parameters:
     value: 'host-inventory-db'
   - name: INVENTORY_SECRET_KEY_NAME_PREFIX
     value: ''
+
+  - name: TENANT_TRANSLATOR_HOST
+    value: "apicast.3scale-dev.svc.cluster.local"
+  - name: TENANT_TRANSLATOR_PORT
+    value: '8891'
+  - name: POPULATOR_LOG_FORMAT
+    value: cloudwatch
+  - name: ORG_ID_POPULATOR_IMAGE
+    value: quay.io/cloudservices/tenant-utils
+  - name: ORG_ID_POPULATOR_IMAGE_TAG
+    value: latest
+  - name: ORG_ID_POPULATOR_CRON_CPU_REQUEST
+    value: 50m
+  - name: ORG_ID_POPULATOR_CRON_MEMORY_REQUEST
+    value: 512Mi
+  - name: ORG_ID_POPULATOR_CRON_CPU_LIMIT
+    value: 300m
+  - name: ORG_ID_POPULATOR_CRON_MEMORY_LIMIT
+    value: 1Gi
+  - name: ORG_ID_POPULATOR_SCHEDULE
+    value: 0 0 * * *
+  - name: POPULATOR_RUN_NUMBER # increment to run the org_id populator(s) again.
+    value: "1"
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -831,6 +855,84 @@ objects:
             - name: logs
               emptyDir:
 
+      - name: opt-in-org-id-populator
+        podSpec:
+          image: ${ORG_ID_POPULATOR_IMAGE}:${ORG_ID_POPULATOR_IMAGE_TAG}
+          command:
+            - ./org-id-column-populator
+            - -H
+            - $(DATABASE_HOST)
+            - -p
+            - $(DATABASE_PORT)
+            - -u
+            - $(DATABASE_USERNAME)
+            - -w
+            - $(DATABASE_PASSWORD)
+            - -n
+            - $(DATABASE_DATABASE)
+            - -a
+            - account_number
+            - -o
+            - org_id
+            - -t
+            - account_config
+            - --ean-translator-addr
+            - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+            - -s
+            - disable
+          env:
+            - name: DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: rhsm-db
+                  key: db.host
+            - name: DATABASE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: rhsm-db
+                  key: db.port
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rhsm-db
+                  key: db.user
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rhsm-db
+                  key: db.password
+            - name: DATABASE_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: rhsm-db
+                  key: db.name
+            - name: POPULATOR_LOG_FORMAT
+              value: ${POPULATOR_LOG_FORMAT}
+            - name: ORG_ID_POPULATOR_IMAGE
+              value: ${ORG_ID_POPULATOR_IMAGE}
+            - name: ORG_ID_POPULATOR_IMAGE
+              value: ${ORG_ID_POPULATOR_IMAGE}
+            - name: LOG_FORMAT
+              value: ${POPULATOR_LOG_FORMAT}
+            - name: LOG_BATCH_FREQUENCY
+              value: "1"
+          resources:
+            requests:
+              cpu: ${ORG_ID_POPULATOR_CRON_CPU_REQUEST}
+              memory: ${ORG_ID_POPULATOR_CRON_MEMORY_REQUEST}
+            limits:
+              cpu: ${ORG_ID_POPULATOR_CRON_CPU_LIMIT}
+              memory: ${ORG_ID_POPULATOR_CRON_MEMORY_LIMIT}
+
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: opt-in-org-id-populator-${POPULATOR_RUN_NUMBER}
+  spec:
+    appName: swatch-tally
+    jobs:
+      - opt-in-org-id-populator
+
 - apiVersion: v1
   kind: Secret
   metadata:
@@ -844,3 +946,4 @@ objects:
     name: cloudigrade-psk
   data:
     psk: ZHVtbXk=
+

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -133,18 +133,18 @@ parameters:
     value: quay.io/cloudservices/tenant-utils
   - name: ORG_ID_POPULATOR_IMAGE_TAG
     value: latest
-  - name: ORG_ID_POPULATOR_CRON_CPU_REQUEST
+  - name: ORG_ID_POPULATOR_CPU_REQUEST
     value: 50m
-  - name: ORG_ID_POPULATOR_CRON_MEMORY_REQUEST
+  - name: ORG_ID_POPULATOR_MEMORY_REQUEST
     value: 512Mi
-  - name: ORG_ID_POPULATOR_CRON_CPU_LIMIT
+  - name: ORG_ID_POPULATOR_CPU_LIMIT
     value: 300m
-  - name: ORG_ID_POPULATOR_CRON_MEMORY_LIMIT
+  - name: ORG_ID_POPULATOR_MEMORY_LIMIT
     value: 1Gi
-  - name: ORG_ID_POPULATOR_SCHEDULE
-    value: 0 0 * * *
   - name: POPULATOR_RUN_NUMBER # increment to run the org_id populator(s) again.
     value: "1"
+  - name: ORG_ID_POPULATOR_BATCH_SIZE
+    value: "100"
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -876,6 +876,8 @@ objects:
             - org_id
             - -t
             - account_config
+            - -b
+            - $(ORG_ID_POPULATOR_BATCH_SIZE)
             - --ean-translator-addr
             - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
             - -s
@@ -906,6 +908,8 @@ objects:
                 secretKeyRef:
                   name: rhsm-db
                   key: db.name
+            - name: ORG_ID_POPULATOR_BATCH_SIZE
+              value: ${ORG_ID_POPULATOR_BATCH_SIZE}
             - name: POPULATOR_LOG_FORMAT
               value: ${POPULATOR_LOG_FORMAT}
             - name: ORG_ID_POPULATOR_IMAGE
@@ -918,11 +922,11 @@ objects:
               value: "1"
           resources:
             requests:
-              cpu: ${ORG_ID_POPULATOR_CRON_CPU_REQUEST}
-              memory: ${ORG_ID_POPULATOR_CRON_MEMORY_REQUEST}
+              cpu: ${ORG_ID_POPULATOR_CPU_REQUEST}
+              memory: ${ORG_ID_POPULATOR_MEMORY_REQUEST}
             limits:
-              cpu: ${ORG_ID_POPULATOR_CRON_CPU_LIMIT}
-              memory: ${ORG_ID_POPULATOR_CRON_MEMORY_LIMIT}
+              cpu: ${ORG_ID_POPULATOR_CPU_LIMIT}
+              memory: ${ORG_ID_POPULATOR_MEMORY_LIMIT}
 
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-489
Added a Job and ClowdJobInvokation to migrate org_id into the account_config table. This job will run immediately when deployed.
**Testing**

**FROM THE MAIN BRANCH**

Ensure that the following component is added to your bonfire config:
```
      - name: swatch-tally
        host: local
        repo: /home/mstead/sandbox/swatch/subscriptions/swatch-tally
        path: /deploy/clowdapp.yaml
        parameters:
         REPLICAS: 1
         IMAGE: quay.io/cloudservices/rhsm-subscriptions
         RHSM_RBAC_USE_STUB: "true"
         DEV_MODE: "true"
```

Deploy to EE:
```
$ export NAMESPACE=$(bonfire namespace reserve -d 1h)

$ bonfire deploy -n $NAMESPACE rhsm \
-C rhsm --no-remove-resources=rhsm \
-C swatch-tally --no-remove-resources=swatch-tally \
--optional-deps-method=none \
-i quay.io/cloudservices/rhsm-subscriptions=latest
```

Once completely deployed, insert some opted in accounts:
```
$ oc project $NAMESPACE

$ for a in 6376293 6411176 941133 6349152; do \
oc exec $(oc -n $NAMESPACE get -o name pod | grep rhsm-db | sed -e 's/pod\// /g') -i -t -- psql rhsm-db \
-c "insert into account_config (account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated) values ('$a', true, true, 'JMX', '2022-08-03 15:43:37.737126+00', '2022-08-03 15:43:37.737126+00');"; \
done;
```

Check out this branch and deploy the app again.
```
$ bonfire deploy -n $NAMESPACE rhsm   -C swatch-tally   --no-remove-resources=swatch-tally   --optional-deps-method=none   -i quay.io/cloudservices/rhsm-subscriptions=latest
```

Check the openshift console to ensure that the `swatch-tally-opt-in-org-id-populator` job has run.

Check the DB to ensure that the org_id column has been fully populated.
```
$ oc exec $(oc -n $NAMESPACE get -o name pod | grep rhsm-db | sed -e 's/pod\// /g') -i -t -- psql rhsm-db -c 'select * from account_config;'
```