### PR TITLE
SWATCH-497 Update hbi queries to use org

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
@@ -39,15 +39,15 @@ public class InventoryDatabaseOperations {
 
   @Transactional(value = "inventoryTransactionManager", readOnly = true)
   public void processHostFacts(
-      Collection<String> accounts, int culledOffsetDays, Consumer<InventoryHostFacts> consumer) {
-    try (Stream<InventoryHostFacts> hostFactStream = repo.getFacts(accounts, culledOffsetDays)) {
+      Collection<String> orgIds, int culledOffsetDays, Consumer<InventoryHostFacts> consumer) {
+    try (Stream<InventoryHostFacts> hostFactStream = repo.getFacts(orgIds, culledOffsetDays)) {
       hostFactStream.forEach(consumer::accept);
     }
   }
 
   @Transactional(value = "inventoryTransactionManager", readOnly = true)
-  public void reportedHypervisors(Collection<String> accounts, Consumer<Object[]> consumer) {
-    try (Stream<Object[]> stream = repo.getReportedHypervisors(accounts)) {
+  public void reportedHypervisors(Collection<String> orgIds, Consumer<Object[]> consumer) {
+    try (Stream<Object[]> stream = repo.getReportedHypervisors(orgIds)) {
       stream.forEach(consumer::accept);
     }
   }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -35,14 +35,14 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
 
   @Query(nativeQuery = true)
   Stream<InventoryHostFacts> getFacts(
-      @Param("accounts") Collection<String> accounts,
+      @Param("orgIds") Collection<String> orgIds,
       @Param("culledOffsetDays") Integer culledOffsetDays);
 
   /**
    * Get a mapping of hypervisor ID to associated hypervisor host's subscription-manager ID. If the
    * hypervisor hasn't been reported, then the hyp_subman_id value will be null.
    *
-   * @param accounts the accounts to filter hosts by.
+   * @param orgIds the orgIds to filter hosts by.
    * @return a stream of Object[] with each entry representing a hypervisor mapping.
    */
   @Query(
@@ -54,7 +54,7 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
               + "from hosts h "
               + "left outer join hosts h_ on h.facts->'rhsm'->>'VM_HOST_UUID' = h_.canonical_facts->>'subscription_manager_id' "
               + "where h.facts->'rhsm'->'VM_HOST_UUID' is not null "
-              + "and h.account IN (:accounts)"
+              + "and h.org_id IN (:orgIds)"
               + "union all "
               + "select "
               + "distinct h.facts->'satellite'->>'virtual_host_uuid' as hyp_id, "
@@ -62,6 +62,6 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
               + "from hosts h "
               + "left outer join hosts h_ on h.facts->'satellite'->>'virtual_host_uuid' = h_.canonical_facts->>'subscription_manager_id' "
               + "where h.facts->'satellite'->'virtual_host_uuid' is not null "
-              + "and h.account IN (:accounts)")
-  Stream<Object[]> getReportedHypervisors(@Param("accounts") Collection<String> accounts);
+              + "and h.org_id IN (:orgIds)")
+  Stream<Object[]> getReportedHypervisors(@Param("orgIds") Collection<String> orgIds);
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -131,7 +131,7 @@ import lombok.Setter;
             + "cross join lateral ( "
             + "    select string_agg(items->>'id', ',') as system_profile_product_ids "
             + "    from jsonb_array_elements(h.system_profile_facts->'installed_products') as items) system_profile "
-            + "where account IN (:accounts)"
+            + "where h.org_id IN (:orgIds)"
             + "   and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')"
             + "   and (h.system_profile_facts->>'host_type' IS NULL OR h.system_profile_facts->>'host_type' <> 'edge')"
             + "   and (stale_timestamp is null "

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -28,8 +28,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.config.AccountConfig;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
 import org.candlepin.subscriptions.registry.TagProfile;
@@ -50,6 +52,7 @@ public class TallySnapshotController {
   private static final Logger log = LoggerFactory.getLogger(TallySnapshotController.class);
 
   private final ApplicationProperties props;
+  private final AccountConfigRepository accountRepo;
   private final InventoryAccountUsageCollector usageCollector;
   private final CloudigradeAccountUsageCollector cloudigradeCollector;
   private final MetricUsageCollector metricUsageCollector;
@@ -64,6 +67,7 @@ public class TallySnapshotController {
   @Autowired
   public TallySnapshotController(
       ApplicationProperties props,
+      AccountConfigRepository accountRepo,
       @Qualifier("applicableProducts") Set<String> applicableProducts,
       InventoryAccountUsageCollector usageCollector,
       CloudigradeAccountUsageCollector cloudigradeCollector,
@@ -76,6 +80,7 @@ public class TallySnapshotController {
       SnapshotSummaryProducer summaryProducer) {
 
     this.props = props;
+    this.accountRepo = accountRepo;
     this.applicableProducts = applicableProducts;
     this.usageCollector = usageCollector;
     this.cloudigradeCollector = cloudigradeCollector;
@@ -90,12 +95,25 @@ public class TallySnapshotController {
 
   @Timed("rhsm-subscriptions.snapshots.single")
   public void produceSnapshotsForAccount(String account) {
+    // NOTE: This lookup should happen when the process starts and should be passed
+    //       along. This should be removed once the task processor is updated to use
+    //       the org_id.
+    AccountConfig accountLookup =
+        accountRepo
+            .findById(account)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        String.format(
+                            "Invalid account number: %s. Has the account been opted in?",
+                            account)));
+
     log.info("Producing snapshots for account {}.", account);
     Map<String, AccountUsageCalculation> accountCalcs = new HashMap<>();
     try {
       accountCalcs.putAll(
           retryTemplate.execute(
-              context -> usageCollector.collect(this.applicableProducts, account)));
+              context -> usageCollector.collect(this.applicableProducts, accountLookup)));
       if (props.isCloudigradeEnabled() && null != accountCalcs.get(account)) {
         String orgId = accountCalcs.get(account).getOwner();
         attemptCloudigradeEnrichment(account, accountCalcs, orgId);

--- a/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
@@ -27,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.config.AccountConfig;
@@ -82,7 +83,7 @@ class AccountConfigRepositoryTest {
 
   @Test
   void testDelete() {
-    AccountConfig config = createConfig("an-account", "org123", true, true);
+    AccountConfig config = createConfig("an-account", "an-org", true, true);
     repository.saveAndFlush(config);
 
     AccountConfig toDelete = repository.getOne(config.getAccountNumber());
@@ -152,8 +153,24 @@ class AccountConfigRepositoryTest {
     assertEquals(2, count);
   }
 
-  private AccountConfig createConfig(
-      String account, String orgId, boolean canSync, boolean canReport) {
+  @Test
+  void testLookupOrgIdByAccountNumber() {
+    AccountConfig expectedConfig = createConfig("A2", "O2", true, false);
+    repository.saveAll(
+        Arrays.asList(
+            createConfig("A1", "O1", true, true),
+            expectedConfig,
+            createConfig("A3", "O3", false, true),
+            createConfig("A4", "O4", false, false)));
+    repository.flush();
+
+    Optional<AccountConfig> result = repository.findById(expectedConfig.getAccountNumber());
+    assertTrue(result.isPresent());
+    assertEquals(expectedConfig, result.get());
+
+  }
+
+  private AccountConfig createConfig(String account, String orgId, boolean canSync, boolean canReport) {
     AccountConfig config = new AccountConfig(account);
     config.setOrgId(orgId);
     config.setOptInType(OptInType.API);

--- a/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
@@ -167,10 +167,10 @@ class AccountConfigRepositoryTest {
     Optional<AccountConfig> result = repository.findById(expectedConfig.getAccountNumber());
     assertTrue(result.isPresent());
     assertEquals(expectedConfig, result.get());
-
   }
 
-  private AccountConfig createConfig(String account, String orgId, boolean canSync, boolean canReport) {
+  private AccountConfig createConfig(
+      String account, String orgId, boolean canSync, boolean canReport) {
     AccountConfig config = new AccountConfig(account);
     config.setOrgId(orgId);
     config.setOptInType(OptInType.API);

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -24,7 +24,10 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
+import org.candlepin.subscriptions.db.model.config.AccountConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +44,8 @@ class TallySnapshotControllerTest {
 
   @Autowired TallySnapshotController controller;
 
+  @MockBean AccountConfigRepository accountRepo;
+
   @MockBean CloudigradeAccountUsageCollector cloudigradeCollector;
 
   @MockBean MetricUsageCollector metricUsageCollector;
@@ -53,6 +58,10 @@ class TallySnapshotControllerTest {
 
   @BeforeEach
   void setup() {
+    AccountConfig accountConfig = new AccountConfig(ACCOUNT);
+    accountConfig.setOrgId("ORG_" + ACCOUNT);
+    when(accountRepo.findById(ACCOUNT)).thenReturn(Optional.of(accountConfig));
+
     defaultCloudigradeIntegrationEnablement = props.isCloudigradeEnabled();
     when(inventoryCollector.collect(any(), any()))
         .thenReturn(ImmutableMap.of(ACCOUNT, new AccountUsageCalculation(ACCOUNT)));


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-497

**NOTE:**
* This PR requires that org_id be set on the AccountConfig (account_config table via opt-in). If the org_id is null, an exception is thrown
* The following PR should be merged and verified working before this is merged (https://github.com/RedHatInsights/rhsm-subscriptions/pull/1353)

**How To Test**

Deploy dependant services:
```
$ podman-compose up -d
```

Import some host data into the local HBI database. 
**The CSV reference here can be found in the comments of SWATCH-497.**
```
$ cat 6089719-hbi-hosts.csv | psql -h 0.0.0.0 -U insights insights -c "copy hosts(id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id) from STDIN delimiter E'\t' csv header;"
```

Run the application:
```
./gradlew clean :bootRun
```

Opt-in the account/org for the test data imported above.
```
curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean","operation":"createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)","arguments":["6089719", "11789772", true, true, true]}'
```

Run a nightly tally for all opted in accounts:
```
curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyConfiguredAccounts()","arguments":[]}'
{"request":{"mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","type":"exec","operation":"tallyConfiguredAccounts()"},"value":null,"timestamp":1661526268,"status":200}[mstead@redcanoe ~]$ curl 'http://localhost:9000/hawtio/jolokia/' -H 'Content-Type: application/json' -d '{"type":"exec","mbean":"org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean","operation":"tallyConfiguredAccounts()","arguments":[]}'
```

Check the DB to ensure that hosts were pulled from HBI and snapshots were created:
```
psql -h 0.0.0.0 -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from tally_snapshots where account_number='6089719';"

psql -h 0.0.0.0 -U rhsm-subscriptions rhsm-subscriptions -c "select h.account_number, h.org_id, m.instance_id, uom, value from hosts h, instance_measurements m where h.id=m.instance_id and account_number='6089719' and org_id='11789772'"
```