### PR TITLE
Remove probes for the metrics job

### DIFF
--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -464,26 +464,6 @@ objects:
                     key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
               - name: PROM_URL
                 value: ${PROM_URL}
-            livenessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /health/liveness
-                port: 9000
-                scheme: HTTP
-              initialDelaySeconds: 15
-              periodSeconds: 20
-              successThreshold: 1
-              timeoutSeconds: 5
-            readinessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /health
-                port: 9000
-                scheme: HTTP
-              initialDelaySeconds: 15
-              periodSeconds: 20
-              successThreshold: 1
-              timeoutSeconds: 5
             resources:
               requests:
                 cpu: ${CPU_REQUEST}


### PR DESCRIPTION
Some jobs seem to be running successfully, but are being marked as failed in stage. Removing the probes to see if it resolves this issue.