### PR TITLE
Fix and prevent null values for instance_count and sockets

### DIFF
--- a/src/main/resources/liquibase/202208301033-default-null-hardware-measurements.xml
+++ b/src/main/resources/liquibase/202208301033-default-null-hardware-measurements.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202208301033-1" author="lburnett">
+    <comment>Set null instances of hardware_measurements.instance_count to 0</comment>
+    <update tableName="hardware_measurements">
+      <column name="instance_count" value="0"/>
+      <where>instance_count IS NULL</where>
+    </update>
+    <addDefaultValue tableName="hardware_measurements" columnName="instance_count"
+      defaultValueNumeric="0"/>
+    <addNotNullConstraint tableName="hardware_measurements" columnName="instance_count"/>
+  </changeSet>
+
+  <changeSet id="202208301033-2" author="lburnett">
+    <comment>Set null instances of hardware_measurements.sockets to 0</comment>
+    <update tableName="hardware_measurements">
+      <column name="sockets" value="0"/>
+      <where>sockets IS NULL</where>
+    </update>
+    <addDefaultValue tableName="hardware_measurements" columnName="sockets"
+      defaultValueNumeric="0"/>
+    <addNotNullConstraint tableName="hardware_measurements" columnName="sockets"/>
+  </changeSet>
+
+</databaseChangeLog>
+  <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -70,5 +70,6 @@
     <include file="liquibase/202208091622-add-org-id-to-account-config.xml"/>
     <include file="liquibase/202208241137-remove-copy-triggers.xml"/>
     <include file="liquibase/202208241637-clean-up-tally-measurements-after-revert.xml"/>
+    <include file="liquibase/202208301033-default-null-hardware-measurements.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.db.model;
 import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,12 +31,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class HardwareMeasurement implements Serializable {
-
-  @NotNull
   @Column(name = "instance_count")
   private int instanceCount;
 
   private int cores;
-
-  @NotNull private int sockets;
+  private int sockets;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.db.model;
 import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,9 +32,13 @@ import lombok.Setter;
 @Getter
 @Setter
 public class HardwareMeasurement implements Serializable {
+
+  @NotNull
   @Column(name = "instance_count")
   private int instanceCount;
 
   private int cores;
+
+  @NotNull
   private int sockets;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
@@ -39,6 +39,5 @@ public class HardwareMeasurement implements Serializable {
 
   private int cores;
 
-  @NotNull
-  private int sockets;
+  @NotNull private int sockets;
 }


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/SWATCH-468

On the main branch first

* Shove stage data into your local instance.  i posted a helper script in slack.  hit me up if you can't find it
* Run the purgesnapshot job and observe error

```bash
SPRING_PROFILES_ACTIVE="purge-snapshots,kafka-queue" DEV_MODE=true ./gradlew :bootRun
```

```
Caused by: java.lang.IllegalArgumentException: Can not set int field org.candlepin.subscriptions.db.model.HardwareMeasurement.instanceCount to null value
```

Switch branches, then retest.  Job should complete without error