### PR TITLE
SWATCH-21: Set sockets and cores when virtual UOM value is available for capacity

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -327,13 +327,13 @@ public class SubscriptionTableController {
     } else if (skuCapacity.getUom() == Uom.CORES) {
       skuCapacity.setPhysicalCapacity(skuCapacity.getPhysicalCapacity() + physicalCores);
       skuCapacity.setVirtualCapacity(skuCapacity.getVirtualCapacity() + virtualCores);
-    } else if (physicalSockets != 0) {
+    } else if (physicalSockets != 0 || virtualSockets != 0) {
       skuCapacity.setPhysicalCapacity(skuCapacity.getPhysicalCapacity() + physicalSockets);
       skuCapacity.setVirtualCapacity(skuCapacity.getVirtualCapacity() + virtualSockets);
       if (skuCapacity.getUom() == null) {
         skuCapacity.setUom(Uom.SOCKETS);
       }
-    } else if (physicalCores != 0) {
+    } else if (physicalCores != 0 || virtualCores != 0) {
       skuCapacity.setPhysicalCapacity(skuCapacity.getPhysicalCapacity() + physicalCores);
       skuCapacity.setVirtualCapacity(skuCapacity.getVirtualCapacity() + virtualCores);
       if (skuCapacity.getUom() == null) {

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -119,6 +119,12 @@ class SubscriptionTableControllerTest {
           ServiceLevel.STANDARD,
           Usage.PRODUCTION,
           true);
+  private static final SubCapSpec RH0180196_VIRTUAL_SOCKETS =
+      SubCapSpec.offering(
+          "RH0180196", "RHEL Server", 0, 0, 2, 0, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+  private static final SubCapSpec RH0180197_VIRTUAL_CORES =
+      SubCapSpec.offering(
+          "RH0180197", "RHEL Server", 0, 0, 0, 2, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
 
   private enum Org {
     STANDARD("711497", "477931");
@@ -720,6 +726,60 @@ class SubscriptionTableControllerTest {
 
     actualItem = actual.getData().get(1);
     assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+  }
+
+  @Test
+  void testGetSkuCapacityReportVirtualSocketsOnly() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a virtual socket
+    // capacity of 2,
+    ProductId productId = RHEL_SERVER;
+    Sub expectedSub = Sub.sub("1234", "1235", 4);
+    List<SubscriptionCapacityView> givenCapacities =
+        givenCapacities(Org.STANDARD, productId, RH0180196_VIRTUAL_SOCKETS.withSub(expectedSub));
+
+
+    when(subscriptionCapacityViewRepository.findAllBy(
+        any(), anyString(), any(), any(), any(), any(), any()))
+        .thenReturn(givenCapacities);
+
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReport actual =
+        subscriptionTableController.capacityReportBySku(
+            productId, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    SkuCapacity actualItem = actual.getData().get(0);
+    assertEquals(RH0180196_VIRTUAL_SOCKETS.sku, actualItem.getSku(), "Wrong SKU");
+    assertCapacities(0, 8, Uom.SOCKETS, actualItem);
+  }
+
+  @Test
+  void testGetSkuCapacityReportVirtualCoresOnly() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a virtual socket
+    // capacity of 2,
+    ProductId productId = RHEL_SERVER;
+    Sub expectedSub = Sub.sub("1234", "1235", 4);
+    List<SubscriptionCapacityView> givenCapacities =
+        givenCapacities(Org.STANDARD, productId, RH0180197_VIRTUAL_CORES.withSub(expectedSub));
+
+
+    when(subscriptionCapacityViewRepository.findAllBy(
+        any(), anyString(), any(), any(), any(), any(), any()))
+        .thenReturn(givenCapacities);
+
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReport actual =
+        subscriptionTableController.capacityReportBySku(
+            productId, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    SkuCapacity actualItem = actual.getData().get(0);
+    assertEquals(RH0180197_VIRTUAL_CORES.sku, actualItem.getSku(), "Wrong SKU");
+    assertCapacities(0, 8, Uom.CORES, actualItem);
   }
 
   private static void assertCapacities(

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -730,16 +730,16 @@ class SubscriptionTableControllerTest {
 
   @Test
   void testGetSkuCapacityReportVirtualSocketsOnly() {
-    // Given an org with one active sub with a quantity of 4 and has an eng product with a virtual socket
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a virtual
+    // socket
     // capacity of 2,
     ProductId productId = RHEL_SERVER;
     Sub expectedSub = Sub.sub("1234", "1235", 4);
     List<SubscriptionCapacityView> givenCapacities =
         givenCapacities(Org.STANDARD, productId, RH0180196_VIRTUAL_SOCKETS.withSub(expectedSub));
 
-
     when(subscriptionCapacityViewRepository.findAllBy(
-        any(), anyString(), any(), any(), any(), any(), any()))
+            any(), anyString(), any(), any(), any(), any(), any()))
         .thenReturn(givenCapacities);
 
     // When requesting a SKU capacity report for the eng product,
@@ -757,16 +757,16 @@ class SubscriptionTableControllerTest {
 
   @Test
   void testGetSkuCapacityReportVirtualCoresOnly() {
-    // Given an org with one active sub with a quantity of 4 and has an eng product with a virtual socket
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a virtual
+    // socket
     // capacity of 2,
     ProductId productId = RHEL_SERVER;
     Sub expectedSub = Sub.sub("1234", "1235", 4);
     List<SubscriptionCapacityView> givenCapacities =
         givenCapacities(Org.STANDARD, productId, RH0180197_VIRTUAL_CORES.withSub(expectedSub));
 
-
     when(subscriptionCapacityViewRepository.findAllBy(
-        any(), anyString(), any(), any(), any(), any(), any()))
+            any(), anyString(), any(), any(), any(), any(), any()))
         .thenReturn(givenCapacities);
 
     // When requesting a SKU capacity report for the eng product,


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-21

Issue was actually when only virtual sockets/cores are set with no physical sockets/cores and no UOM set in request. Capacities were note being totaled correctly in this case. 

Test Steps: 

- Insert test data:
```
INSERT INTO public.offering VALUES ('RH00006S', 'RHEL Server', 'Red Hat Enterprise Linux', NULL, NULL, NULL, 2, 'Red Hat Enterprise Linux Server', 'Premium', 'Production', 'Red Hat Enterprise Linux for Virtual Datacenters with Smart Management, Premium', false);
INSERT INTO public.subscription VALUES ('RH00006S', 'org_123', '9427713', 20, '2021-08-31 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, '9427868', NULL, NULL);
INSERT INTO public.subscription VALUES ('RH00006S', 'org_123', '9427714', 10, '2021-09-01 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, '9427869', NULL, NULL);
INSERT INTO public.subscription VALUES ('RH00006S', 'org_123', '10200808', 2, '2021-10-25 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, '10200965', NULL, NULL);
INSERT INTO public.subscription VALUES ('RH00006S', 'org_123', '10600944', 2, '2022-01-14 05:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, '10601102', NULL, NULL);
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL Server', '9427713', 'org_123', NULL, 40, false, '2021-08-31 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL', '9427713', 'org_123', NULL, 40, false, '2021-08-31 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL for x86', '9427713', 'org_123', NULL, 40, false, '2021-08-31 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL Server', '9427714', 'org_123', NULL, 20, false, '2021-09-01 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL', '9427714', 'org_123', NULL, 20, false, '2021-09-01 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL for x86', '9427714', 'org_123', NULL, 20, false, '2021-09-01 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL Server', '10200808', 'org_123', NULL, 4, false, '2021-10-25 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL', '10200808', 'org_123', NULL, 4, false, '2021-10-25 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL for x86', '10200808', 'org_123', NULL, 4, false, '2021-10-25 04:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL Server', '10600944', 'org_123', NULL, 4, false, '2022-01-14 05:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL', '10600944', 'org_123', NULL, 4, false, '2022-01-14 05:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
INSERT INTO public.subscription_capacity VALUES (NULL, 'RHEL for x86', '10600944', 'org_123', NULL, 4, false, '2022-01-14 05:00:00+00', '2022-08-31 04:00:00+00', NULL, NULL, 'RH00006S', 'Premium', 'Production');
```
- Start app with `DEV_MODE=true ./gradlew :bootRun`
- Run curl and you should see virtual capacity is non 0 
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```