### PR TITLE
Remove dupe template params

### DIFF
--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -48,8 +48,6 @@ parameters:
     value: 'springboot_server'
   - name: SPLUNK_MESSAGE_FORMAT
     value: 'text'
-  - name: SPLUNK_HEC_URL
-    value: https://splunk-hec.redhat.com:8088
   - name: SPLUNK_HEC_CONNECT_TIMEOUT
     value: '5000'
   - name: SPLUNK_HEC_BATCH_SIZE

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -49,8 +49,6 @@ parameters:
     value: '10'
   - name: ENV_NAME
     value: env-swatch-system-conduit
-  - name: IMAGE
-    value: quay.io/cloudservices/rhsm-subscriptions
   - name: ORG_SYNC_SCHEDULE
     value: 0 0 * * *
   - name: ENABLE_SPLUNK_HEC


### PR DESCRIPTION
@awood discovered `IMAGE` in #1283, then I decided it would be wise to
check all of our templates. I used a throwaway python script for this:
https://gist.github.com/kahowell/e9b2cf666c45f9de4770bbcedb0e8181

```
python find-dupe-template-params.py $(find -name clowdapp.yaml)
```

revealed

```
Uh-oh! IMAGE already seen in ./swatch-system-conduit/deploy/clowdapp.yaml
Uh-oh! SPLUNK_HEC_URL already seen in ./swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
```

This removes the redundant params.