### PR TITLE
SWATCH: 290 populate owner_id column of tally_snapshots from account_config table

### DIFF
--- a/src/main/resources/liquibase/202208301423-set-tally-snapshot-owner-id.xml
+++ b/src/main/resources/liquibase/202208301423-set-tally-snapshot-owner-id.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202208301223-1" author="kflahert">
+    <comment>Set null instances of tally_snapshots.owner_id to account_config.org_id value</comment>
+    <update tableName="tally_snapshots">
+      <column name="owner_id" valueComputed="(SELECT a.org_id FROM account_config a WHERE a.account_number=tally_snapshots.account_number)"/>
+      <where>owner_id IS NULL</where>
+    </update>
+  </changeSet>
+
+</databaseChangeLog>
+  <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -71,5 +71,6 @@
     <include file="liquibase/202208241137-remove-copy-triggers.xml"/>
     <include file="liquibase/202208241637-clean-up-tally-measurements-after-revert.xml"/>
     <include file="liquibase/202208301033-default-null-hardware-measurements.xml"/>
+    <include file="liquibase/202208301423-set-tally-snapshot-owner-id.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-290

Test Steps:

- Insert test data:
INSERT INTO public.tally_snapshots VALUES ('06197a03-de1b-49a1-9093-dd61660a8fc1', 'rhosak', 'account123', 'HOURLY', NULL, '2022-06-10 14:00:00+00', NULL, 'Premium', 'Production', 'aws', '027933477046');
INSERT INTO public.tally_snapshots VALUES ('0a4ddeb0-6bcf-493e-a71c-5fc7a987efa8', 'rhosak', '6376293', 'HOURLY', NULL, '2022-07-01 02:00:00+00', NULL, 'Premium', '_ANY', 'aws', '_ANY');
INSERT INTO public.tally_snapshots VALUES ('0beab042-b9ff-4ef3-9a3d-a924f4aa6f97', 'rhosak', '1315336', 'DAILY', NULL, '2022-06-10 00:00:00+00', NULL, 'Premium', '_ANY', '_ANY', '027933477046');
INSERT INTO public.account_config VALUES ('1315336', true, true, 'API', '2022-05-01 00:00:00+00', '2022-05-01 00:00:00+00', '123');
INSERT INTO public.account_config VALUES ('6376293', true, true, 'API', '2022-05-01 00:00:00+00', '2022-05-01 00:00:00+00', '456');
INSERT INTO public.account_config VALUES ('account123', true, true, 'API', '2022-06-06 13:45:37.020113+00', '2022-07-05 18:14:08.738855+00', '789');

- Start app with `DEV_MODE=true ./gradlew :bootRun`
- Check db records of tally_snapshots which should have correct owner_id now.