### PR TITLE
SWATCH-546: add missing rhsm-keystore evn vars to swatch-subscription-sync

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -298,6 +298,20 @@ objects:
                 secretKeyRef:
                   name: tls
                   key: keystore_password
+            - name: RHSM_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tls
+                  key: keystore_password
+            - name: RHSM_KEYSTORE
+              value: /pinhead/keystore.jks
+            - name: RHSM_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tls
+                  key: keystore_password
+            - name: RHSM_TRUSTSTORE
+              value: /pinhead/truststore.jks
             - name: SUBSCRIPTION_KEYSTORE
               value: /pinhead/keystore.jks
             - name: SUBSCRIPTION_URL


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-546