### PR TITLE
Use IQE plugin image for tests

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -12,6 +12,8 @@ export IQE_PLUGINS="rhsm-subscriptions"  # name of the IQE plugin for this APP
 export IQE_MARKER_EXPRESSION="ephemeral"  # This is the value passed to pytest -m
 # export IQE_FILTER_EXPRESSION=""  # This is the value passed to pytest -k
 export IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
+# IQE plugin image
+export IQE_IMAGE_TAG="rhsm-subscriptions"
 # NOTE: workaround for frontend deployment not being ready yet below
 
 


### PR DESCRIPTION
Currently we are using [quay.io/cloudservices/iqe-tests:latest](http://quay.io/cloudservices/iqe-tests:latest) image which comes up with all iqe plugins bundle. Rather than using common image, let's use plugin specific image quay.io/cloudservices/iqe-tests:rhsm-subscriptions to avoid issues due to other plugins. 