### PR TITLE
Add prometheus=rhsm label where missing/misapplied

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -43,6 +43,8 @@ objects:
     kind: ClowdApp
     metadata:
       name: swatch-api
+      labels:
+        prometheus: rhsm
     pullSecrets:
       name: ${IMAGE_PULL_SECRET}
     spec:

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -99,8 +99,8 @@ objects:
     kind: ClowdApp
     metadata:
       name: swatch-metrics
-    labels:
-      prometheus: rhsm
+      labels:
+        prometheus: rhsm
     spec:
       # The name of the ClowdEnvironment providing the services
       envName: ${ENV_NAME}

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -85,6 +85,8 @@ objects:
   kind: ClowdApp
   metadata:
     name: swatch-system-conduit
+    labels:
+      prometheus: rhsm
   spec:
     # The name of the ClowdEnvironment providing the services
     envName: ${ENV_NAME}

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -153,6 +153,8 @@ objects:
   kind: ClowdApp
   metadata:
     name: swatch-tally
+    labels:
+      prometheus: rhsm
   spec:
     # The name of the ClowdEnvironment providing the services
     envName: ${ENV_NAME}


### PR DESCRIPTION
To test, observe the labels in an EE deployment.

```
oc get Deployment -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.metadata.labels.prometheus}{"\n"}{end}'
```

should include (can ignore other deployments):

```
swatch-api-service: rhsm
swatch-metrics-service: rhsm
swatch-producer-aws-service: quarkus
swatch-producer-red-hat-marketplace-service: rhsm
swatch-subscription-sync-service: rhsm
swatch-system-conduit-service: rhsm
swatch-tally-service: rhsm
```

All `swatch-*` Deployments will have `prometheus=rhsm`, except for swatch-producer-aws, which has `prometheus=quarkus`.