### PR TITLE
SWATCH-531: Normalize billing provider rhm to red hat

### DIFF
--- a/bin/GeneratingPrometheusMetricData.adoc
+++ b/bin/GeneratingPrometheusMetricData.adoc
@@ -3,67 +3,18 @@
 Metric data can be generated and imported to a local prometheus service run via podman. This is helpful when you'd like to test some metric gathering changes that aren't already in Observatorium.
 
 == Generate The Test Data
-The following script will create metrics in 5m intervals for all of today.
-
-[source,python]
-----
-#!/usr/bin/python
-
-from datetime import date
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
-import time
-import pytz
-import random
-
-# Time in UTC
-
-today = datetime.now(timezone.utc)
-date_mark = today.replace(minute=0, hour=0, second=0, microsecond=0)
-
-account = 'account123'
-mktp_account = 'mktp-123'
-cluster_id = 'test01'
-
-sub_labels_template = "subscription_labels{{_id=\"{cluster_id}\",billing_model=\"marketplace\",ebs_account=\"{ebs_account}\",external_organization=\"org123\",support=\"Premium\",billing_provider=\"aws\",billing_marketplace_account=\"{mktp_account}\",product=\"rhosak\"}} 1.0 {metric_time}\n"
-rhosak_storage_template = "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes{{_id=\"{cluster_id}\"}} {metered_storage_value} {metric_time}\n"
-
-f = open("sample/metrics.txt", "w")
-f.write("# HELP subscription_labels The total number of HTTP requests.\n")
-f.write("# TYPE subscription_labels counter\n")
-f.write("# HELP kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes The total number of HTTP requests.\n")
-f.write("# TYPE kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes counter\n")
-
-while date_mark.day == today.day and date_mark <= today:
-metric_time = int(date_mark.timestamp())
-metered_storage_value = random.uniform(0.0, 100.0)
-f.write(sub_labels_template.format(cluster_id = cluster_id, ebs_account = account, mktp_account = mktp_account, metric_time = metric_time))
-f.write(rhosak_storage_template.format(cluster_id = cluster_id, metered_storage_value = metered_storage_value, metric_time = metric_time))
-
-  date_mark = date_mark + timedelta(minutes=5)
-
-f.write("# EOF")
-f.close()
-----
-
-== Import Data And Start Prometheus
+The following script will create metrics in 5m intervals for the last 24 hours, and then runs prometheus with the mocked data. You can use env vars to influence the generated data (see ``bin/prometheus-mock-data.sh``).
 
 [source,bash]
 ----
-mkdir prometheus_service; cd prometheus_service
-mkdir prometheus; chmod 777 prometheus
-mkdir sample && ./generate_metrics
-
-# Import the metrics
-podman run --entrypoint /bin/promtool --name prom -p 9090:9090 --rm -ti -v $PWD/prometheus:/prometheus:Z -v $PWD/sample:/sample:Z quay.io/prometheus/prometheus tsdb create-blocks-from openmetrics /sample/metrics.txt .
-
-# Run prometheus
-podman run --name prom -p 9090:9090 --rm -ti -v $PWD/prometheus:/prometheus:Z -v $PWD/sample:/sample:Z quay.io/prometheus/prometheus
+bin/prometheus-mock-data.sh
 ----
 
 == Testing The API
-Take a look at the samples/metrics.txt file and get the time value from the first ( ${START_DATE} ) and the last ( ${END_DATE} ) line and plug them into the curl commands below.
+http://localhost:9090/graph is useful to try PromQL queries.
+
+Using ``START_DATE=$(date -d yesterday +%s)`` and ``END_DATE=$(date +%s)`` (last 24 hours) and plug them into the curl commands below.
+
 [source,bash]
 ----
 curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibytes+*+on%28_id%29+group_right+min_over_time%28subscription_labels%7Bproduct%3D%22rhosak%22%2C+ebs_account%3D%22account123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=${START_DATE}&end=${END_DATE}&step=3600&max_source_resolution=0s'
@@ -73,7 +24,7 @@ curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quo
 ----
 
 == Pointing Subscription Watch At The Local Prometheus
-With this set up, you can now point the metring and tally services at this instance by running the application as follows.
+With this set up, you can now point the metering and tally services at this instance by running the application as follows.
 [source,bash]
 ----
 # Run the metering job

--- a/bin/prometheus-mock-data.sh
+++ b/bin/prometheus-mock-data.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+COMMAND=$1
+
+run_container() {
+  SCRIPT_DIR=$(realpath $(dirname "$0"))
+  podman run --name prometheus-mock \
+    -e CLUSTER_ID \
+    -e BILLING_PROVIDER \
+    -e METRICS \
+    -e PRODUCT \
+    -e MARKETPLACE_ACCOUNT \
+    -e ACCOUNT \
+    -e ORG_ID \
+    --rm \
+    -p 9090:9090 \
+    -v $SCRIPT_DIR/prometheus-mock-data.sh:/entrypoint.sh:Z \
+    --entrypoint=/entrypoint.sh \
+    quay.io/prometheus/prometheus entrypoint
+}
+
+entrypoint() {
+  CLUSTER_ID=${CLUSTER_ID:-test01}
+  BILLING_PROVIDER=${BILLING_PROVIDER:-aws}
+  METRICS="${METRICS:-kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes}"
+  PRODUCT=${PRODUCT:-rhosak}
+  BILLING_PROVIDER=${BILLING_PROVIDER:-aws}
+  MARKETPLACE_ACCOUNT=${MARKETPLACE_ACCOUNT:-mktp-123}
+  ACCOUNT=${ACCOUNT:-account123}
+  ORG_ID=${ORG_ID:-org123}
+
+  FILE=$(mktemp)
+  NOW=$(date +%s)
+  # start at 24 hours ago
+  TIME=$(($NOW - 86400))
+
+  echo "Generating mock data for _id=$CLUSTER_ID,product=$PRODUCT,metrics=$METRICS"
+
+  cat <<EOF > $FILE
+# HELP subscription_labels placeholder
+# TYPE subscription_labels counter
+EOF
+
+  for METRIC in $METRICS; do
+  cat <<EOF >> $FILE
+# HELP $METRIC placeholder
+# TYPE $METRIC counter
+EOF
+  done
+
+  while [ $TIME -lt $NOW ]; do
+    TIME=$(($TIME + 300))
+    cat <<EOF >> $FILE
+subscription_labels{_id="$CLUSTER_ID",billing_model="marketplace",ebs_account="$ACCOUNT",external_organization="$ORG_ID",support="Premium",billing_provider="$BILLING_PROVIDER",billing_marketplace_account="$MARKETPLACE_ACCOUNT",product="$PRODUCT"} 1.0 $TIME
+EOF
+    for METRIC in $METRICS; do
+      VALUE=$(($RANDOM % 100))
+      cat <<EOF >> $FILE
+$METRIC{_id="$CLUSTER_ID"} $VALUE $TIME
+EOF
+    done
+  done
+
+  echo "# EOF" >> $FILE
+
+  echo "Importing mock data"
+  promtool tsdb create-blocks-from openmetrics $FILE /prometheus
+  echo "Running prometheus"
+  # prometheus command copied from the container entrypoint
+  exec prometheus \
+    --config.file=/etc/prometheus/prometheus.yml \
+    --storage.tsdb.path=/prometheus \
+    --web.console.libraries=/usr/share/prometheus/console_libraries \
+    --web.console.templates=/usr/share/prometheus/consoles
+}
+
+if [ "$COMMAND" = "entrypoint" ] ; then
+  entrypoint
+else
+  run_container
+fi

--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -191,7 +191,9 @@ public class MeteringEventFactory {
 
   private static BillingProvider getBillingProvider(
       String billingProvider, String account, String clusterId) {
-    if (billingProvider == null || billingProvider.equals(BillingProvider.__EMPTY__.value())) {
+    if (billingProvider == null
+        || billingProvider.equals(BillingProvider.__EMPTY__.value())
+        || "rhm".equalsIgnoreCase(billingProvider)) {
       return BillingProvider.RED_HAT;
     }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -347,4 +347,25 @@ class MeteringEventFactoryTest {
     assertEquals("snapshot", MeteringEventFactory.getEventType(null));
     assertEquals("snapshot", MeteringEventFactory.getEventType(""));
   }
+
+  @Test
+  void testRhmNormalizedToRedHat() {
+    Event event =
+        MeteringEventFactory.createMetricEvent(
+            "my-account",
+            "my-org",
+            "metric-id",
+            "cluster-id",
+            "Premium",
+            "Production",
+            "ocp",
+            OffsetDateTime.now(),
+            OffsetDateTime.now(),
+            "service_type",
+            "rhm",
+            null,
+            Uom.CORES,
+            12.5);
+    assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
+  }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-531

Pretty simple change, but quite difficult to test without mocked prometheus data, so I took our notes about mocked prometheus data and used them to write a script.

The script uses a few environment variables to allow specifying certain labels, metric data. (See `bin/prometheus-mock-data.sh` for more details).

Testing
-------

Start a prometheus w/ mocked data having billing provider `rhm`:

```
BILLING_PROVIDER=rhm bin/prometheus-mock-data.sh
```

With this still running, start the service and point it at the mock data server:

```
PROM_URL="http://localhost:9090/api/v1/" ./gradlew :bootRun
```

Perform metering (adjust timestamp to be roughly the time you started the mock server):

```
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean' \
  operation='performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)' \
  arguments:='["account123","rhosak","2022-09-09T19:00Z",120]'
```

Check the resulting events (adjust timestamps as needed):

```
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.jmx:name=eventJmxBean,type=EventJmxBean' \
  operation='fetchEventsInTimeRange(java.lang.String,java.lang.String,java.lang.String)' \
  arguments:='["account123","2022-09-09T00:00Z","2022-09-10T00:00Z"]' | jq -r .value | jq
```

Observe `"billing_provider": "red hat"` in the output.