### PR TITLE
SWATCH-161: implement addOrgsToSyncList api

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/OptInType.java
@@ -31,6 +31,9 @@ public enum OptInType {
   /** Configured by an admin via the API. */
   API,
 
+  /** Configured by an admin via the API. */
+  INTERNAL_API,
+
   /** Configured via prometheus detection. */
   PROMETHEUS
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
@@ -51,6 +51,15 @@ public class OrgConfig extends BaseConfig {
     return orgConfig;
   }
 
+  public static OrgConfig fromInternalApi(String orgId, OffsetDateTime timestamp) {
+    OrgConfig orgConfig = new OrgConfig(orgId);
+    orgConfig.setOptInType(OptInType.INTERNAL_API);
+    orgConfig.setSyncEnabled(true);
+    orgConfig.setCreated(timestamp);
+    orgConfig.setUpdated(timestamp);
+    return orgConfig;
+  }
+
   public String getOrgId() {
     return orgId;
   }

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -52,13 +52,11 @@ paths:
       - name: org_ids
         in: query
         required: true
-        style: form
-        explode: false
         schema:
           type: array
           items:
             type: string
-        description: "Comma separated list of org_ids. (Ex. 123,456,789)"
+        description: "List of org IDs to add (Ex. ?org_ids=123&org_ids=456&org_ids=789)"
     post:
       summary: "Add a given list of organizations to the database sync list."
       operationId: addOrgsToSyncList

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/admin/InternalOrganizationSyncResourceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/admin/InternalOrganizationSyncResourceTest.java
@@ -27,13 +27,18 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.util.AssertionErrors.assertFalse;
 import static org.springframework.test.util.AssertionErrors.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.candlepin.subscriptions.conduit.InventoryController;
 import org.candlepin.subscriptions.conduit.job.OrgSyncTaskManager;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
+import org.candlepin.subscriptions.db.model.config.OrgConfig;
 import org.candlepin.subscriptions.exception.MissingAccountNumberException;
 import org.candlepin.subscriptions.utilization.api.model.OrgSyncRequest;
 import org.jboss.resteasy.spi.InternalServerErrorException;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -85,5 +90,14 @@ class InternalOrganizationSyncResourceTest {
     assertFalse(
         "Org ID expected to not exist but does",
         resource.hasOrgInSyncList("123").getExistsInList());
+  }
+
+  @Test
+  void addOrgsToSyncListShouldReturnSucces() {
+    ArgumentCaptor<List<OrgConfig>> orgConfigCaptor = ArgumentCaptor.forClass(List.class);
+    var orgIds = new ArrayList<>(Arrays.asList("123", "456"));
+    assertEquals("Success", resource.addOrgsToSyncList(orgIds).getStatus());
+    verify(repo, times(1)).saveAll(orgConfigCaptor.capture());
+    assertEquals(2, orgConfigCaptor.getValue().size());
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-161

Test Steps:

- Run app with `DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun`
- Run new API 
`curl -X 'POST'  "http://localhost:8000/api/rhsm-subscriptions/v1/internal/organizations-sync-list?org_ids=1512&org_ids=1612&org_ids=1712" -H 'accept: application/vnd.api+json' -H 'x-rh-swatch-psk: placeholder' `
- Check db for 3 new org_config records