### PR TITLE
Address issues w/ org-id-populator job

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -129,6 +129,8 @@ parameters:
     value: "apicast.3scale-dev.svc.cluster.local"
   - name: TENANT_TRANSLATOR_PORT
     value: '8891'
+  - name: TENANT_TRANSLATOR_TIMEOUT
+    value: '40'
   - name: POPULATOR_LOG_FORMAT
     value: cloudwatch
   - name: ORG_ID_POPULATOR_IMAGE
@@ -824,6 +826,8 @@ objects:
             - $(ORG_ID_POPULATOR_BATCH_SIZE)
             - --ean-translator-addr
             - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+            - --ean-translator-timeout
+            - ${TENANT_TRANSLATOR_TIMEOUT}
             - -s
             - disable
           env:

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -799,7 +799,7 @@ objects:
             - name: logs
               emptyDir:
 
-      - name: opt-in-org-id-populator
+      - name: opt-in-org-id-populator-${POPULATOR_RUN_NUMBER}
         podSpec:
           image: ${ORG_ID_POPULATOR_IMAGE}:${ORG_ID_POPULATOR_IMAGE_TAG}
           command:
@@ -879,7 +879,7 @@ objects:
   spec:
     appName: swatch-tally
     jobs:
-      - opt-in-org-id-populator
+      - opt-in-org-id-populator-${POPULATOR_RUN_NUMBER}
 
 - apiVersion: v1
   kind: Secret


### PR DESCRIPTION
Apply POPULATOR_RUN_NUMBER to job name to ensure new job each run: the order that the job is defined, and the ClowdJobInvocation is defined is non-deterministic, which means that the CJI can get outdated definitions otherwise.

Set the timeout to double its default and add a template param so we can tweak further w/out further builds.