### PR TITLE
(swatch-producer-aws) Read subscription endpoint from Clowder

### DIFF
--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -36,8 +36,6 @@ parameters:
     value: '3'
   - name: SPLUNK_HEC_INCLUDE_EX
     value: 'true'
-  - name: SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT
-    value: http://rhsm-capacity-ingress:8000/api/rhsm-subscriptions/v1
   - name: AWS_MARKETPLACE_ENDPOINT_URL
     value: 'http://localhost:8101/aws-marketplace/'
   - name: AWS_MANUAL_SUBMISSION_ENABLED
@@ -68,6 +66,9 @@ objects:
       prometheus: quarkus
   spec:
     envName: ${ENV_NAME}
+
+    dependencies:
+      - swatch-subscription-sync
 
     kafkaTopics:
       - replicas: 1

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 SERVER_PORT=${clowder.endpoints.swatch-producer-aws.port:8000}
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
-SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://${clowder.endpoints.capacity-ingress.hostname}:${clowder.endpoints.capacity-ingress.port}
+SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://${clowder.endpoints.swatch-subscription-sync.hostname}:${clowder.endpoints.swatch-subscription-sync.port}
 AWS_REGION=us-east-1
 AWS_MANUAL_SUBMISSION_ENABLED=false
 AWS_SEND_RETRIES=0


### PR DESCRIPTION
SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT was being explicitly set via app-interface rather than the cdappconfig.json file that is generated by the Clowder operator.

List the swatch-subscription-sync as a dependency in ClowdApp so an entry for it is included in cdappconfig.json

Test steps:

Reserve a namespace
```bash
export NAMESPACE=$(bonfire namespace reserve)
```

Deploy swatch-producer-aws to ephemeral environment
```bash
bonfire deploy -n $NAMESPACE \
  -C rhsm \
  --no-remove-resources=rhsm \
  -C swatch-producer-aws \
  --no-remove-resources=swatch-producer-aws \
  --optional-deps-method=none \
  -i quay.io/cloudservices/rhsm-subscriptions=4f8dc9b \
  -i quay.io/cloudservices/swatch-producer-aws=4f8dc9b \
  -i quay.io/cloudservices/swatch-system-conduit=4f8dc9b \
rhsm
```

After swatch-producer-aws has successfully deployed, confirmed that the cdappconfig.json secret has an endpoints array that has an entry for the  "swatch-subscription-sync" app
```bash
oc project $NAMESPACE

oc get secrets/swatch-producer-aws -o jsonpath={.data."cdappconfig\.json"} | base64 --decode

```

Corresponding MR: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/47425