### PR TITLE
SWATCH-466 Add synchronous api endpoints for tally and metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,9 @@ ext {
 
     billing_api_spec_file = "${internal_spec_dir}/internal-billing-api-spec.yaml"
     billing_config_file = "${internal_spec_dir}/internal-billing-api-config.json"
+
+    metering_api_spec_file = "${internal_spec_dir}/internal-metering-api-spec.yaml"
+    metering_config_file = "${internal_spec_dir}/internal-metering-api-config.json"
 }
 
 tasks.register("buildApiTally", GenerateTask) {
@@ -166,6 +169,18 @@ tasks.register("buildApiBilling", GenerateTask) {
     ]
 }
 
+tasks.register("buildApiMetering", GenerateTask) {
+    generatorName = "jaxrs-spec"
+    inputSpec = metering_api_spec_file
+    configFile = metering_config_file
+    outputDir = "$buildDir/generated/metering"
+    configOptions = [
+            interfaceOnly: "true",
+            generatePom: "false",
+            dateLibrary: "java8",
+    ]
+}
+
 tasks.register("openApiGenerate") {
     dependsOn(provider {
         tasks.findAll { task -> task.name.startsWith('buildApi') }
@@ -182,6 +197,10 @@ tasks.register("validateApiSubSync", ValidateTask) {
 
 tasks.register("validateApiBilling", ValidateTask) {
     inputSpec = billing_api_spec_file
+}
+
+tasks.register("validateApiMetering", ValidateTask) {
+    inputSpec = metering_api_spec_file
 }
 
 tasks.register("apiValidate") {
@@ -210,6 +229,14 @@ tasks.register("generateApiDocsBilling", GenerateTask) {
     generatorName = "html"
     inputSpec = billing_api_spec_file
     outputDir = "$buildDir/internal-billing-docs"
+    generateModelTests = false
+    generateApiTests = false
+}
+
+tasks.register("generateApiDocsMetering", GenerateTask) {
+    generatorName = "html"
+    inputSpec = metering_api_spec_file
+    outputDir = "$buildDir/internal-metering-docs"
     generateModelTests = false
     generateApiTests = false
 }
@@ -247,15 +274,27 @@ tasks.register("generateOpenApiJsonBilling", GenerateTask) {
     ]
 }
 
+tasks.register("generateOpenApiJsonMetering", GenerateTask) {
+    generatorName = "openapi"
+    inputSpec = metering_api_spec_file
+    outputDir = "$buildDir/openapijson"
+    generateModelTests = false
+    generateApiTests = false
+    configOptions = [
+            outputFileName: "internal-metering-openapi.json"
+    ]
+}
+
 processResources {
-    from tasks.generateOpenApiJsonTally, tasks.generateOpenApiJsonSubSync, tasks.generateOpenApiJsonBilling
-    from tally_api_spec_file, sub_sync_api_spec_file, billing_api_spec_file
+    from tasks.generateOpenApiJsonTally, tasks.generateOpenApiJsonSubSync, tasks.generateOpenApiJsonBilling, tasks.generateOpenApiJsonMetering
+    from tally_api_spec_file, sub_sync_api_spec_file, billing_api_spec_file, metering_api_spec_file
 }
 
 sourceSets.main.java.srcDirs += [
     "${buildDir}/generated/tally/src/gen/java",
     "${buildDir}/generated/sub-sync/src/gen/java",
-    "${buildDir}/generated/billing/src/gen/java"
+    "${buildDir}/generated/billing/src/gen/java",
+    "${buildDir}/generated/metering/src/gen/java"
 ]
 
 compileJava {

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -125,4 +125,7 @@ public class ApplicationProperties {
 
   /** If enabled, will sync Subscriptions with the upstream subscription service. */
   private boolean subscriptionSyncEnabled = false;
+
+  /** If enabled, will allow synchronous operations when requested. */
+  private boolean enableSynchronousOperations = false;
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/BaseMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/BaseMeteringResource.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.springframework.util.StringUtils;
+
+/** Base class for metering resources. */
+public class BaseMeteringResource {
+
+  protected ApplicationClock clock;
+
+  public BaseMeteringResource(ApplicationClock clock) {
+    this.clock = clock;
+  }
+
+  protected OffsetDateTime getDate(String dateToParse) {
+    Optional<OffsetDateTime> optionalDate;
+    if (StringUtils.hasText(dateToParse)) {
+      try {
+        // 2018-03-20T09:00:00Z
+        optionalDate = Optional.of(OffsetDateTime.parse(dateToParse));
+      } catch (DateTimeParseException e) {
+        throw new IllegalArgumentException(
+            String.format("Unable to parse date arg '%s'. Invalid format.", dateToParse));
+      }
+    } else {
+      optionalDate = Optional.empty();
+    }
+
+    return getDate(optionalDate);
+  }
+
+  protected OffsetDateTime getDate(Optional<OffsetDateTime> optionalDate) {
+    if (optionalDate.isPresent()) {
+      OffsetDateTime date = optionalDate.get();
+      if (!date.isEqual(clock.startOfHour(date))) {
+        throw new IllegalArgumentException(
+            String.format("Date must start at top of the hour: %s", date));
+      }
+      return date;
+    }
+    // Default to the top of the current hour.
+    return clock.startOfCurrentHour();
+  }
+
+  protected OffsetDateTime getStartDate(OffsetDateTime endDate, Integer rangeInMinutes) {
+    if (rangeInMinutes == null) {
+      throw new IllegalArgumentException("Required argument: rangeInMinutes");
+    }
+
+    if (rangeInMinutes < 0) {
+      throw new IllegalArgumentException("Invalid value specified (Must be >= 0): rangeInMinutes");
+    }
+
+    OffsetDateTime result = endDate.minusMinutes(rangeInMinutes);
+    if (!result.isEqual(clock.startOfHour(result))) {
+      throw new IllegalArgumentException(
+          String.format(
+              "endDate %s - range %s produces time not at top of the hour: %s",
+              endDate, rangeInMinutes, result));
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringConfiguration.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions.metering;
 
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,4 +31,10 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ComponentScan({"org.candlepin.subscriptions.metering.profile"})
-public class MeteringConfiguration {}
+public class MeteringConfiguration {
+
+  @Bean
+  ResourceUtil meteringResourceUtils(ApplicationClock clock) {
+    return new ResourceUtil(clock);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/metering/ResourceUtil.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/ResourceUtil.java
@@ -24,18 +24,20 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
 import org.candlepin.subscriptions.util.ApplicationClock;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** Base class for metering resources. */
-public class BaseMeteringResource {
+/** Utility component for metering resources. */
+@Component
+public class ResourceUtil {
 
   protected ApplicationClock clock;
 
-  public BaseMeteringResource(ApplicationClock clock) {
+  public ResourceUtil(ApplicationClock clock) {
     this.clock = clock;
   }
 
-  protected OffsetDateTime getDate(String dateToParse) {
+  public OffsetDateTime getDate(String dateToParse) {
     Optional<OffsetDateTime> optionalDate;
     if (StringUtils.hasText(dateToParse)) {
       try {
@@ -52,7 +54,7 @@ public class BaseMeteringResource {
     return getDate(optionalDate);
   }
 
-  protected OffsetDateTime getDate(Optional<OffsetDateTime> optionalDate) {
+  public OffsetDateTime getDate(Optional<OffsetDateTime> optionalDate) {
     if (optionalDate.isPresent()) {
       OffsetDateTime date = optionalDate.get();
       if (!date.isEqual(clock.startOfHour(date))) {
@@ -65,7 +67,7 @@ public class BaseMeteringResource {
     return clock.startOfCurrentHour();
   }
 
-  protected OffsetDateTime getStartDate(OffsetDateTime endDate, Integer rangeInMinutes) {
+  public OffsetDateTime getStartDate(OffsetDateTime endDate, Integer rangeInMinutes) {
     if (rangeInMinutes == null) {
       throw new IllegalArgumentException("Required argument: rangeInMinutes");
     }

--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering.api.admin;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import javax.ws.rs.BadRequestException;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.metering.BaseMeteringResource;
+import org.candlepin.subscriptions.metering.admin.api.InternalApi;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
+import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
+import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.resource.ResourceUtils;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class InternalMeteringResource extends BaseMeteringResource implements InternalApi {
+
+  private final ApplicationProperties applicationProperties;
+  private final PrometheusMetricsTaskManager tasks;
+  private final PrometheusMeteringController controller;
+  private final TagProfile tagProfile;
+
+  public InternalMeteringResource(
+      ApplicationProperties applicationProperties,
+      ApplicationClock clock,
+      TagProfile tagProfile,
+      PrometheusMetricsTaskManager tasks,
+      PrometheusMeteringController controller) {
+    super(clock);
+    this.applicationProperties = applicationProperties;
+    this.tagProfile = tagProfile;
+    this.tasks = tasks;
+    this.controller = controller;
+  }
+
+  @Override
+  public void meterProductForAccount(
+      String accountNumber,
+      String productTag,
+      Integer rangeInMinutes,
+      OffsetDateTime endDate,
+      Boolean xRhSwatchSynchronousRequest) {
+    Object principal = ResourceUtils.getPrincipal();
+
+    if (!tagProfile.tagIsPrometheusEnabled(productTag)) {
+      throw new BadRequestException(String.format("Invalid product tag specified: %s", productTag));
+    }
+
+    OffsetDateTime end = getDate(Optional.ofNullable(endDate));
+    OffsetDateTime start = getStartDate(end, rangeInMinutes);
+    log.info(
+        "{} metering for {} against range [{}, {}) triggered via API by {}",
+        productTag,
+        accountNumber,
+        start,
+        end,
+        principal);
+
+    if (ResourceUtils.sanitizeBoolean(xRhSwatchSynchronousRequest, false)) {
+      if (!applicationProperties.isEnableSynchronousOperations()) {
+        throw new BadRequestException("Synchronous metering operations are not enabled.");
+      }
+      performMeteringForAccount(accountNumber, productTag, start, end);
+    } else {
+      queueMeteringForAccount(accountNumber, productTag, start, end);
+    }
+  }
+
+  private void performMeteringForAccount(
+      String accountNumber, String productTag, OffsetDateTime start, OffsetDateTime end) {
+    log.info("Performing {} metering for account {} via API.", productTag, accountNumber);
+    tagProfile
+        .getSupportedMetricsForProduct(productTag)
+        .forEach(
+            metric -> {
+              try {
+                controller.collectMetrics(productTag, metric, accountNumber, start, end);
+              } catch (Exception e) {
+                log.error(
+                    "Problem collecting metrics: {} {} {} [{} -> {}]",
+                    accountNumber,
+                    productTag,
+                    metric,
+                    start,
+                    end,
+                    e);
+              }
+            });
+  }
+
+  private void queueMeteringForAccount(
+      String accountNumber, String productTag, OffsetDateTime start, OffsetDateTime end) {
+    try {
+      log.info("Queuing {} metering for account {} via API.", productTag, accountNumber);
+      tasks.updateMetricsForAccount(accountNumber, productTag, start, end);
+    } catch (Exception e) {
+      log.error("Error queuing {} metering for account {} via API.", productTag, accountNumber, e);
+    }
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -25,31 +25,31 @@ import java.util.Optional;
 import javax.ws.rs.BadRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.metering.BaseMeteringResource;
+import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.admin.api.InternalApi;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.resource.ResourceUtils;
-import org.candlepin.subscriptions.util.ApplicationClock;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class InternalMeteringResource extends BaseMeteringResource implements InternalApi {
+public class InternalMeteringResource implements InternalApi {
 
+  private final ResourceUtil util;
   private final ApplicationProperties applicationProperties;
   private final PrometheusMetricsTaskManager tasks;
   private final PrometheusMeteringController controller;
   private final TagProfile tagProfile;
 
   public InternalMeteringResource(
+      ResourceUtil util,
       ApplicationProperties applicationProperties,
-      ApplicationClock clock,
       TagProfile tagProfile,
       PrometheusMetricsTaskManager tasks,
       PrometheusMeteringController controller) {
-    super(clock);
+    this.util = util;
     this.applicationProperties = applicationProperties;
     this.tagProfile = tagProfile;
     this.tasks = tasks;
@@ -69,8 +69,8 @@ public class InternalMeteringResource extends BaseMeteringResource implements In
       throw new BadRequestException(String.format("Invalid product tag specified: %s", productTag));
     }
 
-    OffsetDateTime end = getDate(Optional.ofNullable(endDate));
-    OffsetDateTime start = getStartDate(end, rangeInMinutes);
+    OffsetDateTime end = util.getDate(Optional.ofNullable(endDate));
+    OffsetDateTime start = util.getStartDate(end, rangeInMinutes);
     log.info(
         "{} metering for {} against range [{}, {}) triggered via API by {}",
         productTag,

--- a/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
@@ -22,11 +22,10 @@ package org.candlepin.subscriptions.metering.jmx;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;
-import org.candlepin.subscriptions.metering.BaseMeteringResource;
+import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.resource.ResourceUtils;
-import org.candlepin.subscriptions.util.ApplicationClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,9 +35,11 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 
 /** Exposes the ability to trigger metering operations from JMX. */
 @ManagedResource
-public class MeteringJmxBean extends BaseMeteringResource {
+public class MeteringJmxBean {
 
   private static final Logger log = LoggerFactory.getLogger(MeteringJmxBean.class);
+
+  private ResourceUtil util;
 
   private PrometheusMetricsTaskManager tasks;
 
@@ -46,10 +47,8 @@ public class MeteringJmxBean extends BaseMeteringResource {
 
   @Autowired
   public MeteringJmxBean(
-      ApplicationClock clock,
-      PrometheusMetricsTaskManager tasks,
-      MetricProperties metricProperties) {
-    super(clock);
+      ResourceUtil util, PrometheusMetricsTaskManager tasks, MetricProperties metricProperties) {
+    this.util = util;
     this.tasks = tasks;
     this.metricProperties = metricProperties;
   }
@@ -62,8 +61,8 @@ public class MeteringJmxBean extends BaseMeteringResource {
     Object principal = ResourceUtils.getPrincipal();
     log.info("{} metering for {} triggered via JMX by {}", productTag, accountNumber, principal);
 
-    OffsetDateTime end = getDate(Optional.empty());
-    OffsetDateTime start = getStartDate(end, metricProperties.getRangeInMinutes());
+    OffsetDateTime end = util.getDate(Optional.empty());
+    OffsetDateTime start = util.getStartDate(end, metricProperties.getRangeInMinutes());
 
     try {
       tasks.updateMetricsForAccount(accountNumber, productTag, start, end);
@@ -89,8 +88,8 @@ public class MeteringJmxBean extends BaseMeteringResource {
       throws IllegalArgumentException {
     Object principal = ResourceUtils.getPrincipal();
 
-    OffsetDateTime end = getDate(endDate);
-    OffsetDateTime start = getStartDate(end, rangeInMinutes);
+    OffsetDateTime end = util.getDate(endDate);
+    OffsetDateTime start = util.getStartDate(end, rangeInMinutes);
     log.info(
         "{} metering for {} against range [{}, {}) triggered via JMX by {}",
         productTag,
@@ -133,8 +132,8 @@ public class MeteringJmxBean extends BaseMeteringResource {
       throws IllegalArgumentException {
     Object principal = ResourceUtils.getPrincipal();
 
-    OffsetDateTime end = getDate(endDate);
-    OffsetDateTime start = getStartDate(end, rangeInMinutes);
+    OffsetDateTime end = util.getDate(endDate);
+    OffsetDateTime start = util.getStartDate(end, rangeInMinutes);
     log.info(
         "Metering for all accounts against range [{}, {}) triggered via JMX by {}",
         start,

--- a/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
@@ -21,7 +21,8 @@
 package org.candlepin.subscriptions.metering.jmx;
 
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import org.candlepin.subscriptions.metering.BaseMeteringResource;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.resource.ResourceUtils;
@@ -32,17 +33,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedOperationParameter;
 import org.springframework.jmx.export.annotation.ManagedResource;
-import org.springframework.util.StringUtils;
 
 /** Exposes the ability to trigger metering operations from JMX. */
 @ManagedResource
-public class MeteringJmxBean {
+public class MeteringJmxBean extends BaseMeteringResource {
 
   private static final Logger log = LoggerFactory.getLogger(MeteringJmxBean.class);
 
   private PrometheusMetricsTaskManager tasks;
-
-  private ApplicationClock clock;
 
   private MetricProperties metricProperties;
 
@@ -51,7 +49,7 @@ public class MeteringJmxBean {
       ApplicationClock clock,
       PrometheusMetricsTaskManager tasks,
       MetricProperties metricProperties) {
-    this.clock = clock;
+    super(clock);
     this.tasks = tasks;
     this.metricProperties = metricProperties;
   }
@@ -64,7 +62,7 @@ public class MeteringJmxBean {
     Object principal = ResourceUtils.getPrincipal();
     log.info("{} metering for {} triggered via JMX by {}", productTag, accountNumber, principal);
 
-    OffsetDateTime end = getDate(null);
+    OffsetDateTime end = getDate(Optional.empty());
     OffsetDateTime start = getStartDate(end, metricProperties.getRangeInMinutes());
 
     try {
@@ -148,43 +146,5 @@ public class MeteringJmxBean {
     } catch (Exception e) {
       log.error("Error triggering {} metering for all accounts via JMX.", productTag, e);
     }
-  }
-
-  private OffsetDateTime getDate(String dateToParse) {
-    if (StringUtils.hasText(dateToParse)) {
-      try {
-        // 2018-03-20T09:00:00Z
-        OffsetDateTime parsed = OffsetDateTime.parse(dateToParse);
-        if (!parsed.isEqual(clock.startOfHour(parsed))) {
-          throw new IllegalArgumentException(
-              String.format("Date must start at top of the hour: %s", parsed));
-        }
-        return parsed;
-      } catch (DateTimeParseException e) {
-        throw new IllegalArgumentException(
-            String.format("Unable to parse date arg '%s'. Invalid format.", dateToParse));
-      }
-    } else {
-      return clock.startOfCurrentHour();
-    }
-  }
-
-  private OffsetDateTime getStartDate(OffsetDateTime endDate, Integer rangeInMinutes) {
-    if (rangeInMinutes == null) {
-      throw new IllegalArgumentException("Required argument: rangeInMinutes");
-    }
-
-    if (rangeInMinutes < 0) {
-      throw new IllegalArgumentException("Invalid value specified (Must be >= 0): rangeInMinutes");
-    }
-
-    OffsetDateTime result = endDate.minusMinutes(rangeInMinutes);
-    if (!result.isEqual(clock.startOfHour(result))) {
-      throw new IllegalArgumentException(
-          String.format(
-              "endDate %s - range %s produces time not at top of the hour: %s",
-              endDate, rangeInMinutes, result));
-    }
-    return result;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJmxProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJmxProfile.java
@@ -20,13 +20,13 @@
  */
 package org.candlepin.subscriptions.metering.profile;
 
+import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.jmx.MeteringJmxBean;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.config.PrometheusServiceConfiguration;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.metering.task.MeteringTasksConfiguration;
 import org.candlepin.subscriptions.task.queue.TaskProducerConfiguration;
-import org.candlepin.subscriptions.util.ApplicationClock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -49,9 +49,9 @@ public class MeteringJmxProfile {
 
   @Bean
   MeteringJmxBean meteringJmxBean(
-      ApplicationClock clock,
+      ResourceUtil meteringResourceUtil,
       PrometheusMetricsTaskManager taskManager,
       MetricProperties metricProperties) {
-    return new MeteringJmxBean(clock, taskManager, metricProperties);
+    return new MeteringJmxBean(meteringResourceUtil, taskManager, metricProperties);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -33,6 +33,7 @@ import org.candlepin.subscriptions.task.queue.TaskConsumerConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
@@ -55,6 +56,7 @@ import org.springframework.retry.support.RetryTemplate;
   TaskConsumerConfiguration.class,
   MeteringTasksConfiguration.class
 })
+@ComponentScan("org.candlepin.subscriptions.metering.api")
 public class OpenShiftWorkerProfile {
 
   @Bean(name = "openshiftMetricRetryTemplate")

--- a/src/main/java/org/candlepin/subscriptions/resource/api/ApiSpecController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/ApiSpecController.java
@@ -58,6 +58,12 @@ public class ApiSpecController {
   @Value("classpath:internal-tally-openapi.json")
   private Resource internalTallyApiJson;
 
+  @Value("classpath:internal-metering-api-spec.yaml")
+  private Resource internalMeteringApiYaml;
+
+  @Value("classpath:internal-metering-openapi.json")
+  private Resource internalMeteringApiJson;
+
   private String getResourceAsString(Resource r) {
     try (InputStream is = r.getInputStream()) {
       return IOUtils.toString(is, StandardCharsets.UTF_8);
@@ -92,5 +98,13 @@ public class ApiSpecController {
 
   public String getInternalTallyApiJson() {
     return getResourceAsString(internalTallyApiJson);
+  }
+
+  public String getInternalMeteringApiYaml() {
+    return getResourceAsString(internalMeteringApiYaml);
+  }
+
+  public String getInternalMeteringApiJson() {
+    return getResourceAsString(internalMeteringApiJson);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/InternalMeteringApiJsonResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/InternalMeteringApiJsonResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource.api;
+
+import org.candlepin.subscriptions.metering.admin.api.InternalMeteringOpenapiJsonApi;
+import org.springframework.stereotype.Component;
+
+/** Serves the OpenAPI json for the internal metering sync API */
+@Component
+public class InternalMeteringApiJsonResource implements InternalMeteringOpenapiJsonApi {
+
+  private ApiSpecController controller;
+
+  public InternalMeteringApiJsonResource(ApiSpecController controller) {
+    this.controller = controller;
+  }
+
+  @Override
+  public String getOpenApiJson() {
+    return controller.getInternalMeteringApiJson();
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/resource/api/InternalMeteringApiYamlResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/InternalMeteringApiYamlResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource.api;
+
+import org.candlepin.subscriptions.metering.admin.api.InternalMeteringOpenapiYamlApi;
+import org.springframework.stereotype.Component;
+
+/** Serves the OpenAPI json for the internal metering sync API */
+@Component
+public class InternalMeteringApiYamlResource implements InternalMeteringOpenapiYamlApi {
+
+  private ApiSpecController controller;
+
+  public InternalMeteringApiYamlResource(ApiSpecController controller) {
+    this.controller = controller;
+  }
+
+  @Override
+  public String getOpenApiYaml() {
+    return controller.getInternalMeteringApiYaml();
+  }
+}

--- a/src/main/spec/internal-metering-api-config.json
+++ b/src/main/spec/internal-metering-api-config.json
@@ -1,0 +1,6 @@
+{
+  "invokerPackage": "org.candlepin.subscriptions.metering.admin",
+  "apiPackage": "org.candlepin.subscriptions.metering.admin.api",
+  "modelPackage": "org.candlepin.subscriptions.metering.admin.api.model",
+  "groupId": "org.candlepin"
+}

--- a/src/main/spec/internal-metering-api-spec.yaml
+++ b/src/main/spec/internal-metering-api-spec.yaml
@@ -1,0 +1,55 @@
+openapi: "3.0.2"
+info:
+  title: "rhsm-subscriptions internal metering API"
+  version: 1.0.0
+
+paths:
+  /internal/metering/{productTag}:
+    description: 'Operations related to product metering.'
+    post:
+      operationId: meterProductForAccount
+      summary: "Perform product metering for account."
+      parameters:
+        - name: accountNumber
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: productTag
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: endDate
+          in: query
+          schema:
+            type: string
+            format: date-time
+            description: "The end date for the metering request. (e.g. 22-05-03T10:00:00Z). Default: Top of the current hour."
+        - name: rangeInMinutes
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: x-rh-swatch-synchronous-request
+          in: header
+          required: false
+          schema:
+            type: boolean
+            default: "false"
+            description: "When present, a synchronous request is made."
+      responses:
+        '200':
+          description: "Metering was successful."
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags:
+        - internalProductMetering
+  /internal-metering-openapi.json:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
+  /internal-metering-openapi.yaml:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"

--- a/src/main/spec/internal-tally-api-spec.yaml
+++ b/src/main/spec/internal-tally-api-spec.yaml
@@ -40,6 +40,48 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+  /internal/tally/hourly:
+    description: 'Operations pertaining to the hourly tally.'
+    post:
+      operationId: performHourlyTallyForAccount
+      summary: "Immediately perform the hourly tally for a specific account."
+      parameters:
+        - name: account
+          in: query
+          required: true
+          schema:
+            type: string
+          description: "The account number to tally."
+        - name: start
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+            description: "The start date for the tally (e.g. 22-05-03T10:00:00Z). Must be specified along with the end parameter."
+        - name: end
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+            description: "The end date for the tally (e.g. 22-05-03T10:00:00Z). Must be specified along with the start parameter."
+        - name: x-rh-swatch-synchronous-request
+          in: header
+          required: false
+          schema:
+            type: boolean
+            default: "false"
+            description: "When present, a synchronous request is made."
+      responses:
+        '200':
+          description: "The hourly tally operation succeeded for the specified account."
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
   /internal-tally-openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
   /internal-tally-openapi.yaml:

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.BadRequestException;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.registry.TagProfile;
@@ -53,6 +54,7 @@ class InternalMeteringResourceTest {
   @Mock private PrometheusMeteringController controller;
 
   private ApplicationProperties appProps;
+  private ResourceUtil util;
   private ApplicationClock clock;
   private InternalMeteringResource resource;
 
@@ -60,11 +62,12 @@ class InternalMeteringResourceTest {
   void setupTest() {
     appProps = new ApplicationProperties();
     clock = new FixedClockConfiguration().fixedClock();
+    util = new ResourceUtil(clock);
     lenient().when(tagProfile.tagIsPrometheusEnabled(VALID_PRODUCT)).thenReturn(true);
     lenient()
         .when(tagProfile.getSupportedMetricsForProduct(VALID_PRODUCT))
         .thenReturn(Set.of(Uom.INSTANCE_HOURS));
-    resource = new InternalMeteringResource(appProps, clock, tagProfile, tasks, controller);
+    resource = new InternalMeteringResource(util, appProps, tagProfile, tasks, controller);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.metering.api.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.Set;
+import javax.ws.rs.BadRequestException;
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
+import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
+import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InternalMeteringResourceTest {
+
+  private static final String VALID_PRODUCT = "rhosak";
+
+  @Mock private TagProfile tagProfile;
+  @Mock private PrometheusMetricsTaskManager tasks;
+  @Mock private PrometheusMeteringController controller;
+
+  private ApplicationProperties appProps;
+  private ApplicationClock clock;
+  private InternalMeteringResource resource;
+
+  @BeforeEach
+  void setupTest() {
+    appProps = new ApplicationProperties();
+    clock = new FixedClockConfiguration().fixedClock();
+    lenient().when(tagProfile.tagIsPrometheusEnabled(VALID_PRODUCT)).thenReturn(true);
+    lenient()
+        .when(tagProfile.getSupportedMetricsForProduct(VALID_PRODUCT))
+        .thenReturn(Set.of(Uom.INSTANCE_HOURS));
+    resource = new InternalMeteringResource(appProps, clock, tagProfile, tasks, controller);
+  }
+
+  @Test
+  void ensureBadRequestIfProductTagIsInvalid() {
+    String productId = "test-product";
+    when(tagProfile.tagIsPrometheusEnabled(productId)).thenReturn(false);
+
+    OffsetDateTime end = clock.startOfCurrentHour();
+    assertThrows(
+        BadRequestException.class,
+        () -> resource.meterProductForAccount("account1", productId, 120, end, false));
+  }
+
+  @Test
+  void ensureMeterProductValidatesDateRange() {
+    OffsetDateTime start = clock.startOfCurrentHour();
+    OffsetDateTime end = start.plusMinutes(5L);
+    // asynchronous
+    IllegalArgumentException iae1 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> resource.meterProductForAccount("account1", VALID_PRODUCT, 120, end, false));
+    assertEquals("Date must start at top of the hour: 2019-05-24T12:05Z", iae1.getMessage());
+    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, clock.startOfHour(end), false);
+
+    // synchronous
+    IllegalArgumentException iae2 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> resource.meterProductForAccount("account1", VALID_PRODUCT, 120, end, true));
+    assertEquals("Date must start at top of the hour: 2019-05-24T12:05Z", iae2.getMessage());
+
+    // Avoid additional exception by enabling synchronous operations.
+    appProps.setEnableSynchronousOperations(true);
+    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, clock.startOfHour(end), true);
+  }
+
+  @Test
+  void preventSynchronousMeteringForAccountWhenSyncRequestsDisabled() {
+    OffsetDateTime end = clock.startOfCurrentHour();
+    BadRequestException bre =
+        assertThrows(
+            BadRequestException.class,
+            () -> resource.meterProductForAccount("account1", VALID_PRODUCT, 120, end, true));
+    assertEquals("Synchronous metering operations are not enabled.", bre.getMessage());
+  }
+
+  @Test
+  void allowAsynchronousMeteringForAccountWhenSyncRequestsDisabled() {
+    OffsetDateTime endDate = clock.startOfCurrentHour();
+    OffsetDateTime startDate = endDate.minusMinutes(120);
+    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, endDate, false);
+    verify(tasks).updateMetricsForAccount("account1", VALID_PRODUCT, startDate, endDate);
+    verifyNoInteractions(controller);
+  }
+
+  @Test
+  void allowSynchronousMeteringForAccountWhenSyncRequestsEnabled() {
+    appProps.setEnableSynchronousOperations(true);
+
+    OffsetDateTime endDate = clock.startOfCurrentHour();
+    OffsetDateTime startDate = endDate.minusMinutes(120);
+    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, endDate, true);
+    verify(controller)
+        .collectMetrics(VALID_PRODUCT, Uom.INSTANCE_HOURS, "account1", startDate, endDate);
+    verifyNoInteractions(tasks);
+  }
+
+  @Test
+  void performAsynchronousMeteringForAccountWhenHeaderIsFalseAndSynchronousEnabled() {
+    appProps.setEnableSynchronousOperations(true);
+
+    OffsetDateTime endDate = clock.startOfCurrentHour();
+    OffsetDateTime startDate = endDate.minusMinutes(120);
+    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, endDate, false);
+    verify(tasks).updateMetricsForAccount("account1", VALID_PRODUCT, startDate, endDate);
+    verifyNoInteractions(controller);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBeanTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.OffsetDateTime;
 import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.registry.TagProfile;
@@ -45,6 +46,7 @@ class MeteringJmxBeanTest {
   @Mock private TagProfile tagProfile;
 
   private ApplicationClock clock;
+  private ResourceUtil util;
   private MetricProperties metricProps;
   private MeteringJmxBean jmx;
 
@@ -54,7 +56,8 @@ class MeteringJmxBeanTest {
     metricProps.setRangeInMinutes(60);
 
     clock = new FixedClockConfiguration().fixedClock();
-    jmx = new MeteringJmxBean(clock, tasks, metricProps);
+    util = new ResourceUtil(clock);
+    jmx = new MeteringJmxBean(util, tasks, metricProps);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.OffsetDateTime;
+import javax.ws.rs.BadRequestException;
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
+import org.candlepin.subscriptions.tally.TallySnapshotController;
+import org.candlepin.subscriptions.tally.billing.RemittanceController;
+import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.util.DateRange;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InternalTallyResourceTest {
+
+  @Mock private MarketplaceResendTallyController resendTallyController;
+  @Mock private RemittanceController remittanceController;
+  @Mock private TallySnapshotController snapshotController;
+  @Mock private CaptureSnapshotsTaskManager snapshotTaskManager;
+
+  private InternalTallyResource resource;
+  private ApplicationProperties appProps;
+  private ApplicationClock clock;
+
+  @BeforeEach
+  void setupTest() {
+    clock = new FixedClockConfiguration().fixedClock();
+    appProps = new ApplicationProperties();
+    resource =
+        new InternalTallyResource(
+            clock,
+            appProps,
+            resendTallyController,
+            remittanceController,
+            snapshotController,
+            snapshotTaskManager);
+  }
+
+  @Test
+  void ensurePerformHourlyTallyForAccountValidatesDateRange() {
+    OffsetDateTime start = clock.startOfCurrentHour();
+    OffsetDateTime end = start.plusMinutes(5L);
+    // asynchronous
+    IllegalArgumentException iae1 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> resource.performHourlyTallyForAccount("account1", start, end, false));
+    assertEquals(
+        "Start/End times must be at the top of the hour: [2019-05-24T12:00:00Z -> 2019-05-24T12:05:00Z]",
+        iae1.getMessage());
+
+    resource.performHourlyTallyForAccount(
+        "account1", start, clock.startOfHour(end.plusHours(1)), false);
+
+    // synchronous
+    IllegalArgumentException iae2 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> resource.performHourlyTallyForAccount("account1", start, end, true));
+    assertEquals(
+        "Start/End times must be at the top of the hour: [2019-05-24T12:00:00Z -> 2019-05-24T12:05:00Z]",
+        iae2.getMessage());
+
+    // Avoid additional exception by enabling synchronous operations.
+    appProps.setEnableSynchronousOperations(true);
+    resource.performHourlyTallyForAccount(
+        "account1", start, clock.startOfHour(end.plusHours(1)), true);
+  }
+
+  @Test
+  void preventSynchronousHourlyTallyForAccountWhenSynchronousOperationsDisabled() {
+    OffsetDateTime start = clock.startOfCurrentHour();
+    OffsetDateTime end = start.plusHours(1L);
+    BadRequestException e =
+        assertThrows(
+            BadRequestException.class,
+            () -> resource.performHourlyTallyForAccount("account1", start, end, true));
+    assertEquals("Synchronous tally operations are not enabled.", e.getMessage());
+  }
+
+  @Test
+  void allowSynchronousHourlyTallyForAccountWhenSynchronousOperationsEnabled() {
+    appProps.setEnableSynchronousOperations(true);
+    OffsetDateTime start = clock.startOfCurrentHour();
+    OffsetDateTime end = start.plusHours(1L);
+    resource.performHourlyTallyForAccount("account1", start, end, true);
+    verify(snapshotController)
+        .produceHourlySnapshotsForAccount("account1", new DateRange(start, end));
+    verifyNoInteractions(snapshotTaskManager);
+  }
+
+  @Test
+  void performAsyncHourlyTallyForAccountWhenSynchronousOperationsEnabled() {
+    appProps.setEnableSynchronousOperations(true);
+    OffsetDateTime start = clock.startOfCurrentHour();
+    OffsetDateTime end = start.plusHours(1L);
+    resource.performHourlyTallyForAccount("account1", start, end, false);
+    verify(snapshotTaskManager).tallyAccountByHourly("account1", new DateRange(start, end));
+    verifyNoInteractions(snapshotController);
+  }
+
+  @Test
+  void performAsyncHourlyTallyForAccountWhenSynchronousOperationsDisabled() {
+    OffsetDateTime start = clock.startOfCurrentHour();
+    OffsetDateTime end = start.plusHours(1L);
+    resource.performHourlyTallyForAccount("account1", start, end, false);
+    verify(snapshotTaskManager).tallyAccountByHourly("account1", new DateRange(start, end));
+    verifyNoInteractions(snapshotController);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -164,4 +164,15 @@ public class ResourceUtils {
         ? "_ANY"
         : billingAccountId;
   }
+
+  /**
+   * Simple method to get around sonar complaint: java:S5411 - Boxed "Boolean" should be avoided in
+   * boolean expressions
+   */
+  public static boolean sanitizeBoolean(Boolean value, boolean defaultValue) {
+    if (Objects.isNull(value)) {
+      return defaultValue;
+    }
+    return value;
+  }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/util/DateRange.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/util/DateRange.java
@@ -24,12 +24,14 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Objects;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 /** A simple class that represents a date range. */
 @Getter
 @Setter
+@EqualsAndHashCode
 public class DateRange {
 
   private final OffsetDateTime startDate;


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-466

An internal hourly tally API endpoint was added to run the hourly tally
operation for a single account.

Created internal metering API that will run prometheus product metering for a single account.

If the application is run with the RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS (Boolean)
env var set, the API will support synchronous operations. The
hourly tally/metering can be run synchronously if the following request header
is present:

`x-rh-swatch-synchronous-request: true`


**TESTING NOTES:**
* A telemeter instance should be set up via podman (token-refresher)
* Dates in the requests should be updated appropriately to gather current data.


**Test functionality when synchronous operations are disabled**

```
$ DEV_MODE=true PROM_URL="http://localhost:8888/api/metrics/v1/telemeter/api/v1" ./gradlew clean :bootRun
```

Perform a metering request via internal endpoint with header set to true. Should fail with 404 Bad Request.
```
$ curl -X POST -H "x-rh-swatch-synchronous-request: true" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?accountNumber=941133&rangeInMinutes=120"
```

Perform hourly tally request via internal endpoint with header set to true. Should fail with 404 Bad Request.
```
$ curl -X POST -H "x-rh-swatch-synchronous-request: true" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/hourly?account=941133&start=2022-09-10T10:00:00Z&end=2022-09-14T22:00:00Z"
```

Perform a metering request via internal endpoint with header set to false OR unset. Tally should be queued up and run.
```
$ curl -X POST -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?accountNumber=941133&rangeInMinutes=120"
```

Perform hourly tally request via internal endpoint with header set to false OR unset. Tally should be queued up and run.
```
$ curl -X POST -H "x-rh-swatch-synchronous-request: false" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/hourly?account=941133&start=2022-09-10T10:00:00Z&end=2022-09-14T22:00:00Z"
```

**Test functionality when synchronous operations are enabled.**
Restart the application with synchronous operations enabled.
```
$ RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL="http://localhost:8888/api/metrics/v1/telemeter/api/v1" ./gradlew clean :bootRun
```

Perform a synchronous metering request via the internal endpoint with the header set to true. Metering should be triggered immediately.
```
$ curl -X POST -H "x-rh-swatch-synchronous-request: true" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?accountNumber=941133&rangeInMinutes=120"
```

Perform hourly tally request via internal endpoint with header set to true. Hourly tally should be run immediately.
```
$ curl -X POST -H "x-rh-swatch-synchronous-request: false" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/hourly?account=941133&start=2022-09-10T10:00:00Z&end=2022-09-14T22:00:00Z"
```

Perform a metering request via internal endpoint with header set to false OR unset. Metering should be queued up and run.
```
$ curl -X POST -H "x-rh-swatch-synchronous-request: false" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?accountNumber=941133&rangeInMinutes=120"
```

Perform hourly tally request via internal endpoint with header set to false OR unset. Tally should be queued up and run.
```
$ curl -X POST -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/hourly?account=941133&start=2022-09-10T10:00:00Z&end=2022-09-14T22:00:00Z"
```