### PR TITLE
SWATCH-19: Warn when the RHIT subs service has no sub

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionNotFoundException.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionNotFoundException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription;
+
+import javax.ws.rs.core.Response.Status;
+import lombok.Getter;
+import org.candlepin.subscriptions.exception.ErrorCode;
+import org.candlepin.subscriptions.exception.SubscriptionsException;
+
+@Getter
+public class SubscriptionNotFoundException extends SubscriptionsException {
+
+  private final String subscriptionNumber;
+
+  public SubscriptionNotFoundException(String subscriptionNumber) {
+    super(
+        ErrorCode.SUBSCRIPTION_SERVICE_REQUEST_ERROR,
+        Status.INTERNAL_SERVER_ERROR,
+        "No subscriptions found for subscriptionNumber=" + subscriptionNumber,
+        null,
+        null);
+    this.subscriptionNumber = subscriptionNumber;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -163,7 +163,15 @@ public class SubscriptionSyncController {
     log.debug("Syncing subscription from external service={}", newOrUpdated);
     // UMB doesn't provide all the fields, so if we have an existing DB record, we'll populate from
     // that; otherwise, use the subscription service to fetch missing info
-    enrichMissingFields(newOrUpdated, subscriptionOptional);
+    try {
+      enrichMissingFields(newOrUpdated, subscriptionOptional);
+    } catch (SubscriptionNotFoundException e) {
+      log.warn(
+          "Subscription not found in subscription service; unable to save subscriptionNumber={} for orgId={} without a subscription ID",
+          newOrUpdated.getSubscriptionNumber(),
+          newOrUpdated.getOwnerId());
+      return;
+    }
     log.debug("New subscription that will need to be saved={}", newOrUpdated);
 
     checkForMissingBillingProvider(newOrUpdated);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/SubscriptionsException.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/SubscriptionsException.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.exception;
 
+import java.util.Optional;
 import javax.ws.rs.core.Response.Status;
 import lombok.Getter;
 import org.candlepin.subscriptions.utilization.api.model.Error;
@@ -39,7 +40,7 @@ public class SubscriptionsException extends RuntimeException {
   }
 
   public SubscriptionsException(ErrorCode code, Status status, String message, Throwable e) {
-    this(code, status, message, e.getMessage(), e);
+    this(code, status, message, Optional.ofNullable(e).map(Throwable::getMessage).orElse(null), e);
   }
 
   public SubscriptionsException(


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-19

I also added a timer to the sync by subscription number call, so that we can monitor counts of this issue. Currently we think this only happens in preprod environments with unrealistic test data.

Note that we already had retries set up for this :-)

Testing
-------
Set up keystores/truststores to hit pre-prod RHIT subscription service, then run with:

```
DEV_MODE=true ./gradlew :bootRun
```

Then use the following to mimic a missing account (notice that the command replaces "1234" with a longer string).

```
http -b :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean \
  operation='enqueueSubscriptionXml(java.lang.String)' \
  arguments:="$(cat src/test/resources/mocked-subscription-message.xml | sed s/1234/123456789876/ | jq -R -s '[.]')"
```

See in the logs a message like (after about 8 seconds, due to retries):

```
2022-09-29 16:33:20,581 [thread=org.springframework.jms.JmsListenerEndpointContainer#0-1] [WARN ] [org.candlepin.subscriptions.subscription.SubscriptionSyncController] - Subscription not found in subscription service; unable to save subscriptionNumber=12356789876 for orgId=org123 without a subscription ID
```

Also see the metrics added:

```
http :9000/metrics | grep swatch_get_subscriptions_by_subscription_number_
```

Notice that we can now track when subscriptions are missing by the exception:

```
swatch_get_subscriptions_by_subscription_number_seconds_count{class="org.candlepin.subscriptions.subscription.SubscriptionService",exception="SubscriptionNotFoundException",method="getSubscriptionBySubscriptionNumber",} 2.0
```