### PR TITLE
SWATCH-134 Migrate org_id from account_config to hosts

### DIFF
--- a/src/main/resources/liquibase/202209301035-migrate-org-id-to-hosts-table.xml
+++ b/src/main/resources/liquibase/202209301035-migrate-org-id-to-hosts-table.xml
@@ -1,0 +1,14 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202209301035-1" author="mstead" dbms="postgresql">
+    <comment>Migrate org_id to hosts table from account_config.</comment>
+    <sql>update hosts h set org_id = ac.org_id
+         from account_config ac
+         WHERE h.account_number = ac.account_number and ac.org_id IS NOT NULL and h.org_id is distinct from ac.org_id;</sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -76,5 +76,6 @@
     <include file="liquibase/202209121018-update-primary-key-of-account-config.xml"/>
     <include file="liquibase/202208251616-migrate-cores-sockets-data.xml"/>
     <include file="liquibase/202208191129-add-version-to-host_tally_buckets.xml"/>
+    <include file="liquibase/202209301035-migrate-org-id-to-hosts-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-134

This patch copies the org_id from the account_config table into the records of the hosts table.

# Testing
1. drop and recreate the DB:
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```
2. Check out the `main` branch and deploy: `./gradlew clean :bootRun`
3. Populate some account/host data. From the `bin` directory, run:
```
for i in {1..10}; do \
  ./insert-mock-hosts --account "account-$i" --org "org-$i" --num-physical 200 --num-hypervisors 200; \
  psql -U rhsm-subscriptions rhsm-subscriptions -c "insert into account_config (account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated, org_id) values ('account-$i', True, True, 'JMX', '2022-08-24 17:38:01.167262+00', '2022-08-24 17:38:01.167262+00', 'org-$i');" ; \
done;
```
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "update hosts set org_id = NULL where account_number <> 'account-4'"
```
4. Check out the `mstead/SWATCH-134-migrate-org-id-for-hosts` branch and redeploy: `./gradlew clean :bootRun`.
5. Verify the migration was successful. Run the following query and make sure there are no NULL org_ids.
```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select distinct org_id from hosts"

 org_id 
--------
 org-1
 org-10
 org-2
 org-3
 org-4
 org-5
 org-6
 org-7
 org-8
 org-9
(10 rows)

```