### PR TITLE
SWATCH-152 Migrate org_id from account_config to billable_usage_remittance

### DIFF
--- a/src/main/resources/liquibase/202209301230-migrate-org-id-to-billable-usage-table.xml
+++ b/src/main/resources/liquibase/202209301230-migrate-org-id-to-billable-usage-table.xml
@@ -1,0 +1,14 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202209301230-1" author="mstead" dbms="postgresql">
+    <comment>Migrate org_id to billable_usage_remittance table from account_config.</comment>
+    <sql>update billable_usage_remittance r set org_id = ac.org_id
+         from account_config ac
+         WHERE r.account_number = ac.account_number and ac.org_id IS NOT NULL and r.org_id is distinct from ac.org_id;</sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -78,5 +78,6 @@
     <include file="liquibase/202208191129-add-version-to-host_tally_buckets.xml"/>
     <include file="liquibase/202209301035-migrate-org-id-to-hosts-table.xml"/>
     <include file="liquibase/202209301614-migrate-org-id-to-events-table.xml"/>
+    <include file="liquibase/202209301230-migrate-org-id-to-billable-usage-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-152

This patch copies the org_id from the account_config table into the records of the billable_usage_remittance table.

# Testing

1. drop and recreate the DB:
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```
2. Check out the `main` branch and deploy: `./gradlew clean :bootRun`

3. Create `remittance.sql` file with the following contents.
```
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-1','','rhosak','Storage-gibibyte-months','2022-06','Premium','Production','azure','test',1,'2022-06-08T11:43:34.243629Z',3)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-1','','rhosak','Storage-gibibyte-months','2022-06','Premium','Production','azure','',1,'2022-06-08T12:00:29.97273Z',2)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-1','','rhosak','Storage-gibibyte-months','2022-06','Premium','Production','azure','tbt',1,'2022-06-08T12:00:29.977061Z',5)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-1','','rhosak','Storage-gibibyte-months','2022-06','Premium','Production','azure',' ',1,'2022-06-08T12:00:29.995023Z',3)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-2','','rhosak','Storage-gibibyte-months','2022-06','Premium','Production','red hat','',1,'2022-06-13T12:14:18.19209Z',5)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-2','','rhosak','Transfer-gibibytes','2022-06','Premium','Production','red hat','',4,'2022-06-13T12:14:18.189573Z',5)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-2','','rhosak','Instance-hours','2022-05','Premium','Production','aws','',1,'2022-06-13T12:14:18.268Z',1)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-2','','rhosak','Transfer-gibibytes','2022-05','Premium','Production','aws','',1,'2022-06-13T12:14:18.265839Z',1)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-3','','rhosak','Instance-hours','2022-06','Premium','Production','oracle','644fa825-478d-4ad3-84f0-d58291513228',1,'2022-06-24T15:45:02.610035Z',477)
;
insert into billable_usage_remittance (account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_value,remittance_date,version) values ('account-3','','rhosak','Instance-hours','2022-06','Premium','Production','gcp','abb21964-be44-42d8-9704-b1daccount-11d6c184',1,'2022-06-24T15:44:21.072031Z',343)
;

```


4. Import some opt-in records into account_config.
```
for i in {1..4}; do \
  psql -U rhsm-subscriptions rhsm-subscriptions -c "insert into account_config (account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated, org_id) values ('account-$i', True, True, 'JMX', '2022-08-24 17:38:01.167262+00', '2022-08-24 17:38:01.167262+00', 'org-$i');" ; \
done;
```


5. Import the matching remittance records containing null org_id values.
```
psql -U rhsm-subscriptions rhsm-subscriptions < remittance.sql
```

6. Deploy the `mstead/SWATCH-152-migrate-org-id-for-billable-usage` branch.
7. Verify that the org_id column in the remittance table has been set and that no NULL values exist.
```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select distinct org_id from billable_usage_remittance"
 org_id 
--------
 org-3
 org-2
 org-1
(3 rows)

```