### PR TITLE
Migrate org_id from account_config to events

### DIFF
--- a/src/main/resources/liquibase/202209301614-migrate-org-id-to-events-table.xml
+++ b/src/main/resources/liquibase/202209301614-migrate-org-id-to-events-table.xml
@@ -1,0 +1,15 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202209301614-1" author="mstead" dbms="postgresql">
+    <comment>Migrate org_id to events table from account_config.</comment>
+    <sql>update events e
+         set org_id = ac.org_id, data = jsonb_set(data, '{org_id}', to_jsonb(ac.org_id), true)
+         from account_config ac
+         WHERE e.account_number = ac.account_number and ac.org_id IS NOT NULL;</sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -77,5 +77,6 @@
     <include file="liquibase/202208251616-migrate-cores-sockets-data.xml"/>
     <include file="liquibase/202208191129-add-version-to-host_tally_buckets.xml"/>
     <include file="liquibase/202209301035-migrate-org-id-to-hosts-table.xml"/>
+    <include file="liquibase/202209301614-migrate-org-id-to-events-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-594

The org_id is set in both the events.org_id column and in the JSONB data.

# Testing
1. drop and recreate the DB:
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```
2. Check out the `main` branch and deploy: `./gradlew clean :bootRun`

3. Create `events.sql` file with the following contents.
```
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('198d1b4b-c5d1-4223-acba-45ff21895c05','account-1','2022-08-25T12:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "198d1b4b-c5d1-4223-acba-45ff21895c05", "timestamp": "2022-08-25T12:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T13:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-1", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0',NULL)
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('7c94e7ae-79d0-493e-9ea7-45fcd57fb2bb','account-1','2022-08-25T13:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "7c94e7ae-79d0-493e-9ea7-45fcd57fb2bb", "timestamp": "2022-08-25T13:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T14:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-1", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0',NULL)
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('f3e1e22a-7124-4b59-a919-b52016fda658','account-1','2022-08-25T14:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "f3e1e22a-7124-4b59-a919-b52016fda658", "timestamp": "2022-08-25T14:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T15:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-1", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0',NULL)
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('ae19c018-4860-4ae0-ab04-86d845eeacec','account-1','2022-08-25T15:00:00Z','{"sla": "Premium", "role": "rhacs", "org_id": "org-1", "event_id": "ae19c018-4860-4ae0-ab04-86d845eeacec", "timestamp": "2022-08-25T15:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T16:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-1", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0','account-1')
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('1e53807a-565f-4b23-861a-ec562c27a517','account-2','2022-08-25T16:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "1e53807a-565f-4b23-861a-ec562c27a517", "timestamp": "2022-08-25T16:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T17:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-2", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0',NULL)
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('84f7b3d5-5b7f-482e-9592-8b3fe0130e9f','account-2','2022-08-25T17:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "84f7b3d5-5b7f-482e-9592-8b3fe0130e9f", "timestamp": "2022-08-25T17:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T18:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-2", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0',NULL)
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('34c2f91a-7003-425d-b687-2aa0bbd7a9e2','account-2','2022-08-25T18:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "34c2f91a-7003-425d-b687-2aa0bbd7a9e2", "timestamp": "2022-08-25T18:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T19:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-2", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0',NULL)
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('fe0afd2b-3bc8-4872-8eb5-5d738cb062c0','account-3','2022-08-25T19:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "fe0afd2b-3bc8-4872-8eb5-5d738cb062c0", "timestamp": "2022-08-25T19:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T20:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-3", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0',NULL)
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('63816bd2-7846-48f9-8cbf-1bba1d478f3e','account-3','2022-08-25T20:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "63816bd2-7846-48f9-8cbf-1bba1d478f3e", "timestamp": "2022-08-25T20:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T21:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-3", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0',NULL)
;
insert into events (id,account_number,timestamp,data,event_type,event_source,instance_id,org_id) values ('63dcfb16-7e12-43d6-89e9-2b86fb60d17f','account-3','2022-08-25T21:00:00Z','{"sla": "Premium", "role": "rhacs", "event_id": "63dcfb16-7e12-43d6-89e9-2b86fb60d17f", "timestamp": "2022-08-25T21:00:00Z", "event_type": "snapshot_redhat.com:rhacs:cpu_hour", "expiration": "2022-08-25T22:00:00Z", "instance_id": "cbm1dfmg26uf3pd68gb0", "display_name": "cbm1dfmg26uf3pd68gb0", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 84.0}], "service_type": "Rhacs Cluster", "account_number": "account-3", "billing_provider": "red hat", "billing_account_id": null}','snapshot_redhat.com:rhacs:cpu_hour','prometheus','cbm1dfmg26uf3pd68gb0','account-3')
;

```

4. Insert the events into the DB.
```
psql -U rhsm-subscriptions rhsm-subscriptions < events.sql
```

5. Insert the matching account_config records.
```
for i in {1..4}; do \
  psql -U rhsm-subscriptions rhsm-subscriptions -c "insert into account_config (account_number, sync_enabled, reporting_enabled, opt_in_type, created, updated, org_id) values ('account-$i', True, True, 'JMX', '2022-08-24 17:38:01.167262+00', '2022-08-24 17:38:01.167262+00', 'org-$i');" ; \
done;
```

6. Deploy the `mstead/SWATCH-302-migrate-org-id-to-events` branch.
7. Verify that the org_id column in the event table has been set and that no NULL values exist.
```
rhsm-subscriptions=# select account_number, org_id, data->>'org_id' as data_org_id from events;
 account_number | org_id | data_org_id 
----------------+--------+-------------
 account-1      | org-1  | org-1
 account-1      | org-1  | org-1
 account-1      | org-1  | org-1
 account-1      | org-1  | org-1
 account-2      | org-2  | org-2
 account-2      | org-2  | org-2
 account-2      | org-2  | org-2
 account-3      | org-3  | org-3
 account-3      | org-3  | org-3
 account-3      | org-3  | org-3
(10 rows)

```

