### PR TITLE
SWATCH-102: Set database ssl properties from clowder config

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -35,6 +35,7 @@ import javax.validation.Validator;
 import org.candlepin.subscriptions.capacity.CapacityIngressConfiguration;
 import org.candlepin.subscriptions.capacity.CapacityReconciliationWorkerConfiguration;
 import org.candlepin.subscriptions.clowder.KafkaJaasBeanPostProcessor;
+import org.candlepin.subscriptions.clowder.RdsSslBeanPostProcessor;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.metering.MeteringConfiguration;
 import org.candlepin.subscriptions.product.OfferingWorkerConfiguration;
@@ -197,5 +198,10 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   @Bean
   public KafkaJaasBeanPostProcessor kafkaJaasBeanPostProcessor(Environment env) {
     return new KafkaJaasBeanPostProcessor(env);
+  }
+
+  @Bean
+  public RdsSslBeanPostProcessor rdsSslBeanPostProcessor(Environment env) {
+    return new RdsSslBeanPostProcessor(env);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/RdsSslBeanPostProcessor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/RdsSslBeanPostProcessor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.clowder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import io.micrometer.core.instrument.util.StringUtils;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
+
+/**
+ * A bean post-processor to correctly configure Ssl for Postgres on RDS. Clowder gives us a value
+ * indicating the SSL mode to use and a value of 'verify-full' will cause a certificate file to be
+ * generated and the path added to the jdbc url.
+ */
+public class RdsSslBeanPostProcessor implements BeanPostProcessor, Ordered {
+
+  private static final Logger log = LoggerFactory.getLogger(RdsSslBeanPostProcessor.class);
+
+  private final Environment environment;
+  private int order = Ordered.LOWEST_PRECEDENCE;
+
+  @Override
+  public int getOrder() {
+    return order;
+  }
+
+  public void setOrder(int order) {
+    this.order = order;
+  }
+
+  public RdsSslBeanPostProcessor(Environment environment) {
+    this.environment = environment;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    if (bean instanceof DataSourceProperties && beanName.equals("rhsmDataSourceProperties")) {
+      String sslMode = environment.getProperty("DATABASE_SSL_MODE");
+      // if ssl is disabled no need to change url
+      if (StringUtils.isBlank(sslMode) || sslMode.equals("disable")) {
+        return bean;
+      }
+
+      boolean verifyFull = sslMode.equals("verify-full");
+      String jdbcUrl = ((DataSourceProperties) bean).getUrl();
+      jdbcUrl = jdbcUrl + "&sslmode=" + sslMode;
+
+      if (verifyFull) {
+        String rdsCa = environment.getProperty("DATABASE_SSL_CERT");
+        jdbcUrl = jdbcUrl + "&sslrootcert=" + createTempRdsCertFile(rdsCa);
+      }
+
+      ((DataSourceProperties) bean).setUrl(jdbcUrl);
+    }
+    return bean;
+  }
+
+  private String createTempRdsCertFile(String certData) {
+    if (certData != null) {
+      return createTempCertFile("rds-ca-root", certData);
+    } else {
+      throw new IllegalStateException(
+          "'database.sslMode' is set to 'verify-full' in the Clowder config but the 'database.rdsCa' field is missing");
+    }
+  }
+
+  private String createTempCertFile(String fileName, String certData) {
+    byte[] cert = certData.getBytes(UTF_8);
+    try {
+      File certFile = File.createTempFile(fileName, ".crt");
+      setDeleteTempCertFileOnExit(certFile);
+      return Files.write(Path.of(certFile.getAbsolutePath()), cert).toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Certificate file creation failed", e);
+    }
+  }
+
+  private void setDeleteTempCertFileOnExit(File certFile) {
+    try {
+      certFile.deleteOnExit();
+    } catch (SecurityException e) {
+      log.warn(
+          String.format(
+              "Delete on exit of the %s cert file denied by the security manager",
+              certFile.getName()),
+          e);
+    }
+  }
+}

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -14,6 +14,8 @@ KAFKA_USERNAME: ${clowder.kafka.brokers[0].sasl.username:}
 KAFKA_PASSWORD: ${clowder.kafka.brokers[0].sasl.password:}
 KAFKA_SASL_PROTOCOL: ${clowder.kafka.brokers[0].sasl.securityProtocol:}
 KAFKA_SASL_MECHANISM: ${clowder.kafka.brokers[0].sasl.saslMechanism:}
+DATABASE_SSL_MODE: ${clowder.database.sslMode:disable}
+DATABASE_SSL_CERT: ${clowder.database.rdsCa:}
 
 # This needs to be a PEM encoded certificate string.  If you want to point to a file you can use
 # spring.kafka.ssl.trust-store-location property but that property is mutually exclusive with the
@@ -66,8 +68,6 @@ APP_NAME: rhsm-subscriptions
 DATABASE_HOST: localhost
 DATABASE_PORT: 5432
 DATABASE_DATABASE: rhsm-subscriptions
-DATABASE_SSL_MODE: disable
-DATABASE_SSL_CERT: /dev/null
 DATABASE_USERNAME: rhsm-subscriptions
 DATABASE_PASSWORD: rhsm-subscriptions
 DATABASE_CONNECTION_TIMEOUT_MS: 30000
@@ -157,7 +157,7 @@ rhsm-subscriptions:
     # this mapping required here because it is used by our SecurityConfig, which is shared
     org.candlepin.subscriptions.resteasy: ${PATH_PREFIX}/${APP_NAME}/v1
   datasource:
-    url: jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?reWriteBatchedInserts=true&stringtype=unspecified&sslmode=${DATABASE_SSL_MODE}&sslrootcert=${DATABASE_SSL_CERT}&options=-c%20statement_timeout=${POSTGRES_STATEMENT_TIMEOUT}
+    url: jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?reWriteBatchedInserts=true&stringtype=unspecified&options=-c%20statement_timeout=${POSTGRES_STATEMENT_TIMEOUT}
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
     driver-class-name: org.postgresql.Driver

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions;
 
 import org.candlepin.subscriptions.clowder.KafkaJaasBeanPostProcessor;
+import org.candlepin.subscriptions.clowder.RdsSslBeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -36,5 +37,16 @@ public class SystemConduitConfiguration {
   @Bean
   public KafkaJaasBeanPostProcessor kafkaJaasBeanPostProcessor(Environment env) {
     return new KafkaJaasBeanPostProcessor(env);
+  }
+
+  /**
+   * A bean post-processor responsible for setting up SSL for the database.
+   *
+   * @param env The Spring Environment
+   * @return a rdsSslBeanPostProcessor object
+   */
+  @Bean
+  public RdsSslBeanPostProcessor rdsSslBeanPostProcessor(Environment env) {
+    return new RdsSslBeanPostProcessor(env);
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-102

To test need to setup local database with SSL and add a mock clowder config similar to below:

```
{
	"database": {
		"sslMode": "require",
		"rdsCa": "-----BEGIN CERTIFICATE-----placeholderCertData-----END CERTIFICATE-----\n"
	}
}
```