### PR TITLE
Fix kafka producer properties building

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationConfiguration.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.capacity;
 
-import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
+import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getProducerProperties;
 
 import org.candlepin.subscriptions.subscription.PruneSubscriptionsTask;
 import org.candlepin.subscriptions.subscription.SyncSubscriptionsTask;
@@ -42,19 +42,19 @@ public class CapacityReconciliationConfiguration {
   @Bean
   public ProducerFactory<String, SyncSubscriptionsTask> syncSubscriptionsProducerFactory(
       KafkaProperties kafkaProperties) {
-    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+    return new DefaultKafkaProducerFactory<>(getProducerProperties(kafkaProperties));
   }
 
   @Bean
   public ProducerFactory<String, PruneSubscriptionsTask> pruneSubscriptionsProducerFactory(
       KafkaProperties kafkaProperties) {
-    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+    return new DefaultKafkaProducerFactory<>(getProducerProperties(kafkaProperties));
   }
 
   @Bean
   public ProducerFactory<String, ReconcileCapacityByOfferingTask>
       reconcileCapacityByOfferingProducerFactory(KafkaProperties kafkaProperties) {
-    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+    return new DefaultKafkaProducerFactory<>(getProducerProperties(kafkaProperties));
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/product/ProductConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/product/ProductConfiguration.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.product;
 
-import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
+import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getProducerProperties;
 
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -57,7 +57,7 @@ public class ProductConfiguration {
   @Bean
   public ProducerFactory<String, OfferingSyncTask> offeringSyncProducerFactory(
       KafkaProperties kafkaProperties) {
-    return new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+    return new DefaultKafkaProducerFactory<>(getProducerProperties(kafkaProperties));
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
-import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
+import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getProducerProperties;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashSet;
@@ -173,7 +173,7 @@ public class TallyWorkerConfiguration {
   public ProducerFactory<String, TallySummary> tallySummaryProducerFactory(
       KafkaProperties kafkaProperties, ObjectMapper objectMapper) {
     DefaultKafkaProducerFactory<String, TallySummary> factory =
-        new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+        new DefaultKafkaProducerFactory<>(getProducerProperties(kafkaProperties));
     /*
     Use our customized ObjectMapper. Notably, the spring-kafka default ObjectMapper writes dates as
     timestamps, which produces messages not compatible with JSON-B deserialization.

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.billing;
 
-import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getConfigProps;
+import static org.candlepin.subscriptions.task.queue.kafka.KafkaTaskProducerConfiguration.getProducerProperties;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
@@ -130,7 +130,7 @@ public class BillingProducerConfiguration {
   public ProducerFactory<String, BillableUsage> billableUsageProducerFactory(
       KafkaProperties kafkaProperties, ObjectMapper objectMapper) {
     DefaultKafkaProducerFactory<String, BillableUsage> factory =
-        new DefaultKafkaProducerFactory<>(getConfigProps(kafkaProperties));
+        new DefaultKafkaProducerFactory<>(getProducerProperties(kafkaProperties));
     /*
     Use our customized ObjectMapper. Notably, the spring-kafka default ObjectMapper writes dates as
     timestamps, which produces messages not compatible with JSON-B deserialization.

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
@@ -62,11 +62,11 @@ public class KafkaTaskProducerConfiguration {
   }
 
   @NotNull
-  public static Map<String, Object> getConfigProps(KafkaProperties kafkaProperties) {
-    return Map.of(
-        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers(),
-        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
-        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+  public static Map<String, Object> getProducerProperties(KafkaProperties kafkaProperties) {
+    Map<String, Object> properties = kafkaProperties.buildProducerProperties();
+    properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    return properties;
   }
 
   @Bean


### PR DESCRIPTION
We weren't passing enough properties along into the producer config which meant producers were being instantiated without proper auth config for managed kafka.