### PR TITLE
SWATCH-593 add org id to event key and make mandatory

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -251,7 +251,7 @@ public class PrometheusMeteringController {
       BigDecimal value) {
     EventKey lookupKey =
         new EventKey(
-            account,
+            orgId,
             MeteringEventFactory.EVENT_SOURCE,
             MeteringEventFactory.getEventType(metricId),
             instanceId,

--- a/src/test/java/org/candlepin/subscriptions/db/model/EventKeyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/EventKeyTest.java
@@ -52,21 +52,21 @@ class EventKeyTest {
 
   @Test
   void testEquality() {
-    EventKey ek1 = new EventKey("account", "source", "type", "instance", clock.now());
-    EventKey ek2 = new EventKey("account", "source", "type", "instance", clock.now());
-    EventKey ek3 =
-        new EventKey("account3", "source3", "type3", "instance3", clock.now().minusDays(1));
+    EventKey ek1 = new EventKey("org", "source", "type", "instance", clock.now());
+    EventKey ek2 = new EventKey("org", "source", "type", "instance", clock.now());
+    EventKey ek3 = new EventKey("org3", "source3", "type3", "instance3", clock.now().minusDays(1));
 
     assertEquals(ek1, ek2);
     assertNotEquals(ek1, ek3);
   }
 
   private EventKey keyForInstanceId(String instanceId) {
-    return new EventKey("account", "source", "type", instanceId, clock.now());
+    return new EventKey("org", "source", "type", instanceId, clock.now());
   }
 
   private Event eventForInstanceId(String instanceId) {
     return new Event()
+        .withOrgId("org")
         .withAccountNumber("account")
         .withEventType("type")
         .withEventSource("source")

--- a/swatch-core/schemas/event.yaml
+++ b/swatch-core/schemas/event.yaml
@@ -22,7 +22,7 @@ properties:
   org_id:
     description: Organization identifier associated with this event.
     type: string
-    required: false
+    required: true
   service_type:
     description: Identifier for the type of service being measured. (E.g. RHEL System, OpenShift Cluster)
     type: string

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventKey.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.db.model;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.candlepin.subscriptions.json.Event;
 
@@ -30,22 +31,23 @@ import org.candlepin.subscriptions.json.Event;
  * lookup tables while processing Events pulled from the DB.
  */
 @Getter
+@EqualsAndHashCode
 public class EventKey {
 
-  private String accountNumber;
+  private String orgId;
   private String eventType;
   private String eventSource;
   private String instanceId;
   private OffsetDateTime timestamp;
 
   public EventKey(
-      String accountNumber,
+      String orgId,
       String eventSource,
       String eventType,
       String instanceId,
       OffsetDateTime timestamp) {
-    Objects.requireNonNull(accountNumber, "EventKey requires a non null 'accountNumber'.");
-    this.accountNumber = accountNumber;
+    Objects.requireNonNull(orgId, "EventKey requires a non null 'orgId'.");
+    this.orgId = orgId;
 
     Objects.requireNonNull(eventType, "EventKey requires a non null 'eventType'.");
     this.eventType = eventType;
@@ -62,31 +64,10 @@ public class EventKey {
 
   public static EventKey fromEvent(Event event) {
     return new EventKey(
-        event.getAccountNumber(),
+        event.getOrgId(),
         event.getEventSource(),
         event.getEventType(),
         event.getInstanceId(),
         event.getTimestamp());
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    EventKey eventKey = (EventKey) o;
-    return Objects.equals(accountNumber, eventKey.accountNumber)
-        && Objects.equals(eventType, eventKey.eventType)
-        && Objects.equals(eventSource, eventKey.eventSource)
-        && Objects.equals(instanceId, eventKey.instanceId)
-        && Objects.equals(timestamp, eventKey.timestamp);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountNumber, eventType, eventSource, instanceId, timestamp);
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-593

# Testing
1. Start from a fresh DB and deploy: `PROM_URL="http://localhost:8888/api/metrics/v1/telemeter/api/v1" DEV_MODE=true ./gradlew clean :bootRun`
2. Trigger a metrics run for a test account:
```
curl -X POST -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhacs?accountNumber=10769791&rangeInMinutes=120"
```

3. Ensure Events were pulled in for the account
```
rhsm-subscriptions=# select count(*) from events;
 count 
-------
     2
(1 row)
```

4. Re-run the metrics pull to ensure that no duplicate Events were created. The count should be the same.
5. Trigger an hourly tally run for the same account (**ADJUST THE START AND END APPROPRIATELY BASED ON YOUR EVENTS**):
```
curl -X POST -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/hourly?account=10769791&start=2022-10-03T00:00:00Z&end=2022-10-03T22:00:00Z"
```
6. Snapshot records should be created with no errors due to mandatory org_id on the Event record.