### PR TITLE
SWATCH-575: Validate Mac addresses before pushing them to HBI

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -167,7 +167,7 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   /* Do not declare a MethodValidationPostProcessor!
    *
    * The Spring Core documents instruct the user to create a MethodValidationPostProcessor in order to
-   * enable method validation.  However, Spring Boot takes care of creating that bean that itself:
+   * enable method validation.  However, Spring Boot takes care of creating that bean itself:
    * "The method validation feature supported by Bean Validation 1.1 is automatically enabled as long as a
    * JSR-303 implementation (such as Hibernate validator) is on the classpath" (from
    * https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-validation).

--- a/src/test/java/org/candlepin/subscriptions/validator/MacAddressValidatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/validator/MacAddressValidatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MacAddressValidatorTest {
+  private MacAddressValidator validator = new MacAddressValidator();
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "01-23-45-67-89-ab",
+        "01-23-45-67-89-AB",
+        "01-23-45-67-89-aB",
+        "01:23:45:67:89:ab",
+        "01:23:45:67:89:AB",
+        "01:23:45:67:89:aB",
+        "0123.4567.89ab", // See https://en.wikipedia.org/wiki/MAC_address#Notational_conventions
+        "0123456789ab"
+      })
+  void isValid(String mac) {
+    assertTrue(validator.isValid(mac, null));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "01:23:45-67:89:aB", // Mixed delimiters
+        "xx:23:45:67:89:aB",
+        "I am not a mac address"
+      })
+  void isInvalid(String mac) {
+    assertFalse(validator.isValid(mac, null));
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/validator/Iso8601Validator.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/validator/Iso8601Validator.java
@@ -39,9 +39,8 @@ public class Iso8601Validator implements ConstraintValidator<Iso8601, String> {
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
     // Note that the Jakarta Bean Validation specification recommends to consider null values as
-    // being
-    // valid. If null is not a valid value for an element, it should be annotated with @NotNull
-    // explicitly
+    // being valid. If null is not a valid value for an element, it should be annotated with
+    // @NotNull explicitly
     if (value == null) {
       return true;
     }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/validator/MacAddress.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/validator/MacAddress.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Marks a field as needing MAC address validation. The annotation can be used on a String field or
+ * on a String typed collection.
+ *
+ * <pre>
+ * {@literal @}MacAddress
+ * private String mac
+ *
+ * private List&lt;MacAddress String&gt; ipAddresses
+ * </pre>
+ */
+@Target({FIELD, PARAMETER, ANNOTATION_TYPE, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {MacAddressValidator.class})
+public @interface MacAddress {
+  String message() default "Must be a valid MAC address.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/validator/MacAddressValidator.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/validator/MacAddressValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.validator;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/** A ConstraintValidator that ensures that a MAC address is valid */
+public class MacAddressValidator implements ConstraintValidator<MacAddress, String> {
+  public static final Pattern MAC_REGEX =
+      Pattern.compile(
+          /* Start with a non-capturing group since the ^ operator normally takes precedence over the
+           * | operator.  Then 2 hex characters followed by an optional colon or hyphen in a
+           * capturing group.  That optional character will be treated as the delimiter.  Then look
+           * for 2 more hex characters.  After that, reference the delimiter with the \1
+           * backreference coupled with 2 hex characters and look for that three character unit 4 times.
+           *
+           * After the pipe character is the alternate format which is the comparatively simple 12
+           * hex characters broken into groups of 4 and delimited with periods.
+           *
+           * Simplest of all is the last option which is just 12 hex digits.
+           */
+          "^(?:[0-9a-fA-F]{2}([-:]?)[0-9a-fA-F]{2}(\\1[0-9a-fA-F]{2}){4}|"
+              + "([0-9a-fA-F]{4}\\.[0-9a-fA-F]{4}\\.[0-9a-fA-F]{4})|"
+              + "[0-9a-fA-F]{12})$" // NOSONAR
+          );
+
+  @Override
+  public void initialize(MacAddress constraintAnnotation) {
+    /* intentionally empty */
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    // Note that the Jakarta Bean Validation specification recommends to consider null values as
+    // being valid. If null is not a valid value for an element, it should be annotated with
+    // @NotNull explicitly
+    if (value == null) {
+      return true;
+    }
+    Matcher matcher = MAC_REGEX.matcher(value);
+    return matcher.matches();
+  }
+}

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions;
 
 import org.candlepin.subscriptions.clowder.KafkaJaasBeanPostProcessor;
 import org.candlepin.subscriptions.clowder.RdsSslBeanPostProcessor;
+import org.candlepin.subscriptions.validator.MacAddressValidator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -37,6 +38,18 @@ public class SystemConduitConfiguration {
   @Bean
   public KafkaJaasBeanPostProcessor kafkaJaasBeanPostProcessor(Environment env) {
     return new KafkaJaasBeanPostProcessor(env);
+  }
+
+  /**
+   * Unfortunately there's no one property to apply the MacAddress annotation to. We have to resort
+   * to calling the validator manually when we know we have a String we need to treat as a MAC
+   * address.
+   *
+   * @return an instance of MacAddressValidator
+   */
+  @Bean
+  public MacAddressValidator macAddressValidator() {
+    return new MacAddressValidator();
   }
 
   /**

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -53,6 +53,7 @@ import org.candlepin.subscriptions.conduit.rhsm.client.model.InstalledProducts;
 import org.candlepin.subscriptions.conduit.rhsm.client.model.Pagination;
 import org.candlepin.subscriptions.exception.MissingAccountNumberException;
 import org.candlepin.subscriptions.utilization.api.model.OrgInventory;
+import org.candlepin.subscriptions.validator.MacAddressValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -108,6 +109,7 @@ public class InventoryController {
   private InventoryService inventoryService;
   private RhsmService rhsmService;
   private Validator validator;
+  private MacAddressValidator macValidator;
   private OrgSyncTaskManager taskManager;
   private Counter queueNextPageCounter;
   private Counter finalizeOrgCounter;
@@ -121,12 +123,14 @@ public class InventoryController {
       InventoryService inventoryService,
       RhsmService rhsmService,
       Validator validator,
+      MacAddressValidator macValidator,
       OrgSyncTaskManager taskManager,
       MeterRegistry meterRegistry) {
 
     this.inventoryService = inventoryService;
     this.rhsmService = rhsmService;
     this.validator = validator;
+    this.macValidator = macValidator;
     this.taskManager = taskManager;
     this.queueNextPageCounter = meterRegistry.counter("rhsm-conduit.queue.next-page");
     this.finalizeOrgCounter = meterRegistry.counter("rhsm-conduit.finalize.org");
@@ -349,7 +353,9 @@ public class InventoryController {
             mac != null
                 && !mac.equalsIgnoreCase(NONE)
                 && !mac.equalsIgnoreCase(UNKNOWN)
-                && !isTruncated(mac, factKey);
+                && !isTruncated(mac, factKey)
+                && macValidator.isValid(mac, null);
+
     return filterCommaDelimitedList(s, macTests);
   }
 


### PR DESCRIPTION
HBI has their own validation regex in [SWATCH-575](https://issues.redhat.com/browse/SWATCH-575)

```
'pattern': '^([A-Fa-f0-9]{2}[:-]){5}[A-Fa-f0-9]{2}$|^([A-Fa-f0-9]{4}[.]){2}[A-Fa-f0-9]{4}$|^[A-Fa-f0-9]{12}$|^([A-Fa-f0-9]{2}[:-]){19}[A-Fa-f0-9]{2}$|^[A-Fa-f0-9]{40}$',
```

However, it seems very peculiar to me.

* `([A-Fa-f0-9]{2}[:-]){5}[A-Fa-f0-9]{2}$` - Similar to mine except this regex allows for heterogeneous delimiters (e.g. `01:23:45-67-89:aa`).  I have elected to not allow these in our code since dear God why would you want that.
* `^([A-Fa-f0-9]{4}[.]){2}[A-Fa-f0-9]{4}$` - Identical in function to the one I have for the 3 groups of 4 hex digits format
* `^[A-Fa-f0-9]{12}$` - 12 hexadecimal digits.  Identical in function to the one I have
* `^([A-Fa-f0-9]{2}[:-]){19}[A-Fa-f0-9]{2}$` - This is where is gets weird.  2 hex digit, 1 delimiter units repeated **19** times followed by 2 hex digits.  So this is a 40 hex digit MAC address (20 bytes).
* `^[A-Fa-f0-9]{40}$` - 40 hex digits, no delimiters

I have done some searching and while there seems to be a few references here and there to [64 bit MAC addresses](https://www.lifewire.com/introduction-to-mac-addresses-817937), I can't find anything on 160 bit MAC addresses.  I didn't implement anything for 64 bit MAC addresses since those would fail HBI's validation.