### PR TITLE
SWATCH-297: Configure RHODS product in tag_profile

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1094,6 +1094,7 @@ components:
         - OpenShift-dedicated-metrics
         - rhosak
         - rhacs
+        - rhods
     MetricId:
       type: string
       enum:

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -160,10 +160,16 @@ public class PrometheusMeteringController {
               String clusterId = labels.get("_id");
               String sla = labels.get("support");
               String usage = labels.get("usage");
+
+              // These were added as an edge case with RHODS as it doesn't have product as a label
+              // in prometheus
+              String product = labels.get("product");
+              String resourceName = labels.get("resource_name");
+
               // NOTE: Role comes from the product label despite its name. The values set here
               //       are NOT engineering or swatch product IDs. They map to the roles in the
               //       tag profile. For openshift, the values will be 'ocp' or 'osd'.
-              String role = labels.get("product");
+              String role = product == null ? resourceName : product;
               String billingProvider = labels.get("billing_marketplace");
               String billingAccountId = labels.get("billing_marketplace_account");
               String orgId = labels.get("external_organization");

--- a/src/main/java/org/candlepin/subscriptions/user/StubAccountApi.java
+++ b/src/main/java/org/candlepin/subscriptions/user/StubAccountApi.java
@@ -27,11 +27,29 @@ import org.candlepin.subscriptions.user.api.resources.AccountApi;
 /** Stub implementation of the Account API that returns a canned response. */
 public class StubAccountApi extends AccountApi {
 
+  /**
+   * Generate mock lookups for accountNumber <-> orgId translations.
+   *
+   * <p>Translates any accountNumber (stripping "account" prefix) to org$accountNumber. Translates
+   * any orgId (stripped "org" prefix) to account$orgId.
+   *
+   * <p>As a special exception, it translates orgId 123 to accountNumber 123.
+   *
+   * @param accountSearch (required)
+   * @return mocked API response
+   */
   @Override
-  public Account findAccount(AccountSearch accountSearch) throws ApiException {
-    if ("123".equals(accountSearch.getBy().getId())) {
-      return new Account().ebsAccountNumber("123").id("123");
+  public Account findAccount(AccountSearch accountSearch) {
+    String orgId = accountSearch.getBy().getId();
+    String accountNumber = accountSearch.getBy().getEbsAccountNumber();
+    if ("123".equals(orgId)) {
+      accountNumber = "123";
+    } else if (accountNumber != null) {
+      orgId = "org" + accountNumber.replace("account", "");
+    } else if (orgId != null) {
+      accountNumber = "account" + orgId.replace("org", "");
     }
-    return new Account().ebsAccountNumber("account123").id("org123");
+
+    return new Account().ebsAccountNumber(accountNumber).id(orgId);
   }
 }

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -17,6 +17,10 @@ rhsm-subscriptions:
             max(sum_over_time(#{metric.queryParams[prometheusMetric]}[1h:5m]) / 13.0) by (_id)
             * on(_id) group_right
             min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+          addonSamples: >-
+            #{metric.queryParams[prometheusMetric]}
+            * on(_id) group_right
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{resource_type="addon",resource_name="#{metric.queryParams[resourceName]}", ebs_account="#{runtime[account]}",billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
         backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -98,6 +98,11 @@ tagMappings:
     valueType: role
     tags:
       - rhacs
+  - value: addon-open-data-hub
+    valueType: role
+    tags:
+      - rhods
+
   - value: Red Hat Enterprise Linux Server
     valueType: role
     tags:
@@ -134,6 +139,11 @@ tagMappings:
     valueType: productName
     tags:
       - rhacs
+
+  - value: OpenShift Data Science
+    valueType: productName
+    tags:
+      - rhods
 
   # System Architecture
   - value: aarch64
@@ -263,6 +273,19 @@ tagMetrics:
       prometheusMetric: rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h
       prometheusMetadataMetric: subscription_labels
 
+   #RHODS metrics
+  - tag: rhods
+    metricId: redhat.com:openshift_data_science:cpu_hours
+    rhmMetricId: redhat.com:openshift_data_science:cpu_hours
+    awsDimension: cpu_hour
+    uom: CORES
+    billingWindow: MONTHLY
+    queryKey: addonSamples
+    queryParams:
+      resourceName: addon-open-data-hub
+      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_hours
+      prometheusMetadataMetric: ocm_subscription_resource
+
 # The tagMetaData section defines additional information around how a tag is tallied.  Most notably,
 # tags need to have their finest granularity defined so that we can create accurate snapshots.  A
 # tag that only supports DAILY granularity shouldn't be tallied hourly, for example.  Other metadata
@@ -305,6 +328,13 @@ tagMetaData:
   - tags:
       - rhacs
     serviceType: Rhacs Cluster
+    finestGranularity: HOURLY
+    defaultSla: PREMIUM
+    defaultUsage: PRODUCTION
+    billingModel: PAYG
+  - tags:
+      - rhods
+    serviceType: Rhods Cluster
     finestGranularity: HOURLY
     defaultSla: PREMIUM
     defaultUsage: PRODUCTION


### PR DESCRIPTION
This is to address https://issues.redhat.com/browse/SWATCH-297

Add new tags for rhods in tagprofile yaml
Update ProdcutId in api-spec
Add new queryParam template for addons in metering worker yaml.

Testing Steps:

1. Setup profiles in your configuration with the following
```
DEV_MODE=true;SPRING_PROFILES_ACTIVE=openshift-metering-worker;PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1;USER_USE_STUB=true
```
2. Add the following in MeteringJMXBean to test that 'rhods' would be accepted as a query.
```
http://localhost:9000/hawtio/jolokia/exec/org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean/performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer).

The parameters: 301721915996, rhods, 2022-10-31T19:00:00Z, 20160
```
3. Observe that Prometheus runs the query without issue.
```
[org.candlepin.subscriptions.metering.jmx.MeteringJmxBean] - rhods metering for 301721915996 against range [2022-10-17T19:00Z, 2022-10-31T19:00Z) triggered via JMX by anonymousUser
2022-10-07 16:15:41,987 [thread=http-nio-9000-exec-9] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager] - Queuing rhods Cores metric updates for account 301721915996.
2022-10-07 16:15:41,987 [thread=http-nio-9000-exec-9] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager] - Queuing rhods Cores metric update for account 301721915996 for range [2022-10-17T19:00Z, 2022-10-31T19:00Z)
2022-10-07 16:15:41,987 [thread=http-nio-9000-exec-9] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager] - ACCOUNT: 301721915996 TAG: rhods METRIC: Cores START: 2022-10-17T19:00Z END: 2022-10-31T19:00Z
2022-10-07 16:15:41,987 [thread=http-nio-9000-exec-9] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager] - Done queuing updates of rhods Cores metric
2022-10-07 16:15:41,988 [thread=pool-3-thread-2] [INFO ] [org.candlepin.subscriptions.metering.task.MetricsTask] - Running rhods Cores metrics update task for account: 301721915996
2022-10-07 16:15:41,993 [thread=pool-3-thread-2] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Collecting metrics for account 301721915996: rhods Cores
2022-10-07 16:15:41,993 [thread=pool-3-thread-2] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusService] - Fetching metrics from prometheus: 2022-10-17T20:00Z -> 2022-10-31T19:00Z [Step: 3600]
2022-10-07 16:15:42,277 [thread=pool-3-thread-2] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] - Persisted 0 events for rhods Cores metrics.
2022-10-07 16:15:42,279 [thread=pool-3-thread-2] [INFO ] [org.candlepin.subscriptions.metering.task.MetricsTask] - rhods Cores metrics task complete.
```
You can play around and try to find an event from Prometheus using Thanos -> http://localhost:8082/api/metrics/v1/telemeter 
Below is a PROM query that I use as an template:
```
ocm_subscription_resource{resource_type="addon",resource_name="addon-open-data-hub",billing_model="marketplace"}
```