### PR TITLE
Update instance API to use orgId

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -111,7 +111,7 @@ public class InstancesResource implements InstancesApi {
     int minCores = 0;
     int minSockets = 0;
 
-    String accountNumber = ResourceUtils.getAccountNumber();
+    String orgId = ResourceUtils.getOwnerId();
     ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
     Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
     BillingProvider sanitizedBillingProvider =
@@ -146,7 +146,7 @@ public class InstancesResource implements InstancesApi {
     Measurement.Uom referenceUom = SORT_TO_UOM_MAP.get(sort);
     hosts =
         repository.findAllBy(
-            accountNumber,
+            orgId,
             productId.toString(),
             sanitizedSla,
             sanitizedUsage,

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -730,7 +730,7 @@ class HostRepositoryTest {
     Uom referenceUom = HostsResource.SORT_TO_UOM_MAP.getOrDefault(sort, Uom.CORES);
     Page<Host> results =
         repo.findAllBy(
-            "account123",
+            "ORG_account123",
             "RHEL",
             ServiceLevel._ANY,
             Usage._ANY,
@@ -1000,7 +1000,7 @@ class HostRepositoryTest {
 
     Page<Host> results =
         repo.findAllBy(
-            "a1",
+            "ORG_a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -1017,7 +1017,7 @@ class HostRepositoryTest {
 
     Page<Host> allResults =
         repo.findAllBy(
-            "a1",
+            "ORG_a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -1120,7 +1120,7 @@ class HostRepositoryTest {
 
     Page<Host> results =
         repo.findAllBy(
-            "a1",
+            "ORG_a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
@@ -76,6 +77,7 @@ class HostsResourceTest {
   @MockBean HostRepository repository;
   @MockBean PageLinkCreator pageLinkCreator;
   @MockBean AccountListSource accountListSource;
+  @MockBean AccountConfigRepository accountConfigRepo;
   @Autowired HostsResource resource;
 
   @BeforeEach
@@ -85,6 +87,7 @@ class HostsResourceTest {
             any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt(), any()))
         .thenReturn(mockPage);
     when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
+    when(accountConfigRepo.findOrgByAccountNumber("account123456")).thenReturn("owner123456");
   }
 
   @Test
@@ -405,7 +408,7 @@ class HostsResourceTest {
     when(page.getContent()).thenReturn(List.of(host));
 
     when(repository.findAllBy(
-            "account123456",
+            "owner123456",
             ProductId.OPENSHIFT_DEDICATED_METRICS.toString(),
             ServiceLevel._ANY,
             Usage._ANY,

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -24,6 +24,7 @@ import static org.candlepin.subscriptions.utilization.api.model.ProductId.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
@@ -75,7 +76,17 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                any(), any(), any(), any(), any(), anyInt(), anyInt(), any(), any(), any(), any(),
+                eq("owner123456"),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyInt(),
+                anyInt(),
+                any(),
+                any(),
+                any(),
+                any(),
                 any()))
         .thenReturn(new PageImpl<>(List.of(host)));
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -114,7 +114,7 @@ public interface HostRepository
    * Find all Hosts by bucket criteria and return a page of TallyHostView objects. A TallyHostView
    * is a Host representation detailing what 'bucket' was applied to the current daily snapshots.
    *
-   * @param accountNumber The account number of the hosts to query (required).
+   * @param orgId The organization ID of the hosts to query (required).
    * @param productId The bucket product ID to filter Host by (pass null to ignore).
    * @param sla The bucket service level to filter Hosts by (pass null to ignore).
    * @param usage The bucket usage to filter Hosts by (pass null to ignore).
@@ -129,7 +129,7 @@ public interface HostRepository
    */
   @SuppressWarnings("java:S107")
   default Page<Host> findAllBy(
-      @Param("account") String accountNumber,
+      @Param("orgId") String orgId,
       @Param("product") String productId,
       @Param("sla") ServiceLevel sla,
       @Param("usage") Usage usage,
@@ -144,8 +144,7 @@ public interface HostRepository
 
     HostSpecification searchCriteria = new HostSpecification();
 
-    searchCriteria.add(
-        new SearchCriteria(Host_.ACCOUNT_NUMBER, accountNumber, SearchOperation.EQUAL));
+    searchCriteria.add(new SearchCriteria(Host_.ORG_ID, orgId, SearchOperation.EQUAL));
     searchCriteria.add(
         new SearchCriteria(HostBucketKey_.PRODUCT_ID, productId, SearchOperation.EQUAL));
     searchCriteria.add(new SearchCriteria(HostBucketKey_.SLA, sla, SearchOperation.EQUAL));


### PR DESCRIPTION
- The HostRepository now does its lookup by Host.orgId
- InstanceApi now looks at the orgId specified in the request header when looking up host records via the repository.
- HostResource was updated to lookup the orgId from the account config based on the specified account number. This is temporary, and will be addressed by another card.

# Testing

Insert some mock host data.
```
./insert-mock-hosts --account "account123" --org "org123" --num-physical 200 --num-hypervisors 200;
```

Deploy the app from the **main** branch
```
DEV_MODE=true ./gradlew clean :bootRun
```

Generate the required rh-auth tokens for testing:
```
# Includes account
$ echo -n '{"identity":{"account_number":"account123", "internal":{"org_id":"org123"}}}' | base64 -w 0

eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQ==

# Does not include account
$ echo -n '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w 0

eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19
```

Opt-in the account/org.
```
curl -X PUT -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQ==" "http://localhost:8000/api/rhsm-subscriptions/v1/opt-in" | jq
```

A missing account number in the header results in NO results:
```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL" | jq
{
  "data": [],
  "meta": {
    "count": 0,
    "product": "RHEL",
    "measurements": []
  }
}
```

Check out the branch for this PR and deploy again.

A missing account number in the header returns results based on the orgId in the header:
```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" "http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL" | jq
{
  "data": [
    {
      "id": "0be2b532-e6d4-435d-93a1-33fd9a57c8ef",
      "display_name": "4a001d5c-aee5-4cf4-bd86-a5b678077ed2",
      "billing_provider": "_ANY",
      "billing_account_id": "_ANY",
      "measurements": [],
      "last_seen": "1993-03-26T00:00:00Z"
    },
	
	   -----------
	   --- SNIP --
	   -----------
  ],
  "meta": {
    "count": 600,
    "product": "RHEL",
    "measurements": []
  }

```

Verify that the HostApi is still behaving correctly.

```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQ==" "http://localhost:8000/api/rhsm-subscriptions/v1/hosts/products/RHEL" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   668  100   668    0     0  55666      0 --:--:-- --:--:-- --:--:-- 55666
{
  "data": [
    {
      "inventory_id": "0be2b532-e6d4-435d-93a1-33fd9a57c8ef",
      "insights_id": "4a001d5c-aee5-4cf4-bd86-a5b678077ed2",
      "display_name": "4a001d5c-aee5-4cf4-bd86-a5b678077ed2",
      "subscription_manager_id": "c95d9873-5936-49d2-b1c5-7c58da82efcc",
      "sockets": 1,
      "cores": 4,
      "hardware_type": "PHYSICAL",
      "measurement_type": "VIRTUAL",
      "last_seen": "1993-03-26T00:00:00Z",
      "is_unmapped_guest": false,
      "is_hypervisor": true
    }
  ],
  
  	  -----------
	   --- SNIP --
	   -----------
  
  "meta": {
    "count": 600,
    "product": "RHEL"
  }

```