### PR TITLE
SWATCH-205: Gather metrics by orgId instead of accountNumber

### DIFF
--- a/bin/prometheus-mock-data.sh
+++ b/bin/prometheus-mock-data.sh
@@ -20,13 +20,13 @@ run_container() {
 
 entrypoint() {
   CLUSTER_ID=${CLUSTER_ID:-test01}
-  BILLING_PROVIDER=${BILLING_PROVIDER:-aws}
+  BILLING_PROVIDER=${BILLING_PROVIDER-aws}
   METRICS="${METRICS:-kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes}"
   PRODUCT=${PRODUCT:-rhosak}
-  BILLING_PROVIDER=${BILLING_PROVIDER:-aws}
-  MARKETPLACE_ACCOUNT=${MARKETPLACE_ACCOUNT:-mktp-123}
-  ACCOUNT=${ACCOUNT:-account123}
-  ORG_ID=${ORG_ID:-org123}
+  BILLING_PROVIDER=${BILLING_PROVIDER-aws}
+  MARKETPLACE_ACCOUNT=${MARKETPLACE_ACCOUNT-mktp-123}
+  ACCOUNT=${ACCOUNT-account123}
+  ORG_ID=${ORG_ID-org123}
 
   FILE=$(mktemp)
   NOW=$(date +%s)

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -49,15 +49,15 @@ public class EventController {
   /**
    * Note: calling method needs to use @Transactional
    *
-   * @param accountNumber account identifier
+   * @param orgId Red Hat orgId
    * @param begin beginning of the time range (inclusive)
    * @param end end of the time range (exclusive)
    * @return stream of Event
    */
   public Stream<Event> fetchEventsInTimeRange(
-      String accountNumber, OffsetDateTime begin, OffsetDateTime end) {
-    return repo.findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-            accountNumber, begin, end)
+      String orgId, OffsetDateTime begin, OffsetDateTime end) {
+    return repo.findByOrgIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+            orgId, begin, end)
         .map(EventRecord::getEvent);
   }
 
@@ -70,13 +70,13 @@ public class EventController {
 
   @SuppressWarnings({"linelength", "indentation"})
   public Map<EventKey, Event> mapEventsInTimeRange(
-      String accountNumber,
+      String orgId,
       String eventSource,
       String eventType,
       OffsetDateTime begin,
       OffsetDateTime end) {
-    return repo.findByAccountNumberAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-            accountNumber, eventSource, eventType, begin, end)
+    return repo.findByOrgIdAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+            orgId, eventSource, eventType, begin, end)
         .map(EventRecord::getEvent)
         .collect(Collectors.toMap(EventKey::fromEvent, Function.identity()));
   }

--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -70,13 +70,14 @@ public class InternalMeteringResource implements InternalApi {
       Boolean xRhSwatchSynchronousRequest) {
     Object principal = ResourceUtils.getPrincipal();
 
-    if (orgId == null && accountNumber != null) {
+    if (orgId == null && accountNumber == null) {
+      throw new BadRequestException("Neither orgId nor accountNumber specified");
+    } else if (orgId == null) {
       orgId = accountConfigRepository.findOrgByAccountNumber(accountNumber);
-    }
-
-    if (orgId == null) {
-      throw new BadRequestException(
-          String.format("No orgId found/specified for accountNumber: %s", accountNumber));
+      if (orgId == null) {
+        throw new BadRequestException(
+            String.format("Unable to look up orgId for accountNumber: %s", accountNumber));
+      }
     }
 
     if (!tagProfile.tagIsPrometheusEnabled(productTag)) {

--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import javax.ws.rs.BadRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.admin.api.InternalApi;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
@@ -41,6 +42,7 @@ public class InternalMeteringResource implements InternalApi {
   private final ApplicationProperties applicationProperties;
   private final PrometheusMetricsTaskManager tasks;
   private final PrometheusMeteringController controller;
+  private final AccountConfigRepository accountConfigRepository;
   private final TagProfile tagProfile;
 
   public InternalMeteringResource(
@@ -48,22 +50,34 @@ public class InternalMeteringResource implements InternalApi {
       ApplicationProperties applicationProperties,
       TagProfile tagProfile,
       PrometheusMetricsTaskManager tasks,
-      PrometheusMeteringController controller) {
+      PrometheusMeteringController controller,
+      AccountConfigRepository accountConfigRepository) {
     this.util = util;
     this.applicationProperties = applicationProperties;
     this.tagProfile = tagProfile;
     this.tasks = tasks;
     this.controller = controller;
+    this.accountConfigRepository = accountConfigRepository;
   }
 
   @Override
   public void meterProductForAccount(
-      String accountNumber,
       String productTag,
       Integer rangeInMinutes,
+      String accountNumber,
+      String orgId,
       OffsetDateTime endDate,
       Boolean xRhSwatchSynchronousRequest) {
     Object principal = ResourceUtils.getPrincipal();
+
+    if (orgId == null && accountNumber != null) {
+      orgId = accountConfigRepository.findOrgByAccountNumber(accountNumber);
+    }
+
+    if (orgId == null) {
+      throw new BadRequestException(
+          String.format("No orgId found/specified for accountNumber: %s", accountNumber));
+    }
 
     if (!tagProfile.tagIsPrometheusEnabled(productTag)) {
       throw new BadRequestException(String.format("Invalid product tag specified: %s", productTag));
@@ -83,25 +97,25 @@ public class InternalMeteringResource implements InternalApi {
       if (!applicationProperties.isEnableSynchronousOperations()) {
         throw new BadRequestException("Synchronous metering operations are not enabled.");
       }
-      performMeteringForAccount(accountNumber, productTag, start, end);
+      performMeteringForOrgId(orgId, productTag, start, end);
     } else {
-      queueMeteringForAccount(accountNumber, productTag, start, end);
+      queueMeteringForOrgId(orgId, productTag, start, end);
     }
   }
 
-  private void performMeteringForAccount(
-      String accountNumber, String productTag, OffsetDateTime start, OffsetDateTime end) {
-    log.info("Performing {} metering for account {} via API.", productTag, accountNumber);
+  private void performMeteringForOrgId(
+      String orgId, String productTag, OffsetDateTime start, OffsetDateTime end) {
+    log.info("Performing {} metering for orgId={} via API.", productTag, orgId);
     tagProfile
         .getSupportedMetricsForProduct(productTag)
         .forEach(
             metric -> {
               try {
-                controller.collectMetrics(productTag, metric, accountNumber, start, end);
+                controller.collectMetrics(productTag, metric, orgId, start, end);
               } catch (Exception e) {
                 log.error(
                     "Problem collecting metrics: {} {} {} [{} -> {}]",
-                    accountNumber,
+                    orgId,
                     productTag,
                     metric,
                     start,
@@ -111,13 +125,13 @@ public class InternalMeteringResource implements InternalApi {
             });
   }
 
-  private void queueMeteringForAccount(
-      String accountNumber, String productTag, OffsetDateTime start, OffsetDateTime end) {
+  private void queueMeteringForOrgId(
+      String orgId, String productTag, OffsetDateTime start, OffsetDateTime end) {
     try {
-      log.info("Queuing {} metering for account {} via API.", productTag, accountNumber);
-      tasks.updateMetricsForAccount(accountNumber, productTag, start, end);
+      log.info("Queuing {} metering for orgId={} via API.", productTag, orgId);
+      tasks.updateMetricsForOrgId(orgId, productTag, start, end);
     } catch (Exception e) {
-      log.error("Error queuing {} metering for account {} via API.", productTag, accountNumber, e);
+      log.error("Error queuing {} metering for orgId={} via API.", productTag, orgId, e);
     }
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
@@ -153,7 +153,7 @@ public class MeteringJmxBean {
     try {
       tasks.updateMetricsForOrgId(orgId, productTag, start, end);
     } catch (Exception e) {
-      log.error("Error triggering {} metering for account {} via JMX.", productTag, orgId, e);
+      log.error("Error triggering {} metering for orgId {} via JMX.", productTag, orgId, e);
     }
   }
 

--- a/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/jmx/MeteringJmxBean.java
@@ -72,6 +72,24 @@ public class MeteringJmxBean {
     }
   }
 
+  @ManagedOperation(description = "Perform product metering for a single orgId.")
+  @ManagedOperationParameter(name = "orgId", description = "Red Hat Org ID")
+  @ManagedOperationParameter(name = "productTag", description = "Product tag identifier")
+  public void performMeteringForOrgId(String orgId, String productTag)
+      throws IllegalArgumentException {
+    Object principal = ResourceUtils.getPrincipal();
+    log.info("{} metering for orgId={} triggered via JMX by {}", productTag, orgId, principal);
+
+    OffsetDateTime end = util.getDate(Optional.empty());
+    OffsetDateTime start = util.getStartDate(end, metricProperties.getRangeInMinutes());
+
+    try {
+      tasks.updateMetricsForOrgId(orgId, productTag, start, end);
+    } catch (Exception e) {
+      log.error("Error triggering {} metering for orgId={} via JMX.", productTag, orgId, e);
+    }
+  }
+
   @ManagedOperation(description = "Perform custom product metering for a single account.")
   @ManagedOperationParameter(name = "accountNumber", description = "Red Hat Account Number")
   @ManagedOperationParameter(name = "productTag", description = "Product tag identifier")
@@ -103,6 +121,39 @@ public class MeteringJmxBean {
     } catch (Exception e) {
       log.error(
           "Error triggering {} metering for account {} via JMX.", productTag, accountNumber, e);
+    }
+  }
+
+  @ManagedOperation(description = "Perform custom product metering for a single account.")
+  @ManagedOperationParameter(name = "accountNumber", description = "Red Hat Account Number")
+  @ManagedOperationParameter(name = "productTag", description = "Product tag identifier")
+  @ManagedOperationParameter(
+      name = "endDate",
+      description =
+          "The end date for metrics gathering. Must start at top of the hour. i.e 2018-03-20T09:00:00Z")
+  @ManagedOperationParameter(
+      name = "rangeInMinutes",
+      description =
+          "Period of time (before the end date) to start metrics gathering. Must be >= 0.")
+  public void performCustomMeteringForOrgId(
+      String orgId, String productTag, String endDate, Integer rangeInMinutes)
+      throws IllegalArgumentException {
+    Object principal = ResourceUtils.getPrincipal();
+
+    OffsetDateTime end = util.getDate(endDate);
+    OffsetDateTime start = util.getStartDate(end, rangeInMinutes);
+    log.info(
+        "{} metering for {} against range [{}, {}) triggered via JMX by {}",
+        productTag,
+        orgId,
+        start,
+        end,
+        principal);
+
+    try {
+      tasks.updateMetricsForOrgId(orgId, productTag, start, end);
+    } catch (Exception e) {
+      log.error("Error triggering {} metering for account {} via JMX.", productTag, orgId, e);
     }
   }
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSource.java
@@ -64,7 +64,7 @@ public class PrometheusAccountSource {
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());
     return result.getData().getResult().stream()
-        .map(r -> r.getMetric().getOrDefault("ebs_account", ""))
+        .map(r -> r.getMetric().getOrDefault("external_organization", ""))
         .filter(StringUtils::hasText)
         .collect(Collectors.toSet());
   }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -95,7 +95,7 @@ public class PrometheusMeteringController {
   @Timed("rhsm-subscriptions.metering.openshift")
   @Transactional
   public void collectMetrics(
-      String tag, Uom metric, String account, OffsetDateTime start, OffsetDateTime end) {
+      String tag, Uom metric, String orgId, OffsetDateTime start, OffsetDateTime end) {
     Optional<TagMetric> tagMetric = tagProfile.getTagMetric(tag, metric);
     if (tagMetric.isEmpty()) {
       throw new UnsupportedOperationException(
@@ -116,16 +116,18 @@ public class PrometheusMeteringController {
     - it should already be)
      */
     OffsetDateTime startDate = clock.startOfHour(start).plusHours(1);
-    log.debug("Ensuring marketplace account {} has been set up for syncing/reporting.", account);
-    ensureOptIn(account);
+    log.debug("Ensuring orgId={} has been set up for syncing/reporting.", orgId);
+    // NOTE: https://issues.redhat.com/browse/SWATCH-262 should remove this workaround.
+    // with SWATCH-262, ensureOptIn can be called without using its return value.
+    String accountNumberFromOptIn = ensureOptIn(orgId);
     openshiftRetry.execute(
         context -> {
           try {
 
-            log.info("Collecting metrics for account {}: {} {}", account, tag, metric);
+            log.info("Collecting metrics for orgId={}: {} {}", orgId, tag, metric);
             QueryResult metricData =
                 prometheusService.runRangeQuery(
-                    buildPromQLForMetering(account, tagMetric.get()),
+                    buildPromQLForMetering(orgId, tagMetric.get()),
                     startDate,
                     end,
                     metricProperties.getStep(),
@@ -139,7 +141,7 @@ public class PrometheusMeteringController {
 
             Map<EventKey, Event> existing =
                 eventController.mapEventsInTimeRange(
-                    account,
+                    orgId,
                     MeteringEventFactory.EVENT_SOURCE,
                     MeteringEventFactory.getEventType(tagMetric.get().getMetricId()),
                     // We need to shift the start and end dates by the step, to account for the
@@ -166,7 +168,18 @@ public class PrometheusMeteringController {
               String role = labels.get("product");
               String billingProvider = labels.get("billing_marketplace");
               String billingAccountId = labels.get("billing_marketplace_account");
-              String orgId = labels.get("external_organization");
+              String account = labels.get("ebs_account");
+              // NOTE: https://issues.redhat.com/browse/SWATCH-262 should remove this workaround.
+              if (!StringUtils.hasText(account)) {
+                account = accountNumberFromOptIn;
+                if (!StringUtils.hasText(account)) {
+                  // For now, refuse to process an event that is completely missing accountNumber.
+                  // Otherwise, we'd potentially end up in a state where a customer can't view the
+                  // tally data.
+                  throw new IllegalStateException(
+                      "Refusing to persist event without accountNumber");
+                }
+              }
 
               // For the openshift metrics, we expect our results to be a 'matrix'
               // vector [(instant_time,value), ...] so we only look at the result's getValues()
@@ -220,16 +233,17 @@ public class PrometheusMeteringController {
         });
   }
 
-  private void ensureOptIn(String account) {
+  private String ensureOptIn(String orgId) {
     try {
-      optInController.optInByAccountNumber(account, OptInType.PROMETHEUS, true, true, true);
+      return optInController.optInByOrgId(orgId, OptInType.PROMETHEUS, true, true, true);
     } catch (Exception e) {
-      log.warn("Error while attempting to automatically opt-in account {}", account);
+      log.warn("Error while attempting to automatically opt-in orgId={}", orgId);
       // Keep the logs clean unless specified.
       if (log.isDebugEnabled()) {
-        log.debug("Opt-in error for account {}.", account, e);
+        log.debug("Opt-in error for orgId={}.", orgId, e);
       }
     }
+    return null;
   }
 
   @SuppressWarnings("java:S107")
@@ -286,17 +300,14 @@ public class PrometheusMeteringController {
     }
   }
 
-  private String buildPromQLForMetering(String account, TagMetric tagMetric) {
-    Map<String, String> args = new HashMap<>();
-    args.put("account", account);
-
+  private String buildPromQLForMetering(String orgId, TagMetric tagMetric) {
     // Default the query template if the tag profile didn't specify one.
     if (!StringUtils.hasText(tagMetric.getQueryKey())) {
       tagMetric.setQueryKey(QueryBuilder.DEFAULT_METRIC_QUERY_KEY);
     }
 
     QueryDescriptor descriptor = new QueryDescriptor(tagMetric);
-    descriptor.addRuntimeVar("account", account);
+    descriptor.addRuntimeVar("orgId", orgId);
     return prometheusQueryBuilder.build(descriptor);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactory.java
@@ -42,9 +42,13 @@ public class PrometheusMeteringTaskFactory implements TaskFactory {
   @Override
   public Task build(TaskDescriptor taskDescriptor) {
     if (TaskType.METRICS_COLLECTION.equals(taskDescriptor.getTaskType())) {
+      if (taskDescriptor.hasArg("account")) {
+        throw new IllegalArgumentException(
+            String.format("Task has account rather than orgId: %s", taskDescriptor));
+      }
       return new MetricsTask(
           controller,
-          validateString(taskDescriptor, "account"),
+          validateString(taskDescriptor, "orgId"),
           validateString(taskDescriptor, "productTag"),
           Uom.fromValue(validateString(taskDescriptor, "metric")),
           validateDate(taskDescriptor, "start"),

--- a/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.metering.task;
 
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
@@ -74,11 +75,12 @@ public class MeteringTasksConfiguration {
       TaskQueue queue,
       @Qualifier("meteringTaskQueueProperties") TaskQueueProperties queueProps,
       PrometheusAccountSource accountSource,
+      AccountConfigRepository accountConfigRepository,
       TagProfile tagProfile,
       ApplicationClock clock,
       ApplicationProperties appProps) {
     return new PrometheusMetricsTaskManager(
-        queue, queueProps, accountSource, tagProfile, clock, appProps);
+        queue, queueProps, accountSource, accountConfigRepository, tagProfile, clock, appProps);
   }
 
   // The following beans are defined for the worker profile only allowing

--- a/src/main/java/org/candlepin/subscriptions/metering/task/MetricsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/MetricsTask.java
@@ -34,7 +34,7 @@ public class MetricsTask implements Task {
 
   private static final Logger log = LoggerFactory.getLogger(MetricsTask.class);
 
-  private final String account;
+  private final String orgId;
   private final String productTag;
   private final Uom metric;
   private final OffsetDateTime start;
@@ -44,13 +44,13 @@ public class MetricsTask implements Task {
 
   public MetricsTask(
       PrometheusMeteringController controller,
-      String account,
+      String orgId,
       String productTag,
       Uom metric,
       OffsetDateTime start,
       OffsetDateTime end) {
     this.controller = controller;
-    this.account = account;
+    this.orgId = orgId;
     this.productTag = productTag;
     this.metric = metric;
     this.start = start;
@@ -59,9 +59,9 @@ public class MetricsTask implements Task {
 
   @Override
   public void execute() {
-    log.info("Running {} {} metrics update task for account: {}", productTag, metric, account);
+    log.info("Running {} {} metrics update task for orgId: {}", productTag, metric, orgId);
     try {
-      controller.collectMetrics(productTag, metric, this.account, start, end);
+      controller.collectMetrics(productTag, metric, orgId, start, end);
       log.info("{} {} metrics task complete.", productTag, metric);
     } catch (Exception e) {
       log.error("Problem running task: {}", this.getClass().getSimpleName(), e);

--- a/src/main/java/org/candlepin/subscriptions/security/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInController.java
@@ -130,7 +130,7 @@ public class OptInController {
       boolean enableTallyReporting,
       boolean enableConduitSync) {
     if (orgConfigRepository.existsById(orgId)) {
-      return accountService.lookupAccountNumber(orgId);
+      return accountConfigRepository.findAccountNumberByOrgId(orgId);
     }
     String accountNumber = accountService.lookupAccountNumber(orgId);
     log.info("Opting in account/orgId: {}/{}", accountNumber, orgId);

--- a/src/main/java/org/candlepin/subscriptions/security/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInController.java
@@ -123,19 +123,27 @@ public class OptInController {
   // Separate isolated transaction needed in order to prevent opt-in errors rolling back metrics
   // updates
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void optInByOrgId(
+  public String optInByOrgId(
       String orgId,
       OptInType optInType,
       boolean enableTallySync,
       boolean enableTallyReporting,
       boolean enableConduitSync) {
     if (orgConfigRepository.existsById(orgId)) {
-      return;
+      return accountService.lookupAccountNumber(orgId);
     }
     String accountNumber = accountService.lookupAccountNumber(orgId);
     log.info("Opting in account/orgId: {}/{}", accountNumber, orgId);
-    performOptIn(
-        accountNumber, orgId, optInType, enableTallySync, enableTallyReporting, enableConduitSync);
+    return performOptIn(
+            accountNumber,
+            orgId,
+            optInType,
+            enableTallySync,
+            enableTallyReporting,
+            enableConduitSync)
+        .getData()
+        .getAccount()
+        .getAccountNumber();
   }
 
   @Transactional

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -12,11 +12,11 @@ rhsm-subscriptions:
           default: >-
             #{metric.queryParams[prometheusMetric]}
             * on(_id) group_right
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           5mSamples: >-
             max(sum_over_time(#{metric.queryParams[prometheusMetric]}[1h:5m]) / 13.0) by (_id)
             * on(_id) group_right
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", ebs_account="#{runtime[account]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
         backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,8 +58,8 @@ rhsm-subscriptions:
       metric:
         accountQueryTemplates:
           default: >-
-            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product='#{metric.queryParams[product]}', ebs_account != '', billing_model='marketplace'}[1h]))
-            by (ebs_account)}
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product='#{metric.queryParams[product]}', external_organization != '', billing_model='marketplace'}[1h]))
+            by (external_organization)}
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:0h}
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:1h}

--- a/src/main/spec/internal-metering-api-spec.yaml
+++ b/src/main/spec/internal-metering-api-spec.yaml
@@ -12,7 +12,10 @@ paths:
       parameters:
         - name: accountNumber
           in: query
-          required: true
+          schema:
+            type: string
+        - name: orgId
+          in: query
           schema:
             type: string
         - name: productTag

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -88,8 +88,8 @@ class EventRecordRepositoryTest {
 
     List<EventRecord> found =
         repository
-            .findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-                "account123", OffsetDateTime.now(CLOCK), OffsetDateTime.now(CLOCK).plusYears(1))
+            .findByOrgIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+                "org123", OffsetDateTime.now(CLOCK), OffsetDateTime.now(CLOCK).plusYears(1))
             .collect(Collectors.toList());
 
     assertEquals(1, found.size());
@@ -117,8 +117,8 @@ class EventRecordRepositoryTest {
 
     List<EventRecord> found =
         repository
-            .findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-                "account123", OffsetDateTime.now(CLOCK).minusYears(1), OffsetDateTime.now(CLOCK))
+            .findByOrgIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+                "org123", OffsetDateTime.now(CLOCK).minusYears(1), OffsetDateTime.now(CLOCK))
             .collect(Collectors.toList());
 
     assertEquals(1, found.size());
@@ -164,8 +164,8 @@ class EventRecordRepositoryTest {
 
     List<EventRecord> found =
         repository
-            .findByAccountNumberAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-                e1.getAccountNumber(),
+            .findByOrgIdAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+                e1.getOrgId(),
                 e1.getEventSource(),
                 e1.getEventType(),
                 OffsetDateTime.now(CLOCK).minusYears(1),

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -172,6 +172,6 @@ class InternalMeteringResourceTest {
             () ->
                 resource.meterProductForAccount(
                     VALID_PRODUCT, 120, "account2", null, endDate, false));
-    assertEquals("No orgId found/specified for accountNumber: account2", bre.getMessage());
+    assertEquals("Unable to look up orgId for accountNumber: account2", bre.getMessage());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import javax.ws.rs.BadRequestException;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
@@ -52,6 +53,7 @@ class InternalMeteringResourceTest {
   @Mock private TagProfile tagProfile;
   @Mock private PrometheusMetricsTaskManager tasks;
   @Mock private PrometheusMeteringController controller;
+  @Mock private AccountConfigRepository accountConfigRepository;
 
   private ApplicationProperties appProps;
   private ResourceUtil util;
@@ -67,7 +69,10 @@ class InternalMeteringResourceTest {
     lenient()
         .when(tagProfile.getSupportedMetricsForProduct(VALID_PRODUCT))
         .thenReturn(Set.of(Uom.INSTANCE_HOURS));
-    resource = new InternalMeteringResource(util, appProps, tagProfile, tasks, controller);
+    lenient().when(accountConfigRepository.findOrgByAccountNumber("account1")).thenReturn("org1");
+    resource =
+        new InternalMeteringResource(
+            util, appProps, tagProfile, tasks, controller, accountConfigRepository);
   }
 
   @Test
@@ -78,7 +83,7 @@ class InternalMeteringResourceTest {
     OffsetDateTime end = clock.startOfCurrentHour();
     assertThrows(
         BadRequestException.class,
-        () -> resource.meterProductForAccount("account1", productId, 120, end, false));
+        () -> resource.meterProductForAccount(productId, 120, null, "org1", end, false));
   }
 
   @Test
@@ -89,20 +94,22 @@ class InternalMeteringResourceTest {
     IllegalArgumentException iae1 =
         assertThrows(
             IllegalArgumentException.class,
-            () -> resource.meterProductForAccount("account1", VALID_PRODUCT, 120, end, false));
+            () ->
+                resource.meterProductForAccount(VALID_PRODUCT, 120, "account1", null, end, false));
     assertEquals("Date must start at top of the hour: 2019-05-24T12:05Z", iae1.getMessage());
-    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, clock.startOfHour(end), false);
+    resource.meterProductForAccount(
+        VALID_PRODUCT, 120, null, "org1", clock.startOfHour(end), false);
 
     // synchronous
     IllegalArgumentException iae2 =
         assertThrows(
             IllegalArgumentException.class,
-            () -> resource.meterProductForAccount("account1", VALID_PRODUCT, 120, end, true));
+            () -> resource.meterProductForAccount(VALID_PRODUCT, 120, null, "org1", end, true));
     assertEquals("Date must start at top of the hour: 2019-05-24T12:05Z", iae2.getMessage());
 
     // Avoid additional exception by enabling synchronous operations.
     appProps.setEnableSynchronousOperations(true);
-    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, clock.startOfHour(end), true);
+    resource.meterProductForAccount(VALID_PRODUCT, 120, null, "org1", clock.startOfHour(end), true);
   }
 
   @Test
@@ -111,7 +118,7 @@ class InternalMeteringResourceTest {
     BadRequestException bre =
         assertThrows(
             BadRequestException.class,
-            () -> resource.meterProductForAccount("account1", VALID_PRODUCT, 120, end, true));
+            () -> resource.meterProductForAccount(VALID_PRODUCT, 120, "account1", null, end, true));
     assertEquals("Synchronous metering operations are not enabled.", bre.getMessage());
   }
 
@@ -119,8 +126,8 @@ class InternalMeteringResourceTest {
   void allowAsynchronousMeteringForAccountWhenSyncRequestsDisabled() {
     OffsetDateTime endDate = clock.startOfCurrentHour();
     OffsetDateTime startDate = endDate.minusMinutes(120);
-    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, endDate, false);
-    verify(tasks).updateMetricsForAccount("account1", VALID_PRODUCT, startDate, endDate);
+    resource.meterProductForAccount(VALID_PRODUCT, 120, "account1", null, endDate, false);
+    verify(tasks).updateMetricsForOrgId("org1", VALID_PRODUCT, startDate, endDate);
     verifyNoInteractions(controller);
   }
 
@@ -130,9 +137,9 @@ class InternalMeteringResourceTest {
 
     OffsetDateTime endDate = clock.startOfCurrentHour();
     OffsetDateTime startDate = endDate.minusMinutes(120);
-    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, endDate, true);
+    resource.meterProductForAccount(VALID_PRODUCT, 120, "account1", null, endDate, true);
     verify(controller)
-        .collectMetrics(VALID_PRODUCT, Uom.INSTANCE_HOURS, "account1", startDate, endDate);
+        .collectMetrics(VALID_PRODUCT, Uom.INSTANCE_HOURS, "org1", startDate, endDate);
     verifyNoInteractions(tasks);
   }
 
@@ -142,8 +149,29 @@ class InternalMeteringResourceTest {
 
     OffsetDateTime endDate = clock.startOfCurrentHour();
     OffsetDateTime startDate = endDate.minusMinutes(120);
-    resource.meterProductForAccount("account1", VALID_PRODUCT, 120, endDate, false);
-    verify(tasks).updateMetricsForAccount("account1", VALID_PRODUCT, startDate, endDate);
+    resource.meterProductForAccount(VALID_PRODUCT, 120, null, "org1", endDate, false);
+    verify(tasks).updateMetricsForOrgId("org1", VALID_PRODUCT, startDate, endDate);
     verifyNoInteractions(controller);
+  }
+
+  @Test
+  void meterProductForAccountLooksUpOrgIdWhenNotProvided() {
+    OffsetDateTime endDate = clock.startOfCurrentHour();
+    OffsetDateTime startDate = endDate.minusMinutes(120);
+    resource.meterProductForAccount(VALID_PRODUCT, 120, "account1", null, endDate, false);
+    verify(tasks).updateMetricsForOrgId("org1", VALID_PRODUCT, startDate, endDate);
+    verifyNoInteractions(controller);
+  }
+
+  @Test
+  void meterProductForAccountThrowExceptionWhenOrgIdCannotBeFound() {
+    OffsetDateTime endDate = clock.startOfCurrentHour();
+    BadRequestException bre =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                resource.meterProductForAccount(
+                    VALID_PRODUCT, 120, "account2", null, endDate, false));
+    assertEquals("No orgId found/specified for accountNumber: account2", bre.getMessage());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusAccountSourceTest.java
@@ -150,12 +150,12 @@ class PrometheusAccountSourceTest {
     assertTrue(accounts.containsAll(expectedAccounts));
   }
 
-  private QueryResult buildAccountQueryResult(List<String> accounts) {
+  private QueryResult buildAccountQueryResult(List<String> orgIds) {
     QueryResultData resultData = new QueryResultData().resultType(ResultType.MATRIX);
-    accounts.forEach(
+    orgIds.forEach(
         account -> {
           resultData.addResultItem(
-              new QueryResultDataResultInner().putMetricItem("ebs_account", account));
+              new QueryResultDataResultInner().putMetricItem("external_organization", account));
         });
     return new QueryResult().status(StatusType.SUCCESS).data(resultData);
   }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.net.UrlEscapers;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.prometheus.api.ApiProvider;
 import org.candlepin.subscriptions.prometheus.api.StubApiProvider;
@@ -55,7 +56,7 @@ class PrometheusServiceTest {
   @Test
   void testRangeQueryApi() throws Exception {
     QueryHelper queries = new QueryHelper(tagProfile, queryBuilder);
-    String query = queries.expectedQuery("OpenShift-metrics", "a1");
+    String query = queries.expectedQuery("OpenShift-metrics", Map.of("orgId", "o1"));
     String expectedQuery = UrlEscapers.urlFragmentEscaper().escape(query);
     QueryResult expectedResult = new QueryResult();
 
@@ -76,7 +77,7 @@ class PrometheusServiceTest {
   @Test
   void testQueryApi() throws Exception {
     QueryHelper queries = new QueryHelper(tagProfile, queryBuilder);
-    String query = queries.expectedQuery("OpenShift-metrics", "a1");
+    String query = queries.expectedQuery("OpenShift-metrics", Map.of("orgId", "o1"));
     String expectedQuery = UrlEscapers.urlFragmentEscaper().escape(query);
     QueryResult expectedResult = new QueryResult();
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/QueryHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/QueryHelper.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus;
 
+import java.util.Map;
 import java.util.Optional;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
@@ -38,14 +39,14 @@ public class QueryHelper {
     this.queryBuilder = builder;
   }
 
-  public String expectedQuery(String productTag, String account) {
+  public String expectedQuery(String productTag, Map<String, String> queryParams) {
     Optional<TagMetric> tag = tagProfile.getTagMetric(productTag, Uom.CORES);
     if (tag.isEmpty()) {
       throw new RuntimeException("Bad test configuration! Could not find TagMetric!");
     }
 
     QueryDescriptor descriptor = new QueryDescriptor(tag.get());
-    descriptor.addRuntimeVar("account", account);
+    queryParams.forEach(descriptor::addRuntimeVar);
     return queryBuilder.build(descriptor);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactoryTest.java
@@ -69,7 +69,7 @@ class PrometheusMeteringTaskFactoryTest {
     Task task =
         factory.build(
             TaskDescriptor.builder(TaskType.METRICS_COLLECTION, "a-group")
-                .setSingleValuedArg("account", "12234")
+                .setSingleValuedArg("orgId", "12234")
                 .setSingleValuedArg("productTag", "OpenShift")
                 .setSingleValuedArg("metric", "Cores")
                 .setSingleValuedArg("start", start.toString())
@@ -83,7 +83,7 @@ class PrometheusMeteringTaskFactoryTest {
   }
 
   @Test
-  void testOpenshiftMetricsTaskMissingAccount() {
+  void testOpenshiftMetricsTaskMissingOrgId() {
     TaskDescriptor descriptor =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, "a-group")
             .setSingleValuedArg("start", "2018-03-20T09:12:28Z")
@@ -93,14 +93,14 @@ class PrometheusMeteringTaskFactoryTest {
             .setSingleValuedArg("step", "1h")
             .build();
     Throwable e = assertThrows(IllegalArgumentException.class, () -> factory.build(descriptor));
-    assertEquals("Could not build task. Missing task argument: account", e.getMessage());
+    assertEquals("Could not build task. Missing task argument: orgId", e.getMessage());
   }
 
   @Test
   void testOpenshiftMetricsTaskInvalidStartDateFormat() {
     TaskDescriptor descriptor =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, "a-group")
-            .setSingleValuedArg("account", "1234")
+            .setSingleValuedArg("orgId", "1234")
             .setSingleValuedArg("productTag", "OpenShift")
             .setSingleValuedArg("metric", "Cores")
             .setSingleValuedArg("start", "2018-03-20")
@@ -116,7 +116,7 @@ class PrometheusMeteringTaskFactoryTest {
   void testOpenshiftMetricsTaskInvalidEndDateFormat() {
     TaskDescriptor descriptor =
         TaskDescriptor.builder(TaskType.METRICS_COLLECTION, "a-group")
-            .setSingleValuedArg("account", "1234")
+            .setSingleValuedArg("orgId", "1234")
             .setSingleValuedArg("productTag", "OpenShift")
             .setSingleValuedArg("metric", "Cores")
             .setSingleValuedArg("start", "2018-03-20T09:12:28Z")

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -38,6 +38,9 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
   @Query("select distinct c.orgId from AccountConfig c where c.accountNumber = :account")
   String findOrgByAccountNumber(@Param("account") String accountNumber);
 
+  @Query("select distinct c.accountNumber from AccountConfig c where c.orgId = :orgId")
+  String findAccountNumberByOrgId(@Param("orgId") String orgId);
+
   @Query(
       "select case when count(c) > 0 then true else false end from AccountConfig c "
           + "where c.accountNumber = :account and c.reportingEnabled = TRUE")

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -46,14 +46,13 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
    * * from events where timestamp between '2021-01-01T00:00:00Z' and '2021-01-01T01:00:00Z` would
    * match events at midnight UTC and 1am UTC.
    *
-   * @param accountNumber account number
+   * @param orgId account number
    * @param begin start of the time range (inclusive)
    * @param end end of the time range (exclusive)
    * @return Stream of EventRecords
    */
-  Stream<EventRecord>
-      findByAccountNumberAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-          String accountNumber, OffsetDateTime begin, OffsetDateTime end);
+  Stream<EventRecord> findByOrgIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+      String orgId, OffsetDateTime begin, OffsetDateTime end);
 
   /**
    * Fetch a stream of events for a given account, event type and event source for a given time
@@ -73,8 +72,8 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
    * @return Stream of EventRecords
    */
   Stream<EventRecord>
-      findByAccountNumberAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-          String accountNumber,
+      findByOrgIdAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+          String orgId,
           String eventSource,
           String eventType,
           OffsetDateTime begin,


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-205

I only modified methods that are involved in metrics ingestion. Additionally, I left methods in-place used to trigger metrics ingestion for an account, modifying them to look up the orgId by opt-in.

I modified our prometheus mock data script to allow emptying fields.

Testing
=======

In the background (or separate terminal), run a prometheus instance with mocked data:

```shell
ACCOUNT='' bin/prometheus-mock-data.sh&
```

Start the server, with some debug logging enabled (so you can see the queries if desired):

```shell
LOGGING_LEVEL_ORG_CANDLEPIN=DEBUG \
    USER_USE_STUB=true \
    PROM_URL="http://localhost:9090/api/v1" \
    DEV_MODE=true \
    ./gradlew :bootRun
```

Before testing, clear the account config and org config tables.

```shell
psql -h localhost -U rhsm-subscriptions -c 'truncate account_config'
psql -h localhost -U rhsm-subscriptions -c 'truncate org_config'
```

Between each of the following steps, the following can be used to clear event data to make verification easier:

```shell
psql -h localhost -U rhsm-subscriptions -c 'truncate events'
```

Adjust time ranges if needed.

JMX Endpoints
-------------

1. `performCustomMetering`

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean \
  operation='performCustomMetering(java.lang.String,java.lang.String,java.lang.Integer)' \
  arguments:='["rhosak","2022-10-10T17:00:00Z",120]'
```

Afterwards, query the event table to see that the events have been populated with both `account_number` and `org_id`:

```shell
psql -h localhost -U rhsm-subscriptions -c 'select timestamp, org_id, account_number from events'
```

2. `performCustomMeteringForAccount`  (requires opt-in)

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean \
  operation='performCustomMeteringForAccount(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)' \
  arguments:='["account123","rhosak","2022-10-10T17:00:00Z",120]'
```

View the resulting events as above. Note that this call uses `account_config` to look up the orgId.

3. `performCustomMeteringForOrgId`

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean \
  operation='performCustomMeteringForOrgId(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer)' \
  arguments:='["org123","rhosak","2022-10-10T17:00:00Z",120]'
```

View the resulting events as above.

4. `performMetering`

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean \
  operation='performMetering(java.lang.String)' \
  arguments:='["rhosak"]'
```

5. `performMeteringForAccount`  (requires opt-in)

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean \
  operation='performMeteringForAccount(java.lang.String,java.lang.String)' \
  arguments:='["account123", "rhosak"]'
```

6. `performMeteringForOrgId`

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean \
  operation='performMeteringForOrgId(java.lang.String,java.lang.String)' \
  arguments:='["org123", "rhosak"]'
```

Internal API endpoints
----------------------

Similar to above but using different endpoints:

1. With an orgId:

```shell
http POST :8000/api/rhsm-subscriptions/v1/internal/metering/rhosak \
  orgId==org123 \
  rangeInMinutes==120 \
  x-rh-swatch-psk:placeholder
```

2. With an accountNumber (requires opt-in):

```shell
http POST :8000/api/rhsm-subscriptions/v1/internal/metering/rhosak \
  accountNumber==account123 \
  rangeInMinutes==120 \
  x-rh-swatch-psk:placeholder
```