### PR TITLE
SWATCH-577: replace deprecated 5mSamples prom query with default query

### DIFF
--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -13,10 +13,6 @@ rhsm-subscriptions:
             #{metric.queryParams[prometheusMetric]}
             * on(_id) group_right
             min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
-          5mSamples: >-
-            max(sum_over_time(#{metric.queryParams[prometheusMetric]}[1h:5m]) / 13.0) by (_id)
-            * on(_id) group_right
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           addonSamples: >-
             #{metric.queryParams[prometheusMetric]}
             * on(_id) group_right

--- a/src/test/resources/test_tag_profile.yaml
+++ b/src/test/resources/test_tag_profile.yaml
@@ -138,10 +138,10 @@ tagMetrics:
   - tag: OpenShift-metrics
     metricId: redhat.com:openshift_container_platform:cpu_hour
     uom: CORES
-    queryKey: 5mSamples
+    queryKey: default
     queryParams:
       product: ocp
-      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
+      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_hours
       prometheusMetadataMetric: subscription_labels
 
   # OSD metrics
@@ -149,19 +149,19 @@ tagMetrics:
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
     billingWindow: HOURLY
-    queryKey: 5mSamples
+    queryKey: default
     queryParams:
       product: osd
-      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
+      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_hours
       prometheusMetadataMetric: subscription_labels
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
     billingWindow: HOURLY
-    queryKey: 5mSamples
+    queryKey: default
     queryParams:
       product: osd
-      prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
+      prometheusMetric: cluster:usage:workload:capacity_physical_instance_hours
       prometheusMetadataMetric: subscription_labels
 
   # RHOSAK metrics

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -192,10 +192,10 @@ tagMetrics:
     rhmMetricId: redhat.com:openshift_container_platform:cpu_hour
     uom: CORES
     billingWindow: MONTHLY
-    queryKey: 5mSamples
+    queryKey: default
     queryParams:
       product: ocp
-      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
+      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_hours
       prometheusMetadataMetric: subscription_labels
 
   # OSD metrics
@@ -204,20 +204,20 @@ tagMetrics:
     rhmMetricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
     billingWindow: MONTHLY
-    queryKey: 5mSamples
+    queryKey: default
     queryParams:
       product: osd
-      prometheusMetric: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
+      prometheusMetric:  cluster:usage:workload:capacity_physical_cpu_hours
       prometheusMetadataMetric: subscription_labels
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:cluster_hour
     rhmMetricId: redhat.com:openshift_dedicated:cluster_hour
     uom: INSTANCE_HOURS
     billingWindow: MONTHLY
-    queryKey: 5mSamples
+    queryKey: default
     queryParams:
       product: osd
-      prometheusMetric: group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)
+      prometheusMetric: cluster:usage:workload:capacity_physical_instance_hours
       prometheusMetadataMetric: subscription_labels
 
   # RHOSAK metrics


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-577

Test Steps:

- Run local proxy to Observatorium
- Run MeteringJmxBean performCustomMetering(String, String, Integer) with values (OpenShift-dedicated-metrics, 2022-10-11T11:00:00Z, 60)
- Check db for 2 new events