### PR TITLE
SWATCH-477: Tolerate missing account number w/ opt-in

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
@@ -80,7 +80,7 @@ public class OptInJmxBean {
   public void optOut(String accountNumber, String orgId) {
     Object principal = ResourceUtils.getPrincipal();
     log.info("Opt out for {} triggered via JMX by {}", accountNumber, principal);
-    controller.optOut(accountNumber, orgId);
+    controller.optOut(orgId);
   }
 
   @ManagedOperation(

--- a/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
@@ -43,13 +43,13 @@ public class OptInResource implements OptInApi {
   @SubscriptionWatchAdminOnly
   @Override
   public void deleteOptInConfig() {
-    controller.optOut(validateAccountNumber(), validateOrgId());
+    controller.optOut(validateOrgId());
   }
 
   @SubscriptionWatchAdminOnly
   @Override
   public OptInConfig getOptInConfig() {
-    return controller.getOptInConfig(validateAccountNumber(), validateOrgId());
+    return controller.getOptInConfig(ResourceUtils.getAccountNumber(), validateOrgId());
   }
 
   @SubscriptionWatchAdminOnly
@@ -59,20 +59,12 @@ public class OptInResource implements OptInApi {
     // NOTE: All query params are defaulted to 'true' by the API definition, however we
     //       double check below.
     return controller.optIn(
-        validateAccountNumber(),
+        ResourceUtils.getAccountNumber(),
         validateOrgId(),
         OptInType.API,
         trueIfNull(enableTallySync),
         trueIfNull(enableTallyReporting),
         trueIfNull(enableConduitSync));
-  }
-
-  private String validateAccountNumber() {
-    String accountNumber = ResourceUtils.getAccountNumber();
-    if (accountNumber == null) {
-      throw new BadRequestException("Must specify an account number.");
-    }
-    return accountNumber;
   }
 
   private String validateOrgId() {

--- a/src/main/java/org/candlepin/subscriptions/security/AllowlistedAccountReportAccessService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/AllowlistedAccountReportAccessService.java
@@ -20,13 +20,11 @@
  */
 package org.candlepin.subscriptions.security;
 
-import org.candlepin.subscriptions.db.AccountListSource;
-import org.candlepin.subscriptions.db.model.OrgConfigRepository;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 /**
  * Provides a means to validate that an authentication token has a allowlisted account associated
@@ -38,25 +36,14 @@ import org.springframework.util.StringUtils;
 @Service("reportAccessService")
 public class AllowlistedAccountReportAccessService {
 
-  private AccountListSource accountSource;
-  private OrgConfigRepository orgRepo;
+  private final AccountConfigRepository accountConfigRepository;
 
-  public AllowlistedAccountReportAccessService(
-      AccountListSource accountSource, OrgConfigRepository orgRepo) {
-    this.accountSource = accountSource;
-    this.orgRepo = orgRepo;
+  public AllowlistedAccountReportAccessService(AccountConfigRepository accountConfigRepository) {
+    this.accountConfigRepository = accountConfigRepository;
   }
 
   public boolean providesAccessTo(Authentication auth) throws AccountListSourceException {
     InsightsUserPrincipal principal = (InsightsUserPrincipal) auth.getPrincipal();
-    // If there was no account available from the principal (or not in the header)
-    // allow access based on the org.
-    if (!StringUtils.hasText(principal.getAccountNumber())) {
-      // NOTE: Technically, this should be checking for the reporting_enabled flag,
-      //       but since we don't use that functionality, we decided to allow based on
-      //       org-id opt-in existence.
-      return orgRepo.existsByOrgId(principal.getOwnerId());
-    }
-    return this.accountSource.containsReportingAccount(principal.getAccountNumber());
+    return accountConfigRepository.existsByOrgId(principal.getOwnerId());
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/security/AllowlistedAccountReportAccessService.java
+++ b/src/main/java/org/candlepin/subscriptions/security/AllowlistedAccountReportAccessService.java
@@ -22,7 +22,6 @@ package org.candlepin.subscriptions.security;
 
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
-import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
@@ -42,7 +41,7 @@ public class AllowlistedAccountReportAccessService {
     this.accountConfigRepository = accountConfigRepository;
   }
 
-  public boolean providesAccessTo(Authentication auth) throws AccountListSourceException {
+  public boolean providesAccessTo(Authentication auth) {
     InsightsUserPrincipal principal = (InsightsUserPrincipal) auth.getPrincipal();
     return accountConfigRepository.existsByOrgId(principal.getOwnerId());
   }

--- a/src/main/java/org/candlepin/subscriptions/security/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInController.java
@@ -111,7 +111,7 @@ public class OptInController {
       boolean enableTallySync,
       boolean enableTallyReporting,
       boolean enableConduitSync) {
-    if (accountConfigRepository.existsById(accountNumber)) {
+    if (accountConfigRepository.existsByAccountNumber(accountNumber)) {
       return;
     }
     String orgId = accountService.lookupOrgId(accountNumber);
@@ -147,9 +147,9 @@ public class OptInController {
   }
 
   @Transactional
-  public void optOut(String accountNumber, String orgId) {
-    if (accountConfigRepository.existsById(accountNumber)) {
-      accountConfigRepository.deleteById(accountNumber);
+  public void optOut(String orgId) {
+    if (accountConfigRepository.existsByOrgId(orgId)) {
+      accountConfigRepository.deleteByOrgId(orgId);
     }
 
     if (orgConfigRepository.existsById(orgId)) {
@@ -161,7 +161,7 @@ public class OptInController {
   public OptInConfig getOptInConfig(String accountNumber, String orgId) {
     Optional<AccountConfig> accountConfig =
         StringUtils.hasText(accountNumber)
-            ? accountConfigRepository.findById(accountNumber)
+            ? accountConfigRepository.findByOrgId(orgId)
             : Optional.empty();
     Optional<OrgConfig> orgConfig =
         StringUtils.hasText(orgId) ? orgConfigRepository.findById(orgId) : Optional.empty();

--- a/src/main/resources/liquibase/202210101553-make-account-config-org-id-nullable.xml
+++ b/src/main/resources/liquibase/202210101553-make-account-config-org-id-nullable.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202210101553-1" author="khowell">
+    <comment>Make account_config.account_number nullable.</comment>
+    <dropNotNullConstraint tableName="account_config" columnName="account_number"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -82,5 +82,6 @@
     <include file="liquibase/202209301035-migrate-org-id-to-hosts-table.xml"/>
     <include file="liquibase/202209301614-migrate-org-id-to-events-table.xml"/>
     <include file="liquibase/202209301230-migrate-org-id-to-billable-usage-table.xml"/>
+    <include file="liquibase/202210101553-make-account-config-org-id-nullable.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.ws.rs.core.Response;
-import org.candlepin.subscriptions.db.AccountListSource;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.SubscriptionCapacityRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -41,7 +41,6 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
-import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReport;
 import org.candlepin.subscriptions.utilization.api.model.CapacityReportByMetricId;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
@@ -74,13 +73,13 @@ class CapacityResourceTest {
 
   @MockBean PageLinkCreator pageLinkCreator;
 
-  @MockBean AccountListSource accountListSource;
+  @MockBean AccountConfigRepository accountConfigRepository;
 
   @Autowired CapacityResource resource;
 
   @BeforeEach
-  public void setupTests() throws AccountListSourceException {
-    when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
+  public void setupTests() {
+    when(accountConfigRepository.existsByOrgId("owner123456")).thenReturn(true);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Set;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
-import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -42,7 +41,6 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
-import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.HostReport;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
@@ -76,18 +74,17 @@ class HostsResourceTest {
 
   @MockBean HostRepository repository;
   @MockBean PageLinkCreator pageLinkCreator;
-  @MockBean AccountListSource accountListSource;
   @MockBean AccountConfigRepository accountConfigRepo;
   @Autowired HostsResource resource;
 
   @BeforeEach
-  public void setup() throws AccountListSourceException {
+  public void setup() {
     PageImpl<TallyHostView> mockPage = new PageImpl<>(Collections.emptyList());
     when(repository.getTallyHostViews(
             any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt(), any()))
         .thenReturn(mockPage);
-    when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
     when(accountConfigRepo.findOrgByAccountNumber("account123456")).thenReturn("owner123456");
+    when(accountConfigRepo.existsByOrgId("owner123456")).thenReturn(true);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 import org.candlepin.subscriptions.FixedClockConfiguration;
-import org.candlepin.subscriptions.db.AccountListSource;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.*;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
@@ -45,7 +45,6 @@ import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.RoleProvider;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
-import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.utilization.api.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,12 +75,12 @@ class TallyResourceTest {
   private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
   @MockBean TallySnapshotRepository repository;
   @MockBean PageLinkCreator pageLinkCreator;
-  @MockBean AccountListSource accountListSource;
+  @MockBean AccountConfigRepository accountConfigRepository;
   @Autowired TallyResource resource;
 
   @BeforeEach
-  public void setupTests() throws AccountListSourceException {
-    when(accountListSource.containsReportingAccount("account123456")).thenReturn(true);
+  public void setupTests() {
+    when(accountConfigRepository.existsByOrgId("owner123456")).thenReturn(true);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/security/OptInCheckerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/OptInCheckerTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.exception.OptInRequiredException;
 import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
 import org.candlepin.subscriptions.utilization.api.model.OptInConfigData;
@@ -41,7 +42,7 @@ class OptInCheckerTest {
 
   @Autowired OptInChecker checker;
 
-  @MockBean OptInController controller;
+  @MockBean AccountConfigRepository accountConfigRepository;
 
   @Test
   @WithInvalidPrincipal
@@ -59,7 +60,7 @@ class OptInCheckerTest {
     when(config.getData()).thenReturn(configData);
     when(configData.getOptInComplete()).thenReturn(Boolean.FALSE);
 
-    when(controller.getOptInConfig(anyString(), anyString())).thenReturn(config);
+    when(accountConfigRepository.existsByOrgId(anyString())).thenReturn(false);
 
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
     assertThrows(OptInRequiredException.class, () -> checker.checkAccess(auth));
@@ -74,7 +75,7 @@ class OptInCheckerTest {
     when(config.getData()).thenReturn(configData);
     when(configData.getOptInComplete()).thenReturn(Boolean.TRUE);
 
-    when(controller.getOptInConfig(anyString(), anyString())).thenReturn(config);
+    when(accountConfigRepository.existsByOrgId(anyString())).thenReturn(true);
 
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
     assertTrue(checker.checkAccess(auth));

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -60,7 +60,8 @@ class TallySnapshotControllerTest {
 
   @BeforeEach
   void setup() {
-    AccountConfig accountConfig = new AccountConfig(ACCOUNT);
+    AccountConfig accountConfig = new AccountConfig();
+    accountConfig.setAccountNumber(ACCOUNT);
     accountConfig.setOrgId("ORG_" + ACCOUNT);
     when(accountRepo.findById(ACCOUNT)).thenReturn(Optional.of(accountConfig));
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -54,6 +54,14 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
           + "where c.optInType='API' and c.created between :startOfWeek and :endOfWeek")
   int getCountOfOptInsForDateRange(OffsetDateTime startOfWeek, OffsetDateTime endOfWeek);
 
+  Optional<AccountConfig> findByOrgId(String orgId);
+
+  boolean existsByOrgId(String orgId);
+
+  boolean existsByAccountNumber(String accountNumber);
+
+  void deleteByOrgId(String accountNumber);
+
   default Optional<AccountConfig> createOrUpdateAccountConfig(
       String account,
       String orgId,
@@ -61,12 +69,14 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
       OptInType optInType,
       boolean enableSync,
       boolean enableReporting) {
-    Optional<AccountConfig> found = findById(account);
-    AccountConfig accountConfig = found.orElse(new AccountConfig(account));
+    Optional<AccountConfig> found = findByOrgId(orgId);
+    AccountConfig accountConfig = found.orElse(new AccountConfig());
     if (!found.isPresent()) {
+      accountConfig.setOrgId(orgId);
       accountConfig.setOptInType(optInType);
       accountConfig.setCreated(current);
     }
+    accountConfig.setAccountNumber(account);
     accountConfig.setOrgId(orgId);
     accountConfig.setSyncEnabled(enableSync);
     accountConfig.setReportingEnabled(enableReporting);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/DatabaseAccountListSource.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/DatabaseAccountListSource.java
@@ -44,7 +44,7 @@ public class DatabaseAccountListSource implements AccountListSource {
   @Override
   public boolean containsReportingAccount(String accountNumber) throws AccountListSourceException {
     try {
-      return repository.isReportingEnabled(accountNumber);
+      return repository.existsByAccountNumber(accountNumber);
     } catch (Exception e) {
       throw new AccountListSourceException("Unable to determine if account was in allowlist.", e);
     }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
@@ -31,21 +31,17 @@ import javax.persistence.Table;
 @Table(name = "account_config")
 public class AccountConfig extends BaseConfig {
 
-  @Id
   @Column(name = "account_number")
   private String accountNumber;
 
   @Column(name = "reporting_enabled")
   private Boolean reportingEnabled;
 
+  @Id
   @Column(name = "org_id")
   private String orgId;
 
   public AccountConfig() {}
-
-  public AccountConfig(String accountNumber) {
-    this.accountNumber = accountNumber;
-  }
 
   public String getAccountNumber() {
     return accountNumber;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
@@ -41,8 +41,6 @@ public class AccountConfig extends BaseConfig {
   @Column(name = "org_id")
   private String orgId;
 
-  public AccountConfig() {}
-
   public String getAccountNumber() {
     return accountNumber;
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-477

I had to adjust the ID for AccountConfig entity to be orgId (we had already adjusted the table primary key).

I had to make the account_number column nullable as well.

Testing
=======

Delete any existing opt-in data:

```shell
psql -h localhost -U rhsm-subscriptions -c 'truncate account_config'
psql -h localhost -U rhsm-subscriptions -c 'truncate org_config'
```

Run the server:

```shell
RHSM_RBAC_USE_STUB=true ./gradlew :bootRun
```

1. Non-opted in identity having only `org_id` can get proper response.

```shell
http :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo '
  {"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```
returns 200 having `"opt_in_complete": false`

2. Tally API shows Opt-in required error.

```shell
http :8000/api/rhsm-subscriptions/v1/tally/products/RHEL \
  granularity==DAILY \
  beginning==2022-01-01T00:00Z \
  ending==2022-01-03T00:00Z \
  x-rh-identity:$(echo '
  {"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

3. Non-opted in identity having only `org_id` can opt-in.

```shell
http PUT :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo '
  {"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

4. Identity opted in with only `org_id` is considered fully opted in.

```shell
http :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo '
  {"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

5. Identity opted in with only `org_id` can use tally API without opt-in error.

```shell
http :8000/api/rhsm-subscriptions/v1/tally/products/RHEL \
  granularity==DAILY \
  beginning==2022-01-01T00:00Z \
  ending==2022-01-03T00:00Z \
  x-rh-identity:$(echo '
  {"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```