### PR TITLE
SWATCH-477: Remove unused opt-in flags

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -59,14 +59,11 @@ paths:
                   opt_in_complete: true
                   account:
                     account_number: 12345
-                    tally_sync_enabled: true
-                    tally_reporting_enabled: true
                     opt_in_type: 'API'
                     created: '2017-08-04T17:32:05Z'
                     last_updated: '2017-08-04T17:32:05Z'
                   org:
                     org_id: 1111
-                    conduit_sync_enabled: true
                     opt_in_type: 'API'
                     created: '2017-08-04T17:32:05Z'
                     last_updated: '2017-08-04T17:32:05Z'
@@ -83,27 +80,8 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
     put:
       summary: "Create/Update an account's opt-in configuration. Account and Org ID are defined by the
-                identity header. If no parameters are specified, all everything will be enabled."
+                identity header."
       operationId: putOptInConfig
-      parameters:
-        - name: enable_tally_sync
-          in: query
-          required: false
-          schema:
-            type: boolean
-            default: true
-        - name: enable_tally_reporting
-          in: query
-          required: false
-          schema:
-            type: boolean
-            default: true
-        - name: enable_conduit_sync
-          in: query
-          required: false
-          schema:
-            type: boolean
-            default: true
       responses:
         '200':
           description: "The request for the account's opt-in configuration was successful."
@@ -116,14 +94,11 @@ paths:
                   opt_in_complete: true
                   account:
                     account_number: 12345
-                    tally_sync_enabled: true
-                    tally_reporting_enabled: true
                     opt_in_type: 'API'
                     created: '2017-08-04T17:32:05Z'
                     last_updated: '2017-08-04T17:32:05Z'
                   org:
                     org_id: 1111
-                    conduit_sync_enabled: true
                     opt_in_type: 'API'
                     created: '2017-08-04T17:32:05Z'
                     last_updated: '2017-08-04T17:32:05Z'
@@ -1171,18 +1146,12 @@ components:
               type: object
               required:
                 - account_number
-                - tally_sync_enabled
-                - tally_reporting_enabled
                 - opt_in_type
                 - created
                 - last_updated
               properties:
                 account_number:
                   type: string
-                tally_sync_enabled:
-                  type: boolean
-                tally_reporting_enabled:
-                  type: boolean
                 opt_in_type:
                   type: string
                 created:
@@ -1195,15 +1164,12 @@ components:
               type: object
               required:
                 - org_id
-                - conduit_sync_enabled
                 - opt_in_type
                 - created
                 - last_updated
               properties:
                 org_id:
                   type: string
-                conduit_sync_enabled:
-                  type: boolean
                 opt_in_type:
                   type: string
                 created:

--- a/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/OptInJmxBean.java
@@ -100,14 +100,7 @@ public class OptInJmxBean {
     log.info(
         "Opt in for account {}, org {} triggered via JMX by {}", accountNumber, orgId, principal);
     log.debug("Creating OptInConfig over JMX for account {}, org {}", accountNumber, orgId);
-    OptInConfig config =
-        controller.optIn(
-            accountNumber,
-            orgId,
-            OptInType.JMX,
-            enableTallySync,
-            enableTallyReporting,
-            enableConduitSync);
+    OptInConfig config = controller.optIn(accountNumber, orgId, OptInType.JMX);
 
     String text = "Completed opt in for account %s and org %s:\n%s";
     return String.format(text, accountNumber, orgId, config.toString());
@@ -119,8 +112,7 @@ public class OptInJmxBean {
       boolean enableTallySync,
       boolean enableTallyReporting,
       boolean enableConduitSync) {
-    controller.optInByAccountNumber(
-        accountNumber, OptInType.JMX, enableTallySync, enableTallyReporting, enableConduitSync);
+    controller.optInByAccountNumber(accountNumber, OptInType.JMX);
     return String.format("Completed opt in for account %s", accountNumber);
   }
 
@@ -130,8 +122,7 @@ public class OptInJmxBean {
       boolean enableTallySync,
       boolean enableTallyReporting,
       boolean enableConduitSync) {
-    controller.optInByOrgId(
-        orgId, OptInType.JMX, enableTallySync, enableTallyReporting, enableConduitSync);
+    controller.optInByOrgId(orgId, OptInType.JMX);
     return String.format("Completed opt in for orgId %s", orgId);
   }
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -246,7 +246,7 @@ public class PrometheusMeteringController {
 
   private String ensureOptIn(String orgId) {
     try {
-      return optInController.optInByOrgId(orgId, OptInType.PROMETHEUS, true, true, true);
+      return optInController.optInByOrgId(orgId, OptInType.PROMETHEUS);
     } catch (Exception e) {
       log.warn("Error while attempting to automatically opt-in orgId={}", orgId);
       // Keep the logs clean unless specified.

--- a/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
@@ -67,11 +67,4 @@ public class OptInResource implements OptInApi {
     }
     return ownerId;
   }
-
-  private Boolean trueIfNull(Boolean toVerify) {
-    if (toVerify == null) {
-      return true;
-    }
-    return toVerify;
-  }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/OptInResource.java
@@ -54,17 +54,10 @@ public class OptInResource implements OptInApi {
 
   @SubscriptionWatchAdminOnly
   @Override
-  public OptInConfig putOptInConfig(
-      Boolean enableTallySync, Boolean enableTallyReporting, Boolean enableConduitSync) {
+  public OptInConfig putOptInConfig() {
     // NOTE: All query params are defaulted to 'true' by the API definition, however we
     //       double check below.
-    return controller.optIn(
-        ResourceUtils.getAccountNumber(),
-        validateOrgId(),
-        OptInType.API,
-        trueIfNull(enableTallySync),
-        trueIfNull(enableTallyReporting),
-        trueIfNull(enableConduitSync));
+    return controller.optIn(ResourceUtils.getAccountNumber(), validateOrgId(), OptInType.API);
   }
 
   private String validateOrgId() {

--- a/src/main/resources/liquibase/202210101642-drop-unused-opt-in-flags.xml
+++ b/src/main/resources/liquibase/202210101642-drop-unused-opt-in-flags.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202210101642-1" author="khowell">
+    <comment>Drop unused opt-in flags from account_config.</comment>
+    <dropColumn tableName="account_config" columnName="reporting_enabled"/>
+    <dropColumn tableName="account_config" columnName="sync_enabled"/>
+  </changeSet>
+
+  <changeSet id="202210101642-2" author="khowell">
+    <comment>Drop unused opt-in flags from org_config.</comment>
+    <dropColumn tableName="org_config" columnName="sync_enabled"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -83,5 +83,6 @@
     <include file="liquibase/202209301614-migrate-org-id-to-events-table.xml"/>
     <include file="liquibase/202209301230-migrate-org-id-to-billable-usage-table.xml"/>
     <include file="liquibase/202210101553-make-account-config-org-id-nullable.xml"/>
+    <include file="liquibase/202210101642-drop-unused-opt-in-flags.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -201,7 +201,7 @@ class PrometheusMeteringControllerTest {
             end,
             metricProperties.getStep(),
             metricProperties.getQueryTimeout());
-    verify(optInController).optInByOrgId(expectedOrgId, OptInType.PROMETHEUS, true, true, true);
+    verify(optInController).optInByOrgId(expectedOrgId, OptInType.PROMETHEUS);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
@@ -72,28 +72,8 @@ class OptInResourceTest {
 
   @Test
   void testPut() {
-    resource.putOptInConfig(false, false, false);
-    Mockito.verify(controller)
-        .optIn(
-            "account123456",
-            "owner123456",
-            OptInType.API,
-            Boolean.FALSE,
-            Boolean.FALSE,
-            Boolean.FALSE);
-  }
-
-  @Test
-  void testPutDefaultsToTrue() {
-    resource.putOptInConfig(null, null, null);
-    Mockito.verify(controller)
-        .optIn(
-            "account123456",
-            "owner123456",
-            OptInType.API,
-            Boolean.TRUE,
-            Boolean.TRUE,
-            Boolean.TRUE);
+    resource.putOptInConfig();
+    Mockito.verify(controller).optIn("account123456", "owner123456", OptInType.API);
   }
 
   @Test
@@ -127,7 +107,7 @@ class OptInResourceTest {
   @Test
   @WithMockRedHatPrincipal(value = "123456", nullifyOwner = true)
   void testMissingOrgOnPut() {
-    assertThrows(BadRequestException.class, () -> resource.putOptInConfig(true, true, true));
+    assertThrows(BadRequestException.class, () -> resource.putOptInConfig());
   }
 
   @Test
@@ -135,6 +115,6 @@ class OptInResourceTest {
       value = "123456",
       roles = {})
   void testAccessDeniedForOptInWhenUserIsNotAnAdmin() {
-    assertThrows(AccessDeniedException.class, () -> resource.putOptInConfig(true, true, true));
+    assertThrows(AccessDeniedException.class, () -> resource.putOptInConfig());
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -32,10 +32,10 @@ import org.springframework.data.repository.query.Param;
 /** Defines all operations for storing account config entries. */
 public interface AccountConfigRepository extends JpaRepository<AccountConfig, String> {
 
-  @Query("select distinct c.accountNumber from AccountConfig c where c.syncEnabled = TRUE")
+  @Query("select distinct c.accountNumber from AccountConfig c")
   Stream<String> findSyncEnabledAccounts();
 
-  @Query("select distinct c.orgId from AccountConfig c where c.syncEnabled = TRUE")
+  @Query("select distinct c.orgId from AccountConfig c")
   Stream<String> findSyncEnabledOrgs();
 
   @Query("select distinct c.orgId from AccountConfig c where c.accountNumber = :account")
@@ -43,11 +43,6 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
 
   @Query("select distinct c.accountNumber from AccountConfig c where c.orgId = :orgId")
   String findAccountNumberByOrgId(@Param("orgId") String orgId);
-
-  @Query(
-      "select case when count(c) > 0 then true else false end from AccountConfig c "
-          + "where c.accountNumber = :account and c.reportingEnabled = TRUE")
-  boolean isReportingEnabled(@Param("account") String accountNumber);
 
   @Query(
       "select count(c) from AccountConfig c "
@@ -63,12 +58,7 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
   void deleteByOrgId(String accountNumber);
 
   default Optional<AccountConfig> createOrUpdateAccountConfig(
-      String account,
-      String orgId,
-      OffsetDateTime current,
-      OptInType optInType,
-      boolean enableSync,
-      boolean enableReporting) {
+      String account, String orgId, OffsetDateTime current, OptInType optInType) {
     Optional<AccountConfig> found = findByOrgId(orgId);
     AccountConfig accountConfig = found.orElse(new AccountConfig());
     if (!found.isPresent()) {
@@ -78,8 +68,6 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
     }
     accountConfig.setAccountNumber(account);
     accountConfig.setOrgId(orgId);
-    accountConfig.setSyncEnabled(enableSync);
-    accountConfig.setReportingEnabled(enableReporting);
     accountConfig.setUpdated(current);
     return Optional.of(save(accountConfig));
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/OrgConfigRepository.java
@@ -31,18 +31,17 @@ import org.springframework.data.jpa.repository.Query;
 /** Defines all operations for storing organization config entries. */
 public interface OrgConfigRepository extends JpaRepository<OrgConfig, String> {
 
-  @Query("select distinct c.orgId from OrgConfig c where c.syncEnabled = TRUE")
+  @Query("select distinct c.orgId from OrgConfig c")
   Stream<String> findSyncEnabledOrgs();
 
   default Optional<OrgConfig> createOrUpdateOrgConfig(
-      String orgId, OffsetDateTime current, OptInType optInType, boolean enableSync) {
+      String orgId, OffsetDateTime current, OptInType optInType) {
     Optional<OrgConfig> found = findById(orgId);
     OrgConfig orgConfig = found.orElse(new OrgConfig(orgId));
     if (!found.isPresent()) {
       orgConfig.setOptInType(optInType);
       orgConfig.setCreated(current);
     }
-    orgConfig.setSyncEnabled(enableSync);
     orgConfig.setUpdated(current);
     return Optional.of(save(orgConfig));
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/AccountConfig.java
@@ -34,9 +34,6 @@ public class AccountConfig extends BaseConfig {
   @Column(name = "account_number")
   private String accountNumber;
 
-  @Column(name = "reporting_enabled")
-  private Boolean reportingEnabled;
-
   @Id
   @Column(name = "org_id")
   private String orgId;
@@ -47,14 +44,6 @@ public class AccountConfig extends BaseConfig {
 
   public void setAccountNumber(String accountNumber) {
     this.accountNumber = accountNumber;
-  }
-
-  public Boolean getReportingEnabled() {
-    return reportingEnabled;
-  }
-
-  public void setReportingEnabled(Boolean reportingEnabled) {
-    this.reportingEnabled = reportingEnabled;
   }
 
   public String getOrgId() {
@@ -80,13 +69,11 @@ public class AccountConfig extends BaseConfig {
     }
 
     AccountConfig that = (AccountConfig) o;
-    return Objects.equals(accountNumber, that.accountNumber)
-        && Objects.equals(orgId, that.orgId)
-        && Objects.equals(reportingEnabled, that.reportingEnabled);
+    return Objects.equals(accountNumber, that.accountNumber) && Objects.equals(orgId, that.orgId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), accountNumber, orgId, reportingEnabled);
+    return Objects.hash(super.hashCode(), accountNumber, orgId);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/BaseConfig.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/BaseConfig.java
@@ -31,10 +31,6 @@ import javax.persistence.MappedSuperclass;
 /** Base class for configuration DB objects. */
 @MappedSuperclass
 public class BaseConfig implements Serializable {
-
-  @Column(name = "sync_enabled")
-  protected Boolean syncEnabled;
-
   @Enumerated(EnumType.STRING)
   @Column(name = "opt_in_type")
   protected OptInType optInType;
@@ -44,14 +40,6 @@ public class BaseConfig implements Serializable {
 
   @Column(name = "updated")
   protected OffsetDateTime updated;
-
-  public Boolean getSyncEnabled() {
-    return syncEnabled;
-  }
-
-  public void setSyncEnabled(Boolean syncEnabled) {
-    this.syncEnabled = syncEnabled;
-  }
 
   public OptInType getOptInType() {
     return optInType;
@@ -88,14 +76,13 @@ public class BaseConfig implements Serializable {
     }
 
     BaseConfig that = (BaseConfig) o;
-    return Objects.equals(syncEnabled, that.syncEnabled)
-        && optInType == that.optInType
+    return optInType == that.optInType
         && Objects.equals(created, that.created)
         && Objects.equals(updated, that.updated);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(syncEnabled, optInType, created, updated);
+    return Objects.hash(optInType, created, updated);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/config/OrgConfig.java
@@ -45,7 +45,6 @@ public class OrgConfig extends BaseConfig {
   public static OrgConfig fromJmx(String orgId, OffsetDateTime timestamp) {
     OrgConfig orgConfig = new OrgConfig(orgId);
     orgConfig.setOptInType(OptInType.JMX);
-    orgConfig.setSyncEnabled(true);
     orgConfig.setCreated(timestamp);
     orgConfig.setUpdated(timestamp);
     return orgConfig;
@@ -54,7 +53,6 @@ public class OrgConfig extends BaseConfig {
   public static OrgConfig fromInternalApi(String orgId, OffsetDateTime timestamp) {
     OrgConfig orgConfig = new OrgConfig(orgId);
     orgConfig.setOptInType(OptInType.INTERNAL_API);
-    orgConfig.setSyncEnabled(true);
     orgConfig.setCreated(timestamp);
     orgConfig.setUpdated(timestamp);
     return orgConfig;


### PR DESCRIPTION
Testing
=======

Run the server:

```shell
DEV_MODE=true ./gradlew :bootRun
```

Observe at http://localhost:8000/api-docs that the opt-in API no longer mentions any of the flags.

Verify that getting opt-in status still works:

```shell
http :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo '
  {"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

Verify that opting in still works:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo '
  {"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

Verify that opting out still works:

```shell
http DELETE :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo '
  {"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```