### PR TITLE
SWATCH-576: Add nginx-proxy deployment to ClowdApp/swatch-api

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -247,6 +247,25 @@ objects:
               - name: pinhead
                 secret:
                   secretName: pinhead
+        - name: nginx-proxy
+          minReplicas: 1
+          webServices:
+            public:
+              enabled: true
+          podSpec:
+            image: quay.io/app-sre/ubi8-nginx-118
+            command:
+            - nginx
+            - "-g"
+            - "daemon off;"
+            volumeMounts:
+            - name: swatch-api-nginx-conf
+              mountPath: /etc/nginx
+            volumes:
+            - name: swatch-api-nginx-conf
+              configMap:
+                name: nginx-conf
+
   - kind: Service
     apiVersion: v1
     metadata:
@@ -262,4 +281,36 @@ objects:
           protocol: TCP
           targetPort: 8000
       selector:
-        pod: swatch-api-service
+        pod: swatch-api-nginx-proxy
+
+
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: nginx-conf
+    data:
+      nginx.conf: |-
+        events {}
+        http {
+          upstream swatch-api {
+            server swatch-api-service:8000;
+          }
+
+          server {
+            error_log  stderr;
+            access_log  /dev/stdout;
+            listen 8000;
+            client_max_body_size 500M;
+            client_header_buffer_size 46k;
+
+            location /healthz {
+                auth_basic          off;
+                allow               all;
+                return              200;
+            }
+
+            location ^~/ {
+              proxy_pass http://swatch-api;
+            }
+          }
+        }

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -258,6 +258,9 @@ objects:
             - nginx
             - "-g"
             - "daemon off;"
+            env:
+            - name: DEV_MODE
+              value: ${DEV_MODE}
             volumeMounts:
             - name: swatch-api-nginx-conf
               mountPath: /etc/nginx


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-576


# Deploy rhsm & swatch-api components to ephemeral environment

```bash
export NAMESPACE=$(bonfire namespace reserve)


bonfire deploy -n $NAMESPACE \
  -C rhsm \
  --no-remove-resources=rhsm \
  -C swatch-api \
  --no-remove-resources=swatch-api \
  --optional-deps-method=none \
  -i quay.io/cloudservices/rhsm-subscriptions=3b40fec \
  -i quay.io/cloudservices/swatch-producer-aws=3b40fec \
  -i quay.io/cloudservices/swatch-system-conduit=3b40fec \
rhsm
```

# Expected Results:
- A swatch-api-nginx-proxy pod is deployed and eventually gets into a ready state
- From a console in the namespace with the curl command available (you can use the new swatch-api-nginx-proxy one), you can run get a successful response from 

```bash
curl http://rhsm-subscriptions:8000/api/rhsm-subscriptions/v1/version

{"build":{"version":"1.1.0-snapshot.202210121434+3b40fec","artifact":"rhsm-subscriptions","name":"rhsm-subscriptions","group":"org.candlepin"}}
```

- If you try to curl an authenticated endpoint **without** the `x-rh-identity` header, you get a 401.
```bash
curl http://rhsm-subscriptions:8000/api/rhsm-subscriptions/v1/tally  
{"errors":[{"status":"401","code":"SUBSCRIPTIONS1001","title":"Could not authenticate the user.","detail":"Full authentication is required to access this resource"}]}
```

- When including a valid `x-rh-identity` header, the request authenticates successfully
```bash
curl http://rhsm-subscriptions:8000/api/rhsm-subscriptions/v1/tally -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='

{"errors":[{"status":"403","code":"SUBSCRIPTIONS1004","title":"Access Denied","detail":"Opt-in required."}]}
```



![swatch-api-nginx-proxy - Initial State](https://user-images.githubusercontent.com/19955562/195410668-0e1add8e-fdb1-453a-9455-4a57d0215634.png)


