### PR TITLE
SWATCH-586: seperate virtual and hypervisor report categories for tally api

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -63,8 +63,8 @@ public class TallyResource implements TallyApi {
   private static final Map<ReportCategory, Set<HardwareMeasurementType>> CATEGORY_MAP =
       Map.of(
           ReportCategory.PHYSICAL, Set.of(HardwareMeasurementType.PHYSICAL),
-          ReportCategory.VIRTUAL,
-              Set.of(HardwareMeasurementType.VIRTUAL, HardwareMeasurementType.HYPERVISOR),
+          ReportCategory.VIRTUAL, Set.of(HardwareMeasurementType.VIRTUAL),
+          ReportCategory.HYPERVISOR, Set.of(HardwareMeasurementType.HYPERVISOR),
           ReportCategory.CLOUD, new HashSet<>(HardwareMeasurementType.getCloudProviderTypes()));
   private final TallySnapshotRepository repository;
   private final PageLinkCreator pageLinkCreator;


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-586

Test Steps:

- Insert Test Data:
```
INSERT INTO public.tally_snapshots VALUES ('06197a03-de1b-49a1-9093-dd61660a8fc1', 'RHEL for x86', 'account123', 'DAILY', 'org123', '2022-10-10 00:00:00+00', NULL, 'Premium', '_ANY', '_ANY', '_ANY');
INSERT INTO public.tally_snapshots VALUES ('0beab042-b9ff-4ef3-9a3d-a924f4aa6f97', 'RHEL for x86', 'account123', 'DAILY', 'org123', '2022-10-10 00:00:00+00', NULL, 'Premium', '_ANY', '_ANY', '_ANY');
INSERT INTO public.tally_measurements VALUES ('06197a03-de1b-49a1-9093-dd61660a8fc1', 'VIRTUAL', 'CORES', 1);
INSERT INTO public.tally_measurements VALUES ('0beab042-b9ff-4ef3-9a3d-a924f4aa6f97', 'HYPERVISOR', 'CORES', 6);
```
- Run curl to get hypervisor tallies (should get value of 6):
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86/Cores?category=hypervisor&granularity=Daily&sla=Premium&usage=_ANY&billing_provider=_ANY&beginning=2022-10-09T00%3A32%3A28Z&ending=2022-10-11T17%3A32%3A28Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo'
```
- Run curl to get virtual tallies (should get value of 1):
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86/Cores?category=virtual&granularity=Daily&sla=Premium&usage=_ANY&billing_provider=_ANY&beginning=2022-10-09T00%3A32%3A28Z&ending=2022-10-11T17%3A32%3A28Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo'
```