### PR TITLE
Restore rhacs role in event.yaml

### DIFF
--- a/swatch-core/schemas/event.yaml
+++ b/swatch-core/schemas/event.yaml
@@ -133,6 +133,7 @@ properties:
       - ocp
       - osd
       - rhosak
+      - rhacs
       - addon-open-data-hub
     required: false
   sla:


### PR DESCRIPTION
Accidentally removed in #1504. Sorry!