### PR TITLE
Add data migration via JMX to workaround large datasets

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.jmx;
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
 import org.candlepin.subscriptions.resource.ResourceUtils;
+import org.candlepin.subscriptions.tally.admin.DataMigrationRunner;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
 import org.candlepin.subscriptions.util.DateRange;
 import org.candlepin.subscriptions.validator.ParameterDuration;
@@ -44,9 +45,11 @@ public class TallyJmxBean {
   private static final Logger log = LoggerFactory.getLogger(TallyJmxBean.class);
 
   private final CaptureSnapshotsTaskManager tasks;
+  private final DataMigrationRunner dataMigrationRunner;
 
-  public TallyJmxBean(CaptureSnapshotsTaskManager taskManager) {
+  public TallyJmxBean(CaptureSnapshotsTaskManager taskManager, DataMigrationRunner dataMigrationRunner) {
     this.tasks = taskManager;
+    this.dataMigrationRunner = dataMigrationRunner;
   }
 
   @ManagedOperation(description = "Trigger a tally for an account")
@@ -123,5 +126,11 @@ public class TallyJmxBean {
     }
 
     tasks.updateHourlySnapshotsForAllAccounts(Optional.ofNullable(range));
+  }
+
+  @ManagedOperation(description = "Fix all the things")
+  public void changeSetRunner() {
+
+    dataMigrationRunner.sanityCheck();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/DataMigration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/DataMigration.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import java.lang.reflect.InvocationTargetException;
+import java.sql.Date;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+public abstract class DataMigration {
+  private static final String LIQUIBASE_CHANGELOG_INSERT =
+      "insert into databasechangelog(id, author, filename, dateexecuted, orderexecuted, exectype, md5sum, description, comments, tag, liquibase, contexts, labels, deployment_id)\n"
+          + "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+
+  private static final String MAX_ORDEREXECUTED_QUERY =
+      "select max(orderexecuted) from databasechangelog";
+
+  private static final String DELETE_CHANGELOG_QUERY = "delete from databasechangelog where id=?";
+
+  protected JdbcTemplate jdbcTemplate;
+
+  protected MeterRegistry meterRegistry;
+
+  public DataMigration(JdbcTemplate jdbcTemplate, MeterRegistry meterRegistry) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.meterRegistry = meterRegistry;
+  }
+
+  // Can we stream these back
+  public abstract SqlRowSet extract(String recordOffset, int batchSize);
+
+  public abstract String transformAndLoad(SqlRowSet data);
+
+  public abstract void recordCompleted();
+
+  protected void markLiquibaseChangesetRan(JdbcTemplate jdbcTemplate, Map<String, Object> values) {
+    int maxOrderExecutedValue =
+        Optional.ofNullable(jdbcTemplate.queryForObject(MAX_ORDEREXECUTED_QUERY, Integer.class))
+            .orElse(0);
+    jdbcTemplate.update(DELETE_CHANGELOG_QUERY, values.get("id"));
+    jdbcTemplate.update(
+        LIQUIBASE_CHANGELOG_INSERT,
+        values.get("id"),
+        values.get("author"),
+        values.get("filename"),
+        values.getOrDefault("dateexecuted", Date.valueOf(ZonedDateTime.now().toLocalDate())),
+        values.getOrDefault("orderexecuted", maxOrderExecutedValue + 1),
+        values.getOrDefault("exectype", "MARK_RAN"),
+        values.get("md5sum"),
+        values.getOrDefault("description", "customChange"),
+        values.getOrDefault(
+            "comments", String.format("Manually migrated via %s", this.getClass().getName())),
+        values.get("tag"), // nullable
+        values.getOrDefault("liquibase", "4.9.1"),
+        values.get("contexts"), // nullable
+        values.get("labels"), // nullable
+        values.get("deployment_id")); // nullable
+  }
+
+  static DataMigration getMigration(
+      Class<? extends DataMigration> clazz, JdbcTemplate jdbcTemplate, MeterRegistry meterRegistry)
+      throws NoSuchMethodException, InvocationTargetException, InstantiationException,
+          IllegalAccessException {
+    return clazz
+        .getConstructor(JdbcTemplate.class, MeterRegistry.class)
+        .newInstance(jdbcTemplate, meterRegistry);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/DataMigration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/DataMigration.java
@@ -43,7 +43,7 @@ public abstract class DataMigration {
 
   protected MeterRegistry meterRegistry;
 
-  public DataMigration(JdbcTemplate jdbcTemplate, MeterRegistry meterRegistry) {
+  protected DataMigration(JdbcTemplate jdbcTemplate, MeterRegistry meterRegistry) {
     this.jdbcTemplate = jdbcTemplate;
     this.meterRegistry = meterRegistry;
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/DataMigrationRunner.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/DataMigrationRunner.java
@@ -1,0 +1,94 @@
+package org.candlepin.subscriptions.tally.admin;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class DataMigrationRunner {
+
+
+  @Autowired
+  JdbcTemplate jdbcTemplate;
+
+  public void sanityCheck() {
+    log.info("Bananas");
+    migrateCoresSocketsData();
+
+    var threadPoolSize = 4;
+
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(threadPoolSize);
+
+    migrateCoresSocketsData().forEach(sqlStatement -> {
+      executor.submit(() -> {
+
+        log.info("Running sql: {}", sqlStatement);
+        jdbcTemplate.update(sqlStatement);
+        updateDatabaseChangelog("placeholder for now....we need to shove a comment in somewhere");
+        return null;
+
+      });
+    });
+  }
+
+  // src/main/resources/liquibase/202208251616-migrate-cores-sockets-data.xml
+  public List<String> migrateCoresSocketsData() {
+
+    return Arrays.asList(
+        // 202208251616-1
+        "insert into instance_measurements(instance_id, uom, value) select id, 'CORES', cores from hosts where cores is not null on conflict(instance_id, uom) do update set value =excluded.value;"
+        // 202208251616-2
+        ,
+        "insert into instance_measurements(instance_id, uom, value) select id, 'SOCKETS', sockets from hosts where sockets is not null on conflict(instance_id, uom) do update set value=excluded.value;"
+        // 202208251616-3
+        ,
+        "insert into tally_measurements(snapshot_id, measurement_type, uom, value) select snapshot_id, measurement_type, 'SOCKETS', sockets from hardware_measurements where sockets is not null on conflict(snapshot_id, measurement_type, uom) do update set value=excluded.value;"
+        // 202208251616-4
+        ,
+        "insert into tally_measurements(snapshot_id, measurement_type, uom, value) select snapshot_id, measurement_type, 'CORES', cores from hardware_measurements where cores is not null on conflict(snapshot_id, measurement_type, uom) do update set value=excluded.value;"
+        // 202208251616-5
+        ,
+        "insert into tally_measurements(snapshot_id, measurement_type, uom, value) select snapshot_id, measurement_type, 'INSTANCES', instance_count from hardware_measurements where instance_count is not null on conflict(snapshot_id, measurement_type, uom) do update set value=excluded.value;"
+
+    );
+
+
+  }
+
+
+
+  public void updateDatabaseChangelog(String comment) {
+
+    // TODO
+    log.info("Entry into databasechangelog", comment);
+  }
+
+
+
+  // {
+  // "id": "202209301614-1",
+  // "author": "mstead",
+  // "filename": "liquibase/202209301614-migrate-org-id-to-events-table.xml",
+  // "dateexecuted": "2022-10-12 18:03:48.245371",
+  // "orderexecuted": 143,
+  // "exectype": "EXECUTED",
+  // "md5sum": "8:ba2f1a325928e9bb87387bd97e27f2bc",
+  // "description": "sql",
+  // "comments": "Migrate org_id to events table from account_config.",
+  // "tag": null,
+  // "liquibase": "4.9.1",
+  // "contexts": null,
+  // "labels": null,
+  // "deployment_id": "5597795748"
+  // }
+
+
+}
+

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/HardwareMeasurementMigration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/HardwareMeasurementMigration.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.sql.Types;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.SqlRowSetResultSetExtractor;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+@Slf4j
+public class HardwareMeasurementMigration extends DataMigration {
+
+  public static final SqlRowSetResultSetExtractor SQL_ROW_SET_RESULT_SET_EXTRACTOR =
+      new SqlRowSetResultSetExtractor();
+
+  public static final String INSERT_SQL =
+      "insert into tally_measurements(snapshot_id, measurement_type, uom, value)\n"
+          + "values (?, ?, ?, ?)";
+
+  public static final String UPDATE_SQL =
+      "update tally_measurements set value=? where snapshot_id=? and measurement_type=? and uom=?";
+
+  private static final String HARDWARE_MEASUREMENT_QUERY =
+      "select h.snapshot_id, h.measurement_type, sockets, cores, s.value as s_value, c.value as c_value\n"
+          + "from hardware_measurements h\n"
+          + "         left join tally_measurements s\n"
+          + "                   on s.snapshot_id = h.snapshot_id and s.measurement_type = h.measurement_type and s.uom = 'SOCKETS'\n"
+          + "         left join tally_measurements c\n"
+          + "                   on c.snapshot_id = h.snapshot_id and c.measurement_type = h.measurement_type and c.uom = 'CORES'\n"
+          + "where ?::uuid is null\n"
+          + "   or h.snapshot_id > ?::uuid\n"
+          + "order by h.snapshot_id\n"
+          + "limit ?";
+
+  private final Counter counter;
+
+  public HardwareMeasurementMigration(JdbcTemplate jdbcTemplate, MeterRegistry meterRegistry) {
+    super(jdbcTemplate, meterRegistry);
+    counter = meterRegistry.counter("swatch_hardware_measurement_migration");
+  }
+
+  @Override
+  public SqlRowSet extract(String recordOffset, int batchSize) {
+    return jdbcTemplate.query(
+        HARDWARE_MEASUREMENT_QUERY,
+        new Object[] {recordOffset, recordOffset, batchSize},
+        new int[] {Types.VARCHAR, Types.VARCHAR, Types.NUMERIC},
+        SQL_ROW_SET_RESULT_SET_EXTRACTOR);
+  }
+
+  @Override
+  public String transformAndLoad(SqlRowSet data) {
+    String lastSeenSnapshotId = null;
+    while (data.next()) {
+      String snapshotId = data.getString("snapshot_id");
+      lastSeenSnapshotId = snapshotId;
+      String measurementType = data.getString("measurement_type");
+      Double sockets = extractNullableDouble(data, "sockets");
+      Double cores = extractNullableDouble(data, "cores");
+      Double tallyMeasurementSockets = extractNullableDouble(data, "s_value");
+      Double tallyMeasurementCores = extractNullableDouble(data, "c_value");
+      if (sockets != null && tallyMeasurementSockets == null) {
+        log.debug("Inserting sockets for tally snapshotId: {}", snapshotId);
+        jdbcTemplate.update(INSERT_SQL, snapshotId, measurementType, "SOCKETS", sockets);
+      } else if (!Objects.equals(tallyMeasurementSockets, sockets)) {
+        log.debug("Updating sockets for tally snapshotId: {}", snapshotId);
+        jdbcTemplate.update(UPDATE_SQL, sockets, snapshotId, measurementType, "SOCKETS");
+      }
+      if (cores != null && tallyMeasurementCores == null) {
+        log.debug("Inserting cores for tally snapshotId: {}", snapshotId);
+        jdbcTemplate.update(INSERT_SQL, snapshotId, measurementType, "CORES", cores);
+      } else if (!Objects.equals(tallyMeasurementCores, cores)) {
+        log.debug("Updating cores for tally snapshotId: {}", snapshotId);
+        jdbcTemplate.update(UPDATE_SQL, cores, snapshotId, measurementType, "CORES");
+      }
+      counter.increment();
+    }
+    return lastSeenSnapshotId;
+  }
+
+  @Override
+  @SuppressWarnings("java:S1192") // supress duplicate string warnings
+  public void recordCompleted() {
+    markLiquibaseChangesetRan(
+        jdbcTemplate,
+        Map.of(
+            "id",
+            "202208251616-3",
+            "author",
+            "khowell",
+            "filename",
+            "liquibase/202208251616-migrate-cores-sockets-data.xml",
+            "md5sum",
+            "8:098818ac2df540a55e17763bf64006c3"));
+    markLiquibaseChangesetRan(
+        jdbcTemplate,
+        Map.of(
+            "id",
+            "202208251616-4",
+            "author",
+            "khowell",
+            "filename",
+            "liquibase/202208251616-migrate-cores-sockets-data.xml",
+            "md5sum",
+            "8:5e353189c216fb19646ef4183c28488a"));
+    markLiquibaseChangesetRan(
+        jdbcTemplate,
+        Map.of(
+            "id",
+            "202208251616-5",
+            "author",
+            "khowell",
+            "filename",
+            "liquibase/202208251616-migrate-cores-sockets-data.xml",
+            "md5sum",
+            "8:1891ca4061d152d04b61b6190d86cbac"));
+  }
+
+  private Double extractNullableDouble(SqlRowSet data, String column) {
+    double value = data.getDouble(column);
+    if (data.wasNull()) {
+      return null;
+    }
+    return value;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/HardwareMeasurementMigration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/HardwareMeasurementMigration.java
@@ -126,17 +126,6 @@ public class HardwareMeasurementMigration extends DataMigration {
             "liquibase/202208251616-migrate-cores-sockets-data.xml",
             "md5sum",
             "8:5e353189c216fb19646ef4183c28488a"));
-    markLiquibaseChangesetRan(
-        jdbcTemplate,
-        Map.of(
-            "id",
-            "202208251616-5",
-            "author",
-            "khowell",
-            "filename",
-            "liquibase/202208251616-migrate-cores-sockets-data.xml",
-            "md5sum",
-            "8:1891ca4061d152d04b61b6190d86cbac"));
   }
 
   private Double extractNullableDouble(SqlRowSet data, String column) {

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -73,7 +73,7 @@
     <include file="liquibase/202208301033-default-null-hardware-measurements.xml"/>
     <include file="liquibase/202208301423-set-tally-snapshot-owner-id.xml"/>
     <include file="liquibase/202209121018-update-primary-key-of-account-config.xml"/>
-    <include file="liquibase/202208251616-migrate-cores-sockets-data.xml"/>
+    <!-- <include file="liquibase/202208251616-migrate-cores-sockets-data.xml"/> -->
     <include file="liquibase/202208191129-add-version-to-host_tally_buckets.xml"/>
     <include file="liquibase/202209301035-migrate-org-id-to-hosts-table.xml"/>
     <include file="liquibase/202209301614-migrate-org-id-to-events-table.xml"/>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -73,7 +73,7 @@
     <include file="liquibase/202208301033-default-null-hardware-measurements.xml"/>
     <include file="liquibase/202208301423-set-tally-snapshot-owner-id.xml"/>
     <include file="liquibase/202209121018-update-primary-key-of-account-config.xml"/>
-    <!-- <include file="liquibase/202208251616-migrate-cores-sockets-data.xml"/> -->
+    <include file="liquibase/202208251616-migrate-cores-sockets-data.xml"/>
     <include file="liquibase/202208191129-add-version-to-host_tally_buckets.xml"/>
     <include file="liquibase/202209301035-migrate-org-id-to-hosts-table.xml"/>
     <include file="liquibase/202209301614-migrate-org-id-to-events-table.xml"/>


### PR DESCRIPTION
Testing
=======

Clear tally snapshots table and related:

```
truncate tally_snapshots cascade ;
```

Insert some test data:
```
insert into tally_snapshots(id, product_id, account_number, granularity, owner_id, snapshot_date, unit_of_measure, sla)
VALUES (gen_random_uuid(), 'RHEL', 'account123', 'DAILY', 'org123', now(), null, 'Premium');
insert into tally_snapshots(id, product_id, account_number, granularity, owner_id, snapshot_date, unit_of_measure, sla)
VALUES (gen_random_uuid(), 'RHEL', 'account123', 'DAILY', 'org123', now(), null, 'Premium');
insert into hardware_measurements(snapshot_id, measurement_type, cores, instance_count, sockets)
select id, 'PHYSICAL', 2, 3, 4
from tally_snapshots;
insert into tally_measurements(snapshot_id, measurement_type, uom, value)
select snapshot_id, measurement_type, 'CORES', 10
from hardware_measurements
limit 1;
insert into tally_measurements(snapshot_id, measurement_type, uom, value)
select snapshot_id, measurement_type, 'SOCKETS', 20
from hardware_measurements
limit 1;
```

This produces hardware measurements missing respective tally
measurements, as well as incorrect tally measurements records.

Trigger the new JMX endpoint:

```
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='migrateHardwareMeasurements(java.lang.String,int)' \
  arguments:='["",128]'
```

Query the tables to see that records were both inserted and updated as
appropriate:

```
select h.snapshot_id, h.measurement_type, sockets, cores, c.value as c_value, s.value as s_value
from hardware_measurements h
         left join tally_measurements c
                   on c.snapshot_id = h.snapshot_id and c.measurement_type = h.measurement_type and c.uom = 'CORES'
         left join tally_measurements s
                   on s.snapshot_id = h.snapshot_id and s.measurement_type = h.measurement_type and s.uom = 'SOCKETS'
order by h.snapshot_id
```