### PR TITLE
Workaround some migration issues w/ HardwareMeasurement

### DIFF
--- a/src/main/resources/liquibase/202208251616-migrate-cores-sockets-data.xml
+++ b/src/main/resources/liquibase/202208251616-migrate-cores-sockets-data.xml
@@ -46,14 +46,4 @@
       on conflict(snapshot_id, measurement_type, uom) do update set value=excluded.value;
     </sql>
   </changeSet>
-  <changeSet id="202208251616-5" author="khowell" dbms="postgresql">
-    <comment>Copy data from hardware_measurements.instance_count to tally_measurements.</comment>
-    <sql>
-      insert into tally_measurements(snapshot_id, measurement_type, uom, value)
-      select snapshot_id, measurement_type, 'INSTANCES', instance_count
-      from hardware_measurements
-      where instance_count is not null
-      on conflict(snapshot_id, measurement_type, uom) do update set value=excluded.value;
-    </sql>
-  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -73,7 +73,11 @@
     <include file="liquibase/202208301033-default-null-hardware-measurements.xml"/>
     <include file="liquibase/202208301423-set-tally-snapshot-owner-id.xml"/>
     <include file="liquibase/202209121018-update-primary-key-of-account-config.xml"/>
+    <!--
+    NOTE: we're temporarily disabling 202208251616-migrate-cores-sockets-data.xml because the
+    migration blocks cronjobs, etc
     <include file="liquibase/202208251616-migrate-cores-sockets-data.xml"/>
+    -->
     <include file="liquibase/202208191129-add-version-to-host_tally_buckets.xml"/>
     <include file="liquibase/202209301035-migrate-org-id-to-hosts-table.xml"/>
     <include file="liquibase/202209301614-migrate-org-id-to-events-table.xml"/>

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurement.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Class to represent rows in the hardware_measurements table
+ *
+ * <p>NOTE: to be removed by SWATCH-626
+ */
+@Embeddable
+@Getter
+@Setter
+public class HardwareMeasurement implements Serializable {
+  @Column(name = "instance_count")
+  private int instanceCount;
+
+  private int cores;
+  private int sockets;
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.db.model;
 
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +40,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyClass;
+import javax.persistence.MapKeyColumn;
+import javax.persistence.MapKeyEnumerated;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -94,6 +97,15 @@ public class TallySnapshot implements Serializable {
   @Enumerated(EnumType.STRING)
   @Column(name = "granularity")
   private Granularity granularity;
+
+  /** NOTE: to be removed w/ SWATCH-626 */
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name = "hardware_measurements", joinColumns = @JoinColumn(name = "snapshot_id"))
+  @MapKeyEnumerated(EnumType.STRING)
+  @MapKeyColumn(name = "measurement_type")
+  @Builder.Default
+  private Map<HardwareMeasurementType, HardwareMeasurement> hardwareMeasurements =
+      new EnumMap<>(HardwareMeasurementType.class);
 
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(name = "tally_measurements", joinColumns = @JoinColumn(name = "snapshot_id"))
@@ -200,8 +212,94 @@ public class TallySnapshot implements Serializable {
         tallyMeasurements.get(
             new TallyMeasurementKey(HardwareMeasurementType.TOTAL, Uom.INSTANCE_HOURS)));
 
+    // NOTE to be removed by SWATCH-626
+    if (snapshotHasNoData(snapshot)) {
+      readDataFromHardwareMeasurements(snapshot);
+    }
+
     snapshot.setHasData(id != null);
     return snapshot;
+  }
+
+  // NOTE to be removed by SWATCH-626
+  private boolean snapshotHasNoData(
+      org.candlepin.subscriptions.utilization.api.model.TallySnapshot snapshot) {
+    double currentMeasurements = 0.0;
+    currentMeasurements += snapshot.getCores();
+    currentMeasurements += snapshot.getSockets();
+    currentMeasurements += snapshot.getCloudCores();
+    currentMeasurements += snapshot.getCloudSockets();
+    currentMeasurements += snapshot.getHypervisorCores();
+    currentMeasurements += snapshot.getHypervisorSockets();
+    return currentMeasurements == 0.0;
+  }
+
+  // NOTE: to be removed by SWATCH-626
+  private void readDataFromHardwareMeasurements(
+      org.candlepin.subscriptions.utilization.api.model.TallySnapshot snapshot) {
+    HardwareMeasurement total = this.hardwareMeasurements.get(HardwareMeasurementType.TOTAL);
+    if (total != null) {
+      snapshot.setCores(total.getCores());
+      snapshot.setSockets(total.getSockets());
+      snapshot.setInstanceCount(total.getInstanceCount());
+    }
+
+    HardwareMeasurement physical = this.hardwareMeasurements.get(HardwareMeasurementType.PHYSICAL);
+    if (physical != null) {
+      snapshot.setPhysicalCores(physical.getCores());
+      snapshot.setPhysicalSockets(physical.getSockets());
+      snapshot.setPhysicalInstanceCount(physical.getInstanceCount());
+    }
+
+    HardwareMeasurement virtual = this.hardwareMeasurements.get(HardwareMeasurementType.VIRTUAL);
+    HardwareMeasurement hypervisor =
+        this.hardwareMeasurements.get(HardwareMeasurementType.HYPERVISOR);
+
+    // Sum "HYPERVISOR" and "VIRTUAL" records in the short term
+    int totalVirtualCores = 0;
+    int totalVirtualSockets = 0;
+    int totalVirtualInstanceCount = 0;
+
+    if (virtual != null) {
+      totalVirtualCores += virtual.getCores();
+      totalVirtualSockets += virtual.getSockets();
+      totalVirtualInstanceCount += virtual.getInstanceCount();
+    }
+    if (hypervisor != null) {
+      totalVirtualCores += hypervisor.getCores();
+      totalVirtualSockets += hypervisor.getSockets();
+      totalVirtualInstanceCount += hypervisor.getInstanceCount();
+    }
+    if (hypervisor != null || virtual != null) {
+      snapshot.setHypervisorCores(totalVirtualCores);
+      snapshot.setHypervisorSockets(totalVirtualSockets);
+      snapshot.setHypervisorInstanceCount(totalVirtualInstanceCount);
+    }
+
+    int cloudInstances = 0;
+    int cloudCores = 0;
+    int cloudSockets = 0;
+    HardwareMeasurement cloudigradeMeasurement =
+        this.hardwareMeasurements.get(HardwareMeasurementType.AWS_CLOUDIGRADE);
+    snapshot.setHasCloudigradeData(cloudigradeMeasurement != null);
+    for (HardwareMeasurementType type : HardwareMeasurementType.getCloudProviderTypes()) {
+      HardwareMeasurement measurement = this.hardwareMeasurements.get(type);
+      if (cloudigradeMeasurement != null && type == HardwareMeasurementType.AWS) {
+        if (measurement != null) {
+          snapshot.setHasCloudigradeMismatch(!Objects.equals(cloudigradeMeasurement, measurement));
+        }
+        // if cloudigrade data exists, then HBI-derived AWS data is ignored
+        continue;
+      }
+      if (measurement != null) {
+        cloudInstances += measurement.getInstanceCount();
+        cloudCores += measurement.getCores();
+        cloudSockets += measurement.getSockets();
+      }
+    }
+    snapshot.setCloudInstanceCount(cloudInstances);
+    snapshot.setCloudCores(cloudCores);
+    snapshot.setCloudSockets(cloudSockets);
   }
 
   @Override


### PR DESCRIPTION
Because the `hardware_measurements` to `tally_measurements` migrations were very large, they can't reasonably be done via liquibase without blocking CronJobs from running. Previous PRs (#1520 and follow-ons) have been written to perform the migrations async in the background. In order to unblock the current release, we want to have the readers of the data read from either `hardware_measurements` or `tally_measurements` (whichever has data). (Once the migrations are done, we'll remove this workaround).

1. Drop instances from the changelog, because it's not actually used by the UI anyways.
2. Temporarily comment out the problematic changelog.
3. Restore HardwareMeasurement JPA entity.
4. Add logic to read cores/sockets, etc. from HardwareMeasurement when apparently missing from `tally_measurements` table.

Testing
=======

Insert some data to mimic a couple of scenarios:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF

insert into tally_snapshots(id, product_id, account_number, granularity, owner_id, snapshot_date, unit_of_measure, sla)
VALUES (gen_random_uuid(), 'RHEL', 'account123', 'DAILY', 'org123', '2022-10-16', null, 'Premium');
insert into tally_snapshots(id, product_id, account_number, granularity, owner_id, snapshot_date, unit_of_measure, sla)
VALUES (gen_random_uuid(), 'RHEL', 'account123', 'DAILY', 'org123', '2022-10-17', null, 'Premium');
insert into hardware_measurements(snapshot_id, measurement_type, cores, instance_count, sockets)
select id, 'TOTAL', 2, 3, 4
from tally_snapshots;
insert into tally_measurements(snapshot_id, measurement_type, uom, value)
select snapshot_id, measurement_type, 'CORES', 10
from hardware_measurements
limit 1;
insert into tally_measurements(snapshot_id, measurement_type, uom, value)
select snapshot_id, measurement_type, 'SOCKETS', 20
from hardware_measurements
limit 1;

EOF
```

Note that the above creates a couple of snapshots and then provides `tally_measurements` rows for only one of them, but provides `hardware_measurements` for both.

Ensure opt-in:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo -n '{"identity":{"account_number":"account123","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w0)
```

Tally:

```shell
http :8000/api/rhsm-subscriptions/v1/tally/products/RHEL \
  sla==Premium \
  granularity==DAILY \
  beginning=='2022-10-16T00:00Z' \
  ending=='2022-10-18T00:00Z' \
  x-rh-identity:$(echo -n '{"identity":{"account_number":"account123","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w0)
```

Notice that 2022-10-16 has data coming from tally_measurements (10 cores, 20 sockets), while 2022-10-17 has data coming from hardware_measurements (2 cores, 4 sockets).