### PR TITLE
Add missing replicas template param/usage

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -79,7 +79,7 @@ objects:
       #   - rhsm
       deployments:
         - name: service
-          minReplicas: 1
+          replicas: ${REPLICAS}
           webServices:
             public:
               enabled: true

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -79,7 +79,7 @@ objects:
       #   - rhsm
       deployments:
         - name: service
-          replicas: ${REPLICAS}
+          replicas: ${{REPLICAS}}
           webServices:
             public:
               enabled: true

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -127,7 +127,7 @@ objects:
               enabled: true
             metrics:
               enabled: true
-          replicas: ${REPLICAS}
+          replicas: ${{REPLICAS}}
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command:

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -6,6 +6,8 @@ metadata:
 parameters:
   - name: ENV_NAME
     value: env-swatch-metrics
+  - name: REPLICAS
+    value: '1'
   - name: IMAGE
     value: quay.io/cloudservices/rhsm-subscriptions
   - name: IMAGE_TAG
@@ -125,7 +127,7 @@ objects:
               enabled: true
             metrics:
               enabled: true
-          minReplicas: 1
+          replicas: ${REPLICAS}
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command:

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -16,6 +16,8 @@ parameters:
     value: 1500m
   - name: ENV_NAME
     value: env-swatch-producer-aws
+  - name: REPLICAS
+    value: '1'
   - name: IMAGE
     value: quay.io/cloudservices/swatch-producer-aws
   - name: IMAGE_TAG
@@ -79,7 +81,7 @@ objects:
 
     deployments:
       - name: service
-        minReplicas: 1
+        replicas: ${REPLICAS}
         webServices:
           public:
             enabled: true

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -81,7 +81,7 @@ objects:
 
     deployments:
       - name: service
-        replicas: ${REPLICAS}
+        replicas: ${{REPLICAS}}
         webServices:
           public:
             enabled: true

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -147,7 +147,7 @@ objects:
 
     deployments:
       - name: service
-        replicas: ${REPLICAS}
+        replicas: ${{REPLICAS}}
         webServices:
           public:
             enabled: true

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -147,7 +147,7 @@ objects:
 
     deployments:
       - name: service
-        minReplicas: 1
+        replicas: ${REPLICAS}
         webServices:
           public:
             enabled: true

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -164,7 +164,7 @@ objects:
             enabled: true
           metrics:
             enabled: true
-        minReplicas: 1
+        replicas: ${REPLICAS}
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           command:

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -164,7 +164,7 @@ objects:
             enabled: true
           metrics:
             enabled: true
-        replicas: ${REPLICAS}
+        replicas: ${{REPLICAS}}
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           command:

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -114,7 +114,7 @@ objects:
             enabled: true
           metrics:
             enable: true
-        minReplicas: 1
+        replicas: ${REPLICAS}
         podSpec:
           image: ${CONDUIT_IMAGE}:${IMAGE_TAG}
           command:

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -114,7 +114,7 @@ objects:
             enabled: true
           metrics:
             enable: true
-        replicas: ${REPLICAS}
+        replicas: ${{REPLICAS}}
         podSpec:
           image: ${CONDUIT_IMAGE}:${IMAGE_TAG}
           command:

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -194,7 +194,7 @@ objects:
 
     deployments:
       - name: service
-        minReplicas: 1
+        replicas: ${REPLICAS}
         webServices:
           public:
             enabled: true

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -194,7 +194,7 @@ objects:
 
     deployments:
       - name: service
-        replicas: ${REPLICAS}
+        replicas: ${{REPLICAS}}
         webServices:
           public:
             enabled: true


### PR DESCRIPTION
There was an oversight in the move to clowder, these changes need to scale replicas by template param changes.

I added it to the clowdapps, and then added the template param if missing (it was only missing in swatch-metrics and swatch-producer-aws).