### PR TITLE
SWATCH-195: update AccountResetJmx to reset based on orgId

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/jmx/AccountResetJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/AccountResetJmxBean.java
@@ -51,23 +51,23 @@ public class AccountResetJmxBean {
   @Transactional
   @ManagedOperation(
       description =
-          "Clear tallies, hosts, and events for a given account number.  Enabled via ENABLE_ACCOUNT_RESET environment variable.  Intended only for non-prod environments.")
-  @ManagedOperationParameter(name = "accountNumber", description = "Account number")
-  public String deleteDataAssociatedWithAccount(String accountNumber) {
+          "Clear tallies, hosts, and events for a given org ID.  Enabled via ENABLE_ACCOUNT_RESET environment variable.  Intended only for non-prod environments.")
+  @ManagedOperationParameter(name = "orgId", description = "Organization ID")
+  public String deleteDataAssociatedWithOrg(String orgId) {
     if (!properties.isResetAccountEnabled() && !properties.isDevMode()) {
       log.error(FEATURE_NOT_ENABLED_MESSSAGE);
       throw new JmxException(FEATURE_NOT_ENABLED_MESSSAGE);
     }
 
-    log.info("Received request to delete all data associated with account {}", accountNumber);
+    log.info("Received request to delete all data associated with orgId {}", orgId);
 
     try {
-      accountResetService.deleteDataForAccount(accountNumber);
+      accountResetService.deleteDataForOrg(orgId);
     } catch (Exception e) {
-      throw new JmxException("Unable to delete data for account " + accountNumber, e);
+      throw new JmxException("Unable to delete data for organization " + orgId, e);
     }
 
-    var successMessage = "Finished deleting data associated with account " + accountNumber;
+    var successMessage = "Finished deleting data associated with organization " + orgId;
 
     log.info(successMessage);
 

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
@@ -61,14 +61,14 @@ public class AccountResetService {
   }
 
   @Transactional
-  public void deleteDataForAccount(String accountNumber) {
+  public void deleteDataForOrg(String orgId) {
 
-    accountServiceInventoryRepository.deleteByIdAccountNumber(accountNumber);
-    hostRepo.deleteByAccountNumber(accountNumber);
-    eventRecordRepo.deleteByAccountNumber(accountNumber);
-    tallySnapshotRepository.deleteByAccountNumber(accountNumber);
-    subscriptionRepository.deleteByAccountNumber(accountNumber);
-    subscriptionCapacityRepository.deleteByAccountNumber(accountNumber);
-    remittanceRepository.deleteByKeyAccountNumber(accountNumber);
+    accountServiceInventoryRepository.deleteByOrgId(orgId);
+    hostRepo.deleteByOrgId(orgId);
+    eventRecordRepo.deleteByOrgId(orgId);
+    tallySnapshotRepository.deleteByOwnerId(orgId);
+    subscriptionRepository.deleteByOwnerId(orgId);
+    subscriptionCapacityRepository.deleteByKeyOwnerId(orgId);
+    remittanceRepository.deleteByOrgId(orgId);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
@@ -61,16 +61,18 @@ class BillableUsageRemittanceRepositoryTest {
   }
 
   @Test
-  void deleteByAccount() {
+  void deleteByOrgId() {
     BillableUsageRemittanceEntity remittance1 =
         remittance("account123", "product1", 12.0, clock.startOfCurrentMonth());
+    remittance1.setOrgId("org123");
     BillableUsageRemittanceEntity remittance2 =
         remittance("account555", "product1", 12.0, clock.startOfCurrentMonth());
+    remittance2.setOrgId("org555");
 
     List<BillableUsageRemittanceEntity> toSave = List.of(remittance1, remittance2);
     repository.saveAllAndFlush(toSave);
 
-    repository.deleteByKeyAccountNumber("account123");
+    repository.deleteByOrgId("org123");
     repository.flush();
     assertTrue(repository.findById(remittance1.getKey()).isEmpty());
     Optional<BillableUsageRemittanceEntity> found = repository.findById(remittance2.getKey());

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepository.java
@@ -28,5 +28,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AccountServiceInventoryRepository
     extends JpaRepository<AccountServiceInventory, AccountServiceInventoryId> {
 
-  void deleteByIdAccountNumber(String accountNumber);
+  void deleteByOrgId(String orgId);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
@@ -31,7 +31,7 @@ public interface BillableUsageRemittanceRepository
     extends JpaRepository<BillableUsageRemittanceEntity, BillableUsageRemittanceEntityPK> {
 
   @Query
-  void deleteByKeyAccountNumber(String accountNumber);
+  void deleteByOrgId(String orgId);
 
   @Query
   List<BillableUsageRemittanceEntity> findAllByOrgIdAndKey_ProductIdAndKey_MetricId( // NOSONAR

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -127,5 +127,5 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
           @Param("begin") OffsetDateTime begin,
           @Param("end") OffsetDateTime end);
 
-  void deleteByAccountNumber(String accountNumber);
+  void deleteByOrgId(String orgId);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -199,5 +199,5 @@ public interface HostRepository
 
   Optional<Host> findById(UUID id);
 
-  void deleteByAccountNumber(String accountNumber);
+  void deleteByOrgId(String orgId);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -36,5 +36,5 @@ public interface SubscriptionCapacityRepository
 
   Stream<SubscriptionCapacity> findByKeyOwnerId(String ownerId);
 
-  void deleteByAccountNumber(String accountNumber);
+  void deleteByKeyOwnerId(String ownerId);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -62,7 +62,7 @@ public interface SubscriptionRepository
 
   void deleteBySubscriptionId(String subscriptionId);
 
-  void deleteByAccountNumber(String accountNumber);
+  void deleteByOwnerId(String ownerId);
 
   default List<Subscription> findByCriteria(ReportCriteria reportCriteria, Sort sort) {
     List<SearchCriteria> searchCriteria = new ArrayList<>();

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -103,7 +103,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
       OffsetDateTime beginning,
       OffsetDateTime ending);
 
-  void deleteByAccountNumber(String accountNumber);
+  void deleteByOwnerId(String ownerId);
 
   @SuppressWarnings("java:S107") // repository method has a lot of params, deal with it
   @Query(


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-195

Test Steps:

- Add test data to be deleted:
```
INSERT INTO public.account_services VALUES ('account345', 'HBI_HOST', 'org345');
INSERT INTO public.events VALUES ('09443c41-a773-4e22-970b-07256b0bf43d', 'account345', '2021-10-18 20:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "09443c41-a773-4e22-970b-07256b0bf43d", "timestamp": "2021-10-18T20:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-10-19T20:00:00Z", "instance_id": "aeb1f778-af79-4708-8401-35a5a9e8e877", "display_name": "aeb1f778-af79-4708-8401-35a5a9e8e877", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 8.4}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'aeb1f778-af79-4708-8401-35a5a9e8e877', 'org345');
INSERT INTO public.hosts VALUES ('8504a63f-941d-4d28-9bca-12c2c9c0b18e', '9172fc9d-35bc-4f10-adcd-fc88c895a082', 'account345', '4d596d9d-1a74-4bfe-bc8b-1fca8b946fa8', 'org345', '4d596d9d-1a74-4bfe-bc8b-1fca8b946fa8', '8a9badb4-1041-440c-833d-191ab9a1e7f1', 4, 1, false, NULL, 'PHYSICAL', 0, '1993-03-26 00:00:00+00', false, false, NULL, 'HBI_HOST', '9172fc9d-35bc-4f10-adcd-fc88c895a082', '_ANY', '_ANY');
INSERT INTO public.billable_usage_remittance VALUES ('account345', 'org345', 'rhosak', 'Instance-hours', '2021-10', 'Premium', 'Production', 'red hat', 'dummyId', 3, '2022-06-15 12:57:19.064284+00', 7);
INSERT INTO public.subscription VALUES ('RH00006S', 'org345', '10200808', 2, '2021-10-25 04:00:00+00', '2022-08-31 04:00:00+00', NULL, 'account345', '10200965', NULL, NULL);
INSERT INTO public.subscription_capacity VALUES ('account345', 'RHEL for x86', '7025101', 'org345', 0, NULL, false, '2022-06-12 04:00:00+00', '2023-06-11 04:00:00+00', 3, NULL, 'RH00004', 'Standard', 'Production');
INSERT INTO public.tally_snapshots VALUES ('0c608dfa-3202-4bbf-9a21-d80a298d3d42', 'rhosak', 'account345', 'HOURLY', 'org345', '2022-07-01 02:00:00+00', NULL, '_ANY', '_ANY', '_ANY', '_ANY');
```
- Run AccountResetJmxBean on hawtio with orgID = 'org345
- Check that no records with orgId = org345 exist:
```
select * from account_services where org_id = 'org345';
select * from events where org_id = 'org345';
select * from billable_usage_remittance where org_id = 'org345';
select * from hosts where org_id = 'org345';
select * from subscription where owner_id = 'org345';
select * from subscription_capacity where owner_id = 'org345';
select * from tally_snapshots where owner_id = 'org345';
```
