### PR TITLE
SWATCH-298: Update Tally Retention lookup by OwnerId

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/retention/PurgeSnapshotsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/PurgeSnapshotsJob.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.retention;
 
 import org.candlepin.subscriptions.exception.JobFailureException;
-import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +46,7 @@ public class PurgeSnapshotsJob implements Runnable {
     try {
       retentionController.purgeSnapshots();
       log.info("Snapshot purge complete.");
-    } catch (AccountListSourceException e) {
+    } catch (Exception e) {
       throw new JobFailureException("Could not purge snapshots.", e);
     }
   }

--- a/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionControllerTest.java
@@ -27,7 +27,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
-import org.candlepin.subscriptions.db.AccountListSource;
+import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.junit.jupiter.api.Test;
@@ -49,7 +49,7 @@ class TallyRetentionControllerTest {
 
   @MockBean private TallyRetentionPolicy policy;
   @MockBean private TallySnapshotRepository repository;
-  @MockBean private AccountListSource accountListSource;
+  @MockBean private AccountConfigRepository accountConfigRepository;
 
   @Autowired private TallyRetentionController controller;
 
@@ -57,17 +57,16 @@ class TallyRetentionControllerTest {
   void retentionControllerShouldRemoveSnapshotsForGranularitiesConfigured() throws Exception {
     OffsetDateTime cutoff = OffsetDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault());
     when(policy.getCutoffDate(Granularity.DAILY)).thenReturn(cutoff);
-    controller.cleanStaleSnapshotsForAccount("123456");
+    controller.cleanStaleSnapshotsForOwnerId("123456");
     verify(repository)
-        .deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(
-            "123456", Granularity.DAILY, cutoff);
+        .deleteAllByOwnerIdAndGranularityAndSnapshotDateBefore("123456", Granularity.DAILY, cutoff);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void retentionControllerShouldIgnoreGranularityWithoutCutoff() throws Exception {
     when(policy.getCutoffDate(Granularity.DAILY)).thenReturn(null);
-    controller.cleanStaleSnapshotsForAccount("123456");
+    controller.cleanStaleSnapshotsForOwnerId("123456");
     verifyNoInteractions(repository);
   }
 
@@ -77,12 +76,12 @@ class TallyRetentionControllerTest {
     when(policy.getCutoffDate(Granularity.DAILY)).thenReturn(cutoff);
 
     List<String> testList = Arrays.asList("1", "2", "3", "4");
-    when(accountListSource.purgeReportAccounts()).thenReturn(testList.stream());
+    when(accountConfigRepository.findSyncEnabledOrgs()).thenReturn(testList.stream());
 
     controller.purgeSnapshots();
 
     verify(repository, times(4))
-        .deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(
+        .deleteAllByOwnerIdAndGranularityAndSnapshotDateBefore(
             anyString(), eq(Granularity.DAILY), eq(cutoff));
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -64,7 +64,7 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
    * * from events where timestamp between '2021-01-01T00:00:00Z' and '2021-01-01T01:00:00Z` would
    * match events at midnight UTC and 1am UTC.
    *
-   * @param accountNumber account number
+   * @param orgId account number
    * @param eventSource event source
    * @param eventType event type
    * @param begin start of the time range (inclusive)

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -79,8 +79,8 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
       @Param("pageable") Pageable pageable);
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  void deleteAllByAccountNumberAndGranularityAndSnapshotDateBefore(
-      String accountNumber, Granularity granularity, OffsetDateTime cutoffDate);
+  void deleteAllByOwnerIdAndGranularityAndSnapshotDateBefore(
+      String orgId, Granularity granularity, OffsetDateTime cutoffDate);
 
   @Query(
       value =


### PR DESCRIPTION
This is to address https://issues.redhat.com/browse/SWATCH-298

Add new method for AccountConfigRepository to provide the stream of orgs Refactor orgId reference in EventRecordRepository
Refactor TallyRetentionController to use orgId instead of account Refactor Unit test for Tally Retention lookup.
Rebased Merge Conflicts