### PR TITLE
SWATCH-647 - remove required account_number from optin api spec

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1128,7 +1128,6 @@ components:
         meta:
           type: object
           required:
-            - account_number
             - org_id
           properties:
             account_number:
@@ -1145,7 +1144,6 @@ components:
             account:
               type: object
               required:
-                - account_number
                 - opt_in_type
                 - created
                 - last_updated


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-647

We handled missing account_number with opt-in in  https://github.com/RedHatInsights/rhsm-subscriptions/pull/1505 , But it was still marked as required in openapi spec. 