### PR TITLE
SWATCH-583: add liquibase to populate org_id on existing account_services records

### DIFF
--- a/src/main/resources/liquibase/202210211001-set-account-services-org-id.xml
+++ b/src/main/resources/liquibase/202210211001-set-account-services-org-id.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202210211001-1" author="kflahert">
+    <comment>Set null instances of account_services.org_id to account_config.org_id value</comment>
+    <update tableName="account_services">
+      <column name="org_id" valueComputed="(SELECT a.org_id FROM account_config a WHERE a.account_number=account_services.account_number)"/>
+      <where>org_id IS NULL</where>
+    </update>
+  </changeSet>
+
+</databaseChangeLog>
+  <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -84,5 +84,6 @@
     <include file="liquibase/202209301230-migrate-org-id-to-billable-usage-table.xml"/>
     <include file="liquibase/202210101553-make-account-config-org-id-nullable.xml"/>
     <include file="liquibase/202210101642-drop-unused-opt-in-flags.xml"/>
+    <include file="liquibase/202210211001-set-account-services-org-id.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-583

Test Steps:

- Insert test data:
```
INSERT INTO public.account_config VALUES ('account637', true, true, 'API', '2022-05-01 00:00:00+00', '2022-05-01 00:00:00+00', 'org637');
INSERT INTO public.account_config VALUES ('account899', true, true, 'API', '2022-05-01 00:00:00+00', '2022-05-01 00:00:00+00', 'org899');
INSERT INTO public.account_config VALUES ('account765', true, true, 'API', '2022-06-06 13:45:37.020113+00', '2022-07-05 18:14:08.738855+00', 'org765');
INSERT INTO public.account_services VALUES ('account637', 'HBI_HOST', 'org637');
INSERT INTO public.account_services VALUES ('account899', 'HBI_HOST', 'org899');
INSERT INTO public.account_services VALUES ('account765', 'HBI_HOST', 'org765');
```
- Start app with DEV_MODE=true ./gradlew :bootRun
- Check db records of account_services which should have correct org_id now.