### PR TITLE
Mark orgId as optional in aws usage context lookup

### DIFF
--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -67,7 +67,6 @@ paths:
         description: "Customer's Account Number"
       - name: orgId
         in: query
-        required: true
         schema:
           type: string
         description: "Customer's Org Id"


### PR DESCRIPTION
Was causing:

```
SUBSCRIPTIONS1002: Client request failed validation. - getAwsUsageContext.orgId: must not be null
```

and

```
SWATCHAWS1004: Error looking up AWS usage context
```