### PR TITLE
Update tally api to search by orgId instead of accountNumber

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/ReportCriteria.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ReportCriteria.java
@@ -33,7 +33,7 @@ import org.springframework.data.domain.Pageable;
 @Data
 @Builder
 public class ReportCriteria {
-  private String accountNumber;
+  private String orgId;
   private String productId;
   private String metricId;
   private ReportCategory reportCategory;

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -117,7 +117,7 @@ public class TallyResource implements TallyApi {
 
     Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage =
         repository.findSnapshot(
-            reportCriteria.getAccountNumber(),
+            reportCriteria.getOrgId(),
             reportCriteria.getProductId(),
             reportCriteria.getGranularity(),
             reportCriteria.getServiceLevel(),
@@ -281,7 +281,7 @@ public class TallyResource implements TallyApi {
       throw new BadRequestException(e.getMessage());
     }
     return ReportCriteria.builder()
-        .accountNumber(ResourceUtils.getAccountNumber())
+        .orgId(ResourceUtils.getOrgId())
         .productId(productId.toString())
         .metricId(Optional.ofNullable(metricId).map(MetricId::toString).orElse(null))
         .granularity(granularityFromValue)
@@ -354,7 +354,7 @@ public class TallyResource implements TallyApi {
 
     Page<org.candlepin.subscriptions.db.model.TallySnapshot> snapshotPage =
         repository.findSnapshot(
-            reportCriteria.getAccountNumber(),
+            reportCriteria.getOrgId(),
             reportCriteria.getProductId(),
             reportCriteria.getGranularity(),
             reportCriteria.getServiceLevel(),

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -106,7 +106,7 @@ class TallyResourceTest {
 
     Mockito.when(
             repository.findSnapshot(
-                Mockito.eq("account123456"),
+                Mockito.eq("owner123456"),
                 Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel._ANY),
@@ -134,7 +134,7 @@ class TallyResourceTest {
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)
         .findSnapshot(
-            "account123456",
+            "owner123456",
             RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel._ANY,
@@ -178,7 +178,7 @@ class TallyResourceTest {
 
     Mockito.when(
             repository.findSnapshot(
-                Mockito.eq("account123456"),
+                Mockito.eq("owner123456"),
                 Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
@@ -205,7 +205,7 @@ class TallyResourceTest {
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)
         .findSnapshot(
-            "account123456",
+            "owner123456",
             RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
@@ -233,7 +233,7 @@ class TallyResourceTest {
 
     Mockito.when(
             repository.findSnapshot(
-                Mockito.eq("account123456"),
+                Mockito.eq("owner123456"),
                 Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.EMPTY),
@@ -261,7 +261,7 @@ class TallyResourceTest {
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)
         .findSnapshot(
-            "account123456",
+            "owner123456",
             RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.EMPTY,
@@ -288,7 +288,7 @@ class TallyResourceTest {
 
     Mockito.when(
             repository.findSnapshot(
-                Mockito.eq("account123456"),
+                Mockito.eq("owner123456"),
                 Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
@@ -316,7 +316,7 @@ class TallyResourceTest {
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)
         .findSnapshot(
-            "account123456",
+            "owner123456",
             RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
@@ -343,7 +343,7 @@ class TallyResourceTest {
 
     Mockito.when(
             repository.findSnapshot(
-                Mockito.eq("account123456"),
+                Mockito.eq("owner123456"),
                 Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
@@ -371,7 +371,7 @@ class TallyResourceTest {
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)
         .findSnapshot(
-            "account123456",
+            "owner123456",
             RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
@@ -409,7 +409,7 @@ class TallyResourceTest {
 
     Mockito.when(
             repository.findSnapshot(
-                "account123456",
+                "owner123456",
                 ProductId.OPENSHIFT_DEDICATED_METRICS.toString(),
                 Granularity.DAILY,
                 ServiceLevel.PREMIUM,
@@ -455,7 +455,7 @@ class TallyResourceTest {
 
     Mockito.when(
             repository.findSnapshot(
-                Mockito.eq("account123456"),
+                Mockito.eq("owner123456"),
                 Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
@@ -483,7 +483,7 @@ class TallyResourceTest {
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)
         .findSnapshot(
-            "account123456",
+            "owner123456",
             RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
@@ -502,7 +502,7 @@ class TallyResourceTest {
 
     Mockito.when(
             repository.findSnapshot(
-                Mockito.eq("account123456"),
+                Mockito.eq("owner123456"),
                 Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
@@ -531,7 +531,7 @@ class TallyResourceTest {
     Pageable expectedPageable = PageRequest.of(1, 10);
     Mockito.verify(repository)
         .findSnapshot(
-            "account123456",
+            "owner123456",
             RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
@@ -566,7 +566,7 @@ class TallyResourceTest {
   void reportDataShouldGetFilledWhenPagingParametersAreNotPassed() {
     Mockito.when(
             repository.findSnapshot(
-                "account123456",
+                "owner123456",
                 RHEL_PRODUCT_ID.toString(),
                 Granularity.DAILY,
                 ServiceLevel._ANY,
@@ -612,7 +612,7 @@ class TallyResourceTest {
   void canReportWithOnlyReportingRole() {
     Mockito.when(
             repository.findSnapshot(
-                "account123456",
+                "owner123456",
                 RHEL_PRODUCT_ID.toString(),
                 Granularity.DAILY,
                 ServiceLevel._ANY,
@@ -658,6 +658,8 @@ class TallyResourceTest {
   void testTallyReportDataTotalUsingHardwareMeasurements() {
     TallySnapshot snapshot = new TallySnapshot();
     snapshot.setAccountNumber("account123");
+    snapshot.setOrgId("org123");
+    ;
     snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
     snapshot.setMeasurement(HardwareMeasurementType.TOTAL, Uom.CORES, 4.0);
     when(repository.findSnapshot(

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/SnapshotRollerTester.java
@@ -78,7 +78,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     List<TallySnapshot> currentSnaps =
         repository
             .findSnapshot(
-                account,
+                a1Calc.getOrgId(),
                 getTestProduct(),
                 granularity,
                 ServiceLevel.EMPTY,
@@ -101,12 +101,13 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
       OffsetDateTime endOfGranularPeriod) {
     AccountUsageCalculation a1Calc = createTestData();
     String account = a1Calc.getAccount();
+    String orgId = a1Calc.getOrgId();
     roller.rollSnapshots(account, Arrays.asList(a1Calc));
 
     List<TallySnapshot> currentSnaps =
         repository
             .findSnapshot(
-                account,
+                orgId,
                 getTestProduct(),
                 granularity,
                 ServiceLevel.EMPTY,
@@ -131,7 +132,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     List<TallySnapshot> updatedSnaps =
         repository
             .findSnapshot(
-                account,
+                orgId,
                 getTestProduct(),
                 granularity,
                 ServiceLevel.EMPTY,
@@ -165,10 +166,11 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     int highInstances = 10;
 
     String account = "A1";
+    String orgId = "01";
     AccountUsageCalculation a1HighCalc =
-        createAccountCalc(account, "O1", getTestProduct(), highCores, highSockets, highInstances);
+        createAccountCalc(account, orgId, getTestProduct(), highCores, highSockets, highInstances);
     AccountUsageCalculation a1LowCalc =
-        createAccountCalc(account, "O1", getTestProduct(), lowCores, lowSockets, lowInstances);
+        createAccountCalc(account, orgId, getTestProduct(), lowCores, lowSockets, lowInstances);
 
     AccountUsageCalculation expectedCalc = expectMaxAccepted ? a1HighCalc : a1LowCalc;
 
@@ -178,7 +180,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     List<TallySnapshot> currentSnaps =
         repository
             .findSnapshot(
-                "A1",
+                orgId,
                 getTestProduct(),
                 granularity,
                 ServiceLevel.EMPTY,
@@ -202,7 +204,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     List<TallySnapshot> updatedSnaps =
         repository
             .findSnapshot(
-                account,
+                orgId,
                 getTestProduct(),
                 granularity,
                 ServiceLevel.EMPTY,
@@ -258,9 +260,11 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
     AccountUsageCalculation a1Calc = createTestData();
     String account = a1Calc.getAccount();
+    String orgId = a1Calc.getOrgId();
 
     TallySnapshot orig = new TallySnapshot();
     orig.setAccountNumber("my_account");
+    orig.setOrgId(orgId);
     orig.setServiceLevel(ServiceLevel.EMPTY);
     orig.setUsage(Usage.EMPTY);
     orig.setBillingProvider(BillingProvider.EMPTY);
@@ -271,6 +275,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
 
     TallySnapshot dupe = new TallySnapshot();
     dupe.setAccountNumber("my_account");
+    dupe.setOrgId(orgId);
     dupe.setServiceLevel(ServiceLevel.EMPTY);
     dupe.setUsage(Usage.EMPTY);
     dupe.setBillingProvider(BillingProvider.EMPTY);
@@ -284,7 +289,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     List<TallySnapshot> currentSnaps =
         repository
             .findSnapshot(
-                account,
+                orgId,
                 getTestProduct(),
                 granularity,
                 ServiceLevel.EMPTY,
@@ -306,7 +311,7 @@ public class SnapshotRollerTester<R extends BaseSnapshotRoller> {
     List<TallySnapshot> updatedSnaps =
         repository
             .findSnapshot(
-                account,
+                orgId,
                 getTestProduct(),
                 granularity,
                 ServiceLevel.EMPTY,

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -47,7 +47,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
   @Query(
       value =
           "SELECT distinct t FROM TallySnapshot t left join fetch t.tallyMeasurements where "
-              + "t.accountNumber = :accountNumber and "
+              + "t.orgId = :orgId and "
               + "t.productId = :productId and "
               + "t.granularity = :granularity  and "
               + "t.serviceLevel = :serviceLevel and "
@@ -58,7 +58,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
               + "order by t.snapshotDate",
       countQuery =
           "SELECT count(t) FROM TallySnapshot t where "
-              + "t.accountNumber = :accountNumber and "
+              + "t.orgId = :orgId and "
               + "t.productId = :productId and "
               + "t.granularity = :granularity  and "
               + "t.serviceLevel = :serviceLevel and "
@@ -67,7 +67,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
               + "t.billingAccountId = :billingAcctId and "
               + "t.snapshotDate between :beginning and :ending ")
   Page<TallySnapshot> findSnapshot( // NOSONAR
-      @Param("accountNumber") String accountNumber,
+      @Param("orgId") String orgId,
       @Param("productId") String productId,
       @Param("granularity") Granularity granularity,
       @Param("serviceLevel") ServiceLevel serviceLevel,


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-262
Test Steps:

- Start app with `DEV_MODE=true ./gradlew :bootRun`
- Opt in org456:
```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJhY2NvdW50X251bWJlciI6ICJhY2NvdW50NDU2IiwKICAgICAgICAidHlwZSI6ICJVc2VyIiwKICAgICAgICAidXNlciIgOiB7CiAgICAgICAgICAgICJpc19vcmdfYWRtaW4iOiB0cnVlCiAgICAgICAgfSwKICAgICAgICAiaW50ZXJuYWwiIDogewogICAgICAgICAgICAib3JnX2lkIjogIm9yZzQ1NiIKICAgICAgICB9CiAgICB9Cn0='
```
- Insert tally_snapshots
```
INSERT INTO public.tally_snapshots VALUES ('0beab042-b9ff-4ef3-9a3d-a924f4aa6f97', 'RHEL for x86', 'account123', 'DAILY', 'org123', '2022-10-10 00:00:00+00', NULL, 'Premium', '_ANY', '_ANY', '_ANY');
INSERT INTO public.tally_snapshots VALUES ('06197a03-de1b-49a1-9093-dd61660a8fc1', 'RHEL for x86', 'account456', 'DAILY', 'org456', '2022-10-10 00:00:00+00', NULL, 'Premium', '_ANY', '_ANY', '_ANY');
INSERT INTO public.tally_measurements VALUES ('06197a03-de1b-49a1-9093-dd61660a8fc1', 'VIRTUAL', 'CORES', 1);
INSERT INTO public.tally_measurements VALUES ('0beab042-b9ff-4ef3-9a3d-a924f4aa6f97', 'HYPERVISOR', 'CORES', 6);
```
- Curl API and should get one result of value = 1;
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86/Cores?granularity=Daily&sla=Premium&usage=_ANY&billing_provider=_ANY&billing_account_id=_ANY&beginning=2022-10-09T17%3A32%3A28Z&ending=2022-10-10T17%3A32%3A28Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJhY2NvdW50X251bWJlciI6ICJhY2NvdW50NDU2IiwKICAgICAgICAidHlwZSI6ICJVc2VyIiwKICAgICAgICAidXNlciIgOiB7CiAgICAgICAgICAgICJpc19vcmdfYWRtaW4iOiB0cnVlCiAgICAgICAgfSwKICAgICAgICAiaW50ZXJuYWwiIDogewogICAgICAgICAgICAib3JnX2lkIjogIm9yZzQ1NiIKICAgICAgICB9CiAgICB9Cn0='
```

- Curl deprecated API and should get one result of value = 1
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86?granularity=Daily&sla=Premium&usage=_ANY&beginning=2022-10-09T17%3A32%3A28Z&ending=2022-10-10T17%3A32%3A28Z&use_running_totals_format=false' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJhY2NvdW50X251bWJlciI6ICJhY2NvdW50NDU2IiwKICAgICAgICAidHlwZSI6ICJVc2VyIiwKICAgICAgICAidXNlciIgOiB7CiAgICAgICAgICAgICJpc19vcmdfYWRtaW4iOiB0cnVlCiAgICAgICAgfSwKICAgICAgICAiaW50ZXJuYWwiIDogewogICAgICAgICAgICAib3JnX2lkIjogIm9yZzQ1NiIKICAgICAgICB9CiAgICB9Cn0='
```