### PR TITLE
SWATCH-268: Change hosts APIs underlying queries to use org_id

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -33,7 +33,6 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
-import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Host;
@@ -111,18 +110,13 @@ public class HostsResource implements HostsApi {
   }
 
   private final HostRepository repository;
-  private final AccountConfigRepository accountConfigRepo;
   private final PageLinkCreator pageLinkCreator;
   private final TagProfile tagProfile;
   @Context UriInfo uriInfo;
 
   public HostsResource(
-      HostRepository repository,
-      AccountConfigRepository accountConfigRepo,
-      PageLinkCreator pageLinkCreator,
-      TagProfile tagProfile) {
+      HostRepository repository, PageLinkCreator pageLinkCreator, TagProfile tagProfile) {
     this.repository = repository;
-    this.accountConfigRepo = accountConfigRepo;
     this.pageLinkCreator = pageLinkCreator;
     this.tagProfile = tagProfile;
   }

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -159,9 +159,7 @@ public class HostsResource implements HostsApi {
       minSockets = 1;
     }
 
-    String accountNumber = ResourceUtils.getAccountNumber();
-    // This should be removed as part of https://issues.redhat.com/browse/SWATCH-268
-    String orgId = accountConfigRepo.findOrgByAccountNumber(accountNumber);
+    String orgId = ResourceUtils.getOrgId();
 
     ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
     Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
@@ -217,7 +215,7 @@ public class HostsResource implements HostsApi {
       Pageable page = ResourceUtils.getPageable(offset, limit, sortValue);
       hosts =
           repository.getTallyHostViews(
-              accountNumber,
+              orgId,
               productId.toString(),
               sanitizedSla,
               sanitizedUsage,
@@ -265,9 +263,9 @@ public class HostsResource implements HostsApi {
   @ReportingAccessRequired
   public HypervisorGuestReport getHypervisorGuests(
       String hypervisorUuid, Integer offset, Integer limit) {
-    String accountNumber = ResourceUtils.getAccountNumber();
+    String orgId = ResourceUtils.getOrgId();
     Pageable page = ResourceUtils.getPageable(offset, limit);
-    Page<Host> guests = repository.getHostsByHypervisor(accountNumber, hypervisorUuid, page);
+    Page<Host> guests = repository.getHostsByHypervisor(orgId, hypervisorUuid, page);
     PageLinks links;
     if (offset != null || limit != null) {
       links = pageLinkCreator.getPaginationLinks(uriInfo, guests);

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -200,7 +200,7 @@ class HostRepositoryTest {
 
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            expAccount,
+            expOrg,
             RHEL,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -339,7 +339,7 @@ class HostRepositoryTest {
   void testFindHostsWhenAccountIsDifferent() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account1",
+            "ORG_account1",
             RHEL,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -360,7 +360,7 @@ class HostRepositoryTest {
   void testFindHostsWhenProductIsDifferent() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             COOL_PROD,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -381,7 +381,7 @@ class HostRepositoryTest {
   void testFindHostsWhenSLAIsDifferent() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             RHEL,
             ServiceLevel.SELF_SUPPORT,
             Usage.PRODUCTION,
@@ -402,7 +402,7 @@ class HostRepositoryTest {
   void testFindHostsWhenUsageIsDifferent() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             RHEL,
             ServiceLevel.SELF_SUPPORT,
             Usage.DISASTER_RECOVERY,
@@ -428,7 +428,7 @@ class HostRepositoryTest {
     // When a host has no buckets, it will not be returned.
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account4", null, null, null, null, null, null, 0, 0, PageRequest.of(0, 10));
+            "ORG_account4", null, null, null, null, null, null, 0, 0, PageRequest.of(0, 10));
     assertEquals(0, hosts.stream().count());
   }
 
@@ -455,7 +455,7 @@ class HostRepositoryTest {
     toSave.forEach(x -> x.setDisplayName(DEFAULT_DISPLAY_NAME));
     persistHosts(toSave.toArray(new Host[] {}));
 
-    Page<Host> guests = repo.getHostsByHypervisor(account, uuid, PageRequest.of(0, 10));
+    Page<Host> guests = repo.getHostsByHypervisor("ORG_" + account, uuid, PageRequest.of(0, 10));
     assertEquals(1, guests.getTotalElements());
     assertEquals(uuid, guests.getContent().get(0).getHypervisorUuid());
     assertEquals("guest", guests.getContent().get(0).getInventoryId());
@@ -467,7 +467,7 @@ class HostRepositoryTest {
   void testCanSortByIdForImplicitSort() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -488,7 +488,7 @@ class HostRepositoryTest {
   void testCanSortByDisplayName() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -513,7 +513,7 @@ class HostRepositoryTest {
   void testCanSortByMeasurementType() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account3",
+            "ORG_account3",
             RHEL,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -538,7 +538,7 @@ class HostRepositoryTest {
   void testCanSortByCores() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -563,7 +563,7 @@ class HostRepositoryTest {
   void testCanSortBySockets() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -588,7 +588,7 @@ class HostRepositoryTest {
   void testCanSortByLastSeen() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -613,7 +613,7 @@ class HostRepositoryTest {
   void testCanSortByHardwareType() {
     Page<TallyHostView> hosts =
         repo.getTallyHostViews(
-            "account2",
+            "ORG_account2",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -683,7 +683,7 @@ class HostRepositoryTest {
 
     Page<TallyHostView> results =
         repo.getTallyHostViews(
-            "my_acct",
+            "my_org",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -763,7 +763,16 @@ class HostRepositoryTest {
     Pageable page = PageRequest.of(0, 1, Sort.by(sort));
     assertNotNull(
         repo.getTallyHostViews(
-            "account1234", "product", ServiceLevel._ANY, Usage._ANY, null, null, "", 1, 0, page));
+            "ORG_account1234",
+            "product",
+            ServiceLevel._ANY,
+            Usage._ANY,
+            null,
+            null,
+            "",
+            1,
+            0,
+            page));
   }
 
   @Transactional
@@ -790,7 +799,7 @@ class HostRepositoryTest {
 
     Page<TallyHostView> results =
         repo.getTallyHostViews(
-            "my_acct",
+            "my_org",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -853,7 +862,7 @@ class HostRepositoryTest {
 
     Page<TallyHostView> results =
         repo.getTallyHostViews(
-            "my_acct",
+            "my_org",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -915,7 +924,7 @@ class HostRepositoryTest {
 
     Page<TallyHostView> results =
         repo.getTallyHostViews(
-            "my_acct",
+            "my_org",
             "RHEL",
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -1167,7 +1176,7 @@ class HostRepositoryTest {
 
     Page<TallyHostView> results =
         repo.getTallyHostViews(
-            acctNumber,
+            "ORG_ACCT",
             RHEL,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -83,7 +83,7 @@ class HostsResourceTest {
     when(repository.getTallyHostViews(
             any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt(), any()))
         .thenReturn(mockPage);
-    when(accountConfigRepo.findOrgByAccountNumber("account123456")).thenReturn("owner123456");
+    when(accountConfigRepo.findOrgByAccountNumber("owner123456")).thenReturn("owner123456");
     when(accountConfigRepo.existsByOrgId("owner123456")).thenReturn(true);
   }
 
@@ -105,7 +105,7 @@ class HostsResourceTest {
 
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
@@ -140,7 +140,7 @@ class HostsResourceTest {
 
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
@@ -174,7 +174,7 @@ class HostsResourceTest {
 
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
@@ -209,7 +209,7 @@ class HostsResourceTest {
 
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
@@ -244,7 +244,7 @@ class HostsResourceTest {
 
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
@@ -279,7 +279,7 @@ class HostsResourceTest {
 
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
@@ -308,7 +308,7 @@ class HostsResourceTest {
 
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
@@ -342,7 +342,7 @@ class HostsResourceTest {
         null);
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
@@ -371,7 +371,7 @@ class HostsResourceTest {
 
     verify(repository, only())
         .getTallyHostViews(
-            "account123456",
+            "owner123456",
             ProductId.RHEL.toString(),
             ServiceLevel._ANY,
             Usage._ANY,

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -54,7 +54,7 @@ public interface HostRepository
    * Find all Hosts by bucket criteria and return a page of TallyHostView objects. A TallyHostView
    * is a Host representation detailing what 'bucket' was applied to the current daily snapshots.
    *
-   * @param accountNumber The account number of the hosts to query (required).
+   * @param orgId The orgId of the hosts to query (required).
    * @param productId The bucket product ID to filter Host by (pass null to ignore).
    * @param sla The bucket service level to filter Hosts by (pass null to ignore).
    * @param usage The bucket usage to filter Hosts by (pass null to ignore).
@@ -71,7 +71,7 @@ public interface HostRepository
   @Query(
       value =
           "select b from HostTallyBucket b join fetch b.host h where "
-              + "h.accountNumber = :account and "
+              + "h.orgId = :orgId and "
               + "b.key.productId = :product and "
               + "b.key.sla = :sla and b.key.usage = :usage and "
               + "b.key.billingProvider = :billingProvider and "
@@ -86,7 +86,7 @@ public interface HostRepository
       // is used.
       countQuery =
           "select count(b) from HostTallyBucket b join b.host h where "
-              + "h.accountNumber = :account and "
+              + "h.orgId = :orgId and "
               + "b.key.productId = :product and "
               + "b.key.sla = :sla and b.key.usage = :usage and "
               + "b.key.sla = :sla and b.key.usage = :usage and "
@@ -95,7 +95,7 @@ public interface HostRepository
               + "((lower(h.displayName) LIKE lower(concat('%', :displayNameSubstring,'%')))) and "
               + "b.cores >= :minCores and b.sockets >= :minSockets")
   Page<TallyHostView> getTallyHostViews(
-      @Param("account") String accountNumber,
+      @Param("orgId") String orgId,
       @Param("product") String productId,
       @Param("sla") ServiceLevel sla,
       @Param("usage") Usage usage,
@@ -188,12 +188,10 @@ public interface HostRepository
 
   @Query(
       "select distinct h from Host h where "
-          + "h.accountNumber = :account and "
+          + "h.orgId = :orgId and "
           + "h.hypervisorUuid = :hypervisor_id")
   Page<Host> getHostsByHypervisor(
-      @Param("account") String accountNumber,
-      @Param("hypervisor_id") String hypervisorId,
-      Pageable pageable);
+      @Param("orgId") String orgId, @Param("hypervisor_id") String hypervisorId, Pageable pageable);
 
   List<Host> findByAccountNumber(String accountNumber);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-268

Testing
=======

Insert some hosts.

```shell
bin/insert-mock-hosts \
  --num-guests=4 \
  --num-hypervisors=1 \
  --hypervisor-id=eb0d994a-e129-4a18-860d-3e39294f95df
```

Run the service:

```shell
DEV_MODE=true ./gradlew :bootRun
```

Hit the hosts endpoint and ensure it works correctly:

```shell
http :8000/api/rhsm-subscriptions/v1/hosts/products/RHEL \
  x-rh-identity:$(echo -n '{"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

Notice account_number is not provided.

Hit the guests endpoint and ensure it works correctly:

```shell
http :8000/api/rhsm-subscriptions/v1/hosts/eb0d994a-e129-4a18-860d-3e39294f95df/guests \
  x-rh-identity:$(echo -n '{"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

Notice account_number is not provided.