### PR TITLE
SWATCH-622: add has_infinite_quantity to capacity metric response

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1499,6 +1499,8 @@ components:
           type: integer
           format: int32
           minimum: 0
+        has_infinite_quantity:
+          type: boolean
     HostReportSort:
       type: string
       enum:

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -379,6 +379,7 @@ public class CapacityResource implements CapacityApi {
       Optional<ReportCategory> reportCategory) {
     int value = 0;
     boolean hasData = false;
+    boolean hasInfiniteQuantity = false;
 
     for (SubscriptionCapacity capacity : matches) {
       if (capacity.getBeginDate().isBefore(date) && capacity.getEndDate().isAfter(date)) {
@@ -388,10 +389,15 @@ public class CapacityResource implements CapacityApi {
         } else if (metricId.equals(MetricId.CORES)) {
           value += calculateCoresCapacity(reportCategory, capacity);
         }
+        hasInfiniteQuantity |= Optional.ofNullable(capacity.getHasUnlimitedUsage()).orElse(false);
       }
     }
 
-    return new CapacitySnapshotByMetricId().date(date).value(value).hasData(hasData);
+    return new CapacitySnapshotByMetricId()
+        .date(date)
+        .value(value)
+        .hasData(hasData)
+        .hasInfiniteQuantity(hasInfiniteQuantity);
   }
 
   private int calculateSocketsCapacity(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepositoryImpl.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/CustomizedSubscriptionCapacityRepositoryImpl.java
@@ -157,42 +157,46 @@ public class CustomizedSubscriptionCapacityRepositoryImpl
       Root<SubscriptionCapacity> capacity,
       MetricId metricId,
       ReportCategory reportCategory) {
+    Predicate metricPredicate = null;
     if (metricId.equals(MetricId.CORES)) {
       if (reportCategory != null) {
         switch (reportCategory) {
           case PHYSICAL:
-            predicates.add(cb.greaterThan(capacity.get("physicalCores"), 0));
+            metricPredicate = cb.greaterThan(capacity.get("physicalCores"), 0);
             break;
           case VIRTUAL:
-            predicates.add(cb.greaterThan(capacity.get("virtualCores"), 0));
+            metricPredicate = cb.greaterThan(capacity.get("virtualCores"), 0);
             break;
           default:
             break;
         }
       } else {
-        predicates.add(
+        metricPredicate =
             cb.or(
                 cb.greaterThan(capacity.get("physicalCores"), 0),
-                cb.greaterThan(capacity.get("virtualCores"), 0)));
+                cb.greaterThan(capacity.get("virtualCores"), 0));
       }
     } else if (metricId.equals(MetricId.SOCKETS)) {
       if (reportCategory != null) {
         switch (reportCategory) {
           case PHYSICAL:
-            predicates.add(cb.greaterThan(capacity.get("physicalSockets"), 0));
+            metricPredicate = cb.greaterThan(capacity.get("physicalSockets"), 0);
             break;
           case VIRTUAL:
-            predicates.add(cb.greaterThan(capacity.get("virtualSockets"), 0));
+            metricPredicate = cb.greaterThan(capacity.get("virtualSockets"), 0);
             break;
           default:
             break;
         }
       } else {
-        predicates.add(
+        metricPredicate =
             cb.or(
                 cb.greaterThan(capacity.get("physicalSockets"), 0),
-                cb.greaterThan(capacity.get("virtualSockets"), 0)));
+                cb.greaterThan(capacity.get("virtualSockets"), 0));
       }
+    }
+    if (metricPredicate != null) {
+      predicates.add(cb.or(metricPredicate, cb.isTrue(capacity.get("hasUnlimitedUsage"))));
     }
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-622

Test Steps:

- Create or update 2 Subscriptions/Subscription_capacities, one with has_unlimited_usage = true and one with it set to false.
- Search for each using http://localhost:8000/api-docs/index.html#/capacity/getCapacityReportByMetricId and check that has_infinite_quantity is set correctly 