### PR TITLE
SWATCH-671: Separate tally measurements: virtual/hypervisors

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -40,7 +40,7 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
                 },
             }),
             'canonical_facts': json.dumps({
-                'subscription_manager_id': subscription_manager_id,
+                'subscription_manager_id': subscription_manager_id or str(uuid.uuid4()),
                 'insights_id': str(insights_id),
             }),
             'system_profile_facts': json.dumps({

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -62,7 +62,7 @@ public class RHELProductUsageCollector implements ProductUsageCollector {
       // unique hypervisor instance contributing to the hypervisor counts.
       // Since the guest is unmapped, we only contribute a single socket.
       appliedSockets = normalizedFacts.isMarketplace() ? 0 : 1;
-      prodCalc.addHypervisor(appliedCores, appliedSockets, 1);
+      prodCalc.addUnmappedGuest(appliedCores, appliedSockets, 1);
       return Optional.of(
           createBucket(
               prodCalc, true, appliedCores, appliedSockets, HardwareMeasurementType.VIRTUAL));

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -27,6 +27,7 @@ import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.crea
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertHypervisorTotalsCalculation;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertPhysicalTotalsCalculation;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertVirtualTotalsCalculation;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -133,7 +134,7 @@ class InventoryAccountUsageCollectorTest {
     // no guests running RHEL means no hypervisor total...
     assertNull(
         calc.getCalculation(createUsageKey(TEST_PRODUCT))
-            .getTotals(HardwareMeasurementType.VIRTUAL));
+            .getTotals(HardwareMeasurementType.HYPERVISOR));
     // hypervisor itself gets counted
     checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
   }
@@ -178,10 +179,13 @@ class InventoryAccountUsageCollectorTest {
 
     AccountUsageCalculation calc = calcs.get(ACCOUNT);
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
-    checkHypervisorTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
+    checkVirtualTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
     assertNull(
         calc.getCalculation(createUsageKey(TEST_PRODUCT))
             .getTotals(HardwareMeasurementType.PHYSICAL));
+    assertNull(
+        calc.getCalculation(createUsageKey(TEST_PRODUCT))
+            .getTotals(HardwareMeasurementType.HYPERVISOR));
   }
 
   @Test
@@ -794,6 +798,23 @@ class InventoryAccountUsageCollectorTest {
     UsageCalculation prodCalc = calc.getCalculation(createUsageKey(product));
     assertEquals(product, prodCalc.getProductId());
     assertPhysicalTotalsCalculation(prodCalc, physicalSockets, physicalCores, physicalInstances);
+  }
+
+  private void checkVirtualTotalsCalculation(
+      AccountUsageCalculation calc,
+      String account,
+      String orgId,
+      String product,
+      int cores,
+      int sockets,
+      int instances) {
+    assertEquals(account, calc.getAccount());
+    assertEquals(orgId, calc.getOrgId());
+    assertTrue(calc.containsCalculation(createUsageKey(product)));
+
+    UsageCalculation prodCalc = calc.getCalculation(createUsageKey(product));
+    assertEquals(product, prodCalc.getProductId());
+    assertVirtualTotalsCalculation(prodCalc, sockets, cores, instances);
   }
 
   private void checkHypervisorTotalsCalculation(

--- a/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
@@ -72,6 +72,17 @@ class UsageCalculationTest {
     UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
     IntStream.rangeClosed(0, 4).forEach(i -> calculation.addHypervisor(i + 2, i + 1, i));
 
+    assertHardwareMeasurementTotals(calculation, HardwareMeasurementType.HYPERVISOR, 15, 20, 10);
+    assertHardwareMeasurementTotals(calculation, HardwareMeasurementType.TOTAL, 15, 20, 10);
+    assertNullExcept(
+        calculation, HardwareMeasurementType.TOTAL, HardwareMeasurementType.HYPERVISOR);
+  }
+
+  @Test
+  void testVirtualTotal() {
+    UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
+    IntStream.rangeClosed(0, 4).forEach(i -> calculation.addUnmappedGuest(i + 2, i + 1, i));
+
     assertHardwareMeasurementTotals(calculation, HardwareMeasurementType.VIRTUAL, 15, 20, 10);
     assertHardwareMeasurementTotals(calculation, HardwareMeasurementType.TOTAL, 15, 20, 10);
     assertNullExcept(calculation, HardwareMeasurementType.TOTAL, HardwareMeasurementType.VIRTUAL);

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/Assertions.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/Assertions.java
@@ -48,7 +48,13 @@ public class Assertions {
   public static void assertHypervisorTotalsCalculation(
       UsageCalculation calc, int hypSockets, int hypCores, int hypInstances) {
     assertHardwareMeasurementTotals(
-        calc, HardwareMeasurementType.VIRTUAL, hypSockets, hypCores, hypInstances);
+        calc, HardwareMeasurementType.HYPERVISOR, hypSockets, hypCores, hypInstances);
+  }
+
+  public static void assertVirtualTotalsCalculation(
+      UsageCalculation calc, int sockets, int cores, int instances) {
+    assertHardwareMeasurementTotals(
+        calc, HardwareMeasurementType.VIRTUAL, sockets, cores, instances);
   }
 
   public static void assertHardwareMeasurementTotals(

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -25,6 +25,7 @@ import static org.candlepin.subscriptions.tally.collector.Assertions.assertHyper
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertNullExcept;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertPhysicalTotalsCalculation;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertVirtualTotalsCalculation;
 import static org.candlepin.subscriptions.tally.collector.TestHelper.cloudMachineFacts;
 import static org.candlepin.subscriptions.tally.collector.TestHelper.guestFacts;
 import static org.candlepin.subscriptions.tally.collector.TestHelper.hypervisorFacts;
@@ -58,6 +59,11 @@ class RHELProductUsageCollectorTest {
 
     // Expects no hypervisor totals in this case.
     assertNull(calc.getTotals(HardwareMeasurementType.VIRTUAL));
+    // Expects no virtual totals in this case.
+    assertNull(calc.getTotals(HardwareMeasurementType.HYPERVISOR));
+
+    collector.collectForHypervisor("foo", calc, facts);
+    assertHypervisorTotalsCalculation(calc, 4, 12, 1);
   }
 
   @Test
@@ -72,6 +78,7 @@ class RHELProductUsageCollectorTest {
     assertNull(calc.getTotals(HardwareMeasurementType.TOTAL));
     assertNull(calc.getTotals(HardwareMeasurementType.PHYSICAL));
     assertNull(calc.getTotals(HardwareMeasurementType.VIRTUAL));
+    assertNull(calc.getTotals(HardwareMeasurementType.HYPERVISOR));
   }
 
   @Test
@@ -82,10 +89,10 @@ class RHELProductUsageCollectorTest {
     collector.collect(calc, facts);
 
     // A guest with an unknown hypervisor contributes to the overall totals
-    // It is considered as having its own unique hypervisor and therefore
-    // contributes its own values to the hypervisor counts.
+    // It is counted as virtual
     assertTotalsCalculation(calc, 1, 12, 1);
-    assertHypervisorTotalsCalculation(calc, 1, 12, 1);
+    assertVirtualTotalsCalculation(calc, 1, 12, 1);
+    assertNull(calc.getTotals(HardwareMeasurementType.HYPERVISOR));
     assertNull(calc.getTotals(HardwareMeasurementType.PHYSICAL));
   }
 
@@ -99,6 +106,7 @@ class RHELProductUsageCollectorTest {
     assertTotalsCalculation(calc, 4, 12, 1);
     assertPhysicalTotalsCalculation(calc, 4, 12, 1);
     assertNull(calc.getTotals(HardwareMeasurementType.VIRTUAL));
+    assertNull(calc.getTotals(HardwareMeasurementType.HYPERVISOR));
   }
 
   @Test

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
@@ -165,6 +165,10 @@ public class UsageCalculation {
   }
 
   public void addHypervisor(int cores, int sockets, int instances) {
+    add(HardwareMeasurementType.HYPERVISOR, cores, sockets, instances);
+  }
+
+  public void addUnmappedGuest(int cores, int sockets, int instances) {
     add(HardwareMeasurementType.VIRTUAL, cores, sockets, instances);
   }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-671

We were not yet using separate tally measurement categories for hypervisor and virtual.

Testing
=======

Insert some hosts.

```shell
bin/insert-mock-hosts \
  --num-hypervisors 1 \
  --num-guests 4 \
  --hbi \
  --clear \
  --org org123
bin/insert-mock-hosts \
  --num-guests 1 \
  --hbi \
  --org org123
```

Run the service:
```shell
DEV_MODE=true ./gradlew :bootRun
```

Ensure opt-in:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean \
  operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)' \
  arguments:='["account123","org123",true,true,true]'
```

Trigger a tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org123"]'
```

Check the results from the tally API for both categories (adjust dates as needed):

```shell
http :8000/api/rhsm-subscriptions/v1/tally/products/RHEL/Cores?category=hypervisor \
  beginning==2022-11-03T00:00Z \
  ending==2022-11-05T00:00Z \
  granularity==DAILY \
  x-rh-identity:$(echo -n '{"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

```shell
http :8000/api/rhsm-subscriptions/v1/tally/products/RHEL/Cores?category=virtual \
  beginning==2022-11-03T00:00Z \
  ending==2022-11-05T00:00Z \
  granularity==DAILY \
  x-rh-identity:$(echo -n '{"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```