### PR TITLE
SWATCH-584: Update AccountServiceInventory to use orgId

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
@@ -63,7 +63,7 @@ public class AccountResetService {
   @Transactional
   public void deleteDataForOrg(String orgId) {
 
-    accountServiceInventoryRepository.deleteByOrgId(orgId);
+    accountServiceInventoryRepository.deleteByIdOrgId(orgId);
     hostRepo.deleteByOrgId(orgId);
     eventRecordRepo.deleteByOrgId(orgId);
     tallySnapshotRepository.deleteByOrgId(orgId);

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -83,8 +83,15 @@ public class InventoryAccountUsageCollector {
 
     AccountServiceInventory accountServiceInventory =
         accountServiceInventoryRepository
-            .findById(new AccountServiceInventoryId(account, HBI_INSTANCE_TYPE))
-            .orElse(new AccountServiceInventory(account, HBI_INSTANCE_TYPE));
+            .findById(
+                AccountServiceInventoryId.builder()
+                    .orgId(orgId)
+                    .serviceType(HBI_INSTANCE_TYPE)
+                    .build())
+            .orElse(AccountServiceInventory.forOrgIdAndServiceType(orgId, HBI_INSTANCE_TYPE));
+    if (account != null) {
+      accountServiceInventory.setAccountNumber(account);
+    }
 
     Set<String> duplicateInstanceIds = new HashSet<>();
     Map<String, Host> inventoryHostMap =

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -88,10 +88,13 @@ public class MetricUsageCollector {
     /* load the latest accountServiceInventory state, so we can update host records conveniently */
     AccountServiceInventory accountServiceInventory =
         accountServiceInventoryRepository
-            .findById(new AccountServiceInventoryId(accountNumber, serviceType))
-            .orElse(new AccountServiceInventory(accountNumber, serviceType));
+            .findById(
+                AccountServiceInventoryId.builder().orgId(orgId).serviceType(serviceType).build())
+            .orElse(AccountServiceInventory.forOrgIdAndServiceType(orgId, serviceType));
 
-    accountServiceInventory.setOrgId(orgId);
+    if (accountNumber != null) {
+      accountServiceInventory.setAccountNumber(accountNumber);
+    }
     /*
     Evaluate latest state to determine if we are doing a recalculation and filter to host records for only
     the product profile we're working on

--- a/src/main/resources/liquibase/202211071027-change-account_services-pkey.xml
+++ b/src/main/resources/liquibase/202211071027-change-account_services-pkey.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202211071027-1" author="khowell">
+    <comment>Delete account_services rows missing orgId.</comment>
+    <delete tableName="account_services">
+      <where>org_id is null</where>
+    </delete>
+  </changeSet>
+
+  <changeSet id="202211071027-2" author="khowell">
+    <comment>Drop the hosts FK reference to account_services temporarily.</comment>
+    <dropForeignKeyConstraint baseTableName="hosts" constraintName="fk_hosts_account_services"/>
+  </changeSet>
+
+  <changeSet id="202211071027-3" author="khowell">
+    <comment>Drop primary key.</comment>
+    <dropPrimaryKey tableName="account_services"/>
+  </changeSet>
+
+  <changeSet id="202211071027-4" author="khowell">
+    <comment>Create PK for account_services w/ org_id.</comment>
+    <addPrimaryKey tableName="account_services" columnNames="org_id,service_type"/>
+  </changeSet>
+
+  <changeSet id="202211071027-5" author="khowell">
+    <comment>Drop orphaned host records.</comment>
+    <delete tableName="hosts">
+      <where>
+        org_id is null
+      </where>
+    </delete>
+  </changeSet>
+
+  <changeSet id="202211071027-6" author="khowell">
+    <comment>Create index for hosts referencing account_services w/ org_id.</comment>
+    <addForeignKeyConstraint constraintName="fk_hosts_account_services"
+      baseTableName="hosts" baseColumnNames="org_id,instance_type"
+      referencedTableName="account_services" referencedColumnNames="org_id,service_type"/>
+  </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -88,5 +88,6 @@
     <include file="liquibase/202210251446-change-constraints-indexes-fields-to-events.xml"/>
     <include file="liquibase/202210281140-rename-owner-id-to-org-id.xml"/>
     <include file="liquibase/202211011504-drop-hardware-measurements-table.xml"/>
+    <include file="liquibase/202211071027-change-account_services-pkey.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepositoryTest.java
@@ -50,10 +50,12 @@ class AccountServiceInventoryRepositoryTest {
   @Transactional
   @BeforeAll
   void setupTestData() {
-    AccountServiceInventory service = new AccountServiceInventory("account123", "HBI_HOST");
+    AccountServiceInventory service =
+        AccountServiceInventory.forOrgIdAndServiceType("org123", "HBI_HOST");
 
     Host host = new Host();
     host.setAccountNumber("account123");
+    host.setOrgId("org123");
     host.setInstanceId("1c474d4e-c277-472c-94ab-8229a40417eb");
     host.setDisplayName("name");
     host.setInstanceType("HBI_HOST");
@@ -74,13 +76,17 @@ class AccountServiceInventoryRepositoryTest {
 
   @Test
   void testHbiHostCanBeLoaded() {
-    assertTrue(repo.findById(new AccountServiceInventoryId("account123", "HBI_HOST")).isPresent());
+    assertTrue(
+        repo.findById(
+                AccountServiceInventoryId.builder().orgId("org123").serviceType("HBI_HOST").build())
+            .isPresent());
   }
 
   @Test
   void testCanFetchExistingInstancesViaAccountRepository() {
     Optional<AccountServiceInventory> account =
-        repo.findById(new AccountServiceInventoryId("account123", "HBI_HOST"));
+        repo.findById(
+            AccountServiceInventoryId.builder().orgId("org123").serviceType("HBI_HOST").build());
 
     assertTrue(account.isPresent());
     Map<String, Host> existingInstances = account.get().getServiceInstances();
@@ -89,6 +95,7 @@ class AccountServiceInventoryRepositoryTest {
 
     Host expected = new Host();
     expected.setAccountNumber("account123");
+    expected.setOrgId("org123");
     expected.setDisplayName("name");
     expected.setInstanceId("1c474d4e-c277-472c-94ab-8229a40417eb");
     expected.setInstanceType("HBI_HOST");
@@ -102,7 +109,9 @@ class AccountServiceInventoryRepositoryTest {
   @Test
   void testCanAddHostViaRepo() {
     AccountServiceInventory accountServiceInventory =
-        repo.findById(new AccountServiceInventoryId("account123", "HBI_HOST")).orElseThrow();
+        repo.findById(
+                AccountServiceInventoryId.builder().orgId("org123").serviceType("HBI_HOST").build())
+            .orElseThrow();
 
     String instanceId = "478edb89-b105-4dfd-9a46-0f1427514b76";
     Host host = new Host();
@@ -129,7 +138,9 @@ class AccountServiceInventoryRepositoryTest {
     repo.flush();
 
     AccountServiceInventory fetched =
-        repo.findById(new AccountServiceInventoryId("account123", "HBI_HOST")).orElseThrow();
+        repo.findById(
+                AccountServiceInventoryId.builder().orgId("org123").serviceType("HBI_HOST").build())
+            .orElseThrow();
     assertTrue(fetched.getServiceInstances().containsKey(instanceId));
     Host fetchedInstance = fetched.getServiceInstances().get(instanceId);
     // set ID in order to compare, because JPA doesn't populate the existing object's ID
@@ -142,14 +153,18 @@ class AccountServiceInventoryRepositoryTest {
   @Test
   void testCanRemoveHostViaRepo() {
     AccountServiceInventory accountServiceInventory =
-        repo.findById(new AccountServiceInventoryId("account123", "HBI_HOST")).orElseThrow();
+        repo.findById(
+                AccountServiceInventoryId.builder().orgId("org123").serviceType("HBI_HOST").build())
+            .orElseThrow();
 
     accountServiceInventory.getServiceInstances().clear();
     repo.save(accountServiceInventory);
     repo.flush();
 
     AccountServiceInventory fetched =
-        repo.findById(new AccountServiceInventoryId("account123", "HBI_HOST")).orElseThrow();
+        repo.findById(
+                AccountServiceInventoryId.builder().orgId("org123").serviceType("HBI_HOST").build())
+            .orElseThrow();
     assertTrue(fetched.getServiceInstances().isEmpty());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -142,8 +142,14 @@ class HostRepositoryTest {
             host -> {
               AccountServiceInventory accountServiceInventory =
                   accountServiceInventoryRepository
-                      .findById(new AccountServiceInventoryId(host.getAccountNumber(), "HBI_HOST"))
-                      .orElse(new AccountServiceInventory(host.getAccountNumber(), "HBI_HOST"));
+                      .findById(
+                          AccountServiceInventoryId.builder()
+                              .orgId(host.getOrgId())
+                              .serviceType("HBI_HOST")
+                              .build())
+                      .orElse(
+                          AccountServiceInventory.forOrgIdAndServiceType(
+                              host.getOrgId(), "HBI_HOST"));
               accountServiceInventory.getServiceInstances().put(host.getInstanceId(), host);
               accountServiceInventory =
                   accountServiceInventoryRepository.save(accountServiceInventory);

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -699,12 +699,12 @@ class InventoryAccountUsageCollectorTest {
     dupe.setInstanceId("i2");
 
     AccountServiceInventory accountServiceInventory =
-        new AccountServiceInventory(ACCOUNT, "HBI_HOST");
+        AccountServiceInventory.forOrgIdAndServiceType(ORG_ID, "HBI_HOST");
     accountServiceInventory.getServiceInstances().put(host.getInventoryId().toString(), orig);
     accountServiceInventory.getServiceInstances().put("i2", dupe);
 
     when(accountServiceInventoryRepository.findById(
-            new AccountServiceInventoryId(ACCOUNT, "HBI_HOST")))
+            AccountServiceInventoryId.builder().orgId(ORG_ID).serviceType("HBI_HOST").build()))
         .thenReturn(Optional.of(accountServiceInventory));
 
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), any())).thenReturn(Stream.of(host));

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepository.java
@@ -28,5 +28,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AccountServiceInventoryRepository
     extends JpaRepository<AccountServiceInventory, AccountServiceInventoryId> {
 
-  void deleteByOrgId(String orgId);
+  void deleteByIdOrgId(String orgId);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/AccountServiceInventory.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/AccountServiceInventory.java
@@ -44,16 +44,19 @@ public class AccountServiceInventory implements Serializable {
     id = new AccountServiceInventoryId();
   }
 
-  public AccountServiceInventory(String accountNumber, String serviceType) {
-    id = new AccountServiceInventoryId(accountNumber, serviceType);
+  public static AccountServiceInventory forOrgIdAndServiceType(String orgId, String serviceType) {
+    AccountServiceInventory inventory = new AccountServiceInventory();
+    inventory.id =
+        AccountServiceInventoryId.builder().orgId(orgId).serviceType(serviceType).build();
+    return inventory;
   }
 
-  public String getAccountNumber() {
-    return id.getAccountNumber();
+  public String getOrgId() {
+    return id.getOrgId();
   }
 
-  public void setAccountNumber(String accountNumber) {
-    id.setAccountNumber(accountNumber);
+  public void setOrgId(String orgId) {
+    id.setOrgId(orgId);
   }
 
   public String getServiceType() {
@@ -66,8 +69,8 @@ public class AccountServiceInventory implements Serializable {
 
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
   @JoinColumn(
-      name = "account_number",
-      referencedColumnName = "account_number",
+      name = "org_id",
+      referencedColumnName = "org_id",
       insertable = false,
       updatable = false)
   @JoinColumn(
@@ -80,6 +83,6 @@ public class AccountServiceInventory implements Serializable {
   @MapKeyColumn(name = "instance_id", updatable = false, insertable = false)
   private Map<String, Host> serviceInstances = new HashMap<>();
 
-  @Column(name = "org_id")
-  private String orgId;
+  @Column(name = "account_number")
+  private String accountNumber;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/AccountServiceInventoryId.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/AccountServiceInventoryId.java
@@ -24,16 +24,18 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
 public class AccountServiceInventoryId implements Serializable {
-  @Column(name = "account_number")
-  private String accountNumber;
+  @Column(name = "org_id")
+  private String orgId;
 
   @Column(name = "service_type")
   private String serviceType;


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-584

I changed creation of AccountServiceInventory to use a factory method, and changed AccountServiceInventoryId to use a builder, in order to make it more explicit that orgId is in use.

account_number is still populated when present, but is otherwise unused.

Testing
=======

Insert some hosts.

```shell
bin/insert-mock-hosts \
  --num-hypervisors 1 \
  --num-guests 4 \
  --hbi \
  --clear \
  --org org123
bin/insert-mock-hosts \
  --num-guests 1 \
  --hbi \
  --org org123
```

Run the service:
```shell
DEV_MODE=true ./gradlew :bootRun
```

Ensure opt-in:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean \
  operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)' \
  arguments:='["account123","org123",true,true,true]'
```

Trigger a tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org123"]'
```

Check the results from the instances API:

```shell
http :8000/api/rhsm-subscriptions/v1/instances/products/RHEL \
  beginning==2022-11-03T00:00Z \
  ending==2022-11-05T00:00Z \
  granularity==DAILY \
  x-rh-identity:$(echo -n '{"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

Clear account data (to exercise spring data repo change):

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=accountResetJmxBean,type=AccountResetJmxBean \
  operation='deleteDataAssociatedWithOrg(java.lang.String)' \
  arguments:='["org123"]'
```

The record is gone:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
select * from account_services where org_id='org123'
EOF
```