### PR TITLE
Reorder account_services liquibase change

### DIFF
--- a/src/main/resources/liquibase/202211071027-change-account_services-pkey.xml
+++ b/src/main/resources/liquibase/202211071027-change-account_services-pkey.xml
@@ -7,15 +7,15 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202211071027-1" author="khowell">
+    <comment>Drop the hosts FK reference to account_services temporarily.</comment>
+    <dropForeignKeyConstraint baseTableName="hosts" constraintName="fk_hosts_account_services"/>
+  </changeSet>
+
+  <changeSet id="202211071027-2" author="khowell">
     <comment>Delete account_services rows missing orgId.</comment>
     <delete tableName="account_services">
       <where>org_id is null</where>
     </delete>
-  </changeSet>
-
-  <changeSet id="202211071027-2" author="khowell">
-    <comment>Drop the hosts FK reference to account_services temporarily.</comment>
-    <dropForeignKeyConstraint baseTableName="hosts" constraintName="fk_hosts_account_services"/>
   </changeSet>
 
   <changeSet id="202211071027-3" author="khowell">


### PR DESCRIPTION
In order to fix an issue deploying where an error like:

```
Caused by: liquibase.exception.DatabaseException: ERROR: update or delete on table "account_services" violates foreign key constraint "fk_hosts_account_services" on table "hosts"
Detail: Key (account_number, service_type)=(6356567, HBI_HOST) is still referenced from table "hosts". [Failed SQL: (0) DELETE FROM public.account_services WHERE org_id is null]
```

happens because there are host rows that reference account_services rows missing org_id in stage specifically.