### PR TITLE
SWATCH-631: Migrate Data for OrgId To TallySnapshot Table

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/jmx/TallyJmxBean.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.NotNull;
 import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.tally.admin.DataMigrationRunner;
 import org.candlepin.subscriptions.tally.admin.HardwareMeasurementMigration;
+import org.candlepin.subscriptions.tally.admin.OrgIdToTallySnapshotMigration;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
 import org.candlepin.subscriptions.util.DateRange;
 import org.candlepin.subscriptions.validator.ParameterDuration;
@@ -138,10 +139,30 @@ public class TallyJmxBean {
       description = "Offset to start from (may be null to start from beginning)")
   @ManagedOperationParameter(name = "batchSize", description = "Batch size")
   public void migrateHardwareMeasurements(String snapshotId, int batchSize) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("Batch size cannot be zero");
+    }
     log.info(
         "hardware_measurements migration triggered over JMX by {}", ResourceUtils.getPrincipal());
     dataMigrationRunner.migrate(
         HardwareMeasurementMigration.class,
+        StringUtils.hasText(snapshotId) ? snapshotId : null,
+        batchSize);
+  }
+
+  @ManagedOperation(description = "Trigger tally_snapshots Org_id migration")
+  @ManagedOperationParameter(
+      name = "snapshotId",
+      description = "Offset to start from (may be null to start from beginning)")
+  @ManagedOperationParameter(name = "batchSize", description = "Batch size")
+  public void migrateOrgIdToTallySnapshot(String snapshotId, int batchSize) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("Batch size cannot be zero");
+    }
+    log.info(
+        "Org_id tally_snapshot migration triggered over JMX by {}", ResourceUtils.getPrincipal());
+    dataMigrationRunner.migrate(
+        OrgIdToTallySnapshotMigration.class,
         StringUtils.hasText(snapshotId) ? snapshotId : null,
         batchSize);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/OrgIdToTallySnapshotMigration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/OrgIdToTallySnapshotMigration.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.SqlRowSetResultSetExtractor;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+public class OrgIdToTallySnapshotMigration extends DataMigration {
+
+  public static final SqlRowSetResultSetExtractor SQL_ROW_SET_RESULT_SET_EXTRACTOR =
+      new SqlRowSetResultSetExtractor();
+
+  public static final String UPDATE_SQL = "update tally_snapshots set org_id=? where id =?";
+
+  private static final String ACCOUNT_SERVICE_QUERY =
+      "select t.id, a.org_id, t.org_id as tally_org \n"
+          + "from tally_snapshots t\n"
+          + "         left join account_config a\n"
+          + "                   on a.account_number = t.account_number\n"
+          + "where ?::uuid is null\n"
+          + "   or t.id > ?::uuid\n"
+          + "order by t.id\n"
+          + "limit ?";
+
+  private final Counter counter;
+
+  public OrgIdToTallySnapshotMigration(JdbcTemplate jdbcTemplate, MeterRegistry meterRegistry) {
+    super(jdbcTemplate, meterRegistry);
+    counter = meterRegistry.counter("swatch_orgIdToTallysnapshot_migration");
+  }
+
+  @Override
+  public SqlRowSet extract(String recordOffset, int batchSize) {
+    return jdbcTemplate.query(
+        ACCOUNT_SERVICE_QUERY,
+        new Object[] {recordOffset, recordOffset, batchSize},
+        new int[] {Types.VARCHAR, Types.VARCHAR, Types.NUMERIC},
+        SQL_ROW_SET_RESULT_SET_EXTRACTOR);
+  }
+
+  @Override
+  public String transformAndLoad(SqlRowSet data) {
+    String lastSeenSnapshotId = null;
+    List<Object[]> updateList = new ArrayList<>();
+    int snapshotCount = 0;
+    while (data.next()) {
+      String snapshotId = data.getString("id");
+      String orgId = data.getString("org_id");
+      String tallyOrg = data.getString("tally_org");
+      lastSeenSnapshotId = snapshotId;
+
+      if (!StringUtils.hasText(tallyOrg)) {
+        log.debug("Updating ownerId for tally snapshotId: {}", tallyOrg);
+        updateList.add(new Object[] {orgId, snapshotId});
+      }
+      snapshotCount++;
+    }
+    jdbcTemplate.batchUpdate(UPDATE_SQL, updateList);
+    counter.increment(snapshotCount);
+    return lastSeenSnapshotId;
+  }
+
+  @Override
+  public void recordCompleted() {
+    // intentionally left blank
+  }
+}


### PR DESCRIPTION
This is address https://issues.redhat.com/browse/SWATCH-631

Add new migrator for OrgId to populate Tally Snapshot Add new endpoint to reference New data migration.
Adjusted query to filter properly by accountNumber

Test Steps:
1. Either clear org_id in Tally snapshot or insert test data below.
```
INSERT INTO public.tally_snapshots (id, product_id, account_number, granularity, org_id, snapshot_date, unit_of_measure, sla, usage, billing_provider, billing_account_id) VALUES ('c5310125-46bd-4991-94f8-dccadab62245', 'rhosak', 'account123', 'DAILY', '', '2021-10-31 00:00:00.000000 +00:00', null, 'Premium', '_ANY', 'red hat', 'dummyId');
INSERT INTO public.tally_snapshots (id, product_id, account_number, granularity, org_id, snapshot_date, unit_of_measure, sla, usage, billing_provider, billing_account_id) VALUES ('8d81e216-0c6a-432a-a4b4-a96a43186fd4', 'rhosak', 'account123', 'DAILY', '', '2021-10-31 00:00:00.000000 +00:00', null, '_ANY', 'Production', 'red hat', 'dummyId');
```
2. If you use the test data make sure to insert script in account config table
```
INSERT INTO public.account_config (account_number, opt_in_type, created, updated, org_id) VALUES ('account123', 'PROMETHEUS', '2022-10-07 16:13:04.231491 +00:00', '2022-10-07 16:13:04.231491 +00:00', 'orgId123');
INSERT INTO public.account_config (account_number, opt_in_type, created, updated, org_id) VALUES ('account321', 'PROMETHEUS', '2022-11-10 15:36:02.522000 +00:00', '2022-11-10 15:36:10.849000 +00:00', 'orgId321');
```
3. Now Boot run application and trigger the migrateOrgIdToTallySnapshot(String, int) method in Hawtio, pass null and 0, and all blank org_id in tally snapshot table will be filled with the correct values based on account config.