### PR TITLE
SWATCH-684: Add stricter validation to IP addresses in facts

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/validator/IpAddressValidatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/validator/IpAddressValidatorTest.java
@@ -23,73 +23,64 @@ package org.candlepin.subscriptions.validator;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class IpAddressValidatorTest {
 
   private IpAddressValidator validator = new IpAddressValidator();
 
-  @Test
-  void testIpV4Validation() {
-    assertTrue(validator.isValid("192.168.2.1", null));
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // IPv4
+        "192.168.2.1",
+        // Standard notation
+        "1762:0:0:0:0:B03:1:AF18",
+        // Mixed notation
+        "1762:0:0:0:0:B03:127.32.67.15",
+        // Compressed notation
+        "::1",
+        "1762::B03:1:AF18",
+        // Compressed with variable number 0s
+        "1:0:0:0:0:6:0:0",
+        "1::6:0:0",
+        "1:0:0:0:0:6::",
+        // Compressed mixed notation
+        "1762::B03:127.32.67.15",
+        // Case insensitive
+        "2607:F380:A58:FFFF:0000:0000:0000:0001",
+        "2607:f380:a58:ffff:0000:0000:0000:0001",
+        "2607:f380:A58:FFfF:0000:0000:0000:0001"
+      })
+  void isValid(String ip) {
+    assertTrue(validator.isValid(ip, null));
   }
 
-  @Test
-  void testInvalidIpV4Ip() {
-    assertFalse(validator.isValid("a.b.c.d", null));
-    assertFalse(validator.isValid("192.168.2.8.4", null));
-    assertFalse(validator.isValid("", null));
-    assertFalse(validator.isValid(null, null));
-    assertFalse(validator.isValid("129.2.2.z", null));
-    assertFalse(validator.isValid("129.2.2.", null));
-    assertFalse(validator.isValid(".129.2.2", null));
-    assertFalse(validator.isValid("192.500.2.4", null));
-    assertFalse(validator.isValid("redhat.com", null));
-    assertFalse(validator.isValid("myhost", null));
-    assertFalse(validator.isValid("999.3.3.3", null));
-  }
-
-  @Test
-  void testIpV6Validation() {
-    // Standard notation
-    assertTrue(validator.isValid("1762:0:0:0:0:B03:1:AF18", null));
-
-    // Mixed notation
-    assertTrue(validator.isValid("1762:0:0:0:0:B03:127.32.67.15", null));
-
-    // Compressed notation
-    assertTrue(validator.isValid("::1", null));
-    assertTrue(validator.isValid("1762::B03:1:AF18", null));
-
-    // Compressed with variable number 0s
-    assertTrue(validator.isValid("1:0:0:0:0:6:0:0", null));
-    assertTrue(validator.isValid("1::6:0:0", null));
-    assertTrue(validator.isValid("1:0:0:0:0:6::", null));
-
-    // Compressed mixed notation
-    assertTrue(validator.isValid("1762::B03:127.32.67.15", null));
-  }
-
-  @Test
-  void testInvalidIpV6() {
-    // Can only use :: once
-    assertFalse(validator.isValid("1200::AB00:1234::2552:7777:1313", null));
-
-    // Can't use O in all zeros
-    assertFalse(validator.isValid("1200:0000:AB00:1234:O000:2552:7777:1313", null));
-
-    // A -> F are valid, G is not.
-    assertFalse(validator.isValid("1762:0:0:0:0:G03:1:AF18", null));
-
-    // Invalid character
-    assertFalse(validator.isValid("2607:F380:A58:FFFF;0000:0000:0000:0001", null));
-    assertFalse(validator.isValid("2607:redhat.com", null));
-  }
-
-  @Test
-  void caseInsensitiveIpV6() {
-    assertTrue(validator.isValid("2607:F380:A58:FFFF:0000:0000:0000:0001", null));
-    assertTrue(validator.isValid("2607:f380:a58:ffff:0000:0000:0000:0001", null));
-    assertTrue(validator.isValid("2607:f380:A58:FFfF:0000:0000:0000:0001", null));
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "a.b.c.d",
+        "192.168.2.8.4",
+        "",
+        "129.2.2.z",
+        "129.2.2.",
+        ".129.2.2",
+        "192.500.2.4",
+        "redhat.com",
+        "myhost",
+        "999.3.3.3",
+        // Can only use :: once
+        "1200::AB00:1234::2552:7777:1313",
+        // Can't use O in all zeros
+        "1200:0000:AB00:1234:O000:2552:7777:1313",
+        // A -> F are valid, G is not.
+        "1762:0:0:0:0:G03:1:AF18",
+        // Invalid character
+        "2607:F380:A58:FFFF;0000:0000:0000:0001",
+        "2607:redhat.com"
+      })
+  void isInvalid(String ip) {
+    assertFalse(validator.isValid(ip, null));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/validator/MacAddressValidatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/validator/MacAddressValidatorTest.java
@@ -47,6 +47,7 @@ class MacAddressValidatorTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
+        "",
         "0.0.0.0",
         "192.168.0.10",
         "01:23:45-67:89:aB", // Mixed delimiters

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/validator/IpAddressValidator.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/validator/IpAddressValidator.java
@@ -34,9 +34,11 @@ public class IpAddressValidator implements ConstraintValidator<IpAddress, String
 
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    // A null or empty value is considered invalid.
-    if (value == null || value.isEmpty()) {
-      return false;
+    // Note that the Jakarta Bean Validation specification recommends to consider null values as
+    // being valid. If null is not a valid value for an element, it should be annotated with
+    // @NotNull explicitly
+    if (value == null) {
+      return true;
     }
     return InetAddresses.isInetAddress(value);
   }

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions;
 
 import org.candlepin.subscriptions.clowder.KafkaJaasBeanPostProcessor;
 import org.candlepin.subscriptions.clowder.RdsSslBeanPostProcessor;
+import org.candlepin.subscriptions.validator.IpAddressValidator;
 import org.candlepin.subscriptions.validator.MacAddressValidator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,15 +42,30 @@ public class SystemConduitConfiguration {
   }
 
   /**
-   * Unfortunately there's no one property to apply the MacAddress annotation to. We have to resort
-   * to calling the validator manually when we know we have a String we need to treat as a MAC
-   * address.
+   * An instance of the MacAddressValidator that we use to detect NICs with bad MAC addresses.
+   * Rather than having a ConduitFacts object that fails validation, we use an instance of
+   * MacAddressValidator to skip NICs that have bad MAC addresses and therefore construct a
+   * compliant ConduitFacts object that will pass bean validation later (since the relevant field in
+   * ConduitFacts is tagged with the @MacAddress validation annotation).
    *
    * @return an instance of MacAddressValidator
    */
   @Bean
   public MacAddressValidator macAddressValidator() {
     return new MacAddressValidator();
+  }
+  /**
+   * An instance of the ipAddressValidator that we use to detect NICs with bad IP addresses. Rather
+   * than having a ConduitFacts object that fails validation, we use an instance of
+   * IpAddressValidator to skip NICs that have bad IP addresses and therefore construct a compliant
+   * ConduitFacts object that will pass bean validation later (since the relevant field in
+   * ConduitFacts are tagged with the @IpAddress validation annotation).
+   *
+   * @return an instance of MacAddressValidator
+   */
+  @Bean
+  public IpAddressValidator ipAddressValidator() {
+    return new IpAddressValidator();
   }
 
   /**

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/ConduitFacts.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/ConduitFacts.java
@@ -58,13 +58,13 @@ public class ConduitFacts extends ConsumerInventory {
 
   @Valid
   @Override
-  public List<@IpAddress String> getIpAddresses() {
+  public List<@IpAddress @NotNull String> getIpAddresses() {
     return super.getIpAddresses();
   }
 
   @Valid
   @Override
-  public List<@MacAddress String> getMacAddresses() {
+  public List<@MacAddress @NotNull String> getMacAddresses() {
     return super.getMacAddresses();
   }
 

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -488,11 +488,10 @@ class InventoryControllerTest {
     rhsmFacts.put("net.interface.eth0.ipv6_address.link", "fe80::2323:912a:177a:d8e6");
     rhsmFacts.put("net.interface.eth0.ipv6_address.link_list", "0088::99aa:bbcc:ddee:ff33");
 
-    ConduitFacts conduitFacts = new ConduitFacts();
-    controller.extractIpAddresses(rhsmFacts, conduitFacts);
+    var results = controller.extractIpAddresses(rhsmFacts);
 
     assertThat(
-        conduitFacts.getIpAddresses(),
+        results,
         Matchers.containsInAnyOrder(
             "192.168.1.1",
             "1.2.3.4",
@@ -500,7 +499,7 @@ class InventoryControllerTest {
             "fe80::2323:912a:177a:d8e6",
             "0088::99aa:bbcc:ddee:ff33"));
     // testing whether the duplicates have been removed
-    assertEquals(5, conduitFacts.getIpAddresses().size());
+    assertEquals(5, results.size());
   }
 
   @Test
@@ -541,11 +540,10 @@ class InventoryControllerTest {
     rhsmFacts.put("net.interface.virbr0.ipv4_address", "192.168.122.1");
     rhsmFacts.put("net.interface.wlan0.ipv4_address", "Unknown");
 
-    ConduitFacts conduitFacts = new ConduitFacts();
-    controller.extractIpAddresses(rhsmFacts, conduitFacts);
+    var results = controller.extractIpAddresses(rhsmFacts);
 
     assertThat(
-        conduitFacts.getIpAddresses(),
+        results,
         Matchers.containsInAnyOrder(
             "192.168.1.1", "127.0.0.1", "fe80::2323:912a:177a:d8e6", "192.168.122.1"));
   }
@@ -556,11 +554,10 @@ class InventoryControllerTest {
     rhsmFacts.put("net.interface.eth0.ipv4_address", "192.168.1.1");
     rhsmFacts.put("net.interface.lo.ipv4_address", "127.0.0.1, 192.168.2.1,192.168.2.2,192...");
 
-    ConduitFacts conduitFacts = new ConduitFacts();
-    controller.extractIpAddresses(rhsmFacts, conduitFacts);
-    assertEquals(4, conduitFacts.getIpAddresses().size());
+    var results = controller.extractIpAddresses(rhsmFacts);
+    assertEquals(4, results.size());
     assertThat(
-        conduitFacts.getIpAddresses(),
+        results,
         Matchers.containsInAnyOrder("192.168.1.1", "127.0.0.1", "192.168.2.1", "192.168.2.2"));
   }
 
@@ -784,15 +781,15 @@ class InventoryControllerTest {
     consumer.getFacts().put("distribution.name", "Red Hat Enterprise Linux Workstation");
     consumer.getFacts().put("distribution.version", "6.3");
 
-    var expectedNIC1 = new HbiNetworkInterface();
-    expectedNIC1.setName("virbr0");
-    expectedNIC1.setIpv4Addresses(List.of("192.168.122.1", "ipv4ListTest"));
-    expectedNIC1.setMacAddress("C0:FF:E0:00:00:D8");
+    var virbr0NIC = new HbiNetworkInterface();
+    virbr0NIC.setName("virbr0");
+    virbr0NIC.setIpv4Addresses(List.of("192.168.122.1"));
+    virbr0NIC.setMacAddress("C0:FF:E0:00:00:D8");
 
-    var expectedNIC2 = new HbiNetworkInterface();
-    expectedNIC2.setName("eth0");
-    expectedNIC2.setIpv6Addresses(List.of("ipv6Test", "fe80::f2de:f1ff:fe9e:ccdd"));
-    expectedNIC2.setMacAddress("CA:FE:D1:9E:CC:DD");
+    var eth0NIC = new HbiNetworkInterface();
+    eth0NIC.setName("eth0");
+    eth0NIC.setIpv6Addresses(List.of("fe80::f2de:f1ff:fe9e:ccdd"));
+    eth0NIC.setMacAddress("CA:FE:D1:9E:CC:DD");
 
     var loNIC = new HbiNetworkInterface();
     loNIC.setName("lo");
@@ -814,11 +811,10 @@ class InventoryControllerTest {
     assertEquals("Red Hat Enterprise Linux Workstation", conduitFacts.getOsName());
     assertEquals("6.3", conduitFacts.getOsVersion());
     assertEquals(
-        List.of(expectedNIC1, expectedNIC2, loNIC).size(),
-        conduitFacts.getNetworkInterfaces().size());
+        List.of(virbr0NIC, eth0NIC, loNIC).size(), conduitFacts.getNetworkInterfaces().size());
     assertThat(
         conduitFacts.getNetworkInterfaces(),
-        Matchers.containsInAnyOrder(expectedNIC1, expectedNIC2, loNIC));
+        Matchers.containsInAnyOrder(virbr0NIC, eth0NIC, loNIC));
   }
 
   @Test


### PR DESCRIPTION
Also modify some of the logic around how we handle validation for lists of items versus singleton items.  We want to check lists of items for truncation ("127.0.0.1,192...") and log if the value is truncated.  For singleton items, we don't expect any commas to split on or truncation tokens.  If there happens to be a comma or truncation token, the value will fail the ordinary validation anyway.

See SWATCH-684