### PR TITLE
SDB-3267: adding MW01382 and variant to the list

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -2163,6 +2163,8 @@ objects:
         MW0137162F3RN
         MW0137162RN
         MW0137162S
+        MW01382
+        MW01382F3
         MW01390
         MW01391F3
         MW01392S


### PR DESCRIPTION
adding Red Hat OpenShift Container Platform for Distributed Computing (Edge Server), Premium (2 Cores or 4 vCPUs) to the allow list (and F3 variant)
see SDB-3267