### PR TITLE
SWATCH-591: Rename physical & virtual cores & sockets

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -940,8 +940,8 @@ paths:
                     next_event_date: "2020-04-01T00:00:00Z"
                     next_event_type: Subscription Begin
                     quantity: 3
-                    physical_capacity: 3
-                    virtual_capacity: 3
+                    capacity: 3
+                    hypervisor_capacity: 3
                     total_capacity: 6
                     uom: Sockets
                   - sku: RH00010
@@ -958,8 +958,8 @@ paths:
                     next_event_date: "2020-04-02T00:00:00Z"
                     next_event_type: Subscription Begin
                     quantity: 3
-                    physical_capacity: 3
-                    virtual_capacity": 3
+                    capacity: 3
+                    hypervisor_capacity: 3
                     total_capacity": 6
                     uom: Sockets
                   - sku: RH00009
@@ -976,8 +976,8 @@ paths:
                     next_event_date: "2020-04-01T00:00:00Z"
                     next_event_type: Subscription End
                     quantity: 3
-                    physical_capacity: 6
-                    virtual_capacity: 6
+                    capacity: 6
+                    hypervisor_capacity: 6
                     total_capacity: 12
                     uom: Cores
                 meta:
@@ -1378,6 +1378,7 @@ components:
           type: boolean
           default: false
     CapacityReport:
+      deprecated: true
       properties:
         data:
           type: array
@@ -1432,6 +1433,7 @@ components:
             - product
             - granularity
     CapacitySnapshot:
+      deprecated: true
       required:
         - date
         - has_infinite_quantity
@@ -1809,16 +1811,16 @@ components:
           description: "The summed subscription quantities across the active subscriptions for the offering."
           type: integer
           format: int32
-        physical_capacity:
-          description: "The summed physical capacity of the unit-of-measure of the active subscriptions for the offering."
+        capacity:
+          description: "The summed standard capacity of the unit-of-measure of the active subscriptions for the offering."
           type: integer
           format: int32
-        virtual_capacity:
-          description: "The summed virutal capacity of the unit-of-measure of the active subscriptions for the offering."
+        hypervisor_capacity:
+          description: "The summed hypervisor capacity of the unit-of-measure of the active subscriptions for the offering."
           type: integer
           format: int32
         total_capacity:
-          description: "The combined (physical and virtual) capacity for the offering."
+          description: "The combined (standard and hypervisor) capacity for the offering."
           type: integer
           format: int32
         has_infinite_quantity:

--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -288,10 +288,10 @@ class UpstreamProductData {
     Integer sockets = nullOrInteger(attrs.get(Attr.SOCKET_LIMIT));
 
     /*
-    There are no SKUs today (2021-10-27) that provide both physical capacity and virtual capacity
+    There are no SKUs today (2021-10-27) that provide both standard capacity and hypervisor capacity
     at the same time. It is one or the other.
 
-    If there is no derived SKU, the set the physical capacities. Otherwise, set the virtual
+    If there is no derived SKU, the set the standard capacities. Otherwise, set the hypervisor
     capacities. Whenever there is a derived SKU, there are only engProds/content in the
     derived/derived-children SKUs.
 
@@ -299,11 +299,11 @@ class UpstreamProductData {
     */
 
     if (attrs.get(Attr.DERIVED_SKU) == null) {
-      offering.setPhysicalCores(cores);
-      offering.setPhysicalSockets(sockets);
+      offering.setCores(cores);
+      offering.setSockets(sockets);
     } else {
-      offering.setVirtualCores(cores);
-      offering.setVirtualSockets(sockets);
+      offering.setHypervisorCores(cores);
+      offering.setHypervisorSockets(sockets);
     }
     var hasUnlimitedCores =
         Optional.ofNullable(attrs.get(Attr.CORES))

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -345,18 +345,18 @@ public class CapacityResource implements CapacityApi {
 
     for (SubscriptionCapacity capacity : matches) {
       if (capacity.getBeginDate().isBefore(date) && capacity.getEndDate().isAfter(date)) {
-        int capacityVirtSockets = sanitize(capacity.getVirtualSockets());
+        int capacityVirtSockets = sanitize(capacity.getHypervisorSockets());
         sockets += capacityVirtSockets;
         hypervisorSockets += capacityVirtSockets;
 
-        int capacityPhysicalSockets = sanitize(capacity.getPhysicalSockets());
+        int capacityPhysicalSockets = sanitize(capacity.getSockets());
         sockets += capacityPhysicalSockets;
         physicalSockets += capacityPhysicalSockets;
-        int capacityPhysCores = sanitize(capacity.getPhysicalCores());
+        int capacityPhysCores = sanitize(capacity.getCores());
         cores += capacityPhysCores;
         physicalCores += capacityPhysCores;
 
-        int capacityVirtCores = sanitize(capacity.getVirtualCores());
+        int capacityVirtCores = sanitize(capacity.getHypervisorCores());
         cores += capacityVirtCores;
         hypervisorCores += capacityVirtCores;
 
@@ -408,12 +408,12 @@ public class CapacityResource implements CapacityApi {
     int value = 0;
     if (reportCategory.isPresent()) {
       if (reportCategory.get().equals(ReportCategory.PHYSICAL)) {
-        value += sanitize(capacity.getPhysicalSockets());
+        value += sanitize(capacity.getSockets());
       } else if (reportCategory.get().equals(ReportCategory.VIRTUAL)) {
-        value += sanitize(capacity.getVirtualSockets());
+        value += sanitize(capacity.getHypervisorSockets());
       }
     } else {
-      value += sanitize(capacity.getVirtualSockets()) + sanitize(capacity.getPhysicalSockets());
+      value += sanitize(capacity.getHypervisorSockets()) + sanitize(capacity.getSockets());
     }
     return value;
   }
@@ -423,12 +423,12 @@ public class CapacityResource implements CapacityApi {
     int value = 0;
     if (reportCategory.isPresent()) {
       if (reportCategory.get().equals(ReportCategory.PHYSICAL)) {
-        value += sanitize(capacity.getPhysicalCores());
+        value += sanitize(capacity.getCores());
       } else if (reportCategory.get().equals(ReportCategory.VIRTUAL)) {
-        value += sanitize(capacity.getVirtualCores());
+        value += sanitize(capacity.getHypervisorCores());
       }
     } else {
-      value += sanitize(capacity.getVirtualCores()) + sanitize(capacity.getPhysicalCores());
+      value += sanitize(capacity.getHypervisorCores()) + sanitize(capacity.getCores());
     }
     return value;
   }

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -253,8 +253,8 @@ public class SubscriptionTableController {
       inv.setUom(uom);
     }
     inv.setQuantity(0);
-    inv.setPhysicalCapacity(0);
-    inv.setVirtualCapacity(0);
+    inv.setCapacity(0);
+    inv.setHypervisorCapacity(0);
     inv.setTotalCapacity(0);
     inv.setSubscriptions(new ArrayList<>());
     return inv;
@@ -327,25 +327,25 @@ public class SubscriptionTableController {
         skuCapacity,
         subscriptionCapacityView);
 
-    var physicalSockets = subscriptionCapacityView.getPhysicalSockets();
-    var physicalCores = subscriptionCapacityView.getPhysicalCores();
-    var virtualSockets = subscriptionCapacityView.getVirtualSockets();
-    var virtualCores = subscriptionCapacityView.getVirtualCores();
+    var sockets = subscriptionCapacityView.getSockets();
+    var cores = subscriptionCapacityView.getCores();
+    var hypervisorSockets = subscriptionCapacityView.getHypervisorSockets();
+    var hypervisorCores = subscriptionCapacityView.getHypervisorCores();
     if (skuCapacity.getUom() == Uom.SOCKETS) {
-      skuCapacity.setPhysicalCapacity(skuCapacity.getPhysicalCapacity() + physicalSockets);
-      skuCapacity.setVirtualCapacity(skuCapacity.getVirtualCapacity() + virtualSockets);
+      skuCapacity.setCapacity(skuCapacity.getCapacity() + sockets);
+      skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + hypervisorSockets);
     } else if (skuCapacity.getUom() == Uom.CORES) {
-      skuCapacity.setPhysicalCapacity(skuCapacity.getPhysicalCapacity() + physicalCores);
-      skuCapacity.setVirtualCapacity(skuCapacity.getVirtualCapacity() + virtualCores);
-    } else if (physicalSockets != 0 || virtualSockets != 0) {
-      skuCapacity.setPhysicalCapacity(skuCapacity.getPhysicalCapacity() + physicalSockets);
-      skuCapacity.setVirtualCapacity(skuCapacity.getVirtualCapacity() + virtualSockets);
+      skuCapacity.setCapacity(skuCapacity.getCapacity() + cores);
+      skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + hypervisorCores);
+    } else if (sockets != 0 || hypervisorSockets != 0) {
+      skuCapacity.setCapacity(skuCapacity.getCapacity() + sockets);
+      skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + hypervisorSockets);
       if (skuCapacity.getUom() == null) {
         skuCapacity.setUom(Uom.SOCKETS);
       }
-    } else if (physicalCores != 0 || virtualCores != 0) {
-      skuCapacity.setPhysicalCapacity(skuCapacity.getPhysicalCapacity() + physicalCores);
-      skuCapacity.setVirtualCapacity(skuCapacity.getVirtualCapacity() + virtualCores);
+    } else if (cores != 0 || hypervisorCores != 0) {
+      skuCapacity.setCapacity(skuCapacity.getCapacity() + cores);
+      skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + hypervisorCores);
       if (skuCapacity.getUom() == null) {
         skuCapacity.setUom(Uom.CORES);
       }
@@ -354,8 +354,7 @@ public class SubscriptionTableController {
     boolean hasInfiniteQuantity =
         Optional.ofNullable(subscriptionCapacityView.getHasUnlimitedUsage()).orElse(false);
 
-    skuCapacity.setTotalCapacity(
-        skuCapacity.getPhysicalCapacity() + skuCapacity.getVirtualCapacity());
+    skuCapacity.setTotalCapacity(skuCapacity.getCapacity() + skuCapacity.getHypervisorCapacity());
     skuCapacity.setHasInfiniteQuantity(hasInfiniteQuantity);
   }
 

--- a/src/main/resources/liquibase/202211091649-rename-physical-virtual-cores-sockets-columns.xml
+++ b/src/main/resources/liquibase/202211091649-rename-physical-virtual-cores-sockets-columns.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202211091649-1" author="khowell">
+    <comment>Rename sockets/cores columns in the subscription_capacity table.</comment>
+    <renameColumn tableName="subscription_capacity" oldColumnName="physical_sockets" newColumnName="sockets"/>
+    <renameColumn tableName="subscription_capacity" oldColumnName="virtual_sockets" newColumnName="hypervisor_sockets"/>
+    <renameColumn tableName="subscription_capacity" oldColumnName="physical_cores" newColumnName="cores"/>
+    <renameColumn tableName="subscription_capacity" oldColumnName="virtual_cores" newColumnName="hypervisor_cores"/>
+  </changeSet>
+
+  <changeSet id="202211091649-2" author="khowell">
+    <comment>Rename sockets/cores columns in the offering table.</comment>
+    <renameColumn tableName="offering" oldColumnName="physical_sockets" newColumnName="sockets"/>
+    <renameColumn tableName="offering" oldColumnName="virtual_sockets" newColumnName="hypervisor_sockets"/>
+    <renameColumn tableName="offering" oldColumnName="physical_cores" newColumnName="cores"/>
+    <renameColumn tableName="offering" oldColumnName="virtual_cores" newColumnName="hypervisor_cores"/>
+  </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -89,5 +89,6 @@
     <include file="liquibase/202210281140-rename-owner-id-to-org-id.xml"/>
     <include file="liquibase/202211011504-drop-hardware-measurements-table.xml"/>
     <include file="liquibase/202211071027-change-account_services-pkey.xml"/>
+    <include file="liquibase/202211091649-rename-physical-virtual-cores-sockets-columns.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
@@ -114,12 +114,7 @@ class CapacityReconciliationControllerTest {
 
     Set<String> productIds = Set.of("RHEL", "RHEL Workstation");
     Offering updatedOffering =
-        Offering.builder()
-            .productIds(Set.of(45, 25))
-            .sku("MCT3718")
-            .physicalCores(20)
-            .physicalSockets(40)
-            .build();
+        Offering.builder().productIds(Set.of(45, 25)).sku("MCT3718").cores(20).sockets(40).build();
 
     Subscription updatedSubscription = createSubscription("456", 10);
 
@@ -132,8 +127,8 @@ class CapacityReconciliationControllerTest {
                         .orgId("123")
                         .productId("RHEL")
                         .build())
-                .physicalCores(10)
-                .physicalSockets(15)
+                .cores(10)
+                .sockets(15)
                 .build(),
             SubscriptionCapacity.builder()
                 .key(
@@ -142,8 +137,8 @@ class CapacityReconciliationControllerTest {
                         .orgId("123")
                         .productId("RHEL Workstation")
                         .build())
-                .physicalCores(10)
-                .physicalSockets(15)
+                .cores(10)
+                .sockets(15)
                 .build());
 
     List<SubscriptionCapacity> updatedCapacities =
@@ -181,8 +176,8 @@ class CapacityReconciliationControllerTest {
                         .orgId("123")
                         .productId("RHEL")
                         .build())
-                .physicalCores(10)
-                .physicalSockets(15)
+                .cores(10)
+                .sockets(15)
                 .build(),
             SubscriptionCapacity.builder()
                 .key(
@@ -191,8 +186,8 @@ class CapacityReconciliationControllerTest {
                         .orgId("123")
                         .productId("RHEL Workstation")
                         .build())
-                .physicalCores(10)
-                .physicalSockets(15)
+                .cores(10)
+                .sockets(15)
                 .build());
 
     when(allowlist.productIdMatches(any())).thenReturn(false);
@@ -246,8 +241,8 @@ class CapacityReconciliationControllerTest {
                         .orgId("123")
                         .productId("STALE RHEL")
                         .build())
-                .physicalCores(10)
-                .physicalSockets(15)
+                .cores(10)
+                .sockets(15)
                 .build(),
             SubscriptionCapacity.builder()
                 .key(
@@ -256,8 +251,8 @@ class CapacityReconciliationControllerTest {
                         .orgId("123")
                         .productId("STALE RHEL Workstation")
                         .build())
-                .physicalCores(10)
-                .physicalSockets(15)
+                .cores(10)
+                .sockets(15)
                 .build());
 
     when(allowlist.productIdMatches(any())).thenReturn(true);

--- a/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
@@ -49,8 +49,8 @@ class OfferingRepositoryTest {
     offering.setUsage(Usage.DEVELOPMENT_TEST);
     offering.setServiceLevel(ServiceLevel.PREMIUM);
     offering.setRole("test");
-    offering.setPhysicalCores(1);
-    offering.setPhysicalSockets(1);
+    offering.setCores(1);
+    offering.setSockets(1);
     offering.setProductFamily("test");
     offering.setProductName("test");
     offering.setDescription("test sku");

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepositoryTest.java
@@ -75,10 +75,10 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("account", capacity.getAccountNumber());
     assertEquals("product", capacity.getProductId());
     assertEquals("subscription", capacity.getSubscriptionId());
-    assertEquals(4, capacity.getPhysicalSockets().intValue());
-    assertEquals(20, capacity.getVirtualSockets().intValue());
-    assertEquals(8, capacity.getPhysicalCores().intValue());
-    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals(4, capacity.getSockets().intValue());
+    assertEquals(20, capacity.getHypervisorSockets().intValue());
+    assertEquals(8, capacity.getCores().intValue());
+    assertEquals(40, capacity.getHypervisorCores().intValue());
     assertEquals("orgId", capacity.getOrgId());
     assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
@@ -99,10 +99,10 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("account", capacity.getAccountNumber());
     assertEquals("product", capacity.getProductId());
     assertEquals("subscription", capacity.getSubscriptionId());
-    assertEquals(4, capacity.getPhysicalSockets().intValue());
-    assertEquals(20, capacity.getVirtualSockets().intValue());
-    assertEquals(8, capacity.getPhysicalCores().intValue());
-    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals(4, capacity.getSockets().intValue());
+    assertEquals(20, capacity.getHypervisorSockets().intValue());
+    assertEquals(8, capacity.getCores().intValue());
+    assertEquals(40, capacity.getHypervisorCores().intValue());
     assertEquals("orgId", capacity.getOrgId());
     assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
@@ -123,10 +123,10 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("account", capacity.getAccountNumber());
     assertEquals("product", capacity.getProductId());
     assertEquals("subscription", capacity.getSubscriptionId());
-    assertEquals(4, capacity.getPhysicalSockets().intValue());
-    assertEquals(20, capacity.getVirtualSockets().intValue());
-    assertEquals(8, capacity.getPhysicalCores().intValue());
-    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals(4, capacity.getSockets().intValue());
+    assertEquals(20, capacity.getHypervisorSockets().intValue());
+    assertEquals(8, capacity.getCores().intValue());
+    assertEquals(40, capacity.getHypervisorCores().intValue());
     assertEquals("orgId", capacity.getOrgId());
     assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
@@ -147,10 +147,10 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("account", capacity.getAccountNumber());
     assertEquals("product", capacity.getProductId());
     assertEquals("subscription", capacity.getSubscriptionId());
-    assertEquals(4, capacity.getPhysicalSockets().intValue());
-    assertEquals(20, capacity.getVirtualSockets().intValue());
-    assertEquals(8, capacity.getPhysicalCores().intValue());
-    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals(4, capacity.getSockets().intValue());
+    assertEquals(20, capacity.getHypervisorSockets().intValue());
+    assertEquals(8, capacity.getCores().intValue());
+    assertEquals(40, capacity.getHypervisorCores().intValue());
     assertEquals("orgId", capacity.getOrgId());
     assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
@@ -376,10 +376,10 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("account", capacity.getAccountNumber());
     assertEquals("product", capacity.getProductId());
     assertEquals("subscription", capacity.getSubscriptionId());
-    assertEquals(4, capacity.getPhysicalSockets().intValue());
-    assertEquals(20, capacity.getVirtualSockets().intValue());
-    assertEquals(8, capacity.getPhysicalCores().intValue());
-    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals(4, capacity.getSockets().intValue());
+    assertEquals(20, capacity.getHypervisorSockets().intValue());
+    assertEquals(8, capacity.getCores().intValue());
+    assertEquals(40, capacity.getHypervisorCores().intValue());
     assertEquals("orgId", capacity.getOrgId());
     assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
@@ -401,10 +401,10 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("account", capacity.getAccountNumber());
     assertEquals("product", capacity.getProductId());
     assertEquals("subscription", capacity.getSubscriptionId());
-    assertEquals(4, capacity.getPhysicalSockets().intValue());
-    assertEquals(20, capacity.getVirtualSockets().intValue());
-    assertEquals(8, capacity.getPhysicalCores().intValue());
-    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals(4, capacity.getSockets().intValue());
+    assertEquals(20, capacity.getHypervisorSockets().intValue());
+    assertEquals(8, capacity.getCores().intValue());
+    assertEquals(40, capacity.getHypervisorCores().intValue());
     assertEquals("orgId", capacity.getOrgId());
     assertEquals(NOWISH.minusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
@@ -426,10 +426,10 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("account", capacity.getAccountNumber());
     assertEquals("product", capacity.getProductId());
     assertEquals("subscription", capacity.getSubscriptionId());
-    assertEquals(4, capacity.getPhysicalSockets().intValue());
-    assertEquals(20, capacity.getVirtualSockets().intValue());
-    assertEquals(8, capacity.getPhysicalCores().intValue());
-    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals(4, capacity.getSockets().intValue());
+    assertEquals(20, capacity.getHypervisorSockets().intValue());
+    assertEquals(8, capacity.getCores().intValue());
+    assertEquals(40, capacity.getHypervisorCores().intValue());
     assertEquals("orgId", capacity.getOrgId());
     assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.minusDays(1), capacity.getEndDate());
@@ -451,10 +451,10 @@ class SubscriptionCapacityRepositoryTest {
     assertEquals("account", capacity.getAccountNumber());
     assertEquals("product", capacity.getProductId());
     assertEquals("subscription", capacity.getSubscriptionId());
-    assertEquals(4, capacity.getPhysicalSockets().intValue());
-    assertEquals(20, capacity.getVirtualSockets().intValue());
-    assertEquals(8, capacity.getPhysicalCores().intValue());
-    assertEquals(40, capacity.getVirtualCores().intValue());
+    assertEquals(4, capacity.getSockets().intValue());
+    assertEquals(20, capacity.getHypervisorSockets().intValue());
+    assertEquals(8, capacity.getCores().intValue());
+    assertEquals(40, capacity.getHypervisorCores().intValue());
     assertEquals("orgId", capacity.getOrgId());
     assertEquals(NOWISH.plusDays(1), capacity.getBeginDate());
     assertEquals(FAR_FUTURE.plusDays(1), capacity.getEndDate());
@@ -703,11 +703,11 @@ class SubscriptionCapacityRepositoryTest {
   void testFindByMetricIdOnlyRetrieveCoresCapacity() {
     SubscriptionCapacity cores = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     SubscriptionCapacity sockets = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    cores.setVirtualSockets(0);
-    cores.setPhysicalSockets(0);
+    cores.setHypervisorSockets(0);
+    cores.setSockets(0);
     cores.setSubscriptionId("cores");
-    sockets.setPhysicalCores(0);
-    sockets.setVirtualCores(0);
+    sockets.setCores(0);
+    sockets.setHypervisorCores(0);
     sockets.setSubscriptionId("sockets");
     repository.saveAll(Arrays.asList(cores, sockets));
     repository.flush();
@@ -723,25 +723,24 @@ class SubscriptionCapacityRepositoryTest {
             NOWISH,
             FAR_FUTURE);
     assertEquals(1, found.size());
-    assertEquals(8, found.get(0).getPhysicalCores());
-    assertEquals(40, found.get(0).getVirtualCores());
+    assertEquals(8, found.get(0).getCores());
+    assertEquals(40, found.get(0).getHypervisorCores());
   }
 
   @Test
-  void testFindByMetricIdOnlyRetrieveVirtualCoresCapacity() {
-    SubscriptionCapacity virtualCores =
+  void testFindByMetricIdOnlyRetrieveHypervisorCoresCapacity() {
+    SubscriptionCapacity hypervisorCores =
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    SubscriptionCapacity physicalCores =
-        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    virtualCores.setVirtualSockets(0);
-    virtualCores.setPhysicalSockets(0);
-    virtualCores.setPhysicalCores(0);
-    virtualCores.setSubscriptionId("virtualCores");
-    physicalCores.setPhysicalSockets(0);
-    physicalCores.setVirtualSockets(0);
-    physicalCores.setVirtualCores(0);
-    physicalCores.setSubscriptionId("physicalCores");
-    repository.saveAll(Arrays.asList(virtualCores, physicalCores));
+    SubscriptionCapacity cores = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    hypervisorCores.setHypervisorSockets(0);
+    hypervisorCores.setSockets(0);
+    hypervisorCores.setCores(0);
+    hypervisorCores.setSubscriptionId("hypervisorCores");
+    cores.setSockets(0);
+    cores.setHypervisorSockets(0);
+    cores.setHypervisorCores(0);
+    cores.setSubscriptionId("cores");
+    repository.saveAll(Arrays.asList(hypervisorCores, cores));
     repository.flush();
 
     List<SubscriptionCapacity> found =
@@ -756,24 +755,23 @@ class SubscriptionCapacityRepositoryTest {
             FAR_FUTURE);
 
     assertEquals(1, found.size());
-    assertEquals(40, found.get(0).getVirtualCores());
+    assertEquals(40, found.get(0).getHypervisorCores());
   }
 
   @Test
-  void testFindByMetricIdOnlyRetrievePhysicalCoresCapacity() {
-    SubscriptionCapacity virtualCores =
+  void testFindByMetricIdOnlyRetrieveStandardCoresCapacity() {
+    SubscriptionCapacity hypervisorCores =
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    SubscriptionCapacity physicalCores =
-        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    virtualCores.setVirtualSockets(0);
-    virtualCores.setPhysicalSockets(0);
-    virtualCores.setPhysicalCores(0);
-    virtualCores.setSubscriptionId("virtualCores");
-    physicalCores.setPhysicalSockets(0);
-    physicalCores.setVirtualSockets(0);
-    physicalCores.setVirtualCores(0);
-    physicalCores.setSubscriptionId("physicalCores");
-    repository.saveAll(Arrays.asList(virtualCores, physicalCores));
+    SubscriptionCapacity cores = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    hypervisorCores.setHypervisorSockets(0);
+    hypervisorCores.setSockets(0);
+    hypervisorCores.setCores(0);
+    hypervisorCores.setSubscriptionId("hypervisorCores");
+    cores.setSockets(0);
+    cores.setHypervisorSockets(0);
+    cores.setHypervisorCores(0);
+    cores.setSubscriptionId("cores");
+    repository.saveAll(Arrays.asList(hypervisorCores, cores));
     repository.flush();
 
     List<SubscriptionCapacity> found =
@@ -788,18 +786,18 @@ class SubscriptionCapacityRepositoryTest {
             FAR_FUTURE);
 
     assertEquals(1, found.size());
-    assertEquals(8, found.get(0).getPhysicalCores());
+    assertEquals(8, found.get(0).getCores());
   }
 
   @Test
   void testFindByMetricIdOnlyRetrieveSocketsCapacity() {
     SubscriptionCapacity cores = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     SubscriptionCapacity sockets = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    cores.setVirtualSockets(0);
-    cores.setPhysicalSockets(0);
+    cores.setHypervisorSockets(0);
+    cores.setSockets(0);
     cores.setSubscriptionId("cores");
-    sockets.setPhysicalCores(0);
-    sockets.setVirtualCores(0);
+    sockets.setCores(0);
+    sockets.setHypervisorCores(0);
     sockets.setSubscriptionId("sockets");
     repository.saveAll(Arrays.asList(cores, sockets));
     repository.flush();
@@ -815,25 +813,24 @@ class SubscriptionCapacityRepositoryTest {
             NOWISH,
             FAR_FUTURE);
     assertEquals(1, found.size());
-    assertEquals(4, found.get(0).getPhysicalSockets());
-    assertEquals(20, found.get(0).getVirtualSockets());
+    assertEquals(4, found.get(0).getSockets());
+    assertEquals(20, found.get(0).getHypervisorSockets());
   }
 
   @Test
-  void testFindByMetricIdOnlyRetrieveVirtualSocketsCapacity() {
-    SubscriptionCapacity virtualSockets =
+  void testFindByMetricIdOnlyRetrieveHypervisorSocketsCapacity() {
+    SubscriptionCapacity hypervisorSockets =
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    SubscriptionCapacity physicalSockets =
-        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    virtualSockets.setVirtualCores(0);
-    virtualSockets.setPhysicalSockets(0);
-    virtualSockets.setPhysicalCores(0);
-    virtualSockets.setSubscriptionId("virtualSockets");
-    physicalSockets.setPhysicalCores(0);
-    physicalSockets.setVirtualSockets(0);
-    physicalSockets.setVirtualCores(0);
-    physicalSockets.setSubscriptionId("physicalSockets");
-    repository.saveAll(Arrays.asList(virtualSockets, physicalSockets));
+    SubscriptionCapacity sockets = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    hypervisorSockets.setHypervisorCores(0);
+    hypervisorSockets.setSockets(0);
+    hypervisorSockets.setCores(0);
+    hypervisorSockets.setSubscriptionId("hypervisorSockets");
+    sockets.setCores(0);
+    sockets.setHypervisorSockets(0);
+    sockets.setHypervisorCores(0);
+    sockets.setSubscriptionId("sockets");
+    repository.saveAll(Arrays.asList(hypervisorSockets, sockets));
     repository.flush();
 
     List<SubscriptionCapacity> found =
@@ -848,24 +845,23 @@ class SubscriptionCapacityRepositoryTest {
             FAR_FUTURE);
 
     assertEquals(1, found.size());
-    assertEquals(20, found.get(0).getVirtualSockets());
+    assertEquals(20, found.get(0).getHypervisorSockets());
   }
 
   @Test
-  void testFindByMetricIdOnlyRetrievePhysicalSocketsCapacity() {
-    SubscriptionCapacity virtualSockets =
+  void testFindByMetricIdOnlyRetrieveStandardSocketsCapacity() {
+    SubscriptionCapacity hypervisorSockets =
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    SubscriptionCapacity physicalSockets =
-        createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
-    virtualSockets.setVirtualCores(0);
-    virtualSockets.setPhysicalSockets(0);
-    virtualSockets.setPhysicalCores(0);
-    virtualSockets.setSubscriptionId("virtualSockets");
-    physicalSockets.setPhysicalCores(0);
-    physicalSockets.setVirtualSockets(0);
-    physicalSockets.setVirtualCores(0);
-    physicalSockets.setSubscriptionId("physicalSockets");
-    repository.saveAll(Arrays.asList(virtualSockets, physicalSockets));
+    SubscriptionCapacity sockets = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
+    hypervisorSockets.setHypervisorCores(0);
+    hypervisorSockets.setSockets(0);
+    hypervisorSockets.setCores(0);
+    hypervisorSockets.setSubscriptionId("hypervisorSockets");
+    sockets.setCores(0);
+    sockets.setHypervisorSockets(0);
+    sockets.setHypervisorCores(0);
+    sockets.setSubscriptionId("sockets");
+    repository.saveAll(Arrays.asList(hypervisorSockets, sockets));
     repository.flush();
 
     List<SubscriptionCapacity> found =
@@ -880,7 +876,7 @@ class SubscriptionCapacityRepositoryTest {
             FAR_FUTURE);
 
     assertEquals(1, found.size());
-    assertEquals(4, found.get(0).getPhysicalSockets());
+    assertEquals(4, found.get(0).getSockets());
   }
 
   private SubscriptionCapacity createUnpersisted(OffsetDateTime begin, OffsetDateTime end) {
@@ -892,10 +888,10 @@ class SubscriptionCapacityRepositoryTest {
     capacity.setEndDate(end);
     capacity.setHasUnlimitedUsage(false);
     capacity.setOrgId("orgId");
-    capacity.setPhysicalSockets(4);
-    capacity.setVirtualSockets(20);
-    capacity.setPhysicalCores(8);
-    capacity.setVirtualCores(40);
+    capacity.setSockets(4);
+    capacity.setHypervisorSockets(20);
+    capacity.setCores(8);
+    capacity.setHypervisorCores(40);
     capacity.setServiceLevel(ServiceLevel.PREMIUM);
     capacity.setUsage(Usage.PRODUCTION);
     return capacity;

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepositoryTest.java
@@ -354,25 +354,25 @@ class SubscriptionCapacityViewRepositoryTest {
   void shouldMatchCapacityWithCoresIfSpecified() {
     SubscriptionCapacity sockets = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     sockets.setSubscriptionId("sockets");
-    sockets.setPhysicalSockets(10);
-    sockets.setVirtualSockets(10);
-    sockets.setPhysicalCores(null);
-    sockets.setVirtualCores(null);
+    sockets.setSockets(10);
+    sockets.setHypervisorSockets(10);
+    sockets.setCores(null);
+    sockets.setHypervisorCores(null);
 
     SubscriptionCapacity cores = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     cores.setSubscriptionId("cores");
-    cores.setPhysicalCores(10);
-    cores.setVirtualCores(10);
-    cores.setPhysicalSockets(null);
-    cores.setVirtualSockets(null);
+    cores.setCores(10);
+    cores.setHypervisorCores(10);
+    cores.setSockets(null);
+    cores.setHypervisorSockets(null);
 
     SubscriptionCapacity socketsAndCores =
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     socketsAndCores.setSubscriptionId("socketsAndCores");
-    socketsAndCores.setPhysicalCores(10);
-    socketsAndCores.setVirtualCores(null);
-    socketsAndCores.setPhysicalSockets(10);
-    socketsAndCores.setVirtualSockets(10);
+    socketsAndCores.setCores(10);
+    socketsAndCores.setHypervisorCores(null);
+    socketsAndCores.setSockets(10);
+    socketsAndCores.setHypervisorSockets(10);
 
     subscriptionRepository.saveAllAndFlush(
         List.of(
@@ -411,8 +411,8 @@ class SubscriptionCapacityViewRepositoryTest {
     assertEquals(2, found.size());
     found.forEach(
         subscriptionCapacityView -> {
-          assertNotNull(subscriptionCapacityView.getPhysicalCores());
-          assertNotNull(subscriptionCapacityView.getVirtualCores());
+          assertNotNull(subscriptionCapacityView.getCores());
+          assertNotNull(subscriptionCapacityView.getHypervisorCores());
         });
   }
 
@@ -421,26 +421,26 @@ class SubscriptionCapacityViewRepositoryTest {
   void shouldFilterCapacityByCategory() {
     SubscriptionCapacity hypervisor = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     hypervisor.setSubscriptionId("hypervisor");
-    hypervisor.setPhysicalSockets(10);
-    hypervisor.setVirtualSockets(10);
-    hypervisor.setPhysicalCores(10);
-    hypervisor.setVirtualCores(10);
+    hypervisor.setSockets(10);
+    hypervisor.setHypervisorSockets(10);
+    hypervisor.setCores(10);
+    hypervisor.setHypervisorCores(10);
 
     SubscriptionCapacity nonHypervisor =
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     nonHypervisor.setSubscriptionId("nonHypervisor");
-    nonHypervisor.setPhysicalSockets(10);
-    nonHypervisor.setVirtualSockets(0);
-    nonHypervisor.setPhysicalCores(10);
-    nonHypervisor.setVirtualCores(0);
+    nonHypervisor.setSockets(10);
+    nonHypervisor.setHypervisorSockets(0);
+    nonHypervisor.setCores(10);
+    nonHypervisor.setHypervisorCores(0);
 
     SubscriptionCapacity noCoresNonHypervisor =
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     noCoresNonHypervisor.setSubscriptionId("noCoresNonHypervisor");
-    noCoresNonHypervisor.setPhysicalSockets(10);
-    noCoresNonHypervisor.setVirtualSockets(0);
-    noCoresNonHypervisor.setPhysicalCores(0);
-    noCoresNonHypervisor.setVirtualCores(0);
+    noCoresNonHypervisor.setSockets(10);
+    noCoresNonHypervisor.setHypervisorSockets(0);
+    noCoresNonHypervisor.setCores(0);
+    noCoresNonHypervisor.setHypervisorCores(0);
 
     subscriptionRepository.saveAllAndFlush(
         List.of(
@@ -475,14 +475,10 @@ class SubscriptionCapacityViewRepositoryTest {
             ORG_ID, NON_HYPERVISOR, PRODUCT_ID, null, null, NOWISH, FAR_FUTURE.plusDays(4), null);
     assertEquals(2, results.size());
     assertThat(
-        results.stream()
-            .map(SubscriptionCapacityView::getPhysicalCores)
-            .collect(Collectors.toList()),
+        results.stream().map(SubscriptionCapacityView::getCores).collect(Collectors.toList()),
         containsInAnyOrder(0, 10));
     assertThat(
-        results.stream()
-            .map(SubscriptionCapacityView::getPhysicalSockets)
-            .collect(Collectors.toList()),
+        results.stream().map(SubscriptionCapacityView::getSockets).collect(Collectors.toList()),
         everyItem(Matchers.equalTo(10)));
 
     results =
@@ -492,8 +488,8 @@ class SubscriptionCapacityViewRepositoryTest {
     var record = results.get(0);
     assertAll(
         () -> {
-          assertEquals(10, record.getVirtualCores());
-          assertEquals(10, record.getVirtualSockets());
+          assertEquals(10, record.getHypervisorCores());
+          assertEquals(10, record.getHypervisorSockets());
         });
 
     results =
@@ -511,25 +507,25 @@ class SubscriptionCapacityViewRepositoryTest {
   void shouldMatchCapacityWithSocketsIfSpecified() {
     SubscriptionCapacity sockets = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     sockets.setSubscriptionId("sockets");
-    sockets.setPhysicalSockets(10);
-    sockets.setVirtualSockets(10);
-    sockets.setPhysicalCores(null);
-    sockets.setVirtualCores(null);
+    sockets.setSockets(10);
+    sockets.setHypervisorSockets(10);
+    sockets.setCores(null);
+    sockets.setHypervisorCores(null);
 
     SubscriptionCapacity cores = createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     cores.setSubscriptionId("cores");
-    cores.setPhysicalCores(10);
-    cores.setVirtualCores(10);
-    cores.setPhysicalSockets(null);
-    cores.setVirtualSockets(null);
+    cores.setCores(10);
+    cores.setHypervisorCores(10);
+    cores.setSockets(null);
+    cores.setHypervisorSockets(null);
 
     SubscriptionCapacity socketsAndCores =
         createUnpersisted(NOWISH.plusDays(1), FAR_FUTURE.plusDays(1));
     socketsAndCores.setSubscriptionId("socketsAndCores");
-    socketsAndCores.setPhysicalCores(10);
-    socketsAndCores.setVirtualCores(10);
-    socketsAndCores.setPhysicalSockets(10);
-    socketsAndCores.setVirtualSockets(null);
+    socketsAndCores.setCores(10);
+    socketsAndCores.setHypervisorCores(10);
+    socketsAndCores.setSockets(10);
+    socketsAndCores.setHypervisorSockets(null);
 
     subscriptionRepository.saveAllAndFlush(
         List.of(
@@ -567,8 +563,8 @@ class SubscriptionCapacityViewRepositoryTest {
     assertEquals(2, found.size());
     found.forEach(
         subscriptionCapacityView -> {
-          assertNotNull(subscriptionCapacityView.getPhysicalSockets());
-          assertNotNull(subscriptionCapacityView.getVirtualSockets());
+          assertNotNull(subscriptionCapacityView.getSockets());
+          assertNotNull(subscriptionCapacityView.getHypervisorSockets());
         });
   }
 
@@ -614,10 +610,10 @@ class SubscriptionCapacityViewRepositoryTest {
     capacity.setEndDate(end);
     capacity.setHasUnlimitedUsage(false);
     capacity.setOrgId(ORG_ID);
-    capacity.setPhysicalSockets(4);
-    capacity.setVirtualSockets(20);
-    capacity.setPhysicalCores(8);
-    capacity.setVirtualCores(40);
+    capacity.setSockets(4);
+    capacity.setHypervisorSockets(20);
+    capacity.setCores(8);
+    capacity.setHypervisorCores(40);
     capacity.setServiceLevel(ServiceLevel.PREMIUM);
     capacity.setUsage(Usage.PRODUCTION);
     capacity.setSku(TEST_SKU);

--- a/src/test/java/org/candlepin/subscriptions/db/model/OfferingTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/OfferingTest.java
@@ -38,10 +38,10 @@ class OfferingTest {
     offering.setUsage(Usage.DEVELOPMENT_TEST);
     offering.setServiceLevel(ServiceLevel.PREMIUM);
     offering.setRole("testrole");
-    offering.setPhysicalCores(2);
-    offering.setPhysicalSockets(3);
-    offering.setVirtualCores(4);
-    offering.setVirtualSockets(5);
+    offering.setCores(2);
+    offering.setSockets(3);
+    offering.setHypervisorCores(4);
+    offering.setHypervisorSockets(5);
     offering.setProductFamily("testproductfamily");
     offering.setProductName("testproductname");
     assertEquals("testsku", offering.getSku());
@@ -50,10 +50,10 @@ class OfferingTest {
     assertEquals(Usage.DEVELOPMENT_TEST, offering.getUsage());
     assertEquals(ServiceLevel.PREMIUM, offering.getServiceLevel());
     assertEquals("testrole", offering.getRole());
-    assertEquals(2, offering.getPhysicalCores());
-    assertEquals(3, offering.getPhysicalSockets());
-    assertEquals(4, offering.getVirtualCores());
-    assertEquals(5, offering.getVirtualSockets());
+    assertEquals(2, offering.getCores());
+    assertEquals(3, offering.getSockets());
+    assertEquals(4, offering.getHypervisorCores());
+    assertEquals(5, offering.getHypervisorSockets());
     assertEquals("testproductfamily", offering.getProductFamily());
     assertEquals("testproductname", offering.getProductName());
   }

--- a/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/UpstreamProductDataTest.java
@@ -81,17 +81,17 @@ class UpstreamProductDataTest {
     assertEquals(expected, actual);
   }
 
-  /** Valid given MW00330 sku with core value set to 16, physical core value is 16 */
+  /** Valid given MW00330 sku with core value set to 16, standard core value is 16 */
   @Test
-  void testOfferingFromUpstreamOpenShiftPhysicalCores() {
+  void testOfferingFromUpstreamOpenShiftStandardCores() {
     // Given an Openshift SKU that exists upstream,
     var sku = "MW00330";
 
-    // When given the result of a physical,
+    // When given the result of a standard,
     var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
 
     // Then cores equals 16
-    assertEquals(16, actual.getPhysicalCores());
+    assertEquals(16, actual.getCores());
   }
 
   @Test
@@ -108,9 +108,10 @@ class UpstreamProductDataTest {
         Set.of(
             69, 70, 83, 84, 86, 91, 92, 93, 127, 176, 180, 182, 201, 205, 240, 241, 246, 248, 317,
             318, 394, 395, 408, 479, 491, 588));
-    // (because there is a derived sku, no physical capacity should be set, only virtual capacity.
-    // See https://issues.redhat.com/browse/ENT-4301?focusedCommentId=19210665 for details)
-    expected.setVirtualSockets(2);
+    // (because there is a derived sku, no standard capacity should be set, only hypervisor
+    // capacity. See https://issues.redhat.com/browse/ENT-4301?focusedCommentId=19210665 for
+    // details)
+    expected.setHypervisorSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
     expected.setProductName("RHEL for SAP HANA");
     expected.setDescription(
@@ -124,7 +125,7 @@ class UpstreamProductDataTest {
     // When getting the upstream Offering,
     var actual = UpstreamProductData.offeringFromUpstream(sku, stub).orElseThrow();
 
-    // Then the resulting Offering has the expected virtual sockets from derived sku,
+    // Then the resulting Offering has the expected hypervisor sockets from derived sku,
     // and engOIDs from the derived sku child.
     assertEquals(expected, actual);
   }
@@ -143,7 +144,7 @@ class UpstreamProductDataTest {
             69, 70, 84, 86, 91, 92, 93, 94, 127, 133, 176, 180, 182, 201, 205, 240, 246, 271, 272,
             273, 274, 317, 318, 394, 395, 408, 479, 491, 588, 605));
     expected.setRole("Red Hat Enterprise Linux Server");
-    expected.setPhysicalSockets(2);
+    expected.setSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
     expected.setProductName("RHEL Server");
     expected.setDescription(
@@ -173,8 +174,8 @@ class UpstreamProductDataTest {
             68, 69, 70, 71, 83, 84, 85, 86, 90, 91, 92, 93, 132, 133, 172, 176, 179, 180, 190, 201,
             202, 203, 205, 206, 207, 240, 242, 244, 246, 273, 274, 287, 293, 317, 318, 342, 343,
             394, 395, 396, 397, 408, 479, 491, 588));
-    expected.setPhysicalCores(4); // Because IFL is 1 which gets multiplied by magical constant 4
-    expected.setPhysicalSockets(2);
+    expected.setCores(4); // Because IFL is 1 which gets multiplied by magical constant 4
+    expected.setSockets(2);
     expected.setProductFamily("Red Hat Enterprise Linux");
     expected.setProductName("RHEL Developer Workstation");
     expected.setDescription("Red Hat Enterprise Linux Developer Workstation, Enterprise");

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -170,18 +170,18 @@ class CapacityResourceTest {
   @Test
   void testShouldCalculateCapacityBasedOnMultipleSubscriptions() {
     SubscriptionCapacity capacity = new SubscriptionCapacity();
-    capacity.setVirtualSockets(5);
-    capacity.setPhysicalSockets(2);
-    capacity.setVirtualCores(20);
-    capacity.setPhysicalCores(8);
+    capacity.setHypervisorSockets(5);
+    capacity.setSockets(2);
+    capacity.setHypervisorCores(20);
+    capacity.setCores(8);
     capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity.setEndDate(max);
 
     SubscriptionCapacity capacity2 = new SubscriptionCapacity();
-    capacity2.setVirtualSockets(7);
-    capacity2.setPhysicalSockets(11);
-    capacity2.setVirtualCores(14);
-    capacity2.setPhysicalCores(22);
+    capacity2.setHypervisorSockets(7);
+    capacity2.setSockets(11);
+    capacity2.setHypervisorCores(14);
+    capacity2.setCores(22);
     capacity2.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity2.setEndDate(max);
 
@@ -475,18 +475,18 @@ class CapacityResourceTest {
   @Test
   void testReportByMetricIdShouldCalculateCapacityBasedOnMultipleSubscriptions() {
     SubscriptionCapacity capacity = new SubscriptionCapacity();
-    capacity.setVirtualSockets(5);
-    capacity.setPhysicalSockets(2);
-    capacity.setVirtualCores(20);
-    capacity.setPhysicalCores(8);
+    capacity.setHypervisorSockets(5);
+    capacity.setSockets(2);
+    capacity.setHypervisorCores(20);
+    capacity.setCores(8);
     capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity.setEndDate(max);
 
     SubscriptionCapacity capacity2 = new SubscriptionCapacity();
-    capacity2.setVirtualSockets(7);
-    capacity2.setPhysicalSockets(11);
-    capacity2.setVirtualCores(14);
-    capacity2.setPhysicalCores(22);
+    capacity2.setHypervisorSockets(7);
+    capacity2.setSockets(11);
+    capacity2.setHypervisorCores(14);
+    capacity2.setCores(22);
     capacity2.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity2.setEndDate(max);
 
@@ -505,10 +505,10 @@ class CapacityResourceTest {
   @Test
   void testReportByMetricIdShouldCalculateCapacityAllSockets() {
     SubscriptionCapacity capacity = new SubscriptionCapacity();
-    capacity.setVirtualSockets(5);
-    capacity.setPhysicalSockets(2);
-    capacity.setVirtualCores(20);
-    capacity.setPhysicalCores(8);
+    capacity.setHypervisorSockets(5);
+    capacity.setSockets(2);
+    capacity.setHypervisorCores(20);
+    capacity.setCores(8);
     capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity.setEndDate(max);
 
@@ -527,10 +527,10 @@ class CapacityResourceTest {
   @Test
   void testReportByMetricIdShouldCalculateCapacityVirtualSockets() {
     SubscriptionCapacity capacity = new SubscriptionCapacity();
-    capacity.setVirtualSockets(5);
-    capacity.setPhysicalSockets(2);
-    capacity.setVirtualCores(20);
-    capacity.setPhysicalCores(8);
+    capacity.setHypervisorSockets(5);
+    capacity.setSockets(2);
+    capacity.setHypervisorCores(20);
+    capacity.setCores(8);
     capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity.setEndDate(max);
 
@@ -565,10 +565,10 @@ class CapacityResourceTest {
   @Test
   void testReportByMetricIdShouldCalculateCapacityPhysicalSockets() {
     SubscriptionCapacity capacity = new SubscriptionCapacity();
-    capacity.setVirtualSockets(5);
-    capacity.setPhysicalSockets(2);
-    capacity.setVirtualCores(20);
-    capacity.setPhysicalCores(8);
+    capacity.setHypervisorSockets(5);
+    capacity.setSockets(2);
+    capacity.setHypervisorCores(20);
+    capacity.setCores(8);
     capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity.setEndDate(max);
 
@@ -603,10 +603,10 @@ class CapacityResourceTest {
   @Test
   void testReportByMetricIdShouldCalculateCapacityAllCores() {
     SubscriptionCapacity capacity = new SubscriptionCapacity();
-    capacity.setVirtualSockets(5);
-    capacity.setPhysicalSockets(2);
-    capacity.setVirtualCores(20);
-    capacity.setPhysicalCores(8);
+    capacity.setHypervisorSockets(5);
+    capacity.setSockets(2);
+    capacity.setHypervisorCores(20);
+    capacity.setCores(8);
     capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity.setEndDate(max);
 
@@ -625,10 +625,10 @@ class CapacityResourceTest {
   @Test
   void testReportByMetricIdShouldCalculateCapacityVirtualCores() {
     SubscriptionCapacity capacity = new SubscriptionCapacity();
-    capacity.setVirtualSockets(5);
-    capacity.setPhysicalSockets(2);
-    capacity.setVirtualCores(20);
-    capacity.setPhysicalCores(8);
+    capacity.setHypervisorSockets(5);
+    capacity.setSockets(2);
+    capacity.setHypervisorCores(20);
+    capacity.setCores(8);
     capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity.setEndDate(max);
 
@@ -663,10 +663,10 @@ class CapacityResourceTest {
   @Test
   void testReportByMetricIdShouldCalculateCapacityPhysicalCores() {
     SubscriptionCapacity capacity = new SubscriptionCapacity();
-    capacity.setVirtualSockets(5);
-    capacity.setPhysicalSockets(2);
-    capacity.setVirtualCores(20);
-    capacity.setPhysicalCores(8);
+    capacity.setHypervisorSockets(5);
+    capacity.setSockets(2);
+    capacity.setHypervisorCores(20);
+    capacity.setCores(8);
     capacity.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     capacity.setEndDate(max);
 
@@ -816,7 +816,7 @@ class CapacityResourceTest {
   static Stream<Arguments> usageLists() {
     SubscriptionCapacity limited = new SubscriptionCapacity();
     limited.setHasUnlimitedUsage(false);
-    limited.setPhysicalCores(4);
+    limited.setCores(4);
     limited.setBeginDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
     limited.setEndDate(max);
     SubscriptionCapacity unlimited = new SubscriptionCapacity();

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerOnDemandTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerOnDemandTest.java
@@ -541,10 +541,10 @@ class SubscriptionTableControllerOnDemandTest {
     // Fields in this section specify the Offering used in the SubscriptionCapacity.
     private final String sku;
     private final String productName;
-    private final Integer physicalSockets;
-    private final Integer physicalCores;
-    private final Integer virtualSockets;
-    private final Integer virtualCores;
+    private final Integer sockets;
+    private final Integer cores;
+    private final Integer hypervisorSockets;
+    private final Integer hypervisorCores;
     private final ServiceLevel serviceLevel;
     private final Usage usage;
     private final boolean hasUnlimitedUsage;
@@ -552,20 +552,20 @@ class SubscriptionTableControllerOnDemandTest {
     private SubCapSpec(
         String sku,
         String productName,
-        Integer physicalSockets,
-        Integer physicalCores,
-        Integer virtualSockets,
-        Integer virtualCores,
+        Integer sockets,
+        Integer cores,
+        Integer hypervisorSockets,
+        Integer hypervisorCores,
         ServiceLevel serviceLevel,
         Usage usage,
         boolean hasUnlimitedUsage,
         Sub sub) {
       this.sku = sku;
       this.productName = productName;
-      this.physicalSockets = physicalSockets;
-      this.physicalCores = physicalCores;
-      this.virtualSockets = virtualSockets;
-      this.virtualCores = virtualCores;
+      this.sockets = sockets;
+      this.cores = cores;
+      this.hypervisorSockets = hypervisorSockets;
+      this.hypervisorCores = hypervisorCores;
       this.serviceLevel = serviceLevel;
       this.usage = usage;
       this.hasUnlimitedUsage = hasUnlimitedUsage;
@@ -580,20 +580,20 @@ class SubscriptionTableControllerOnDemandTest {
     public static SubCapSpec offering(
         String sku,
         String productName,
-        Integer physicalSockets,
-        Integer physicalCores,
-        Integer virtualSockets,
-        Integer virtualCores,
+        Integer sockets,
+        Integer cores,
+        Integer hypervisorSockets,
+        Integer hypervisorCores,
         ServiceLevel serviceLevel,
         Usage usage,
         Boolean hasUnlimitedUsage) {
       return new SubCapSpec(
           sku,
           productName,
-          physicalSockets,
-          physicalCores,
-          virtualSockets,
-          virtualCores,
+          sockets,
+          cores,
+          hypervisorSockets,
+          hypervisorCores,
           serviceLevel,
           usage,
           hasUnlimitedUsage,
@@ -607,10 +607,10 @@ class SubscriptionTableControllerOnDemandTest {
       return new SubCapSpec(
           sku,
           productName,
-          physicalSockets,
-          physicalCores,
-          virtualSockets,
-          virtualCores,
+          sockets,
+          cores,
+          hypervisorSockets,
+          hypervisorCores,
           serviceLevel,
           usage,
           hasUnlimitedUsage,

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -119,10 +119,10 @@ class SubscriptionTableControllerTest {
           ServiceLevel.STANDARD,
           Usage.PRODUCTION,
           true);
-  private static final SubCapSpec RH0180196_VIRTUAL_SOCKETS =
+  private static final SubCapSpec RH0180196_HYPERVISOR_SOCKETS =
       SubCapSpec.offering(
           "RH0180196", "RHEL Server", 0, 0, 2, 0, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
-  private static final SubCapSpec RH0180197_VIRTUAL_CORES =
+  private static final SubCapSpec RH0180197_HYPERVISOR_CORES =
       SubCapSpec.offering(
           "RH0180197", "RHEL Server", 0, 0, 0, 2, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
 
@@ -751,13 +751,13 @@ class SubscriptionTableControllerTest {
   }
 
   @Test
-  void testGetSkuCapacityReportVirtualSocketsOnly() {
-    // Given an org with one active sub with a quantity of 4 and has an eng product with a virtual
-    // socket capacity of 2,
+  void testGetSkuCapacityReportHypervisorSocketsOnly() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a
+    // hypervisor socket capacity of 2,
     ProductId productId = RHEL_SERVER;
     Sub expectedSub = Sub.sub("1234", "1235", 4);
     List<SubscriptionCapacityView> givenCapacities =
-        givenCapacities(Org.STANDARD, productId, RH0180196_VIRTUAL_SOCKETS.withSub(expectedSub));
+        givenCapacities(Org.STANDARD, productId, RH0180196_HYPERVISOR_SOCKETS.withSub(expectedSub));
 
     when(subscriptionCapacityViewRepository.findAllBy(
             any(), any(), anyString(), any(), any(), any(), any(), any()))
@@ -772,18 +772,18 @@ class SubscriptionTableControllerTest {
     // quantity and capacities.
     assertEquals(1, actual.getData().size(), "Wrong number of items returned");
     SkuCapacity actualItem = actual.getData().get(0);
-    assertEquals(RH0180196_VIRTUAL_SOCKETS.sku, actualItem.getSku(), "Wrong SKU");
+    assertEquals(RH0180196_HYPERVISOR_SOCKETS.sku, actualItem.getSku(), "Wrong SKU");
     assertCapacities(0, 8, Uom.SOCKETS, actualItem);
   }
 
   @Test
-  void testGetSkuCapacityReportVirtualCoresOnly() {
-    // Given an org with one active sub with a quantity of 4 and has an eng product with a virtual
-    // socket capacity of 2,
+  void testGetSkuCapacityReportHypervisorCoresOnly() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a
+    // hypervisor socket capacity of 2,
     ProductId productId = RHEL_SERVER;
     Sub expectedSub = Sub.sub("1234", "1235", 4);
     List<SubscriptionCapacityView> givenCapacities =
-        givenCapacities(Org.STANDARD, productId, RH0180197_VIRTUAL_CORES.withSub(expectedSub));
+        givenCapacities(Org.STANDARD, productId, RH0180197_HYPERVISOR_CORES.withSub(expectedSub));
 
     when(subscriptionCapacityViewRepository.findAllBy(
             any(), any(), anyString(), any(), any(), any(), any(), any()))
@@ -798,17 +798,16 @@ class SubscriptionTableControllerTest {
     // quantity and capacities.
     assertEquals(1, actual.getData().size(), "Wrong number of items returned");
     SkuCapacity actualItem = actual.getData().get(0);
-    assertEquals(RH0180197_VIRTUAL_CORES.sku, actualItem.getSku(), "Wrong SKU");
+    assertEquals(RH0180197_HYPERVISOR_CORES.sku, actualItem.getSku(), "Wrong SKU");
     assertCapacities(0, 8, Uom.CORES, actualItem);
   }
 
   private static void assertCapacities(
-      int expectedPhysCap, int expectedVirtCap, Uom expectedUom, SkuCapacity actual) {
+      int expectedCap, int expectedHypCap, Uom expectedUom, SkuCapacity actual) {
     assertEquals(expectedUom, actual.getUom(), "Wrong UOM");
-    assertEquals(expectedPhysCap, actual.getPhysicalCapacity(), "Wrong Physical Capacity");
-    assertEquals(expectedVirtCap, actual.getVirtualCapacity(), "Wrong Virtual Capacity");
-    assertEquals(
-        expectedPhysCap + expectedVirtCap, actual.getTotalCapacity(), "Wrong Total Capacity");
+    assertEquals(expectedCap, actual.getCapacity(), "Wrong Standard Capacity");
+    assertEquals(expectedHypCap, actual.getHypervisorCapacity(), "Wrong Hypervisor Capacity");
+    assertEquals(expectedCap + expectedHypCap, actual.getTotalCapacity(), "Wrong Total Capacity");
   }
 
   private static void assertSubscription(Sub expectedSub, SkuCapacitySubscription actual) {
@@ -854,10 +853,10 @@ class SubscriptionTableControllerTest {
     // Fields in this section specify the Offering used in the SubscriptionCapacity.
     private final String sku;
     private final String productName;
-    private final Integer physicalSockets;
-    private final Integer physicalCores;
-    private final Integer virtualSockets;
-    private final Integer virtualCores;
+    private final Integer sockets;
+    private final Integer cores;
+    private final Integer hypervisorSockets;
+    private final Integer hypervisorCores;
     private final ServiceLevel serviceLevel;
     private final Usage usage;
     private final boolean hasUnlimitedUsage;
@@ -865,20 +864,20 @@ class SubscriptionTableControllerTest {
     private SubCapSpec(
         String sku,
         String productName,
-        Integer physicalSockets,
-        Integer physicalCores,
-        Integer virtualSockets,
-        Integer virtualCores,
+        Integer sockets,
+        Integer cores,
+        Integer hypervisorSockets,
+        Integer hypervisorCores,
         ServiceLevel serviceLevel,
         Usage usage,
         boolean hasUnlimitedUsage,
         Sub sub) {
       this.sku = sku;
       this.productName = productName;
-      this.physicalSockets = physicalSockets;
-      this.physicalCores = physicalCores;
-      this.virtualSockets = virtualSockets;
-      this.virtualCores = virtualCores;
+      this.sockets = sockets;
+      this.cores = cores;
+      this.hypervisorSockets = hypervisorSockets;
+      this.hypervisorCores = hypervisorCores;
       this.serviceLevel = serviceLevel;
       this.usage = usage;
       this.hasUnlimitedUsage = hasUnlimitedUsage;
@@ -893,20 +892,20 @@ class SubscriptionTableControllerTest {
     public static SubCapSpec offering(
         String sku,
         String productName,
-        Integer physicalSockets,
-        Integer physicalCores,
-        Integer virtualSockets,
-        Integer virtualCores,
+        Integer sockets,
+        Integer cores,
+        Integer hypervisorSockets,
+        Integer hypervisorCores,
         ServiceLevel serviceLevel,
         Usage usage,
         Boolean hasUnlimitedUsage) {
       return new SubCapSpec(
           sku,
           productName,
-          physicalSockets,
-          physicalCores,
-          virtualSockets,
-          virtualCores,
+          sockets,
+          cores,
+          hypervisorSockets,
+          hypervisorCores,
           serviceLevel,
           usage,
           hasUnlimitedUsage,
@@ -920,10 +919,10 @@ class SubscriptionTableControllerTest {
       return new SubCapSpec(
           sku,
           productName,
-          physicalSockets,
-          physicalCores,
-          virtualSockets,
-          virtualCores,
+          sockets,
+          cores,
+          hypervisorSockets,
+          hypervisorCores,
           serviceLevel,
           usage,
           hasUnlimitedUsage,
@@ -943,10 +942,10 @@ class SubscriptionTableControllerTest {
           .accountNumber(org.accountNumber)
           .beginDate(sub.start)
           .endDate(sub.end)
-          .physicalCores(totalCapacity(physicalCores, sub.quantity))
-          .physicalSockets(totalCapacity(physicalSockets, sub.quantity))
-          .virtualSockets(totalCapacity(virtualSockets, sub.quantity))
-          .virtualCores(totalCapacity(virtualCores, sub.quantity))
+          .cores(totalCapacity(cores, sub.quantity))
+          .sockets(totalCapacity(sockets, sub.quantity))
+          .hypervisorSockets(totalCapacity(hypervisorSockets, sub.quantity))
+          .hypervisorCores(totalCapacity(hypervisorCores, sub.quantity))
           .hasUnlimitedUsage(hasUnlimitedUsage)
           .sku(sku)
           .serviceLevel(serviceLevel)

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
@@ -136,16 +136,16 @@ public interface SubscriptionCapacityViewRepository
   static Specification<SubscriptionCapacityView> matchingUomForCores() {
     return (root, query, builder) ->
         builder.or(
-            builder.isNotNull(root.get(SubscriptionCapacityView_.physicalCores)),
-            builder.isNotNull(root.get(SubscriptionCapacityView_.virtualCores)),
+            builder.isNotNull(root.get(SubscriptionCapacityView_.cores)),
+            builder.isNotNull(root.get(SubscriptionCapacityView_.hypervisorCores)),
             builder.isTrue(root.get(SubscriptionCapacityView_.hasUnlimitedUsage)));
   }
 
   static Specification<SubscriptionCapacityView> matchingUomForSockets() {
     return (root, query, builder) ->
         builder.or(
-            builder.isNotNull(root.get(SubscriptionCapacityView_.physicalSockets)),
-            builder.isNotNull(root.get(SubscriptionCapacityView_.virtualSockets)),
+            builder.isNotNull(root.get(SubscriptionCapacityView_.sockets)),
+            builder.isNotNull(root.get(SubscriptionCapacityView_.hypervisorSockets)),
             builder.isTrue(root.get(SubscriptionCapacityView_.hasUnlimitedUsage)));
   }
 
@@ -156,13 +156,13 @@ public interface SubscriptionCapacityViewRepository
         case NON_HYPERVISOR:
           // Has no virt capacity
           return builder.and(
-              builder.equal(root.get(SubscriptionCapacityView_.virtualSockets), 0),
-              builder.equal(root.get(SubscriptionCapacityView_.virtualCores), 0));
+              builder.equal(root.get(SubscriptionCapacityView_.hypervisorSockets), 0),
+              builder.equal(root.get(SubscriptionCapacityView_.hypervisorCores), 0));
         case HYPERVISOR:
           // Has some virt capacity
           return builder.or(
-              builder.greaterThan(root.get(SubscriptionCapacityView_.virtualSockets), 0),
-              builder.greaterThan(root.get(SubscriptionCapacityView_.virtualCores), 0));
+              builder.greaterThan(root.get(SubscriptionCapacityView_.hypervisorSockets), 0),
+              builder.greaterThan(root.get(SubscriptionCapacityView_.hypervisorCores), 0));
         default:
           throw new IllegalStateException("Unhandled HypervisorReportCategory value");
       }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -108,21 +108,21 @@ public class Offering implements Serializable {
   @Column(name = "oid")
   private Set<Integer> productIds;
 
-  /** Effective physical CPU cores capacity per quantity of subscription to this offering. */
-  @Column(name = "physical_cores")
-  private Integer physicalCores;
+  /** Effective standard CPU cores capacity per quantity of subscription to this offering. */
+  @Column(name = "cores")
+  private Integer cores;
 
-  /** Effective physical CPU sockets capacity per quantity of subscription to this offering. */
-  @Column(name = "physical_sockets")
-  private Integer physicalSockets;
+  /** Effective standard CPU sockets capacity per quantity of subscription to this offering. */
+  @Column(name = "sockets")
+  private Integer sockets;
 
-  /** Effective virtual CPU cores capacity per quantity of subscription to this offering. */
-  @Column(name = "virtual_cores")
-  private Integer virtualCores;
+  /** Effective hypervisor CPU cores capacity per quantity of subscription to this offering. */
+  @Column(name = "hypervisor_cores")
+  private Integer hypervisorCores;
 
-  /** Effective virtual CPU sockets capacity per quantity of subscription to this offering. */
-  @Column(name = "virtual_sockets")
-  private Integer virtualSockets;
+  /** Effective hypervisor CPU sockets capacity per quantity of subscription to this offering. */
+  @Column(name = "hypervisor_sockets")
+  private Integer hypervisorSockets;
 
   /** Syspurpose Role for the offering */
   @Column(name = "role")

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacity.java
@@ -40,17 +40,17 @@ public class SubscriptionCapacity implements Serializable {
   @Column(name = "account_number")
   private String accountNumber;
 
-  @Column(name = "physical_sockets")
-  private Integer physicalSockets;
+  @Column(name = "sockets")
+  private Integer sockets;
 
-  @Column(name = "virtual_sockets")
-  private Integer virtualSockets;
+  @Column(name = "hypervisor_sockets")
+  private Integer hypervisorSockets;
 
-  @Column(name = "physical_cores")
-  private Integer physicalCores;
+  @Column(name = "cores")
+  private Integer cores;
 
-  @Column(name = "virtual_cores")
-  private Integer virtualCores;
+  @Column(name = "hypervisor_cores")
+  private Integer hypervisorCores;
 
   // Lombok would name the getter "isHasUnlimitedGuestSockets"
   @Getter(AccessLevel.NONE)
@@ -119,10 +119,11 @@ public class SubscriptionCapacity implements Serializable {
         .serviceLevel(offering.getServiceLevel())
         .usage(offering.getUsage())
         .sku(offering.getSku())
-        .physicalSockets(totalCapacity(offering.getPhysicalSockets(), subscription.getQuantity()))
-        .virtualSockets(totalCapacity(offering.getVirtualSockets(), subscription.getQuantity()))
-        .virtualCores(totalCapacity(offering.getVirtualCores(), subscription.getQuantity()))
-        .physicalCores(totalCapacity(offering.getPhysicalCores(), subscription.getQuantity()))
+        .sockets(totalCapacity(offering.getSockets(), subscription.getQuantity()))
+        .hypervisorSockets(
+            totalCapacity(offering.getHypervisorSockets(), subscription.getQuantity()))
+        .hypervisorCores(totalCapacity(offering.getHypervisorCores(), subscription.getQuantity()))
+        .cores(totalCapacity(offering.getCores(), subscription.getQuantity()))
         .hasUnlimitedUsage(offering.getHasUnlimitedUsage())
         .build();
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
@@ -40,10 +40,10 @@ import org.hibernate.annotations.Subselect;
         + "sc.sku, \n"
         + "sc.sla, \n"
         + "sc.usage, \n"
-        + "sc.physical_sockets, \n"
-        + "sc.virtual_sockets, \n"
-        + "sc.physical_cores, \n"
-        + "sc.virtual_cores, \n"
+        + "sc.sockets, \n"
+        + "sc.hypervisor_sockets, \n"
+        + "sc.cores, \n"
+        + "sc.hypervisor_cores, \n"
         + "sc.end_date, \n"
         + "sc.begin_date, \n"
         + "sc.account_number, \n"
@@ -80,17 +80,17 @@ public class SubscriptionCapacityView {
   @Column(name = "usage")
   private Usage usage;
 
-  @Column(name = "physical_sockets")
-  private Integer physicalSockets;
+  @Column(name = "sockets")
+  private Integer sockets;
 
-  @Column(name = "virtual_sockets")
-  private Integer virtualSockets;
+  @Column(name = "hypervisor_sockets")
+  private Integer hypervisorSockets;
 
-  @Column(name = "physical_cores")
-  private Integer physicalCores;
+  @Column(name = "cores")
+  private Integer cores;
 
-  @Column(name = "virtual_cores")
-  private Integer virtualCores;
+  @Column(name = "hypervisor_cores")
+  private Integer hypervisorCores;
 
   @Column(name = "end_date")
   private OffsetDateTime endDate;
@@ -107,19 +107,19 @@ public class SubscriptionCapacityView {
   @Column(name = "has_unlimited_usage")
   private Boolean hasUnlimitedUsage;
 
-  public Integer getPhysicalSockets() {
-    return Objects.isNull(physicalSockets) ? 0 : physicalSockets;
+  public Integer getSockets() {
+    return Objects.isNull(sockets) ? 0 : sockets;
   }
 
-  public Integer getPhysicalCores() {
-    return Objects.isNull(physicalCores) ? 0 : physicalCores;
+  public Integer getCores() {
+    return Objects.isNull(cores) ? 0 : cores;
   }
 
-  public Integer getVirtualCores() {
-    return Objects.isNull(virtualCores) ? 0 : virtualCores;
+  public Integer getHypervisorCores() {
+    return Objects.isNull(hypervisorCores) ? 0 : hypervisorCores;
   }
 
-  public Integer getVirtualSockets() {
-    return Objects.isNull(virtualSockets) ? 0 : virtualSockets;
+  public Integer getHypervisorSockets() {
+    return Objects.isNull(hypervisorSockets) ? 0 : hypervisorSockets;
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-591

* Physical sockets are now just referred to as "sockets".
* Physical cores are now just referred to as "cores".
* Virtual sockets are now referred to as "hypervisor sockets".
* Virtual cores are now referred to as "hypervisor cores".

Note: I left the deprecated capacity API alone since it will be removed in the near future.

Testing
=======

Insert some data:

```shell
bin/insert-mock-hosts \
  --num-hypervisors 1 \
  --num-guests 4 \
  --hbi \
  --clear \
  --org org123
bin/insert-mock-hosts \
  --num-guests 1 \
  --hbi \
  --org org123
```

Run the service:
```shell
DEV_MODE=true ./gradlew :bootRun
```

Ensure opt-in:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean \
  operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)' \
  arguments:='["account123","org123",true,true,true]'
```

Trigger a tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org123"]'
```

Check the results from the instances API:

```shell
http :8000/api/rhsm-subscriptions/v1/instances/products/RHEL \
  beginning==2022-11-03T00:00Z \
  ending==2022-11-05T00:00Z \
  granularity==DAILY \
  x-rh-identity:$(echo -n '{"identity":{
    "type":"User",
    "user":{"is_org_admin":true},
    "internal":{"org_id":"org123"}
  }}' | base64 -w0)
```

Clear account data (to exercise spring data repo change):

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=accountResetJmxBean,type=AccountResetJmxBean \
  operation='deleteDataAssociatedWithOrg(java.lang.String)' \
  arguments:='["org123"]'
```

The record is gone:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
select * from account_services where org_id='org123'
EOF
```