### PR TITLE
SWATCH-692: Make BillableUsageController use orgId instead of account

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -168,7 +168,7 @@ public class BillableUsageController {
         new TallyMeasurementKey(
             HardwareMeasurementType.PHYSICAL, Uom.fromValue(usage.getUom().value()));
     return snapshotRepository.sumMeasurementValueForPeriod(
-        usage.getAccountNumber(),
+        usage.getOrgId(),
         usage.getProductId(),
         // Billable usage has already been filtered to HOURLY only.
         Granularity.HOURLY,

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -306,9 +306,9 @@ class TallySnapshotRepositoryTest {
   }
 
   @Test
-  void testFindMontlyTotal() {
+  void testFindMonthlyTotal() {
     //    List<TallySnapshot> tallySnapshots = new ArrayList<>();
-    String expectedAccountNumber = "Acme Inc.";
+    String expectedOrgId = "Acme Inc.";
     String expectedProduct = "rocket-skates";
     Granularity expectedGranularity = Granularity.HOURLY;
     ServiceLevel expectedServiceLevel = ServiceLevel.PREMIUM;
@@ -325,7 +325,7 @@ class TallySnapshotRepositoryTest {
         createSequencedSnapshots(
             NOWISH,
             5,
-            expectedAccountNumber,
+            expectedOrgId,
             expectedProduct,
             expectedGranularity,
             expectedMeasurementType,
@@ -337,7 +337,7 @@ class TallySnapshotRepositoryTest {
     TallyMeasurementKey key = new TallyMeasurementKey(expectedMeasurementType, expectedUom);
     Double monthlyTotal =
         repository.sumMeasurementValueForPeriod(
-            expectedAccountNumber,
+            expectedOrgId,
             expectedProduct,
             expectedGranularity,
             expectedServiceLevel,
@@ -351,8 +351,8 @@ class TallySnapshotRepositoryTest {
   }
 
   @Test
-  void testFindMontlyTotalForDateRange() {
-    String expectedAccountNumber = "Acme Inc.";
+  void testFindMonthlyTotalForDateRange() {
+    String expectedOrgId = "Acme Inc.";
     String expectedProduct = "rocket-skates";
     Granularity expectedGranularity = Granularity.HOURLY;
     ServiceLevel expectedServiceLevel = ServiceLevel.PREMIUM;
@@ -369,7 +369,7 @@ class TallySnapshotRepositoryTest {
         createSequencedSnapshots(
             NOWISH,
             5,
-            expectedAccountNumber,
+            expectedOrgId,
             expectedProduct,
             expectedGranularity,
             expectedMeasurementType,
@@ -383,7 +383,7 @@ class TallySnapshotRepositoryTest {
         new TallyMeasurementKey(HardwareMeasurementType.AWS, Uom.STORAGE_GIBIBYTES);
     Double monthlyTotal =
         repository.sumMeasurementValueForPeriod(
-            expectedAccountNumber,
+            expectedOrgId,
             expectedProduct,
             expectedGranularity,
             expectedServiceLevel,
@@ -403,7 +403,7 @@ class TallySnapshotRepositoryTest {
     assertEquals(
         0.0,
         repository.sumMeasurementValueForPeriod(
-            "account1",
+            "org1",
             "p1",
             Granularity.DAILY,
             ServiceLevel.STANDARD,
@@ -418,7 +418,7 @@ class TallySnapshotRepositoryTest {
   private List<TallySnapshot> createSequencedSnapshots(
       OffsetDateTime start,
       int numOfSnaps,
-      String accoutNumber,
+      String orgId,
       String product,
       Granularity granularity,
       HardwareMeasurementType measurementType,
@@ -428,7 +428,7 @@ class TallySnapshotRepositoryTest {
     OffsetDateTime next = start;
     for (int i = 1; i <= numOfSnaps; i++) {
       TallySnapshot snap =
-          createUnpersisted("orgSeq", accoutNumber, product, granularity, 1, 2, 3, next);
+          createUnpersisted(orgId, "accountSeq", product, granularity, 1, 2, 3, next);
       snap.setMeasurement(HardwareMeasurementType.PHYSICAL, Uom.CORES, 1.0);
       snap.setMeasurement(measurementType, measurementUom, measurementValue);
       snaps.add(snap);

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -153,7 +153,7 @@ class BillableUsageControllerTest {
         new TallyMeasurementKey(
             HardwareMeasurementType.PHYSICAL, Measurement.Uom.fromValue(usage.getUom().value()));
     when(snapshotRepo.sumMeasurementValueForPeriod(
-            usage.getAccountNumber(),
+            usage.getOrgId(),
             usage.getProductId(),
             Granularity.HOURLY,
             ServiceLevel.fromString(usage.getSla().value()),

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions.tally.billing;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
@@ -101,7 +103,7 @@ class RemittanceControllerTest {
     List<TallySnapshot> snaps = new ArrayList<>();
     TallySnapshot expectedSnapshot1 =
         buildSnapshot(
-            "account123",
+            "org123",
             "rhosak",
             Granularity.HOURLY,
             ServiceLevel.PREMIUM,
@@ -114,7 +116,7 @@ class RemittanceControllerTest {
 
     TallySnapshot expectedSnapshot2 =
         buildSnapshot(
-            "account345",
+            "org345",
             "rhosak",
             Granularity.HOURLY,
             ServiceLevel.PREMIUM,
@@ -137,11 +139,7 @@ class RemittanceControllerTest {
 
     controller.syncRemittance();
     verify(remittanceRepo, times(2)).save(savedRemittance.capture());
-    assertEquals(2, savedRemittance.getAllValues().size());
-    assertTrue(
-        savedRemittance
-            .getAllValues()
-            .containsAll(List.of(expectedRemittance1, expectedRemittance2)));
+    assertThat(savedRemittance.getAllValues(), containsInAnyOrder(expectedRemittance1, expectedRemittance2));
   }
 
   @Test
@@ -149,7 +147,7 @@ class RemittanceControllerTest {
     List<TallySnapshot> snaps = new ArrayList<>();
     TallySnapshot snapshot =
         buildSnapshot(
-            "account123",
+            "org123",
             "my-product",
             Granularity.HOURLY,
             ServiceLevel.PREMIUM,
@@ -172,7 +170,7 @@ class RemittanceControllerTest {
     List<TallySnapshot> snaps = new ArrayList<>();
     TallySnapshot snapshot =
         buildSnapshot(
-            "account123",
+            "org123",
             "rhosak",
             Granularity.HOURLY,
             ServiceLevel.PREMIUM,
@@ -223,7 +221,7 @@ class RemittanceControllerTest {
     BillableUsageRemittanceEntity remittance = createRemittance(snapshot, remittedValue);
 
     when(snapshotRepo.sumMeasurementValueForPeriod(
-            snapshot.getAccountNumber(),
+            snapshot.getOrgId(),
             snapshot.getProductId(),
             snapshot.getGranularity(),
             snapshot.getServiceLevel(),
@@ -239,7 +237,7 @@ class RemittanceControllerTest {
   }
 
   private TallySnapshot buildSnapshot(
-      String account,
+      String orgId,
       String productId,
       Granularity granularity,
       ServiceLevel sla,
@@ -252,7 +250,7 @@ class RemittanceControllerTest {
     measurements.put(new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, uom), val);
     measurements.put(new TallyMeasurementKey(HardwareMeasurementType.TOTAL, uom), val);
     return TallySnapshot.builder()
-        .accountNumber(account)
+        .orgId(orgId)
         .productId(productId)
         .snapshotDate(snapshotDate)
         .tallyMeasurements(measurements)

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
@@ -22,8 +22,6 @@ package org.candlepin.subscriptions.tally.billing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -139,7 +137,9 @@ class RemittanceControllerTest {
 
     controller.syncRemittance();
     verify(remittanceRepo, times(2)).save(savedRemittance.capture());
-    assertThat(savedRemittance.getAllValues(), containsInAnyOrder(expectedRemittance1, expectedRemittance2));
+    assertThat(
+        savedRemittance.getAllValues(),
+        containsInAnyOrder(expectedRemittance1, expectedRemittance2));
   }
 
   @Test

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -109,7 +109,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
   @Query(
       "select coalesce(sum(VALUE(m)), 0.0) from TallySnapshot s "
           + "left join s.tallyMeasurements m on key(m) = :measurementKey "
-          + "where s.accountNumber = :accountNumber and "
+          + "where s.orgId = :orgId and "
           + "s.productId = :productId and "
           + "s.granularity = :granularity and "
           + "s.serviceLevel = :serviceLevel and "
@@ -118,7 +118,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
           + "s.billingAccountId = :billingAcctId and "
           + "s.snapshotDate >= :beginning and s.snapshotDate <= :ending")
   Double sumMeasurementValueForPeriod(
-      @Param("accountNumber") String accountNumber,
+      @Param("orgId") String orgId,
       @Param("productId") String productId,
       @Param("granularity") Granularity granularity,
       @Param("serviceLevel") ServiceLevel serviceLevel,


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-692

Testing
=======

(Adapted from #1177).

Clean out relevant tables:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
delete from events;
delete from tally_snapshots;
delete from instance_monthly_totals;
delete from instance_measurements;
delete from billable_usage_remittance;
EOF
```

Run the service:

```shell
DEV_MODE=true ./gradlew :bootRun
```

Load events into the DB:

```shell
bin/import-events.py --file bin/events.csv
```

Opt in all accounts from the events:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean \
  operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)' \
  arguments:='["account123","org123",true,true,true]'
```

Do an hourly tally for all accounts:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyAllAccountsByHourly(java.lang.String,java.lang.String)' \
  arguments:='["2021-10-18T00:00Z","2021-10-19T00:00Z"]'
```

Capture the remittance table after the hourly tally:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
select * from billable_usage_remittance order by account_number, product_id, metric_id, billing_provider
EOF
```

Alter account_number on the tally_snapshot records:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
update tally_snapshots set account_number='foobar' where 1=1;
EOF
```

Rerun hourly tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyAllAccountsByHourly(java.lang.String,java.lang.String)' \
  arguments:='["2021-10-18T00:00Z","2021-10-19T00:00Z"]'
```

Make sure the remittance table after the hourly tally doesn't increase or get more rows:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
select * from billable_usage_remittance order by account_number, product_id, metric_id, billing_provider
EOF
```

Notice that in spite of the tally snapshots having `account_number=foobar`, the remittance values don't change (and new ones are not created).