### PR TITLE
Capture time properly in splunk HEC events

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/logback/RhsmSplunkHecEventHeaderSerializer.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/logback/RhsmSplunkHecEventHeaderSerializer.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.logback;
 import com.splunk.logging.EventHeaderSerializer;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -36,7 +37,7 @@ public class RhsmSplunkHecEventHeaderSerializer implements EventHeaderSerializer
   @Override
   public Map<String, Object> serializeEventHeader(
       HttpEventCollectorEventInfo eventInfo, Map<String, Object> metadata) {
-
+    metadata.put("time", String.format(Locale.US, "%.3f", eventInfo.getTime()));
     var fields = (Map<String, Object>) metadata.getOrDefault("fields", new HashMap<>());
 
     // TODO


### PR DESCRIPTION
This applies specifically to our spring-boot based deployments.

Since we were using a custom event header serializer, we need to supply `time` appropriately.

Testing
=======

Check the ephemeral deployment for this PR. Check in splunk for `namespace=${ephemeral_namespace} host=swatch-tally-service*`. Note that the timestamp emitted in `message` and recorded for the splunk event should match down to the microsecond.