### PR TITLE
SWATCH-643: Map tally usage by orgId instead of account number

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -62,9 +62,9 @@ public class EventController {
   }
 
   public Stream<Event> fetchEventsInTimeRangeByServiceType(
-      String accountNumber, String serviceType, OffsetDateTime begin, OffsetDateTime end) {
-    return repo.findByAccountNumberAndServiceTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-            accountNumber, serviceType, begin, end)
+      String orgId, String serviceType, OffsetDateTime begin, OffsetDateTime end) {
+    return repo.findByOrgIdAndServiceTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+            orgId, serviceType, begin, end)
         .map(EventRecord::getEvent);
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountUsageCalculation.java
@@ -35,8 +35,8 @@ public class AccountUsageCalculation {
   private Map<UsageCalculation.Key, UsageCalculation> calculations;
   private Set<String> products;
 
-  public AccountUsageCalculation(String account) {
-    this.account = account;
+  public AccountUsageCalculation(String orgId) {
+    this.orgId = orgId;
     this.calculations = new HashMap<>();
     this.products = new HashSet<>();
   }
@@ -54,12 +54,12 @@ public class AccountUsageCalculation {
     return account;
   }
 
-  public String getOrgId() {
-    return orgId;
+  public void setAccount(String account) {
+    this.account = account;
   }
 
-  public void setOrgId(String orgId) {
-    this.orgId = orgId;
+  public String getOrgId() {
+    return orgId;
   }
 
   public void addCalculation(UsageCalculation calc) {

--- a/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollector.java
@@ -57,22 +57,21 @@ public class CloudigradeAccountUsageCollector {
    * Add measurements from cloudigrade to usage calculations
    *
    * @param accountCalcs map of existing account to usage calculations
-   * @param account account to enrich calculations for
    * @param orgId org id to enrich calculations
    * @throws ApiException if the cloudigrade service errs
    */
   @Timed("rhsm-subscriptions.snapshots.cloudigrade")
   public void enrichUsageWithCloudigradeData(
-      Map<String, AccountUsageCalculation> accountCalcs, String account, String orgId)
+      Map<String, AccountUsageCalculation> accountCalcs, String orgId)
       throws ApiException, org.candlepin.subscriptions.cloudigrade.internal.ApiException {
-    log.info("Cloudigrade enriching usage using org {} and account {}", orgId, account);
+    log.info("Cloudigrade enriching usage using orgId={}", orgId);
     ConcurrencyReport cloudigradeUsage = getDailyConcurrencyReport(orgId);
     if (cloudigradeUsage == null) {
       return;
     }
 
-    accountCalcs.putIfAbsent(account, new AccountUsageCalculation(account));
-    AccountUsageCalculation usageCalc = accountCalcs.get(account);
+    accountCalcs.putIfAbsent(orgId, new AccountUsageCalculation(orgId));
+    AccountUsageCalculation usageCalc = accountCalcs.get(orgId);
     if (cloudigradeUsage.getData().size() > 1) {
       log.warn("Got more than one day's worth of data from cloudigrade; using the first");
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
@@ -72,7 +72,7 @@ public class CombiningRollupSnapshotStrategy {
   }
 
   /**
-   * @param accountNumber The target account
+   * @param orgId The ID of the target org
    * @param affectedRange the overall date range that we looked for calculations
    * @param affectedProductTags the set of product tags that are applicable
    * @param accountCalcs Map of times and account calculations at that time
@@ -82,7 +82,7 @@ public class CombiningRollupSnapshotStrategy {
    */
   @Transactional
   public Map<String, List<TallySnapshot>> produceSnapshotsFromCalculations(
-      String accountNumber,
+      String orgId,
       DateRange affectedRange,
       Set<String> affectedProductTags,
       Map<OffsetDateTime, AccountUsageCalculation> accountCalcs,
@@ -93,7 +93,7 @@ public class CombiningRollupSnapshotStrategy {
     Map<TallySnapshotNaturalKey, List<TallySnapshot>> derivedExistingSnapshots = new HashMap<>();
 
     catalogExistingSnapshots(
-        accountNumber,
+        orgId,
         affectedRange,
         totalExistingSnapshots,
         derivedExistingSnapshots,
@@ -132,14 +132,14 @@ public class CombiningRollupSnapshotStrategy {
     Map<String, List<TallySnapshot>> totalSnapshotsToSend =
         Stream.of(finestGranularitySnapshotsInRange, rollupSnapshots)
             .flatMap(List::stream)
-            .collect(Collectors.groupingBy(TallySnapshot::getAccountNumber));
+            .collect(Collectors.groupingBy(TallySnapshot::getOrgId));
 
-    log.info("Finished producing finestGranularitySnapshots for account {}.", accountNumber);
+    log.info("Finished producing finestGranularitySnapshots for orgId={}.", orgId);
     return totalSnapshotsToSend;
   }
 
   private void catalogExistingSnapshots(
-      String accountNumber,
+      String orgId,
       DateRange reportDateRange,
       Map<TallySnapshotNaturalKey, TallySnapshot> totalExistingSnapshots,
       Map<TallySnapshotNaturalKey, List<TallySnapshot>> derivedExistingSnapshots,
@@ -167,11 +167,10 @@ public class CombiningRollupSnapshotStrategy {
       }
 
       var snapMap =
-          getCurrentSnapshotsByAccount(
-              accountNumber, swatchProductIds, granularity, effectiveStartTime, effectiveEndTime);
+          getCurrentSnapshotsByOrgId(
+              orgId, swatchProductIds, granularity, effectiveStartTime, effectiveEndTime);
 
-      List<TallySnapshot> existingSnapshots =
-          snapMap.getOrDefault(accountNumber, Collections.emptyList());
+      List<TallySnapshot> existingSnapshots = snapMap.getOrDefault(orgId, Collections.emptyList());
 
       existingSnapshots.forEach(
           snap -> {
@@ -191,15 +190,15 @@ public class CombiningRollupSnapshotStrategy {
   }
 
   @SuppressWarnings("indentation")
-  protected Map<String, List<TallySnapshot>> getCurrentSnapshotsByAccount(
-      String account,
+  protected Map<String, List<TallySnapshot>> getCurrentSnapshotsByOrgId(
+      String orgId,
       Collection<String> products,
       Granularity granularity,
       OffsetDateTime begin,
       OffsetDateTime end) {
     try (Stream<TallySnapshot> snapStream =
-        tallyRepo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
-            account, products, granularity, begin, end)) {
+        tallyRepo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
+            orgId, products, granularity, begin, end)) {
       return snapStream.collect(Collectors.groupingBy(TallySnapshot::getAccountNumber));
     }
   }
@@ -287,7 +286,7 @@ public class CombiningRollupSnapshotStrategy {
           for (UsageCalculation.Key usageKey : accountCalc.getKeys()) {
             var snapshotKey =
                 new TallySnapshotNaturalKey(
-                    accountCalc.getAccount(),
+                    accountCalc.getOrgId(),
                     usageKey.getProductId(),
                     granularity,
                     usageKey.getSla(),
@@ -427,7 +426,7 @@ public class CombiningRollupSnapshotStrategy {
                   firstFinestGranularitySnapshot.getSnapshotDate(), granularity);
           var snapshotKey =
               new TallySnapshotNaturalKey(
-                  firstFinestGranularitySnapshot.getAccountNumber(),
+                  firstFinestGranularitySnapshot.getOrgId(),
                   firstFinestGranularitySnapshot.getProductId(),
                   granularity,
                   usageKey.getSla(),

--- a/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
@@ -199,7 +199,7 @@ public class CombiningRollupSnapshotStrategy {
     try (Stream<TallySnapshot> snapStream =
         tallyRepo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             orgId, products, granularity, begin, end)) {
-      return snapStream.collect(Collectors.groupingBy(TallySnapshot::getAccountNumber));
+      return snapStream.collect(Collectors.groupingBy(TallySnapshot::getOrgId));
     }
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyController.java
@@ -61,7 +61,7 @@ public class MarketplaceResendTallyController {
     var snapshots = snapshotRepository.findAllById(snapshotIds);
     log.info("Resending tally snapshots for {} messages", snapshots.size());
     Map<String, List<TallySnapshot>> totalSnapshots =
-        snapshots.stream().collect(Collectors.groupingBy(TallySnapshot::getAccountNumber));
+        snapshots.stream().collect(Collectors.groupingBy(TallySnapshot::getOrgId));
     summaryProducer.produceTallySummaryMessages(totalSnapshots);
     return snapshots.size();
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/MaxSeenSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MaxSeenSnapshotStrategy.java
@@ -73,17 +73,17 @@ public class MaxSeenSnapshotStrategy {
 
   @Transactional
   public List<TallySnapshot> produceSnapshotsFromCalculations(
-      String account, Collection<AccountUsageCalculation> accountCalcs) {
+      String orgId, Collection<AccountUsageCalculation> accountCalcs) {
     Stream<BaseSnapshotRoller> rollers =
         Stream.of(
             hourlyRoller, dailyRoller, weeklyRoller, monthlyRoller, quarterlyRoller, yearlyRoller);
     var newAndUpdatedSnapshots =
         rollers
-            .map(roller -> roller.rollSnapshots(account, accountCalcs))
+            .map(roller -> roller.rollSnapshots(orgId, accountCalcs))
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
-    summaryProducer.produceTallySummaryMessages(Map.of(account, newAndUpdatedSnapshots));
-    log.info("Finished producing snapshots for account {}", account);
+    summaryProducer.produceTallySummaryMessages(Map.of(orgId, newAndUpdatedSnapshots));
+    log.info("Finished producing snapshots for orgId={}", orgId);
     return newAndUpdatedSnapshots;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -156,7 +156,9 @@ public class MetricUsageCollector {
         accountCalcs.put(offset, accountUsageCalculation);
       }
     }
-    accountCalcs.values().forEach(calc -> calc.setOrgId(accountServiceInventory.getOrgId()));
+    accountCalcs
+        .values()
+        .forEach(calc -> calc.setAccount(accountServiceInventory.getAccountNumber()));
     accountServiceInventoryRepository.save(accountServiceInventory);
 
     return new CollectionResult(
@@ -171,6 +173,7 @@ public class MetricUsageCollector {
     OffsetDateTime endDateTime = startDateTime.plusHours(1);
 
     Map<String, List<Event>> eventToHostMapping =
+        // FIXME This needs to do the lookup by OrgId
         eventController
             .fetchEventsInTimeRangeByServiceType(
                 accountServiceInventory.getAccountNumber(),
@@ -204,15 +207,17 @@ public class MetricUsageCollector {
                   .collect(Collectors.toSet());
           staleMeasurements.forEach(host.getMeasurements()::remove);
         });
-    return tallyCurrentAccountState(accountServiceInventory.getAccountNumber(), thisHoursInstances);
+    return tallyCurrentAccountState(accountServiceInventory, thisHoursInstances);
   }
 
   private AccountUsageCalculation tallyCurrentAccountState(
-      String accountNumber, Map<String, Host> thisHoursInstances) {
+      AccountServiceInventory accountInventory, Map<String, Host> thisHoursInstances) {
     if (thisHoursInstances.isEmpty()) {
       return null;
     }
-    AccountUsageCalculation accountUsageCalculation = new AccountUsageCalculation(accountNumber);
+    AccountUsageCalculation accountUsageCalculation =
+        new AccountUsageCalculation(accountInventory.getOrgId());
+    accountUsageCalculation.setAccount(accountInventory.getAccountNumber());
     thisHoursInstances
         .values()
         .forEach(

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -173,10 +173,9 @@ public class MetricUsageCollector {
     OffsetDateTime endDateTime = startDateTime.plusHours(1);
 
     Map<String, List<Event>> eventToHostMapping =
-        // FIXME This needs to do the lookup by OrgId
         eventController
             .fetchEventsInTimeRangeByServiceType(
-                accountServiceInventory.getAccountNumber(),
+                accountServiceInventory.getOrgId(),
                 accountServiceInventory.getServiceType(),
                 startDateTime,
                 endDateTime)

--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -60,14 +60,12 @@ public class SnapshotSummaryProducer {
   public void produceTallySummaryMessages(Map<String, List<TallySnapshot>> newAndUpdatedSnapshots) {
     AtomicInteger totalTallies = new AtomicInteger();
     newAndUpdatedSnapshots.forEach(
-        (account, snapshots) ->
+        (orgId, snapshots) ->
             snapshots.stream()
-                // NOTE: The orgId should be passed in the same way as the account. When the APIs
-                // are changed to require an orgID, this should be updated to not take the orgId
-                // from the snapshot when they are mapped to a summary.
                 .map(
                     snapshot ->
-                        summaryMapper.mapSnapshots(account, snapshot.getOrgId(), List.of(snapshot)))
+                        summaryMapper.mapSnapshots(
+                            snapshot.getAccountNumber(), orgId, List.of(snapshot)))
                 .forEach(
                     summary -> {
                       if (validateTallySummary(summary)) {

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -102,11 +102,11 @@ public class TallySnapshotController {
 
   @Timed("rhsm-subscriptions.snapshots.single")
   public void produceSnapshotsForOrg(String orgId) {
-    String account = accountRepo.findAccountNumberByOrgId(orgId);
-    if (Objects.isNull(account) || Objects.isNull(orgId)) {
-      throw new IllegalArgumentException(
-          String.format("Incomplete opt-in configuration - account=%s orgId=%s", account, orgId));
+    if (Objects.isNull(orgId)) {
+      throw new IllegalArgumentException("A non-null orgId is required for tally operations.");
     }
+
+    String account = accountRepo.findAccountNumberByOrgId(orgId);
     log.info("Producing snapshots for Org ID {} with Account {}.", orgId, account);
     Map<String, AccountUsageCalculation> accountCalcs = new HashMap<>();
     try {
@@ -138,12 +138,11 @@ public class TallySnapshotController {
   @Transactional(propagation = Propagation.NEVER)
   @Timed("rhsm-subscriptions.snapshots.single.hourly")
   public void produceHourlySnapshotsForOrg(String orgId, DateRange snapshotRange) {
-    String accountNumber = accountRepo.findAccountNumberByOrgId(orgId);
-    if (Objects.isNull(accountNumber) || Objects.isNull(orgId)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Incomplete opt-in configuration - account=%s orgId=%s", accountNumber, orgId));
+    if (Objects.isNull(orgId)) {
+      throw new IllegalArgumentException("A non-null orgId is required for tally operations.");
     }
+
+    String accountNumber = accountRepo.findAccountNumberByOrgId(orgId);
     log.info("Producing snapshots for Org ID {} with Account {}.", orgId, accountNumber);
     tagProfile
         .getServiceTypes()

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotNaturalKey.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotNaturalKey.java
@@ -34,7 +34,7 @@ import org.candlepin.subscriptions.db.model.Usage;
 @AllArgsConstructor
 public class TallySnapshotNaturalKey {
 
-  private String accountNumber;
+  private String orgId;
   private String swatchProductId;
   private Granularity granularity;
   private ServiceLevel serviceLevel;
@@ -44,7 +44,7 @@ public class TallySnapshotNaturalKey {
   private OffsetDateTime referenceDate;
 
   public TallySnapshotNaturalKey(TallySnapshot snapshot) {
-    this.accountNumber = snapshot.getAccountNumber();
+    this.orgId = snapshot.getOrgId();
     this.swatchProductId = snapshot.getProductId();
     this.granularity = snapshot.getGranularity();
     this.serviceLevel = snapshot.getServiceLevel();

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -76,7 +76,7 @@ public class DefaultProductUsageCollector implements ProductUsageCollector {
 
   @Override
   public Optional<HostTallyBucket> collectForHypervisor(
-      String account, UsageCalculation prodCalc, NormalizedFacts hypervisorFacts) {
+      String orgId, UsageCalculation prodCalc, NormalizedFacts hypervisorFacts) {
 
     /* do nothing for hypervisor-guest mappings by default */
     return Optional.empty();

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollector.java
@@ -41,11 +41,11 @@ public interface ProductUsageCollector {
   /**
    * Collect and append usage data based on hypervisor-guest mappings.
    *
-   * @param account the account number
+   * @param orgId the org ID.
    * @param prodCalc which usage key's calculation to update
    * @param hypervisorFacts facts about the hypervisor
    * @return HostTallyBucket the bucket representing the counts applied by the specified host
    */
   Optional<HostTallyBucket> collectForHypervisor(
-      String account, UsageCalculation prodCalc, NormalizedFacts hypervisorFacts);
+      String orgId, UsageCalculation prodCalc, NormalizedFacts hypervisorFacts);
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -85,17 +85,17 @@ public class RHELProductUsageCollector implements ProductUsageCollector {
 
   @Override
   public Optional<HostTallyBucket> collectForHypervisor(
-      String account, UsageCalculation prodCalc, NormalizedFacts hypervisorFacts) {
+      String orgId, UsageCalculation prodCalc, NormalizedFacts hypervisorFacts) {
 
     int appliedCores = hypervisorFacts.getCores() != null ? hypervisorFacts.getCores() : 0;
     int appliedSockets = hypervisorFacts.getSockets() != null ? hypervisorFacts.getSockets() : 0;
 
     if (appliedSockets == 0) {
       log.warn(
-          "Hypervisor in account {} has no sockets and will"
+          "Hypervisor in org {} has no sockets and will"
               + " not contribute to the totals. The tally for the RHEL product will not be"
               + " accurate since all associated guests will not contribute to the tally.",
-          account);
+          orgId);
     }
 
     prodCalc.addHypervisor(appliedCores, appliedSockets, 1);

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -285,6 +285,8 @@ public class FactNormalizer {
       // Check for cores and sockets. If not included, default to 0.
 
       normalizedFacts.setOrgId(hostFacts.getOrgId());
+      normalizedFacts.setAccount(hostFacts.getAccount());
+
       handleRole(normalizedFacts, hostFacts.getSyspurposeRole());
       handleSla(normalizedFacts, hostFacts, hostFacts.getSyspurposeSla());
       handleUsage(normalizedFacts, hostFacts, hostFacts.getSyspurposeUsage());

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -40,6 +40,8 @@ public class NormalizedFacts {
   private Integer cores;
   private Integer sockets;
   private String orgId;
+  private String account;
+
   /** Subscription-manager ID (UUID) of the hypervisor for this system */
   private String hypervisorUuid;
 

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRoller.java
@@ -52,14 +52,14 @@ public class DailySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      String account, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing daily snapshots for account {}.", account);
+      String orgId, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing daily snapshots for orgId={}.", orgId);
 
     Map<String, List<TallySnapshot>> existingSnapsForToday =
         Map.of(
-            account,
-            getCurrentSnapshotsByAccount(
-                account,
+            orgId,
+            getCurrentSnapshotsByOrgId(
+                orgId,
                 getApplicableProducts(accountCalcs, DAILY),
                 DAILY,
                 clock.startOfToday(),

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRoller.java
@@ -51,14 +51,14 @@ public class HourlySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      String account, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing hourly snapshots for account {}.", account);
+      String orgId, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing hourly snapshots for orgId={}.", orgId);
 
     Map<String, List<TallySnapshot>> existingSnapsForTheHour =
         Map.of(
-            account,
-            getCurrentSnapshotsByAccount(
-                account,
+            orgId,
+            getCurrentSnapshotsByOrgId(
+                orgId,
                 getApplicableProducts(accountCalcs, HOURLY),
                 HOURLY,
                 clock.startOfCurrentHour(),

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRoller.java
@@ -52,14 +52,14 @@ public class MonthlySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      String account, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing monthly snapshots for account {}.", account);
+      String orgId, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing monthly snapshots for orgId={}.", orgId);
 
     Map<String, List<TallySnapshot>> currentMonthlySnaps =
         Map.of(
-            account,
-            getCurrentSnapshotsByAccount(
-                account,
+            orgId,
+            getCurrentSnapshotsByOrgId(
+                orgId,
                 getApplicableProducts(accountCalcs, MONTHLY),
                 MONTHLY,
                 clock.startOfCurrentMonth(),

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRoller.java
@@ -55,14 +55,14 @@ public class QuarterlySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      String account, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing quarterly snapshots for account {}.", account);
+      String orgId, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing quarterly snapshots for orgId={}.", orgId);
 
     Map<String, List<TallySnapshot>> currentQuarterlySnaps =
         Map.of(
-            account,
-            getCurrentSnapshotsByAccount(
-                account,
+            orgId,
+            getCurrentSnapshotsByOrgId(
+                orgId,
                 getApplicableProducts(accountCalcs, QUARTERLY),
                 QUARTERLY,
                 clock.startOfCurrentQuarter(),

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRoller.java
@@ -52,14 +52,14 @@ public class WeeklySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      String account, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing weekly snapshots for account {}.", account);
+      String orgId, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing weekly snapshots for orgId={}.", orgId);
 
     Map<String, List<TallySnapshot>> currentForWeek =
         Map.of(
-            account,
-            getCurrentSnapshotsByAccount(
-                account,
+            orgId,
+            getCurrentSnapshotsByOrgId(
+                orgId,
                 getApplicableProducts(accountCalcs, WEEKLY),
                 WEEKLY,
                 clock.startOfCurrentWeek(),

--- a/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRoller.java
@@ -52,14 +52,14 @@ public class YearlySnapshotRoller extends BaseSnapshotRoller {
   @Override
   @Transactional
   public Collection<TallySnapshot> rollSnapshots(
-      String account, Collection<AccountUsageCalculation> accountCalcs) {
-    log.debug("Producing yearly snapshots for account {}.", account);
+      String orgId, Collection<AccountUsageCalculation> accountCalcs) {
+    log.debug("Producing yearly snapshots for orgId={}.", orgId);
 
     Map<String, List<TallySnapshot>> currentYearlySnaps =
         Map.of(
-            account,
-            getCurrentSnapshotsByAccount(
-                account,
+            orgId,
+            getCurrentSnapshotsByOrgId(
+                orgId,
                 getApplicableProducts(accountCalcs, YEARLY),
                 YEARLY,
                 clock.startOfCurrentYear(),

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -168,7 +168,7 @@ class TallySnapshotRepositoryTest {
   }
 
   @Test
-  void testFindByAccountNumberInAndProductIdInAndGranularityAndSnapshotDateBetween() {
+  void testFindByOrgIdInAndProductIdInAndGranularityAndSnapshotDateBetween() {
     String product1 = "Product1";
     String product2 = "Product2";
     // Will not be found - out of date range.
@@ -197,8 +197,8 @@ class TallySnapshotRepositoryTest {
     List<String> products = Arrays.asList(product1, product2);
     List<TallySnapshot> found =
         repository
-            .findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
-                "Account1", products, Granularity.DAILY, min, max)
+            .findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
+                "Org1", products, Granularity.DAILY, min, max)
             .collect(Collectors.toList());
     assertEquals(1, found.size());
 
@@ -228,12 +228,8 @@ class TallySnapshotRepositoryTest {
 
     List<TallySnapshot> found =
         repository
-            .findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
-                "Acme Inc.",
-                Arrays.asList("rocket-skates"),
-                Granularity.DAILY,
-                LONG_AGO,
-                FAR_FUTURE)
+            .findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
+                "OrgAcme", Arrays.asList("rocket-skates"), Granularity.DAILY, LONG_AGO, FAR_FUTURE)
             .collect(Collectors.toList());
 
     TallySnapshot expected = found.get(0);

--- a/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CloudigradeAccountUsageCollectorTest.java
@@ -52,7 +52,6 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles({"worker", "test"})
 class CloudigradeAccountUsageCollectorTest {
-  public static final String ACCOUNT = "foo123";
   public static final String ORG_ID = "Org123";
 
   @MockBean CloudigradeService cloudigradeService;
@@ -63,7 +62,7 @@ class CloudigradeAccountUsageCollectorTest {
   void testEnrichUsageWithCloudigradeDataHaltsWithBadOrg() throws Exception {
     when(cloudigradeService.cloudigradeUserExists(ORG_ID)).thenReturn(false);
     var calculations = new HashMap<String, AccountUsageCalculation>();
-    collector.enrichUsageWithCloudigradeData(calculations, ACCOUNT, ORG_ID);
+    collector.enrichUsageWithCloudigradeData(calculations, ORG_ID);
     verify(cloudigradeService, never())
         .listDailyConcurrentUsages(any(), any(), any(), any(), any());
   }
@@ -88,7 +87,7 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.cloudigradeUserExists(ORG_ID)).thenReturn(true);
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
-    collector.enrichUsageWithCloudigradeData(calculations, ACCOUNT, ORG_ID);
+    collector.enrichUsageWithCloudigradeData(calculations, ORG_ID);
     assertEquals(1, calculations.size());
   }
 
@@ -106,8 +105,8 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
 
-    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT, ORG_ID);
+    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ORG_ID);
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ORG_ID, accountUsage), ORG_ID);
     assertEquals(
         1,
         accountUsage
@@ -137,8 +136,8 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
 
-    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT, ORG_ID);
+    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ORG_ID);
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ORG_ID, accountUsage), ORG_ID);
     assertEquals(0, accountUsage.getKeys().size());
   }
 
@@ -164,8 +163,8 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.cloudigradeUserExists(ORG_ID)).thenReturn(true);
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
-    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT, ORG_ID);
+    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ORG_ID);
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ORG_ID, accountUsage), ORG_ID);
     assertEquals(
         1,
         accountUsage
@@ -193,8 +192,8 @@ class CloudigradeAccountUsageCollectorTest {
         new ConcurrencyReport().data(Collections.singletonList(concurrentUsage));
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
-    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT, ORG_ID);
+    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ORG_ID);
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ORG_ID, accountUsage), ORG_ID);
     assertEquals(0, accountUsage.getKeys().size());
   }
 
@@ -211,8 +210,8 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.cloudigradeUserExists(ORG_ID)).thenReturn(true);
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
-    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT, ORG_ID);
+    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ORG_ID);
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ORG_ID, accountUsage), ORG_ID);
     assertEquals(0, accountUsage.getKeys().size());
   }
 
@@ -244,8 +243,8 @@ class CloudigradeAccountUsageCollectorTest {
     when(cloudigradeService.cloudigradeUserExists(ORG_ID)).thenReturn(true);
     when(cloudigradeService.listDailyConcurrentUsages(any(), any(), any(), any(), any()))
         .thenReturn(report);
-    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ACCOUNT);
-    collector.enrichUsageWithCloudigradeData(usageMapOf(ACCOUNT, accountUsage), ACCOUNT, ORG_ID);
+    AccountUsageCalculation accountUsage = new AccountUsageCalculation(ORG_ID);
+    collector.enrichUsageWithCloudigradeData(usageMapOf(ORG_ID, accountUsage), ORG_ID);
     assertEquals(1, accountUsage.getKeys().size());
     Optional<UsageCalculation.Key> usageKey = accountUsage.getKeys().stream().findFirst();
     assertTrue(usageKey.isPresent());
@@ -258,9 +257,9 @@ class CloudigradeAccountUsageCollectorTest {
   }
 
   private Map<String, AccountUsageCalculation> usageMapOf(
-      String account, AccountUsageCalculation accountUsage) {
+      String orgId, AccountUsageCalculation accountUsage) {
     HashMap<String, AccountUsageCalculation> map = new HashMap<>();
-    map.put(account, accountUsage);
+    map.put(orgId, accountUsage);
     return map;
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
@@ -74,7 +74,7 @@ class CombiningRollupSnapshotStrategyTest {
     AccountUsageCalculation noonUsage = createAccountUsageCalculation(usageKey, 4.0);
     AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2021-02-24T12:00:00Z"),
             OffsetDateTime.parse("2021-02-26T12:00:00Z")),
@@ -128,7 +128,7 @@ class CombiningRollupSnapshotStrategyTest {
     AccountUsageCalculation day1Usage = createAccountUsageCalculation(usageKey, 4.0);
     AccountUsageCalculation day2Usage = createAccountUsageCalculation(usageKey, 3.0);
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2021-02-24T12:00:00Z"),
             OffsetDateTime.parse("2021-02-26T12:00:00Z")),
@@ -196,7 +196,7 @@ class CombiningRollupSnapshotStrategyTest {
     AccountUsageCalculation noonUsage = createAccountUsageCalculation(usageKey, 4.0);
     AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2021-02-24T12:00:00Z"),
             OffsetDateTime.parse("2021-02-26T12:00:00Z")),
@@ -250,7 +250,7 @@ class CombiningRollupSnapshotStrategyTest {
     AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
 
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2021-02-24T12:00:00Z"),
             OffsetDateTime.parse("2021-02-26T12:00:00Z")),
@@ -310,7 +310,7 @@ class CombiningRollupSnapshotStrategyTest {
     AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
 
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2021-02-24T12:00:00Z"),
             OffsetDateTime.parse("2021-02-26T12:00:00Z")),
@@ -392,7 +392,7 @@ class CombiningRollupSnapshotStrategyTest {
     when(repo.save(any())).then(invocation -> invocation.getArgument(0));
 
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2021-02-24T12:00:00Z"),
             OffsetDateTime.parse("2021-02-26T12:00:00Z")),
@@ -488,7 +488,7 @@ class CombiningRollupSnapshotStrategyTest {
             any(), any(), any(), any(), any()))
         .then(invocation -> Stream.of(existingSnapshot));
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2022-10-24T13:00:00Z"),
             OffsetDateTime.parse("2022-10-24T14:00:00Z")),
@@ -507,7 +507,7 @@ class CombiningRollupSnapshotStrategyTest {
             any(), any(), any(), any(), any()))
         .then(invocation -> Stream.of(existingSnapshot));
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2022-10-24T13:00:00Z"),
             OffsetDateTime.parse("2022-10-24T14:00:00Z")),
@@ -527,7 +527,7 @@ class CombiningRollupSnapshotStrategyTest {
         .then(invocation -> Stream.of(existingSnapshot));
     when(repo.save(any())).then(invocation -> invocation.getArgument(0));
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-        "account123",
+        "org123",
         new DateRange(
             OffsetDateTime.parse("2022-10-24T13:00:00Z"),
             OffsetDateTime.parse("2022-10-24T14:00:00Z")),

--- a/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategyTest.java
@@ -60,7 +60,7 @@ class CombiningRollupSnapshotStrategyTest {
 
   @Test
   void testConsecutiveHoursAddedTogether() {
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), any(), any(), any()))
         .then(invocation -> Stream.empty());
     UsageCalculation.Key usageKey =
@@ -114,7 +114,7 @@ class CombiningRollupSnapshotStrategyTest {
     OffsetDateTime hourlyTimestamp2 = OffsetDateTime.parse("2021-02-26T11:00:00Z");
     OffsetDateTime dailyTimestamp1 = OffsetDateTime.parse("2021-02-25T00:00:00Z");
     OffsetDateTime dailyTimestamp2 = OffsetDateTime.parse("2021-02-26T00:00:00Z");
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), any(), any(), any()))
         .then(invocation -> Stream.empty());
     UsageCalculation.Key usageKey =
@@ -179,10 +179,10 @@ class CombiningRollupSnapshotStrategyTest {
     TallySnapshot noonSnapshot =
         createTallySnapshot(Granularity.HOURLY, "2021-02-25T12:00:00Z", 4.0);
     noonSnapshot.setId(UUID.randomUUID());
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), eq(Granularity.HOURLY), any(), any()))
         .thenReturn(Stream.of(noonSnapshot));
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), eq(Granularity.DAILY), any(), any()))
         .thenReturn(Stream.empty());
     UsageCalculation.Key usageKey =
@@ -231,10 +231,10 @@ class CombiningRollupSnapshotStrategyTest {
     TallySnapshot dailySnapshot =
         createTallySnapshot(Granularity.DAILY, "2021-02-25T00:00:00Z", 7.0);
     dailySnapshot.setId(UUID.randomUUID());
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), eq(Granularity.HOURLY), any(), any()))
         .thenReturn(Stream.empty());
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), eq(Granularity.DAILY), any(), any()))
         .thenReturn(Stream.of(dailySnapshot));
     UsageCalculation.Key usageKey =
@@ -289,11 +289,11 @@ class CombiningRollupSnapshotStrategyTest {
     TallySnapshot dailySnapshot =
         createTallySnapshot(Granularity.DAILY, "2021-02-25T00:00:00Z", 7.0);
 
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), eq(Granularity.HOURLY), any(), any()))
         .thenReturn(Stream.of(noonSnapshot, afternoonSnapshot));
 
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), eq(Granularity.DAILY), any(), any()))
         .thenReturn(Stream.of(dailySnapshot));
 
@@ -357,7 +357,7 @@ class CombiningRollupSnapshotStrategyTest {
     existingHourlySnapshot3.setId(UUID.randomUUID());
     existingHourlySnapshot3.setBillingProvider(BillingProvider.AWS);
 
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), eq(Granularity.HOURLY), any(), any()))
         .thenReturn(
             Stream.of(existingHourlySnapshot1, existingHourlySnapshot2, existingHourlySnapshot3));
@@ -370,7 +370,7 @@ class CombiningRollupSnapshotStrategyTest {
         createTallySnapshot(Granularity.DAILY, "2021-02-25T00:00:00Z", 16.0);
     existingDailySnapshot2.setId(UUID.randomUUID());
     existingDailySnapshot2.setBillingProvider(BillingProvider.AWS);
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), eq(Granularity.DAILY), any(), any()))
         .thenReturn(Stream.of(existingDailySnapshot1, existingDailySnapshot2));
 
@@ -437,7 +437,7 @@ class CombiningRollupSnapshotStrategyTest {
 
   @Test
   void testFinestGranularitySnapshotFilteredByDateRange() {
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), any(), any(), any()))
         .then(invocation -> Stream.empty());
     UsageCalculation.Key usageKey =
@@ -452,7 +452,7 @@ class CombiningRollupSnapshotStrategyTest {
     AccountUsageCalculation afternoonUsage = createAccountUsageCalculation(usageKey, 3.0);
     Map<String, List<TallySnapshot>> talliesToSendByAccount =
         combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
-            "account123",
+            "org123",
             new DateRange(
                 OffsetDateTime.parse("2021-02-25T13:00:00Z"),
                 OffsetDateTime.parse("2021-02-25T14:00:00Z")),
@@ -473,9 +473,9 @@ class CombiningRollupSnapshotStrategyTest {
         createTallySnapshot(Granularity.DAILY, "2021-02-25T00:00:00Z", 7.0);
 
     assertEquals(1, talliesToSendByAccount.keySet().size());
-    assertTrue(talliesToSendByAccount.containsKey("account123"));
+    assertTrue(talliesToSendByAccount.containsKey("org123"));
 
-    List<TallySnapshot> talliesToSend = talliesToSendByAccount.get("account123");
+    List<TallySnapshot> talliesToSend = talliesToSendByAccount.get("org123");
     assertEquals(2, talliesToSend.size());
     assertThat(talliesToSend, containsInAnyOrder(afternoonSnapshot, dailySnapshot));
   }
@@ -484,7 +484,7 @@ class CombiningRollupSnapshotStrategyTest {
   void testExistingOlderFinestGranularitySnapshotMeasurementsPreserved() {
     TallySnapshot existingSnapshot =
         createTallySnapshot(Granularity.HOURLY, "2022-10-24T12:00:00Z", 4.0);
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), any(), any(), any()))
         .then(invocation -> Stream.of(existingSnapshot));
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
@@ -503,7 +503,7 @@ class CombiningRollupSnapshotStrategyTest {
   void testExistingNewerFinestGranularitySnapshotMeasurementsPreserved() {
     TallySnapshot existingSnapshot =
         createTallySnapshot(Granularity.HOURLY, "2022-10-24T14:00:00Z", 4.0);
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), any(), any(), any()))
         .then(invocation -> Stream.of(existingSnapshot));
     combiningRollupSnapshotStrategy.produceSnapshotsFromCalculations(
@@ -522,7 +522,7 @@ class CombiningRollupSnapshotStrategyTest {
   void testFinestGranularitySnapshotClearedWhenUsageNotPresent() {
     TallySnapshot existingSnapshot =
         createTallySnapshot(Granularity.HOURLY, "2022-10-24T13:00:00Z", 4.0);
-    when(repo.findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
+    when(repo.findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
             any(), any(), any(), any(), any()))
         .then(invocation -> Stream.of(existingSnapshot));
     when(repo.save(any())).then(invocation -> invocation.getArgument(0));
@@ -540,7 +540,8 @@ class CombiningRollupSnapshotStrategyTest {
 
   private AccountUsageCalculation createAccountUsageCalculation(
       UsageCalculation.Key usageKey, double v) {
-    AccountUsageCalculation usage = new AccountUsageCalculation("account123");
+    AccountUsageCalculation usage = new AccountUsageCalculation("org123");
+    usage.setAccount("account123");
     usage.addUsage(usageKey, HardwareMeasurementType.PHYSICAL, Measurement.Uom.CORES, v);
     usage.getProducts().add(OPEN_SHIFT_HOURLY);
 
@@ -563,6 +564,7 @@ class CombiningRollupSnapshotStrategyTest {
         .snapshotDate(snapshotDate)
         .productId(OPEN_SHIFT_HOURLY)
         .accountNumber("account123")
+        .orgId("org123")
         .tallyMeasurements(measurements)
         .granularity(granularity)
         .serviceLevel(ServiceLevel.PREMIUM)

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTest.java
@@ -100,9 +100,9 @@ class InventoryAccountUsageCollectorTest {
     Map<String, AccountUsageCalculation> calcs =
         collector.collect(NON_RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation calc = calcs.get(ORG_ID);
     // odd sockets are rounded up.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, NON_RHEL, 12, 4, 1);
     checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, NON_RHEL, 12, 4, 1);
@@ -126,9 +126,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation calc = calcs.get(ORG_ID);
     // odd sockets are rounded up.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
     // no guests running RHEL means no hypervisor total...
@@ -151,9 +151,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation calc = calcs.get(ORG_ID);
     UsageCalculation productCalc = calc.getCalculation(createUsageKey(TEST_PRODUCT));
     assertNull(productCalc.getTotals(HardwareMeasurementType.TOTAL));
     assertNull(productCalc.getTotals(HardwareMeasurementType.PHYSICAL));
@@ -175,9 +175,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation calc = calcs.get(ORG_ID);
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
     checkVirtualTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
     assertNull(
@@ -202,9 +202,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation calc = calcs.get(ORG_ID);
     // odd sockets are rounded up.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
     checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
@@ -243,14 +243,14 @@ class InventoryAccountUsageCollectorTest {
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, account1, orgId1);
     calcs.putAll(collector.collect(RHEL_PRODUCTS, account2, orgId2));
     assertEquals(2, calcs.size());
-    assertThat(calcs, Matchers.hasKey(account1));
-    assertThat(calcs, Matchers.hasKey(account2));
+    assertThat(calcs, Matchers.hasKey(orgId1));
+    assertThat(calcs, Matchers.hasKey(orgId2));
 
-    AccountUsageCalculation a1Calc = calcs.get(account1);
+    AccountUsageCalculation a1Calc = calcs.get(orgId1);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, account1, orgId1, "RHEL", 12, 8, 2);
 
-    AccountUsageCalculation a2Calc = calcs.get(account2);
+    AccountUsageCalculation a2Calc = calcs.get(orgId2);
     assertEquals(1, a2Calc.getProducts().size());
     checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 6, 2, 1);
   }
@@ -284,9 +284,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation a1Calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation a1Calc = calcs.get(ORG_ID);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", 16, 16, 2);
     checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", ServiceLevel._ANY, 16, 16, 2);
@@ -325,9 +325,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation a1Calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation a1Calc = calcs.get(ORG_ID);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", 16, 16, 2);
     checkTotalsCalculation(
@@ -395,14 +395,14 @@ class InventoryAccountUsageCollectorTest {
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, account1, orgId1);
     calcs.putAll(collector.collect(RHEL_PRODUCTS, account2, orgId2));
     assertEquals(2, calcs.size());
-    assertThat(calcs, Matchers.hasKey(account1));
-    assertThat(calcs, Matchers.hasKey(account2));
+    assertThat(calcs, Matchers.hasKey(orgId1));
+    assertThat(calcs, Matchers.hasKey(orgId2));
 
-    AccountUsageCalculation a1Calc = calcs.get(account1);
+    AccountUsageCalculation a1Calc = calcs.get(orgId1);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
 
-    AccountUsageCalculation a2Calc = calcs.get(account2);
+    AccountUsageCalculation a2Calc = calcs.get(orgId2);
     assertEquals(1, a2Calc.getProducts().size());
     checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 12, 6, 1);
   }
@@ -426,22 +426,24 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation accountCalc = calcs.get(ACCOUNT);
+    AccountUsageCalculation accountCalc = calcs.get(ORG_ID);
     assertEquals(1, accountCalc.getProducts().size());
     checkTotalsCalculation(accountCalc, ACCOUNT, ORG_ID, TEST_PRODUCT, 8, 2, 1);
   }
 
   @Test
-  void throwsISEOnAttemptToCalculateFactsBelongingToADifferentOwnerForSameAccount() {
+  void throwsISEOnAttemptToCalculateFactsBelongingToADifferentAccountForSameOrgId() {
     InventoryHostFacts h1 =
-        createRhsmHost(ACCOUNT, "Owner1", Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+        createRhsmHost(
+            "Account1", ORG_ID, Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
     h1.setSystemProfileCoresPerSocket(1);
     h1.setSystemProfileSockets(2);
 
     InventoryHostFacts h2 =
-        createRhsmHost(ACCOUNT, "Owner2", Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+        createRhsmHost(
+            "Account2", ORG_ID, Arrays.asList(TEST_PRODUCT_ID), "", OffsetDateTime.now());
 
     mockReportedHypervisors(ORG_ID, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
@@ -452,7 +454,8 @@ class InventoryAccountUsageCollectorTest {
             IllegalStateException.class, () -> collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID));
 
     String expectedMessage =
-        String.format("Attempt to set a different org for an account: %s:%s", "Owner1", "Owner2");
+        String.format(
+            "Attempt to set a different account for an org: %s:%s", "Account1", "Account2");
     assertEquals(expectedMessage, e.getMessage());
   }
 
@@ -495,15 +498,15 @@ class InventoryAccountUsageCollectorTest {
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, account1, orgId1);
     calcs.putAll(collector.collect(RHEL_PRODUCTS, account2, orgId2));
     assertEquals(2, calcs.size());
-    assertThat(calcs, Matchers.hasKey(account1));
-    assertThat(calcs, Matchers.hasKey(account2));
+    assertThat(calcs, Matchers.hasKey(orgId1));
+    assertThat(calcs, Matchers.hasKey(orgId2));
 
-    AccountUsageCalculation a1Calc = calcs.get(account1);
+    AccountUsageCalculation a1Calc = calcs.get(orgId1);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
     checkPhysicalTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
 
-    AccountUsageCalculation a2Calc = calcs.get(account2);
+    AccountUsageCalculation a2Calc = calcs.get(orgId2);
     assertEquals(1, a2Calc.getProducts().size());
     checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 10, 4, 2);
     checkPhysicalTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 10, 4, 2);
@@ -536,9 +539,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation calc = calcs.get(ORG_ID);
     // odd sockets are rounded up for hypervisor.
     // hypervisor gets counted twice - once for itself, once for the guests
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 24, 8, 2);
@@ -573,9 +576,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation calc = calcs.get(ORG_ID);
     // odd sockets are rounded up for hypervisor.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
     checkHypervisorTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
@@ -605,7 +608,7 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
     ArgumentCaptor<AccountServiceInventory> accountService =
         ArgumentCaptor.forClass(AccountServiceInventory.class);
@@ -668,9 +671,9 @@ class InventoryAccountUsageCollectorTest {
 
     Map<String, AccountUsageCalculation> calcs = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
     assertEquals(1, calcs.size());
-    assertThat(calcs, Matchers.hasKey(ACCOUNT));
+    assertThat(calcs, Matchers.hasKey(ORG_ID));
 
-    AccountUsageCalculation calc = calcs.get(ACCOUNT);
+    AccountUsageCalculation calc = calcs.get(ORG_ID);
     // odd sockets are rounded up.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
     checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);

--- a/src/test/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyControllerTest.java
@@ -47,11 +47,11 @@ class MarketplaceResendTallyControllerTest {
             "deadbeef-0000-0000-0000-defaceace111",
             "cafeface-0000-0000-0000-000000000000");
     var t1 = new TallySnapshot();
-    t1.setAccountNumber("1");
+    t1.setOrgId("1");
     var t2 = new TallySnapshot();
-    t2.setAccountNumber("1");
+    t2.setOrgId("1");
     var t3 = new TallySnapshot();
-    t3.setAccountNumber("1");
+    t3.setOrgId("1");
     var tallyList = List.of(t1, t2, t3);
 
     when(repository.findAllById(Mockito.anyIterable())).thenReturn(tallyList);

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -79,7 +79,7 @@ class SnapshotSummaryProducerTest {
   void testProduceSummary() {
     Map<String, List<TallySnapshot>> updateMap = new HashMap<>();
     updateMap.put(
-        "a1",
+        "org1",
         List.of(
             buildSnapshot(
                 "a1",
@@ -92,7 +92,7 @@ class SnapshotSummaryProducerTest {
                 Uom.CORES,
                 20.4)));
     updateMap.put(
-        "a2",
+        "org2",
         List.of(
             buildSnapshot(
                 "a2",

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -62,12 +62,15 @@ class TallySnapshotControllerTest {
   void setup() {
     AccountConfig accountConfig = new AccountConfig();
     accountConfig.setAccountNumber(ACCOUNT);
-    accountConfig.setOrgId("ORG_" + ACCOUNT);
+    accountConfig.setOrgId(ORG_ID);
     when(accountRepo.findById(ACCOUNT)).thenReturn(Optional.of(accountConfig));
 
     defaultCloudigradeIntegrationEnablement = props.isCloudigradeEnabled();
+    AccountUsageCalculation accountCalc = new AccountUsageCalculation(ORG_ID);
+    accountCalc.setAccount(ACCOUNT);
+
     when(inventoryCollector.collect(any(), any(), any()))
-        .thenReturn(ImmutableMap.of(ACCOUNT, new AccountUsageCalculation(ACCOUNT)));
+        .thenReturn(ImmutableMap.of(ORG_ID, accountCalc));
   }
 
   @AfterEach
@@ -80,7 +83,7 @@ class TallySnapshotControllerTest {
     props.setCloudigradeEnabled(true);
     when(accountRepo.findAccountNumberByOrgId(ORG_ID)).thenReturn(ACCOUNT);
     controller.produceSnapshotsForOrg(ORG_ID);
-    verify(cloudigradeCollector).enrichUsageWithCloudigradeData(any(), any(), any());
+    verify(cloudigradeCollector).enrichUsageWithCloudigradeData(any(), any());
   }
 
   @Test
@@ -103,9 +106,9 @@ class TallySnapshotControllerTest {
     when(accountRepo.findAccountNumberByOrgId(ORG_ID)).thenReturn(ACCOUNT);
     doThrow(new RuntimeException())
         .when(cloudigradeCollector)
-        .enrichUsageWithCloudigradeData(any(), any(), any());
+        .enrichUsageWithCloudigradeData(any(), any());
     controller.produceSnapshotsForOrg(ORG_ID);
-    verify(cloudigradeCollector, times(2)).enrichUsageWithCloudigradeData(any(), any(), any());
+    verify(cloudigradeCollector, times(2)).enrichUsageWithCloudigradeData(any(), any());
   }
 
   @Test
@@ -122,6 +125,6 @@ class TallySnapshotControllerTest {
     when(accountRepo.findOrgByAccountNumber(ACCOUNT)).thenReturn(ORG_ID);
     when(accountRepo.findAccountNumberByOrgId(ORG_ID)).thenReturn(ACCOUNT);
     controller.produceSnapshotsForAccount(ACCOUNT);
-    verify(cloudigradeCollector).enrichUsageWithCloudigradeData(any(), any(), any());
+    verify(cloudigradeCollector).enrichUsageWithCloudigradeData(any(), any());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -94,13 +94,6 @@ class TallySnapshotControllerTest {
   }
 
   @Test
-  void testWhenCloudigradeAccountUsageCollectorEnabledAndMissingAccount_EnrichmentNotInvoked() {
-    props.setCloudigradeEnabled(true);
-    assertThrows(IllegalArgumentException.class, () -> controller.produceSnapshotsForOrg(ORG_ID));
-    verifyNoInteractions(cloudigradeCollector);
-  }
-
-  @Test
   void testCloudigradeAccountUsageCollectorExceptionIgnored() throws Exception {
     props.setCloudigradeEnabled(true);
     when(accountRepo.findAccountNumberByOrgId(ORG_ID)).thenReturn(ACCOUNT);

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -79,13 +79,6 @@ class DailySnapshotRollerTest {
   }
 
   @Test
-  @SuppressWarnings("java:S2699") /* NOTE(khowell): have no idea why sonar thinks no assertions */
-  void testEmptySnapshotsNotPersisted() {
-    tester.performDoesNotPersistEmptySnapshots(
-        Granularity.DAILY, clock.startOfToday(), clock.endOfToday());
-  }
-
-  @Test
   @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
   void testHandlesDuplicates() {
     tester.performRemovesDuplicates(Granularity.DAILY, clock.startOfToday(), clock.endOfToday());

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
@@ -102,13 +102,6 @@ class HourlySnapshotRollerTest {
 
   @Test
   @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
-  void testEmptySnapshotsNotPersisted() {
-    tester.performDoesNotPersistEmptySnapshots(
-        HOURLY, clock.startOfCurrentHour(), clock.endOfCurrentHour());
-  }
-
-  @Test
-  @SuppressWarnings("java:S2699") /* Sonar thinks no assertions */
   void testHandlesDuplicates() {
     tester.performRemovesDuplicates(HOURLY, clock.startOfCurrentHour(), clock.endOfCurrentHour());
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -109,7 +109,7 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
    * Find all the events based on the account number and service type that exist during the
    * specified range.
    *
-   * @param accountNumber
+   * @param orgId
    * @param serviceType
    * @param begin
    * @param end
@@ -118,10 +118,10 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
   @Query(
       nativeQuery = true,
       value =
-          "select * from events where account_number=:accountNumber and data->>'service_type'=:serviceType and timestamp >= :begin and timestamp < :end order by timestamp")
+          "select * from events where org_id=:orgId and data->>'service_type'=:serviceType and timestamp >= :begin and timestamp < :end order by timestamp")
   Stream<EventRecord>
-      findByAccountNumberAndServiceTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-          @Param("accountNumber") String accountNumber,
+      findByOrgIdAndServiceTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+          @Param("orgId") String orgId,
           @Param("serviceType") String serviceType,
           @Param("begin") OffsetDateTime begin,
           @Param("end") OffsetDateTime end);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -85,19 +85,19 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
   @Query(
       value =
           "SELECT distinct t FROM TallySnapshot t left join fetch t.tallyMeasurements where "
-              + "t.accountNumber = :accountNumber and "
+              + "t.orgId = :orgId and "
               + "t.productId in (:productIds) and "
               + "t.granularity = :granularity  and "
               + "t.snapshotDate between :beginning and :ending "
               + "order by t.snapshotDate",
       countQuery =
           "SELECT count(t) FROM TallySnapshot t where "
-              + "t.accountNumber = :accountNumber and "
+              + "t.orgId = :orgId and "
               + "t.productId in (:productIds) and "
               + "t.granularity = :granularity  and "
               + "t.snapshotDate between :beginning and :ending ")
-  Stream<TallySnapshot> findByAccountNumberAndProductIdInAndGranularityAndSnapshotDateBetween(
-      String accountNumber,
+  Stream<TallySnapshot> findByOrgIdAndProductIdInAndGranularityAndSnapshotDateBetween(
+      String orgId,
       Collection<String> productIds,
       Granularity granularity,
       OffsetDateTime beginning,


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-643

AccountUsageCalculations are now based on orgId and all usage
collection mappings are now done by orgId instead of
account number.

This refactor allowed for completely removing account dependancy
from all cloudigrade usage collection.

## Testing
Clean out the DBs:
```
psql -h localhost -U insights insights <<EOF
delete from hosts;
EOF


psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
delete from events;
delete from tally_snapshots;
delete from tally_measurements;
delete from instance_monthly_totals;
delete from instance_measurements;
delete from billable_usage_remittance;
EOF
```

Insert some hosts.

```shell
bin/insert-mock-hosts \
  --num-hypervisors 1 \
  --num-guests 4 \
  --hbi \
  --clear \
  --org org123
```

Run the service:
```shell
DEV_MODE=true ./gradlew :bootRun
```

Ensure opt-in:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean \
  operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)' \
  arguments:='["account123","org123",true,true,true]'
```

Trigger a nightly tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org123"]'
```

Verify the tally ran completely, and check the data.
```
select org_id, granularity, snapshot_date, uom, value from tally_snapshots s inner join tally_measurements m on s.id = m.snapshot_id where measurement_type='TOTAL'  and product_id='RHEL' and sla='_ANY' and usage='_ANY' and billing_provider='_ANY' and billing_account_id='_ANY' order by snapshot_date desc, granularity, uom;
```

**Run the tally again, and ensure that it results in the same number of snapshots and spotcheck to make sure they did not change.**

Next test the hourly metering tally. Start by cleaning out the DB.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
delete from events;
delete from tally_snapshots;
delete from tally_measurements;
delete from instance_monthly_totals;
delete from instance_measurements;
delete from billable_usage_remittance;
EOF
```

Load some events into the DB.
```
bin/import-events.py --file bin/events.csv
```

Opt In the account:
```
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean \
  operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)' \
  arguments:='["account123","org123",true,true,true]'
```

Run the hourly tally:
```
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyAllAccountsByHourly(java.lang.String,java.lang.String)' \
  arguments:='["2021-10-18T00:00Z","2021-10-19T00:00Z"]'
```

Verify the tally ran, and check the data. Make sure that the summations from the 2 and 3rd queries line up with those in the first.
```
-- Get the instance totals
select h.instance_id, t.uom, t.value from instance_monthly_totals t, hosts h where t.instance_id = h.id and month='2021-10' and h.instance_id::text in (select distinct e.instance_id from events e where e.org_id='org123' and extract(month from e.timestamp) = 10) order by h.instance_id;

-- Verify Cores
select e.instance_id, sum((measurements->>'value')::numeric) from events e, jsonb_array_elements(data->'measurements') measurements where org_id='org123' and extract(month from timestamp) = 10 and measurements->>'uom' = 'Cores' group by e.instance_id order by instance_id;

-- Verify Instance Hours
select e.instance_id, sum((measurements->>'value')::numeric) from events e, jsonb_array_elements(data->'measurements') measurements where org_id='org123' and extract(month from timestamp) = 10 and measurements->>'uom' = 'Instance-hours' group by e.instance_id order by instance_id;
```

**Re-run the tally and ensure that the values do not change. This is the key part that the mapping changes affect.**