### PR TITLE
SWATCH-133: add flag to enable and disable forced subscription sync for payg subs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceProperties.java
@@ -58,4 +58,7 @@ public class SubscriptionServiceProperties extends HttpClientProperties {
 
   /** Do not sync any subs starting later than this much in the future from now. */
   private Period ignoreStartingLaterThan = Period.ofMonths(2);
+
+  /** Allow force sync of PAYG subscriptions */
+  private boolean enablePaygSubscriptionForceSync;
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -491,6 +491,10 @@ public class SubscriptionSyncController {
 
   @Transactional
   public void forceSyncSubscriptionsForOrg(String orgId, boolean paygOnly) {
+    if (paygOnly && !properties.isEnablePaygSubscriptionForceSync()) {
+      log.info("Force sync of payg subscriptions disabled");
+      return;
+    }
     log.info("Starting force sync for orgId: {}", orgId);
     var subscriptions = subscriptionService.getSubscriptionsByOrgId(orgId);
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,6 +77,7 @@ rhsm-subscriptions:
     page-size: ${SUBSCRIPTION_PAGE_SIZE:1000}
     ignore-expired-older-than: ${SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN:2m}
     ignore-starting-later-than: ${SUBSCRIPTION_IGNORE_STARTING_LATER_THAN:2m}
+    enable-payg-subscription-force-sync: ${ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC:false}
   user-service:
     use-stub: ${USER_USE_STUB:false}
     url: https://${USER_HOST:localhost}:${USER_PORT:443}

--- a/swatch-core-test/src/main/resources/application-test.yaml
+++ b/swatch-core-test/src/main/resources/application-test.yaml
@@ -18,6 +18,7 @@ rhsm-subscriptions:
     tasks:
       topic: platform.rhsm-subscriptions.subscription-sync
       kafka-group-id: subscription-worker
+    enable-payg-subscription-force-sync: true
   capacity:
     tasks:
       topic: platform.rhsm-subscriptions.capacity-reconcile

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -90,6 +90,8 @@ parameters:
     value: placeholder
   - name: UMB_PROCESSING_ENABLED
     value: 'true'
+  - name: ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC
+    value: 'false'
   - name: ENABLE_SPLUNK_HEC
     value: 'true'
   - name: SPLUNK_SOURCE
@@ -397,6 +399,8 @@ objects:
               value: ${UMB_PROCESSING_ENABLED}
             - name: UMB_SERVICE_ACCOUNT_NAME
               value: ${UMB_SERVICE_ACCOUNT_NAME}
+            - name: ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC
+              value: ${ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC}
             - name: UMB_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-133

- Start app with: `DEV_MODE=true ./gradlew :bootRun`
- Curl: `curl   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext?orgId=123&date=2022-01-01T00%3A00Z&productId=rhosak&sla=Premium&usage=Production&accountNumber=123&awsAccountId=123'   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'`
- Check logs to ensure force sync messages are not there: 
```
2022-11-21 18:51:39,058 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.subscription.SubscriptionSyncController] self- Starting force sync for orgId: 123
2022-11-21 18:51:39,069 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.subscription.SubscriptionSyncController] self- Finished force sync for orgId: 123
```

