### PR TITLE
SWATCH-564: Add annotations to ignore sidecar DVO checks

### DIFF
--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -133,6 +133,10 @@ objects:
               enabled: true
           replicas: ${{REPLICAS}}
           podSpec:
+            metadata:
+              annotations:
+                ignore-check.kube-linter.io/no-liveness-probe: The token refresher sidecar container doesn't have a liveness probe instrumented but the service container does
+                ignore-check.kube-linter.io/no-readiness-probe: The token refresher sidecar container doesn't have a readiness probe instrumented but the service container does
             image: ${IMAGE}:${IMAGE_TAG}
             command:
               - /bin/bash


### PR DESCRIPTION
* The token refresher sidecar doesn't create health probes and is triggering DVO check failures
* Add annotations to bypass these checks for the deployment due to the sidecar.

Related to: https://issues.redhat.com/browse/SWATCH-564