### PR TITLE
SWATCH-648 SWATCH-723 SWATCH-724 Various fixes for account => orgId migration

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -74,20 +74,20 @@ public class InternalSubscriptionResource implements InternalApi {
 
   @Override
   public AwsUsageContext getAwsUsageContext(
-      String accountNumber,
       String orgId,
       OffsetDateTime date,
       String productId,
+      String accountNumber,
       String sla,
       String usage,
-      String billingAccountId) {
+      String awsAccountId) {
     UsageCalculation.Key usageKey =
         new Key(
             productId,
             ServiceLevel.fromString(sla),
             Usage.fromString(usage),
             BillingProvider.AWS,
-            billingAccountId);
+            awsAccountId);
 
     // Set start date one hour in past to pickup recently terminated subscriptions
     var start = date.minusHours(1);

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -117,9 +117,7 @@ public class PrometheusMeteringController {
      */
     OffsetDateTime startDate = clock.startOfHour(start).plusHours(1);
     log.debug("Ensuring orgId={} has been set up for syncing/reporting.", orgId);
-    // NOTE: https://issues.redhat.com/browse/SWATCH-262 should remove this workaround.
-    // with SWATCH-262, ensureOptIn can be called without using its return value.
-    String accountNumberFromOptIn = ensureOptIn(orgId);
+    ensureOptIn(orgId);
     openshiftRetry.execute(
         context -> {
           try {
@@ -175,8 +173,6 @@ public class PrometheusMeteringController {
               String billingProvider = labels.get("billing_marketplace");
               String billingAccountId = labels.get("billing_marketplace_account");
               String account = labels.get("ebs_account");
-              // NOTE: https://issues.redhat.com/browse/SWATCH-262 should remove this workaround.
-              account = ensureAccountNumber(account, accountNumberFromOptIn);
 
               // For the openshift metrics, we expect our results to be a 'matrix'
               // vector [(instant_time,value), ...] so we only look at the result's getValues()
@@ -228,20 +224,6 @@ public class PrometheusMeteringController {
             throw e;
           }
         });
-  }
-
-  // SWATCH-262 should remove this method
-  private String ensureAccountNumber(String account, String accountNumberFromOptIn) {
-    if (StringUtils.hasText(account)) {
-      return account;
-    }
-    if (!StringUtils.hasText(accountNumberFromOptIn)) {
-      // For now, refuse to process an event that is completely missing accountNumber.
-      // Otherwise, we'd potentially end up in a state where a customer can't view the
-      // tally data.
-      throw new IllegalStateException("Refusing to persist event without accountNumber");
-    }
-    return accountNumberFromOptIn;
   }
 
   private String ensureOptIn(String orgId) {

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -226,14 +226,13 @@ public class PrometheusMeteringController {
         });
   }
 
-  private String ensureOptIn(String orgId) {
+  private void ensureOptIn(String orgId) {
     try {
-      return optInController.optInByOrgId(orgId, OptInType.PROMETHEUS);
+      optInController.optInByOrgId(orgId, OptInType.PROMETHEUS);
     } catch (Exception e) {
       log.warn("Error while attempting to automatically opt-in orgId={}", orgId);
       log.debug("Opt-in error for orgId=" + orgId, e);
     }
-    return null;
   }
 
   @SuppressWarnings("java:S107")

--- a/src/main/java/org/candlepin/subscriptions/security/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInController.java
@@ -103,15 +103,14 @@ public class OptInController {
   // Separate isolated transaction needed in order to prevent opt-in errors rolling back metrics
   // updates
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public String optInByOrgId(String orgId, OptInType optInType) {
-    if (accountConfigRepository.existsById(orgId)) {
-      return accountConfigRepository.findAccountNumberByOrgId(orgId);
+  public void optInByOrgId(String orgId, OptInType optInType) {
+    if (!accountConfigRepository.existsById(orgId)) {
+      log.info("Opting in orgId={}", orgId);
+      // NOTE Passing null here should be cleaned up once account number
+      // support is completely removed from opt-in.
+      // https://issues.redhat.com/browse/SWATCH-662
+      performOptIn(null, orgId, optInType).getData().getAccount().getAccountNumber();
     }
-
-    log.info("Opting in orgId={}", orgId);
-    // NOTE Passing null here should be cleaned up once account number
-    // support is completely removed from opt-in.
-    return performOptIn(null, orgId, optInType).getData().getAccount().getAccountNumber();
   }
 
   @Transactional

--- a/src/main/java/org/candlepin/subscriptions/security/OptInController.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInController.java
@@ -104,12 +104,14 @@ public class OptInController {
   // updates
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public String optInByOrgId(String orgId, OptInType optInType) {
-    if (orgConfigRepository.existsById(orgId)) {
+    if (accountConfigRepository.existsById(orgId)) {
       return accountConfigRepository.findAccountNumberByOrgId(orgId);
     }
-    String accountNumber = accountService.lookupAccountNumber(orgId);
-    log.info("Opting in account/orgId: {}/{}", accountNumber, orgId);
-    return performOptIn(accountNumber, orgId, optInType).getData().getAccount().getAccountNumber();
+
+    log.info("Opting in orgId={}", orgId);
+    // NOTE Passing null here should be cleaned up once account number
+    // support is completely removed from opt-in.
+    return performOptIn(null, orgId, optInType).getData().getAccount().getAccountNumber();
   }
 
   @Transactional

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -148,6 +148,19 @@ public class MetricUsageCollector {
                   instance.clearMonthlyTotals(effectiveStartDateTime, effectiveEndDateTime));
     }
 
+    Map<OffsetDateTime, AccountUsageCalculation> accountCalcs =
+        collectHourlyCalculations(
+            accountServiceInventory, effectiveStartDateTime, effectiveEndDateTime);
+    accountServiceInventoryRepository.save(accountServiceInventory);
+
+    return new CollectionResult(
+        new DateRange(effectiveStartDateTime, effectiveEndDateTime), accountCalcs, isRecalculating);
+  }
+
+  private Map<OffsetDateTime, AccountUsageCalculation> collectHourlyCalculations(
+      AccountServiceInventory accountServiceInventory,
+      OffsetDateTime effectiveStartDateTime,
+      OffsetDateTime effectiveEndDateTime) {
     Map<OffsetDateTime, AccountUsageCalculation> accountCalcs = new HashMap<>();
     for (OffsetDateTime offset = effectiveStartDateTime;
         offset.isBefore(effectiveEndDateTime);
@@ -168,10 +181,7 @@ public class MetricUsageCollector {
         }
       }
     }
-    accountServiceInventoryRepository.save(accountServiceInventory);
-
-    return new CollectionResult(
-        new DateRange(effectiveStartDateTime, effectiveEndDateTime), accountCalcs, isRecalculating);
+    return accountCalcs;
   }
 
   @Transactional

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -152,13 +152,14 @@ public class MetricUsageCollector {
     for (OffsetDateTime offset = effectiveStartDateTime;
         offset.isBefore(effectiveEndDateTime);
         offset = offset.plusHours(1)) {
-      AccountUsageCalculation accountUsageCalculation = collectHour(accountServiceInventory, offset);
+      AccountUsageCalculation accountUsageCalculation =
+          collectHour(accountServiceInventory, offset);
 
       if (accountUsageCalculation != null) {
         // The associated account number for a calculation has already been determined from the
         // hosts instances (based on the event). Pass that info along if it isn't already known.
-        if (!StringUtils.hasText(accountServiceInventory.getAccountNumber()) &&
-          StringUtils.hasText(accountUsageCalculation.getAccount())) {
+        if (!StringUtils.hasText(accountServiceInventory.getAccountNumber())
+            && StringUtils.hasText(accountUsageCalculation.getAccount())) {
           accountServiceInventory.setAccountNumber(accountUsageCalculation.getAccount());
         }
 
@@ -231,35 +232,35 @@ public class MetricUsageCollector {
         .values()
         .forEach(
             instance -> {
-                instance.getBuckets()
-                    .forEach(
-                        bucket -> {
-                          UsageCalculation.Key usageKey =
-                              new UsageCalculation.Key(
-                                  bucket.getKey().getProductId(),
-                                  bucket.getKey().getSla(),
-                                  bucket.getKey().getUsage(),
-                                  bucket.getKey().getBillingProvider(),
-                                  bucket.getKey().getBillingAccountId());
-                          instance
-                              .getMeasurements()
-                              .forEach(
-                                  (uom, value) ->
-                                      accountUsageCalculation.addUsage(
-                                          usageKey,
-                                          getHardwareMeasurementType(instance),
-                                          uom,
-                                          value));
-                        }
-                    );
+              instance
+                  .getBuckets()
+                  .forEach(
+                      bucket -> {
+                        UsageCalculation.Key usageKey =
+                            new UsageCalculation.Key(
+                                bucket.getKey().getProductId(),
+                                bucket.getKey().getSla(),
+                                bucket.getKey().getUsage(),
+                                bucket.getKey().getBillingProvider(),
+                                bucket.getKey().getBillingAccountId());
+                        instance
+                            .getMeasurements()
+                            .forEach(
+                                (uom, value) ->
+                                    accountUsageCalculation.addUsage(
+                                        usageKey,
+                                        getHardwareMeasurementType(instance),
+                                        uom,
+                                        value));
+                      });
 
-                // Pull the account number from the first instance. All instances should have
-                // the same account.
-                if (Objects.isNull(accountUsageCalculation.getAccount()) && StringUtils.hasText(instance.getAccountNumber())) {
-                  accountUsageCalculation.setAccount(instance.getAccountNumber());
-                }
-            }
-         );
+              // Pull the account number from the first instance. All instances should have
+              // the same account.
+              if (Objects.isNull(accountUsageCalculation.getAccount())
+                  && StringUtils.hasText(instance.getAccountNumber())) {
+                accountUsageCalculation.setAccount(instance.getAccountNumber());
+              }
+            });
     return accountUsageCalculation;
   }
 

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -61,7 +61,7 @@ paths:
     parameters:
       - name: accountNumber
         in: query
-        required: true
+        required: false
         schema:
           type: string
         description: "Customer's Account Number"

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -96,7 +96,7 @@ class InternalSubscriptionResourceTest {
         NotFoundException.class,
         () ->
             resource.getAwsUsageContext(
-                "account123", null, defaultLookUpDate, "rhosak", "Premium", "Production", "123"));
+                null, defaultLookUpDate, "rhosak", "account123", "Premium", "Production", "123"));
     Counter counter = meterRegistry.counter("swatch_missing_aws_subscription");
     assertEquals(1.0, counter.count());
   }
@@ -113,7 +113,7 @@ class InternalSubscriptionResourceTest {
         NotFoundException.class,
         () ->
             resource.getAwsUsageContext(
-                null, "org123", defaultLookUpDate, "rhosak", "Premium", "Production", "123"));
+                "org123", defaultLookUpDate, "rhosak", null, "Premium", "Production", "123"));
     Counter counter = meterRegistry.counter("swatch_missing_aws_subscription");
     assertEquals(1.0, counter.count());
   }
@@ -134,7 +134,7 @@ class InternalSubscriptionResourceTest {
         .thenReturn(List.of(sub1, sub2));
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
-            "account123", null, defaultLookUpDate, "rhosak", "Premium", "Production", "123");
+            null, defaultLookUpDate, "rhosak", "account123", "Premium", "Production", "123");
     Counter counter = meterRegistry.counter("swatch_ambiguous_aws_subscription");
     assertEquals(1.0, counter.count());
     assertEquals("foo1", awsUsageContext.getProductCode());
@@ -158,7 +158,7 @@ class InternalSubscriptionResourceTest {
         .thenReturn(List.of(sub1, sub2));
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
-            null, "org123", defaultLookUpDate, "rhosak", "Premium", "Production", "123");
+            "org123", defaultLookUpDate, "rhosak", null, "Premium", "Production", "123");
     Counter counter = meterRegistry.counter("swatch_ambiguous_aws_subscription");
     assertEquals(1.0, counter.count());
     assertEquals("foo1", awsUsageContext.getProductCode());
@@ -185,7 +185,7 @@ class InternalSubscriptionResourceTest {
             SubscriptionsException.class,
             () -> {
               resource.getAwsUsageContext(
-                  "account123", null, lookupDate, "rhosak", "Premium", "Production", "123");
+                  null, lookupDate, "rhosak", "account123", "Premium", "Production", "123");
             });
 
     assertEquals(
@@ -212,7 +212,7 @@ class InternalSubscriptionResourceTest {
             SubscriptionsException.class,
             () -> {
               resource.getAwsUsageContext(
-                  null, "org123", lookupDate, "rhosak", "Premium", "Production", "123");
+                  "org123", lookupDate, "rhosak", null, "Premium", "Production", "123");
             });
 
     assertEquals(
@@ -238,7 +238,7 @@ class InternalSubscriptionResourceTest {
     var lookupDate = endDate.plusMinutes(30);
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
-            "account123", null, lookupDate, "rhosak", "Premium", "Production", "123");
+            null, lookupDate, "rhosak", null, "Premium", "Production", "123");
     assertEquals("bar1", awsUsageContext.getProductCode());
     assertEquals("bar2", awsUsageContext.getCustomerId());
     assertEquals("bar3", awsUsageContext.getAwsSellerAccountId());
@@ -262,7 +262,7 @@ class InternalSubscriptionResourceTest {
     var lookupDate = endDate.plusMinutes(30);
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
-            null, "org123", lookupDate, "rhosak", "Premium", "Production", "123");
+            "org123", lookupDate, "rhosak", null, "Premium", "Production", "123");
     assertEquals("bar1", awsUsageContext.getProductCode());
     assertEquals("bar2", awsUsageContext.getCustomerId());
     assertEquals("bar3", awsUsageContext.getAwsSellerAccountId());

--- a/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
@@ -153,4 +153,10 @@ class AccountConfigRepositoryTest {
     config.setUpdated(config.getCreated().plusDays(1));
     return config;
   }
+
+  @Test
+  void testFindAccountNumberByOrgId() {
+    String account = repository.findAccountNumberByOrgId("12344444");
+    assertNull(account);
+  }
 }

--- a/src/test/java/org/candlepin/subscriptions/security/OptInControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/OptInControllerTest.java
@@ -194,11 +194,9 @@ class OptInControllerTest {
   }
 
   @Test
-  void testOptInViaOrgId() {
+  void testOptInViaOrgIdOnly() {
     controller.optInByOrgId("org123", OptInType.API);
-
     assertTrue(orgRepo.existsByOrgId("org123"));
-    assertTrue(accountRepo.existsByAccountNumber("account123"));
   }
 
   @Test

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/AccountConfigRepository.java
@@ -28,6 +28,7 @@ import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.util.StringUtils;
 
 /** Defines all operations for storing account config entries. */
 public interface AccountConfigRepository extends JpaRepository<AccountConfig, String> {
@@ -62,13 +63,17 @@ public interface AccountConfigRepository extends JpaRepository<AccountConfig, St
     Optional<AccountConfig> found = findByOrgId(orgId);
     AccountConfig accountConfig = found.orElse(new AccountConfig());
     if (!found.isPresent()) {
-      accountConfig.setOrgId(orgId);
       accountConfig.setOptInType(optInType);
       accountConfig.setCreated(current);
     }
-    accountConfig.setAccountNumber(account);
     accountConfig.setOrgId(orgId);
     accountConfig.setUpdated(current);
+
+    // Only set the account number if it is known.
+    if (StringUtils.hasText(account)) {
+      accountConfig.setAccountNumber(account);
+    }
+
     return Optional.of(save(accountConfig));
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/BillableUsageProcessor.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/processors/BillableUsageProcessor.java
@@ -150,10 +150,10 @@ public class BillableUsageProcessor {
       throws AwsUsageContextLookupException {
     try {
       return internalSubscriptionsApi.getAwsUsageContext(
-          billableUsage.getAccountNumber(),
           billableUsage.getOrgId(),
           billableUsage.getSnapshotDate(),
           billableUsage.getProductId(),
+          billableUsage.getAccountNumber(),
           Optional.ofNullable(billableUsage.getSla()).map(SlaEnum::value).orElse(null),
           Optional.ofNullable(billableUsage.getUsage()).map(UsageEnum::value).orElse(null),
           Optional.ofNullable(billableUsage.getBillingAccountId()).orElse("_ANY"));


### PR DESCRIPTION
I'm sorry about the single PR that covers the 3 cards (subtasks) but as I was working on them, they were all sort of dependant on one another and were hard to untangle without conflicts.

1. https://issues.redhat.com/browse/SWATCH-648
    * Ignore account when not found during opt-in.
    * Remove unnecessary account checks when metering
2. https://issues.redhat.com/browse/SWATCH-723
    * Properly set account during hourly tally
    We were setting account_number on account calculations based on AccountInventoryService.account which may not exist if there is no account associated with an org. This patch will set it based on the first host instance that has a value set. This way the account number is in essance coming from the event that created the host.
3. https://issues.redhat.com/browse/SWATCH-724
    * Account number not required for awsUsageContext API


# How To Test

Please reach out if you have any issues with setting up for testing.

### Part 1

Generate some mock prometheus data without the ebs_account label and WITH external_organization set, and run the service. **Edit** the `bin/prometheus-mock-data.sh` script and remove the **ebs_account="...."** portion of the metric template.

```diff
-subscription_labels{_id="$CLUSTER_ID",billing_model="marketplace",ebs_account="$ACCOUNT",external_organization="$ORG_ID",support="Premium",billing_provider="$BILLING_PROVIDER",billing_marketplace_account="$MARKETPLACE_ACCOUNT",product="$PRODUCT"} 1.0 $TIME
+subscription_labels{_id="$CLUSTER_ID",billing_model="marketplace",external_organization="$ORG_ID",support="Premium",billing_provider="$BILLING_PROVIDER",billing_marketplace_account="$MARKETPLACE_ACCOUNT",product="$PRODUCT"} 1.0 $TIME

```

Run the script with a custom org. This should start a prometheus service for you.
```
ORG_ID=my-org ./bin/prometheus-mock-data.sh
```

Ensure your DB is fresh
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```

In a seperate terminal, launch the app (replace ${REPLACE} with act)
```
PROM_URL="http://localhost:9090/api/v1/" ./gradlew :bootRun
```

Run metering with your custom org from above.
```
curl -X POST -H "x-rh-swatch-synchronous-request: false" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?orgId=my-org&rangeInMinutes=120"
```

Check to make sure that metrics were found and that events were created successfully without an account number.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from events"
```

Run the hourly tally for this account. **Ensure to update the date range"
```
http :9000/hawtio/jolokia   type=exec   mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["my-org", "2022-12-13T00:00Z","2022-12-13T23:00Z"]'
```

Ensure that snapshots are produced (account number will not be set on the snapshots).
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from tally_snapshots"
```


### Part 2
**Revert the changes to the data generation script** and run it again with a custom org and account.
```
ORG_ID=my-org ACCOUNT=my-account ./bin/prometheus-mock-data.sh
```

Run metering with your custom org from above.
```
curl -X POST -H "x-rh-swatch-synchronous-request: false" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?orgId=my-org&rangeInMinutes=120"
```

Check to make sure that metrics were found and that events were created successfully WITH an account number on NEW/UPDATED Events.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from events"
```

Run the hourly tally for this account. **Ensure to update the date range"
```
http :9000/hawtio/jolokia   type=exec   mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["my-org", "2022-12-13T00:00Z","2022-12-13T23:00Z"]'
```

Ensure that snapshots are produced (account number WILL be set on NEW  snapshots).
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from tally_snapshots"
```

### Part 3
Create a custom product allow list with the following products.
```
MW02164HR
MW01882
```

Run the application configured against your custom allow list and production product/subscription services. **Be sure to replace the allow list path and truststore/passwords**

**!!!** The keystore/password for prod can be found in vault. **!!!**

```
PRODUCT_ALLOWLIST_RESOURCE_LOCATION=file:${PATH_TO_YOUR_ALLOW_LIST} PRODUCT_URL=https://product.api.redhat.com/svcrest/product/v3 PRODUCT_KEYSTORE=${YOUR_PATH}/keystore.jks PRODUCT_KEYSTORE_PASSWORD=${PROD_KEYSTORE_PASSWORD} RHSM_URL=https://api.rhsm.redhat.com/v1 RHSM_KEYSTORE=${YOUR_PATH}/keystore.jks RHSM_KEYSTORE_PASSWORD=${PROD_KEYSTORE_PASSWORD} SUBSCRIPTION_USE_STUB=false SUBSCRIPTION_KEYSTORE=${YOUR_PATH}/keystore.jks SUBSCRIPTION_KEYSTORE_PASSWORD=${PROD_KEYSTORE_PASSWORD}  SUBSCRIPTION_URL=https://subscription.api.redhat.com/svcrest/subscription/v5 DEV_MODE=true ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC=true PROM_URL="http://localhost:9090/api/v1/" ./gradlew :bootRun
```

Get the AWS usage context for org 13617887 (without account number) 
```
http GET :8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext orgId==13617887  productId==rhosak sla==Premium usage==Production date=="2022-12-09T19:00Z" awsAccountId==324151919439 x-rh-swatch-psk:placeholder
```