### PR TITLE
SWATCH-729: Migrate osd billling factor

### DIFF
--- a/src/test/resources/test_tag_profile.yaml
+++ b/src/test/resources/test_tag_profile.yaml
@@ -148,6 +148,7 @@ tagMetrics:
   - tag: OpenShift-dedicated-metrics
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
+    billingFactor: 0.25
     billingWindow: HOURLY
     queryKey: default
     queryParams:

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -203,7 +203,7 @@ tagMetrics:
     metricId: redhat.com:openshift_dedicated:4cpu_hour
     rhmMetricId: redhat.com:openshift_dedicated:4cpu_hour
     uom: CORES
-    #billingFactor: 0.25
+    billingFactor: 0.25
     billingWindow: MONTHLY
     queryKey: default
     queryParams:


### PR DESCRIPTION
This is to address  [SWATCH-729 ](https://issues.redhat.com/browse/SWATCH-729) 

This is to allow usage to calculate tag-metric for osd specifically as billing factor will be used to remove the hard coded division logic in the RHM Producer. Which is currently dividing the cores uom values for osd by 4. Billing Factor is configured for osd to be 0.25 which should give the same output and make the hard coded logic in the RHM Marketplace Mapper redundant. 

This is a followup to https://github.com/RedHatInsights/rhsm-subscriptions/pull/1661

# Testing Steps
Run workflow with 'main' and than using the data saved in the DB rerun tally with this branch. The remittance table should have billing factor updated for `osd` and the calculation should be the same for cores value.
```
select * from billable_usage_remittance where product_id = 'OpenShift-dedicated-metrics';
```
Run the service:

```shell
USER_USE_STUB=true SUBSCRIPTION_USE_STUB=true CG_USE_STUB=true CLOUDIGRADE_ENABLED=false DEV_MODE=true ./gradlew clean :bootRun
```

Load events into the DB:

```shell
bin/import-events.py --file bin/events.csv
```

Opt in all accounts from the events:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean \
  operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)' \
  arguments:='["account123","org123",true,true,true]'
```

Do an hourly tally for all accounts:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyAllAccountsByHourly(java.lang.String,java.lang.String)' \
  arguments:='["2021-10-18T00:00Z","2021-10-19T00:00Z"]'
```
Make sure that the remittance table values gets updated with the new billing factor value, if you run into issues I used https://github.com/RedHatInsights/rhsm-subscriptions/pull/1177 as a reference to check the remittance table.