### PR TITLE
Delete stale hosts (no longer in HBI) during tally

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -180,6 +180,12 @@ public class InventoryAccountUsageCollector {
           totalHosts.increment();
         });
 
+    log.info(
+        "Removing {} stale host records (HBI records no longer present).", inventoryHostMap.size());
+    inventoryHostMap.values().stream()
+        .map(Host::getInstanceId)
+        .forEach(accountServiceInventory.getServiceInstances()::remove);
+
     // apply data from guests to hypervisor records
     hypervisorData.collectGuestData(accountCalc, hostSeenBucketKeysLookup);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-738

This issue was a regression caused by an oversight during a refactor of the InventoryAccountUsageCollector.

# How To Test
Generate some hosts in the HBI database.
```
./bin/insert-mock-hosts --num-hypervisors 4 --num-guests 8 --hbi --clear --org org123 --account account123
```

Delete the hosts in the Swatch DB
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "delete from hosts"
```

Run the application.
```
DEV_MODE=true ./gradlew :bootRun
```

Opt-int the org.
```
http :9000/hawtio/jolokia   type=exec   mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean   operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)'   arguments:='["account123","org123",true,true,true]'
```

Run the nightly tally for the org.
```
http :9000/hawtio/jolokia   type=exec   mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean   operation='tallyOrg(java.lang.String)'   arguments:='["org123"]'
```

Observe that host records are created in the hosts table of the swatch DB.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from hosts;"
```

Delete the hosts from the HBI DB.
```
psql -U insights insights -c "delete from hosts"
```

Re-run the nightly tally
```
http :9000/hawtio/jolokia   type=exec   mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean   operation='tallyOrg(java.lang.String)'   arguments:='["org123"]'
```

Observe that the hosts in the swatch DB have been deleted since they are no longer in the inventory DB.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from hosts;"
```