### PR TITLE
SWATCH-395: Add methods to sync offering data from UMB messages

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/product/OfferingJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingJmxBean.java
@@ -25,10 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.capacity.CapacityReconciliationController;
 import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.security.SecurityProperties;
-import org.candlepin.subscriptions.umb.UmbProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
-import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jmx.JmxException;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedOperationParameter;
@@ -47,21 +45,14 @@ public class OfferingJmxBean {
   private final CapacityReconciliationController capacityReconciliationController;
   private final SecurityProperties properties;
 
-  private final UmbProperties umbProperties;
-  private final JmsTemplate jmsTemplate;
-
   @Autowired
   public OfferingJmxBean(
       OfferingSyncController offeringSync,
       CapacityReconciliationController capacityReconciliationController,
-      SecurityProperties properties,
-      UmbProperties umbProperties,
-      JmsTemplate jmsTemplate) {
+      SecurityProperties properties) {
     this.offeringSync = offeringSync;
     this.capacityReconciliationController = capacityReconciliationController;
     this.properties = properties;
-    this.umbProperties = umbProperties;
-    this.jmsTemplate = jmsTemplate;
   }
 
   @ManagedOperation(description = "Sync an offering from the upstream source.")
@@ -164,8 +155,8 @@ public class OfferingJmxBean {
     }
     try {
       Object principal = ResourceUtils.getPrincipal();
-      jmsTemplate.convertAndSend(umbProperties.getProductTopic(), productXml);
       log.info("Sync of UMB product triggered over JMX by {}", principal);
+      offeringSync.syncUmbProductFromXml(productXml);
     } catch (Exception e) {
       log.error("Error saving UMB product", e);
       throw new JmxException("Error saving product. See log for details.");

--- a/src/main/java/org/candlepin/subscriptions/product/OfferingSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingSyncController.java
@@ -275,6 +275,10 @@ public class OfferingSyncController {
     Set<String> parentSkus =
         offeringRepository.findSkusForChildSku(sku).collect(Collectors.toSet());
     parentSkus.forEach(this::enqueueOfferingSyncTask);
+    // NOTE: below, don't simply call parentSkus.forEach(this::syncDerivedSku), as this will cause
+    // more DB queries than needed, as implemented below, there is one query, no matter the number
+    // of parent SKUs. Calling syncDerivedSku in a loop would cause a separate query for each
+    // matching parent SKU
     offeringRepository.findSkusForDerivedSkus(parentSkus).forEach(this::enqueueOfferingSyncTask);
   }
 

--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -243,12 +243,14 @@ class UpstreamProductData {
     if (StringUtils.hasText(offering.getDerivedSku())) {
       data.attrs.put(Attr.DERIVED_SKU, offering.getDerivedSku());
     }
+    // NOTE: an offering will only have either sockets OR hypervisor sockets, never both
     if (offering.getSockets() != null) {
       data.attrs.put(Attr.SOCKET_LIMIT, offering.getSockets().toString());
     }
     if (offering.getHypervisorSockets() != null) {
       data.attrs.put(Attr.SOCKET_LIMIT, offering.getHypervisorSockets().toString());
     }
+    // NOTE: an offering will only have either cores OR hypervisor cores, never both
     if (offering.getCores() != null) {
       data.attrs.put(Attr.CORES, offering.getCores().toString());
     }

--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -32,8 +32,10 @@ import org.candlepin.subscriptions.product.api.model.AttributeValue;
 import org.candlepin.subscriptions.product.api.model.EngineeringProduct;
 import org.candlepin.subscriptions.product.api.model.OperationalProduct;
 import org.candlepin.subscriptions.product.api.model.RESTProductTree;
+import org.candlepin.subscriptions.umb.UmbOperationalProduct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 /**
  * Provides an easier way to translate an operational product, its children, and their derived
@@ -82,6 +84,7 @@ class UpstreamProductData {
 
   private String sku;
   private SortedSet<String> children = new TreeSet<>();
+  private SortedSet<String> derivedChildren = new TreeSet<>();
   private SortedSet<Integer> engOids = new TreeSet<>();
   private EnumMap<Attr, String> attrs = new EnumMap<>(Attr.class);
   private List<String> conflicts = new ArrayList<>();
@@ -145,6 +148,126 @@ class UpstreamProductData {
     return offer;
   }
 
+  /**
+   * Compose offering data using a UMB message, using external data source if needed.
+   *
+   * <p>There are 4 use cases where we must an external data source:
+   *
+   * <ul>
+   *   <li>Offering not seen before - we need to fetch eng IDs and attributes for any child/derived
+   *       SKUs
+   *   <li>Offering has child SKU changes - we need to fetch eng IDs and attributes for child SKUs
+   *   <li>Offering has derived SKU changes - we need to fetch eng IDs and attributes for derived
+   *       SKU and its children
+   *   <li>Offering has attributes not present in the UMB message - we must assume these may have
+   *       been "inherited" from a child/derived SKU.
+   * </ul>
+   *
+   * (Future work could cache more information to reduce data source usage).
+   *
+   * @param product umb data for the offering
+   * @param existingData existing offering from swatch DB if present, or null
+   * @param productDataSource external data source used to lookup SKU info when needed
+   * @return the resulting offering, or Optional.empty() if the SKU doesn't exist in data source
+   */
+  public static Optional<Offering> offeringFromUmbData(
+      UmbOperationalProduct product, Offering existingData, ProductDataSource productDataSource) {
+    if (existingData == null) {
+      LOGGER.debug("Must sync SKU={} from data source because no existing data", product.getSku());
+      return offeringFromUpstream(product.getSku(), productDataSource);
+    }
+    UpstreamProductData umbData = createFromUmbMessage(product);
+    UpstreamProductData existingProductData = UpstreamProductData.createFromOffering(existingData);
+    for (Attr attr : existingProductData.attrs.keySet()) {
+      if (!umbData.attrs.containsKey(attr)) {
+        // when there are attributes that exist in the DB but not in UMB message, we assume they may
+        // come from child SKUs or derived SKUs
+        LOGGER.debug(
+            "Must sync SKU={} from data source because attribute={} is not defined in UMB message, but may be defined in child/derived SKU",
+            product.getSku(),
+            attr);
+        return offeringFromUpstream(product.getSku(), productDataSource);
+      }
+    }
+    if (!Objects.equals(umbData.children, existingProductData.children)) {
+      LOGGER.debug(
+          "Must sync SKU={} from data source because child SKUs changed from {} to {}",
+          product.getSku(),
+          existingProductData.children,
+          umbData.children);
+      return offeringFromUpstream(product.getSku(), productDataSource);
+    }
+    if (!Objects.equals(
+        umbData.attrs.get(Attr.DERIVED_SKU), existingProductData.attrs.get(Attr.DERIVED_SKU))) {
+      LOGGER.debug(
+          "Must sync SKU={} from data source because derived SKU changed from {} to {}",
+          product.getSku(),
+          existingProductData.attrs.get(Attr.DERIVED_SKU),
+          umbData.attrs.get(Attr.DERIVED_SKU));
+      return offeringFromUpstream(product.getSku(), productDataSource);
+    }
+    existingProductData.attrs.forEach(umbData::putIfNoConflict);
+    umbData.engOids.addAll(existingProductData.engOids);
+    return Optional.of(umbData.toOffering());
+  }
+
+  private static UpstreamProductData createFromUmbMessage(UmbOperationalProduct product) {
+    UpstreamProductData data = new UpstreamProductData(product.getSku());
+    if (product.getChildSkus() != null) {
+      data.children.addAll(product.getChildSkus());
+    }
+    Arrays.stream(product.getAttributes())
+        .filter(attr -> CODE_TO_ENUM.containsKey(attr.getCode()))
+        .forEach(attr -> data.attrs.put(CODE_TO_ENUM.get(attr.getCode()), attr.getValue()));
+    data.attrs.put(Attr.X_DESCRIPTION, product.getSkuDescription());
+    data.attrs.put(Attr.X_ROLE, product.getRole());
+    return data;
+  }
+
+  private static UpstreamProductData createFromOffering(Offering offering) {
+    UpstreamProductData data = new UpstreamProductData(offering.getSku());
+    data.children.addAll(offering.getChildSkus());
+    data.engOids.addAll(offering.getProductIds());
+    if (StringUtils.hasText(offering.getRole())) {
+      data.attrs.put(Attr.X_ROLE, offering.getRole());
+    }
+    if (StringUtils.hasText(offering.getProductFamily())) {
+      data.attrs.put(Attr.PRODUCT_FAMILY, offering.getProductFamily());
+    }
+    if (StringUtils.hasText(offering.getProductName())) {
+      data.attrs.put(Attr.PRODUCT_NAME, offering.getProductName());
+    }
+    if (StringUtils.hasText(offering.getDescription())) {
+      data.attrs.put(Attr.X_DESCRIPTION, offering.getDescription());
+    }
+    if (StringUtils.hasText(offering.getDerivedSku())) {
+      data.attrs.put(Attr.DERIVED_SKU, offering.getDerivedSku());
+    }
+    if (offering.getSockets() != null) {
+      data.attrs.put(Attr.SOCKET_LIMIT, offering.getSockets().toString());
+    }
+    if (offering.getHypervisorSockets() != null) {
+      data.attrs.put(Attr.SOCKET_LIMIT, offering.getHypervisorSockets().toString());
+    }
+    if (offering.getCores() != null) {
+      data.attrs.put(Attr.CORES, offering.getCores().toString());
+    }
+    if (offering.getHypervisorCores() != null) {
+      data.attrs.put(Attr.CORES, offering.getHypervisorCores().toString());
+    }
+    if (Objects.equals(Boolean.TRUE, offering.getHasUnlimitedUsage())) {
+      data.attrs.put(Attr.CORES, UNLIMITED_CORES_OR_SOCKETS);
+      data.attrs.put(Attr.SOCKET_LIMIT, UNLIMITED_CORES_OR_SOCKETS);
+    }
+    if (offering.getServiceLevel() != null && offering.getServiceLevel() != ServiceLevel.EMPTY) {
+      data.attrs.put(Attr.SERVICE_TYPE, offering.getServiceLevel().getValue());
+    }
+    if (offering.getUsage() != null && offering.getUsage() != Usage.EMPTY) {
+      data.attrs.put(Attr.USAGE, offering.getUsage().getValue());
+    }
+    return data;
+  }
+
   private Offering toOffering() {
     if (!conflicts.isEmpty()) {
       String conflictItems = String.join(System.lineSeparator(), conflicts);
@@ -162,6 +285,7 @@ class UpstreamProductData {
     offering.setProductFamily(attrs.get(Attr.PRODUCT_FAMILY));
     offering.setProductName(attrs.get(Attr.PRODUCT_NAME));
     offering.setDescription(attrs.get(Attr.X_DESCRIPTION));
+    offering.setDerivedSku(attrs.get(Attr.DERIVED_SKU));
 
     calcCapacityForOffering(offering);
 
@@ -202,8 +326,8 @@ class UpstreamProductData {
   /**
    * If the DERIVED_SKU attribute exists, will fetch the product tree of the derived SKU and merge
    * it with the offering. Merging means its attributes and its children's attributes will be used
-   * in the offering if not yet yet, and the derived sku and its child skus will be added as child
-   * skus of the offering.
+   * in the offering if not yet, and the derived sku and its child skus will be added as child skus
+   * of the offering.
    *
    * <p>It is unclear if derived SKUs <b>should</b> have the attributes merged and the derived SKUs
    * listed as children in the longer term. For now though, this simplification fits with how we
@@ -224,7 +348,8 @@ class UpstreamProductData {
         if (derived.isEmpty()) {
           LOGGER.warn("No tree found for derivedSku=\"{}\" of offeringSku=\"{}\"", derivedSku, sku);
         } else {
-          merge(derived.get());
+          derivedChildren.addAll(derived.get().children);
+          derived.get().attrs.forEach(this::putIfNoConflict);
         }
       } catch (ApiException e) {
         throw new ExternalServiceException(
@@ -274,6 +399,8 @@ class UpstreamProductData {
   private Set<String> allSkus() {
     var skus = new HashSet<>(children);
     skus.add(sku);
+    Optional.ofNullable(attrs.get(Attr.DERIVED_SKU)).ifPresent(skus::add);
+    skus.addAll(derivedChildren);
     return skus;
   }
 

--- a/src/main/java/org/candlepin/subscriptions/umb/Reference.java
+++ b/src/main/java/org/candlepin/subscriptions/umb/Reference.java
@@ -38,4 +38,25 @@ public class Reference {
   private String entityName;
   private String qualifier;
   @JacksonXmlText private String value;
+
+  public String getSystem() {
+    if (system == null) {
+      return null;
+    }
+    return system.strip();
+  }
+
+  public String getEntityName() {
+    if (entityName == null) {
+      return null;
+    }
+    return entityName.strip();
+  }
+
+  public String getQualifier() {
+    if (qualifier == null) {
+      return null;
+    }
+    return qualifier.strip();
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/umb/UmbOperationalProduct.java
+++ b/src/main/java/org/candlepin/subscriptions/umb/UmbOperationalProduct.java
@@ -48,23 +48,34 @@ public class UmbOperationalProduct {
   @JacksonXmlElementWrapper(useWrapping = false)
   private ProductAttribute[] attributes;
 
-  public String getAttribute(String code) {
-    if (attributes == null) {
-      return null;
-    }
-    return Arrays.stream(attributes)
-        .filter(attribute -> code.equals(attribute.getCode()))
-        .map(ProductAttribute::getValue)
-        .findFirst()
-        .orElse(null);
-  }
-
   public Set<String> getChildSkus() {
     if (productRelationship == null || productRelationship.getChildProducts() == null) {
       return Set.of();
     }
     return Arrays.stream(productRelationship.getChildProducts())
         .map(ChildProduct::getSku)
+        .map(String::strip)
         .collect(Collectors.toSet());
+  }
+
+  public String getSku() {
+    if (sku == null) {
+      return null;
+    }
+    return sku.strip();
+  }
+
+  public String getSkuDescription() {
+    if (skuDescription == null) {
+      return null;
+    }
+    return skuDescription.strip();
+  }
+
+  public String getRole() {
+    if (role == null) {
+      return null;
+    }
+    return role.strip();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/umb/UmbOperationalProduct.java
+++ b/src/main/java/org/candlepin/subscriptions/umb/UmbOperationalProduct.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -44,4 +47,24 @@ public class UmbOperationalProduct {
   @JsonProperty("Attribute")
   @JacksonXmlElementWrapper(useWrapping = false)
   private ProductAttribute[] attributes;
+
+  public String getAttribute(String code) {
+    if (attributes == null) {
+      return null;
+    }
+    return Arrays.stream(attributes)
+        .filter(attribute -> code.equals(attribute.getCode()))
+        .map(ProductAttribute::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  public Set<String> getChildSkus() {
+    if (productRelationship == null || productRelationship.getChildProducts() == null) {
+      return Set.of();
+    }
+    return Arrays.stream(productRelationship.getChildProducts())
+        .map(ChildProduct::getSku)
+        .collect(Collectors.toSet());
+  }
 }

--- a/src/main/resources/liquibase/202212161446-add-derived-sku-to-offering.xml
+++ b/src/main/resources/liquibase/202212161446-add-derived-sku-to-offering.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202212161446-1" author="khowell">
+    <comment>
+      Add derived SKU column to offering, so that we can easily detect changes in derived SKUs.
+    </comment>
+    <addColumn tableName="offering">
+      <column name="derived_sku" type="VARCHAR(255)"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -97,5 +97,6 @@
     <include file="liquibase/202301041519-fix-tally-snapshot-index-for-rollup-query.xml"/>
     <include file="liquibase/202212011334-add-billing-factor-column-to-remittance-table.xml"/>
     <include file="liquibase/202301031409-update-tally-instance-view.xml"/>
+    <include file="liquibase/202212161446-add-derived-sku-to-offering.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -60,5 +61,27 @@ class OfferingRepositoryTest {
     assertEquals(offering.hashCode(), actual.hashCode());
     repository.delete(actual);
     assertEquals(initialOfferingCount, repository.count());
+  }
+
+  @Test
+  @Transactional
+  void testFindSkusForDerivedSkus() {
+    var expectedOffering = Offering.builder().sku("foo").derivedSku("derived").build();
+    var extra = Offering.builder().sku("foo2").build();
+    repository.save(expectedOffering);
+    repository.save(extra);
+    var actual = repository.findSkusForDerivedSkus(Set.of("derived")).collect(Collectors.toSet());
+    assertEquals(Set.of("foo"), actual);
+  }
+
+  @Test
+  @Transactional
+  void testFindSkusForChildSkus() {
+    var expectedOffering = Offering.builder().sku("foo").childSkus(Set.of("child")).build();
+    var extra = Offering.builder().sku("foo2").build();
+    repository.save(expectedOffering);
+    repository.save(extra);
+    var actual = repository.findSkusForChildSku("child").collect(Collectors.toSet());
+    assertEquals(Set.of("foo"), actual);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/umb/OperationalProductMessageTest.java
+++ b/src/test/java/org/candlepin/subscriptions/umb/OperationalProductMessageTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 class OperationalProductMessageTest {
@@ -50,20 +52,21 @@ class OperationalProductMessageTest {
                                     .identifiers(
                                         Identifiers.builder()
                                             .references(
-                                                new Reference[] {
-                                                  Reference.builder()
-                                                      .system("PRODUCT")
-                                                      .entityName("Engineering Product")
-                                                      .qualifier("number")
-                                                      .value("273")
-                                                      .build(),
-                                                  Reference.builder()
-                                                      .system("PRODUCT")
-                                                      .entityName("Engineering Product")
-                                                      .qualifier("number")
-                                                      .value("274")
-                                                      .build(),
-                                                })
+                                                Stream.of(
+                                                        273, 274, 272, 182, 127, 240, 246, 91, 133,
+                                                        180, 84, 70, 86, 94, 93, 176, 92, 317, 318,
+                                                        271, 69, 201, 205, 394, 395, 408, 491, 479,
+                                                        588, 605)
+                                                    .map(
+                                                        id ->
+                                                            Reference.builder()
+                                                                .system("PRODUCT")
+                                                                .entityName("Engineering Product")
+                                                                .qualifier("number")
+                                                                .value(id.toString())
+                                                                .build())
+                                                    .collect(Collectors.toList())
+                                                    .toArray(new Reference[] {}))
                                             .build())
                                     .attributes(
                                         new ProductAttribute[] {
@@ -108,12 +111,23 @@ class OperationalProductMessageTest {
                                                 new ChildProduct[] {
                                                   ChildProduct.builder().sku("SVCRH01").build(),
                                                   ChildProduct.builder().sku("SVCRH01V4").build(),
+                                                  ChildProduct.builder().sku("SVCMPV4").build()
                                                 })
                                             .parentProduct(
                                                 ParentProduct.builder().sku("RH0180191").build())
                                             .build())
                                     .attributes(
                                         new ProductAttribute[] {
+                                          ProductAttribute.builder()
+                                              .code("PRODUCT_NAME")
+                                              .name("Product Name")
+                                              .value("RHEL Server")
+                                              .build(),
+                                          ProductAttribute.builder()
+                                              .code("PRODUCT_FAMILY")
+                                              .name("Product Family")
+                                              .value("Red Hat Enterprise Linux")
+                                              .build(),
                                           ProductAttribute.builder()
                                               .code("ENTITLEMENT_QTY")
                                               .name("Entitlement Qty")
@@ -123,6 +137,11 @@ class OperationalProductMessageTest {
                                               .code("SERVICE_TYPE")
                                               .name("Service Type")
                                               .value("Standard")
+                                              .build(),
+                                          ProductAttribute.builder()
+                                              .code("SOCKET_LIMIT")
+                                              .name("Socket Limit")
+                                              .value("2")
                                               .build(),
                                           ProductAttribute.builder()
                                               .code("USAGE")

--- a/src/test/resources/mocked-product-message.xml
+++ b/src/test/resources/mocked-product-message.xml
@@ -16,7 +16,20 @@
           <ChildProduct>
             <Sku>SVCRH01V4</Sku>
           </ChildProduct>
+          <ChildProduct>
+            <Sku>SVCMPV4</Sku>
+          </ChildProduct>
         </ProductRelationship>
+        <Attribute>
+          <Code>PRODUCT_NAME</Code>
+          <Name>Product Name</Name>
+          <Value>RHEL Server</Value>
+        </Attribute>
+        <Attribute>
+          <Code>PRODUCT_FAMILY</Code>
+          <Name>Product Family</Name>
+          <Value>Red Hat Enterprise Linux</Value>
+        </Attribute>
         <Attribute>
           <Code>ENTITLEMENT_QTY</Code>
           <Name>Entitlement Qty</Name>
@@ -26,6 +39,11 @@
           <Code>SERVICE_TYPE</Code>
           <Name>Service Type</Name>
           <Value>Standard</Value>
+        </Attribute>
+        <Attribute>
+          <Code>SOCKET_LIMIT</Code>
+          <Name>Socket Limit</Name>
+          <Value>2</Value>
         </Attribute>
         <Attribute>
           <Code>USAGE</Code>

--- a/src/test/resources/mocked-svc-product-message.xml
+++ b/src/test/resources/mocked-svc-product-message.xml
@@ -6,6 +6,34 @@
         <Identifiers>
           <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">273</Reference>
           <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">274</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">272</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">182</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">127</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">240</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">246</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">91</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">133</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">180</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">84</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">70</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">86</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">94</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">93</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">176</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">92</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">317</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">318</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">271</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">69</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">201</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">205</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">394</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">395</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">408</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">491</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">479</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">588</Reference>
+          <Reference system="PRODUCT" entity-name="Engineering Product" qualifier="number">605</Reference>
         </Identifiers>
         <Sku>SVCRH01</Sku>
         <SkuDescription>Red Hat Enterprise Linux Server</SkuDescription>

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
@@ -21,11 +21,21 @@
 package org.candlepin.subscriptions.db;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.model.Offering;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Repository interface for the Offering entity */
 public interface OfferingRepository extends JpaRepository<Offering, String> {
 
   List<Offering> findByProductName(String productName);
+
+  @Query(value = "select sku from Offering where :sku member of childSkus")
+  Stream<String> findSkusForChildSku(@Param("sku") String sku);
+
+  @Query(value = "select sku from Offering where derivedSku in :derivedSkus")
+  Stream<String> findSkusForDerivedSkus(@Param("derivedSkus") Set<String> derivedSkus);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.db.model;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -86,11 +87,12 @@ public class Offering implements Serializable {
   private String productFamily;
 
   /** Internal identifiers for products that compose an Offering. */
+  @Builder.Default
   @ElementCollection
   @LazyCollection(LazyCollectionOption.FALSE)
   @CollectionTable(name = "sku_child_sku", joinColumns = @JoinColumn(name = "sku"))
   @Column(name = "child_sku")
-  private Set<String> childSkus;
+  private Set<String> childSkus = new HashSet<>();
 
   /**
    * Numeric identifiers for Engineering Products provided by the offering.
@@ -102,11 +104,12 @@ public class Offering implements Serializable {
    *
    * <p>Sometimes referred to as "provided products".
    */
+  @Builder.Default
   @ElementCollection
   @LazyCollection(LazyCollectionOption.FALSE)
   @CollectionTable(name = "sku_oid", joinColumns = @JoinColumn(name = "sku"))
   @Column(name = "oid")
-  private Set<Integer> productIds;
+  private Set<Integer> productIds = new HashSet<>();
 
   /** Effective standard CPU cores capacity per quantity of subscription to this offering. */
   @Column(name = "cores")
@@ -139,6 +142,10 @@ public class Offering implements Serializable {
   @Getter(AccessLevel.NONE)
   @Column(name = "has_unlimited_usage")
   private Boolean hasUnlimitedUsage;
+
+  // Derived SKU, needed to track necessary updates when a derived SKU is changed
+  @Column(name = "derived_sku")
+  private String derivedSku;
 
   public Boolean getHasUnlimitedUsage() {
     return hasUnlimitedUsage;


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-395

The implementation uses the RHIT product service when necessary to fetch
additional information.

I had to add a "derived_sku" column to offering to be able to detect if
derived SKU changes.

Testing
-------

Start the service:

```shell
LOGGING_LEVEL_ORG_CANDLEPIN=DEBUG \
  PRODUCT_USE_STUB=true \
  DEV_MODE=true \
  ./gradlew :bootRun
```

Using JMX, trigger sync the mocked product message in src/test/resources:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean \
  operation='syncProductFromXml(java.lang.String)' \
  arguments:="$(cat src/test/resources/mocked-product-message.xml | jq -R -s '[.]')"
```

You should see the product definition for RH0180191 land in the offering table:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
select * from offering;
EOF
```

Next, show that triggering a message for the SVC sku forces that offering to be resynced:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean \
  operation='syncProductFromXml(java.lang.String)' \
  arguments:="$(cat src/test/resources/mocked-svc-product-message.xml | jq -R -s '[.]')"
```

You can modify attributes in the message to test various scenarios, though all the scenarios are
covered in OfferingSyncControllerTest.