### PR TITLE
Add swatch.java-conventions to swatch-core-test

### DIFF
--- a/buildSrc/src/main/groovy/swatch.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.java-conventions.gradle
@@ -19,14 +19,6 @@ dependencies {
     annotationProcessor libraries["lombok"]
     testCompileOnly libraries["lombok"]
     testAnnotationProcessor libraries["lombok"]
-
-    // common testing deps, junit + mockito + hamcrest
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
-    testImplementation "org.junit.jupiter:junit-jupiter-params"
-    testImplementation "org.mockito:mockito-core"
-    testImplementation "org.mockito:mockito-junit-jupiter"
-    testImplementation "org.hamcrest:hamcrest"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
 spotless {

--- a/buildSrc/src/main/groovy/swatch.spring-boot-dependencies-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-dependencies-conventions.gradle
@@ -3,6 +3,16 @@ plugins {
     id "io.spring.dependency-management"
 }
 
+dependencies {
+    // common testing deps, junit + mockito + hamcrest
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.junit.jupiter:junit-jupiter-params"
+    testImplementation "org.mockito:mockito-core"
+    testImplementation "org.mockito:mockito-junit-jupiter"
+    testImplementation "org.hamcrest:hamcrest"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+}
+
 // Define all versions here so that all projects will use the same versions.
 dependencyManagement {
     imports {

--- a/swatch-core-test/build.gradle
+++ b/swatch-core-test/build.gradle
@@ -1,10 +1,3 @@
 plugins {
-    id 'java'
-}
-
-dependencies {
-}
-
-tasks.withType(JavaCompile) {
-    options.encoding = 'UTF-8'
+    id 'swatch.java-conventions'
 }

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -28,7 +28,9 @@ dependencies {
     implementation libraries["splunk-library-javalogging"]
     implementation project(":clients:swatch-internal-subscription-client")
     testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.quarkus:quarkus-junit5-mockito'
     testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.testcontainers:postgresql'


### PR DESCRIPTION
When I switched my JAVA_HOME to java 17, I got some odd errors like

```
> Could not resolve all task dependencies for configuration ':testRuntimeClasspath'.
   > Could not resolve project :swatch-core-test.
     Required by:
         project :
      > No matching variant of project :swatch-core-test was found. The consumer was configured to find a runtime of a library compatible with Java 11, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally but
...
```

which was happening because the swatch-core-test was being built w/ default compatibility (17 when JAVA_HOME points to Java 17). By applying the swatch.java-conventions, its explicitly set to Java 11, along with the rest of the swatch modules.