### PR TITLE
SWATCH-358 On OperationalProduct message listener call syncoffering

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/product/OfferingSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingSyncController.java
@@ -33,6 +33,7 @@ import org.candlepin.subscriptions.capacity.files.ProductAllowlist;
 import org.candlepin.subscriptions.db.OfferingRepository;
 import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.umb.UmbOperationalProduct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -131,9 +132,12 @@ public class OfferingSyncController {
    *     was skipped.
    */
   private SyncResult syncOffering(Offering newState) {
-    LOGGER.debug("New state of offering to save: {}", newState);
     Optional<Offering> persistedOffering = offeringRepository.findById(newState.getSku());
+    return syncOffering(newState, persistedOffering);
+  }
 
+  private SyncResult syncOffering(Offering newState, Optional<Offering> persistedOffering) {
+    LOGGER.debug("New state of offering to save: {}", newState);
     if (alreadySynced(persistedOffering, newState)) {
       return SyncResult.SKIPPED_MATCHING;
     }
@@ -195,5 +199,9 @@ public class OfferingSyncController {
 
   public void deleteOffering(String sku) {
     offeringRepository.deleteById(sku);
+  }
+
+  public void syncUmbProduct(UmbOperationalProduct umbOperationalProduct) {
+    // Integrate with SWATCH-395
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/product/OfferingWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingWorker.java
@@ -73,6 +73,7 @@ public class OfferingWorker extends SeekableKafkaConsumer {
   public void receive(String productMessageXml) throws JsonProcessingException {
     log.debug("Received message from UMB offering product{}", productMessageXml);
     if (!umbProperties.isProcessingEnabled()) {
+      log.debug("UMB processing is not enabled");
       return;
     }
     CanonicalMessage productMessage =

--- a/src/main/java/org/candlepin/subscriptions/subscription/ActiveMQServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/ActiveMQServiceConfiguration.java
@@ -33,10 +33,10 @@ import org.springframework.util.StringUtils;
 @Service
 @Slf4j
 @Profile("capacity-ingress")
-public class ActiveMQUtils {
+public class ActiveMQServiceConfiguration {
   private final UmbProperties umbProperties;
 
-  public ActiveMQUtils(UmbProperties umbProperties) {
+  public ActiveMQServiceConfiguration(UmbProperties umbProperties) {
     this.umbProperties = umbProperties;
   }
 
@@ -58,6 +58,7 @@ public class ActiveMQUtils {
       }
     } else {
       // default to an embedded broker
+      log.debug("Defaulting to an embedded broker");
       factory.setBrokerURL("vm://localhost?broker.persistent=false");
     }
     if (umbProperties.providesTruststore()) {

--- a/src/main/java/org/candlepin/subscriptions/subscription/ActiveMQUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/ActiveMQUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.activemq.ActiveMQSslConnectionFactory;
+import org.candlepin.subscriptions.umb.UmbProperties;
+import org.springframework.boot.autoconfigure.jms.activemq.ActiveMQProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@Slf4j
+@Profile("capacity-ingress")
+public class ActiveMQUtils {
+  private final UmbProperties umbProperties;
+
+  public ActiveMQUtils(UmbProperties umbProperties) {
+    this.umbProperties = umbProperties;
+  }
+
+  @Bean
+  @ConfigurationProperties(prefix = "spring.activemq")
+  public ActiveMQProperties activeMQProperties() {
+    return new ActiveMQProperties();
+  }
+
+  @Bean
+  public ActiveMQSslConnectionFactory activeMQSslConnectionFactory(
+      ActiveMQProperties activeMQProperties) throws Exception {
+    ActiveMQSslConnectionFactory factory = new ActiveMQSslConnectionFactory();
+    factory.setExceptionListener(e -> log.error("Exception thrown in ActiveMQ connection", e));
+    if (StringUtils.hasText(activeMQProperties.getBrokerUrl())) {
+      factory.setBrokerURL(activeMQProperties.getBrokerUrl());
+      if (!umbProperties.providesTruststore() || !umbProperties.usesClientAuth()) {
+        log.warn("UMB config requires keystore and truststore - not provided or not valid.");
+      }
+    } else {
+      // default to an embedded broker
+      factory.setBrokerURL("vm://localhost?broker.persistent=false");
+    }
+    if (umbProperties.providesTruststore()) {
+      factory.setTrustStore(umbProperties.getTruststore().getFile().getAbsolutePath());
+      factory.setTrustStorePassword(String.valueOf(umbProperties.getTruststorePassword()));
+    }
+    if (umbProperties.usesClientAuth()) {
+      factory.setKeyStore(umbProperties.getKeystore().getFile().getAbsolutePath());
+      factory.setKeyStorePassword(String.valueOf(umbProperties.getKeystorePassword()));
+    }
+    return factory;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/umb/UmbProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/umb/UmbProperties.java
@@ -42,7 +42,7 @@ public class UmbProperties extends TlsProperties {
 
   private String subscriptionTopic = "VirtualTopic.canonical.subscription";
 
-  private String productTopic = "VirtualTopic.canonical.product";
+  private String productTopic = "VirtualTopic.canonical.operationalProduct";
 
   /**
    * Factory method that produces queue names that match UMB convention for VirtualTopics when
@@ -54,12 +54,12 @@ public class UmbProperties extends TlsProperties {
    * subscriptions. Given subscription watch needs a single notification per *environment*, we use
    * swatch-$namespace-$topic.
    */
-  public String getConsumerTopic(String topic) {
+  private String getConsumerTopic(String topic) {
     if (!topic.startsWith("VirtualTopic")) {
       return topic;
     }
-    String id = String.format("swatch-%s-%s", namespace, topic.replace(".", "_"));
-    return String.format("Consumer.%s.%s.%s", serviceAccountName, id, topic);
+    String subscriptionId = String.format("swatch-%s-%s", namespace, topic.replace(".", "_"));
+    return String.format("Consumer.%s.%s.%s", serviceAccountName, subscriptionId, topic);
   }
 
   public String getSubscriptionTopic() {

--- a/src/main/java/org/candlepin/subscriptions/umb/UmbProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/umb/UmbProperties.java
@@ -42,6 +42,8 @@ public class UmbProperties extends TlsProperties {
 
   private String subscriptionTopic = "VirtualTopic.canonical.subscription";
 
+  private String productTopic = "VirtualTopic.canonical.product";
+
   /**
    * Factory method that produces queue names that match UMB convention for VirtualTopics when
    * needed.
@@ -56,11 +58,15 @@ public class UmbProperties extends TlsProperties {
     if (!topic.startsWith("VirtualTopic")) {
       return topic;
     }
-    String subscriptionId = String.format("swatch-%s-%s", namespace, topic.replace(".", "_"));
-    return String.format("Consumer.%s.%s.%s", serviceAccountName, subscriptionId, topic);
+    String id = String.format("swatch-%s-%s", namespace, topic.replace(".", "_"));
+    return String.format("Consumer.%s.%s.%s", serviceAccountName, id, topic);
   }
 
   public String getSubscriptionTopic() {
     return getConsumerTopic(subscriptionTopic);
+  }
+
+  public String getProductTopic() {
+    return getConsumerTopic(productTopic);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingJmxBeanTest.java
@@ -33,11 +33,13 @@ import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
 import org.candlepin.subscriptions.security.SecurityProperties;
+import org.candlepin.subscriptions.umb.UmbProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jmx.JmxException;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,13 +49,21 @@ class OfferingJmxBeanTest {
 
   @Mock CapacityReconciliationController capacityReconciliationController;
 
+  @Mock private JmsTemplate mockJmsTemplate;
+
   OfferingJmxBean subject;
   SecurityProperties properties;
 
   @BeforeEach
   void setup() {
     properties = new SecurityProperties();
-    subject = new OfferingJmxBean(offeringSync, capacityReconciliationController, properties);
+    subject =
+        new OfferingJmxBean(
+            offeringSync,
+            capacityReconciliationController,
+            properties,
+            new UmbProperties(),
+            mockJmsTemplate);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingWorkerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.umb.UmbProperties;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -37,10 +38,11 @@ class OfferingWorkerTest {
     TaskQueueProperties props = mock(TaskQueueProperties.class);
     KafkaConsumerRegistry consumerReg = mock(KafkaConsumerRegistry.class);
     OfferingSyncController controller = mock(OfferingSyncController.class);
+    UmbProperties umbProperties = mock(UmbProperties.class);
 
     when(controller.syncOffering(anyString())).thenReturn(SyncResult.FETCHED_AND_SYNCED);
 
-    OfferingWorker subject = new OfferingWorker(props, consumerReg, controller);
+    OfferingWorker subject = new OfferingWorker(props, consumerReg, controller, umbProperties);
 
     // When an allowlisted SKU is received,
     String sku = "RH00604F5";

--- a/src/test/java/org/candlepin/subscriptions/product/OfferingWorkerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/product/OfferingWorkerTest.java
@@ -34,7 +34,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles({"capacity-ingress"})
+@ActiveProfiles({"capacity-ingress", "test", "api"})
 class OfferingWorkerTest {
 
   @Autowired OfferingWorker offeringWorker;

--- a/src/test/java/org/candlepin/subscriptions/umb/UmbPropertiesTest.java
+++ b/src/test/java/org/candlepin/subscriptions/umb/UmbPropertiesTest.java
@@ -43,4 +43,22 @@ class UmbPropertiesTest {
         "Consumer.sa.swatch-ns-VirtualTopic_foo_bar.VirtualTopic.foo.bar",
         properties.getSubscriptionTopic());
   }
+
+  @Test
+  void testShouldLeaveProductNonVirtualTopicAlone() {
+    UmbProperties properties = new UmbProperties();
+    properties.setProductTopic("foobar");
+    assertEquals("foobar", properties.getProductTopic());
+  }
+
+  @Test
+  void shouldApplyProductUmbVirtualTopicPatternToConsumerTopic() {
+    UmbProperties properties = new UmbProperties();
+    properties.setNamespace("ns");
+    properties.setServiceAccountName("sa");
+    properties.setProductTopic("VirtualTopic.foo.bar");
+    assertEquals(
+        "Consumer.sa.swatch-ns-VirtualTopic_foo_bar.VirtualTopic.foo.bar",
+        properties.getProductTopic());
+  }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-358
1. Run:
```USER_USE_STUB=true SUBSCRIPTION_USE_STUB=true CG_USE_STUB=true CLOUDIGRADE_ENABLED=false DEV_MODE=true ./gradlew clean :bootRun```

2. Execute the JMX endpoint in offeringJmxBean> syncProductFromXml(String) with the content present in one of the file: 

>src/test/resources/mocked-product-message.xml
or
src/test/resources/mocked-svc-product-message.xml

3. Result in log:
```2023-01-04 21:00:56,921 [thread=org.springframework.jms.JmsListenerEndpointContainer#0-1] [INFO ] [org.candlepin.subscriptions.product.OfferingWorker] - Received UMB message for productSku=RH0180191```

5. Note: The rest of the controller syncUmbProduct code will be done as part of SWATCH-395