### PR TITLE
Fix unique tally constraint for rollup query

### DIFF
--- a/src/main/resources/liquibase/202301041519-fix-tally-snapshot-index-for-rollup-query.xml
+++ b/src/main/resources/liquibase/202301041519-fix-tally-snapshot-index-for-rollup-query.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202301041519-1" author="khowell">
+    <comment>Create org-id based index for use in rollup queries.</comment>
+    <!--
+    NOTE: this index is equivalent to tally_snapshot_unique_constraint except for column ordering
+    and the intentional absence of account_number.
+    -->
+    <createIndex tableName="tally_snapshots" indexName="tally_snapshot_unique_org_id" unique="true">
+      <column name="org_id"/>
+      <column name="product_id"/>
+      <column name="granularity"/>
+      <column name="snapshot_date"/>
+      <column name="sla"/>
+      <column name="usage"/>
+      <column name="unit_of_measure"/>
+    </createIndex>
+  </changeSet>
+  <changeSet id="202301041519-2" author="khowell">
+    <comment>Drop now-redundant unique constraint.</comment>
+    <dropUniqueConstraint tableName="tally_snapshots" constraintName="tally_snapshot_unique_constraint"/>
+  </changeSet>
+  <changeSet id="202301041519-3" author="khowell">
+    <comment>Rename unique constraint.</comment>
+    <sql>alter index tally_snapshot_unique_org_id rename to tally_snapshot_unique_constraint</sql>
+  </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -94,5 +94,6 @@
     <include file="liquibase/202211281427-change-account_services-account-number-drop_not_null.xml"/>
     <include file="liquibase/202211301043-update-host-table-constraints.xml"/>
     <include file="liquibase/202212121039-create-tally-instance-view.xml"/>
+    <include file="liquibase/202301041519-fix-tally-snapshot-index-for-rollup-query.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Turns out that because the unique constraint had `account_number` as one of its first columns, the query planner was unable to use this index, and instead fell back to a much less specific index.

This change reorders the columns a bit to make it hopefully less likely to need updates in the future, and removes `account_number`.

Testing
-------

Start the service on the `main` branch:

```shell
./gradlew :bootRun
```

Next, insert some data into the tally_snapshots table (this makes the query planner more likely to actually use the index :-))

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
do
\$\$
    begin
        for i in 1..10000
            loop
                insert into tally_snapshots(id, product_id, account_number, granularity, org_id, snapshot_date,
                                            unit_of_measure, sla)
                values (
                        gen_random_uuid(),
                        'RHEL',
                        i,
                        'DAILY',
                        i,
                        now() - random() * interval '1 year',
                        'CORES',
                        '_ANY'
                       );
            end loop;
        end;
\$\$;
EOF
```

Next, observe on `main` the following query (this query was extracted by running the service with verbose logging):

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
explain analyze
select distinct tallysnaps0_.id                 as id1_15_,
                tallysnaps0_.account_number     as account_2_15_,
                tallysnaps0_.billing_account_id as billing_3_15_,
                tallysnaps0_.billing_provider   as billing_4_15_,
                tallysnaps0_.granularity        as granular5_15_,
                tallysnaps0_.org_id             as org_id6_15_,
                tallysnaps0_.product_id         as product_7_15_,
                tallysnaps0_.sla                as sla8_15_,
                tallysnaps0_.snapshot_date      as snapshot9_15_,
                tallysnaps0_.usage              as usage10_15_,
                tallymeasu1_.snapshot_id        as snapshot1_14_0__,
                tallymeasu1_.value              as value2_14_0__,
                tallymeasu1_.measurement_type   as measurem3_0__,
                tallymeasu1_.uom                as uom4_0__
from tally_snapshots tallysnaps0_
         left outer join tally_measurements tallymeasu1_ on tallysnaps0_.id = tallymeasu1_.snapshot_id
where 1 = 1
  and tallysnaps0_.org_id = 'org123'
  -- and tallysnaps0_.account_number = 'account123'
  and (tallysnaps0_.product_id in ('RHEL'))
  and tallysnaps0_.granularity = 'DAILY'
  and (tallysnaps0_.snapshot_date between '2022-01-01' and '2022-01-31')
order by tallysnaps0_.snapshot_date;
EOF
```

Observe the index used only matches product_id and org_id. (You can also observe that with account_number uncommented, for comparison, uses the unique constraint).

Next, redeploy with this branch, and observe that the updated constraint is used in the query plan.