### PR TITLE
SWATCH-587: use tally_instance_view to get records for instance api

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -13,7 +13,8 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
                   subscription_manager_id=None, cores=None, sockets=None, is_guest=None, hypervisor_uuid=None,
                   hardware_type=None, measurement_type=None, num_of_guests=None, last_seen=None, product=None,
                   sla=None, usage=None, is_unmapped_guest=None, is_hypervisor=None, cloud_provider=None,
-                  skip_buckets=False, is_hbi=False, is_marketplace=False, host_type=None, billing_provider=None, billing_account_id=None):
+                  skip_buckets=False, is_hbi=False, is_marketplace=False, host_type=None, billing_provider=None,
+                  billing_account_id=None, uom=None):
     account = account_number or "account123"
     org = org_id or "org123"
     host_id = uuid.uuid4()
@@ -81,8 +82,9 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
         }
 
     _generate_insert('hosts', **host_fields)
+    _generate_measurements(host_id, uom, 1.0)
     if not is_hbi and not skip_buckets:
-        _generate_buckets(host_id, product, sla, usage, cores=cores, sockets=sockets, measurement_type=measurement_type,
+        _generate_buckets(host_id, product, sla, usage, as_hypervisor=is_hypervisor, cores=cores, sockets=sockets, measurement_type=measurement_type,
         billing_provider=billing_provider, billing_account_id=billing_account_id)
     return host_fields
 
@@ -113,19 +115,40 @@ def _generate_buckets(host_id, product, sla, usage, as_hypervisor=False, measure
     bucket_fields = {
         'host_id': host_id,
         'product_id': product or 'RHEL',
-        'as_hypervisor': as_hypervisor,
+        'as_hypervisor': 'False',
         'measurement_type': measurement_type,
         'cores': cores,
         'sockets': sockets,
         'billing_provider': billing_provider,
         'billing_account_id': billing_account_id
     }
-
+    if as_hypervisor and measurement_type == 'PHYSICAL':
+          hypervisor_bucket_fields = {
+              'host_id': host_id,
+              'product_id': product or 'RHEL',
+              'as_hypervisor': 'True',
+              'measurement_type': 'HYPERVISOR',
+              'cores': cores,
+              'sockets': sockets,
+              'billing_provider': billing_provider,
+              'billing_account_id': billing_account_id
+          }
     sla_vals = ["_ANY", sla]
     usage_vals = ["_ANY", usage]
     for next_sla in sla_vals:
         for next_usage in usage_vals:
             _generate_insert("host_tally_buckets", sla=next_sla, usage=next_usage, **bucket_fields)
+            if as_hypervisor and measurement_type == 'PHYSICAL':
+                _generate_insert("host_tally_buckets", sla=next_sla, usage=next_usage, **hypervisor_bucket_fields)
+
+
+def _generate_measurements(host_id, uom, value):
+    measurement_fields = {
+        'instance_id': host_id,
+        'uom': uom,
+        'value': value,
+    }
+    _generate_insert("instance_measurements", **measurement_fields)
 
 
 def _create_account_service(account, service_type, org_id):
@@ -203,6 +226,9 @@ parser.add_argument('--billing-provider',
 parser.add_argument('--billing-account-id',
                     default="_ANY",
                     help='Set the billing_account_id for the inserted records')
+parser.add_argument('--uom',
+                    default="CORES",
+                    help='Set the uom for the inserted records')
 
 args = parser.parse_args()
 if args.is_hbi:
@@ -247,7 +273,8 @@ for i in range(args.num_accounts):
                       product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
                       is_hbi=args.is_hbi, num_of_guests=args.num_guests,
                       cloud_provider='AWS', is_marketplace=args.is_marketplace, host_type=args.host_type,
-                      billing_provider=args.billing_provider, billing_account_id=args.billing_account_id)
+                      billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
+                      uom=args.uom)
 
     for i in range(args.num_physical):
         generate_host(account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
@@ -255,7 +282,8 @@ for i in range(args.num_accounts):
                       is_hbi=args.is_hbi, num_of_guests=args.num_guests,
                       is_marketplace=args.is_marketplace,
                       host_type=args.host_type,
-                      billing_provider=args.billing_provider, billing_account_id=args.billing_account_id)
+                      billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
+                      uom=args.uom)
 
     hypervisor = None
     for i in range(args.num_hypervisors):
@@ -265,7 +293,8 @@ for i in range(args.num_accounts):
                                    is_hypervisor=True, is_hbi=args.is_hbi,
                                    is_marketplace=args.is_marketplace,
                                    host_type=args.host_type,
-                                   billing_provider=args.billing_provider, billing_account_id=args.billing_account_id)
+                                   billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
+                                   uom=args.uom)
         # create a physical entry for the host as well.
         generate_host(account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
                       product=args.product,
@@ -273,7 +302,7 @@ for i in range(args.num_accounts):
                       is_hbi=args.is_hbi,
                       is_marketplace=args.is_marketplace,
                       host_type=args.host_type,
-                     billing_provider=args.billing_provider, billing_account_id=args.billing_account_id)
+                     billing_provider=args.billing_provider, billing_account_id=args.billing_account_id, uom=args.uom)
 
     create_unmapped = args.unmapped_guests
     for i in range(args.num_guests):
@@ -294,7 +323,8 @@ for i in range(args.num_accounts):
                       cores=args.cores, sockets=args.sockets, is_unmapped_guest=create_unmapped,
                       skip_buckets=skip_buckets, is_hbi=args.is_hbi,
                       is_marketplace=args.is_marketplace, host_type=args.host_type,
-                      billing_provider=args.billing_provider, billing_account_id=args.billing_account_id)
+                      billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
+                      uom=args.uom)
 
 output.write('commit;')
 

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -213,7 +213,7 @@ public class InstancesResource implements InstancesApi {
       instance.setBillingProvider(tallyInstanceView.getHostBillingProvider().asOpenApiEnum());
     }
     for (String uom : measurements) {
-      if (tallyInstanceView.getUom().equals(Measurement.Uom.fromValue(uom))) {
+      if (tallyInstanceView.getKey().getUom().equals(Measurement.Uom.fromValue(uom))) {
         measurementList.add(
             tallyInstanceView.getMonthlyTotals().values().stream().findFirst().orElse(0.0));
       } else {

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -32,13 +32,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
-import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.TallyInstanceViewRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
-import org.candlepin.subscriptions.db.model.Host;
-import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyInstanceView;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.registry.TagProfile;
@@ -65,7 +64,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class InstancesResource implements InstancesApi {
 
-  private final HostRepository repository;
+  private final TallyInstanceViewRepository repository;
   private final PageLinkCreator pageLinkCreator;
   private final TagProfile tagProfile;
 
@@ -73,7 +72,7 @@ public class InstancesResource implements InstancesApi {
       ImmutableMap.<InstanceReportSort, String>builder()
           .put(InstanceReportSort.DISPLAY_NAME, "displayName")
           .put(InstanceReportSort.LAST_SEEN, "lastSeen")
-          .put(InstanceReportSort.BILLING_PROVIDER, "billingProvider")
+          .put(InstanceReportSort.BILLING_PROVIDER, "hostBillingProvider")
           .put(InstanceReportSort.NUMBER_OF_GUESTS, "numOfGuests")
           .putAll(getUomSorts())
           .build();
@@ -84,8 +83,10 @@ public class InstancesResource implements InstancesApi {
   @Context UriInfo uriInfo;
 
   public InstancesResource(
-      HostRepository instancesRepository, PageLinkCreator pageLinkCreator, TagProfile tagProfile) {
-    this.repository = instancesRepository;
+      TallyInstanceViewRepository tallyInstanceViewRepository,
+      PageLinkCreator pageLinkCreator,
+      TagProfile tagProfile) {
+    this.repository = tallyInstanceViewRepository;
     this.pageLinkCreator = pageLinkCreator;
     this.tagProfile = tagProfile;
   }
@@ -130,7 +131,7 @@ public class InstancesResource implements InstancesApi {
         getHardwareMeasurementTypesFromCategory(reportCategory);
 
     List<InstanceData> payload;
-    Page<Host> hosts;
+    Page<TallyInstanceView> instances;
     if (sort != null) {
       Sort.Order userDefinedOrder = new Sort.Order(dirValue, INSTANCE_SORT_PARAM_MAPPING.get(sort));
       sortValue = Sort.by(userDefinedOrder, implicitOrder);
@@ -149,10 +150,10 @@ public class InstancesResource implements InstancesApi {
     String month = InstanceMonthlyTotalKey.formatMonthId(start);
     // We depend on a "reference UOM" in order to filter out instances that were not active in
     // the selected month. This is also used for sorting purposes (same join). See
-    // org.candlepin.subscriptions.db.HostSpecification#toPredicate and
-    // org.candlepin.subscriptions.db.HostRepository#findAllBy.
+    // org.candlepin.subscriptions.db.TallyInstanceViewSpecification#toPredicate and
+    // org.candlepin.subscriptions.db.TallyInstanceViewRepository#findAllBy.
     Measurement.Uom referenceUom = SORT_TO_UOM_MAP.get(sort);
-    hosts =
+    instances =
         repository.findAllBy(
             orgId,
             productId.toString(),
@@ -168,13 +169,13 @@ public class InstancesResource implements InstancesApi {
             hardwareMeasurementTypes,
             page);
     payload =
-        hosts.getContent().stream()
-            .map(h -> asTallyHostViewApiInstance(h, month, measurements))
+        instances.getContent().stream()
+            .map(tallyInstanceView -> asTallyHostViewApiInstance(tallyInstanceView, measurements))
             .collect(Collectors.toList());
 
     PageLinks links;
     if (offset != null || limit != null) {
-      links = pageLinkCreator.getPaginationLinks(uriInfo, hosts);
+      links = pageLinkCreator.getPaginationLinks(uriInfo, instances);
     } else {
       links = null;
     }
@@ -183,7 +184,7 @@ public class InstancesResource implements InstancesApi {
         .links(links)
         .meta(
             new InstanceMeta()
-                .count((int) hosts.getTotalElements())
+                .count((int) instances.getTotalElements())
                 .product(productId)
                 .serviceLevel(sla)
                 .usage(usage)
@@ -203,32 +204,27 @@ public class InstancesResource implements InstancesApi {
   }
 
   private InstanceData asTallyHostViewApiInstance(
-      Host host, String monthId, List<String> measurements) {
+      TallyInstanceView tallyInstanceView, List<String> measurements) {
     var instance = new InstanceData();
     List<Double> measurementList = new ArrayList<>();
-    instance.setId(host.getInstanceId());
-    instance.setDisplayName(host.getDisplayName());
-    if (Objects.nonNull(host.getBillingProvider())) {
-      instance.setBillingProvider(host.getBillingProvider().asOpenApiEnum());
+    instance.setId(tallyInstanceView.getKey().getInstanceId().toString());
+    instance.setDisplayName(tallyInstanceView.getDisplayName());
+    if (Objects.nonNull(tallyInstanceView.getHostBillingProvider())) {
+      instance.setBillingProvider(tallyInstanceView.getHostBillingProvider().asOpenApiEnum());
     }
-
     for (String uom : measurements) {
-      measurementList.add(
-          Optional.ofNullable(host.getMonthlyTotal(monthId, Measurement.Uom.fromValue(uom)))
-              .orElse(0.0));
+      if (tallyInstanceView.getUom().equals(Measurement.Uom.fromValue(uom))) {
+        measurementList.add(
+            tallyInstanceView.getMonthlyTotals().values().stream().findFirst().orElse(0.0));
+      } else {
+        measurementList.add(0.0);
+      }
     }
-    if (!host.getBuckets().isEmpty()) {
-      host.getBuckets().stream()
-          .findFirst()
-          .map(HostTallyBucket::getMeasurementType)
-          .map(Objects::toString)
-          .ifPresent(instance::setCategory);
-    }
-    instance.setBillingAccountId(host.getBillingAccountId());
+    instance.setCategory(tallyInstanceView.getKey().getMeasurementType().name());
+    instance.setBillingAccountId(tallyInstanceView.getHostBillingAccountId());
     instance.setMeasurements(measurementList);
-    instance.setLastSeen(host.getLastSeen());
-    instance.setNumberOfGuests(host.getNumOfGuests());
-
+    instance.setLastSeen(tallyInstanceView.getLastSeen());
+    instance.setNumberOfGuests(tallyInstanceView.getNumOfGuests());
     return instance;
   }
 
@@ -266,6 +262,6 @@ public class InstancesResource implements InstancesApi {
 
   private static Map<InstanceReportSort, String> getUomSorts() {
     return getSortToUomMap().keySet().stream()
-        .collect(Collectors.toMap(Function.identity(), key -> "monthlyTotals"));
+        .collect(Collectors.toMap(Function.identity(), key -> "value"));
   }
 }

--- a/src/main/resources/liquibase/202301031409-update-tally-instance-view.xml
+++ b/src/main/resources/liquibase/202301031409-update-tally-instance-view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202301031409-1" author="kflahert">
+    <dropView viewName="tally_instance_view"/>
+  </changeSet>
+
+  <changeSet id="202301031409-2" author="kflahert">
+    <comment>Create view of hosts and host_tally_buckets for use in Instance API</comment>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_view">
+      select distinct org_id,
+                      h.id,
+                      cast(h.instance_id as UUID) as instance_id,
+                      display_name,
+                      h.billing_provider as host_billing_provider,
+                      h.billing_account_id as host_billing_account_id,
+                      b.billing_provider as bucket_billing_provider,
+                      b.billing_account_id as bucket_billing_account_id,
+                      last_seen,
+                      num_of_guests,
+                      product_id,
+                      sla,
+                      usage,
+                      COALESCE(b.measurement_type, 'EMPTY') AS measurement_type,
+                      m.uom,
+                      m.value,
+                      b.sockets,
+                      b.cores
+      from hosts h
+        join host_tally_buckets b on h.id = b.host_id left outer join instance_measurements m on h.id = m.instance_id;
+    </createView>
+  </changeSet>
+
+</databaseChangeLog>
+  <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -96,5 +96,6 @@
     <include file="liquibase/202212121039-create-tally-instance-view.xml"/>
     <include file="liquibase/202301041519-fix-tally-snapshot-index-for-rollup-query.xml"/>
     <include file="liquibase/202212011334-add-billing-factor-column-to-remittance-table.xml"/>
+    <include file="liquibase/202301031409-update-tally-instance-view.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
@@ -1,0 +1,654 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.candlepin.subscriptions.db.model.AccountServiceInventory;
+import org.candlepin.subscriptions.db.model.AccountServiceInventoryId;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyInstanceView;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.resource.InstancesResource;
+import org.candlepin.subscriptions.utilization.api.model.InstanceReportSort;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@TestInstance(Lifecycle.PER_CLASS)
+class TallyInstanceViewRepositoryTest {
+
+  private final String RHEL = "RHEL";
+  private final String COOL_PROD = "COOL_PROD";
+  private static final String DEFAULT_DISPLAY_NAME = "REDHAT_PWNS";
+  private static final String SANITIZED_MISSING_DISPLAY_NAME = "";
+
+  @Autowired private TallyInstanceViewRepository repo;
+  @Autowired private HostRepository hostRepo;
+  @Autowired private AccountServiceInventoryRepository accountServiceInventoryRepository;
+
+  @Transactional
+  @BeforeAll
+  void setupTestData() {
+
+    Host host8 = createHost("inventory8", "account123");
+    Host host9 = createHost("inventory9", "account123");
+    Host host10 = createHost("inventory10", "account123");
+
+    for (Uom uom : Uom.values()) {
+      host8.addToMonthlyTotal(
+          OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC), uom, 100.0);
+      host8.setMeasurement(uom, 100.0);
+      host9.addToMonthlyTotal(
+          OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC), uom, 0.0);
+      host9.setMeasurement(uom, 0.0);
+      host10.addToMonthlyTotal(
+          OffsetDateTime.of(LocalDateTime.of(2021, 2, 1, 0, 0, 0), ZoneOffset.UTC), uom, 50.0);
+      host10.setMeasurement(uom, 50.0);
+    }
+
+    addBucketToHost(host8, RHEL, ServiceLevel._ANY, Usage._ANY, HardwareMeasurementType.PHYSICAL);
+    addBucketToHost(host9, RHEL, ServiceLevel._ANY, Usage._ANY, HardwareMeasurementType.PHYSICAL);
+    addBucketToHost(host10, RHEL, ServiceLevel._ANY, Usage._ANY, HardwareMeasurementType.PHYSICAL);
+
+    persistHosts(host8, host9, host10).stream()
+        .collect(Collectors.toMap(Host::getInventoryId, Function.identity()));
+  }
+
+  @Transactional
+  @AfterAll
+  void cleanup() {
+    accountServiceInventoryRepository.deleteAll();
+  }
+
+  public List<Host> persistHosts(Host... hosts) {
+    List<Host> toSave = Arrays.asList(hosts);
+    toSave.stream()
+        .filter(h -> h.getDisplayName() == null)
+        .forEach(x -> x.setDisplayName(DEFAULT_DISPLAY_NAME));
+    List<Host> results = new ArrayList<>();
+    Arrays.stream(hosts)
+        .forEach(
+            host -> {
+              AccountServiceInventory accountServiceInventory =
+                  accountServiceInventoryRepository
+                      .findById(
+                          AccountServiceInventoryId.builder()
+                              .orgId(host.getOrgId())
+                              .serviceType("HBI_HOST")
+                              .build())
+                      .orElse(new AccountServiceInventory(host.getOrgId(), "HBI_HOST"));
+              accountServiceInventory.getServiceInstances().put(host.getInstanceId(), host);
+              accountServiceInventory =
+                  accountServiceInventoryRepository.save(accountServiceInventory);
+              results.add(accountServiceInventory.getServiceInstances().get(host.getInstanceId()));
+            });
+    accountServiceInventoryRepository.flush();
+    return results;
+  }
+
+  @Transactional
+  @ParameterizedTest
+  @MethodSource("org.candlepin.subscriptions.db.HostRepositoryTest#instanceSortParams")
+  void canSortByInstanceBasedSortMethods(InstanceReportSort sort) {
+
+    String sortValue = InstancesResource.INSTANCE_SORT_PARAM_MAPPING.get(sort);
+    Pageable page = PageRequest.of(0, 2, Sort.by(sortValue));
+    Uom referenceUom = InstancesResource.SORT_TO_UOM_MAP.getOrDefault(sort, Uom.CORES);
+    Page<TallyInstanceView> results =
+        repo.findAllBy(
+            "ORG_account123",
+            "RHEL",
+            ServiceLevel._ANY,
+            Usage._ANY,
+            "",
+            0,
+            0,
+            "2021-01",
+            referenceUom,
+            BillingProvider._ANY,
+            "_ANY",
+            null,
+            page);
+
+    assertEquals(2, results.getTotalElements());
+
+    if (sortValue.equals("monthlyTotals")) {
+      List<TallyInstanceView> payload = results.toList();
+      assertEquals(0.0, payload.get(0).getMonthlyTotals().get(0));
+      assertEquals(100.0, payload.get(1).getMonthlyTotals().get(0));
+    }
+  }
+
+  @Test
+  @Transactional
+  void testFilterByBillingModel() {
+    Host host1 = createHost("i1", "a1");
+    host1.setBillingProvider(BillingProvider.RED_HAT);
+    addBucketToHost(
+        host1,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.RED_HAT);
+    addBucketToHost(
+        host1,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider._ANY);
+
+    Host host2 = createHost("i2", "a1");
+    host2.setBillingProvider(BillingProvider.AWS);
+    addBucketToHost(
+        host2,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.AWS);
+    addBucketToHost(
+        host2,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider._ANY);
+
+    Host host3 = createHost("i3", "a1");
+    addBucketToHost(
+        host3,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.EMPTY);
+    addBucketToHost(
+        host3,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider._ANY);
+
+    persistHosts(host1, host2, host3);
+
+    InstanceReportSort sort = InstanceReportSort.CORES;
+    String sortValue = InstancesResource.INSTANCE_SORT_PARAM_MAPPING.get(sort);
+    Pageable page = PageRequest.of(0, 10, Sort.by(sortValue));
+
+    Page<TallyInstanceView> results =
+        repo.findAllBy(
+            "ORG_a1",
+            COOL_PROD,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            "",
+            0,
+            0,
+            null,
+            Uom.CORES,
+            BillingProvider.AWS,
+            "_ANY",
+            null,
+            page);
+    assertEquals(1L, results.getTotalElements());
+    assertEquals(BillingProvider.AWS, results.getContent().get(0).getHostBillingProvider());
+
+    Page<TallyInstanceView> allResults =
+        repo.findAllBy(
+            "ORG_a1",
+            COOL_PROD,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            "",
+            0,
+            0,
+            null,
+            Uom.CORES,
+            BillingProvider._ANY,
+            "_ANY",
+            null,
+            page);
+    assertEquals(3L, allResults.getTotalElements());
+    Map<String, TallyInstanceView> hostToBill =
+        allResults.stream()
+            .collect(
+                Collectors.toMap(t -> t.getKey().getInstanceId().toString(), Function.identity()));
+
+    assertTrue(
+        hostToBill
+            .keySet()
+            .containsAll(
+                Arrays.asList(host1.getInstanceId(), host2.getInstanceId(), host3.getInstanceId())),
+        "Result did not contain expected hosts!");
+    assertEquals(
+        BillingProvider.RED_HAT, hostToBill.get(host1.getInstanceId()).getHostBillingProvider());
+    assertEquals(
+        BillingProvider.AWS, hostToBill.get(host2.getInstanceId()).getHostBillingProvider());
+    assertEquals(
+        BillingProvider._ANY, hostToBill.get(host3.getInstanceId()).getHostBillingProvider());
+  }
+
+  @Test
+  @Transactional
+  void testSortByBillingProvider() {
+    Host host1 = createHost("i1", "a1");
+    host1.setBillingProvider(BillingProvider.RED_HAT);
+    addBucketToHost(
+        host1,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.RED_HAT);
+    addBucketToHost(
+        host1,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider._ANY);
+
+    Host host2 = createHost("i2", "a1");
+    host2.setBillingProvider(BillingProvider.AWS);
+    addBucketToHost(
+        host2,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.AWS);
+    addBucketToHost(
+        host2,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider._ANY);
+
+    Host host3 = createHost("i3", "a1");
+    host3.setBillingProvider(null);
+    addBucketToHost(
+        host3,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.EMPTY);
+    addBucketToHost(
+        host3,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider._ANY);
+
+    Host host4 = createHost("i4", "a1");
+    host4.setBillingProvider(BillingProvider.ORACLE);
+    addBucketToHost(
+        host4,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.ORACLE);
+    addBucketToHost(
+        host4,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider._ANY);
+
+    persistHosts(host1, host2, host3, host4);
+    hostRepo.flush();
+
+    Sort asc =
+        Sort.by(
+            Direction.DESC,
+            InstancesResource.INSTANCE_SORT_PARAM_MAPPING.get(InstanceReportSort.BILLING_PROVIDER));
+    Pageable page = PageRequest.of(0, 10, asc);
+
+    Page<TallyInstanceView> results =
+        repo.findAllBy(
+            "ORG_a1",
+            COOL_PROD,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            "",
+            0,
+            0,
+            null,
+            Uom.CORES,
+            BillingProvider._ANY,
+            "_ANY",
+            null,
+            page);
+    assertEquals(4L, results.getTotalElements());
+    assertEquals(BillingProvider.EMPTY, results.getContent().get(0).getHostBillingProvider());
+    assertEquals(BillingProvider.RED_HAT, results.getContent().get(1).getHostBillingProvider());
+    assertEquals(BillingProvider.ORACLE, results.getContent().get(2).getHostBillingProvider());
+    assertEquals(BillingProvider.AWS, results.getContent().get(3).getHostBillingProvider());
+  }
+
+  @Transactional
+  @Test
+  void testFilterByHardwareMeasurementTypes() {
+    Host host1 = createHost(UUID.randomUUID().toString(), "a1");
+    host1.setBillingProvider(BillingProvider.RED_HAT);
+    addBucketToHost(
+        host1,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.RED_HAT);
+
+    Host host2 = createHost(UUID.randomUUID().toString(), "a1");
+    host2.setBillingProvider(BillingProvider.RED_HAT);
+    addBucketToHost(
+        host2,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.VIRTUAL,
+        BillingProvider.RED_HAT);
+
+    Host host3 = createHost(UUID.randomUUID().toString(), "a1");
+    addBucketToHost(
+        host3,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.HYPERVISOR,
+        BillingProvider.RED_HAT);
+
+    persistHosts(host1, host2, host3);
+
+    InstanceReportSort sort = InstanceReportSort.CORES;
+    String sortValue = InstancesResource.INSTANCE_SORT_PARAM_MAPPING.get(sort);
+    Pageable page = PageRequest.of(0, 10, Sort.by(sortValue));
+
+    Page<TallyInstanceView> results =
+        repo.findAllBy(
+            "ORG_a1",
+            COOL_PROD,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            "",
+            0,
+            0,
+            null,
+            Uom.CORES,
+            BillingProvider.RED_HAT,
+            "_ANY",
+            List.of(HardwareMeasurementType.VIRTUAL),
+            page);
+    assertEquals(1L, results.getTotalElements());
+    assertEquals(
+        HardwareMeasurementType.VIRTUAL, results.getContent().get(0).getKey().getMeasurementType());
+
+    Page<TallyInstanceView> allResults =
+        repo.findAllBy(
+            "ORG_a1",
+            COOL_PROD,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            "",
+            0,
+            0,
+            null,
+            Uom.CORES,
+            BillingProvider.RED_HAT,
+            "_ANY",
+            null,
+            page);
+    assertEquals(3L, allResults.getTotalElements());
+    Map<String, TallyInstanceView> hostToBill =
+        allResults.stream()
+            .collect(
+                Collectors.toMap(
+                    instance -> instance.getKey().getInstanceId().toString(), Function.identity()));
+    assertTrue(
+        hostToBill
+            .keySet()
+            .containsAll(
+                Arrays.asList(host1.getInstanceId(), host2.getInstanceId(), host3.getInstanceId())),
+        "Result did not contain expected hosts!");
+    assertEquals(
+        HardwareMeasurementType.PHYSICAL,
+        hostToBill.get(host1.getInstanceId()).getKey().getMeasurementType());
+    assertEquals(
+        HardwareMeasurementType.VIRTUAL,
+        hostToBill.get(host2.getInstanceId()).getKey().getMeasurementType());
+    assertEquals(
+        HardwareMeasurementType.HYPERVISOR,
+        hostToBill.get(host3.getInstanceId()).getKey().getMeasurementType());
+  }
+
+  @Transactional
+  @Test
+  void testGetResultWithEmptyMeasurmentType() {
+    Host host1 = createHost(UUID.randomUUID().toString(), "a1");
+    host1.setBillingProvider(BillingProvider.RED_HAT);
+    addBucketToHost(
+        host1, COOL_PROD, ServiceLevel.PREMIUM, Usage.PRODUCTION, null, BillingProvider.RED_HAT);
+
+    persistHosts(host1);
+
+    InstanceReportSort sort = InstanceReportSort.CORES;
+    String sortValue = InstancesResource.INSTANCE_SORT_PARAM_MAPPING.get(sort);
+    Pageable page = PageRequest.of(0, 10, Sort.by(sortValue));
+
+    Page<TallyInstanceView> results =
+        repo.findAllBy(
+            "ORG_a1",
+            COOL_PROD,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            "",
+            0,
+            0,
+            null,
+            Uom.CORES,
+            BillingProvider.RED_HAT,
+            "_ANY",
+            null,
+            page);
+    assertEquals(1L, results.getTotalElements());
+    assertEquals(
+        HardwareMeasurementType.EMPTY, results.getContent().get(0).getKey().getMeasurementType());
+  }
+
+  @Transactional
+  @Test
+  void testFilterByCloudHardwareMeasurementTypes() {
+    Host host1 = createHost(UUID.randomUUID().toString(), "a1");
+    host1.setBillingProvider(BillingProvider.RED_HAT);
+    addBucketToHost(
+        host1,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.AWS,
+        BillingProvider.RED_HAT);
+
+    Host host2 = createHost(UUID.randomUUID().toString(), "a1");
+    host2.setBillingProvider(BillingProvider.RED_HAT);
+    addBucketToHost(
+        host2,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.AZURE,
+        BillingProvider.RED_HAT);
+
+    Host host3 = createHost(UUID.randomUUID().toString(), "a1");
+    addBucketToHost(
+        host3,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.GOOGLE,
+        BillingProvider.RED_HAT);
+
+    Host host4 = createHost(UUID.randomUUID().toString(), "a1");
+    addBucketToHost(
+        host4,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.AWS_CLOUDIGRADE,
+        BillingProvider.RED_HAT);
+
+    Host host5 = createHost(UUID.randomUUID().toString(), "a1");
+    addBucketToHost(
+        host5,
+        COOL_PROD,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        HardwareMeasurementType.PHYSICAL,
+        BillingProvider.RED_HAT);
+
+    persistHosts(host1, host2, host3, host4, host5);
+
+    InstanceReportSort sort = InstanceReportSort.CORES;
+    String sortValue = InstancesResource.INSTANCE_SORT_PARAM_MAPPING.get(sort);
+    Pageable page = PageRequest.of(0, 10, Sort.by(sortValue));
+
+    Page<TallyInstanceView> results =
+        repo.findAllBy(
+            "ORG_a1",
+            COOL_PROD,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            "",
+            0,
+            0,
+            null,
+            Uom.CORES,
+            BillingProvider.RED_HAT,
+            "_ANY",
+            HardwareMeasurementType.getCloudProviderTypes(),
+            page);
+    assertEquals(4L, results.getTotalElements());
+    Map<String, TallyInstanceView> hostToBill =
+        results.stream()
+            .collect(
+                Collectors.toMap(t -> t.getKey().getInstanceId().toString(), Function.identity()));
+    assertTrue(
+        hostToBill
+            .keySet()
+            .containsAll(
+                Arrays.asList(
+                    host1.getInstanceId(),
+                    host2.getInstanceId(),
+                    host3.getInstanceId(),
+                    host4.getInstanceId())));
+  }
+
+  private Host createHost(String inventoryId, String account) {
+    Host host =
+        new Host(
+            inventoryId,
+            UUID.randomUUID().toString(),
+            account,
+            "ORG_" + account,
+            "SUBMAN_" + inventoryId);
+    host.setBillingAccountId("_ANY");
+    host.setBillingProvider(BillingProvider._ANY);
+    host.setInstanceId(UUID.randomUUID().toString());
+    host.setMeasurement(Uom.SOCKETS, 1.0);
+    host.setMeasurement(Uom.CORES, 1.0);
+    return host;
+  }
+
+  private HostTallyBucket addBucketToHost(
+      Host host, String productId, ServiceLevel sla, Usage usage) {
+    return addBucketToHost(host, productId, sla, usage, HardwareMeasurementType.PHYSICAL);
+  }
+
+  private HostTallyBucket addBucketToHost(
+      Host host,
+      String productId,
+      ServiceLevel sla,
+      Usage usage,
+      HardwareMeasurementType measurementType) {
+    return addBucketToHost(
+        host, productId, sla, usage, measurementType, BillingProvider._ANY, "_ANY");
+  }
+
+  private HostTallyBucket addBucketToHost(
+      Host host,
+      String productId,
+      ServiceLevel sla,
+      Usage usage,
+      HardwareMeasurementType measurementType,
+      BillingProvider billingProvider) {
+    return addBucketToHost(host, productId, sla, usage, measurementType, billingProvider, "_ANY");
+  }
+
+  private HostTallyBucket addBucketToHost(
+      Host host,
+      String productId,
+      ServiceLevel sla,
+      Usage usage,
+      HardwareMeasurementType measurementType,
+      BillingProvider billingProvider,
+      String billingAccountId) {
+    return host.addBucket(
+        productId, sla, usage, billingProvider, billingAccountId, true, 4, 2, measurementType);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -79,7 +79,7 @@ class InstancesResourceTest {
         .setInstanceId(UUID.fromString("d6214a0b-b344-4778-831c-d53dcacb2da3"));
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
-    tallyInstanceView.setUom(Measurement.Uom.SOCKETS);
+    tallyInstanceView.getKey().setUom(Measurement.Uom.SOCKETS);
 
     Mockito.when(
             repository.findAllBy(
@@ -161,7 +161,7 @@ class InstancesResourceTest {
         .setInstanceId(UUID.fromString("d6214a0b-b344-4778-831c-d53dcacb2da3"));
     tallyInstanceViewPhysical.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceViewPhysical.getKey().setMeasurementType(HardwareMeasurementType.PHYSICAL);
-    tallyInstanceViewPhysical.setUom(Measurement.Uom.CORES);
+    tallyInstanceViewPhysical.getKey().setUom(Measurement.Uom.CORES);
 
     var tallyInstanceViewHypervisor = new TallyInstanceView();
     tallyInstanceViewHypervisor.setKey(new TallyInstanceViewKey());
@@ -173,7 +173,7 @@ class InstancesResourceTest {
         .setInstanceId(UUID.fromString("d6214a0b-b344-4778-831c-d53dcacb2da3"));
     tallyInstanceViewHypervisor.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceViewHypervisor.getKey().setMeasurementType(HardwareMeasurementType.HYPERVISOR);
-    tallyInstanceViewHypervisor.setUom(Measurement.Uom.CORES);
+    tallyInstanceViewHypervisor.getKey().setUom(Measurement.Uom.CORES);
 
     Mockito.when(
             repository.findAllBy(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import javax.validation.constraints.NotNull;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyInstanceView;
+import org.candlepin.subscriptions.db.model.TallyInstanceViewKey_;
+import org.candlepin.subscriptions.db.model.TallyInstanceView_;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.util.StringUtils;
+
+/** Provides access to TallyInstanceView database entities. */
+@SuppressWarnings({"linelength", "indentation"})
+public interface TallyInstanceViewRepository
+    extends JpaRepository<TallyInstanceView, UUID>,
+        JpaSpecificationExecutor<TallyInstanceView>,
+        TagProfileLookup {
+
+  @Override
+  Page<TallyInstanceView> findAll(
+      Specification<TallyInstanceView> specification, Pageable pageable);
+
+  /**
+   * Find all Hosts by bucket criteria and return a page of TallyInstanceView objects. A
+   * TallyInstanceView is a Host representation detailing what 'bucket' was applied to the current
+   * daily snapshots.
+   *
+   * @param orgId The organization ID of the hosts to query (required).
+   * @param productId The bucket product ID to filter Host by (pass null to ignore).
+   * @param sla The bucket service level to filter Hosts by (pass null to ignore).
+   * @param usage The bucket usage to filter Hosts by (pass null to ignore).
+   * @param displayNameSubstring Case-insensitive string to filter Hosts' display name by (pass null
+   *     or empty string to ignore)
+   * @param minCores Filter to Hosts with at least this number of cores.
+   * @param minSockets Filter to Hosts with at least this number of sockets.
+   * @param month Filter to Hosts with with monthly instance totals in provided month
+   * @param referenceUom Uom used when filtering to a specific month.
+   * @param pageable the current paging info for this query.
+   * @return a page of Host entities matching the criteria.
+   */
+  @SuppressWarnings("java:S107")
+  default Page<TallyInstanceView> findAllBy(
+      @Param("orgId") String orgId,
+      @Param("product") String productId,
+      @Param("sla") ServiceLevel sla,
+      @Param("usage") Usage usage,
+      @NotNull @Param("displayNameSubstring") String displayNameSubstring,
+      @Param("minCores") int minCores,
+      @Param("minSockets") int minSockets,
+      String month,
+      Uom referenceUom,
+      BillingProvider billingProvider,
+      String billingAccountId,
+      List<HardwareMeasurementType> hardwareMeasurementTypes,
+      Pageable pageable) {
+
+    TallyInstanceViewSpecification searchCriteria = new TallyInstanceViewSpecification();
+
+    Uom effectiveUom = Optional.ofNullable(referenceUom).orElse(getDefaultUomForProduct(productId));
+
+    searchCriteria.add(new SearchCriteria(TallyInstanceView_.ORG_ID, orgId, SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(TallyInstanceViewKey_.PRODUCT_ID, productId, SearchOperation.EQUAL));
+    searchCriteria.add(new SearchCriteria(TallyInstanceViewKey_.SLA, sla, SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(TallyInstanceViewKey_.USAGE, usage, SearchOperation.EQUAL));
+
+    searchCriteria.add(
+        new SearchCriteria(
+            TallyInstanceViewKey_.BUCKET_BILLING_PROVIDER, billingProvider, SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(
+            TallyInstanceViewKey_.BUCKET_BILLING_ACCOUNT_ID,
+            billingAccountId,
+            SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(
+            TallyInstanceView_.DISPLAY_NAME, displayNameSubstring, SearchOperation.CONTAINS));
+    if (effectiveUom != null) {
+      searchCriteria.add(
+          new SearchCriteria(TallyInstanceView_.UOM, effectiveUom, SearchOperation.EQUAL));
+    }
+    searchCriteria.add(
+        new SearchCriteria(TallyInstanceView_.CORES, minCores, SearchOperation.GREATER_THAN_EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(
+            TallyInstanceView_.SOCKETS, minSockets, SearchOperation.GREATER_THAN_EQUAL));
+
+    if (StringUtils.hasText(month) && effectiveUom != null) {
+      searchCriteria.add(
+          new SearchCriteria(
+              InstanceMonthlyTotalKey_.MONTH,
+              new InstanceMonthlyTotalKey(month, effectiveUom),
+              SearchOperation.EQUAL));
+    }
+    if (Objects.nonNull(hardwareMeasurementTypes) && !hardwareMeasurementTypes.isEmpty()) {
+      searchCriteria.add(
+          new SearchCriteria(
+              TallyInstanceViewKey_.MEASUREMENT_TYPE,
+              hardwareMeasurementTypes,
+              SearchOperation.IN));
+    }
+
+    return findAll(searchCriteria, pageable);
+  }
+
+  default Uom getDefaultUomForProduct(String productId) {
+    return Optional.ofNullable(getTagProfile().uomsForTag(productId)).orElse(List.of()).stream()
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -112,7 +112,7 @@ public interface TallyInstanceViewRepository
             TallyInstanceView_.DISPLAY_NAME, displayNameSubstring, SearchOperation.CONTAINS));
     if (effectiveUom != null) {
       searchCriteria.add(
-          new SearchCriteria(TallyInstanceView_.UOM, effectiveUom, SearchOperation.EQUAL));
+          new SearchCriteria(TallyInstanceViewKey_.UOM, effectiveUom, SearchOperation.EQUAL));
     }
     searchCriteria.add(
         new SearchCriteria(TallyInstanceView_.CORES, minCores, SearchOperation.GREATER_THAN_EQUAL));

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewSpecification.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewSpecification.java
@@ -72,6 +72,7 @@ public class TallyInstanceViewSpecification implements Specification<TallyInstan
             TallyInstanceViewKey_.BUCKET_BILLING_PROVIDER, root.get(TallyInstanceView_.KEY),
             TallyInstanceViewKey_.INSTANCE_ID, root.get(TallyInstanceView_.KEY),
             TallyInstanceViewKey_.MEASUREMENT_TYPE, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.UOM, root.get(TallyInstanceView_.KEY),
             InstanceMonthlyTotalKey_.MONTH, instanceMonthlyTotalRoot);
 
     for (SearchCriteria criteria : list) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewSpecification.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewSpecification.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.MapJoin;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
+import org.candlepin.subscriptions.db.model.TallyInstanceView;
+import org.candlepin.subscriptions.db.model.TallyInstanceViewKey_;
+import org.candlepin.subscriptions.db.model.TallyInstanceView_;
+import org.springframework.data.jpa.domain.Specification;
+
+public class TallyInstanceViewSpecification implements Specification<TallyInstanceView> {
+
+  private final transient List<SearchCriteria> list;
+
+  public TallyInstanceViewSpecification() {
+    this.list = new ArrayList<>();
+  }
+
+  public void add(SearchCriteria criteria) {
+    list.add(criteria);
+  }
+
+  @Override
+  @SuppressWarnings("java:S3776")
+  public Predicate toPredicate(
+      Root<TallyInstanceView> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+
+    query.distinct(true);
+
+    List<Predicate> predicates = new ArrayList<>();
+
+    MapJoin<Host, InstanceMonthlyTotalKey, Double> instanceMonthlyTotalRoot =
+        root.joinMap(TallyInstanceView_.MONTHLY_TOTALS, JoinType.LEFT);
+
+    Map<String, Path<?>> rootPaths =
+        Map.of(
+            TallyInstanceViewKey_.PRODUCT_ID, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.SLA, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.USAGE, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.BUCKET_BILLING_ACCOUNT_ID, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.BUCKET_BILLING_PROVIDER, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.INSTANCE_ID, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.MEASUREMENT_TYPE, root.get(TallyInstanceView_.KEY),
+            InstanceMonthlyTotalKey_.MONTH, instanceMonthlyTotalRoot);
+
+    for (SearchCriteria criteria : list) {
+      Path<?> path = rootPaths.getOrDefault(criteria.getKey(), root);
+      if (criteria.getOperation().equals(SearchOperation.GREATER_THAN)) {
+        predicates.add(
+            builder.greaterThan(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.LESS_THAN)) {
+        predicates.add(
+            builder.lessThan(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_EQUAL)) {
+        predicates.add(
+            builder.greaterThanOrEqualTo(
+                path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.LESS_THAN_EQUAL)) {
+        predicates.add(
+            builder.lessThanOrEqualTo(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.NOT_EQUAL)) {
+        predicates.add(builder.notEqual(path.get(criteria.getKey()), criteria.getValue()));
+      } else if (criteria.getOperation().equals(SearchOperation.EQUAL)) {
+        var key =
+            Objects.equals(instanceMonthlyTotalRoot, path)
+                ? instanceMonthlyTotalRoot.key()
+                : path.get(criteria.getKey());
+
+        predicates.add(builder.equal(key, criteria.getValue()));
+      } else if (criteria.getOperation().equals(SearchOperation.CONTAINS)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                "%" + criteria.getValue().toString().toLowerCase() + "%"));
+      } else if (criteria.getOperation().equals(SearchOperation.MATCH_END)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                criteria.getValue().toString().toLowerCase() + "%"));
+      } else if (criteria.getOperation().equals(SearchOperation.MATCH_START)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                "%" + criteria.getValue().toString().toLowerCase()));
+      } else if (criteria.getOperation().equals(SearchOperation.IN)) {
+        predicates.add(builder.in(path.get(criteria.getKey())).value(criteria.getValue()));
+      } else if (criteria.getOperation().equals(SearchOperation.NOT_IN)) {
+        predicates.add(builder.not(path.get(criteria.getKey())).in(criteria.getValue()));
+      }
+    }
+
+    return builder.and(predicates.toArray(new Predicate[0]));
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
@@ -33,7 +33,8 @@ public enum HardwareMeasurementType {
   AWS_CLOUDIGRADE, // AWS, measured by cloudigrade
   GOOGLE,
   ALIBABA,
-  AZURE;
+  AZURE,
+  EMPTY;
 
   public static boolean isSupportedCloudProvider(String name) {
     if (name == null || name.isEmpty()) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -35,6 +35,7 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import org.candlepin.subscriptions.json.Measurement;
 import org.springframework.data.annotation.Immutable;
 
 @Setter
@@ -84,5 +85,10 @@ public class TallyInstanceView implements Serializable {
 
   public TallyInstanceView() {
     key = new TallyInstanceViewKey();
+  }
+
+  public Double getMonthlyTotal(String monthId, Measurement.Uom uom) {
+    var key = new InstanceMonthlyTotalKey(monthId, uom);
+    return monthlyTotals.get(key);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -29,15 +29,12 @@ import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-import org.candlepin.subscriptions.json.Measurement;
 import org.springframework.data.annotation.Immutable;
 
 @Setter
@@ -77,10 +74,6 @@ public class TallyInstanceView implements Serializable {
   private int sockets;
 
   private Double value;
-
-  @Enumerated(EnumType.STRING)
-  @Column(name = "uom")
-  private Measurement.Uom uom;
 
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -89,6 +89,6 @@ public class TallyInstanceView implements Serializable {
 
   public Double getMonthlyTotal(String monthId, Measurement.Uom uom) {
     var totalKey = new InstanceMonthlyTotalKey(monthId, uom);
-    return monthlyTotals.get(key);
+    return monthlyTotals.get(totalKey);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -88,7 +88,7 @@ public class TallyInstanceView implements Serializable {
   }
 
   public Double getMonthlyTotal(String monthId, Measurement.Uom uom) {
-    var key = new InstanceMonthlyTotalKey(monthId, uom);
+    var totalKey = new InstanceMonthlyTotalKey(monthId, uom);
     return monthlyTotals.get(key);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.candlepin.subscriptions.json.Measurement;
+import org.springframework.data.annotation.Immutable;
+
+@Setter
+@Getter
+@Entity
+@Immutable
+@Table(name = "tally_instance_view")
+public class TallyInstanceView implements Serializable {
+
+  @EmbeddedId private TallyInstanceViewKey key;
+
+  @Column(name = "id")
+  private String id;
+
+  @Column(name = "host_billing_provider")
+  private BillingProvider hostBillingProvider;
+
+  @Column(name = "host_billing_account_id")
+  private String hostBillingAccountId;
+
+  @NotNull
+  @Column(name = "display_name", nullable = false)
+  private String displayName;
+
+  @NotNull
+  @Column(name = "org_id")
+  private String orgId;
+
+  @Column(name = "num_of_guests")
+  private Integer numOfGuests;
+
+  @Column(name = "last_seen")
+  private OffsetDateTime lastSeen;
+
+  private int cores;
+
+  private int sockets;
+
+  private Double value;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "uom")
+  private Measurement.Uom uom;
+
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(
+      name = "instance_monthly_totals",
+      joinColumns = @JoinColumn(name = "instance_id", referencedColumnName = "id"))
+  @Column(name = "value")
+  private Map<InstanceMonthlyTotalKey, Double> monthlyTotals = new HashMap<>();
+
+  public TallyInstanceView() {
+    key = new TallyInstanceViewKey();
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
@@ -31,6 +31,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.candlepin.subscriptions.json.Measurement;
 
 /** An embeddable composite key for a tally instance view. */
 @Embeddable
@@ -60,4 +61,8 @@ public class TallyInstanceViewKey implements Serializable {
   @Enumerated(EnumType.STRING)
   @Column(name = "measurement_type")
   private HardwareMeasurementType measurementType;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "uom")
+  private Measurement.Uom uom;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/** An embeddable composite key for a tally instance view. */
+@Embeddable
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class TallyInstanceViewKey implements Serializable {
+
+  @Column(name = "instance_id")
+  private UUID instanceId;
+
+  @Column(name = "product_id")
+  private String productId;
+
+  private ServiceLevel sla;
+
+  private Usage usage;
+
+  @Column(name = "bucket_billing_provider")
+  private BillingProvider bucketBillingProvider;
+
+  @Column(name = "bucket_billing_account_id")
+  private String bucketBillingAccountId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "measurement_type")
+  private HardwareMeasurementType measurementType;
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-587

Test Steps:

- Create test hosts: `bin/insert-mock-hosts   --num-guests=1   --num-hypervisors=1   --hypervisor-id=eb0d994a-e129-4a18-860d-3e39294f95df`
- Start app with: `DEV_MODE=true ./gradlew :bootRun`
- Run curl and should get records with VIRTUAL, PHYSICAL and HYPERVISOR measurement categories:
`curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL'   -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`