### PR TITLE
SWATCH-770 Allow enabling synchronous operations via template parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ RHSM_RBAC_USE_STUB=true ./gradlew bootRun
 * `CLOUDIGRADE_PSK`: pre-shared key for cloudigrade authentication
 * `SWATCH_*_PSK`: pre-shared keys for internal service-to-service authentication
   where the `*` represents the name of an authorized service
+* `ENABLE_SYNCHRONOUS_OPERATIONS`: allow any supported APIs to bypass kafka and run the operation immediately when requested.
 
 </details>
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,6 +64,7 @@ rhsm-subscriptions:
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:1h}
   subscription-sync-enabled: ${SUBSCRIPTION_SYNC_ENABLED:false}
+  enable-synchronous-operations: ${ENABLE_SYNCHRONOUS_OPERATIONS:false}
   subscription:
     use-stub: ${SUBSCRIPTION_USE_STUB:false}
     url: ${SUBSCRIPTION_URL:https://subscription.stage.api.redhat.com/svcrest/subscription/v5}

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -99,6 +99,8 @@ parameters:
     value: '3'
   - name: KAFKA_METERING_TASKS_PARTITIONS
     value: '3'
+  - name: ENABLE_SYNCHRONOUS_OPERATIONS
+    value: 'false'
 
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
@@ -306,6 +308,8 @@ objects:
                   secretKeyRef:
                     name: swatch-psks
                     key: self
+              - name: ENABLE_SYNCHRONOUS_OPERATIONS
+                value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
             livenessProbe:
               failureThreshold: 3
               httpGet:

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -145,6 +145,8 @@ parameters:
     value: '3'
   - name: KAFKA_SUBSCRIPTIONS_TASKS_PARTITIONS
     value: '3'
+  - name: ENABLE_SYNCHRONOUS_OPERATIONS
+    value: 'false'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -371,6 +373,8 @@ objects:
               value: ${ENABLE_ACCOUNT_RESET}
             - name: DEVTEST_EVENT_EDITING_ENABLED
               value: ${DEVTEST_EVENT_EDITING_ENABLED}
+            - name: ENABLE_SYNCHRONOUS_OPERATIONS
+              value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-770

The ENABLE_SYNCHRONOUS_OPERATIONS environment variable can be used to enable/disable synchronous admin operations.

The ENABLE_SYNCHRONOUS_OPERATIONS parameter can be specified in the swatch-tally and swatch-metrics templates to enable the feature when deploying.

## TESTING
Test that the environment variable can be used to enable this feature.

1. Deploy the app without setting the env var
```
PROM_URL="http://localhost:8888/api/metrics/v1/telemeter/api/v1" SPRING_PROFILES_ACTIVE=openshift-metering-worker,worker,kafka-queue DEV_MODE=true ./gradlew clean :bootRun
```
2. Test that the synchronous operations are disabled. 
```
curl -X POST -H "x-rh-swatch-synchronous-request: true" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?orgId=941133&rangeInMinutes=120"
```
```
curl -X POST -H "x-rh-swatch-synchronous-request: true" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=941133&start=2022-09-10T10:00:00Z&end=2022-09-14T22:00:00Z"
```
3. Deploy the app with the env var set
```
ENABLE_SYNCHRONOUS_OPERATIONS=true PROM_URL="http://localhost:8888/api/metrics/v1/telemeter/api/v1" SPRING_PROFILES_ACTIVE=openshift-metering-worker,worker,kafka-queue DEV_MODE=true ./gradlew clean :bootRun
```
4. Test that the synchronous operations are allowed. 
```
curl -X POST -H "x-rh-swatch-synchronous-request: true" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?orgId=941133&rangeInMinutes=120"
```
```
curl -X POST -H "x-rh-swatch-synchronous-request: true" -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=941133&start=2022-09-10T10:00:00Z&end=2022-09-14T22:00:00Z"
```