### PR TITLE
SWATCH-760: Make conduit retries configurable, bump defaults

### DIFF
--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -40,6 +40,14 @@ parameters:
     value: 1500m
   - name: RHSM_URL
     value: https://api.rhsm.qa.redhat.com/v1
+  - name: RHSM_MAX_ATTEMPTS
+    value: '10'
+  - name: RHSM_BACK_OFF_MAX_INTERVAL
+    value: 64s
+  - name: RHSM_BACK_OFF_INITIAL_INTERVAL
+    value: 1s
+  - name: RHSM_BACK_OFF_MULTIPLIER
+    value: '2'
   - name: DATABASE_CONNECTION_TIMEOUT_MS
     value: '30000'
   # TODO This has been lowered from what it was in the previous environment (from 25 to 10)
@@ -197,6 +205,14 @@ objects:
               value: kafka
             - name: RHSM_URL
               value: ${RHSM_URL}
+            - name: RHSM_MAX_ATTEMPTS
+              value: ${RHSM_MAX_ATTEMPTS}
+            - name: RHSM_BACK_OFF_MAX_INTERVAL
+              value: ${RHSM_BACK_OFF_MAX_INTERVAL}
+            - name: RHSM_BACK_OFF_INITIAL_INTERVAL
+              value: ${RHSM_BACK_OFF_INITIAL_INTERVAL}
+            - name: RHSM_BACK_OFF_MULTIPLIER
+              value: ${RHSM_BACK_OFF_MULTIPLIER}
             - name: LOGGING_LEVEL_ROOT
               value: ${LOGGING_LEVEL_ROOT}
             - name: LOGGING_LEVEL_ORG_CANDLEPIN

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/rhsm/RhsmClientConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/rhsm/RhsmClientConfiguration.java
@@ -47,8 +47,8 @@ public class RhsmClientConfiguration {
    */
   @Bean
   @ConfigurationProperties(prefix = "rhsm-conduit.rhsm")
-  public RhsmApiProperties rhsmApiProperties() {
-    return new RhsmApiProperties();
+  public RhsmProperties rhsmApiProperties() {
+    return new RhsmProperties();
   }
 
   /**
@@ -64,12 +64,14 @@ public class RhsmClientConfiguration {
   }
 
   @Bean(name = "rhsmRetryTemplate")
-  public RetryTemplate rhsmRetryTemplate() {
+  public RetryTemplate rhsmRetryTemplate(RhsmProperties properties) {
     SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
-    retryPolicy.setMaxAttempts(4);
+    retryPolicy.setMaxAttempts(properties.getMaxAttempts());
 
     ExponentialRandomBackOffPolicy backOffPolicy = new ExponentialRandomBackOffPolicy();
-    backOffPolicy.setInitialInterval(1000);
+    backOffPolicy.setInitialInterval(properties.getBackOffInitialInterval().toMillis());
+    backOffPolicy.setMaxInterval(properties.getBackOffMaxInterval().toMillis());
+    backOffPolicy.setMultiplier(properties.getBackOffMultiplier());
 
     RetryTemplate retryTemplate = new RetryTemplate();
     retryTemplate.setRetryPolicy(retryPolicy);

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/rhsm/RhsmProperties.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/rhsm/RhsmProperties.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.conduit.rhsm;
+
+import java.time.Duration;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.candlepin.subscriptions.conduit.rhsm.client.RhsmApiProperties;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class RhsmProperties extends RhsmApiProperties {
+
+  /** How many attempts before giving up. */
+  private Integer maxAttempts;
+
+  /** Retry backoff interval. */
+  private Duration backOffInitialInterval;
+
+  /** Retry backoff interval. */
+  private Duration backOffMaxInterval;
+
+  /** Retry exponential backoff multiplier. */
+  private Double backOffMultiplier;
+}

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -16,6 +16,10 @@ rhsm-conduit:
     max-connections: ${RHSM_MAX_CONNECTIONS:100}
     truststore: file:${RHSM_TRUSTSTORE:}
     truststore-password: ${RHSM_TRUSTSTORE_PASSWORD:changeit}
+    max-attempts: ${RHSM_MAX_ATTEMPTS:10}
+    back-off-max-interval: ${RHSM_BACK_OFF_MAX_INTERVAL:64s}
+    back-off-initial-interval: ${RHSM_BACK_OFF_INITIAL_INTERVAL:1s}
+    back-off-multiplier: ${RHSM_BACK_OFF_MULTIPLIER:2}
   inventory-service:
     use-stub: ${INVENTORY_USE_STUB:true}
     api-key: ${INVENTORY_API_KEY:changeit}

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/rhsm/RhsmServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/rhsm/RhsmServiceTest.java
@@ -82,7 +82,7 @@ class RhsmServiceTest {
         ApiException.class,
         () -> mockBackedService.getPageOfConsumers("123", null, mockBackedService.formattedTime()));
 
-    verify(rhsmApi, times(4))
+    verify(rhsmApi, times(10))
         .getConsumersForOrg(anyString(), any(Integer.class), nullable(String.class), anyString());
   }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-760

In order to alleviate transient connection issues that current retry settings are insufficient for.

Testing
-------

See that the following env vars are respected/validated by setting them to `placeholder` and seeing the deployment fail:

```shell
RHSM_MAX_ATTEMPTS=placeholder \
  ./gradlew :swatch-system-conduit:bootRun

RHSM_BACK_OFF_MAX_INTERVAL=placeholder \
  ./gradlew :swatch-system-conduit:bootRun

RHSM_BACK_OFF_INITIAL_INTERVAL=placeholder \
  ./gradlew :swatch-system-conduit:bootRun

RHSM_BACK_OFF_MULTIPLIER=placeholder \
  ./gradlew :swatch-system-conduit:bootRun
```

Then run with:

```shell
RHSM_URL=http://localhost:8910/does-not-exist \
  RHSM_MAX_ATTEMPTS=1 \
  ./gradlew :swatch-system-conduit:bootRun
```

and see it fail quickly with an attempt to sync:

```shell
http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg \
  x-rh-swatch-psk:placeholder \
  org_id=org123
```

Then change `RHSM_MAX_ATTEMPTS` to `2` and see it take longer to fail.