### PR TITLE
SWATCH-782: Add a configurable threshold for HBI tallies

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -128,4 +128,7 @@ public class ApplicationProperties {
 
   /** If enabled, will allow synchronous operations when requested. */
   private boolean enableSynchronousOperations = false;
+
+  /** Sets a hard limit on the size of accounts that HBI-based tally will attempt to process. */
+  private int tallyMaxHbiAccountSize;
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
@@ -59,4 +59,8 @@ public class InventoryDatabaseOperations {
     }
     log.info("Found {} reported hypervisors.", hypervisorData.getHypervisorMapping().size());
   }
+
+  public int activeSystemCountForOrgId(String orgId, int culledOffsetDays) {
+    return repo.activeSystemCountForOrgId(orgId, culledOffsetDays);
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/SystemThresholdException.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SystemThresholdException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+/** Thrown to indicate that a customer has more system records than the configured threshold */
+public class SystemThresholdException extends RuntimeException {
+  /* intentionally empty */
+  SystemThresholdException(String orgId, int threshold, int actual) {
+    super(
+        String.format(
+            "Skipping tally for orgId=%s because it has activeHbiSystems=%d (greater than threshold=%d)",
+            orgId, actual, threshold));
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -115,6 +115,9 @@ public class TallySnapshotController {
       if (props.isCloudigradeEnabled()) {
         attemptCloudigradeEnrichment(accountCalc);
       }
+    } catch (SystemThresholdException e) {
+      log.warn(e.getMessage());
+      return;
     } catch (Exception e) {
       log.error(
           "Could not collect existing usage snapshots for orgId={} account={}", orgId, account, e);

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -54,3 +54,4 @@ rhsm-subscriptions:
     kafka-group-id: ${KAFKA_GROUP_ID:rhsm-subscriptions-task-processor}
     seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
     seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+  tally-max-hbi-account-size: ${TALLY_MAX_HBI_ACCOUNT_SIZE:2147483647}  # Integer.MAX_VALUE by default

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -147,6 +147,8 @@ parameters:
     value: '3'
   - name: ENABLE_SYNCHRONOUS_OPERATIONS
     value: 'false'
+  - name: TALLY_MAX_HBI_ACCOUNT_SIZE
+    value: '2147483647'  # Integer.MAX_VALUE by default
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -375,6 +377,8 @@ objects:
               value: ${DEVTEST_EVENT_EDITING_ENABLED}
             - name: ENABLE_SYNCHRONOUS_OPERATIONS
               value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
+            - name: TALLY_MAX_HBI_ACCOUNT_SIZE
+              value: ${TALLY_MAX_HBI_ACCOUNT_SIZE}
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-782

`TALLY_MAX_HBI_ACCOUNT_SIZE` when overridden limits the size of accounts that will be processed. Any account going over this limit will be logged with a warning, and skipped.

Note that I intentionally set the default to `Integer.MAX_VALUE`, as this makes it easy to "disable" the check by just not overriding it, and I plan to override with a reasonable value for prod specifically via template parameter.

Testing
-------

Set up some fake HBI data:

```shell
bin/insert-mock-hosts --num-physical=2 --org=org123 --hbi
```

Run the service with a low threshold:

```shell
TALLY_MAX_HBI_ACCOUNT_SIZE=1 ./gradlew :bootRun
```

Trigger a tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean' \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org123"]'
```

Observe logging that shows the org was skipped:

```
2023-01-13 15:16:19,185 [thread=rhsm-subscriptions-task-processor-0-C-1] [WARN ] [org.candlepin.subscriptions.tally.TallySnapshotController] - Skipping tally for orgId=org123 because it has activeHbiSystems=2 (greater than threshold=1)
```