### PR TITLE
Add MACHINE_POOL parameter to swatch-tally

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -149,6 +149,8 @@ parameters:
     value: 'false'
   - name: TALLY_MAX_HBI_ACCOUNT_SIZE
     value: '2147483647'  # Integer.MAX_VALUE by default
+  - name: MACHINE_POOL
+    value: '' # don't restrict to a specific machine pool by default
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -417,6 +419,7 @@ objects:
             - name: pinhead
               secret:
                 secretName: pinhead
+          machinePool: ${MACHINE_POOL}
 
     jobs:
       - name: tally
@@ -546,6 +549,7 @@ objects:
           volumes:
             - name: logs
               emptyDir:
+          machinePool: ${MACHINE_POOL}
 
       - name: hourly
         schedule: ${CAPTURE_HOURLY_SNAPSHOT_SCHEDULE}


### PR DESCRIPTION
Default to empty string, this doesn't set tolerations at all (see https://github.com/RedHatInsights/clowder/blob/a85b276baf1b70f31d8fab1f325dcc5e64cc2617/controllers/cloud.redhat.com/providers/job/impl.go#L80)