### PR TITLE
SWATCH-761: Consider null values for sockets and cores when filtering by category

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityRepository.java
@@ -156,8 +156,13 @@ public interface SubscriptionCapacityRepository
 
       var standardPredicate = builder.greaterThan(root.get(standardAttribute), 0);
       var hypervisorPredicate = builder.greaterThan(root.get(hypervisorAttribute), 0);
-      // Has no hypervisor capacity at all
-      var nonHypervisorPredicate = builder.equal(root.get(hypervisorAttribute), 0);
+      // Has no hypervisor capacity at all.  In practices, subscriptions with non-hypervisor SKUs
+      // have null for hypervisor_cores and hypervisor_sockets, but I am checking for zero here also
+      // just to cover the bases.
+      var nonHypervisorPredicate =
+          builder.or(
+              builder.isNull(root.get(hypervisorAttribute)),
+              builder.equal(root.get(hypervisorAttribute), 0));
 
       if (Objects.nonNull(hypervisorReportCategory)) {
         switch (hypervisorReportCategory) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
@@ -155,9 +155,17 @@ public interface SubscriptionCapacityViewRepository
       switch (hypervisorReportCategory) {
         case NON_HYPERVISOR:
           // Has no virt capacity
-          return builder.and(
-              builder.equal(root.get(SubscriptionCapacityView_.hypervisorSockets), 0),
-              builder.equal(root.get(SubscriptionCapacityView_.hypervisorCores), 0));
+          var zeroCoresAndSockets =
+              builder.and(
+                  builder.equal(root.get(SubscriptionCapacityView_.hypervisorSockets), 0),
+                  builder.equal(root.get(SubscriptionCapacityView_.hypervisorCores), 0));
+          var nullCoresAndSockets =
+              builder.and(
+                  builder.isNull(root.get(SubscriptionCapacityView_.hypervisorSockets)),
+                  builder.isNull(root.get(SubscriptionCapacityView_.hypervisorCores)));
+          // In practices, subscriptions with non-hypervisor SKUs have null for hypervisor_cores
+          // and hypervisor_sockets, but I am checking for zero here also just to cover the bases.
+          return builder.or(zeroCoresAndSockets, nullCoresAndSockets);
         case HYPERVISOR:
           // Has some virt capacity
           return builder.or(


### PR DESCRIPTION
Our category filter for physical systems operated on the principle that physical systems have zero hypervisor cores and zero hypervisor sockets. This assumption is true in theory; however, we must also account for systems that have *null* hypervisor cores and *null* hypervisor sockets. In fact, looking at the production data, there are *no* records in subscriptions_capacity that have a zero for hypervisor_cores or hypervisor_sockets; they all use null instead.

This patch adds the consideration of null values when filtering for physical systems.

See https://issues.redhat.com/browse/SWATCH-761

Should also fix https://issues.redhat.com/browse/SWATCH-590

---
# Testing

* The easiest test is just to take this PR as a patch, remove the patch sections under `src/main` and apply only the unit tests.  Run the tests and they'll fail.  Apply the missing patch sections and the tests will pass.

* Test data is attached to the Jira card.  It's in the form of a tarball of CSV files.  Import each CSV into the corresponding table in the rhsm-subscriptions database.  Then run the following:

```
http :8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL beginning==2023-01-01T00:00:00.000Z ending==2023-01-10T23:59:59.999Z category==physical x-rh-identity:$(echo -n '{"identity":{"account_number":"6388073","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"13432096"}}}' | base64 -w0)
```

Before the fix, no records are returned.  Afterwards, one record with SKU `RH00004` will be returned.