### PR TITLE
SWATCH-687 Perform nightly tallies via DB

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -131,4 +131,7 @@ public class ApplicationProperties {
 
   /** Sets a hard limit on the size of accounts that HBI-based tally will attempt to process. */
   private int tallyMaxHbiAccountSize;
+
+  /** If enabled, nightly tally will calculated via host objects */
+  private boolean legacyNightlyTallyEnabled = false;
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -49,7 +49,7 @@ public class DefaultProductUsageCollector implements ProductUsageCollector {
       if (normalizedFacts.isMarketplace()) {
         appliedSockets = 0;
       }
-      prodCalc.addToTotal(appliedCores, appliedSockets, 1);
+      prodCalc.addVirtual(appliedCores, appliedSockets, 1);
     }
   }
 

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -55,3 +55,4 @@ rhsm-subscriptions:
     seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
     seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
   tally-max-hbi-account-size: ${TALLY_MAX_HBI_ACCOUNT_SIZE:2147483647}  # Integer.MAX_VALUE by default
+  legacy-nightly-tally-enabled: ${LEGACY_NIGHTLY_TALLY_ENABLED:false}

--- a/src/test/java/org/candlepin/subscriptions/db/HostTallyBucketRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostTallyBucketRepositoryTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.db.model.AccountBucketTally;
+import org.candlepin.subscriptions.db.model.AccountServiceInventory;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostBucketKey;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.Measurement.Uom;
+import org.candlepin.subscriptions.tally.InventoryAccountUsageCollector;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class HostTallyBucketRepositoryTest {
+
+  @Autowired private AccountServiceInventoryRepository accountRepo;
+
+  @Autowired private HostTallyBucketRepository bucketRepo;
+
+  @Test
+  @Transactional
+  void testTallyHostBucketsQuery() {
+    AccountServiceInventory account = new AccountServiceInventory("org123", "HBI_HOST");
+
+    Host h1 = createHost("inv1", "org123");
+    h1.addBucket(
+        "P1",
+        ServiceLevel._ANY,
+        Usage._ANY,
+        BillingProvider.RED_HAT,
+        "redhat1",
+        false,
+        1,
+        4,
+        HardwareMeasurementType.PHYSICAL);
+    account.getServiceInstances().put(h1.getInstanceId(), h1);
+
+    Host h2 = createHost("inv2", "org123");
+    h2.addBucket(
+        "P1",
+        ServiceLevel._ANY,
+        Usage._ANY,
+        BillingProvider.RED_HAT,
+        "redhat1",
+        false,
+        2,
+        8,
+        HardwareMeasurementType.PHYSICAL);
+    account.getServiceInstances().put(h2.getInstanceId(), h2);
+
+    Host h3 = createHost("inv3", "org123");
+    h3.addBucket(
+        "P1",
+        ServiceLevel._ANY,
+        Usage._ANY,
+        BillingProvider.RED_HAT,
+        "redhat1",
+        false,
+        3,
+        6,
+        HardwareMeasurementType.PHYSICAL);
+    account.getServiceInstances().put(h3.getInstanceId(), h3);
+
+    // Should not be included in instances since there are no buckets assigned to the host.
+    Host h4 = createHost("inv4", "org123");
+    account.getServiceInstances().put(h4.getInstanceId(), h4);
+
+    // Should be ignored since the instance type is not HBI_INSTANCE.
+    AccountServiceInventory nonHBIServiceAccount = new AccountServiceInventory("org123", "NON_HBI");
+    Host h5 = createHost("inv5", "org123");
+    h5.setInstanceType("NON_HBI");
+    h5.addBucket(
+        "P1",
+        ServiceLevel._ANY,
+        Usage._ANY,
+        BillingProvider.RED_HAT,
+        "redhat1",
+        false,
+        3,
+        6,
+        HardwareMeasurementType.PHYSICAL);
+    nonHBIServiceAccount.getServiceInstances().put(h5.getInstanceId(), h5);
+
+    accountRepo.save(account);
+    accountRepo.flush();
+
+    Stream<AccountBucketTally> orgTally =
+        bucketRepo.tallyHostBuckets("org123", InventoryAccountUsageCollector.HBI_INSTANCE_TYPE);
+    List<AccountBucketTally> tallies = orgTally.collect(Collectors.toList());
+    assertEquals(1, tallies.size());
+
+    AccountBucketTally abt = tallies.get(0);
+    assertBucketTally(abt, 6.0, 18.0, 3.0);
+  }
+
+  @Transactional
+  @Test
+  void testUnsetCoresAndSocketsResultInCountingZerosDuringTally() {
+    AccountServiceInventory account = new AccountServiceInventory("org123", "HBI_HOST");
+
+    Host h1 = createHost("inv1", "org123");
+    HostTallyBucket bucket = new HostTallyBucket();
+    bucket.setKey(
+        new HostBucketKey(
+            h1, "P1", ServiceLevel._ANY, Usage._ANY, BillingProvider.RED_HAT, "redhat1", false));
+    bucket.setHost(h1);
+    // Keep cores/sockets as unset
+    bucket.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+    h1.addBucket(bucket);
+    account.getServiceInstances().put(h1.getInstanceId(), h1);
+
+    accountRepo.save(account);
+    accountRepo.flush();
+
+    Stream<AccountBucketTally> orgTally =
+        bucketRepo.tallyHostBuckets("org123", InventoryAccountUsageCollector.HBI_INSTANCE_TYPE);
+    List<AccountBucketTally> tallies = orgTally.collect(Collectors.toList());
+    assertEquals(1, tallies.size());
+
+    AccountBucketTally abt = tallies.get(0);
+    assertBucketTally(abt, 0.0, 0.0, 1.0);
+  }
+
+  private void assertBucketTally(
+      AccountBucketTally tally, Double expSockets, Double expCores, Double expInstanceCount) {
+    assertEquals("P1", tally.getProductId());
+    assertEquals(HardwareMeasurementType.PHYSICAL, tally.getMeasurementType());
+    assertEquals(Usage._ANY, tally.getUsage());
+    assertEquals(ServiceLevel._ANY, tally.getSla());
+    assertEquals(BillingProvider.RED_HAT, tally.getBillingProvider());
+    assertEquals("redhat1", tally.getBillingAccountId());
+    assertEquals(expSockets, tally.getSockets());
+    assertEquals(expCores, tally.getCores());
+    assertEquals(expInstanceCount, tally.getInstances());
+  }
+
+  private Host createHost(String inventoryId, String orgId) {
+    Host host =
+        new Host(
+            inventoryId,
+            "INSIGHTS_" + inventoryId,
+            orgId + "_ACCOUNT",
+            orgId,
+            "SUBMAN_" + inventoryId);
+    host.setDisplayName(orgId);
+    host.setMeasurement(Uom.SOCKETS, 1.0);
+    host.setMeasurement(Uom.CORES, 1.0);
+    return host;
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorLegacyTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorLegacyTallyTest.java
@@ -1,0 +1,836 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createGuest;
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createHypervisor;
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createRhsmHost;
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createSystemProfileHost;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertHypervisorTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertPhysicalTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertVirtualTotalsCalculation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.Stream.Builder;
+import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.inventory.db.InventoryRepository;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"worker", "test"})
+class InventoryAccountUsageCollectorLegacyTallyTest {
+
+  private static final String TEST_PRODUCT = "RHEL";
+  public static final Integer TEST_PRODUCT_ID = 1;
+  private static final String NON_RHEL = "OTHER PRODUCT";
+  public static final Integer NON_RHEL_PRODUCT_ID = 2000;
+
+  public static final Set<String> RHEL_PRODUCTS = new HashSet<>(List.of(TEST_PRODUCT));
+  public static final Set<String> NON_RHEL_PRODUCTS = new HashSet<>(List.of(NON_RHEL));
+  private static final String BILLING_ACCOUNT_ID_ANY = "_ANY";
+
+  public static final String ACCOUNT = "foo123";
+  public static final String ORG_ID = "org123";
+
+  @MockBean private InventoryRepository inventoryRepo;
+  @MockBean private HostRepository hostRepo;
+  @MockBean private AccountServiceInventoryRepository accountServiceInventoryRepository;
+  @Autowired private InventoryAccountUsageCollector collector;
+  @Autowired private MeterRegistry meterRegistry;
+
+  @Test
+  void hypervisorCountsIgnoredForNonRhelProduct() {
+    InventoryHostFacts hypervisor = createHypervisor(ACCOUNT, ORG_ID, NON_RHEL_PRODUCT_ID);
+    hypervisor.setSystemProfileCoresPerSocket(4);
+    hypervisor.setSystemProfileSockets(3);
+
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(
+        hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
+    mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(hypervisor));
+
+    OrgHostsData orgHostsData = collector.collect(NON_RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation calc = collector.tally(NON_RHEL_PRODUCTS, orgHostsData);
+    // odd sockets are rounded up.
+    checkTotalsCalculation(calc, ACCOUNT, ORG_ID, NON_RHEL, 12, 4, 1);
+    checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, NON_RHEL, 12, 4, 1);
+    assertNull(
+        calc.getCalculation(createUsageKey(NON_RHEL)).getTotals(HardwareMeasurementType.VIRTUAL));
+  }
+
+  @Test
+  void hypervisorTotalsForRHEL() {
+    InventoryHostFacts hypervisor = createHypervisor(ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+    hypervisor.setSystemProfileCoresPerSocket(4);
+    hypervisor.setSystemProfileSockets(3);
+
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(
+        hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
+    mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(hypervisor));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    // odd sockets are rounded up.
+    checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+    // no guests running RHEL means no hypervisor total...
+    assertNull(
+        calc.getCalculation(createUsageKey(TEST_PRODUCT))
+            .getTotals(HardwareMeasurementType.HYPERVISOR));
+    // hypervisor itself gets counted
+    checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+  }
+
+  @Test
+  void guestWithKnownHypervisorNotAddedToTotalsForRHEL() {
+    InventoryHostFacts guest = createGuest("hyper-1", ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(guest.getHypervisorUuid(), guest.getHypervisorUuid());
+    mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(guest));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    UsageCalculation productCalc = calc.getCalculation(createUsageKey(TEST_PRODUCT));
+    assertNull(productCalc.getTotals(HardwareMeasurementType.TOTAL));
+    assertNull(productCalc.getTotals(HardwareMeasurementType.PHYSICAL));
+    assertNull(productCalc.getTotals(HardwareMeasurementType.VIRTUAL));
+  }
+
+  @Test
+  void guestUnknownHypervisorTotalsForRHEL() {
+    InventoryHostFacts guest = createGuest(null, ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+    guest.setSystemProfileCoresPerSocket(4);
+    guest.setSystemProfileSockets(3);
+
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(guest.getHypervisorUuid(), null);
+    mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(guest));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
+    checkVirtualTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
+    assertNull(
+        calc.getCalculation(createUsageKey(TEST_PRODUCT))
+            .getTotals(HardwareMeasurementType.PHYSICAL));
+    assertNull(
+        calc.getCalculation(createUsageKey(TEST_PRODUCT))
+            .getTotals(HardwareMeasurementType.HYPERVISOR));
+  }
+
+  @Test
+  void physicalSystemTotalsForRHEL() {
+    List<Integer> products = List.of(TEST_PRODUCT_ID);
+
+    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    host.setSystemProfileCoresPerSocket(4);
+    host.setSystemProfileSockets(3);
+    mockReportedHypervisors(ORG_ID, new HashMap<>());
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    // odd sockets are rounded up.
+    checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+    checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+    assertNull(
+        calc.getCalculation(createUsageKey(TEST_PRODUCT))
+            .getTotals(HardwareMeasurementType.VIRTUAL));
+  }
+
+  @Test
+  void testTallyCoresAndSocketsOfRhelWhenInventoryFoundForAccount() {
+    String account1 = "A1";
+    String orgId1 = "O1";
+
+    String account2 = "A2";
+    String orgId2 = "O2";
+
+    List<Integer> products = List.of(TEST_PRODUCT_ID);
+
+    InventoryHostFacts host1 = createRhsmHost(account1, orgId1, products, "", OffsetDateTime.now());
+    host1.setSystemProfileCoresPerSocket(1);
+    host1.setSystemProfileSockets(4);
+
+    InventoryHostFacts host2 = createRhsmHost(account1, orgId1, products, "", OffsetDateTime.now());
+    host2.setSystemProfileCoresPerSocket(2);
+    host2.setSystemProfileSockets(4);
+
+    InventoryHostFacts host3 = createRhsmHost(account2, orgId2, products, "", OffsetDateTime.now());
+    host3.setSystemProfileCoresPerSocket(3);
+    host3.setSystemProfileSockets(2);
+
+    mockReportedHypervisors(List.of(orgId1, orgId2), new HashMap<>());
+    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
+    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3));
+
+    OrgHostsData orgHostsData1 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
+    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData1);
+    assertEquals(1, a1Calc.getProducts().size());
+    checkTotalsCalculation(a1Calc, account1, orgId1, "RHEL", 12, 8, 2);
+
+    OrgHostsData orgHostsData2 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
+    AccountUsageCalculation a2Calc = collector.tally(RHEL_PRODUCTS, orgHostsData2);
+    assertEquals(1, a2Calc.getProducts().size());
+    checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 6, 2, 1);
+  }
+
+  @Test
+  void testTallyForMultipleSlas() {
+    InventoryHostFacts host1 =
+        createRhsmHost(
+            ACCOUNT,
+            ORG_ID,
+            TEST_PRODUCT_ID.toString(),
+            ServiceLevel.STANDARD,
+            "",
+            OffsetDateTime.now());
+    host1.setSystemProfileCoresPerSocket(1);
+    host1.setSystemProfileSockets(6);
+
+    InventoryHostFacts host2 =
+        createRhsmHost(
+            ACCOUNT,
+            ORG_ID,
+            TEST_PRODUCT_ID.toString(),
+            ServiceLevel.PREMIUM,
+            "",
+            OffsetDateTime.now());
+    host2.setSystemProfileCoresPerSocket(1);
+    host2.setSystemProfileSockets(10);
+
+    mockReportedHypervisors(ORG_ID, new HashMap<>());
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host1, host2));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    assertEquals(1, a1Calc.getProducts().size());
+    checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", 16, 16, 2);
+    checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", ServiceLevel._ANY, 16, 16, 2);
+    checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", ServiceLevel.STANDARD, 6, 6, 1);
+    checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", ServiceLevel.PREMIUM, 10, 10, 1);
+  }
+
+  @Test
+  void testTallyForMultipleUsages() {
+    InventoryHostFacts host1 =
+        createRhsmHost(
+            ACCOUNT,
+            ORG_ID,
+            TEST_PRODUCT_ID.toString(),
+            ServiceLevel.EMPTY,
+            Usage.DEVELOPMENT_TEST,
+            "",
+            OffsetDateTime.now());
+    host1.setSystemProfileCoresPerSocket(1);
+    host1.setSystemProfileSockets(6);
+
+    InventoryHostFacts host2 =
+        createRhsmHost(
+            ACCOUNT,
+            ORG_ID,
+            TEST_PRODUCT_ID.toString(),
+            ServiceLevel.EMPTY,
+            Usage.PRODUCTION,
+            "",
+            OffsetDateTime.now());
+    host2.setSystemProfileCoresPerSocket(1);
+    host2.setSystemProfileSockets(10);
+
+    mockReportedHypervisors(ORG_ID, new HashMap<>());
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host1, host2));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    assertEquals(1, a1Calc.getProducts().size());
+    checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", 16, 16, 2);
+    checkTotalsCalculation(
+        a1Calc,
+        ACCOUNT,
+        ORG_ID,
+        "RHEL",
+        ServiceLevel.EMPTY,
+        Usage._ANY,
+        BillingProvider._ANY,
+        BILLING_ACCOUNT_ID_ANY,
+        16,
+        16,
+        2);
+    checkTotalsCalculation(
+        a1Calc,
+        ACCOUNT,
+        ORG_ID,
+        "RHEL",
+        ServiceLevel.EMPTY,
+        Usage.DEVELOPMENT_TEST,
+        BillingProvider._ANY,
+        BILLING_ACCOUNT_ID_ANY,
+        6,
+        6,
+        1);
+    checkTotalsCalculation(
+        a1Calc,
+        ACCOUNT,
+        ORG_ID,
+        "RHEL",
+        ServiceLevel.EMPTY,
+        Usage.PRODUCTION,
+        BillingProvider._ANY,
+        BILLING_ACCOUNT_ID_ANY,
+        10,
+        10,
+        1);
+  }
+
+  @Test
+  void testTallyCoresAndSocketsOfRhelViaSystemProfileOnly() {
+    String account1 = "A1";
+    String orgId1 = "O1";
+
+    String account2 = "A2";
+    String orgId2 = "O2";
+
+    InventoryHostFacts host1 =
+        createSystemProfileHost(
+            account1, orgId1, List.of(TEST_PRODUCT_ID), 1, 4, OffsetDateTime.now());
+    InventoryHostFacts host2 =
+        createSystemProfileHost(
+            account1, orgId1, List.of(TEST_PRODUCT_ID), 2, 4, OffsetDateTime.now());
+    InventoryHostFacts host3 =
+        createSystemProfileHost(
+            account2, orgId2, List.of(TEST_PRODUCT_ID), 2, 6, OffsetDateTime.now());
+
+    mockReportedHypervisors(List.of(orgId1, orgId2), new HashMap<>());
+    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
+    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3));
+
+    OrgHostsData orgHostsData1 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
+    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData1);
+    assertEquals(1, a1Calc.getProducts().size());
+    checkTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
+
+    OrgHostsData orgHostsData2 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
+    AccountUsageCalculation a2Calc = collector.tally(RHEL_PRODUCTS, orgHostsData2);
+    assertEquals(1, a2Calc.getProducts().size());
+    checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 12, 6, 1);
+  }
+
+  @Test
+  void testCalculationDoesNotIncludeHostWhenProductDoesntMatch() {
+    InventoryHostFacts h1 =
+        createRhsmHost(ACCOUNT, ORG_ID, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+    h1.setSystemProfileCoresPerSocket(4);
+    h1.setSystemProfileSockets(2);
+
+    InventoryHostFacts h2 = createRhsmHost(ACCOUNT, ORG_ID, List.of(32), "", OffsetDateTime.now());
+    h2.setSystemProfileCoresPerSocket(12);
+    h2.setSystemProfileSockets(14);
+
+    mockReportedHypervisors(ORG_ID, new HashMap<>());
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(h1, h2));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation accountCalc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    assertEquals(1, accountCalc.getProducts().size());
+    checkTotalsCalculation(accountCalc, ACCOUNT, ORG_ID, TEST_PRODUCT, 8, 2, 1);
+  }
+
+  @Test
+  void throwsISEOnAttemptToCalculateFactsBelongingToADifferentAccountForSameOrgId() {
+    InventoryHostFacts h1 =
+        createRhsmHost("Account1", ORG_ID, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+    h1.setSystemProfileCoresPerSocket(1);
+    h1.setSystemProfileSockets(2);
+
+    InventoryHostFacts h2 =
+        createRhsmHost("Account2", ORG_ID, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+
+    mockReportedHypervisors(ORG_ID, new HashMap<>());
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(h1, h2));
+
+    var orgHostData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    Throwable e =
+        assertThrows(
+            IllegalStateException.class, () -> collector.tally(RHEL_PRODUCTS, orgHostData));
+
+    String expectedMessage =
+        String.format(
+            "Attempt to set a different account for an org: %s:%s", "Account1", "Account2");
+    assertEquals(expectedMessage, e.getMessage());
+  }
+
+  @Test
+  void testTallyCoresAndSocketsOfRhelForPhysicalSystems() {
+    String account1 = "A1";
+    String orgId1 = "O1";
+
+    String account2 = "A2";
+    String orgId2 = "O2";
+
+    List<String> orgIds = List.of(orgId1, orgId2);
+
+    InventoryHostFacts host1 =
+        createRhsmHost(account1, orgId1, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+    host1.setSystemProfileCoresPerSocket(1);
+    host1.setSystemProfileSockets(4);
+
+    InventoryHostFacts host2 = createHypervisor(account1, orgId1, TEST_PRODUCT_ID);
+    host2.setSystemProfileCoresPerSocket(2);
+    host2.setSystemProfileSockets(4);
+
+    InventoryHostFacts host3 =
+        createRhsmHost(account2, orgId2, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+    host3.setSystemProfileCoresPerSocket(5);
+    host3.setSystemProfileSockets(1);
+
+    InventoryHostFacts host4 = createHypervisor(account2, orgId2, TEST_PRODUCT_ID);
+    host4.setSystemProfileCoresPerSocket(5);
+    host4.setSystemProfileSockets(1);
+
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(host2.getSubscriptionManagerId(), null);
+    expectedHypervisorMap.put(host4.getSubscriptionManagerId(), null);
+    mockReportedHypervisors(orgIds, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
+    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3, host4));
+
+    OrgHostsData orgHostsData1 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
+    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData1);
+    assertEquals(1, a1Calc.getProducts().size());
+    checkTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
+    checkPhysicalTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
+
+    OrgHostsData orgHostsData2 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
+    AccountUsageCalculation a2Calc = collector.tally(RHEL_PRODUCTS, orgHostsData2);
+    assertEquals(1, a2Calc.getProducts().size());
+    checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 10, 4, 2);
+    checkPhysicalTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 10, 4, 2);
+  }
+
+  @Test
+  void testHypervisorCalculationsWhenMapped() {
+    InventoryHostFacts hypervisor = createHypervisor(ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+    hypervisor.setSystemProfileCoresPerSocket(4);
+    hypervisor.setSystemProfileSockets(3);
+
+    // Guests should not end up in the total since only the hypervisor should be counted.
+    InventoryHostFacts guest1 =
+        createGuest(hypervisor.getSubscriptionManagerId(), ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+    guest1.setSystemProfileCoresPerSocket(4);
+    guest1.setSystemProfileSockets(3);
+
+    InventoryHostFacts guest2 =
+        createGuest(hypervisor.getSubscriptionManagerId(), ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+    guest2.setSystemProfileCoresPerSocket(4);
+    guest2.setSystemProfileSockets(2);
+
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(
+        hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
+    mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
+        .thenReturn(Stream.of(hypervisor, guest1, guest2));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    // odd sockets are rounded up for hypervisor.
+    // hypervisor gets counted twice - once for itself, once for the guests
+    checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 24, 8, 2);
+    checkHypervisorTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+    checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+  }
+
+  @Test
+  void testHypervisorCalculationsWhenMappedWithNoProductsOnHypervisor() {
+    InventoryHostFacts hypervisor = createHypervisor(ACCOUNT, ORG_ID, null);
+    hypervisor.setSystemProfileCoresPerSocket(4);
+    hypervisor.setSystemProfileSockets(3);
+
+    // Guests should not end up in the total since only the hypervisor should be counted.
+    InventoryHostFacts guest1 =
+        createGuest(hypervisor.getSubscriptionManagerId(), ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+    guest1.setSystemProfileCoresPerSocket(4);
+    guest1.setSystemProfileSockets(3);
+
+    InventoryHostFacts guest2 =
+        createGuest(hypervisor.getSubscriptionManagerId(), ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+    guest2.setSystemProfileCoresPerSocket(4);
+    guest2.setSystemProfileSockets(3);
+
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(
+        hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
+    mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
+        .thenReturn(Stream.of(hypervisor, guest1, guest2));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    // odd sockets are rounded up for hypervisor.
+    checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+    checkHypervisorTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+    assertNull(
+        calc.getCalculation(createUsageKey(TEST_PRODUCT))
+            .getTotals(HardwareMeasurementType.PHYSICAL));
+  }
+
+  @Test
+  void testGuestCountIsTrackedOnHost() {
+    InventoryHostFacts hypervisor = createHypervisor(ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+
+    // Guests should not end up in the total since only the hypervisor should be counted.
+    InventoryHostFacts guest1 =
+        createGuest(hypervisor.getSubscriptionManagerId(), ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+
+    InventoryHostFacts guest2 =
+        createGuest(hypervisor.getSubscriptionManagerId(), ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(
+        hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
+    mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
+        .thenReturn(Stream.of(hypervisor, guest1, guest2));
+
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+
+    ArgumentCaptor<AccountServiceInventory> accountService =
+        ArgumentCaptor.forClass(AccountServiceInventory.class);
+    verify(accountServiceInventoryRepository).save(accountService.capture());
+
+    Map<String, Host> savedGuests =
+        accountService.getAllValues().stream()
+            .map(AccountServiceInventory::getServiceInstances)
+            .map(Map::values)
+            .flatMap(Collection::stream)
+            .filter(h -> h.getHypervisorUuid() != null)
+            .collect(Collectors.toMap(Host::getInventoryId, host -> host));
+    assertEquals(2, savedGuests.size());
+    assertTrue(savedGuests.containsKey(guest1.getInventoryId().toString()));
+    assertTrue(savedGuests.containsKey(guest2.getInventoryId().toString()));
+
+    Host savedHypervisor =
+        accountService.getAllValues().stream()
+            .map(AccountServiceInventory::getServiceInstances)
+            .map(Map::values)
+            .flatMap(Collection::stream)
+            .filter(h -> h.getHypervisorUuid() == null)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(hypervisor.getSubscriptionManagerId(), savedHypervisor.getSubscriptionManagerId());
+    assertEquals(2, savedHypervisor.getNumOfGuests().intValue());
+  }
+
+  @Test
+  void testTotalHosts() {
+    Counter counter = meterRegistry.counter("rhsm-subscriptions.tally.hbi_hosts");
+    double initialCount = counter.count();
+
+    InventoryHostFacts hypervisor = createHypervisor(ACCOUNT, ORG_ID, TEST_PRODUCT_ID);
+
+    Map<String, String> expectedHypervisorMap = new HashMap<>();
+    expectedHypervisorMap.put(
+        hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
+    mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(hypervisor));
+
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    assertEquals(1, counter.count() - initialCount);
+  }
+
+  @Test
+  void accountsWithNullInventoryIdFiltered() {
+    List<Integer> products = List.of(TEST_PRODUCT_ID);
+    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    host.setSystemProfileCoresPerSocket(4);
+    host.setSystemProfileSockets(3);
+
+    mockReportedHypervisors(ORG_ID, new HashMap<>());
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host));
+
+    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    // odd sockets are rounded up.
+    checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+    checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
+    assertNull(
+        calc.getCalculation(createUsageKey(TEST_PRODUCT))
+            .getTotals(HardwareMeasurementType.VIRTUAL));
+  }
+
+  @Test
+  void removesDuplicateHostRecords() {
+    List<Integer> products = List.of(TEST_PRODUCT_ID);
+    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    host.setSystemProfileCoresPerSocket(4);
+    host.setSystemProfileSockets(3);
+    Host orig =
+        new Host(
+            host.getInventoryId().toString(),
+            "insights1",
+            host.getAccount(),
+            host.getOrgId(),
+            null);
+    orig.setInstanceId(host.getInventoryId().toString());
+    Host dupe =
+        new Host(
+            host.getInventoryId().toString(),
+            "insights2",
+            host.getAccount(),
+            host.getOrgId(),
+            null);
+    dupe.setInstanceId("i2");
+
+    AccountServiceInventory accountServiceInventory =
+        new AccountServiceInventory(ORG_ID, "HBI_HOST");
+    accountServiceInventory.getServiceInstances().put(host.getInventoryId().toString(), orig);
+    accountServiceInventory.getServiceInstances().put("i2", dupe);
+
+    when(accountServiceInventoryRepository.findById(
+            AccountServiceInventoryId.builder().orgId(ORG_ID).serviceType("HBI_HOST").build()))
+        .thenReturn(Optional.of(accountServiceInventory));
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), any())).thenReturn(Stream.of(host));
+
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+
+    assertEquals(1, accountServiceInventory.getServiceInstances().size());
+  }
+
+  @Test
+  void ensureStaleHostsAreDeleted() {
+    List<Integer> products = List.of(TEST_PRODUCT_ID);
+    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    host.setSystemProfileCoresPerSocket(4);
+    host.setSystemProfileSockets(3);
+    Host orig =
+        new Host(
+            host.getInventoryId().toString(),
+            "insights1",
+            host.getAccount(),
+            host.getOrgId(),
+            null);
+    orig.setInstanceId(host.getInventoryId().toString());
+    Host noLongerReported =
+        new Host("i2-inventory-id", "insights2", host.getAccount(), host.getOrgId(), null);
+    noLongerReported.setInstanceId("i2");
+
+    AccountServiceInventory accountServiceInventory =
+        new AccountServiceInventory(ORG_ID, "HBI_HOST");
+    accountServiceInventory.getServiceInstances().put(host.getInventoryId().toString(), orig);
+    accountServiceInventory.getServiceInstances().put("i2", noLongerReported);
+
+    when(accountServiceInventoryRepository.findById(
+            AccountServiceInventoryId.builder().orgId(ORG_ID).serviceType("HBI_HOST").build()))
+        .thenReturn(Optional.of(accountServiceInventory));
+
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), any())).thenReturn(Stream.of(host));
+
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+
+    assertEquals(1, accountServiceInventory.getServiceInstances().size());
+  }
+
+  private void checkTotalsCalculation(
+      AccountUsageCalculation calc,
+      String account,
+      String owner,
+      String product,
+      int cores,
+      int sockets,
+      int instances) {
+    checkTotalsCalculation(
+        calc, account, owner, product, ServiceLevel._ANY, cores, sockets, instances);
+  }
+
+  private void checkTotalsCalculation(
+      AccountUsageCalculation calc,
+      String account,
+      String owner,
+      String product,
+      ServiceLevel serviceLevel,
+      int cores,
+      int sockets,
+      int instances) {
+
+    checkTotalsCalculation(
+        calc,
+        account,
+        owner,
+        product,
+        serviceLevel,
+        Usage._ANY,
+        BillingProvider._ANY,
+        BILLING_ACCOUNT_ID_ANY,
+        cores,
+        sockets,
+        instances);
+  }
+
+  private void checkTotalsCalculation(
+      AccountUsageCalculation calc,
+      String account,
+      String owner,
+      String product,
+      ServiceLevel serviceLevel,
+      Usage usage,
+      BillingProvider billingProvider,
+      String billingAccountId,
+      int cores,
+      int sockets,
+      int instances) {
+    assertEquals(account, calc.getAccount());
+    assertEquals(owner, calc.getOrgId());
+    assertTrue(
+        calc.containsCalculation(
+            createUsageKey(product, serviceLevel, usage, billingProvider, billingAccountId)));
+
+    UsageCalculation prodCalc =
+        calc.getCalculation(
+            createUsageKey(product, serviceLevel, usage, billingProvider, billingAccountId));
+
+    assertEquals(product, prodCalc.getProductId());
+    assertEquals(serviceLevel, prodCalc.getSla());
+    assertEquals(billingProvider, prodCalc.getBillingProvider());
+    assertEquals(billingAccountId, prodCalc.getBillingAccountId());
+    assertTotalsCalculation(prodCalc, sockets, cores, instances);
+  }
+
+  private void checkPhysicalTotalsCalculation(
+      AccountUsageCalculation calc,
+      String account,
+      String owner,
+      String product,
+      int physicalCores,
+      int physicalSockets,
+      int physicalInstances) {
+    assertEquals(account, calc.getAccount());
+    assertEquals(owner, calc.getOrgId());
+    assertTrue(calc.containsCalculation(createUsageKey(product)));
+
+    UsageCalculation prodCalc = calc.getCalculation(createUsageKey(product));
+    assertEquals(product, prodCalc.getProductId());
+    assertPhysicalTotalsCalculation(prodCalc, physicalSockets, physicalCores, physicalInstances);
+  }
+
+  private void checkVirtualTotalsCalculation(
+      AccountUsageCalculation calc,
+      String account,
+      String orgId,
+      String product,
+      int cores,
+      int sockets,
+      int instances) {
+    assertEquals(account, calc.getAccount());
+    assertEquals(orgId, calc.getOrgId());
+    assertTrue(calc.containsCalculation(createUsageKey(product)));
+
+    UsageCalculation prodCalc = calc.getCalculation(createUsageKey(product));
+    assertEquals(product, prodCalc.getProductId());
+    assertVirtualTotalsCalculation(prodCalc, sockets, cores, instances);
+  }
+
+  private void checkHypervisorTotalsCalculation(
+      AccountUsageCalculation calc,
+      String account,
+      String owner,
+      String product,
+      int hypCores,
+      int hypSockets,
+      int hypInstances) {
+    assertEquals(account, calc.getAccount());
+    assertEquals(owner, calc.getOrgId());
+    assertTrue(calc.containsCalculation(createUsageKey(product)));
+
+    UsageCalculation prodCalc = calc.getCalculation(createUsageKey(product));
+    assertEquals(product, prodCalc.getProductId());
+    assertHypervisorTotalsCalculation(prodCalc, hypSockets, hypCores, hypInstances);
+  }
+
+  private UsageCalculation.Key createUsageKey(String product) {
+    return createUsageKey(product, ServiceLevel._ANY);
+  }
+
+  private UsageCalculation.Key createUsageKey(String product, ServiceLevel sla) {
+    return new UsageCalculation.Key(
+        product, sla, Usage._ANY, BillingProvider._ANY, BILLING_ACCOUNT_ID_ANY);
+  }
+
+  private UsageCalculation.Key createUsageKey(
+      String product,
+      ServiceLevel sla,
+      Usage usage,
+      BillingProvider billingProvider,
+      String billingAcctId) {
+    return new UsageCalculation.Key(product, sla, usage, billingProvider, billingAcctId);
+  }
+
+  private void mockReportedHypervisors(String orgId, Map<String, String> expectedHypervisorMap) {
+    mockReportedHypervisors(List.of(orgId), expectedHypervisorMap);
+  }
+
+  private void mockReportedHypervisors(
+      List<String> orgIds, Map<String, String> expectedHypervisorMap) {
+    Builder<Object[]> streamBuilder = Stream.builder();
+    for (Entry<String, String> entry : expectedHypervisorMap.entrySet()) {
+      streamBuilder.accept(new Object[] {entry.getKey(), entry.getValue()});
+    }
+    when(inventoryRepo.getReportedHypervisors(orgIds)).thenReturn(streamBuilder.build());
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import static org.candlepin.subscriptions.tally.InventoryAccountUsageCollector.HBI_INSTANCE_TYPE;
 import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createGuest;
 import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createHypervisor;
 import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createRhsmHost;
@@ -28,13 +29,22 @@ import static org.candlepin.subscriptions.tally.collector.Assertions.assertHyper
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertPhysicalTotalsCalculation;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertTotalsCalculation;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertVirtualTotalsCalculation;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.OffsetDateTime;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -42,12 +52,23 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.db.HostRepository;
-import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.db.HostTallyBucketRepository;
+import org.candlepin.subscriptions.db.model.AccountBucketTally;
+import org.candlepin.subscriptions.db.model.AccountServiceInventory;
+import org.candlepin.subscriptions.db.model.AccountServiceInventoryId;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostBucketKey;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.inventory.db.InventoryRepository;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.junit.jupiter.api.Test;
@@ -59,7 +80,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles({"worker", "test"})
-class InventoryAccountUsageCollectorTest {
+class InventoryAccountUsageCollectorTallyTest {
 
   private static final String TEST_PRODUCT = "RHEL";
   public static final Integer TEST_PRODUCT_ID = 1;
@@ -75,6 +96,7 @@ class InventoryAccountUsageCollectorTest {
 
   @MockBean private InventoryRepository inventoryRepo;
   @MockBean private HostRepository hostRepo;
+  @MockBean private HostTallyBucketRepository hostBucketRepository;
   @MockBean private AccountServiceInventoryRepository accountServiceInventoryRepository;
   @Autowired private InventoryAccountUsageCollector collector;
   @Autowired private MeterRegistry meterRegistry;
@@ -92,8 +114,10 @@ class InventoryAccountUsageCollectorTest {
 
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(hypervisor));
 
-    OrgHostsData orgHostsData = collector.collect(NON_RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation calc = collector.tally(NON_RHEL_PRODUCTS, orgHostsData);
+    collector.collect(NON_RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation calc = collector.tally(ORG_ID);
     // odd sockets are rounded up.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, NON_RHEL, 12, 4, 1);
     checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, NON_RHEL, 12, 4, 1);
@@ -114,8 +138,10 @@ class InventoryAccountUsageCollectorTest {
 
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(hypervisor));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation calc = collector.tally(ORG_ID);
     // odd sockets are rounded up.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
     // no guests running RHEL means no hypervisor total...
@@ -135,12 +161,13 @@ class InventoryAccountUsageCollectorTest {
 
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(guest));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
-    UsageCalculation productCalc = calc.getCalculation(createUsageKey(TEST_PRODUCT));
-    assertNull(productCalc.getTotals(HardwareMeasurementType.TOTAL));
-    assertNull(productCalc.getTotals(HardwareMeasurementType.PHYSICAL));
-    assertNull(productCalc.getTotals(HardwareMeasurementType.VIRTUAL));
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation calc = collector.tally(ORG_ID);
+    // Calculation expected to be empty because there were no buckets created during collection.
+    assertEquals(0, calc.getProducts().size());
+    assertEquals(0, calc.getKeys().size());
   }
 
   @Test
@@ -155,8 +182,10 @@ class InventoryAccountUsageCollectorTest {
 
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(guest));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation calc = collector.tally(ORG_ID);
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
     checkVirtualTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 1, 1);
     assertNull(
@@ -178,8 +207,10 @@ class InventoryAccountUsageCollectorTest {
 
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation calc = collector.tally(ORG_ID);
     // odd sockets are rounded up.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
     checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
@@ -214,13 +245,28 @@ class InventoryAccountUsageCollectorTest {
     when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
     when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3));
 
-    OrgHostsData orgHostsData1 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
-    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData1);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
+
+    ArgumentCaptor<AccountServiceInventory> accountService =
+        ArgumentCaptor.forClass(AccountServiceInventory.class);
+    verify(accountServiceInventoryRepository, times(2)).save(accountService.capture());
+    Map<String, AccountServiceInventory> inventories =
+        accountService.getAllValues().stream()
+            .collect(Collectors.toMap(i -> i.getOrgId(), Function.identity()));
+    assertTrue(inventories.containsKey(orgId1));
+    assertTrue(inventories.containsKey(orgId2));
+
+    when(hostBucketRepository.tallyHostBuckets(orgId1, HBI_INSTANCE_TYPE))
+        .thenReturn(getTalliesFromAccountService(inventories.get(orgId1)));
+    when(hostBucketRepository.tallyHostBuckets(orgId2, HBI_INSTANCE_TYPE))
+        .thenReturn(getTalliesFromAccountService(inventories.get(orgId2)));
+
+    AccountUsageCalculation a1Calc = collector.tally(orgId1);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, account1, orgId1, "RHEL", 12, 8, 2);
 
-    OrgHostsData orgHostsData2 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
-    AccountUsageCalculation a2Calc = collector.tally(RHEL_PRODUCTS, orgHostsData2);
+    AccountUsageCalculation a2Calc = collector.tally(orgId2);
     assertEquals(1, a2Calc.getProducts().size());
     checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 6, 2, 1);
   }
@@ -252,8 +298,10 @@ class InventoryAccountUsageCollectorTest {
     mockReportedHypervisors(ORG_ID, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host1, host2));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation a1Calc = collector.tally(ORG_ID);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", 16, 16, 2);
     checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", ServiceLevel._ANY, 16, 16, 2);
@@ -290,8 +338,10 @@ class InventoryAccountUsageCollectorTest {
     mockReportedHypervisors(ORG_ID, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host1, host2));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation a1Calc = collector.tally(ORG_ID);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, ACCOUNT, ORG_ID, "RHEL", 16, 16, 2);
     checkTotalsCalculation(
@@ -354,13 +404,28 @@ class InventoryAccountUsageCollectorTest {
     when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
     when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3));
 
-    OrgHostsData orgHostsData1 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
-    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData1);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
+
+    ArgumentCaptor<AccountServiceInventory> accountService =
+        ArgumentCaptor.forClass(AccountServiceInventory.class);
+    verify(accountServiceInventoryRepository, times(2)).save(accountService.capture());
+    Map<String, AccountServiceInventory> inventories =
+        accountService.getAllValues().stream()
+            .collect(Collectors.toMap(i -> i.getOrgId(), Function.identity()));
+    assertTrue(inventories.containsKey(orgId1));
+    assertTrue(inventories.containsKey(orgId2));
+
+    when(hostBucketRepository.tallyHostBuckets(orgId1, HBI_INSTANCE_TYPE))
+        .thenReturn(getTalliesFromAccountService(inventories.get(orgId1)));
+    when(hostBucketRepository.tallyHostBuckets(orgId2, HBI_INSTANCE_TYPE))
+        .thenReturn(getTalliesFromAccountService(inventories.get(orgId2)));
+
+    AccountUsageCalculation a1Calc = collector.tally(orgId1);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
 
-    OrgHostsData orgHostsData2 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
-    AccountUsageCalculation a2Calc = collector.tally(RHEL_PRODUCTS, orgHostsData2);
+    AccountUsageCalculation a2Calc = collector.tally(orgId2);
     assertEquals(1, a2Calc.getProducts().size());
     checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 12, 6, 1);
   }
@@ -380,34 +445,12 @@ class InventoryAccountUsageCollectorTest {
 
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(h1, h2));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation accountCalc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation accountCalc = collector.tally(ORG_ID);
     assertEquals(1, accountCalc.getProducts().size());
     checkTotalsCalculation(accountCalc, ACCOUNT, ORG_ID, TEST_PRODUCT, 8, 2, 1);
-  }
-
-  @Test
-  void throwsISEOnAttemptToCalculateFactsBelongingToADifferentAccountForSameOrgId() {
-    InventoryHostFacts h1 =
-        createRhsmHost("Account1", ORG_ID, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
-    h1.setSystemProfileCoresPerSocket(1);
-    h1.setSystemProfileSockets(2);
-
-    InventoryHostFacts h2 =
-        createRhsmHost("Account2", ORG_ID, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
-
-    mockReportedHypervisors(ORG_ID, new HashMap<>());
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(h1, h2));
-
-    var orgHostData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    Throwable e =
-        assertThrows(
-            IllegalStateException.class, () -> collector.tally(RHEL_PRODUCTS, orgHostData));
-
-    String expectedMessage =
-        String.format(
-            "Attempt to set a different account for an org: %s:%s", "Account1", "Account2");
-    assertEquals(expectedMessage, e.getMessage());
   }
 
   @Test
@@ -446,14 +489,29 @@ class InventoryAccountUsageCollectorTest {
     when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
     when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3, host4));
 
-    OrgHostsData orgHostsData1 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
-    AccountUsageCalculation a1Calc = collector.tally(RHEL_PRODUCTS, orgHostsData1);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId1);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
+
+    ArgumentCaptor<AccountServiceInventory> accountService =
+        ArgumentCaptor.forClass(AccountServiceInventory.class);
+    verify(accountServiceInventoryRepository, times(2)).save(accountService.capture());
+    Map<String, AccountServiceInventory> inventories =
+        accountService.getAllValues().stream()
+            .collect(Collectors.toMap(i -> i.getOrgId(), Function.identity()));
+    assertTrue(inventories.containsKey(orgId1));
+    assertTrue(inventories.containsKey(orgId2));
+
+    when(hostBucketRepository.tallyHostBuckets(orgId1, HBI_INSTANCE_TYPE))
+        .thenReturn(getTalliesFromAccountService(inventories.get(orgId1)));
+    when(hostBucketRepository.tallyHostBuckets(orgId2, HBI_INSTANCE_TYPE))
+        .thenReturn(getTalliesFromAccountService(inventories.get(orgId2)));
+
+    AccountUsageCalculation a1Calc = collector.tally(orgId1);
     assertEquals(1, a1Calc.getProducts().size());
     checkTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
     checkPhysicalTotalsCalculation(a1Calc, account1, orgId1, TEST_PRODUCT, 12, 8, 2);
 
-    OrgHostsData orgHostsData2 = collector.collect(RHEL_PRODUCTS, ACCOUNT, orgId2);
-    AccountUsageCalculation a2Calc = collector.tally(RHEL_PRODUCTS, orgHostsData2);
+    AccountUsageCalculation a2Calc = collector.tally(orgId2);
     assertEquals(1, a2Calc.getProducts().size());
     checkTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 10, 4, 2);
     checkPhysicalTotalsCalculation(a2Calc, account2, orgId2, TEST_PRODUCT, 10, 4, 2);
@@ -484,8 +542,10 @@ class InventoryAccountUsageCollectorTest {
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
         .thenReturn(Stream.of(hypervisor, guest1, guest2));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation calc = collector.tally(ORG_ID);
     // odd sockets are rounded up for hypervisor.
     // hypervisor gets counted twice - once for itself, once for the guests
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 24, 8, 2);
@@ -518,8 +578,10 @@ class InventoryAccountUsageCollectorTest {
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
         .thenReturn(Stream.of(hypervisor, guest1, guest2));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation calc = collector.tally(ORG_ID);
     // odd sockets are rounded up for hypervisor.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
     checkHypervisorTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
@@ -604,8 +666,10 @@ class InventoryAccountUsageCollectorTest {
     mockReportedHypervisors(ORG_ID, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host));
 
-    OrgHostsData orgHostsData = collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
-    AccountUsageCalculation calc = collector.tally(RHEL_PRODUCTS, orgHostsData);
+    collector.collect(RHEL_PRODUCTS, ACCOUNT, ORG_ID);
+    mockBucketRepositoryFromAccountService();
+
+    AccountUsageCalculation calc = collector.tally(ORG_ID);
     // odd sockets are rounded up.
     checkTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
     checkPhysicalTotalsCalculation(calc, ACCOUNT, ORG_ID, TEST_PRODUCT, 12, 4, 1);
@@ -832,5 +896,62 @@ class InventoryAccountUsageCollectorTest {
       streamBuilder.accept(new Object[] {entry.getKey(), entry.getValue()});
     }
     when(inventoryRepo.getReportedHypervisors(orgIds)).thenReturn(streamBuilder.build());
+  }
+
+  // Set up the HostBucketRepository with data that is created from the saved Host's
+  // Buckets to simulate buckets that exist in the DB.
+  private void mockBucketRepositoryFromAccountService() {
+    ArgumentCaptor<AccountServiceInventory> accountService =
+        ArgumentCaptor.forClass(AccountServiceInventory.class);
+    verify(accountServiceInventoryRepository).save(accountService.capture());
+    assertNotNull(accountService.getValue());
+    when(hostBucketRepository.tallyHostBuckets(ORG_ID, HBI_INSTANCE_TYPE))
+        .thenReturn(getTalliesFromAccountService(accountService.getValue()));
+  }
+
+  private Stream<AccountBucketTally> getTalliesFromAccountService(
+      AccountServiceInventory inventory) {
+    // Simulate what the tally query will return.
+    Collection<Host> hosts = inventory.getServiceInstances().values();
+
+    Map<UsageCalculation.Key, Map<HardwareMeasurementType, AccountBucketTally>> tallyResults =
+        new HashMap<>();
+
+    for (Host host : hosts) {
+      for (HostTallyBucket bucket : host.getBuckets()) {
+        HostBucketKey bucketKey = bucket.getKey();
+        UsageCalculation.Key usageKey =
+            new UsageCalculation.Key(
+                bucketKey.getProductId(),
+                bucketKey.getSla(),
+                bucketKey.getUsage(),
+                bucketKey.getBillingProvider(),
+                bucketKey.getBillingAccountId());
+        Map<HardwareMeasurementType, AccountBucketTally> bucketTallyMap =
+            tallyResults.computeIfAbsent(usageKey, k -> new EnumMap(HardwareMeasurementType.class));
+
+        TestAccountBucketTally tally =
+            (TestAccountBucketTally)
+                bucketTallyMap.computeIfAbsent(
+                    bucket.getMeasurementType(),
+                    k ->
+                        new TestAccountBucketTally(
+                            bucketKey.getProductId(),
+                            host.getAccountNumber(),
+                            bucket.getMeasurementType(),
+                            bucketKey.getSla(),
+                            bucketKey.getUsage(),
+                            bucketKey.getBillingProvider(),
+                            bucketKey.getBillingAccountId(),
+                            0.0,
+                            0.0,
+                            0.0));
+        tally.setCores(tally.getCores() + bucket.getCores());
+        tally.setSockets(tally.getSockets() + bucket.getSockets());
+        tally.setInstances(tally.getInstances() + 1.0);
+      }
+    }
+
+    return tallyResults.values().stream().map(m -> m.values()).flatMap(Collection::stream);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -70,6 +70,7 @@ class TallySnapshotControllerTest {
 
     when(inventoryCollector.collect(any(), any(), any())).thenReturn(new OrgHostsData(ORG_ID));
     when(inventoryCollector.tally(any(), any())).thenReturn(accountCalc);
+    when(inventoryCollector.tally(any())).thenReturn(accountCalc);
   }
 
   @AfterEach
@@ -118,5 +119,21 @@ class TallySnapshotControllerTest {
     when(accountRepo.findAccountNumberByOrgId(ORG_ID)).thenReturn(ACCOUNT);
     controller.produceSnapshotsForAccount(ACCOUNT);
     verify(cloudigradeCollector).enrichUsageWithCloudigradeData(any());
+  }
+
+  @Test
+  void dbTallyWhenLegacyTallyIsDisabled() {
+    props.setLegacyNightlyTallyEnabled(false);
+    controller.produceSnapshotsForOrg(ORG_ID);
+    verify(inventoryCollector).tally(ORG_ID);
+  }
+
+  @Test
+  void legacyTallyWhenLegacyTallyIsEnabled() {
+    props.setLegacyNightlyTallyEnabled(true);
+    when(accountRepo.findAccountNumberByOrgId(ORG_ID)).thenReturn(ACCOUNT);
+
+    controller.produceSnapshotsForOrg(ORG_ID);
+    verify(inventoryCollector).tally(any(), any());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/TestAccountBucketTally.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TestAccountBucketTally.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.candlepin.subscriptions.db.model.AccountBucketTally;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+
+/**
+ * Since we can't instantiate the AccountBucketTally projection interface, we implement one for
+ * testing.
+ */
+@Data
+@AllArgsConstructor
+public class TestAccountBucketTally implements AccountBucketTally {
+  private String productId;
+  private String accountNumber;
+  private HardwareMeasurementType measurementType;
+  private ServiceLevel sla;
+  private Usage usage;
+  private BillingProvider billingProvider;
+  private String billingAccountId;
+  private Double cores;
+  private Double sockets;
+  private Double instances;
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -24,6 +24,7 @@ import static org.candlepin.subscriptions.tally.collector.Assertions.assertHardw
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertNullExcept;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertPhysicalTotalsCalculation;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertTotalsCalculation;
+import static org.candlepin.subscriptions.tally.collector.Assertions.assertVirtualTotalsCalculation;
 import static org.candlepin.subscriptions.tally.collector.TestHelper.cloudMachineFacts;
 import static org.candlepin.subscriptions.tally.collector.TestHelper.guestFacts;
 import static org.candlepin.subscriptions.tally.collector.TestHelper.hypervisorFacts;
@@ -67,10 +68,9 @@ class DefaultProductUsageCollectorTest {
     UsageCalculation calc = new UsageCalculation(createUsageKey());
     collector.collect(calc, facts);
 
-    // A guest with a known hypervisor contributes to the overall totals,
-    // but does not contribute to the hypervisor or physical totals.
+    assertVirtualTotalsCalculation(calc, 3, 12, 1);
     assertTotalsCalculation(calc, 3, 12, 1);
-    assertNullExcept(calc, HardwareMeasurementType.TOTAL);
+    assertNullExcept(calc, HardwareMeasurementType.VIRTUAL, HardwareMeasurementType.TOTAL);
   }
 
   @Test
@@ -80,10 +80,9 @@ class DefaultProductUsageCollectorTest {
     UsageCalculation calc = new UsageCalculation(createUsageKey());
     collector.collect(calc, facts);
 
-    // A guest with an unknown hypervisor contributes to the overall totals
-    // but does not contribute to the hypervisor or physical totals.
+    assertVirtualTotalsCalculation(calc, 3, 12, 1);
     assertTotalsCalculation(calc, 3, 12, 1);
-    assertNullExcept(calc, HardwareMeasurementType.TOTAL);
+    assertNullExcept(calc, HardwareMeasurementType.VIRTUAL, HardwareMeasurementType.TOTAL);
   }
 
   @Test

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import static org.hibernate.jpa.QueryHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.QueryHints.HINT_READONLY;
+
+import java.util.stream.Stream;
+import javax.persistence.QueryHint;
+import org.candlepin.subscriptions.db.model.AccountBucketTally;
+import org.candlepin.subscriptions.db.model.HostBucketKey;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.CrudRepository;
+
+public interface HostTallyBucketRepository extends CrudRepository<HostTallyBucket, HostBucketKey> {
+
+  @Query(
+      """
+          select
+            b.key.productId as productId, h.accountNumber as accountNumber, b.measurementType as measurementType, b.key.usage as usage,
+            b.key.sla as sla, b.key.billingProvider as billingProvider, b.key.billingAccountId as billingAccountId,
+            sum(b.cores) as cores, sum(b.sockets) as sockets, count(h.id) as instances
+          from Host h inner join h.buckets b
+            where h.id = b.host.id and h.orgId=:orgId and h.instanceType=:instanceType
+          group by b.key.productId, h.accountNumber, b.measurementType, b.key.usage, b.key.sla, b.key.billingProvider, b.key.billingAccountId
+  """)
+  @QueryHints(
+      value = {
+        @QueryHint(name = HINT_FETCH_SIZE, value = "1024"),
+        @QueryHint(name = HINT_READONLY, value = "true")
+      })
+  public Stream<AccountBucketTally> tallyHostBuckets(String orgId, String instanceType);
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/AccountBucketTally.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/AccountBucketTally.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+/**
+ * Projects the tallied TallyHostBucket values for an account. These values are used when performing
+ * nightly tallies of account data.
+ */
+public interface AccountBucketTally {
+  String getProductId();
+
+  // Grab the account only if it exists (not required)
+  String getAccountNumber();
+
+  ServiceLevel getSla();
+
+  BillingProvider getBillingProvider();
+
+  HardwareMeasurementType getMeasurementType();
+
+  Usage getUsage();
+
+  String getBillingAccountId();
+
+  Double getCores();
+
+  Double getSockets();
+
+  Double getInstances();
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
@@ -155,9 +155,13 @@ public class UsageCalculation {
   }
 
   public void add(HardwareMeasurementType type, int cores, int sockets, int instances) {
-    add(type, Uom.CORES, (double) cores);
-    add(type, Uom.SOCKETS, (double) sockets);
-    add(type, Uom.INSTANCES, (double) instances);
+    add(type, (double) cores, (double) sockets, (double) instances);
+  }
+
+  public void add(HardwareMeasurementType type, Double cores, Double sockets, Double instances) {
+    add(type, Uom.CORES, cores);
+    add(type, Uom.SOCKETS, sockets);
+    add(type, Uom.INSTANCES, instances);
   }
 
   public void addPhysical(int cores, int sockets, int instances) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/tally/UsageCalculation.java
@@ -169,6 +169,10 @@ public class UsageCalculation {
   }
 
   public void addUnmappedGuest(int cores, int sockets, int instances) {
+    addVirtual(cores, sockets, instances);
+  }
+
+  public void addVirtual(int cores, int sockets, int instances) {
     add(HardwareMeasurementType.VIRTUAL, cores, sockets, instances);
   }
 

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -157,6 +157,8 @@ parameters:
     value: '' # don't restrict to a specific machine pool by default
   - name: JOB_MACHINE_POOL
     value: ''
+  - name: LEGACY_NIGHTLY_TALLY_ENABLED
+    value: 'false'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -387,6 +389,8 @@ objects:
               value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
             - name: TALLY_MAX_HBI_ACCOUNT_SIZE
               value: ${TALLY_MAX_HBI_ACCOUNT_SIZE}
+            - name: LEGACY_NIGHTLY_TALLY_ENABLED
+              value: ${LEGACY_NIGHTLY_TALLY_ENABLED}
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
## Detail
Perform the nightly tally for an org by querying the DB instead
of holding all hosts and their facts in memory to perform the
calculations.

Since everything we are tallying for an org has already been persisted
as 'buckets', we can perform our calculations via the query using
the bucket data. The query is using the cores and sockets on the bucket itself
because these fields are normailzed before being stored, unlike
the instance measurements.

An environment variable was added to allow enabling the old
legacy tally functionality should we identify any issues and would like
to disable the new tally logic.

This new tally logic should address the issue outlined in bug [SWATCH-49 Virtual satellites are not considered in tally](https://issues.redhat.com/browse/SWATCH-49) and will likely cause some discrepancy in IQE tests. Any virtual non-RHEL instance will now be properly tallied as VIRTUAL in both the DB based tally AND the legacy tally.

## References:
https://issues.redhat.com/browse/SWATCH-687

## How To Test
Use the steps below as a guide to testing, but please try and find ways to break this outside of what I describe. Using the insert-mock-hosts script is a good way to generate data for testing against a large number of hosts per org, BUT, it isn't the greatest at creating the various combos of data that we need to pull in from HBI. I'd suggest finding an org in stage and pulling a smallish subset of data from the inventory DB to test. Ideally the data should have some RHEL and non-RHEL hosts to tally.

**NOTES:**
* Be sure to replace `YOUR_TEST_ORG_ID`,  in the commands below, with the org_id that will have data in the inventory DB.
* Load some host records into the inventory DB for an org. This inventory data will be what we are basing our tally tests off of.

### Scenario 1: Existing Tally Data and re-tally occurs via DB Tally

Start with a fresh swatch DB, deploy the **main** branch.
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions  &&  DEV_MODE=true ./gradlew clean :bootRun
```

Run a nightly tally on the test org.
```
http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrg(java.lang.String)'   arguments:='["YOUR_TEST_ORG_ID"]'
```

Once complete, capture the key parts of the tally as follows.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select s.product_id, m.measurement_type, m.uom, s.usage, s.sla, s.billing_provider, s.billing_account_id, s.granularity, m.value from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.org_id = 'YOUR_TEST_ORG_ID' order by s.product_id, s.granularity, m.measurement_type, m.uom, s.usage, s.sla, s.billing_provider, s.billing_account_id;" > main_tally

```

Deploy the **mstead/nightly-tally-via-db** branch (legacy tally NOT activated) and run a nightly tally for your test org.
```
DEV_MODE=true ./gradlew clean :bootRun
```
Run a nightly tally on the test org.
```
http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrg(java.lang.String)'   arguments:='["YOUR_TEST_ORG_ID"]'
```

Once complete, note in the logs that the tally was done via DB.
```
[INFO ] [org.candlepin.subscriptions.tally.InventoryAccountUsageCollector] - Running tally via DB for orgId=YOUR_TEST_ORG_ID
```

Capture the result of the tally as follows.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select s.product_id, m.measurement_type, m.uom, s.usage, s.sla, s.billing_provider, s.billing_account_id, s.granularity, m.value from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.org_id = 'YOUR_TEST_ORG_ID' order by s.product_id, s.granularity, m.measurement_type, m.uom, s.usage, s.sla, s.billing_provider, s.billing_account_id;" > db_tally_on_existing_tally_data
```

Diff the SQL files you captured above. Any discrepancies you see should only be additional tallies for VIRTUAL non-rhel systems. This is because tallying by DB fixes https://issues.redhat.com/browse/SWATCH-49.

**NOTE**: The snip below shows net new tally records. The TOTAL value does not change for the product as we have always correctly updated the TOTALS correctly for VIRTUAL non RHEL.
```diff
$ diff main_tally db_tally_on_existing_tally_data
>  Satellite        | VIRTUAL          | CORES     |       |         | _ANY             | _ANY               | DAILY       |     4
>  Satellite        | VIRTUAL          | CORES     |       | _ANY    | _ANY             | _ANY               | DAILY       |     4
>  Satellite        | VIRTUAL          | CORES     | _ANY  |         | _ANY             | _ANY               | DAILY       |     4
>  Satellite        | VIRTUAL          | CORES     | _ANY  | _ANY    | _ANY             | _ANY               | DAILY       |     4
>  Satellite        | VIRTUAL          | INSTANCES |       |         | _ANY             | _ANY               | DAILY       |     1
>  Satellite        | VIRTUAL          | INSTANCES |       | _ANY    | _ANY             | _ANY               | DAILY       |     1
>  Satellite        | VIRTUAL          | INSTANCES | _ANY  |         | _ANY             | _ANY               | DAILY       |     1
>  Satellite        | VIRTUAL          | INSTANCES | _ANY  | _ANY    | _ANY             | _ANY               | DAILY       |     1
>  Satellite        | VIRTUAL          | SOCKETS   |       |         | _ANY             | _ANY               | DAILY       |     8
>  Satellite        | VIRTUAL          | SOCKETS   |       | _ANY    | _ANY             | _ANY               | DAILY       |     8
>  Satellite        | VIRTUAL          | SOCKETS   | _ANY  |         | _ANY             | _ANY               | DAILY       |     8
>  Satellite        | VIRTUAL          | SOCKETS   | _ANY  | _ANY    | _ANY             | _ANY               | DAILY       |     8
--- snip ---

```

### Scenario 2: Verify that tally results of initial tallies from both legacy and DB tallies are the same.
In this test, start from fresh and run a new tally using legacy tally and compare it to the DB tally from the last test. This PR includes a patch for fixing SWATCH-49 when legacy tally is run. This was done to ensure that both methods of tallying result in the same state.

Deploy the **mstead/nightly-tally-via-db** branch (legacy tally activated) and run a nightly tally for your test org.
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions  && LEGACY_NIGHTLY_TALLY_ENABLED=true DEV_MODE=true ./gradlew clean :bootRun
```
Run a nightly tally on the test org.
```
http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrg(java.lang.String)'   arguments:='["YOUR_TEST_ORG_ID"]'
```

Once complete, note in the logs that the legacy tally was run.
```
[INFO ] [org.candlepin.subscriptions.tally.InventoryAccountUsageCollector] - Running legacy nightly tally for orgId=YOUR_TEST_ORG_ID
```

Capture the result of the tally as follows.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select s.product_id, m.measurement_type, m.uom, s.usage, s.sla, s.billing_provider, s.billing_account_id, s.granularity, m.value from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and s.org_id = 'YOUR_TEST_ORG_ID' order by s.product_id, s.granularity, m.measurement_type, m.uom, s.usage, s.sla, s.billing_provider, s.billing_account_id;" > legacy_tally_fresh_db
```

Diff the SQL files. There should be no differences.
```
$ diff db_tally_on_existing_tally_data legacy_tally_fresh_db
$
```



