### PR TITLE
SWATCH-686: Minimize nightly memory usage by streaming system updates

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -82,7 +82,8 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
         }
 
     _generate_insert('hosts', **host_fields)
-    _generate_measurements(host_id, uom, 1.0)
+    if not is_hbi:
+        _generate_measurements(host_id, uom, 1.0)
     if not is_hbi and not skip_buckets:
         _generate_buckets(host_id, product, sla, usage, as_hypervisor=is_hypervisor, cores=cores, sockets=sockets, measurement_type=measurement_type,
         billing_provider=billing_provider, billing_account_id=billing_account_id)
@@ -296,13 +297,14 @@ for i in range(args.num_accounts):
                                    billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
                                    uom=args.uom)
         # create a physical entry for the host as well.
-        generate_host(account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
-                      product=args.product,
-                      sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True,
-                      is_hbi=args.is_hbi,
-                      is_marketplace=args.is_marketplace,
-                      host_type=args.host_type,
-                     billing_provider=args.billing_provider, billing_account_id=args.billing_account_id, uom=args.uom)
+        if not args.is_hbi:
+            generate_host(account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
+                          product=args.product,
+                          sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True,
+                          is_hbi=args.is_hbi,
+                          is_marketplace=args.is_marketplace,
+                          host_type=args.host_type,
+                          billing_provider=args.billing_provider, billing_account_id=args.billing_account_id, uom=args.uom)
 
     create_unmapped = args.unmapped_guests
     for i in range(args.num_guests):

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -134,4 +134,12 @@ public class ApplicationProperties {
 
   /** If enabled, nightly tally will calculated via host objects */
   private boolean legacyNightlyTallyEnabled = false;
+
+  /**
+   * Interval for system update flush when for reconciliation of HBI data w/ swatch system data.
+   *
+   * <p>Lower values will cause more frequent flushing, and keep memory usage low, while higher
+   * values flush less often, but consume more memory.
+   */
+  private Long hbiReconciliationFlushInterval;
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -91,6 +91,7 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
               + "and h.org_id IN (:orgIds)")
   Stream<Object[]> getReportedHypervisors(@Param("orgIds") Collection<String> orgIds);
 
+  /* NOTE: in below query, ordering is crucial for correct streaming reconciliation of HBI data */
   @Query(
       nativeQuery = true,
       value =
@@ -102,6 +103,7 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
            and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
            and (h.system_profile_facts->>'host_type' IS NULL OR h.system_profile_facts->>'host_type' <> 'edge')
            and NOW() < stale_timestamp + make_interval(days => :culledOffsetDays)
+        -- NOTE: ordering is crucial for correct streaming reconciliation of HBI data
         order by subscription_manager_id
       """)
   @QueryHints(

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -20,12 +20,17 @@
  */
 package org.candlepin.subscriptions.inventory.db;
 
+import static org.hibernate.jpa.QueryHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.QueryHints.HINT_READONLY;
+
 import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
+import javax.persistence.QueryHint;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHost;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
@@ -34,9 +39,17 @@ import org.springframework.data.repository.query.Param;
 public interface InventoryRepository extends Repository<InventoryHost, UUID> {
 
   @Query(nativeQuery = true)
-  Stream<InventoryHostFacts> getFacts(
-      @Param("orgIds") Collection<String> orgIds,
-      @Param("culledOffsetDays") Integer culledOffsetDays);
+  @QueryHints(
+      value = {
+        @QueryHint(name = HINT_FETCH_SIZE, value = "1024"),
+        @QueryHint(name = HINT_READONLY, value = "true")
+      })
+  Stream<InventoryHostFacts> streamFacts(
+      @Param("orgId") String orgId, @Param("culledOffsetDays") Integer culledOffsetDays);
+
+  default Stream<InventoryHostFacts> getFacts(Collection<String> orgIds, Integer culledOffsetDays) {
+    return orgIds.stream().flatMap(orgId -> streamFacts(orgId, culledOffsetDays));
+  }
 
   @Query(
       nativeQuery = true,
@@ -77,4 +90,25 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
               + "where h.facts->'satellite'->'virtual_host_uuid' is not null "
               + "and h.org_id IN (:orgIds)")
   Stream<Object[]> getReportedHypervisors(@Param("orgIds") Collection<String> orgIds);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          """
+        select
+        h.canonical_facts->>'subscription_manager_id' as subscription_manager_id
+        from hosts h
+        where h.org_id=:orgId
+           and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
+           and (h.system_profile_facts->>'host_type' IS NULL OR h.system_profile_facts->>'host_type' <> 'edge')
+           and NOW() < stale_timestamp + make_interval(days => :culledOffsetDays)
+        order by subscription_manager_id
+      """)
+  @QueryHints(
+      value = {
+        @QueryHint(name = HINT_FETCH_SIZE, value = "1024"),
+        @QueryHint(name = HINT_READONLY, value = "true")
+      })
+  Stream<String> streamActiveSubscriptionManagerIds(
+      @Param("orgId") String orgId, @Param("culledOffsetDays") Integer culledOffsetDays);
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -87,6 +87,8 @@ import lombok.Setter;
  * check insights-host-inventory/blob/master/swagger/system_profile.spec.yaml for queries on HBI Database.
  * Second step: Add new field as a ColumnResult
  * Third step : update inventory host facts constructor with new column
+ *
+ * NOTE: in below query, ordering is crucial for correct streaming reconciliation of HBI data
  */
 @NamedNativeQuery(
     name = "InventoryHost.streamFacts",
@@ -146,6 +148,7 @@ import lombok.Setter;
            and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
            and (h.system_profile_facts->>'host_type' IS NULL OR h.system_profile_facts->>'host_type' <> 'edge')
            and NOW() < stale_timestamp + make_interval(days => :culledOffsetDays)
+        -- NOTE: ordering is crucial for correct streaming reconciliation of HBI data
         order by hardware_subman_id, any_hypervisor_uuid, inventory_id
     """,
     resultSetMapping = "inventoryHostFactsMapping")

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -74,7 +74,8 @@ import lombok.Setter;
             @ColumnResult(name = "subscription_manager_id"),
             @ColumnResult(name = "insights_id"),
             @ColumnResult(name = "cloud_provider"),
-            @ColumnResult(name = "stale_timestamp", type = OffsetDateTime.class)
+            @ColumnResult(name = "stale_timestamp", type = OffsetDateTime.class),
+            @ColumnResult(name = "hardware_subman_id")
           })
     })
 /* This query is complex so that we can fetch all the product IDs as a comma-delimited string all in one
@@ -88,54 +89,65 @@ import lombok.Setter;
  * Third step : update inventory host facts constructor with new column
  */
 @NamedNativeQuery(
-    name = "InventoryHost.getFacts",
+    name = "InventoryHost.streamFacts",
     query =
-        "select h.id as inventory_id, h.org_id, h.modified_on, h.account, h.display_name, "
-            + "h.facts->'rhsm'->>'IS_VIRTUAL' as is_virtual, "
-            + "h.facts->'rhsm'->>'VM_HOST_UUID' as hypervisor_uuid, "
-            + "h.facts->'satellite'->>'virtual_host_uuid' as satellite_hypervisor_uuid, "
-            + "h.facts->'satellite'->>'system_purpose_role' as satellite_role, "
-            + "h.facts->'satellite'->>'system_purpose_sla' as satellite_sla, "
-            + "h.facts->'satellite'->>'system_purpose_usage' as satellite_usage, "
-            + "h.facts->'rhsm'->>'GUEST_ID' as guest_id, "
-            + "h.facts->'rhsm'->>'SYNC_TIMESTAMP' as sync_timestamp, "
-            + "h.facts->'rhsm'->>'SYSPURPOSE_ROLE' as syspurpose_role, "
-            + "h.facts->'rhsm'->>'SYSPURPOSE_SLA' as syspurpose_sla, "
-            + "h.facts->'rhsm'->>'SYSPURPOSE_USAGE' as syspurpose_usage, "
-            + "h.facts->'rhsm'->>'SYSPURPOSE_UNITS' as syspurpose_units, "
-            + "h.facts->'rhsm'->>'BILLING_MODEL' as  billing_model, "
-            + "h.facts->'qpc'->>'IS_RHEL' as is_rhel, "
-            + "h.system_profile_facts->>'infrastructure_type' as system_profile_infrastructure_type, "
-            + "h.system_profile_facts->>'cores_per_socket' as system_profile_cores_per_socket, "
-            + "h.system_profile_facts->>'number_of_sockets' as system_profile_sockets, "
-            + "h.system_profile_facts->>'cloud_provider' as cloud_provider, "
-            + "h.system_profile_facts->>'arch' as system_profile_arch, "
-            + "h.system_profile_facts->>'is_marketplace' as is_marketplace, "
-            + "h.canonical_facts->>'subscription_manager_id' as subscription_manager_id, "
-            + "h.canonical_facts->>'insights_id' as insights_id, "
-            + "rhsm_products.products, "
-            + "qpc_prods.qpc_products, "
-            + "qpc_certs.qpc_product_ids, "
-            + "system_profile.system_profile_product_ids, "
-            + "h.stale_timestamp "
-            + "from hosts h "
-            + "cross join lateral ( "
-            + "    select string_agg(items, ',') as products "
-            + "    from jsonb_array_elements_text(h.facts->'rhsm'->'RH_PROD') as items) rhsm_products "
-            + "cross join lateral ( "
-            + "    select string_agg(items, ',') as qpc_products "
-            + "    from jsonb_array_elements_text(h.facts->'qpc'->'rh_products_installed') as items) qpc_prods "
-            + "cross join lateral ( "
-            + "    select string_agg(items, ',') as qpc_product_ids "
-            + "    from jsonb_array_elements_text(h.facts->'qpc'->'rh_product_certs') as items) qpc_certs "
-            + "cross join lateral ( "
-            + "    select string_agg(items->>'id', ',') as system_profile_product_ids "
-            + "    from jsonb_array_elements(h.system_profile_facts->'installed_products') as items) system_profile "
-            + "where h.org_id IN (:orgIds)"
-            + "   and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')"
-            + "   and (h.system_profile_facts->>'host_type' IS NULL OR h.system_profile_facts->>'host_type' <> 'edge')"
-            + "   and (stale_timestamp is null "
-            + "   or  (NOW() < stale_timestamp + make_interval(days => :culledOffsetDays)))",
+        """
+        select
+        h.id as inventory_id, h.org_id, h.modified_on, h.account, h.display_name,
+        h.facts->'rhsm'->>'IS_VIRTUAL' as is_virtual,
+        h.facts->'rhsm'->>'VM_HOST_UUID' as hypervisor_uuid,
+        h.facts->'satellite'->>'virtual_host_uuid' as satellite_hypervisor_uuid,
+        h.facts->'satellite'->>'system_purpose_role' as satellite_role,
+        h.facts->'satellite'->>'system_purpose_sla' as satellite_sla,
+        h.facts->'satellite'->>'system_purpose_usage' as satellite_usage,
+        h.facts->'rhsm'->>'GUEST_ID' as guest_id,
+        h.facts->'rhsm'->>'SYNC_TIMESTAMP' as sync_timestamp,
+        h.facts->'rhsm'->>'SYSPURPOSE_ROLE' as syspurpose_role,
+        h.facts->'rhsm'->>'SYSPURPOSE_SLA' as syspurpose_sla,
+        h.facts->'rhsm'->>'SYSPURPOSE_USAGE' as syspurpose_usage,
+        h.facts->'rhsm'->>'SYSPURPOSE_UNITS' as syspurpose_units,
+        h.facts->'rhsm'->>'BILLING_MODEL' as  billing_model,
+        h.facts->'qpc'->>'IS_RHEL' as is_rhel,
+        h.system_profile_facts->>'infrastructure_type' as system_profile_infrastructure_type,
+        h.system_profile_facts->>'cores_per_socket' as system_profile_cores_per_socket,
+        h.system_profile_facts->>'number_of_sockets' as system_profile_sockets,
+        h.system_profile_facts->>'cloud_provider' as cloud_provider,
+        h.system_profile_facts->>'arch' as system_profile_arch,
+        h.system_profile_facts->>'is_marketplace' as is_marketplace,
+        h.canonical_facts->>'subscription_manager_id' as subscription_manager_id,
+        h.canonical_facts->>'insights_id' as insights_id,
+        rhsm_products.products,
+        qpc_prods.qpc_products,
+        qpc_certs.qpc_product_ids,
+        system_profile.system_profile_product_ids,
+        h.stale_timestamp,
+        coalesce(
+            h.facts->'rhsm'->>'VM_HOST_UUID',
+            h.facts->'satellite'->>'virtual_host_uuid',
+            h.canonical_facts->>'subscription_manager_id') as hardware_subman_id,
+        coalesce(
+            h.facts->'rhsm'->>'VM_HOST_UUID',
+            h.facts->'satellite'->>'virtual_host_uuid'
+        ) as any_hypervisor_uuid
+        from hosts h
+        cross join lateral (
+            select string_agg(items, ',') as products
+            from jsonb_array_elements_text(h.facts->'rhsm'->'RH_PROD') as items) rhsm_products
+        cross join lateral (
+            select string_agg(items, ',') as qpc_products
+            from jsonb_array_elements_text(h.facts->'qpc'->'rh_products_installed') as items) qpc_prods
+        cross join lateral (
+            select string_agg(items, ',') as qpc_product_ids
+            from jsonb_array_elements_text(h.facts->'qpc'->'rh_product_certs') as items) qpc_certs
+        cross join lateral (
+            select string_agg(items->>'id', ',') as system_profile_product_ids
+            from jsonb_array_elements(h.system_profile_facts->'installed_products') as items) system_profile
+        where h.org_id=:orgId
+           and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
+           and (h.system_profile_facts->>'host_type' IS NULL OR h.system_profile_facts->>'host_type' <> 'edge')
+           and NOW() < stale_timestamp + make_interval(days => :culledOffsetDays)
+        order by hardware_subman_id, any_hypervisor_uuid, inventory_id
+    """,
     resultSetMapping = "inventoryHostFactsMapping")
 @Getter
 @Setter

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -63,6 +63,7 @@ public class InventoryHostFacts {
   private String billingModel;
   private String cloudProvider;
   private OffsetDateTime staleTimestamp;
+  private String hardwareSubmanId;
 
   public InventoryHostFacts() {
     // Used for testing
@@ -104,7 +105,8 @@ public class InventoryHostFacts {
       String subscriptionManagerId,
       String insightsId,
       String cloudProvider,
-      OffsetDateTime staleTimestamp) {
+      OffsetDateTime staleTimestamp,
+      String hardwareSubmanId) {
     this.inventoryId = inventoryId;
     this.modifiedOn = modifiedOn;
     this.account = account;
@@ -136,6 +138,7 @@ public class InventoryHostFacts {
     this.billingModel = billingModel;
     this.cloudProvider = cloudProvider;
     this.staleTimestamp = staleTimestamp;
+    this.hardwareSubmanId = hardwareSubmanId;
   }
 
   public void setProducts(String products) {

--- a/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.inventory.db.InventoryRepository;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/** Coordinates processing of HBI and swatch data in a streaming, collated fashion. */
+@Slf4j
+@Component
+public class InventorySwatchDataCollator {
+  public interface Processor {
+    void accept(
+        InventoryHostFacts hbiSystem,
+        Host swatchSystem,
+        OrgHostsData orgHostsData,
+        int iterationCount);
+  }
+
+  private final InventoryRepository inventoryRepository;
+  private final HostRepository hostRepository;
+
+  @Autowired
+  public InventorySwatchDataCollator(
+      InventoryRepository inventoryRepository, HostRepository hostRepository) {
+    this.inventoryRepository = inventoryRepository;
+    this.hostRepository = hostRepository;
+  }
+
+  /**
+   * Fetches HBI and swatch system data in a consistent order, collates the records, and invokes a
+   * handler on them.
+   *
+   * <p>Two primary streams - HBI system records and swatch system records are collated.
+   *
+   * <p>A third supplemental stream is used to track the presence of hypervisor records, with this
+   * stream being ordered in a compatible way with the HBI system record stream and swatch system
+   * record stream. This allows evaluation of hypervisor presence to happen in a compatible
+   * streaming technique as well.
+   *
+   * <p>The order of the streams is hardware_subman_uuid first, then hypervisor_uuid, then
+   * inventory_id. The hardware_subman_uuid sort causes all the systems running on a hypervisor to
+   * be processed in a group, hypervisor_uuid forces the hypervisor itself to be processed last in
+   * the group, and inventory_id as a final sort term is used to ensure a consistent order.
+   *
+   * <p>Each iteration operates against a single inventory ID, calling the processor with:
+   * <li>the HBI record if present
+   * <li>the Swatch record if present
+   * <li>information collected for the underlying hardware (in OrgHostsData). OrgHostsData is
+   *     persistent across iterations for the same hypervisor.
+   *
+   * @param orgId orgId to operate on
+   * @param culledOffsetDays number of days before a system is considered culled by HBI
+   * @param processor delegate that implements the Processor functional interface, to be called for
+   *     each iteration.
+   * @return the number of unique inventory IDs processed.
+   */
+  public int collateData(String orgId, int culledOffsetDays, Processor processor) {
+    Stream<InventoryHostFacts> inventorySystemStream =
+        inventoryRepository.streamFacts(orgId, culledOffsetDays);
+    Stream<String> activeSubmanIdStream =
+        inventoryRepository.streamActiveSubscriptionManagerIds(orgId, culledOffsetDays);
+    Stream<Host> swatchSystemStream = hostRepository.streamHbiHostsByOrgId(orgId);
+
+    PeekingIterator<InventoryHostFacts> inventoryDataIterator =
+        Iterators.peekingIterator(inventorySystemStream.iterator());
+    PeekingIterator<Host> swatchDataIterator =
+        Iterators.peekingIterator(swatchSystemStream.iterator());
+    PeekingIterator<String> activeSubmanIdIterator =
+        Iterators.peekingIterator(activeSubmanIdStream.iterator());
+
+    OrgHostsData orgHostsData = new OrgHostsData("placeholder"); // orgId not used
+    int iterationCount = 0;
+
+    while (inventoryDataIterator.hasNext() || swatchDataIterator.hasNext()) {
+      iterationCount++;
+      InventoryHostFacts nextHbiSystem = peekOrNull(inventoryDataIterator);
+      Host nextSwatchHost = peekOrNull(swatchDataIterator);
+
+      String activeInventoryId = minInventoryId(nextHbiSystem, nextSwatchHost);
+
+      // limit further operation to "active" records - those that should be processed in this
+      // iteration
+      InventoryHostFacts activeHbiSystem =
+          Optional.ofNullable(nextHbiSystem)
+              .filter(host -> Objects.equals(host.getInventoryId().toString(), activeInventoryId))
+              .orElse(null);
+      Host activeSwatchSystem =
+          Optional.ofNullable(nextSwatchHost)
+              .filter(host -> Objects.equals(host.getInventoryId(), activeInventoryId))
+              .orElse(null);
+
+      if (activeHbiSystem != null) {
+        // consume the hbi system from the stream, to prepare for the next iteration
+        inventoryDataIterator.next();
+        Optional<String> hypervisorUuid =
+            Stream.of(
+                    activeHbiSystem.getHypervisorUuid(),
+                    activeHbiSystem.getSatelliteHypervisorUuid())
+                .filter(Objects::nonNull)
+                .findFirst();
+        if (hypervisorUuid.isPresent() && !orgHostsData.hasHypervisorUuid(hypervisorUuid.get())) {
+          orgHostsData = trackActiveHypervisor(hypervisorUuid.get(), activeSubmanIdIterator);
+        }
+      }
+      if (activeSwatchSystem != null) {
+        // consume the swatch system from the stream to prepare for the next iteration
+        swatchDataIterator.next();
+      }
+      processor.accept(activeHbiSystem, activeSwatchSystem, orgHostsData, iterationCount);
+    }
+    return iterationCount;
+  }
+
+  private <T> T peekOrNull(PeekingIterator<T> iterator) {
+    return iterator.hasNext() ? iterator.peek() : null;
+  }
+
+  private String minInventoryId(InventoryHostFacts inventoryHost, Host swatchHost) {
+    return Stream.of(
+            Optional.ofNullable(inventoryHost)
+                .map(InventoryHostFacts::getInventoryId)
+                .map(UUID::toString)
+                .orElse(null),
+            Optional.ofNullable(swatchHost).map(Host::getInventoryId).orElse(null))
+        .filter(Objects::nonNull)
+        .min(String::compareTo)
+        .orElseThrow();
+  }
+
+  /**
+   * Return an instance of OrgHostsData that tracks the active hypervisor, iterating through the
+   * stream of activeSubmanIds.
+   *
+   * <p>If the hypervisor UUID is present in HBI data, the returned OrgHostsData will have a
+   * placeholder Host record for tracking buckets and guest counts, otherwise it will have no data.
+   *
+   * @param hypervisorUuid the hardware subman ID to start tracking
+   * @param activeSubmanIds iterator of stream of present subman IDs
+   */
+  private OrgHostsData trackActiveHypervisor(
+      String hypervisorUuid, PeekingIterator<String> activeSubmanIds) {
+    log.debug("Active hypervisorUuid={}", hypervisorUuid);
+    while (activeSubmanIds.hasNext() && activeSubmanIds.peek().compareTo(hypervisorUuid) < 0) {
+      // discard any subman IDs less than the specified hypervisor UUID
+      activeSubmanIds.next();
+    }
+    OrgHostsData orgHostsData = new OrgHostsData("placeholder"); // orgId not used
+    if (activeSubmanIds.hasNext() && Objects.equals(activeSubmanIds.peek(), hypervisorUuid)) {
+      Host placeholder = new Host();
+      placeholder.setNumOfGuests(0);
+      log.debug("Adding placeholder for hypervisorUuid={}", hypervisorUuid);
+      orgHostsData.addHostToHypervisor(hypervisorUuid, placeholder);
+      orgHostsData.addHypervisorFacts(hypervisorUuid, new NormalizedFacts());
+      orgHostsData.addHostMapping(hypervisorUuid, hypervisorUuid);
+    }
+    return orgHostsData;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -119,7 +119,7 @@ public class TallySnapshotController {
         }
         accountCalc = optAccountCalc.get();
       } else {
-        accountCalc = performTally(orgId, account);
+        accountCalc = performTally(orgId);
       }
 
       if (props.isCloudigradeEnabled()) {
@@ -241,9 +241,12 @@ public class TallySnapshotController {
     return Optional.of(usageCollector.tally(this.applicableProducts, orgHostsData));
   }
 
-  private AccountUsageCalculation performTally(String orgId, String account) {
+  private AccountUsageCalculation performTally(String orgId) {
     retryTemplate.execute(
-        context -> usageCollector.collect(this.applicableProducts, account, orgId));
+        context -> {
+          usageCollector.reconcileSystemDataWithHbi(orgId, this.applicableProducts);
+          return null;
+        });
     return usageCollector.tally(orgId);
   }
 }

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -20,6 +20,7 @@ rhsm-subscriptions:
       hikari:
         connection-timeout: ${INVENTORY_DATABASE_CONNECTION_TIMEOUT_MS:30000}
         maximum-pool-size: ${INVENTORY_DATABASE_MAX_POOL_SIZE:10}
+        auto-commit: false  # required to enable cursor-based streaming in native queries
   account-list-resource-location: ${ACCOUNT_LIST_RESOURCE_LOCATION:}
 
   cloudigrade-enabled: ${CLOUDIGRADE_ENABLED:false}
@@ -56,3 +57,4 @@ rhsm-subscriptions:
     seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
   tally-max-hbi-account-size: ${TALLY_MAX_HBI_ACCOUNT_SIZE:2147483647}  # Integer.MAX_VALUE by default
   legacy-nightly-tally-enabled: ${LEGACY_NIGHTLY_TALLY_ENABLED:false}
+  hbi-reconciliation-flush-interval: ${HBI_RECONCILIATION_FLUSH_INTERVAL:1024}

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorReconcileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorReconcileTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.in;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Set;
+import javax.persistence.EntityManager;
+import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.HostTallyBucketRepository;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostHardwareType;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.inventory.db.InventoryDatabaseOperations;
+import org.candlepin.subscriptions.inventory.db.InventoryRepository;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.candlepin.subscriptions.tally.facts.FactNormalizer;
+import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryAccountUsageCollectorReconcileTest {
+  @Mock FactNormalizer factNormalizer;
+  @Mock InventoryDatabaseOperations inventory;
+  @Mock AccountServiceInventoryRepository accountServiceInventoryRepository;
+  @Mock InventoryRepository inventoryRepository;
+  @Mock HostRepository hostRepository;
+  @Mock EntityManager entityManager;
+  @Mock HostTallyBucketRepository tallyBucketRepository;
+  @Mock ApplicationProperties props;
+  @Mock MeterRegistry meterRegistry;
+  @Mock InventorySwatchDataCollator collator;
+
+  InventoryAccountUsageCollector setupCollector() {
+    return new InventoryAccountUsageCollector(
+        factNormalizer,
+        inventory,
+        accountServiceInventoryRepository,
+        hostRepository,
+        entityManager,
+        tallyBucketRepository,
+        props,
+        meterRegistry,
+        collator);
+  }
+
+  @Test
+  void testFlushingHappensAtConfiguredInterval() {
+    ArgumentCaptor<InventorySwatchDataCollator.Processor> captor =
+        ArgumentCaptor.forClass(InventorySwatchDataCollator.Processor.class);
+
+    when(props.getHbiReconciliationFlushInterval()).thenReturn(2L);
+    when(collator.collateData(any(), anyInt(), captor.capture())).thenReturn(5);
+    when(factNormalizer.normalize(any(), any())).thenReturn(new NormalizedFacts());
+
+    var collector = setupCollector();
+    collector.reconcileSystemDataWithHbi("org123", Set.of("RHEL"));
+    // at this point, the iterations haven't actually run, since we're mocking the collator.
+    var processor = captor.getValue();
+    var mockHbiSystem = InventoryHostFactTestHelper.createHypervisor("account", "org", 1);
+    processor.accept(mockHbiSystem, null, new OrgHostsData("placeholder"), 1);
+    processor.accept(mockHbiSystem, null, new OrgHostsData("placeholder"), 2);
+    processor.accept(mockHbiSystem, null, new OrgHostsData("placeholder"), 3);
+    processor.accept(mockHbiSystem, null, new OrgHostsData("placeholder"), 4);
+    processor.accept(mockHbiSystem, null, new OrgHostsData("placeholder"), 5);
+    verify(hostRepository, times(2)).flush();
+    verify(entityManager, times(2)).clear();
+  }
+
+  @Test
+  void testCreate() {
+    when(factNormalizer.normalize(any(), any())).thenReturn(new NormalizedFacts());
+
+    var collector = setupCollector();
+    InventoryHostFacts hbiSystem =
+        InventoryHostFactTestHelper.createHypervisor("account123", "org123", 1);
+    collector.reconcileHbiSystemWithSwatchSystem(
+        hbiSystem, null, new OrgHostsData("org123"), Set.of("RHEL"));
+    verify(hostRepository).save(any());
+  }
+
+  @Test
+  void testUpdate() {
+    when(factNormalizer.normalize(any(), any())).thenReturn(new NormalizedFacts());
+
+    var collector = setupCollector();
+    InventoryHostFacts hbiSystem =
+        InventoryHostFactTestHelper.createHypervisor("account123", "org123", 1);
+    Host swatchSystem = new Host();
+    collector.reconcileHbiSystemWithSwatchSystem(
+        hbiSystem, swatchSystem, new OrgHostsData("org123"), Set.of("RHEL"));
+    verify(hostRepository).save(swatchSystem);
+  }
+
+  @Test
+  void testDelete() {
+    var collector = setupCollector();
+    Host swatchSystem = new Host();
+    collector.reconcileHbiSystemWithSwatchSystem(
+        null, swatchSystem, new OrgHostsData("org123"), Set.of("RHEL"));
+    verify(hostRepository).delete(swatchSystem);
+  }
+
+  @Test
+  void testGuestBucketsTracked() {
+    NormalizedFacts guestFacts = new NormalizedFacts();
+    guestFacts.setProducts(Set.of("RHEL"));
+    guestFacts.setHardwareType(HostHardwareType.VIRTUALIZED);
+    guestFacts.setHypervisorUnknown(false);
+    guestFacts.setHypervisorUuid("123e4567-e89b-12d3-a456-426614174000");
+    when(factNormalizer.normalize(any(), any())).thenReturn(guestFacts);
+
+    var collector = setupCollector();
+    var hbiSystem = new InventoryHostFacts();
+    Host swatchSystem = new Host();
+    OrgHostsData orgHostsData = new OrgHostsData("org123");
+    Host hypervisorRecord = new Host();
+    orgHostsData.addHostToHypervisor("123e4567-e89b-12d3-a456-426614174000", hypervisorRecord);
+    orgHostsData.addHostMapping(
+        "123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174000");
+    orgHostsData.addHypervisorFacts("123e4567-e89b-12d3-a456-426614174000", new NormalizedFacts());
+    collector.reconcileHbiSystemWithSwatchSystem(
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"));
+    HostTallyBucket expectedEmptyBucket =
+        new HostTallyBucket(
+            swatchSystem,
+            "RHEL",
+            ServiceLevel.EMPTY,
+            Usage.EMPTY,
+            BillingProvider._ANY,
+            "_ANY",
+            true,
+            0,
+            0,
+            HardwareMeasurementType.HYPERVISOR);
+    HostTallyBucket expectedAnyBucket =
+        new HostTallyBucket(
+            swatchSystem,
+            "RHEL",
+            ServiceLevel._ANY,
+            Usage._ANY,
+            BillingProvider._ANY,
+            "_ANY",
+            true,
+            0,
+            0,
+            HardwareMeasurementType.HYPERVISOR);
+    assertThat(expectedEmptyBucket, in(hypervisorRecord.getBuckets()));
+    assertThat(expectedAnyBucket, in(hypervisorRecord.getBuckets()));
+    assertTrue(swatchSystem.getBuckets().isEmpty());
+  }
+
+  @Test
+  void testHypervisorBucketsApplied() {
+    NormalizedFacts hypervisorFacts = new NormalizedFacts();
+    hypervisorFacts.setProducts(Set.of("RHEL"));
+    hypervisorFacts.setHardwareType(HostHardwareType.PHYSICAL);
+    hypervisorFacts.setSockets(4);
+    hypervisorFacts.setCores(8);
+    when(factNormalizer.normalize(any(), any())).thenReturn(hypervisorFacts);
+
+    var collector = setupCollector();
+    var hbiSystem = new InventoryHostFacts();
+    hbiSystem.setSubscriptionManagerId("123e4567-e89b-12d3-a456-426614174000");
+    Host swatchSystem = new Host();
+    OrgHostsData orgHostsData = new OrgHostsData("org123");
+    Host placeholder = new Host();
+    HostTallyBucket expectedBucket =
+        new HostTallyBucket(
+            swatchSystem,
+            "hitchhiker",
+            ServiceLevel._ANY,
+            Usage._ANY,
+            BillingProvider._ANY,
+            "_ANY",
+            true,
+            0,
+            0,
+            HardwareMeasurementType.HYPERVISOR);
+    placeholder.addBucket(expectedBucket);
+    orgHostsData.addHostToHypervisor("123e4567-e89b-12d3-a456-426614174000", placeholder);
+    orgHostsData.addHostMapping(
+        "123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174000");
+    orgHostsData.addHypervisorFacts("123e4567-e89b-12d3-a456-426614174000", new NormalizedFacts());
+    collector.reconcileHbiSystemWithSwatchSystem(
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"));
+    assertThat(expectedBucket, in(swatchSystem.getBuckets()));
+    assertEquals(4.0, expectedBucket.getSockets());
+    assertEquals(8.0, expectedBucket.getCores());
+  }
+
+  @Test
+  void testStaleHypervisorBucketsRemoved() {
+    NormalizedFacts hypervisorFacts = new NormalizedFacts();
+    hypervisorFacts.setHardwareType(HostHardwareType.PHYSICAL);
+    hypervisorFacts.setSockets(4);
+    hypervisorFacts.setCores(8);
+    when(factNormalizer.normalize(any(), any())).thenReturn(hypervisorFacts);
+
+    var collector = setupCollector();
+    var hbiSystem = new InventoryHostFacts();
+    hbiSystem.setSubscriptionManagerId("123e4567-e89b-12d3-a456-426614174000");
+    Host swatchSystem = new Host();
+    OrgHostsData orgHostsData = new OrgHostsData("org123");
+    Host placeholder = new Host();
+    HostTallyBucket staleBucket =
+        new HostTallyBucket(
+            swatchSystem,
+            "stale",
+            ServiceLevel._ANY,
+            Usage._ANY,
+            BillingProvider._ANY,
+            "_ANY",
+            true,
+            0,
+            0,
+            HardwareMeasurementType.HYPERVISOR);
+    swatchSystem.addBucket(staleBucket);
+    orgHostsData.addHostToHypervisor("123e4567-e89b-12d3-a456-426614174000", placeholder);
+    orgHostsData.addHostMapping(
+        "123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174000");
+    orgHostsData.addHypervisorFacts("123e4567-e89b-12d3-a456-426614174000", new NormalizedFacts());
+    collector.reconcileHbiSystemWithSwatchSystem(
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"));
+    assertTrue(swatchSystem.getBuckets().isEmpty());
+  }
+
+  @Test
+  void testNonHypervisorBucketsApplied() {
+    NormalizedFacts normalizedFacts = new NormalizedFacts();
+    normalizedFacts.setProducts(Set.of("RHEL"));
+    normalizedFacts.setHardwareType(HostHardwareType.PHYSICAL);
+    when(factNormalizer.normalize(any(), any())).thenReturn(normalizedFacts);
+
+    var collector = setupCollector();
+    var hbiSystem = new InventoryHostFacts();
+    Host swatchSystem = new Host();
+    OrgHostsData orgHostsData = new OrgHostsData("org123");
+    collector.reconcileHbiSystemWithSwatchSystem(
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"));
+    HostTallyBucket expectedEmptyBucket =
+        new HostTallyBucket(
+            swatchSystem,
+            "RHEL",
+            ServiceLevel.EMPTY,
+            Usage.EMPTY,
+            BillingProvider._ANY,
+            "_ANY",
+            false,
+            0,
+            0,
+            HardwareMeasurementType.PHYSICAL);
+    HostTallyBucket expectedAnyBucket =
+        new HostTallyBucket(
+            swatchSystem,
+            "RHEL",
+            ServiceLevel._ANY,
+            Usage._ANY,
+            BillingProvider._ANY,
+            "_ANY",
+            false,
+            0,
+            0,
+            HardwareMeasurementType.PHYSICAL);
+    assertThat(expectedEmptyBucket, in(swatchSystem.getBuckets()));
+    assertThat(expectedAnyBucket, in(swatchSystem.getBuckets()));
+  }
+
+  @Test
+  void testNonHypervisorStaleBucketsRemoved() {
+    NormalizedFacts normalizedFacts = new NormalizedFacts();
+    normalizedFacts.setHardwareType(HostHardwareType.PHYSICAL);
+    when(factNormalizer.normalize(any(), any())).thenReturn(normalizedFacts);
+
+    var collector = setupCollector();
+    var hbiSystem = new InventoryHostFacts();
+    Host swatchSystem = new Host();
+    OrgHostsData orgHostsData = new OrgHostsData("org123");
+    collector.reconcileHbiSystemWithSwatchSystem(
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"));
+    HostTallyBucket staleBucket =
+        new HostTallyBucket(
+            swatchSystem,
+            "stale",
+            ServiceLevel._ANY,
+            Usage._ANY,
+            BillingProvider._ANY,
+            "_ANY",
+            false,
+            0,
+            0,
+            HardwareMeasurementType.PHYSICAL);
+    swatchSystem.addBucket(staleBucket);
+    collector.reconcileHbiSystemWithSwatchSystem(
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"));
+    assertTrue(swatchSystem.getBuckets().isEmpty());
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollatorTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.inventory.db.InventoryRepository;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.candlepin.subscriptions.tally.InventorySwatchDataCollator.Processor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InventorySwatchDataCollatorTest {
+  @Mock InventoryRepository inventoryRepository;
+
+  @Mock HostRepository hostRepository;
+
+  @Mock Processor processor;
+
+  @Test
+  void testCollatorDoesNothingWithNoData() {
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of());
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    verifyNoInteractions(processor);
+    assertEquals(0, iterations);
+  }
+
+  @Test
+  void testCollatorWorksWithOnlyHbiData() {
+    InventoryHostFacts hbiSystem = new InventoryHostFacts();
+    hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    verify(processor).accept(hbiSystem, null, new OrgHostsData("placeholder"), 1);
+    assertEquals(1, iterations);
+  }
+
+  @Test
+  void testCollatorWorksWithOnlySwatchData() {
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of());
+
+    Host swatchSystem = new Host();
+    swatchSystem.setInventoryId("123e4567-e89b-12d3-a456-426614174000");
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of(swatchSystem));
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    verify(processor).accept(null, swatchSystem, new OrgHostsData("placeholder"), 1);
+    assertEquals(1, iterations);
+  }
+
+  @Test
+  void testCollatorProcessesSameInventoryIdTogetherInOneIteration() {
+    InventoryHostFacts hbiSystem = new InventoryHostFacts();
+    hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+
+    Host swatchSystem = new Host();
+    swatchSystem.setInventoryId("123e4567-e89b-12d3-a456-426614174000");
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of(swatchSystem));
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    verify(processor).accept(hbiSystem, swatchSystem, new OrgHostsData("placeholder"), 1);
+    assertEquals(1, iterations);
+  }
+
+  @Test
+  void testCollatorProcessesDifferentInventoryIdsInSeparateIterations() {
+    InventoryHostFacts hbiSystem = new InventoryHostFacts();
+    hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+
+    Host swatchSystem = new Host();
+    swatchSystem.setInventoryId("223e4567-e89b-12d3-a456-426614174000");
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of(swatchSystem));
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    verify(processor).accept(hbiSystem, null, new OrgHostsData("placeholder"), 1);
+    verify(processor).accept(null, swatchSystem, new OrgHostsData("placeholder"), 2);
+    assertEquals(2, iterations);
+  }
+
+  @Test
+  void testCollatorTracksPresentHypervisorUuidForGuest() {
+    InventoryHostFacts hbiSystem = new InventoryHostFacts();
+    hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    hbiSystem.setHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+        .thenReturn(Stream.of("223e4567-e89b-12d3-a456-426614174000"));
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    ArgumentCaptor<OrgHostsData> orgHostsDataArgumentCaptor =
+        ArgumentCaptor.forClass(OrgHostsData.class);
+    verify(processor).accept(eq(hbiSystem), eq(null), orgHostsDataArgumentCaptor.capture(), eq(1));
+    OrgHostsData orgHostsData = orgHostsDataArgumentCaptor.getValue();
+    assertTrue(orgHostsData.hasHypervisorUuid("223e4567-e89b-12d3-a456-426614174000"));
+    assertEquals(
+        0,
+        orgHostsData
+            .hypervisorHostMap()
+            .get("223e4567-e89b-12d3-a456-426614174000")
+            .getNumOfGuests());
+    assertEquals(1, iterations);
+  }
+
+  @Test
+  void testCollatorTracksPresentHypervisorUuidViaSatelliteHypervisorUuidForGuest() {
+    InventoryHostFacts hbiSystem = new InventoryHostFacts();
+    hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    hbiSystem.setSatelliteHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+        .thenReturn(Stream.of("223e4567-e89b-12d3-a456-426614174000"));
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    ArgumentCaptor<OrgHostsData> orgHostsDataArgumentCaptor =
+        ArgumentCaptor.forClass(OrgHostsData.class);
+    verify(processor).accept(eq(hbiSystem), eq(null), orgHostsDataArgumentCaptor.capture(), eq(1));
+    OrgHostsData orgHostsData = orgHostsDataArgumentCaptor.getValue();
+    assertTrue(orgHostsData.hasHypervisorUuid("223e4567-e89b-12d3-a456-426614174000"));
+    assertEquals(
+        0,
+        orgHostsData
+            .hypervisorHostMap()
+            .get("223e4567-e89b-12d3-a456-426614174000")
+            .getNumOfGuests());
+    assertEquals(1, iterations);
+  }
+
+  @Test
+  void testCollatorDoesNotTrackAbsentHypervisorUuidForGuest() {
+    InventoryHostFacts hbiSystem = new InventoryHostFacts();
+    hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    hbiSystem.setHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+        .thenReturn(Stream.of("323e4567-e89b-12d3-a456-426614174000"));
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    ArgumentCaptor<OrgHostsData> orgHostsDataArgumentCaptor =
+        ArgumentCaptor.forClass(OrgHostsData.class);
+    verify(processor).accept(eq(hbiSystem), eq(null), orgHostsDataArgumentCaptor.capture(), eq(1));
+    OrgHostsData orgHostsData = orgHostsDataArgumentCaptor.getValue();
+    assertFalse(orgHostsData.hasHypervisorUuid("223e4567-e89b-12d3-a456-426614174000"));
+    assertEquals(1, iterations);
+  }
+
+  @Test
+  void testCollatorSkipsSubmanIdsNotNeeded() {
+    InventoryHostFacts hbiSystem = new InventoryHostFacts();
+    hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    hbiSystem.setHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+        .thenReturn(
+            Stream.of(
+                "123e4567-e89b-12d3-a456-426614174000",
+                "123e4567-e89b-12d3-a456-426614174001",
+                "223e4567-e89b-12d3-a456-426614174000"));
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    var iterations = collator.collateData("foo", 7, processor);
+
+    ArgumentCaptor<OrgHostsData> orgHostsDataArgumentCaptor =
+        ArgumentCaptor.forClass(OrgHostsData.class);
+    verify(processor).accept(eq(hbiSystem), eq(null), orgHostsDataArgumentCaptor.capture(), eq(1));
+    OrgHostsData orgHostsData = orgHostsDataArgumentCaptor.getValue();
+    assertTrue(orgHostsData.hasHypervisorUuid("223e4567-e89b-12d3-a456-426614174000"));
+    assertEquals(
+        0,
+        orgHostsData
+            .hypervisorHostMap()
+            .get("223e4567-e89b-12d3-a456-426614174000")
+            .getNumOfGuests());
+    assertEquals(1, iterations);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -58,6 +58,7 @@ import org.springframework.util.StringUtils;
 public interface HostRepository
     extends JpaRepository<Host, UUID>, JpaSpecificationExecutor<Host>, TagProfileLookup {
 
+  /* NOTE: in below query, ordering is crucial for correct streaming reconciliation of HBI data */
   @Query(
       value =
           """

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -153,6 +153,8 @@ parameters:
     value: 'false'
   - name: TALLY_MAX_HBI_ACCOUNT_SIZE
     value: '2147483647'  # Integer.MAX_VALUE by default
+  - name: HBI_RECONCILIATION_FLUSH_INTERVAL
+    value: '1024'
   - name: MACHINE_POOL
     value: '' # don't restrict to a specific machine pool by default
   - name: JOB_MACHINE_POOL
@@ -391,6 +393,8 @@ objects:
               value: ${TALLY_MAX_HBI_ACCOUNT_SIZE}
             - name: LEGACY_NIGHTLY_TALLY_ENABLED
               value: ${LEGACY_NIGHTLY_TALLY_ENABLED}
+            - name: HBI_RECONCILIATION_FLUSH_INTERVAL
+              value: ${HBI_RECONCILIATION_FLUSH_INTERVAL}
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-686

By ordering records from HBI and swatch in a consistent order, and then collating the results, we
can handle updates with minimal memory usage.

I integrated with changes from #1776; this update strategy is applied only when
`legacyNightlyTallyEnabled=false`.

In order to make the logic easier to follow (and hopefully easier to re-use once we start processing
HBI events), I split the changes up as follows:

1. a new class `InventorySwatchDataCollator` that handles collation of streams of system information
   from HBI and swatch.
2. methods added to InventoryAccountUsageCollector that handle reconciliation of state between HBI
   and swatch
3. a coordinator method in InventoryAccountUsageCollector that invokes `InventorySwatchDataCollator`
   and flushes at configured intervals.

I had to set auto-commit to false on the HBI connection in order to allow streaming.

Testing
=======

Set up an HBI org with 50,000 physical systems:

```shell
bin/insert-mock-hosts --org=org456 --hbi --clear --num-physical=50000
```

Add 3 hypervisors with 100,000 systems each:

```shell
for i in $(seq 3); do
  bin/insert-mock-hosts --org=org456 --hbi --num-hypervisors=1 --num-guests=100000
done
```

Next run the following testing steps (repeat for `main` and this branch for comparison)...

Reset hosts and related tables (critical between test runs):

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
truncate table hosts cascade;
EOF
```

Run the application:

```shell
LOGGING_LEVEL_ORG_CANDLEPIN_TALLY=DEBUG \
  ./gradlew :bootRun \
  --args='--logging.level.org.hibernate.SQL=DEBUG'
```

Connect to the application via `jconsole`:

```shell
jconsole
```

Select `org.candlepin.subscriptions.BootApplication`

This will allow you to see the memory usage as the tally progresses.

Trigger a tally for org456:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean' \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org456"]'
```

Trigger a retally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean' \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org456"]'
```

Observe:

1. The memory usage for this branch is minimal (~300 Mb, and if you force GC, it stays even lower)
2. The logged sql queries are minimal. (On a re-tally there are no inserts, and only the initial selects)

Also make the following call to check the overall runtime once the tally completes (or use a clock):

Notice the overall runtime is often faster (feel free to adjust the shape of the HBI data and see
how it performs, though I expect we'll work with performance engineers to validate as well).

```shell
http :9000/metrics | grep spring_kafka_listener_seconds_sum | grep rhsm-subscriptions-task-processor
```
