### PR TITLE
Adding SKUs SER0710 and SER0683

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -6390,8 +6390,10 @@ objects:
         SER0602
         SER0620
         SER0621
+        SER0683
         SER0705
         SER0709
+        SER0710
         SER0713
         SER0715
         SER0717


### PR DESCRIPTION
SER0710
Description : Red Hat OpenShift Platform Plus (Bare Metal Node), Self-Support (1-2 sockets, NFR, Partner Only)

SER0683
Description : Red Hat OpenShift Data Foundation Advanced, Self-Support (2 Cores, NFR, Partner Only)