### PR TITLE
Fix Missing Major release

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -191,6 +191,10 @@ public abstract class InventoryService {
     if (versions.length == 2) {
       operatingSystem.setMajor(Integer.parseInt(versions[0]));
       operatingSystem.setMinor(Integer.parseInt(versions[1]));
+    } else if (versions.length == 1 && !versions[0].isBlank()) {
+      // This is for cases if a single digit is given as these are required fields
+      operatingSystem.setMajor(Integer.parseInt(versions[0]));
+      operatingSystem.setMinor(0);
     } else {
       log.warn(
           "Invalid OperatingSystemVersion: found \"{}\" but should be in format \"major.minor\"",


### PR DESCRIPTION
This is to address [SWATCH-764](https://issues.redhat.com/browse/SWATCH-764)


Issue: rhsm-conduit received a host that had a single digit as its `os_release` which was 5.
```
"system_profile":{"operating_system":{"name":"RHEL"},"os_release":"5","arch":"x86_64","bios_vendor":"Phoenix Technologies LTD"}
```
The current logic is that we only set system profile major and minor when we receive a string with the length of 2, which is the cause of this problem, and to prevent a edge case `"` an additional condition has been added.

Testing Steps
---
1. Run Rhsm-conduit with these environment viables or profiles:
```
DEV_MODE=true;RHSM_USE_STUB=true
```
2. Go to `StubRhsmApi` and make the `distribution.version` a single digit number.
3. Run `syncOrg(String)` in Hawtio for conduit, the input string can be anything as we will be leveraging the mock values here.
```
http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.conduit.jmx-RhsmConduitJmxBean-rhsmConduitJmxBean
```
Make sure Kafka pods are running and use either Big Data tools in the IDE or Kafka UI:
 If you're using Big Data Tool make sure to create a consumer within the `platform.inventory.host-ingress` topic to see the message being sent.

The expected message output received from Rhsm-conduit when the we get a single digit should have a minor version of `0`:
```
{"operation":"add_host","data":{"account":"ACCOUNT_1","org_id":"orgId321","subscription_manager_id":"663b6f0d-cfe5-488e-aa14-24855c1275eb","bios_uuid":"acc67480-4957-4c45-b6ac-7c2614c9045f","fqdn":"host1.test.com","facts":[{"namespace":"rhsm","facts":{"SYNC_TIMESTAMP":"2023-01-24T16:28:48.956227664Z","IS_VIRTUAL":true,"SYSPURPOSE_SLA":"Premium","MEMORY":32,"ARCHITECTURE":"x86_64","VM_HOST":"hypervisor1.test.com","SYSPURPOSE_UNITS":"Sockets","RH_PROD":["72"],"orgId":"orgId321","BILLING_MODEL":"standard"}}],"system_profile":{"operating_system":{"major":6,"minor":0,"name":"RHEL"},"os_release":"6","arch":"x86_64","cores_per_socket":2,"infrastructure_type":"virtual","system_memory_bytes":33543999488,"number_of_sockets":2,"owner_id":"663b6f0d-cfe5-488e-aa14-24855c1275eb"},"stale_timestamp":"2023-01-26T16:28:48.956227664Z","reporter":"rhsm-conduit"},"platform_metadata":{"request_id":"5f30fac1-721f-41fd-8c0a-897a9ea4c653"}}

```
