### PR TITLE
SWATCH-763 Error parsing IP Address on rhsm-conduit messages to HBI

### DIFF
--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -51,6 +51,15 @@ public class StubRhsmApi extends RhsmApi {
     consumer1.getFacts().put("network.fqdn", "host1.test.com");
     consumer1.getFacts().put("dmi.system.uuid", UUID.randomUUID().toString());
     consumer1.getFacts().put("Ip-addresses", "192.168.1.1, 10.0.0.1");
+    consumer1.getFacts().put("net.interface.eth0.ipv4_address", "192.168.1.1, 10.0.0.1");
+    consumer1
+        .getFacts()
+        .put("net.interface.virbr0.ipv4_address_list", "192.168.122.1, ipv4ListTest");
+    consumer1.getFacts().put("net.interface.lo.ipv4_address_list", "192.167.11.2");
+    consumer1.getFacts().put("net.interface.lo.ipv4_address", "redacted, 192.167.11.2");
+    consumer1.getFacts().put("net.interface.lo.ipv4_address", "redacted");
+    consumer1.getFacts().put("net.interface.lo.ipv6_address", "fe80::250:56ff:febe:f55a,redacted");
+    consumer1.getFacts().put("net.interface.lo.ipv6_address", "redacted");
     consumer1.getFacts().put("Mac-addresses", "00:00:00:00:00:00, ff:ff:ff:ff:ff:ff");
     consumer1.getFacts().put("cpu.cpu_socket(s)", "2");
     consumer1.getFacts().put("cpu.core(s)_per_socket", "2");

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -442,6 +442,56 @@ class InventoryControllerTest {
   }
 
   @Test
+  void testFilterLoopbackIpV4Address() {
+    String factPrefix = "net.interface.lo.";
+
+    String loIpFact = "192.168.0.1,redacted, removed";
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+
+    consumer.getFacts().put(factPrefix + "ipv4_address", loIpFact);
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(1, conduitFacts.getNetworkInterfaces().get(0).getIpv4Addresses().size());
+    assertEquals(
+        List.of("192.168.0.1"), conduitFacts.getNetworkInterfaces().get(0).getIpv4Addresses());
+
+    String invalidLoIpFact = "redacted, removed";
+    consumer.getFacts().put(factPrefix + "ipv4_address", invalidLoIpFact);
+
+    conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(1, conduitFacts.getNetworkInterfaces().get(0).getIpv4Addresses().size());
+    assertEquals(
+        List.of("127.0.0.1"), conduitFacts.getNetworkInterfaces().get(0).getIpv4Addresses());
+  }
+
+  @Test
+  void testFilterLoopbackIpV6Address() {
+    String factPrefix = "net.interface.lo.";
+
+    String loIpFact = "fe80::250:56ff:febe:f55a,redacted, removed";
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+
+    consumer.getFacts().put(factPrefix + "ipv6_address", loIpFact);
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(1, conduitFacts.getNetworkInterfaces().get(0).getIpv6Addresses().size());
+    assertEquals(
+        List.of("fe80::250:56ff:febe:f55a"),
+        conduitFacts.getNetworkInterfaces().get(0).getIpv6Addresses());
+
+    String invalidLoIpFact = "redacted, removed";
+    consumer.getFacts().put(factPrefix + "ipv6_address", invalidLoIpFact);
+
+    conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(1, conduitFacts.getNetworkInterfaces().get(0).getIpv6Addresses().size());
+    assertEquals(List.of("::1"), conduitFacts.getNetworkInterfaces().get(0).getIpv6Addresses());
+  }
+
+  @Test
   void testTruncatedIpV6AddressIsIgnoredForNics() {
     String factPrefix = "net.interface.virbr0.";
 
@@ -563,7 +613,8 @@ class InventoryControllerTest {
   void testTruncatedIPsAreIgnored() {
     Map<String, String> rhsmFacts = new HashMap<>();
     rhsmFacts.put("net.interface.eth0.ipv4_address", "192.168.1.1");
-    rhsmFacts.put("net.interface.lo.ipv4_address", "127.0.0.1, 192.168.2.1,192.168.2.2,192...");
+    rhsmFacts.put(
+        "net.interface.lo.ipv4_address", "127.0.0.1, 192.168.2.1,192.168.2.2,192...,redacted");
 
     var results = controller.extractIpAddresses(rhsmFacts);
     assertEquals(4, results.size());


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-763

- The problem was we validate IP addresses, but since we use a different code path to populate loop back IPs, we missed to validate there.

1. There are two ways to run this code and verify:

- A: Run with stub
Run: ```RHSM_USE_STUB=true DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun```

- B: Connect with actual service
Change the RHSM_URL to prod url in application.yaml instead of `http://localhost:9090`. Run the script `fetch-vault-credentials`) by changing environment and token to get prod certs and keystore.
Run: ```DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun```


2. Run: ```http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg   x-rh-swatch-psk:placeholder   org_id=11716302```
3. In both cases it shouldn't emit message with ipv4_addresses or ipv6_addresses as redacted. If there is only one value then the value will be replaced by 127.0.0.1 for IPv4 loopback address and ::1 for IPv6. If there are more than one value and one of them is valid then it will not emit default values. Basically if the loopback IP addresses have size=0 after filtering then emit default value or just show the correct values.

4. New message sent in Kafka queue `platform.inventory.host-ingress` when the loopback IP address `size=0` :
```0,700,Sat Jan 21 22:12:32 EST 2023,,{"operation":"add_host","data":{"account":"ACCOUNT_1","org_id":"11716302","subscription_manager_id":"16d80b65-3409-437f-a488-3c49b2ab749c","bios_uuid":"d7f6dabd-2d8a-43db-aeb6-e7618b9d9285","ip_addresses":["201.202.203.204","192.168.1.1","192.168.122.1","10.0.0.1"],"fqdn":"host1.test.com","facts":[{"namespace":"rhsm","facts":{"SYNC_TIMESTAMP":"2023-01-22T03:12:32.919624082Z","IS_VIRTUAL":true,"SYSPURPOSE_SLA":"Premium","MEMORY":32,"ARCHITECTURE":"x86_64","VM_HOST":"hypervisor1.test.com","SYSPURPOSE_UNITS":"Sockets","RH_PROD":["72"],"orgId":"11716302","BILLING_MODEL":"standard"}}],"system_profile":{"operating_system":{"major":6,"minor":3,"name":"RHEL"},"os_release":"6.3","arch":"x86_64","cores_per_socket":2,"infrastructure_type":"virtual","system_memory_bytes":33543999488,"number_of_sockets":2,"owner_id":"16d80b65-3409-437f-a488-3c49b2ab749c","network_interfaces":[{"ipv4_addresses":["127.0.0.1"],"mac_address":"00:00:00:00:00:00","name":"lo"}]},"stale_timestamp":"2023-01-24T03:12:32.919624082Z","reporter":"rhsm-conduit"},"platform_metadata":{"request_id":"a73571bc-0c84-4bbc-9955-30868d758a9b"}}```

or

5. Object sent in Kafka queue `platform.inventory.host-ingress` New message with :
```0,700,Sat Jan 21 22:12:32 EST 2023,,{"operation":"add_host","data":{"account":"ACCOUNT_1","org_id":"11716302","subscription_manager_id":"16d80b65-3409-437f-a488-3c49b2ab749c","bios_uuid":"d7f6dabd-2d8a-43db-aeb6-e7618b9d9285","ip_addresses":["201.202.203.204","192.168.1.1","192.168.122.1","10.0.0.1"],"fqdn":"host1.test.com","facts":[{"namespace":"rhsm","facts":{"SYNC_TIMESTAMP":"2023-01-22T03:12:32.919624082Z","IS_VIRTUAL":true,"SYSPURPOSE_SLA":"Premium","MEMORY":32,"ARCHITECTURE":"x86_64","VM_HOST":"hypervisor1.test.com","SYSPURPOSE_UNITS":"Sockets","RH_PROD":["72"],"orgId":"11716302","BILLING_MODEL":"standard"}}],"system_profile":{"operating_system":{"major":6,"minor":3,"name":"RHEL"},"os_release":"6.3","arch":"x86_64","cores_per_socket":2,"infrastructure_type":"virtual","system_memory_bytes":33543999488,"number_of_sockets":2,"owner_id":"16d80b65-3409-437f-a488-3c49b2ab749c","network_interfaces":[{"ipv4_addresses":["205.206.207.208"],"mac_address":"00:00:00:00:00:00","name":"lo"}]},"stale_timestamp":"2023-01-24T03:12:32.919624082Z","reporter":"rhsm-conduit"},"platform_metadata":{"request_id":"a73571bc-0c84-4bbc-9955-30868d758a9b"}}```
