### PR TITLE
SWATCH-807: Don't filter by month if product is non PAYG in instance API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -784,6 +784,11 @@ paths:
           schema:
             $ref: '#/components/schemas/UsageType'
           description: "Include only hosts for the specified usage level."
+        - name: uom
+          in: query
+          schema:
+            $ref: '#/components/schemas/MetricId'
+          description: "Include only hosts with a specific unit of measure"
         - name: billing_provider
           in: query
           schema:


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-807

-added UOM query param to filter by

Test Steps (non PAYG filtered skips instance_monthly_totals filter by month):

- Create test hosts:` bin/insert-mock-hosts   --num-guests=1   --num-hypervisors=1   --hypervisor-id=eb0d994a-e129-4a18-860d-3e39294f95df`
- Start app with: DEV_MODE=true ./gradlew :bootRun
- Run curl and should get records with VIRTUAL, PHYSICAL and HYPERVISOR measurement categories:
- `curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=cores'   -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`

Test Steps(no duplicates for non PAYG instances)
-Create test data:
```INSERT INTO public.hosts VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '4375bb4f-5714-44ff-9324-694b4dac1436', '5925020', NULL, 'org123', 'ip-172-31-35-25.us-west-2.compute.internal', '1b0fe0cd-9d75-4b17-8332-525a9ee98694', 4, 1, false, NULL, 'CLOUD', NULL, '2023-01-17 00:27:02.32783+00', false, false, 'AWS', 'HBI_HOST', '4375bb4f-5714-44ff-9324-694b4dac1436', NULL, NULL);
INSERT INTO public.hosts VALUES ('3f01028c-728a-454b-a801-6736e557700f', 'ff9e9f28-304d-4825-863f-cab7aaa251a8', '5925020', NULL, 'org123', 'attackiq-1.zdalisv.dfw.ibm.com', 'a337f14f-7e7e-49b8-a47c-694a087bb92e', NULL, NULL, true, NULL, 'VIRTUALIZED', NULL, '2023-01-17 00:55:49.420985+00', true, false, NULL, 'HBI_HOST', 'ff9e9f28-304d-4825-863f-cab7aaa251a8', NULL, NULL);

INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '', 'RHEL for IBM z', '', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '_ANY', 'RHEL for IBM z', '', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '', 'RHEL', '', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '_ANY', 'RHEL', '', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '', 'RHEL for IBM z', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '_ANY', 'RHEL for IBM z', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '', 'RHEL', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '_ANY', 'RHEL', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '', 'RHEL for x86', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '_ANY', 'RHEL for x86', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '', 'RHEL Server', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '_ANY', 'RHEL Server', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '', 'RHEL', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '_ANY', 'RHEL', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '', 'RHEL Server', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '_ANY', 'RHEL Server', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '', 'RHEL for x86', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '_ANY', 'RHEL for x86', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '', 'RHEL', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', '_ANY', 'RHEL', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);

INSERT INTO public.instance_measurements VALUES ('3f01028c-728a-454b-a801-6736e557700f', 'SOCKETS', 2);
INSERT INTO public.instance_measurements VALUES ('3f01028c-728a-454b-a801-6736e557700f', 'CORES', 2);
INSERT INTO public.instance_measurements VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', 'SOCKETS', 1);
INSERT INTO public.instance_measurements VALUES ('2b0cec31-84fe-46e3-a73c-fa22badd2ba8', 'CORES', 2);
```
- curl with no UOM and should get duplicates:
```
curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL'   -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
- curl with a UOM and no duplicates should appear:
```
curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=sockets'   -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```


