### PR TITLE
Adding Sku MCT4383

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -1559,6 +1559,7 @@ objects:
         MCT4051
         MCT4051F3
         MCT4121HR
+        MCT4383
         MW00003
         MW00003F3
         MW00003F3RN


### PR DESCRIPTION
MCT4383 - Premium: Red Hat OpenShift Platform Plus for OpenShift Container Platform, Premium (On-Demand, Production Support)