### PR TITLE
SWATCH-730:Remove Hard coded division from RHM Producer

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -167,24 +167,6 @@ public class RhMarketplacePayloadMapper {
         tagProfile.rhmMetricIdForTagAndUom(billableUsage.getProductId(), uom);
     Double value = billableUsage.getValue();
 
-    // RHM is expecting counts of 4 vCPU-hour blocks, but currently does not have a way
-    // to do this automatically. If we detect this case, divide the cores value by 4.
-    //
-    // We need a longer term process to get that information onto the SKU/product
-    // definition
-    // itself so that we are not hard coding this type of value in our code. This will do
-    // for now. Wll be removed eventually in Phase 3 of SWATCH-582 subtasks
-    if (OPENSHIFT_DEDICATED_4_CPU_HOUR.equalsIgnoreCase(rhmMarketplaceMetricId)
-        && (billableUsage.getBillingFactor() == 1.0 || billableUsage.getBillingFactor() == null)
-        && !Objects.isNull(value)
-        && Uom.CORES.equals(uom)) {
-      value = value / 4;
-      log.debug(
-          "Found cores measurement for metric ID {}. Dividing cores by 4: {}",
-          OPENSHIFT_DEDICATED_4_CPU_HOUR,
-          value);
-    }
-
     UsageMeasurement usageMeasurement = new UsageMeasurement();
     usageMeasurement.setValue(value);
     usageMeasurement.setMetricId(rhmMarketplaceMetricId);


### PR DESCRIPTION
This is to address https://issues.redhat.com/browse/SWATCH-730

This is the last phase of changes for implementing billing factor from https://github.com/RedHatInsights/rhsm-subscriptions/pull/166.

This is regression testing only.

# Testing Steps
Run workflow with 'main' and than using the data saved in the DB rerun tally with this branch. The remittance table should have billing factor updated for `osd` and the calculation should be the same for cores value.
```
select * from billable_usage_remittance where product_id = 'OpenShift-dedicated-metrics';
```
Run the service:

```shell
USER_USE_STUB=true SUBSCRIPTION_USE_STUB=true CG_USE_STUB=true CLOUDIGRADE_ENABLED=false DEV_MODE=true ./gradlew clean :bootRun
```

Load events into the DB:

```shell
bin/import-events.py --file bin/events.csv
```

Opt in all accounts from the events:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean \
  operation='createOrUpdateOptInConfig(java.lang.String,java.lang.String,boolean,boolean,boolean)' \
  arguments:='["account123","org123",true,true,true]'
```

Do an hourly tally for all accounts:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyAllAccountsByHourly(java.lang.String,java.lang.String)' \
  arguments:='["2021-10-18T00:00Z","2021-10-19T00:00Z"]'
```
This should create a `osd` remittance with a billing factor of `0.25` and it should have same values with the mock events when compared with the `main` branch.