### PR TITLE
Added sku SER0730 - Self-Support: Red Hat OpenShift Platform Plus wit…

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -6393,6 +6393,7 @@ objects:
         SER0715
         SER0717
         SER0719
+        SER0730
         SER0737
         SER0739
         SER0741


### PR DESCRIPTION
What:
Added sku SER0730 - Self-Support: Red Hat OpenShift Platform Plus with Red Hat OpenShift Data Foundation Advanced, Self-Support (2 Cores or 4vCPUs, NFR, Partner Only)

Why:
Customer needs to apply subscription against this sku

Tickets:
https://access.redhat.com/support/cases/#/case/03409895
