### PR TITLE
SWATCH-98 Populate is_marketplace if present in azure or aws facts

### DIFF
--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -70,6 +70,7 @@ public class StubRhsmApi extends RhsmApi {
     consumer1.getFacts().put("ocm.billing_model", "standard");
     consumer1.getFacts().put("distribution.name", "Red Hat Enterprise Linux Workstation");
     consumer1.getFacts().put("distribution.version", "6.3");
+    consumer1.getFacts().put("azure_offer", "RHEL");
     InstalledProducts product = new InstalledProducts();
     product.setProductId("72");
     consumer1.getInstalledProducts().add(product);

--- a/swatch-system-conduit/schemas/inventory/hbi-system-profile.yaml
+++ b/swatch-system-conduit/schemas/inventory/hbi-system-profile.yaml
@@ -23,6 +23,8 @@ properties:
     type: integer
   owner_id:
     type: string
+  is_marketplace:
+    type: boolean
   network_interfaces:
     type: array
     items:

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -104,6 +105,8 @@ public class InventoryController {
   public static final String VIRT_IS_GUEST = "virt.is_guest";
   public static final String INSIGHTS_ID = "insights_id";
   public static final String OPENSHIFT_CLUSTER_UUID = "openshift.cluster_uuid";
+  public static final String AZURE_OFFER = "azure_offer";
+  public static final String AWS_BILLING_PRODUCTS = "aws_billing_products";
   public static final String OCM_UNITS = "ocm.units";
   public static final String OCM_BILLING_MODEL = "ocm.billing_model";
   public static final String UNKNOWN = "unknown";
@@ -180,7 +183,17 @@ public class InventoryController {
             .collect(Collectors.toList());
     facts.setRhProd(productIds);
 
+    extractMarketPlaceFacts(rhsmFacts, facts);
     return facts;
+  }
+
+  private void extractMarketPlaceFacts(Map<String, String> rhsmFacts, ConduitFacts facts) {
+    var azureOffer = rhsmFacts.get(AZURE_OFFER);
+    var awsBillingProducts = rhsmFacts.get(AWS_BILLING_PRODUCTS);
+    if (StringUtils.hasText(azureOffer) && !Objects.equals(azureOffer, "rhel-byos")
+        || StringUtils.hasText(awsBillingProducts)) {
+      facts.setIsMarketplace(true);
+    }
   }
 
   private String extractCloudProvider(Map<String, String> rhsmFacts) {

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -137,6 +137,7 @@ public abstract class InventoryService {
     systemProfile.setNumberOfSockets(facts.getCpuSockets());
     systemProfile.setOwnerId(facts.getSubscriptionManagerId());
     systemProfile.setNetworkInterfaces(facts.getNetworkInterfaces());
+    systemProfile.setIsMarketplace(facts.getIsMarketplace());
     return systemProfile;
   }
 

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -261,6 +261,8 @@ components:
           type: string
         billing_model:
           type: string
+        is_marketplace:
+          type: boolean
     DefaultResponse:
       properties:
         status:

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -492,6 +492,65 @@ class InventoryControllerTest {
   }
 
   @Test
+  void testIsMarketplaceFacts_WhenAzureOfferPresent() {
+    String azureOfferFact = "azure_offer";
+    String azzureOffer = "RHEL";
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+
+    consumer.getFacts().put(azureOfferFact, azzureOffer);
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(true, conduitFacts.getIsMarketplace());
+
+    azureOfferFact = "azure_offer";
+    azzureOffer = " ";
+    consumer.getFacts().put(azureOfferFact, azzureOffer);
+
+    conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertNull(conduitFacts.getIsMarketplace());
+
+    azureOfferFact = "azure_offer";
+    azzureOffer = "rhel-byos";
+    consumer.getFacts().put(azureOfferFact, azzureOffer);
+
+    conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertNull(conduitFacts.getIsMarketplace());
+  }
+
+  @Test
+  void testIsMarketplaceFacts_WhenAwsBillingProductsPresent() {
+    String awsBillingProductsFact = "aws_billing_products";
+    String awsBillingProducts = "bi-6fa54";
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+
+    consumer.getFacts().put(awsBillingProductsFact, awsBillingProducts);
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(true, conduitFacts.getIsMarketplace());
+
+    awsBillingProductsFact = "aws_billing_products";
+    awsBillingProducts = " ";
+    consumer.getFacts().put(awsBillingProductsFact, awsBillingProducts);
+
+    conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertNull(conduitFacts.getIsMarketplace());
+  }
+
+  @Test
+  void testIsMarketplaceFacts_WhenAzureOfferOrAWSBillingProductsNotPresent() {
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertNull(conduitFacts.getIsMarketplace());
+  }
+
+  @Test
   void testTruncatedIpV6AddressIsIgnoredForNics() {
     String factPrefix = "net.interface.virbr0.";
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-98

- Description: You should see in the kafka queue under system_profile> is_marketplace true if "aws_billing_products" fact is present and non-empty or "azure_offer" fact is present, non-empty, and not equal to "rhel-byos". In all other cases it won't show up in the feed since it will be null. The way to test this is through stub since I checked with teamnado team and QA they don't have an org that contains above fields in RHSM API.

1. Run with stub
Run: ```RHSM_USE_STUB=true DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun```

2. Run: ```http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg   x-rh-swatch-psk:placeholder   org_id=org123```

3. Result: 
 - New message sent in Kafka queue `platform.inventory.host-ingress`
 - ```0,3233,Mon Jan 30 11:47:35 EST 2023,,{"operation":"add_host","data":{"account":"ACCOUNT_1","org_id":"org123","subscription_manager_id":"2dc4e9f5-a5aa-43e1-bbe1-a463de42adc1","bios_uuid":"ba222b4d-3888-43b2-be5f-1bbdac8ab9e2","ip_addresses":["192.167.11.2","192.168.1.1","192.168.122.1","10.0.0.1"],"fqdn":"host1.test.com","facts":[{"namespace":"rhsm","facts":{"SYNC_TIMESTAMP":"2023-01-30T16:47:35.017522881Z","IS_VIRTUAL":true,"SYSPURPOSE_SLA":"Premium","MEMORY":32,"ARCHITECTURE":"x86_64","VM_HOST":"hypervisor1.test.com","SYSPURPOSE_UNITS":"Sockets","RH_PROD":["72"],"orgId":"org123","BILLING_MODEL":"standard"}}],"system_profile":{"operating_system":{"major":6,"minor":3,"name":"RHEL"},"os_release":"6.3","arch":"x86_64","cores_per_socket":2,"infrastructure_type":"virtual","system_memory_bytes":33543999488,"number_of_sockets":2,"owner_id":"2dc4e9f5-a5aa-43e1-bbe1-a463de42adc1","is_marketplace":true,"network_interfaces":[{"ipv4_addresses":["127.0.0.1"],"mac_address":"00:00:00:00:00:00","name":"lo"}]},"stale_timestamp":"2023-02-01T16:47:35.017522881Z","reporter":"rhsm-conduit"},"platform_metadata":{"request_id":"4c0b202b-1e0c-45d9-b54b-e243d50252be"}}```

