### PR TITLE
SWATCH-835 Add subscription_manager_id and set default num_of_guests …

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1722,6 +1722,8 @@ components:
           type: integer
         category:
           type: string
+        subscription_manager_id:
+          type: string
       example:
         id: d6214a0b-b344-4778-831c-d53dcacb2da3
         display_name: rhv.example.com

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -241,6 +241,7 @@ public class InstancesResource implements InstancesApi {
     instance.setMeasurements(measurementList);
     instance.setLastSeen(tallyInstanceView.getLastSeen());
     instance.setNumberOfGuests(tallyInstanceView.getNumOfGuests());
+    instance.setSubscriptionManagerId(tallyInstanceView.getSubscriptionManagerId());
     return instance;
   }
 

--- a/src/main/resources/liquibase/202301311609-update-tally-instance-view-default-num-of-guest-add-subscription_manager_id.xml
+++ b/src/main/resources/liquibase/202301311609-update-tally-instance-view-default-num-of-guest-add-subscription_manager_id.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202301311609-1" author="kshah">
+    <dropView viewName="tally_instance_view"/>
+  </changeSet>
+
+  <changeSet id="202301311609-2" author="kshah">
+    <comment>Create view of hosts and host_tally_buckets for use in Instance API</comment>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_view">
+      select distinct org_id,
+                      h.id,
+                      cast(h.instance_id as UUID) as instance_id,
+                      display_name,
+                      h.billing_provider as host_billing_provider,
+                      h.billing_account_id as host_billing_account_id,
+                      b.billing_provider as bucket_billing_provider,
+                      b.billing_account_id as bucket_billing_account_id,
+                      last_seen,
+                      coalesce(num_of_guests, 0) AS num_of_guests,
+                      product_id,
+                      sla,
+                      usage,
+                      COALESCE(b.measurement_type, 'EMPTY') AS measurement_type,
+                      m.uom,
+                      m.value,
+                      b.sockets,
+                      b.cores,
+                      h.subscription_manager_id
+      from hosts h
+        join host_tally_buckets b on h.id = b.host_id left outer join instance_measurements m on h.id = m.instance_id;
+    </createView>
+  </changeSet>
+
+</databaseChangeLog>
+  <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -98,5 +98,6 @@
     <include file="liquibase/202212011334-add-billing-factor-column-to-remittance-table.xml"/>
     <include file="liquibase/202301031409-update-tally-instance-view.xml"/>
     <include file="liquibase/202212161446-add-derived-sku-to-offering.xml"/>
+    <include file="liquibase/202301311609-update-tally-instance-view-default-num-of-guest-add-subscription_manager_id.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -76,6 +76,9 @@ public class TallyInstanceView implements Serializable {
 
   private Double value;
 
+  @Column(name = "subscription_manager_id")
+  private String subscriptionManagerId;
+
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(
       name = "instance_monthly_totals",


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-835

Test Steps:

- Create test hosts:
  - `bin/insert-mock-hosts   --num-guests=4   --num-hypervisors=1   --hypervisor-id=eb0d994a-e129-4a18-860d-3e39294f95df`
  - `bin/insert-mock-hosts   --num-aws=1`
- Start app: `DEV_MODE=true ./gradlew :bootRun`
- Run the following 2 curl commands and check that categories are returned in correct order.
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=cores&sort=category&dir=desc' \
  -H 'accept: application/json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=cores&sort=category&dir=asc' \
  -H 'accept: application/json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

- Response now contains number_of_guests= 0 where its null in host table and it also includes subscription_manager_id.
{
    "data": [
        {
            "id": "test",
            "display_name": "test",
            "billing_provider": "_ANY",
            "billing_account_id": "_ANY",
            "measurements": [
                0.0
            ],
            "last_seen": "1993-03-26T00:00:00Z",
            "number_of_guests": 0,
            "category": "VIRTUAL",
            "subscription_manager_id": "test"
        },
        {
            "id": "test",
            "display_name": "test",
            "billing_provider": "_ANY",
            "billing_account_id": "_ANY",
            "measurements": [
                0.0
            ],
            "last_seen": "1993-03-26T00:00:00Z",
            "number_of_guests": 2,
            "category": "VIRTUAL",
            "subscription_manager_id": "test"
        }
],
    "meta": {
        "count": 19,
        "product": "RHEL",
        "measurements": [
            "Sockets"
        ]
    }
}