### PR TITLE
SWATCH-843: Hotfix to address the billable usage NPE issue

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageCalculation.java
@@ -29,5 +29,6 @@ import lombok.Data;
 class BillableUsageCalculation {
   private double remittedValue;
   private double billableValue;
+  private double billingFactor;
   private OffsetDateTime remittanceDate;
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
@@ -234,6 +234,7 @@ class RemittanceControllerTest {
         // NOTE: We are mocking the repository's sum call, so this value doesn't have to match the
         // snapshot.
         .remittedValue(remittedValue)
+        .billingFactor(1.0)
         .remittanceDate(clock.now())
         .build();
   }


### PR DESCRIPTION
This hot-fix is to address a prod issue for https://issues.redhat.com/browse/SWATCH-843,
as billing factor was not set in remittance table and the calculation were returning `Null` whenever we try to get the information from the latest remittance.

the following  [line.](https://github.com/RedHatInsights/rhsm-subscriptions/blob/7d3d306928fff3f3562c6e2563c9d680596531b8/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java#L117)  was the only place billing factor is being set. instead it was pointed out that billing factor should be set from `BillableUsageCalculation` and assign billing factor outside the calculation method.