### PR TITLE
[hotfix] SWATCH-843: Hotfix to address billable usage NPE in prod

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageCalculation.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageCalculation.java
@@ -29,5 +29,6 @@ import lombok.Data;
 class BillableUsageCalculation {
   private double remittedValue;
   private double billableValue;
+  private double billingFactor;
   private OffsetDateTime remittanceDate;
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -95,6 +95,17 @@ public class BillableUsageController {
         .orElse(BillableUsageRemittanceEntity.builder().key(key).remittedValue(0.0).build());
   }
 
+  /**
+   * Find the latest remitted value and billing factor used for that remittance in the database.
+   * Convert it to use the billing factor that's currently listed in the tag profile.
+   * This might be a no-op if the factor hasn't changed.
+   * BillableUsage should be the difference between the current usage and the previous usage at the newest tag profile billing factor.
+   * Integer-only billing is then applied before remitting. example later
+   * @param measuredTotal
+   * @param usage
+   * @param remittance
+   * @return
+   */
   private BillableUsageCalculation calculateBillableUsage(
       double measuredTotal, BillableUsage usage, BillableUsageRemittanceEntity remittance) {
     var tagMetricOptional =
@@ -107,17 +118,20 @@ public class BillableUsageController {
     double billableValue;
     double remittedValue;
     var currentRemittedValue = remittance.getRemittedValue();
+    var prevBillingFactor = remittance.getBillingFactor();
 
+    if(Objects.isNull(prevBillingFactor)){
+      prevBillingFactor = 1.0;
+    }
+
+    // if the tag factor is different from latest billing factor,
+    // we will calculate the difference based on the current tag metric,
+    // if not we will just calculate as usual
     if (tagFactor != 1.0) {
-      var prevBilled = currentRemittedValue / remittance.getBillingFactor(); // previously billed
+      var prevBilled = currentRemittedValue /prevBillingFactor; // previously billed
       var unbilledAmount = measuredTotal - prevBilled;
       var updatedBill = unbilledAmount * tagFactor;
       var prevBilledAdjusted = prevBilled * tagFactor;
-
-      if (usage.getBillingFactor() != tagFactor) {
-        usage.setBillingFactor(tagFactor);
-        remittance.setBillingFactor(usage.getBillingFactor());
-      }
 
       billableValue = Math.ceil(updatedBill);
       remittedValue = checkIfBilled(billableValue) + prevBilledAdjusted;
@@ -131,6 +145,7 @@ public class BillableUsageController {
         .billableValue(billableValue)
         .remittedValue(remittedValue)
         .remittanceDate(clock.now())
+        .billingFactor(tagFactor)
         .build();
   }
 
@@ -167,8 +182,9 @@ public class BillableUsageController {
 
     // Update the reported usage value to the newly calculated one.
     usage.setValue(usageCalc.getBillableValue());
+    usage.setBillingFactor(usageCalc.getBillingFactor());
 
-    if (updateRemittance(remittance, usage.getOrgId(), usageCalc, usage.getBillingFactor())) {
+    if (updateRemittance(remittance, usage.getOrgId(), usageCalc)) {
       remittance.setAccountNumber(usage.getAccountNumber());
       log.debug("Updating remittance: {}", remittance);
       billableUsageRemittanceRepository.save(remittance);
@@ -180,8 +196,7 @@ public class BillableUsageController {
   private boolean updateRemittance(
       BillableUsageRemittanceEntity remittance,
       String orgId,
-      BillableUsageCalculation usageCalc,
-      Double tagFactor) {
+      BillableUsageCalculation usageCalc) {
     boolean updated = false;
     if (!Objects.equals(remittance.getKey().getOrgId(), orgId) && StringUtils.hasText(orgId)) {
       remittance.getKey().setOrgId(orgId);
@@ -191,8 +206,8 @@ public class BillableUsageController {
       remittance.setRemittedValue(usageCalc.getRemittedValue());
       updated = true;
     }
-    if (!Objects.equals(remittance.getBillingFactor(), tagFactor)) {
-      remittance.setBillingFactor(tagFactor);
+    if (!Objects.equals(remittance.getBillingFactor(), usageCalc.getBillingFactor())) {
+      remittance.setBillingFactor(usageCalc.getBillingFactor());
       updated = true;
     }
     // Only update the date if the remittance was updated.


### PR DESCRIPTION
This hot-fix is to address a prod issue for https://issues.redhat.com/browse/SWATCH-843,
as billing factor was not set in remittance table and the calculation were returning `Null` whenever we try to get the information from the latest remittance.

the following  [line.](https://github.com/RedHatInsights/rhsm-subscriptions/blob/7d3d306928fff3f3562c6e2563c9d680596531b8/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java#L117)  was the only place billing factor is being set. instead it was pointed out that billing factor should be set from `BillableUsageCalculation` and assign billing factor outside the calculation method.