### PR TITLE
SWATCH-822: Update instance api reponse to include cloud_provider 

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1093,6 +1093,13 @@ components:
         - virtual
         - cloud
         - hypervisor
+    CloudProvider:
+      type: string
+      enum:
+        - aws
+        - gcp
+        - azure
+        - alibaba
     BillingAccountId:
       type: string
     Uom:
@@ -1721,6 +1728,9 @@ components:
         number_of_guests:
           type: integer
         category:
+          $ref: '#/components/schemas/ReportCategory'
+        cloud_provider:
+          $ref: '#/components/schemas/CloudProvider'
           type: string
         subscription_manager_id:
           type: string
@@ -1732,6 +1742,8 @@ components:
           - null
           - 1
         last_seen: '2020-01-01T00:00:00Z'
+        cloud_provider: aws
+        category: cloud
         number_of_guests: 4
     CandlepinPool:
       description: Subset of Candlepin pool data that rhsm-subscriptions understands.


### PR DESCRIPTION
- and fix category to return "cloud" instead of "aws,gcp etc.."

https://issues.redhat.com/browse/SWATCH-822

Test Steps:

- Insert data: 

```
INSERT INTO public.hosts VALUES ('3f01028c-728a-454b-a801-6736e557700f', 'ff9e9f28-304d-4825-863f-cab7aaa251a8', '5925020', NULL, 'org123', 'attackiq-1.zdalisv.dfw.com', 'a337f14f-7e7e-49b8-a47c-694a087bb92e', NULL, NULL, true, NULL, 'AWS', NULL, '2023-01-17 00:55:49.420985+00', true, false, NULL, 'HBI_HOST', 'ff9e9f28-304d-4825-863f-cab7aaa251a8', NULL, NULL);

INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '', 'RHEL for IBM z', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '_ANY', 'RHEL for IBM z', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '', 'RHEL', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '_ANY', 'RHEL', '', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '', 'RHEL for IBM z', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '_ANY', 'RHEL for IBM z', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '', 'RHEL', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('3f01028c-728a-454b-a801-6736e557700f', '_ANY', 'RHEL', '_ANY', true, 2, 1, 'AWS', '_ANY', '_ANY', 0);

INSERT INTO public.instance_measurements VALUES ('3f01028c-728a-454b-a801-6736e557700f', 'SOCKETS', 2);
INSERT INTO public.instance_measurements VALUES ('3f01028c-728a-454b-a801-6736e557700f', 'CORES', 2);
```
- Run curl: 
```
curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=cores&sort=category&dir=asc' -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
- Result should contain cloud_provider=aws and category=cloud