### PR TITLE
SWATCH-590: Correct handling of report category for capacity reports

### DIFF
--- a/buildSrc/src/main/groovy/swatch.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.java-conventions.gradle
@@ -55,5 +55,9 @@ test {
     environment "TESTCONTAINERS_CHECKS_DISABLE", "true"
 
     maxHeapSize = "1024m"
+}
 
+tasks.withType(Jar).configureEach {
+    // Here to address https://youtrack.jetbrains.com/issue/IDEA-305759
+    duplicatesStrategy = DuplicatesStrategy.WARN
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -559,7 +559,7 @@ class CapacityResourceTest {
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
-    assertEquals(5, capacitySnapshot.getValue());
+    assertEquals(2, capacitySnapshot.getValue());
   }
 
   @Test
@@ -657,7 +657,7 @@ class CapacityResourceTest {
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
-    assertEquals(20, capacitySnapshot.getValue());
+    assertEquals(8, capacitySnapshot.getValue());
   }
 
   @Test
@@ -785,7 +785,7 @@ class CapacityResourceTest {
             "owner123456",
             RHEL,
             MetricId.CORES,
-            ReportCategory.VIRTUAL,
+            HypervisorReportCategory.HYPERVISOR,
             ServiceLevel.STANDARD,
             Usage.PRODUCTION,
             Granularity.WEEKLY,

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HypervisorReportCategory.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HypervisorReportCategory.java
@@ -30,16 +30,9 @@ public enum HypervisorReportCategory {
     if (reportCategory == null) {
       return null;
     }
-    switch (reportCategory) {
-      case PHYSICAL:
-      case VIRTUAL:
-      case CLOUD:
-        return NON_HYPERVISOR;
-      case HYPERVISOR:
-        return HYPERVISOR;
-      default:
-        throw new IllegalStateException(
-            "Unable to map " + reportCategory + " to a " + "HypervisorReportCategory");
-    }
+    return switch (reportCategory) {
+      case PHYSICAL, VIRTUAL, CLOUD -> NON_HYPERVISOR;
+      case HYPERVISOR -> HYPERVISOR;
+    };
   }
 }


### PR DESCRIPTION
# Testing
## Setup
* Download swatch-590.dump.gz from https://issues.redhat.com/browse/SWATCH-590
* `gunzip swatch-590.dump.gz`
* Create a test database: `createdb -h localhost -U postgres -O rhsm-subscriptions swatch590`
* Import to the test database: `psql -h localhost -U rhsm-subscriptions swatch590 -f ~/swatch-590.dump`
* Start the application against the test database: `DATABASE_DATABASE=swatch590 ./gradlew :bootRun`

## Test Steps
* On `main`:
  * Request capacity reports for a) no category, b) physical, and c) hypervisor:
  ```shell
  http :8000/api/rhsm-subscriptions/v1/capacity/products/RHEL/Sockets granularity==daily \
  beginning==2023-01-31T11:00:00.000Z ending==2023-02-01T11:59:59.999Z \
  x-rh-identity:$(echo -n '{"identity":{"account_number":"7108473","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"14492399"}}}' | base64 -w0)

  http :8000/api/rhsm-subscriptions/v1/capacity/products/RHEL/Sockets granularity==daily  \
  beginning==2023-01-31T11:00:00.000Z ending==2023-02-01T11:59:59.999Z \
  x-rh-identity:$(echo -n '{"identity":{"account_number":"7108473","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"14492399"}}}' | base64 -w0) \
  category==physical

  http :8000/api/rhsm-subscriptions/v1/capacity/products/RHEL/Sockets granularity==daily \
  beginning==2023-01-31T11:00:00.000Z ending==2023-02-01T11:59:59.999Z \
  x-rh-identity:$(echo -n '{"identity":{"account_number":"7108473","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"14492399"}}}' | base64 -w0) \
  category==hypervisor
  ```
* Observe that the results are
  * 12 for no category
  * 6 for physical
  * 0 for hypervisor 
* Apply this branch.  Rerun the same `http` commands and observe the results are now
  * 12 for no category
  * 6 for physical
  * 6 for hypervisor