### PR TITLE
Do not have a placeholder mock juint

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -62,12 +62,3 @@ source $CICD_ROOT/deploy_ephemeral_env.sh
  source $CICD_ROOT/post_test_results.sh
 
 
-# Need to make a placeholder results file to make tests pass
-# Inspired by https://github.com/RedHatInsights/insights-rbac/blo/243b57a20ea2c1da87fe4292a2df9b19e1157efd/pr_check.sh
-# which is listed in the bonfire docs as an example pr_check file
-    mkdir -p artifacts
-    cat << EOF > artifacts/junit-placeholder.xml
-    <testsuite tests="1">
-        <testcase classname="placeholder" name="placeholdertest"/>
-    </testsuite>
-EOF


### PR DESCRIPTION
Having a placeholder juint may confuse prchecks and could result in green checks even if no tests were run