### PR TITLE
SWATCH-829 Endpoint that swatch contracts can use to map a SKU to the swatch product tags

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -42,6 +42,7 @@ import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.UsageCalculation.Key;
 import org.candlepin.subscriptions.utilization.admin.api.InternalApi;
 import org.candlepin.subscriptions.utilization.admin.api.model.AwsUsageContext;
+import org.candlepin.subscriptions.utilization.admin.api.model.OfferingProductTags;
 import org.candlepin.subscriptions.utilization.admin.api.model.TerminationRequest;
 import org.candlepin.subscriptions.utilization.admin.api.model.TerminationRequestData;
 import org.springframework.stereotype.Component;
@@ -144,6 +145,15 @@ public class InternalSubscriptionResource implements InternalApi {
         .productCode(productCode)
         .customerId(customerId)
         .awsSellerAccountId(sellerAccount);
+  }
+
+  /**
+   * @param sku
+   * @return OfferingProductTags
+   */
+  @Override
+  public OfferingProductTags getSkuProductTags(String sku) {
+    return subscriptionSyncController.findProductTags(sku);
   }
 
   @Override

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -114,6 +114,38 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
+  /internal/offerings/{sku}/product_tags:
+    description: "Mapping sku to product tags."
+    parameters:
+      - name: sku
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: "Lookup product tags by sku"
+      operationId: getSkuProductTags
+      responses:
+        '200':
+          description: "The request to get product tags by sku ."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OfferingProductTags'
+              example:
+                data:
+                  - Rho one
+                  - Rho two
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags:
+        - internalSubscriptions
   /internal/subscriptions/terminate/{subscription_id}:
     description: "Terminate a subscription with a given end date."
     parameters:
@@ -172,6 +204,12 @@ components:
         subscriptionStartDate:
           type: string
           format: date-time
+    OfferingProductTags:
+      properties:
+        data:
+          type: array
+          items:
+            type: string
     TerminationRequest:
       properties:
         data:

--- a/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
@@ -84,4 +84,15 @@ class OfferingRepositoryTest {
     var actual = repository.findSkusForChildSku("child").collect(Collectors.toSet());
     assertEquals(Set.of("foo"), actual);
   }
+
+  @Test
+  @Transactional
+  void testFindProductNameForSkus() {
+    var expectedOffering = Offering.builder().sku("foo").productName("test").build();
+    var extra = Offering.builder().sku("foo2").build();
+    repository.save(expectedOffering);
+    repository.save(extra);
+    var actual = repository.findProductNameBySku("foo");
+    assertEquals("test", actual.get());
+  }
 }

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -57,6 +57,7 @@ import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.UsageCalculation.Key;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.utilization.admin.api.model.OfferingProductTags;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -473,6 +474,31 @@ class SubscriptionSyncControllerTest {
             "account123", Optional.empty(), key, rangeStart, rangeEnd, false);
     assertEquals(1, actual.size());
     assertEquals("xyz", actual.get(0).getBillingProviderId());
+  }
+
+  @Test
+  void findProductTagsBySku_WhenSkuPresent() {
+    when(offeringRepository.findProductNameBySku("sku")).thenReturn(Optional.of("productname"));
+    when(mockProfile.tagForOfferingProductName("productname")).thenReturn("producttag");
+
+    OfferingProductTags productTags = subscriptionSyncController.findProductTags("sku");
+    assertEquals(1, productTags.getData().size());
+    assertEquals("producttag", productTags.getData().get(0));
+  }
+
+  @Test
+  void findProductTagsBySku_WhenSkuNotPresent() {
+    when(offeringRepository.findProductNameBySku("sku")).thenReturn(Optional.empty());
+    when(mockProfile.tagForOfferingProductName("productname1")).thenReturn("producttag");
+
+    OfferingProductTags productTags = subscriptionSyncController.findProductTags("sku");
+    assertNull(productTags.getData());
+
+    when(offeringRepository.findProductNameBySku("sku")).thenReturn(Optional.of("productname"));
+    when(mockProfile.tagForOfferingProductName("productname")).thenReturn(null);
+
+    OfferingProductTags productTags2 = subscriptionSyncController.findProductTags("sku");
+    assertNull(productTags2.getData());
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -50,6 +50,7 @@ import org.candlepin.subscriptions.db.model.OrgConfigRepository;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Subscription;
 import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.exception.MissingOfferingException;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.subscription.api.model.ExternalReference;
 import org.candlepin.subscriptions.subscription.api.model.SubscriptionProduct;
@@ -490,13 +491,14 @@ class SubscriptionSyncControllerTest {
   void findProductTagsBySku_WhenSkuNotPresent() {
     when(offeringRepository.findProductNameBySku("sku")).thenReturn(Optional.empty());
     when(mockProfile.tagForOfferingProductName("productname1")).thenReturn("producttag");
-
-    OfferingProductTags productTags = subscriptionSyncController.findProductTags("sku");
-    assertNull(productTags.getData());
+    RuntimeException e =
+        assertThrows(
+            MissingOfferingException.class,
+            () -> subscriptionSyncController.findProductTags("sku"));
+    assertEquals("Sku sku not found in Offering", e.getMessage());
 
     when(offeringRepository.findProductNameBySku("sku")).thenReturn(Optional.of("productname"));
     when(mockProfile.tagForOfferingProductName("productname")).thenReturn(null);
-
     OfferingProductTags productTags2 = subscriptionSyncController.findProductTags("sku");
     assertNull(productTags2.getData());
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.db;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.model.Offering;
@@ -38,4 +39,7 @@ public interface OfferingRepository extends JpaRepository<Offering, String> {
 
   @Query(value = "select sku from Offering where derivedSku in :derivedSkus")
   Stream<String> findSkusForDerivedSkus(@Param("derivedSkus") Set<String> derivedSkus);
+
+  @Query("select distinct o.productName from Offering o where o.sku = :sku")
+  Optional<String> findProductNameBySku(@Param("sku") String sku);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -74,7 +74,9 @@ public enum ErrorCode {
   SUBSCRIPTION_SERVICE_MARKETPLACE_ID_LOOKUP_ERROR(
       3001, "Could not find marketplace subscription id"),
 
-  ACCOUNT_MISSING_ERROR(3002, "Account not present according to RH IT services");
+  ACCOUNT_MISSING_ERROR(3002, "Account not present according to RH IT services"),
+
+  OFFERING_MISSING_ERROR(3003, "Sku not present in Offering");
 
   private static final String CODE_PREFIX = "SUBSCRIPTIONS";
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/MissingOfferingException.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/MissingOfferingException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.exception;
+
+import javax.ws.rs.core.Response.Status;
+import lombok.Getter;
+import org.candlepin.subscriptions.utilization.api.model.Error;
+
+/**
+ * Application's base exception class. Provides a means to create an Error object that should be
+ * typically return as part of an error response.
+ */
+public class MissingOfferingException extends RuntimeException {
+
+  @Getter private final Status status;
+  @Getter private final String detail;
+  @Getter private final ErrorCode code;
+
+  public MissingOfferingException(ErrorCode code, Status status, String message, String detail) {
+    this(code, status, message, detail, null);
+  }
+
+  public MissingOfferingException(
+      ErrorCode code, Status status, String message, String detail, Throwable e) {
+    super(message, e);
+    this.code = code;
+    this.status = status;
+    this.detail = detail;
+  }
+
+  public Error error() {
+    return new Error()
+        .code(this.code.getCode())
+        .status(String.valueOf(status.getStatusCode()))
+        .title(this.getMessage())
+        .detail(this.detail);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/OfferingExceptionMapper.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/OfferingExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.exception.mapper;
+
+import javax.ws.rs.ext.Provider;
+import org.candlepin.subscriptions.exception.MissingOfferingException;
+import org.candlepin.subscriptions.utilization.api.model.Error;
+import org.springframework.stereotype.Component;
+
+/** An exception mapper used to map all MissingOfferingException to an error response. */
+@Component
+@Provider
+public class OfferingExceptionMapper extends BaseExceptionMapper<MissingOfferingException> {
+  @Override
+  protected Error buildError(MissingOfferingException exception) {
+    return exception.error();
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-829

- **Description**: This is a new API that will allow any service to lookup the swatch product(s) associated with a given SKU. (This lookup will use the offering information already stored in the database) and map the`product_name` to a swatch `product_tag` via info in `tag_profile.yaml`. If the offering does not exist then return 404. If it does exist, then return an empty list if there are no tags found for that particular offering.

- **Test Steps**:
```
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW01484', 'OpenShift Dedicated', null, 0, 0, 0, 0, 'osd', 'Premium', 'Production', 'Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)', null, null);

INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('RH0180191', 'RHEL Server', 'Red Hat Enterprise Linux', null, 2, null, null, 'Red Hat Enterprise Linux Server', 'Standard', 'Production', 'Red Hat Enterprise Linux Server, Standard (1-2 sockets) (Up to 4 guests) with Smart Management', false, null);
```
  
  - Run: `USER_USE_STUB=true SUBSCRIPTION_USE_STUB=true CG_USE_STUB=true RHSM_USE_STUB=true  CLOUDIGRADE_ENABLED=false DEV_MODE=true ./gradlew clean :bootRun`
  
1.  No matching Offering Product Names and sku
   - Run: `curl -X 'GET'   http://localhost:8000/api/rhsm-subscriptions/v1/internal/offerings/123/product_tags   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'`
   -  Response: {"errors":[{"status":"404","code":"SUBSCRIPTIONS3003","title":"Sku 123 not found in Offering"}]}
 2. No matching Offering Product Name
  - Run: `curl -X 'GET'   http://localhost:8000/api/rhsm-subscriptions/v1/internal/offerings/RH0180191/product_tags   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'`
  -  Response: {}
 3. Matching sku and Offering Product Name
  - Run: `curl -X 'GET'   http://localhost:8000/api/rhsm-subscriptions/v1/internal/offerings/MW01484/product_tags   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'`
  - Response: {"data":["OpenShift-dedicated-metrics"]}
