### PR TITLE
Consolidate some dependabot PRs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.13-10.1669632202
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.13-12.1675790156
 
 COPY build/libs/* /deployments/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.13-10.1669632202
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.13-12.1675790156
 USER root
 WORKDIR /tmp/src
 ADD . /tmp/src

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.13-10.1669632202
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.13-12.1675790156
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/swatch-producer-aws/src/main/docker/Dockerfile.legacy-jar
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.13-10.1669632202
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.13-12.1675790156
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 


### PR DESCRIPTION



Bumps ubi9/openjdk-17 from 1.13-10.1669632202 to 1.13-12.1675790156.

---
updated-dependencies:
- dependency-name: ubi9/openjdk-17
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>