### PR TITLE
SWATCH 868: Suppress warning about shifting account number for empty string

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -109,7 +109,8 @@ public class InventoryAccountUsageCollector {
           String hostAccount = facts.getAccount();
           if (hostAccount != null) {
             String currentAccount = accountCalc.getAccount();
-            if (currentAccount != null && !currentAccount.equalsIgnoreCase(hostAccount)) {
+            if (StringUtils.hasText(currentAccount)
+                && !currentAccount.equalsIgnoreCase(hostAccount)) {
               throw new IllegalStateException(
                   String.format(
                       "Attempt to set a different account for an org: %s:%s",


### PR DESCRIPTION
To set the account number on the AccountUsageCalculation, we pull the account number from the NormalizedFacts of the hosts.  The code is written such that the account number is set when processing the first host and that subsequent host processing will check to make sure the account number is unchanged in the NormalizedFacts.  Any NormalizedFacts object with a differing account number results in an IllegalArgumentException.  A comment notes that "there could be stale data in inventory with no account set".

There is an edge case where the first NormalizedFacts object has no account set and the others do.  In that case, we would actually want to update the account number with the more meaningful data.  This patch alters InventoryAccountUsageController#collect() to only throw the IllegalArgumentException if the AccountUsageCalculation account number is non-empty, non-null, and non-whitespace, and we receive a differing account number value from the NormalizedFacts object.  If the AccountUsageCalculation account number is null, empty, or only whitespace, it will be updated with the NormalizedFacts object account number.

See https://issues.redhat.com/browse/SWATCH-868
---
# Testing
* The fix is covered in unit tests, so check out this branch and run the unit tests.  Observe that everything passes.
   ```bash
   ./gradlew :test --tests "org.candlepin.subscriptions.tally.InventoryAccountUsageCollectorTest*"
   ```
* Revert the InventoryAccountUsageCollector change from this branch
   ```bash
   git restore --source origin/main src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
   ```
* Run the unit tests again and observe that `overwritesBlankAccountNumberInNormalizedFacts()` fails.
   ```bash
   ./gradlew :test --tests "org.candlepin.subscriptions.tally.InventoryAccountUsageCollectorTest*"
   ```