### PR TITLE
SWATCH-864: add instance_id and host id to instance api

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1669,14 +1669,25 @@ components:
           $ref: '#/components/schemas/InstanceMeta'
       example:
         data:
-          - inventory_id: d6214a0b-b344-4778-831c-d53dcacb2da3
-            display_name: guest01.example.com
-            subscription_manager_id: adafd9d5-5b00-42fa-a6c9-75801d45cc6d
+          - id: d6214a0b-b344-4778-831c-d53dcacb2da3
+            instance_id: 879180f3-76a4-46d5-8fff-7fb32067340b
+            display_name: rhv.example.com
+            billing_provider: red hat
+            billing_account_id: e460fbca-a351-4c6a-a36a-18fdbfbc5a20
+            measurements:
+              - 42
+              - null
+              - 1
             last_seen: '2020-01-01T00:00:00Z'
             number_of_guests: 4
-          - inventory_id: 9358e312-1c9f-42f4-8910-dcef6e970852
-            display_name: guest02.example.com
-            subscription_manager_id: b101a72f-1859-4489-acb8-d6d31c2578c4
+            category: HYPERVISOR
+          - id: 70b6f70b-0c38-46a3-8b9b-7c1703e2d74f
+            instance_id: f273515a-e168-4c00-b7bd-86be9994fb8b
+            display_name: rhv.example.com
+            billing_provider: red hat
+            billing_account_id: e460fbca-a351-4c6a-a36a-18fdbfbc5a20
+            measurements:
+              - 2
             last_seen: '2020-01-01T00:00:00Z'
             number_of_guests: 1
         links:
@@ -1707,6 +1718,9 @@ components:
       properties:
         id:
           type: string
+          description: ID of the host record
+        instance_id:
+          type: string
         display_name:
           type: string
         billing_provider:
@@ -1731,12 +1745,14 @@ components:
           $ref: '#/components/schemas/ReportCategory'
         cloud_provider:
           $ref: '#/components/schemas/CloudProvider'
-          type: string
         subscription_manager_id:
           type: string
       example:
         id: d6214a0b-b344-4778-831c-d53dcacb2da3
+        instance_id: 879180f3-76a4-46d5-8fff-7fb32067340b
         display_name: rhv.example.com
+        billing_provider: red hat
+        billing_account_id: e460fbca-a351-4c6a-a36a-18fdbfbc5a20
         measurements:
           - 42
           - null

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -229,7 +229,8 @@ public class InstancesResource implements InstancesApi {
       boolean isPAYG) {
     var instance = new InstanceData();
     List<Double> measurementList = new ArrayList<>();
-    instance.setId(tallyInstanceView.getKey().getInstanceId().toString());
+    instance.setId(tallyInstanceView.getId());
+    instance.setInstanceId(tallyInstanceView.getKey().getInstanceId().toString());
     instance.setDisplayName(tallyInstanceView.getDisplayName());
     if (Objects.nonNull(tallyInstanceView.getHostBillingProvider())) {
       instance.setBillingProvider(tallyInstanceView.getHostBillingProvider().asOpenApiEnum());

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -75,6 +75,7 @@ class InstancesResourceTest {
 
     var tallyInstanceView = new TallyInstanceView();
     tallyInstanceView.setKey(new TallyInstanceViewKey());
+    tallyInstanceView.setId("testHostId");
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
@@ -114,7 +115,8 @@ class InstancesResourceTest {
               .orElse(0.0));
     }
     var data = new InstanceData();
-    data.setId(tallyInstanceView.getKey().getInstanceId().toString());
+    data.setId("testHostId");
+    data.setInstanceId(tallyInstanceView.getKey().getInstanceId().toString());
     data.setDisplayName(tallyInstanceView.getDisplayName());
     data.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
     data.setLastSeen(tallyInstanceView.getLastSeen());
@@ -203,7 +205,7 @@ class InstancesResourceTest {
             new PageImpl<>(List.of(tallyInstanceViewPhysical, tallyInstanceViewHypervisor)));
 
     var dataPhysical = new InstanceData();
-    dataPhysical.setId(tallyInstanceViewPhysical.getKey().getInstanceId().toString());
+    dataPhysical.setInstanceId(tallyInstanceViewPhysical.getKey().getInstanceId().toString());
     dataPhysical.setDisplayName(tallyInstanceViewPhysical.getDisplayName());
     dataPhysical.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
     dataPhysical.setLastSeen(tallyInstanceViewPhysical.getLastSeen());
@@ -212,7 +214,7 @@ class InstancesResourceTest {
     dataPhysical.setCategory(ReportCategory.PHYSICAL);
 
     var dataHypervisor = new InstanceData();
-    dataHypervisor.setId(tallyInstanceViewHypervisor.getKey().getInstanceId().toString());
+    dataHypervisor.setInstanceId(tallyInstanceViewHypervisor.getKey().getInstanceId().toString());
     dataHypervisor.setDisplayName(tallyInstanceViewHypervisor.getDisplayName());
     dataHypervisor.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
     dataHypervisor.setLastSeen(tallyInstanceViewHypervisor.getLastSeen());
@@ -297,7 +299,8 @@ class InstancesResourceTest {
               .orElse(0.0));
     }
     var data = new InstanceData();
-    data.setId(tallyInstanceView.getKey().getInstanceId().toString());
+    data.setId(tallyInstanceView.getId());
+    data.setInstanceId(tallyInstanceView.getKey().getInstanceId().toString());
     data.setDisplayName(tallyInstanceView.getDisplayName());
     data.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
     data.setLastSeen(tallyInstanceView.getLastSeen());


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-864

Test Steps

- Insert mock hosts: `bin/insert-mock-hosts --num-physical=1`
- Start app with: `DEV_MODE=true ./gradlew :bootRun`
- curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=cores'   -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
- Check that 'id' matches host id field and instance_id matches instance_id field