### PR TITLE
SWATCH-800: Add BASILISK placeholder PAYG product

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,11 @@ Service that syncs system data from Hosted Candlepin into HBI.
 | capacity-ingress          | platform.rhsm-subscriptions.subscription-prune | swatch-subscriptions-sync           |
 </details>
 
+## BASILISK (placeholder/testing PAYG product)
+
+In order to generate mock data for BASILISK, use `PRODUCT=BASILISK bin/prometheus-mock-data.sh` (this generates mock data into a prometheus process),
+or use `bin/import-events.py --file bin/BASILISK.csv` to import BASILISK data directly in, bypassing prometheus.
+
 ## License
 
 Subscription watch components are licensed GPLv3 (see LICENSE for more details).

--- a/bin/BASILISK.csv
+++ b/bin/BASILISK.csv
@@ -1,0 +1,13 @@
+event_type,account,org_id,instance,timestamp,expiration,role,sla,uom,value,service_type,billing_provider,billing_account_id
+redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,BASILISK,Premium,Storage-gibibytes,0.2,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,BASILISK,Premium,Storage-gibibytes,0.5,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,BASILISK,Premium,Storage-gibibytes,0.75,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,BASILISK,Premium,Storage-gibibytes,1.5,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:cluster_hour,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,BASILISK,Premium,Instance-hours,1,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:cluster_hour,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,BASILISK,Premium,Instance-hours,0,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:cluster_hour,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,BASILISK,Premium,Instance-hours,1,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:cluster_hour,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,BASILISK,Premium,Instance-hours,1,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:transfer_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,BASILISK,Premium,Transfer-gibibytes,1.5,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:transfer_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,BASILISK,Premium,Transfer-gibibytes,2.5,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:transfer_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,BASILISK,Premium,Transfer-gibibytes,3.5,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:transfer_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,BASILISK,Premium,Transfer-gibibytes,2,BASILISK Instance,red hat,dummyId

--- a/bin/prometheus-mock-data.sh
+++ b/bin/prometheus-mock-data.sh
@@ -21,7 +21,7 @@ run_container() {
 entrypoint() {
   CLUSTER_ID=${CLUSTER_ID:-test01}
   BILLING_PROVIDER=${BILLING_PROVIDER:-aws}
-  METRICS="${METRICS:-kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes}"
+  METRICS="${METRICS:-kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months}"
   PRODUCT=${PRODUCT:-rhosak}
   MARKETPLACE_ACCOUNT=${MARKETPLACE_ACCOUNT:-mktp-123}
   ACCOUNT=${ACCOUNT:-account123}

--- a/src/main/resources/liquibase/202302141154-add-basilisk-product.xml
+++ b/src/main/resources/liquibase/202302141154-add-basilisk-product.xml
@@ -1,0 +1,22 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202302141154-1" author="khowell">
+    <comment>Add offering for BASILISK SKU</comment>
+    <insert tableName="offering">
+      <column name="sku" value="BASILISK"/>
+      <column name="product_name" value="BASILISK"/>
+      <column name="role" value="BASLISK"/>
+      <column name="sla" value="Premium"/>
+      <column name="usage" value="Production"/>
+      <column name="cores" value="0"/>
+      <column name="sockets" value="0"/>
+      <column name="hypervisor_cores" value="0"/>
+      <column name="hypervisor_sockets" value="0"/>
+    </insert>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -100,5 +100,6 @@
     <include file="liquibase/202301251546-remove-sockets-and-cores-from-hosts-table.xml"/>
     <include file="liquibase/202212161446-add-derived-sku-to-offering.xml"/>
     <include file="liquibase/202301311609-update-tally-instance-view-default-num-of-guest-add-subscription_manager_id.xml"/>
+    <include file="liquibase/202302141154-add-basilisk-product.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-core/schemas/event.yaml
+++ b/swatch-core/schemas/event.yaml
@@ -135,6 +135,7 @@ properties:
       - rhosak
       - rhacs
       - addon-open-data-hub
+      - BASILISK
     required: false
   sla:
     description: Service level for the subject.

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -102,6 +102,10 @@ tagMappings:
     valueType: role
     tags:
       - rhods
+  - value: BASILISK
+    valueType: role
+    tags:
+      - BASILISK
 
   - value: Red Hat Enterprise Linux Server
     valueType: role
@@ -144,6 +148,11 @@ tagMappings:
     valueType: productName
     tags:
       - rhods
+
+  - value: BASILISK
+    valueType: productName
+    tags:
+      - BASILISK
 
   # System Architecture
   - value: aarch64
@@ -287,6 +296,38 @@ tagMetrics:
       prometheusMetric: cluster:usage:workload:capacity_virtual_cpu_hours
       prometheusMetadataMetric: ocm_subscription_resource
 
+  # BASILISK metrics
+  - tag: BASILISK
+    metricId: redhat.com:BASILISK:transfer_gb
+    rhmMetricId: redhat.com:BASILISK:transfer_gb
+    awsDimension: transfer_gb
+    uom: TRANSFER_GIBIBYTES
+    billingWindow: MONTHLY
+    queryParams:
+      product: BASILISK
+      prometheusMetric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
+      prometheusMetadataMetric: subscription_labels
+  - tag: BASILISK
+    metricId: redhat.com:BASILISK:cluster_hour
+    rhmMetricId: redhat.com:BASILISK:cluster_hour
+    awsDimension: cluster_hour
+    uom: INSTANCE_HOURS
+    billingWindow: MONTHLY
+    queryParams:
+      product: BASILISK
+      prometheusMetric: kafka_id:strimzi_resource_state:max_over_time1h
+      prometheusMetadataMetric: subscription_labels
+  - tag: BASILISK
+    metricId: redhat.com:BASILISK:storage_gib_months
+    rhmMetricId: redhat.com:BASILISK:storage_gib_months
+    awsDimension: storage_gb
+    uom: STORAGE_GIBIBYTE_MONTHS
+    billingWindow: MONTHLY
+    queryParams:
+      product: BASILISK
+      prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
+      prometheusMetadataMetric: subscription_labels
+
   # RHEL metrics. This is ugly and we should find a way to consolidate this.
   - tag: RHEL
     uom: SOCKETS
@@ -356,6 +397,13 @@ tagMetaData:
   - tags:
       - rhods
     serviceType: Rhods Cluster
+    finestGranularity: HOURLY
+    defaultSla: PREMIUM
+    defaultUsage: PRODUCTION
+    billingModel: PAYG
+  - tags:
+      - BASILISK
+    serviceType: BASILISK Instance
     finestGranularity: HOURLY
     defaultSla: PREMIUM
     defaultUsage: PRODUCTION

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -728,6 +728,7 @@ objects:
       name: capacity-allowlist
     data:
       product-allowlist.txt: |-
+        BASILISK
         CL110
         CL110A
         CL110IGE


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-800

It's essentially RHOSAK, but with a different product_tag, offering name, and product/role.

We chose RHOSAK, because it's a recent PAYG implementation and has multiple metrics.

Note I also updated the mock prometheus script to use monthly storage metrics.

Testing
=======

Try running a mock prometheus w/ BASILISK data:

```shell
PRODUCT=BASILISK bin/prometheus-mock-data.sh
```

Also run our service:

```shell
DEV_MODE=true ./gradlew :bootRun
```

Trigger an import of metrics (adjust the timestamp to be top of the previous hour):

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.metering.jmx:name=meteringJmxBean,type=MeteringJmxBean \
  operation='performCustomMetering(java.lang.String,java.lang.String,java.lang.Integer)' \
  arguments:='["BASILISK","2023-02-10T17:00:00Z",1200]'
```

Observe that BASILISK events are in the DB:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
select * from events; -- where event_type like '%BASILISK%'
EOF
```

Try an hourly tally (again adjust the tally interval timestamps):

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)' \
  arguments:='["org123", "2023-02-01T00:00Z","2023-02-28T17:00Z"]'
```

Observe we have tally results:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
select * from hosts;
select * from tally_snapshots;
EOF
```

Clear events:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
truncate table events;
truncate table hosts cascade;
truncate table tally_snapshots cascade;
EOF
```

Run the import events script with BASILISK data:

```shell
bin/import-events.py --file=bin/BASILISK.csv
```

Try an hourly tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)' \
  arguments:='["org123", "2021-10-01T00:00Z","2021-10-28T17:00Z"]'
```

See again that there are tally results for BASILISK:

```shell
psql -h localhost -U rhsm-subscriptions <<EOF
select * from hosts;
select * from tally_snapshots;
EOF
```