### PR TITLE
SWATCH-800: Add BASILISK to api spec

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1075,6 +1075,7 @@ components:
         - rhosak
         - rhacs
         - rhods
+        - BASILISK
     MetricId:
       type: string
       enum:


### PR DESCRIPTION
Forgot to do this in #1844.