### PR TITLE
SWATCH-869 Remove cast on instance_id in tally_instance_view

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -82,7 +82,8 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
         }
 
     _generate_insert('hosts', **host_fields)
-    _generate_measurements(host_id, uom, 1.0)
+    if not is_hbi:
+        _generate_measurements(host_id, uom, 1.0)
     if not is_hbi and not skip_buckets:
         _generate_buckets(host_id, product, sla, usage, as_hypervisor=is_hypervisor, cores=cores, sockets=sockets, measurement_type=measurement_type,
         billing_provider=billing_provider, billing_account_id=billing_account_id)
@@ -296,13 +297,14 @@ for i in range(args.num_accounts):
                                    billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
                                    uom=args.uom)
         # create a physical entry for the host as well.
-        generate_host(account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
-                      product=args.product,
-                      sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True,
-                      is_hbi=args.is_hbi,
-                      is_marketplace=args.is_marketplace,
-                      host_type=args.host_type,
-                     billing_provider=args.billing_provider, billing_account_id=args.billing_account_id, uom=args.uom)
+        if not args.is_hbi:
+            generate_host(account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
+                          product=args.product,
+                          sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True,
+                          is_hbi=args.is_hbi,
+                          is_marketplace=args.is_marketplace,
+                          host_type=args.host_type,
+                          billing_provider=args.billing_provider, billing_account_id=args.billing_account_id, uom=args.uom)
 
     create_unmapped = args.unmapped_guests
     for i in range(args.num_guests):

--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -67,8 +67,6 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
             'org_id': org,
             'display_name': display_name or insights_id,
             'subscription_manager_id': subscription_manager_id or uuid.uuid4(),
-            'cores': cores,
-            'sockets': sockets,
             'is_guest': is_guest or False,
             'hypervisor_uuid': hypervisor_uuid or None,
             'hardware_type': hardware_type or 'PHYSICAL',

--- a/src/main/resources/liquibase/202302151544-remove-uuid-cast-on-instance-id-in-tally-instance-view.xml
+++ b/src/main/resources/liquibase/202302151544-remove-uuid-cast-on-instance-id-in-tally-instance-view.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202302151544-1" author="mstead">
+    <dropView viewName="tally_instance_view"/>
+  </changeSet>
+
+  <changeSet id="202302151544-2" author="mstead">
+    <comment>Create view of hosts and host_tally_buckets for use in Instance API</comment>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_view">
+      select
+          distinct org_id,
+          h.id,
+          h.instance_id as instance_id,
+          h.display_name,
+          h.billing_provider as host_billing_provider,
+          h.billing_account_id as host_billing_account_id,
+          b.billing_provider as bucket_billing_provider,
+          b.billing_account_id as bucket_billing_account_id,
+          h.last_seen,
+          coalesce(h.num_of_guests, 0) AS num_of_guests,
+          b.product_id,
+          b.sla,
+          b.usage,
+          coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+          m.uom,
+          m.value,
+          b.sockets,
+          b.cores,
+          h.subscription_manager_id
+      from hosts h
+          join host_tally_buckets b on h.id = b.host_id
+          left outer join instance_measurements m on h.id = m.instance_id;
+    </createView>
+  </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -101,5 +101,6 @@
     <include file="liquibase/202212161446-add-derived-sku-to-offering.xml"/>
     <include file="liquibase/202301311609-update-tally-instance-view-default-num-of-guest-add-subscription_manager_id.xml"/>
     <include file="liquibase/202302141154-add-basilisk-product.xml"/>
+    <include file="/liquibase/202302151544-remove-uuid-cast-on-instance-id-in-tally-instance-view.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -78,9 +78,7 @@ class InstancesResourceTest {
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
-    tallyInstanceView
-        .getKey()
-        .setInstanceId(UUID.fromString("d6214a0b-b344-4778-831c-d53dcacb2da3"));
+    tallyInstanceView.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
     tallyInstanceView.getKey().setUom(Measurement.Uom.SOCKETS);
@@ -163,9 +161,7 @@ class InstancesResourceTest {
     tallyInstanceViewPhysical.setDisplayName("rhv.example.com");
     tallyInstanceViewPhysical.setNumOfGuests(3);
     tallyInstanceViewPhysical.setLastSeen(OffsetDateTime.now());
-    tallyInstanceViewPhysical
-        .getKey()
-        .setInstanceId(UUID.fromString("d6214a0b-b344-4778-831c-d53dcacb2da3"));
+    tallyInstanceViewPhysical.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     tallyInstanceViewPhysical.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceViewPhysical.getKey().setMeasurementType(HardwareMeasurementType.PHYSICAL);
     tallyInstanceViewPhysical.getKey().setUom(Measurement.Uom.SOCKETS);
@@ -176,9 +172,7 @@ class InstancesResourceTest {
     tallyInstanceViewHypervisor.setDisplayName("rhv.example.com");
     tallyInstanceViewHypervisor.setNumOfGuests(3);
     tallyInstanceViewHypervisor.setLastSeen(OffsetDateTime.now());
-    tallyInstanceViewHypervisor
-        .getKey()
-        .setInstanceId(UUID.fromString("d6214a0b-b344-4778-831c-d53dcacb2da3"));
+    tallyInstanceViewHypervisor.getKey().setInstanceId("d6214a0bb3444778831cd53dcacb2da3");
     tallyInstanceViewHypervisor.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceViewHypervisor.getKey().setMeasurementType(HardwareMeasurementType.HYPERVISOR);
     tallyInstanceViewHypervisor.getKey().setUom(Measurement.Uom.SOCKETS);
@@ -261,9 +255,7 @@ class InstancesResourceTest {
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
-    tallyInstanceView
-        .getKey()
-        .setInstanceId(UUID.fromString("d6214a0b-b344-4778-831c-d53dcacb2da3"));
+    tallyInstanceView.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.AWS);
     tallyInstanceView.getKey().setUom(Measurement.Uom.CORE_SECONDS);
@@ -360,9 +352,7 @@ class InstancesResourceTest {
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
-    tallyInstanceView
-        .getKey()
-        .setInstanceId(UUID.fromString("d6214a0b-b344-4778-831c-d53dcacb2da3"));
+    tallyInstanceView.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
     tallyInstanceView.getKey().setProductId("RHEL");

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.db.model;
 
 import java.io.Serializable;
-import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
@@ -43,7 +42,7 @@ import org.candlepin.subscriptions.json.Measurement;
 public class TallyInstanceViewKey implements Serializable {
 
   @Column(name = "instance_id")
-  private UUID instanceId;
+  private String instanceId;
 
   @Column(name = "product_id")
   private String productId;


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-869

Our instance view was casting host.instance_id to a UUID, but,
host.instance_id on the hosts table isn't always a proper UUID(
i.e OpenShift Clusters).

When querying against the view, if the instance_id stored in the
host table is not a proper UUID, it would cause an error at the DB level.

This patch removes the cast on instance_id and updates the field to a
String in the view class.

**NOTE** This PR also fixes a couple issues in the insert-mock-hosts script. The fixes are in separate commits.

## Testing
**Check out this PR's branch so that the fixes are applied to the insert-mock-hosts script** and insert a couple mock hosts into the tally DB.
```
bin/insert-mock-hosts --org=123456 --num-physical=2
```

**CHECK OUT THE MAIN BRANCH**

Determine the host IDs so that we can update the instance_id of one of them to not be a UUID (script generates a UUID as the instance_id)
```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select id, instance_id from hosts where org_id='123456'"
                  id                  |             instance_id              
--------------------------------------+--------------------------------------
 d0a96421-f5f6-436c-b7e9-d8eaa514afa4 | 7239bc70-1300-4903-844f-369fd833933b
 831f224c-ce01-426f-9698-bc8becfcc1a0 | 2b6cb6c5-f5e5-4244-a6e9-de0f0764c75f
(2 rows)
```

Update the instance_id of one record with something that is not a UUID. This example uses a cluster id from OpenShift metrics.
```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "update hosts set instance_id='c5ff3f4ctr234ihcgr8g' where id='d0a96421-f5f6-436c-b7e9-d8eaa514afa4'"
```
A simple query will reproduce the bug.
```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from tally_instance_view where org_id='123456'"
ERROR:  invalid input syntax for type uuid: "c5ff3f4ctr234ihcgr8g"
```

Deploy the application
```
DEV_MODE=true ./gradlew clean :bootRun
```

Reproduce via the Instances API
```
$ curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=cores&sort=category&dir=asc' -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ=='
{"errors":[{"status":"500","code":"SUBSCRIPTIONS1000","title":"An internal server error has occurred. Check the server logs for further details.","detail":"could not extract ResultSet; SQL [n/a]; nested exception is org.hibernate.exception.DataException: could not extract ResultSet"}]}
```

Examining the stack trace you should see:
```
Caused by: org.postgresql.util.PSQLException: ERROR: invalid input syntax for type uuid: "c5ff3f4ctr234ihcgr8g"
```

Check out this PR's branch and deploy the app.
```
DEV_MODE=true ./gradlew clean :bootRun
```

Run the query again and results should be returned.
```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from tally_instance_view where org_id='123456'"
```

Test the API again as well and a proper response should be returned.
```
curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=cores&sort=category&dir=asc' -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNDU2In19fQ=='
```