### PR TITLE
SWATCH-830: Subscriptions sync map for swatch contracts

### DIFF
--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-fault-tolerance'
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
+    implementation project(':clients:swatch-internal-subscription-client')
     implementation libraries["clowder-quarkus-config-source"]
     implementation libraries["quarkus-logging-splunk"]
     implementation libraries["splunk-library-javalogging"]

--- a/swatch-contracts/src/main/java/com/redhat/swatch/rest/SwatchPskHeaderFilter.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/rest/SwatchPskHeaderFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.rest;
+
+import io.quarkus.arc.Unremovable;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Slf4j
+// NOTE: without @Unremovable quarkus attempts to optimize this bean out because it's only
+// referenced in application.properties
+@Unremovable
+@ApplicationScoped
+public class SwatchPskHeaderFilter implements ClientRequestFilter {
+
+  @ConfigProperty(name = "SWATCH_SELF_PSK")
+  String psk;
+
+  @Override
+  public void filter(ClientRequestContext requestContext) {
+    requestContext.getHeaders().add("x-rh-swatch-psk", psk);
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/subscriptions/SubscriptionSyncResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/subscriptions/SubscriptionSyncResource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.subscriptions;
+
+import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
+import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi;
+import com.redhat.swatch.openapi.model.OfferingProductTags;
+import com.redhat.swatch.openapi.resource.OfferingsApi;
+import com.redhat.swatch.subscriptions.mapper.ProductTagsMapper;
+import javax.inject.Inject;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.ProcessingException;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+public class SubscriptionSyncResource implements OfferingsApi {
+
+  @RestClient @Inject InternalSubscriptionsApi internalSubscriptionsApi;
+
+  @Inject ProductTagsMapper mapper;
+
+  public OfferingProductTags getSkuProductTags(@PathParam("sku") String sku) {
+    try {
+      return mapper.clientToApi(internalSubscriptionsApi.getSkuProductTags(sku));
+    } catch (ApiException e) {
+      throw new ProcessingException(e);
+    }
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/subscriptions/mapper/ProductTagsMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/subscriptions/mapper/ProductTagsMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.subscriptions.mapper;
+
+import com.redhat.swatch.clients.swatch.internal.subscription.api.model.OfferingProductTags;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "cdi")
+public interface ProductTagsMapper {
+
+  com.redhat.swatch.openapi.model.OfferingProductTags clientToApi(OfferingProductTags contract);
+}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 SERVER_PORT=${clowder.endpoints.swatch-contracts.port:8000}
+SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://swatch-subscription-sync-service:8000/api/rhsm-subscriptions/v1
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
 DATABASE_HOST: ${clowder.database.hostname:localhost}
@@ -24,6 +25,7 @@ SPLUNK_HEC_INCLUDE_EX=false
 %dev.SPLUNKMETA_host=${USER}@${HOSTNAME}
 %dev.SPLUNKMETA_namespace=local
 %dev.SPLUNK_HEC_INCLUDE_EX=true
+%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8001/api/rhsm-subscriptions/v1
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
@@ -77,3 +79,7 @@ quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".key-store-password=${KEYSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
+
+# configuration properties for subscriptions-sync
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.rest.SwatchPskHeaderFilter

--- a/swatch-contracts/src/main/resources/swatch_contracts_openapi.yaml
+++ b/swatch-contracts/src/main/resources/swatch_contracts_openapi.yaml
@@ -183,6 +183,32 @@ paths:
         -
           test: []
       operationId: createContract
+  /internal/offerings/{sku}/product_tags:
+      description: "Mapping sku to product tags."
+      parameters:
+        - name: sku
+          in: path
+          required: true
+          schema:
+            type: string
+      get:
+        summary: "Lookup product tags by sku"
+        operationId: getSkuProductTags
+        responses:
+          '200':
+            description: "The request to get product tags by sku ."
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/OfferingProductTags'
+                example:
+                  data:
+                    - Rho one
+                    - Rho two
+        tags:
+          - Offerings
+        security:
+          - test: []
 components:
   schemas:
     Error:
@@ -284,6 +310,12 @@ components:
       example:
         metric_id: Instance-hours
         value: 68.6
+    OfferingProductTags:
+      properties:
+        data:
+          type: array
+          items:
+            type: string
   securitySchemes:
     support:
       type: apiKey


### PR DESCRIPTION
This PR is to address SWATCH-830, we want swatch-contract to have the ability to sync a sku to product tag from rhsm.
 
Testing Steps:
We want to have data in the offerings table within `rhsm` database:
```
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW01485', 'OpenShift Container Platform', null, 0, 0, 0, 0, 'ocp', 'Premium', 'Production', 'Red Hat OpenShift Container Platform (Hourly)', null, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW01484', 'OpenShift Dedicated', null, 0, 0, 0, 0, 'osd', 'Premium', 'Production', 'Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)', null, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW01882', 'OpenShift Streams for Apache Kafka', null, 0, 0, 0, 0, 'rhosak', 'Premium', 'Production', 'Red Hat OpenShift Streams for Apache Kafka (Hourly)', null, null);
```
Next we want to run both boot application and swatch-contract in parallel. Make sure Boot Application is using a different port.
```
server.port = 8001
```
Once `swatch-contract` is running paste the link below into your browser for the Open API:
```
http://localhost:8000/q/swagger-ui/#/default/get_internal_offerings__sku__product_tags
```
Validation step: paste any`sku` from your offering table in rshm database into the contract API ` sku` parameter:
```
MW01484
```

The below response should look like below:
```
{
  "data": [
    "OpenShift-dedicated-metrics"
  ]
}
```