### PR TITLE
SWATCH-853: Tally - increase timing slack with conduit

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ RHSM_RBAC_USE_STUB=true ./gradlew bootRun
 * `PATH_PREFIX`: path prefix in the URLs (default: api)
 * `INVENTORY_USE_STUB`: Use stubbed inventory REST API
 * `INVENTORY_API_KEY`: API key for inventory service
-* `INVENTORY_HOST_LAST_SYNC_THRESHOLD`: reject hosts that haven't checked in since this duration (e.g. 24h)
+* `HOST_LAST_SYNC_THRESHOLD`: reject hosts that haven't checked in since this duration (e.g. 24h)
 * `INVENTORY_DATABASE_HOST`: inventory DB host
 * `INVENTORY_DATABASE_DATABASE`: inventory DB database
 * `INVENTORY_DATABASE_USERNAME`: inventory DB user

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -63,7 +63,7 @@ public class ApplicationProperties {
    * outdated. The host's rhsm.SYNC_TIMESTAMP fact is checked against this threshold. The default is
    * 24 hours.
    */
-  private int hostLastSyncThresholdHours = 24;
+  private Duration hostLastSyncThreshold = Duration.ofHours(24);
 
   /**
    * The batch size of account numbers that will be processed at a time while producing snapshots.

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -357,6 +357,8 @@ public class FactNormalizer {
     if (lastSync == null) {
       return false;
     }
-    return lastSync.isBefore(clock.now().minus(hostSyncThreshold));
+    // NOTE: sync threshold is relative to conduit schedule - i.e. midnight UTC
+    // otherwise the sync threshold would be offset by the tally schedule, which would be confusing
+    return lastSync.isBefore(clock.startOfToday().minus(hostSyncThreshold));
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.facts;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,14 +49,15 @@ public class FactNormalizer {
   private static final Logger log = LoggerFactory.getLogger(FactNormalizer.class);
 
   private final ApplicationClock clock;
-  private final int hostSyncThresholdHours;
+  private final Duration hostSyncThreshold;
   private final Map<Integer, Set<String>> engProductIdToSwatchProductIdsMap;
   private final Map<String, Set<String>> roleToProductsMap;
 
   public FactNormalizer(
       ApplicationProperties props, TagProfile tagProfile, ApplicationClock clock) {
     this.clock = clock;
-    this.hostSyncThresholdHours = props.getHostLastSyncThresholdHours();
+    this.hostSyncThreshold = props.getHostLastSyncThreshold();
+    log.info("rhsm-conduit stale threshold: {}", this.hostSyncThreshold);
     this.engProductIdToSwatchProductIdsMap = tagProfile.getEngProductIdToSwatchProductIdsMap();
     this.roleToProductsMap = tagProfile.getRoleToTagLookup();
   }
@@ -355,6 +357,6 @@ public class FactNormalizer {
     if (lastSync == null) {
       return false;
     }
-    return lastSync.isBefore(clock.now().minusHours(hostSyncThresholdHours));
+    return lastSync.isBefore(clock.now().minus(hostSyncThreshold));
   }
 }

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -58,3 +58,4 @@ rhsm-subscriptions:
   tally-max-hbi-account-size: ${TALLY_MAX_HBI_ACCOUNT_SIZE:2147483647}  # Integer.MAX_VALUE by default
   legacy-nightly-tally-enabled: ${LEGACY_NIGHTLY_TALLY_ENABLED:false}
   hbi-reconciliation-flush-interval: ${HBI_RECONCILIATION_FLUSH_INTERVAL:1024}
+  host-last-sync-threshold: ${HOST_LAST_SYNC_THRESHOLD:24h}

--- a/swatch-system-conduit/README.md
+++ b/swatch-system-conduit/README.md
@@ -12,7 +12,7 @@ The following environment variables are specific to the system-conduit service:
 * `RHSM_KEYSTORE_PASSWORD`: RHSM API client cert keystore password
 * `RHSM_BATCH_SIZE`: host sync batch size
 * `RHSM_MAX_CONNECTIONS`: maximum concurrent connections to RHSM API
-* `INVENTORY_HOST_LAST_SYNC_THRESHOLD`: reject hosts that haven't checked in since this duration (e.g. 24h)
+* `HOST_LAST_SYNC_THRESHOLD`: reject hosts that haven't checked in since this duration (e.g. 24h)
 * `INVENTORY_ENABLE_KAFKA`: whether kafka should be used (inventory API otherwise)
 * `INVENTORY_HOST_INGRESS_TOPIC`: kafka topic to emit host records
 * `INVENTORY_ADD_UUID_HYPHENS`: whether to add missing UUID hyphens to the Insights ID

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -95,6 +95,8 @@ parameters:
     value: '3'
   - name: KAFKA_HOST_INGRESS_PARTITIONS
     value: '3'
+  - name: HOST_LAST_SYNC_THRESHOLD
+    value: '30h'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -227,6 +229,8 @@ objects:
               value: ${KAFKA_SEEK_OVERRIDE_END}
             - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
               value: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP}
+            - name: HOST_LAST_SYNC_THRESHOLD
+              value: ${HOST_LAST_SYNC_THRESHOLD}
             - name: DATABASE_HOST
               valueFrom:
                 secretKeyRef:

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/rhsm/RhsmService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/rhsm/RhsmService.java
@@ -58,6 +58,7 @@ public class RhsmService {
       RhsmApi api,
       @Qualifier("rhsmRetryTemplate") RetryTemplate retryTemplate) {
     this.hostCheckinThreshold = inventoryServiceProperties.getHostLastSyncThreshold();
+    log.info("rhsm-conduit stale threshold: {}", hostCheckinThreshold);
     this.batchSize = apiProperties.getRequestBatchSize();
     this.api = api;
     this.retryTemplate = retryTemplate;

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -23,7 +23,7 @@ rhsm-conduit:
   inventory-service:
     use-stub: ${INVENTORY_USE_STUB:true}
     api-key: ${INVENTORY_API_KEY:changeit}
-    host-last-sync-threshold: ${INVENTORY_HOST_LAST_SYNC_THRESHOLD:24h}
+    host-last-sync-threshold: ${HOST_LAST_SYNC_THRESHOLD:24h}
     add-uuid-hyphens: ${INVENTORY_ADD_UUID_HYPHENS:false}
     # FIXME: misnamed, it's actually in hours
     stale-host-offset-in-days: ${INVENTORY_STALE_HOST_OFFSET_HOURS:48}

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -91,11 +91,13 @@ parameters:
     value: 1s
   - name: TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER
     value: '2'
+  - name: HOST_LAST_SYNC_THRESHOLD
+    value: 30h
 
   - name: PURGE_SNAPSHOT_SCHEDULE
     value: 0 3 * * *
   - name: CAPTURE_SNAPSHOT_SCHEDULE
-    value: 0 1 * * *
+    value: 0 6 * * *
   - name: CAPTURE_HOURLY_SNAPSHOT_SCHEDULE
     value: '@hourly'
   - name: EVENT_RECORD_RETENTION
@@ -395,6 +397,8 @@ objects:
               value: ${LEGACY_NIGHTLY_TALLY_ENABLED}
             - name: HBI_RECONCILIATION_FLUSH_INTERVAL
               value: ${HBI_RECONCILIATION_FLUSH_INTERVAL}
+            - name: HOST_LAST_SYNC_THRESHOLD
+              value: ${HOST_LAST_SYNC_THRESHOLD}
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-853

Assumptions about conduit updates being processed before tally were insufficient. Accordingly, we're adding some timing slack.

Per PM input:
* Updated stale threshold to 30 hours (instead of 24 hours).
* Updated the schedule for nightly tallies to 6 am UTC, so HBI has longer to process updates before we tally.

With this change, systems that haven't checked in can take up to 30 hours before being filtered from tallies.

I also changed the stale threshold to use midnight UTC as its reference point, so that the stale threshold doesn't get offset by the tally schedule. A 30 hour threshold should mean that a system checked in more than 30 hours prior to the last sync, rather than 30 hours from the time of the tally.

Testing
=======

This is essentially just configuration changes.

Observe the logging of the updated default of 30 hours when deployed to ephemeral environment (`/retest` and look at the tally startup logs, or alternatively manually deploy to ephemeral and then view the logs).

Also observe the updated cronjob schedule for `swatch-tally-tally` in the environment.