### PR TITLE
SWATCH-819 Add contractEnabled flag to TagMetaData

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagMetaData.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagMetaData.java
@@ -47,4 +47,5 @@ public class TagMetaData {
   private ServiceLevel defaultSla;
   private Usage defaultUsage;
   private String billingModel;
+  private boolean contractEnabled;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagProfile.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagProfile.java
@@ -143,6 +143,7 @@ public class TagProfile {
     if (StringUtils.hasText(tagMetaData.getServiceType())) {
       serviceTypes.add(tagMetaData.getServiceType());
     }
+    validateTagMetaData(tagMetaData);
     tagMetaData
         .getTags()
         .forEach(
@@ -150,6 +151,15 @@ public class TagProfile {
               tagMetaDataToTagLookup.put(tag, tagMetaData);
               finestGranularityLookup.put(tag, tagMetaData.getFinestGranularity());
             });
+  }
+
+  private void validateTagMetaData(TagMetaData tagMetaData) {
+    if (tagMetaData.isContractEnabled() && !"PAYG".equals(tagMetaData.getBillingModel())) {
+      throw new IllegalStateException(
+          String.format(
+              "A tag can only be configured as contractEnabled if billingModel=PAYG. %s",
+              tagMetaData));
+    }
   }
 
   public boolean tagSupportsEngProduct(String tag, String engId) {
@@ -314,6 +324,15 @@ public class TagProfile {
       return StringUtils.hasText(billingModel) && "PAYG".equalsIgnoreCase(billingModel);
     }
 
+    return false;
+  }
+
+  public boolean isTagContractEnabled(String productTag) {
+    var tagMeta = this.getTagMetaDataByTag(productTag);
+    if (tagMeta.isPresent()) {
+      String billingModel = tagMeta.get().getBillingModel();
+      return tagMeta.get().isContractEnabled() && "PAYG".equalsIgnoreCase(billingModel);
+    }
     return false;
   }
 }

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -408,3 +408,4 @@ tagMetaData:
     defaultSla: PREMIUM
     defaultUsage: PRODUCTION
     billingModel: PAYG
+    contractEnabled: true


### PR DESCRIPTION
# Details
TagMetaData now has a new 'contractEnabled' field that can be set for a configured tag. By default it is set to false.

The contractEnabled field can only be set to true if the billingModel field is 'PAYG'. If not, the application will fail to start up, indicating a configuration error.

The BASILISK configuration has been updated to enable contracts.

# Reference
https://issues.redhat.com/browse/SWATCH-819

# How To Test
1. Start the application and verify that the added configuration for BASILISK does not prevent the application from starting.
```
./gradlew clean :bootRun
```

2. Verify that the app will not start when `contractEnabled` is set to `true` and `billingModel` is NOT `PAYG`. To do this, edit the `tag_profile.yaml` file and set the `billingModel` to anything other than `PAYG` for the BASILISK `tagMetaData`.
```
tagMetaData:
  #
  # Other meta data sections
  #
  - tags:
      - BASILISK
    serviceType: BASILISK Instance
    finestGranularity: HOURLY
    defaultSla: PREMIUM
    defaultUsage: PRODUCTION
    billingModel: NOTPAYG    <=========== UPDATE THIS!!!
    contractEnabled: true
```

3. Start the application
```
./gradlew clean :bootRun
```

4. Verify in the logs that the application does not start up due to the invalid configuration.
```
Caused by: java.lang.IllegalStateException: A tag can only be configured as contractEnabled if billingModel=PAYG. TagMetaData(tags=[BASILISK], serviceType=BASILISK Instance, finestGranularity=HOURLY, defaultSla=PREMIUM, defaultUsage=PRODUCTION, billingModel=NOTPAYG, contractEnabled=true)
```