### PR TITLE
SWATCH-872: update exception message to print relevant product API response info

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
+++ b/src/main/java/org/candlepin/subscriptions/product/UpstreamProductData.java
@@ -111,7 +111,9 @@ class UpstreamProductData {
     } catch (ApiException e) {
       throw new ExternalServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR,
-          "Unable to retrieve upstream offeringSku=\"" + sku + "\"",
+          String.format(
+              "Unable to retrieve upstream offeringSku=\"%s\". API returned status: %s, message: %s, and responseBody: %s",
+              sku, e.getCode(), e.getMessage(), e.getResponseBody()),
           e);
     }
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-872

Test Steps:

- Configure app to connect to stage product service with appropriate certs.
- start app with `DEV_MODE=true ./gradlew :bootRun `
- Open http://localhost:9000/hawtio/jmx/operations?nid=root-org.candlepin.subscriptions.product-OfferingJmxBean-offeringJmxBean and call operation with sku of empty string "  ";
- Should see log similar too (unsure if we will ever get non null response body but prefer to print in case there is more detail):
```
org.candlepin.subscriptions.exception.ExternalServiceException: Unable to retrieve upstream offeringSku="". API returned status: 404, message: error, and responseBody: null
```
