### PR TITLE
SWATCH-902 Fix major/minor version parsing in system-conduit

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -189,7 +189,7 @@ public abstract class InventoryService {
   private void setOperatingSystemVersion(
       HbiSystemProfileOperatingSystem operatingSystem, String operatingSystemVersion) {
     var versions = operatingSystemVersion.split("\\.");
-    if (versions.length == 2) {
+    if (versions.length >= 2) {
       operatingSystem.setMajor(Integer.parseInt(versions[0]));
       operatingSystem.setMinor(Integer.parseInt(versions[1]));
     } else if (versions.length == 1 && !versions[0].isBlank()) {


### PR DESCRIPTION
# Details
**JIRA** https://issues.redhat.com/browse/SWATCH-902

The code was assuming that an OS version will only be made up two parts (major.minor), when in reality it could include more (i.e x.y.z).

This patch ensures that os versions such as 1.2.34, 1.2.3.45 (and so on) are considered when determining the major/minor version values.


# How To Test

1. Check out `main` branch
2. Update the `distribution.version` consumer fact in `StubRhsmApi.java` to reflect the release version in the error message: `5.14.0.70.22.1.rt21.94.rhel9u0`
3. Deploy the  application
```
RHSM_USE_STUB=true DEV_MODE=true ./gradlew swatch-system-conduit:bootRun
```
4. Sync an org via system-conduit
```
http :9000/hawtio/jolokia type=exec mbean=org.candlepin.subscriptions.conduit.jmx:name=rhsmConduitJmxBean,type=RhsmConduitJmxBean  operation='syncOrg(java.lang.String)'   arguments:='["org123"]'
```
5. Check the logs and you should see the following exception:
```
2023-02-23 17:08:08,610 [thread=http-nio-9000-exec-6] [WARN ] [org.candlepin.subscriptions.conduit.inventory.InventoryService] - Invalid OperatingSystemVersion: found "5.14.0.70.22.1.rt21.94.rhel9u0" but should be in format "major.minor"
```

6. Stash the changes to the StubRhsmApi using git so you don't have to make them again after switching branches.
```
$ git stash
```

7. Check out the branch for this PR

8. Apply the stub changes that were stashed away:
```
git stash apply
```

9. Deploy the swatch-system-conduit again
```
RHSM_USE_STUB=true DEV_MODE=true ./gradlew swatch-system-conduit:bootRun
```

10. Sync org again.
```
http :9000/hawtio/jolokia type=exec mbean=org.candlepin.subscriptions.conduit.jmx:name=rhsmConduitJmxBean,type=RhsmConduitJmxBean  operation='syncOrg(java.lang.String)'   arguments:='["org123"]'
```

11. No error log should be present!