### PR TITLE
SWATCH-965: Add MW02291 to allowlist

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -2442,6 +2442,7 @@ objects:
         MW0222833F3RN
         MW0222833RN
         MW0222833S
+        MW02291
         MW0232248
         MW0232248F3
         MW0232248F3RN


### PR DESCRIPTION
RHACS is using an additional SKU. Will also create a hotfix version so we can get this update to prod faster.