### PR TITLE
SWATCH-561 Log unknown org as WARNING when not found via RHSM API

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -68,6 +68,12 @@ public enum ErrorCode {
    */
   INVENTORY_SERVICE_REQUEST_ERROR(2002, "Inventory API Error"),
 
+  /** An unexpected exception was thrown by the RHSM service * */
+  RHSM_SERVICE_REQUEST_ERROR(2100, "RHSM Service Error"),
+
+  /** An unknown Org was used to make a request. * */
+  RHSM_SERVICE_UNKNOWN_ORG_ERROR(2101, "Org not present according to RH IT services"),
+
   // Metering Errors
   SUBSCRIPTION_SERVICE_REQUEST_ERROR(3000, "Subscription Service Error"),
 

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/jmx/RhsmConduitJmxBean.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/jmx/RhsmConduitJmxBean.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.conduit.InventoryController;
 import org.candlepin.subscriptions.conduit.job.OrgSyncTaskManager;
-import org.candlepin.subscriptions.conduit.rhsm.client.ApiException;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
 import org.candlepin.subscriptions.db.model.config.OrgConfig;
+import org.candlepin.subscriptions.exception.ExternalServiceException;
 import org.candlepin.subscriptions.exception.MissingAccountNumberException;
 import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -70,6 +70,9 @@ public class RhsmConduitJmxBean {
         "Starting JMX-initiated sync for org ID {} by {}", orgId, ResourceUtils.getPrincipal());
     try {
       controller.updateInventoryForOrg(orgId);
+    } catch (ExternalServiceException e) {
+      log.warn(e.getMessage());
+      throw new RhsmJmxException(e.getMessage());
     } catch (Exception e) {
       log.error("Error during JMX-initiated sync for org ID {}", orgId, e);
       throw new RhsmJmxException(e);
@@ -83,6 +86,9 @@ public class RhsmConduitJmxBean {
         ResourceUtils.getPrincipal());
     try {
       tasks.syncFullOrgList();
+    } catch (ExternalServiceException e) {
+      log.warn(e.getMessage());
+      throw new RhsmJmxException(e.getMessage());
     } catch (Exception e) {
       log.error("Error during JMX-initiated sync for full org list", e);
       throw new RhsmJmxException(e);
@@ -143,9 +149,9 @@ public class RhsmConduitJmxBean {
   public OrgInventory getInventoryForOrg(String orgId, String offset) throws RhsmJmxException {
     try {
       return controller.getInventoryForOrg(orgId, offset);
-    } catch (ApiException e) {
-      log.error("Unable to fetch org systems via JMX");
-      throw new RhsmJmxException(e);
+    } catch (ExternalServiceException e) {
+      log.warn(e.getMessage());
+      throw new RhsmJmxException(e.getMessage());
     } catch (MissingAccountNumberException e) {
       log.error("Systems are missing account number in orgId {}", orgId);
       throw new RhsmJmxException(e);

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/jmx/RhsmJmxException.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/jmx/RhsmJmxException.java
@@ -29,4 +29,8 @@ public class RhsmJmxException extends Exception {
   public RhsmJmxException(Throwable t) {
     super(t);
   }
+
+  public RhsmJmxException(String message) {
+    super(message);
+  }
 }


### PR DESCRIPTION
# Details
The InventoryController will now throw an ExternalServiceException instead of a general ApiException. If a 400 is detected when listing consumers from the RHSM API, it assumes that the org does not exist and sets an appropriate error code.

Callers have been updated, where applicable, to log a warning instead of an error (logging the entire exception).

# Reference
https://issues.redhat.com/browse/SWATCH-561

# Testing

Launch the app with the RHSM API configured against stage and adjust the backoff interval for retry in swatch-system-conduit. The keystore/password can be found in vault (reach out if you need help with this).
```
RHSM_BACK_OFF_MAX_INTERVAL=1s RHSM_URL=${STAGE_RHSM_API_URL} RHSM_KEYSTORE=${STAGE_RHSM_API_KEYSTORE} RHSM_KEYSTORE_PASSWORD=${STAGE_RHSM_API_KEYSTORE_PASSWORD} DEV_MODE=true ./gradlew clean swatch-system-conduit:bootRun
```

Opt-in an orgs. Use the DB so that you don't have to load all the other services.
```
insert into account_config (account_number, org_id, opt_in_type, created, updated) values ('account123', 'org123', 'JMX', '2023-03-01 14:16:34.432968-04', '2023-03-01 14:16:34.432968-04');
```
```
insert into org_config (org_id, opt_in_type, created, updated) values ('org123', 'JMX', '2023-03-01 14:16:34.432968-04', '2023-03-01 14:16:34.432968-04');
```

### Internal APIs
Internal APIs should now only log a warning. Run each and make sure this is what you are seeing.
```
http POST :8000/api/rhsm-subscriptions/v1/internal/rpc/syncAllOrgs x-rh-swatch-psk:placeholder
```

This API now returns a 404 when the org_id is not found, however should still only log a warning.
```
http POST :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg org_id=org123 x-rh-swatch-psk:placeholder
```

### JMX Endpoints

Calling any of the applicable JMX endpoints should now only log a warning when the org_id is not found. Run the following and keep an eye on the log files to make sure.
```
http :9000/hawtio/jolokia  type=exec mbean='org.candlepin.subscriptions.conduit.jmx:name=rhsmConduitJmxBean,type=RhsmConduitJmxBean'   operation='getInventoryForOrg(java.lang.String,java.lang.String)'   arguments:='["org123", ""]'
```

```
http :9000/hawtio/jolokia  type=exec mbean='org.candlepin.subscriptions.conduit.jmx:name=rhsmConduitJmxBean,type=RhsmConduitJmxBean'   operation='syncFullOrgList()'   arguments:='[]'
```

```
http :9000/hawtio/jolokia  type=exec mbean='org.candlepin.subscriptions.conduit.jmx:name=rhsmConduitJmxBean,type=RhsmConduitJmxBean'   operation='syncOrg(java.lang.String)'   arguments:='["org123"]'
```
