### PR TITLE
SWATCH-896: Add running total to newer Tally API

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -201,6 +201,14 @@ paths:
           type: integer
           minimum: 1
         description: "The numbers of items to return"
+      - name: use_running_totals_format
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default:
+            false
+        description: "Defines the end of the report period. Defaults to the current time. Dates should be provided in UTC."
     get:
       summary: "Fetch tally report data for an account and product. "
       description: "If page header parameters are omitted, any dates missing data will have an entry with null as the value."


### PR DESCRIPTION
This PR is to address https://issues.redhat.com/browse/SWATCH-896

These changes will allow the newer tally API to display the running total amount when needed.

Testing Steps:
First populate your events table, if you don't have some already in your local DB.
```
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('dcf4adc8-9f23-476a-9c94-9a405ce2facd', 'account123', '2021-10-30 20:00:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "dcf4adc8-9f23-476a-9c94-9a405ce2facd", "timestamp": "2021-10-30T20:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-11-01T01:00:00Z", "instance_id": "c5mu16smf1c22rn8e730", "display_name": "c5mu16smf1c22rn8e730", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 1.0}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('4cf4adc8-9f23-476a-9c94-9a405ce2facd', 'account123', '2021-10-31 20:00:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "4cf4adc8-9f23-476a-9c94-9a405ce2facd", "timestamp": "2021-10-31T20:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-11-01T01:00:00Z", "instance_id": "c5mu16smf1c22rn8e730", "display_name": "c5mu16smf1c22rn8e730", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 1.0}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('4cf4adc7-9f23-476a-9c94-9a405ee2face', 'account123', '2021-10-31 18:00:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "4cf4adc7-9f23-476a-9c94-9a405ee2face", "timestamp": "2021-10-31T18:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-11-01T00:00:00Z", "instance_id": "c5mu16smf1c22rn8e730", "display_name": "c5mu16smf1c22rn8e730", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 1.0}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('9cf4adc8-9f23-476a-9c94-9a405ce2facd', 'account123', '2021-10-29 20:00:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "9cf4adc8-9f23-476a-9c94-9a405ce2facd", "timestamp": "2021-10-29T20:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-11-01T01:00:00Z", "instance_id": "c5mu16smf1c22rn8e730", "display_name": "c5mu16smf1c22rn8e730", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 1.0}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');
```
2. Now run the tally JMX bean `tallyOrgByHourly()` use the follow parameters if you used the example data in step 1:
```
org123, 2021-10-01T00:00Z, 2021-11-01T00:00Z
```
3. Once tally is done running make sure to opt-in and use the following curl command:
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Cores?granularity=Hourly&beginning=2021-10-29T20%3A00%3A00Z&ending=2021-10-31T21%3A00%3A00Z&use_running_totals_format=true' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
4. Observe in the response that the data does not increase  from `1` at the beginning of the offset till `2021-10-30T20:00:00Z` in the hourly tally, if you skip to the end of the response you should see `4` 