### PR TITLE
SWATCH-805 Add server partner api to test resource

### DIFF
--- a/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
+++ b/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
@@ -85,8 +85,18 @@ components:
             - aws_marketplace
         status:
           type: string
+        partnerIdentities:
+          $ref: '#/components/schemas/PartnerIdentityV1'
         purchase:
           $ref: '#/components/schemas/PurchaseV1'
+    PartnerIdentityV1:
+      properties:
+        awsCustomerId:
+          type: string
+        awsAccountId:
+          type: string
+        sellerAccountId:
+          type: string
     PurchaseV1:
       properties:
         productCode:

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -25,11 +25,17 @@ import com.redhat.swatch.contract.openapi.model.Dimension;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "cdi")
 public interface ContractMapper {
@@ -51,11 +57,9 @@ public interface ContractMapper {
   default ContractEntity reconcileUpstreamContract(PartnerEntitlementContract upstreamContract) {
     ContractEntity entity = partnerContractToContractEntity(upstreamContract);
     entity.setMetrics(dimensionToContractMetricEntity(upstreamContract.getCurrentDimensions()));
-    if (Objects.nonNull(upstreamContract.getCurrentDimensions())) {
-      entity.setEndDate(upstreamContract.getCurrentDimensions().get(0).getExpirationDate());
     return entity;
   }
-  
+
   @AfterMapping
   default void propogateContractUuid(
       @MappingTarget final ContractEntity.ContractEntityBuilder contractEntity,

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -21,23 +21,15 @@
 package com.redhat.swatch.contract.model;
 
 import com.redhat.swatch.contract.openapi.model.Contract;
-import com.redhat.swatch.contract.openapi.model.Dimensions;
+import com.redhat.swatch.contract.openapi.model.Dimension;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "cdi")
 public interface ContractMapper {
@@ -52,60 +44,16 @@ public interface ContractMapper {
 
   @Mapping(target = "metricId", source = "dimension.dimensionName")
   @Mapping(target = "value", source = "dimension.dimensionValue")
-  ContractMetricEntity convert(Dimensions dimension);
+  ContractMetricEntity dimensionToContractMetricEntity(Dimension dimension);
 
-  Set<ContractMetricEntity> convert(List<Dimensions> dimensions);
+  Set<ContractMetricEntity> dimensionToContractMetricEntity(List<Dimension> dimensions);
 
   default ContractEntity reconcileUpstreamContract(PartnerEntitlementContract upstreamContract) {
     ContractEntity entity = partnerContractToContractEntity(upstreamContract);
-    entity.setMetrics(convert(upstreamContract.getCurrentDimensions()));
+    entity.setMetrics(dimensionToContractMetricEntity(upstreamContract.getCurrentDimensions()));
     if (Objects.nonNull(upstreamContract.getCurrentDimensions())) {
       entity.setEndDate(upstreamContract.getCurrentDimensions().get(0).getExpirationDate());
     }
     return entity;
-  }
-
-  /*default ContractEntity reconcileUpstreamContract(PartnerEntitlementContract upstreamContract) {
-    ContractEntity entity = partnerContractToContractEntity(upstreamContract);
-    if (Objects.isNull(entity) && Objects.isNull(upstreamContract.getCurrentDimensions())) {
-      Set<ContractMetricEntity> contractMetricEntitySet =
-          upstreamContract.getCurrentDimensions().stream()
-              .map(
-                  dimensions ->
-                      new ContractMetricEntity(
-                          null,
-                          dimensions.getDimensionName(),
-                          Integer.valueOf(dimensions.getDimensionValue()),
-                          null))
-              .collect(Collectors.toSet());
-      entity.setMetrics(contractMetricEntitySet);
-    }
-    return entity;
-  }*/
-
-  @AfterMapping
-  default void propogateContractUuid(
-      @MappingTarget final ContractEntity.ContractEntityBuilder contractEntity,
-      final Contract contractDto) {
-
-    if (Objects.requireNonNullElse(contractDto.getMetrics(), new ArrayList<>()).isEmpty()) {
-      contractEntity.metrics(new HashSet<>());
-    } else {
-      var metrics =
-          contractDto.getMetrics().stream()
-              .map(
-                  (x -> {
-                    var builder = ContractMetricEntity.builder();
-                    builder.metricId(x.getMetricId());
-                    builder.value(x.getValue());
-                    if (Objects.nonNull(contractDto.getUuid())) {
-                      builder.contractUuid(UUID.fromString(contractDto.getUuid()));
-                    }
-                    return builder.build();
-                  }))
-              .collect(Collectors.toSet());
-
-      contractEntity.metrics(metrics);
-    }
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
@@ -111,16 +111,13 @@ public class ContractEntity extends PanacheEntityBase {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ContractEntity that = (ContractEntity) o;
-    return Objects.equals(uuid, that.uuid)
-        && Objects.equals(subscriptionNumber, that.subscriptionNumber)
-        && Objects.equals(lastUpdated, that.lastUpdated)
-        && Objects.equals(startDate, that.startDate)
-        && Objects.equals(endDate, that.endDate)
+    return Objects.equals(subscriptionNumber, that.subscriptionNumber)
         && Objects.equals(orgId, that.orgId)
         && Objects.equals(sku, that.sku)
         && Objects.equals(billingProvider, that.billingProvider)
         && Objects.equals(billingAccountId, that.billingAccountId)
-        && Objects.equals(productId, that.productId);
+        && Objects.equals(productId, that.productId)
+        && Objects.equals(metrics, that.metrics);
   }
 
   @Override
@@ -135,6 +132,7 @@ public class ContractEntity extends PanacheEntityBase {
         sku,
         billingProvider,
         billingAccountId,
-        productId);
+        productId,
+        metrics);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractMetricEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractMetricEntity.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.contract.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import java.util.Objects;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -32,11 +33,15 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.ToString.Exclude;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Entity
 @IdClass(ContractMetricEmbeddableId.class)
 @Table(name = "contract_metrics")
@@ -61,4 +66,17 @@ public class ContractMetricEntity extends PanacheEntityBase {
   @ManyToOne(targetEntity = ContractEntity.class, fetch = FetchType.LAZY)
   @JoinColumn(name = "contract_uuid", insertable = false, updatable = false)
   private ContractEntity contract;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ContractMetricEntity that = (ContractMetricEntity) o;
+    return value == that.value && Objects.equals(metricId, that.metricId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(contractUuid, metricId, value);
+  }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
@@ -98,10 +98,7 @@ public class ContractRepository implements PanacheRepositoryBase<ContractEntity,
 
     String query =
         nonNullParams.keySet().stream()
-            .map(
-                key -> {
-                  return key + "=:" + key;
-                })
+            .map(key -> key + "=:" + key)
             .collect(Collectors.joining(" and "));
 
     if (isCurrentlyActive) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.contract.repository;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
@@ -80,14 +81,43 @@ public class ContractRepository implements PanacheRepositoryBase<ContractEntity,
     return find(query, nonNullParams).list();
   }
 
+  public Optional<ContractEntity> getContract(
+      Map<String, Object> parameters, boolean isCurrentlyActive) {
+    if (parameters == null) {
+      return Optional.empty();
+    }
+
+    Map<String, Object> nonNullParams =
+        parameters.entrySet().stream()
+            .filter(entry -> entry.getValue() != null)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    if (nonNullParams.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String query =
+        nonNullParams.keySet().stream()
+            .map(
+                key -> {
+                  return key + "=:" + key;
+                })
+            .collect(Collectors.joining(" and "));
+
+    if (isCurrentlyActive) {
+      query += " and endDate IS NULL ";
+    }
+
+    var contractTable = "select c from " + ContractEntity.class.getName() + " c where ";
+    query = contractTable + query;
+
+    log.info("Dynamically generated query: {}", query);
+
+    return find(query, nonNullParams).singleResultOptional();
+  }
+
   public ContractEntity findContract(UUID uuid) {
     log.info("Find contract by uuid {}", uuid);
     return find("uuid", uuid).firstResult();
-  }
-
-  public ContractEntity findContractBySubscriptionNumber(UUID uuid) {
-    log.info("Find contract by uuid {}", uuid);
-    // return find("end_date", ).firstResult();
-    return null;
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
@@ -84,4 +84,10 @@ public class ContractRepository implements PanacheRepositoryBase<ContractEntity,
     log.info("Find contract by uuid {}", uuid);
     return find("uuid", uuid).firstResult();
   }
+
+  public ContractEntity findContractBySubscriptionNumber(UUID uuid) {
+    log.info("Find contract by uuid {}", uuid);
+    // return find("end_date", ).firstResult();
+    return null;
+  }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -21,7 +21,7 @@
 package com.redhat.swatch.contract.resource;
 
 import com.redhat.swatch.contract.openapi.model.Contract;
-import com.redhat.swatch.contract.openapi.model.ContractPartnerEntitlement;
+import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.openapi.resource.ApiException;
 import com.redhat.swatch.contract.openapi.resource.DefaultApi;
@@ -35,16 +35,32 @@ import javax.transaction.Transactional;
 import javax.ws.rs.ProcessingException;
 import lombok.extern.slf4j.Slf4j;
 
+/*import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import com.redhat.swatch.JmsPriceProducer;*/
+
 @Slf4j
 @ApplicationScoped
 public class ContractsTestingResource implements DefaultApi {
 
   @Inject ContractService service;
 
+  /*  @Inject
+  JmsPriceProducer producer;
+
+  @Inject
+  @Channel("prices")
+  Emitter<String> emitter;
+
+  @Transactional
+  public void testActiveMQ(){
+    producer.generate();
+    emitter.send("Hello Kartik producer");
+  }*/
+
   @Override
   @Transactional
   public Contract createContract(Contract contract) throws ApiException, ProcessingException {
-
     return service.createContract(contract);
   }
 
@@ -81,9 +97,8 @@ public class ContractsTestingResource implements DefaultApi {
   }
 
   @Override
-  public StatusResponse createPartnerEntitlementContract(
-      ContractPartnerEntitlement contractPartnerEntitlement)
+  public StatusResponse createPartnerEntitlementContract(PartnerEntitlementContract contract)
       throws ApiException, ProcessingException {
-    return null;
+    return service.createPartnerContract(contract);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -21,6 +21,8 @@
 package com.redhat.swatch.contract.resource;
 
 import com.redhat.swatch.contract.openapi.model.Contract;
+import com.redhat.swatch.contract.openapi.model.ContractPartnerEntitlement;
+import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.openapi.resource.ApiException;
 import com.redhat.swatch.contract.openapi.resource.DefaultApi;
 import com.redhat.swatch.contract.service.ContractService;
@@ -76,5 +78,12 @@ public class ContractsTestingResource implements DefaultApi {
       throws ApiException, ProcessingException {
 
     return service.updateContract(contract);
+  }
+
+  @Override
+  public StatusResponse createPartnerEntitlementContract(
+      ContractPartnerEntitlement contractPartnerEntitlement)
+      throws ApiException, ProcessingException {
+    return null;
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -20,6 +20,7 @@
  */
 package com.redhat.swatch.contract.resource;
 
+/*import com.redhat.swatch.JmsPriceProducer;*/
 import com.redhat.swatch.contract.openapi.model.Contract;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
@@ -45,8 +46,7 @@ public class ContractsTestingResource implements DefaultApi {
 
   @Inject ContractService service;
 
-  /*  @Inject
-  JmsPriceProducer producer;
+  /*@Inject JmsPriceProducer producer;
 
   @Inject
   @Channel("prices")
@@ -56,11 +56,16 @@ public class ContractsTestingResource implements DefaultApi {
   public void testActiveMQ(){
     producer.generate();
     emitter.send("Hello Kartik producer");
+
+    Jsonb jsonb = JsonbBuilder.create();
+    String jsonString = jsonb.toJson(contract);
+    producer.sendContract(jsonString);
   }*/
 
   @Override
   @Transactional
   public Contract createContract(Contract contract) throws ApiException, ProcessingException {
+    // producer.send("Hello Kartik shah");
     return service.createContract(contract);
   }
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -20,7 +20,6 @@
  */
 package com.redhat.swatch.contract.resource;
 
-/*import com.redhat.swatch.JmsPriceProducer;*/
 import com.redhat.swatch.contract.openapi.model.Contract;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
@@ -36,36 +35,15 @@ import javax.transaction.Transactional;
 import javax.ws.rs.ProcessingException;
 import lombok.extern.slf4j.Slf4j;
 
-/*import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
-import com.redhat.swatch.JmsPriceProducer;*/
-
 @Slf4j
 @ApplicationScoped
 public class ContractsTestingResource implements DefaultApi {
 
   @Inject ContractService service;
 
-  /*@Inject JmsPriceProducer producer;
-
-  @Inject
-  @Channel("prices")
-  Emitter<String> emitter;
-
-  @Transactional
-  public void testActiveMQ(){
-    producer.generate();
-    emitter.send("Hello Kartik producer");
-
-    Jsonb jsonb = JsonbBuilder.create();
-    String jsonString = jsonb.toJson(contract);
-    producer.sendContract(jsonString);
-  }*/
-
   @Override
   @Transactional
   public Contract createContract(Contract contract) throws ApiException, ProcessingException {
-    // producer.send("Hello Kartik shah");
     return service.createContract(contract);
   }
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/SubscriptionSyncResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/SubscriptionSyncResource.java
@@ -25,11 +25,15 @@ import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.Inte
 import com.redhat.swatch.contract.model.ProductTagsMapper;
 import com.redhat.swatch.contract.openapi.model.OfferingProductTags;
 import com.redhat.swatch.contract.openapi.resource.OfferingsApi;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.ProcessingException;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+@Slf4j
+@ApplicationScoped
 public class SubscriptionSyncResource implements OfferingsApi {
 
   @RestClient @Inject InternalSubscriptionsApi internalSubscriptionsApi;

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -25,10 +25,12 @@ import com.redhat.swatch.clients.rh.partner.gateway.api.resources.ApiException;
 import com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi;
 import com.redhat.swatch.contract.model.ContractMapper;
 import com.redhat.swatch.contract.openapi.model.Contract;
+import com.redhat.swatch.contract.openapi.model.OfferingProductTags;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractRepository;
+import com.redhat.swatch.contract.resource.SubscriptionSyncResource;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -50,9 +52,15 @@ public class ContractService {
 
   @Inject @RestClient PartnerApi partnerApi;
 
-  ContractService(ContractRepository contractRepository, ContractMapper mapper) {
+  @Inject SubscriptionSyncResource syncResource;
+
+  ContractService(
+      ContractRepository contractRepository,
+      ContractMapper mapper,
+      SubscriptionSyncResource syncResource) {
     this.contractRepository = contractRepository;
     this.mapper = mapper;
+    this.syncResource = syncResource;
   }
 
   @Transactional
@@ -134,39 +142,59 @@ public class ContractService {
   @Transactional
   public StatusResponse createPartnerContract(PartnerEntitlementContract contract) {
     StatusResponse statusResponse = new StatusResponse();
-    ContractEntity entity;
+    ContractEntity entity = null;
     try {
+      // Fill up information from upstream and swatch
       entity = mapper.reconcileUpstreamContract(contract);
       collectMissingUpStreamContractDetails(entity, contract);
-    } catch (Exception e) {
-      log.debug(e.getMessage());
+      if (Objects.isNull(entity)
+          || Objects.isNull(entity.getSubscriptionNumber())
+          || Objects.isNull(entity.getOrgId())
+          || Objects.isNull(entity.getSku())
+          || Objects.isNull(entity.getBillingProvider())
+          || Objects.isNull(entity.getBillingAccountId())
+          || Objects.isNull(entity.getProductId())) { // Check all non-null fields
+        statusResponse.setMessage("Empty value in non-null fields");
+        return statusResponse;
+      }
+    } catch (NumberFormatException e) {
+      log.error(e.getMessage());
       statusResponse.setMessage("An Error occurred while reconciling contract");
+      return statusResponse;
+    } catch (ApiException e) {
+      log.error(e.getMessage());
+      statusResponse.setMessage("An Error occurred while calling Partner Api");
       return statusResponse;
     }
 
-    if (Objects.nonNull(entity)) {
-      Optional<ContractEntity> existing = currentlyActiveContract(entity);
-      boolean isDuplicateContract = false;
-      if (existing.isPresent()) {
-        ContractEntity existingContract = existing.get();
-        isDuplicateContract = isDuplicateContract(entity, existingContract);
-        if (isDuplicateContract) {
-          statusResponse.setMessage("Duplicate record found");
-        } else {
-          var now = OffsetDateTime.now();
-          persistContract(existingContract, now);
-
-          entity.setUuid(UUID.randomUUID());
-          persistContract(entity, now);
-        }
+    Optional<ContractEntity> existing = currentlyActiveContract(entity);
+    boolean isDuplicateContract = false;
+    if (existing.isPresent()) {
+      ContractEntity existingContract = existing.get();
+      isDuplicateContract = isDuplicateContract(entity, existingContract);
+      if (isDuplicateContract) {
+        statusResponse.setMessage("Duplicate record found");
       } else {
+        // Record found in contract table but, the contract has changed
         var now = OffsetDateTime.now();
-        entity.setUuid(UUID.randomUUID());
+        persistContract(existingContract, now);
+
+        var uuid = UUID.randomUUID();
+        entity.setUuid(uuid);
+        entity.getMetrics().forEach(f -> f.setContractUuid(uuid));
+        entity.setProductId("temp");
         persistContract(entity, now);
-        statusResponse.setMessage("New contract created");
+        statusResponse.setMessage("Previous contract archived and new contract created");
       }
     } else {
-      statusResponse.setMessage("Empty entity passed");
+      // New contract
+      var now = OffsetDateTime.now();
+      var uuid = UUID.randomUUID();
+      entity.setUuid(uuid);
+      entity.getMetrics().forEach(f -> f.setContractUuid(uuid));
+      entity.setProductId("temp");
+      persistContract(entity, now);
+      statusResponse.setMessage("New contract created");
     }
 
     return statusResponse;
@@ -186,31 +214,39 @@ public class ContractService {
   }
 
   private boolean isDuplicateContract(ContractEntity newEntity, ContractEntity existing) {
-
-    return false;
+    return Objects.equals(newEntity, existing);
   }
 
-  private void collectMissingUpStreamContractDetails(
-      ContractEntity entity, PartnerEntitlementContract contract) {
-    try {
-      if (Objects.nonNull(contract.getCloudIdentifiers())
-          && Objects.nonNull(contract.getCloudIdentifiers().getAwsCustomerId())) {
-        var result =
-            partnerApi.getPartnerEntitlements(
-                new QueryPartnerEntitlementV1()
-                    .customerAwsAccountId(contract.getCloudIdentifiers().getAwsCustomerId()));
-        var partnerEntitlements = result.getPartnerEntitlements();
-        var entitlement = partnerEntitlements.get(0);
-        if (Objects.nonNull(entitlement)) {
-          entity.setOrgId(entitlement.getRhAccountId());
-          var purchase = entitlement.getPurchase();
-          if (Objects.nonNull(purchase)) {
-            entity.setSku(purchase.getSku());
+  // SWATCH-1014 reformat this logic
+  private void collectMissingUpStreamContractDetails( // NOSONAR
+      ContractEntity entity, PartnerEntitlementContract contract) throws ApiException {
+    if (Objects.nonNull(contract.getCloudIdentifiers()) // NOSONAR
+        && Objects.nonNull(contract.getCloudIdentifiers().getAwsCustomerId())) {
+      var result =
+          partnerApi.getPartnerEntitlements(
+              new QueryPartnerEntitlementV1()
+                  .customerAwsAccountId(contract.getCloudIdentifiers().getAwsCustomerId()));
+      var partnerEntitlements = result.getPartnerEntitlements();
+      var entitlement = partnerEntitlements.get(0);
+      if (Objects.nonNull(entitlement)) {
+        entity.setOrgId(entitlement.getRhAccountId());
+        entity.setBillingProvider(entitlement.getSourcePartner().value());
+        var partnerIdentity = entitlement.getPartnerIdentities();
+        if (Objects.nonNull(partnerIdentity)) {
+          entity.setBillingAccountId(partnerIdentity.getAwsAccountId());
+        }
+        var purchase = entitlement.getPurchase();
+        if (Objects.nonNull(purchase)) {
+          entity.setSku(purchase.getSku());
+          OfferingProductTags productTags = syncResource.getSkuProductTags(purchase.getSku());
+          if (Objects.nonNull(productTags.getData())
+              && Objects.nonNull(productTags.getData().get(0))) {
+            entity.setProductId(productTags.getData().get(0));
+          } else {
+            log.error("Error getting product tags");
           }
         }
       }
-    } catch (ApiException e) {
-      throw new RuntimeException(e);
     }
   }
 }

--- a/swatch-contracts/src/main/resources/openapi.yaml
+++ b/swatch-contracts/src/main/resources/openapi.yaml
@@ -217,7 +217,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContractPartnerEntitlement'
+              $ref: '#/components/schemas/PartnerEntitlementContract'
             examples:
               contract info:
                 value:
@@ -246,8 +246,6 @@ paths:
                   value:
                     status: 'Success'
                     message: "Contract created"
-                    update_date: '2023-03-01T00:00:00Z'
-                    uuid: 8ece4096-bef6-4ad6-b0db-20c8e6b2a78c
           description: Success
 components:
   schemas:
@@ -356,13 +354,13 @@ components:
           type: array
           items:
             type: string
-    ContractPartnerEntitlement:
+    PartnerEntitlementContract:
       properties:
         action:
           description: Create or update contract
           type: string
-          enum:
-            - contract-updated
+#          enum:
+#            - contract-updated
         redHatSubscriptionNumber:
           description: Map it to subscription_number
           type: string
@@ -396,15 +394,6 @@ components:
           type: string
         message:
           type: string
-        uuid:
-          description: Randomly generated if not set
-          type: string
-          example: 8ece4096-bef6-4ad6-b0db-20c8e6b2a78c
-        updateDate:
-          format: date-time
-          description: ''
-          type: string
-          example: '2023-03-01T00:00:00Z'
   securitySchemes:
     support:
       type: apiKey

--- a/swatch-contracts/src/main/resources/openapi.yaml
+++ b/swatch-contracts/src/main/resources/openapi.yaml
@@ -209,6 +209,46 @@ paths:
           - Offerings
         security:
           - test: []
+  '/api/rhsm-subscriptions/v1/internal/rpc/partner/contracts':
+    post:
+      operationId: createPartnerEntitlementContract
+      requestBody:
+        description: Create a contract record from partner entitlement.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractPartnerEntitlement'
+            examples:
+              contract info:
+                value:
+                  action: contract-updated
+                  redHatSubscriptionNumber: some text
+                  currentDimensions:
+                    -
+                      dimensionName: some text
+                      dimensionValue: 5
+                      expirationDate: '2018-02-10T09:30Z'
+                    -
+                      dimensionName: some text
+                      dimensionValue: 10
+                      expirationDate: '2018-02-10T09:30Z'
+                  cloudIdentifiers:
+                    awsCustomerId: some text
+                    productCode: some text
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+              examples:
+                status response:
+                  value:
+                    status: 'Success'
+                    message: "Contract created"
+                    update_date: '2023-03-01T00:00:00Z'
+                    uuid: 8ece4096-bef6-4ad6-b0db-20c8e6b2a78c
+          description: Success
 components:
   schemas:
     Error:
@@ -316,6 +356,55 @@ components:
           type: array
           items:
             type: string
+    ContractPartnerEntitlement:
+      properties:
+        action:
+          description: Create or update contract
+          type: string
+          enum:
+            - contract-updated
+        redHatSubscriptionNumber:
+          description: Map it to subscription_number
+          type: string
+        currentDimensions:
+          description: ''
+          type: array
+          items:
+            $ref: '#/components/schemas/Dimensions'
+          example: '[{"dimensionName": "test_dim_1", "dimensionValue": 5, "expirationDate": "2023-02-15T00:00:00Z"}]'
+        cloudIdentifiers:
+          type: object
+          properties:
+            awsCustomerId:
+              type: string
+            productCode:
+              type: string
+    Dimensions:
+      properties:
+        dimensionName:
+          type: string
+        dimensionValue:
+          type: string
+        expirationDate:
+          format: date-time
+          description: ''
+          type: string
+          example: '2023-03-01T00:00:00Z'
+    StatusResponse:
+      properties:
+        status:
+          type: string
+        message:
+          type: string
+        uuid:
+          description: Randomly generated if not set
+          type: string
+          example: 8ece4096-bef6-4ad6-b0db-20c8e6b2a78c
+        updateDate:
+          format: date-time
+          description: ''
+          type: string
+          example: '2023-03-01T00:00:00Z'
   securitySchemes:
     support:
       type: apiKey

--- a/swatch-contracts/src/main/resources/openapi.yaml
+++ b/swatch-contracts/src/main/resources/openapi.yaml
@@ -359,7 +359,7 @@ components:
           description: ''
           type: array
           items:
-            $ref: '#/components/schemas/Dimensions'
+            $ref: '#/components/schemas/Dimension'
           example: '[{"dimensionName": "test_dim_1", "dimensionValue": 5, "expirationDate": "2023-02-15T00:00:00Z"}]'
         cloudIdentifiers:
           type: object
@@ -368,7 +368,7 @@ components:
               type: string
             productCode:
               type: string
-    Dimensions:
+    Dimension:
       properties:
         dimensionName:
           type: string

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointIntegrationTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.openapi.model.Contract;
+import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.service.ContractService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
@@ -103,5 +104,39 @@ class ContractsHttpEndpointIntegrationTest {
         .delete("/api/rhsm-subscriptions/v1/internal/contracts/123")
         .then()
         .statusCode(204);
+  }
+
+  @Test
+  void createPartnerEntitlementContract() {
+    StatusResponse statusResponse = new StatusResponse();
+    statusResponse.setMessage("Contract created successfully");
+    when(contractService.createPartnerContract(any())).thenReturn(statusResponse);
+    String contract =
+        """
+                    {
+                      "action" : "contract-updated",
+                      "redHatSubscriptionNumber" : "12400374",
+                      "currentDimensions" : [ {
+                        "dimensionName" : "test_dim_1",
+                        "dimensionValue" : "5",
+                        "expirationDate" : "2023-02-15T00:00:00Z"
+                      }, {
+                        "dimensionName" : "test_dim_2",
+                        "dimensionValue" : "10",
+                        "expirationDate" : "2023-02-15T00:00:00Z"
+                      } ],
+                      "cloudIdentifiers" : {
+                        "awsCustomerId" : "EK57ooq39qs",
+                        "productCode" : "ek1lel8qbwnqimt2wogc5nmey"
+                      }
+                    }
+                    """;
+    given()
+        .contentType(ContentType.JSON)
+        .body(contract)
+        .when()
+        .post("/api/rhsm-subscriptions/v1/internal/rpc/partner/contracts")
+        .then()
+        .statusCode(200);
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
@@ -74,35 +74,40 @@ public class WireMockResource
                     .withHeader("Content-Type", "application/json")
                     .withBody(
                         """
-                        {
-                          "partnerEntitlements": [
-                            {
-                              "rhAccountId": "org123",
-                              "sourcePartner": "aws_marketplace",
-                              "purchase": {
-                                "productCode": "1234567890abcdefghijklmno",
-                                "sku": "RH000000",
-                                "subscriptionNumber": "123456",
-                                "contracts": [
                                 {
-                                  "startDate": "2022-09-23T20:07:51.010445Z",
-                                  "endDate": "2022-10-23T20:07:51.01054Z",
-                                  "dimensions": [
+                                  "partnerEntitlements": [
                                     {
-                                      "name": "foobar",
-                                      "value": 1000000
+                                      "rhAccountId": "org123",
+                                      "sourcePartner": "aws_marketplace",
+                                      "partnerIdentities": {
+                                        "awsCustomerId": "e1dSCLwo6ib",
+                                        "awsAccountId": "896801664647",
+                                        "sellerAccountId": "568056954830"
+                                      },
+                                      "purchase": {
+                                        "productCode": "1234567890abcdefghijklmno",
+                                        "sku": "RH000000",
+                                        "subscriptionNumber": "123456",
+                                        "contracts": [
+                                        {
+                                          "startDate": "2022-09-23T20:07:51.010445Z",
+                                          "endDate": "2022-10-23T20:07:51.01054Z",
+                                          "dimensions": [
+                                            {
+                                              "name": "foobar",
+                                              "value": 1000000
+                                            }
+                                          ]
+                                        }
+                                        ]
+                                      },
+                                      "status": "SUBSCRIBED",
+                                      "extra": "this shows we ignore unknown fields"
                                     }
-                                  ]
+                                  ],
+                                  "hasNext": true
                                 }
-                                ]
-                              },
-                              "status": "SUBSCRIBED",
-                              "extra": "this shows we ignore unknown fields"
-                            }
-                          ],
-                          "hasNext": true
-                        }
-                        """)));
+                                """)));
   }
 
   @Override

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -31,16 +31,21 @@ import com.redhat.swatch.contract.BaseUnitTest;
 import com.redhat.swatch.contract.openapi.model.Contract;
 import com.redhat.swatch.contract.openapi.model.Dimension;
 import com.redhat.swatch.contract.openapi.model.Metric;
+import com.redhat.swatch.contract.openapi.model.OfferingProductTags;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
+import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContractCloudIdentifiers;
+import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
 import com.redhat.swatch.contract.repository.ContractRepository;
+import com.redhat.swatch.contract.resource.SubscriptionSyncResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import javax.inject.Inject;
@@ -56,6 +61,7 @@ class ContractServiceTest extends BaseUnitTest {
   @Inject ContractService contractService;
   @InjectMock ContractRepository contractRepository;
 
+  @InjectMock SubscriptionSyncResource syncResource;
   ContractEntity actualContract1;
 
   Contract contractDto;
@@ -175,14 +181,146 @@ class ContractServiceTest extends BaseUnitTest {
   }
 
   @Test
-  void createPartnerContract() {
+  void createPartnerContract_WhenNonNullEntityAndContractNotFoundInDB() {
     var contract = new PartnerEntitlementContract();
     contract.setRedHatSubscriptionNumber("12400374");
     Dimension dimensions = new Dimension();
     dimensions.setDimensionName("test_dim_1");
     dimensions.setDimensionValue("5");
     contract.setCurrentDimensions(List.of(dimensions));
-    contractService.createPartnerContract(contract);
-    // verify(contractRepository).persist();
+
+    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
+        new PartnerEntitlementContractCloudIdentifiers();
+    cloudIdentifiers.setAwsCustomerId("awsc123");
+    contract.setCloudIdentifiers(cloudIdentifiers);
+
+    OfferingProductTags productTags = new OfferingProductTags();
+    productTags.data(List.of("MH123"));
+    when(syncResource.getSkuProductTags(any())).thenReturn(productTags);
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+    assertEquals("New contract created", statusResponse.getMessage());
+  }
+
+  @Test
+  void createPartnerContract_WhenNullEntityThrowError() {
+    var contract = new PartnerEntitlementContract();
+    contract.setRedHatSubscriptionNumber("12400374");
+    Dimension dimensions = new Dimension();
+    dimensions.setDimensionName("test_dim_1");
+    dimensions.setDimensionValue("5");
+    contract.setCurrentDimensions(List.of(dimensions));
+
+    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
+        new PartnerEntitlementContractCloudIdentifiers();
+    cloudIdentifiers.setAwsCustomerId("awsc123");
+    contract.setCloudIdentifiers(cloudIdentifiers);
+
+    OfferingProductTags productTags = new OfferingProductTags();
+    productTags.data(null);
+    when(syncResource.getSkuProductTags(any())).thenReturn(productTags);
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+    assertEquals("Empty value in non-null fields", statusResponse.getMessage());
+  }
+
+  @Test
+  void createPartnerContract_NotDuplicateContractThenPersist() {
+    ContractEntity incomingContract = new ContractEntity();
+    var uuid = UUID.randomUUID();
+    OffsetDateTime offsetDateTime = OffsetDateTime.now();
+
+    var contract = new PartnerEntitlementContract();
+    contract.setRedHatSubscriptionNumber("12400374");
+    Dimension dimensions = new Dimension();
+    dimensions.setDimensionName("test_dim_1");
+    dimensions.setDimensionValue("5");
+    contract.setCurrentDimensions(List.of(dimensions));
+
+    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
+        new PartnerEntitlementContractCloudIdentifiers();
+    cloudIdentifiers.setAwsCustomerId("awsc123");
+    contract.setCloudIdentifiers(cloudIdentifiers);
+
+    ContractEntity existingContract = new ContractEntity();
+    existingContract.setUuid(uuid);
+    existingContract.setBillingAccountId("awsc123");
+    existingContract.setStartDate(offsetDateTime);
+    existingContract.setEndDate(null);
+    existingContract.setBillingProvider("aws_marketplace");
+    existingContract.setSku("RH000000");
+    existingContract.setProductId("BASILISK123");
+    existingContract.setOrgId("org123");
+    existingContract.setLastUpdated(offsetDateTime);
+    existingContract.setSubscriptionNumber("12400374");
+
+    ContractMetricEntity contractMetric4 = new ContractMetricEntity();
+    contractMetric4.setContractUuid(uuid);
+    contractMetric4.setMetricId("test_dim_1");
+    contractMetric4.setValue(5);
+
+    existingContract.setMetrics(Set.of(contractMetric4));
+
+    OfferingProductTags productTags = new OfferingProductTags();
+    productTags.data(List.of("MH123"));
+    when(syncResource.getSkuProductTags(any())).thenReturn(productTags);
+
+    Map<String, Object> stringObjectMap =
+        Map.of("subscriptionNumber", contract.getRedHatSubscriptionNumber());
+    when(contractRepository.getContract(stringObjectMap, true))
+        .thenReturn(Optional.of(existingContract));
+
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+    assertEquals(
+        "Previous contract archived and new contract created", statusResponse.getMessage());
+  }
+
+  @Test
+  void createPartnerContract_DuplicateContractThenDoNotPersist() {
+    ContractEntity incomingContract = new ContractEntity();
+    var uuid = UUID.randomUUID();
+    OffsetDateTime offsetDateTime = OffsetDateTime.now();
+
+    var contract = new PartnerEntitlementContract();
+    contract.setRedHatSubscriptionNumber("12400374");
+    Dimension dimensions = new Dimension();
+    dimensions.setDimensionName("test_dim_1");
+    dimensions.setDimensionValue("5");
+    contract.setCurrentDimensions(List.of(dimensions));
+
+    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
+        new PartnerEntitlementContractCloudIdentifiers();
+    cloudIdentifiers.setAwsCustomerId("896801664647");
+    contract.setCloudIdentifiers(cloudIdentifiers);
+
+    ContractEntity existingContract = new ContractEntity();
+    existingContract.setUuid(uuid);
+    existingContract.setBillingAccountId("896801664647");
+    existingContract.setStartDate(offsetDateTime);
+    existingContract.setEndDate(null);
+    existingContract.setBillingProvider("aws_marketplace");
+    existingContract.setSku("RH000000");
+    existingContract.setProductId("BASILISK123");
+    existingContract.setOrgId("org123");
+    existingContract.setLastUpdated(offsetDateTime);
+    existingContract.setSubscriptionNumber("12400374");
+
+    ContractMetricEntity contractMetric4 = new ContractMetricEntity();
+    contractMetric4.setContractUuid(uuid);
+    contractMetric4.setMetricId("test_dim_1");
+    contractMetric4.setValue(5);
+
+    existingContract.setMetrics(Set.of(contractMetric4));
+
+    OfferingProductTags productTags = new OfferingProductTags();
+    productTags.data(List.of("BASILISK123"));
+    when(syncResource.getSkuProductTags(any())).thenReturn(productTags);
+
+    Map<String, Object> stringObjectMap =
+        Map.of("subscriptionNumber", contract.getRedHatSubscriptionNumber());
+    when(contractRepository.getContract(stringObjectMap, true))
+        .thenReturn(Optional.of(existingContract));
+
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+    assertEquals(
+        "Previous contract archived and new contract created", statusResponse.getMessage());
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -29,7 +29,9 @@ import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.BaseUnitTest;
 import com.redhat.swatch.contract.openapi.model.Contract;
+import com.redhat.swatch.contract.openapi.model.Dimensions;
 import com.redhat.swatch.contract.openapi.model.Metric;
+import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
 import com.redhat.swatch.contract.repository.ContractRepository;
@@ -170,5 +172,17 @@ class ContractServiceTest extends BaseUnitTest {
     assertEquals(
         expected.getMetrics().stream().toList().get(0).getMetricId(),
         actual.getMetrics().stream().toList().get(0).getMetricId());
+  }
+
+  @Test
+  void createPartnerContract() {
+    var contract = new PartnerEntitlementContract();
+    contract.setRedHatSubscriptionNumber("12400374");
+    Dimensions dimensions = new Dimensions();
+    dimensions.setDimensionName("test_dim_1");
+    dimensions.setDimensionValue("5");
+    contract.setCurrentDimensions(List.of(dimensions));
+    contractService.createPartnerContract(contract);
+    // verify(contractRepository).persist();
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.BaseUnitTest;
 import com.redhat.swatch.contract.openapi.model.Contract;
-import com.redhat.swatch.contract.openapi.model.Dimensions;
+import com.redhat.swatch.contract.openapi.model.Dimension;
 import com.redhat.swatch.contract.openapi.model.Metric;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.repository.ContractEntity;
@@ -178,7 +178,7 @@ class ContractServiceTest extends BaseUnitTest {
   void createPartnerContract() {
     var contract = new PartnerEntitlementContract();
     contract.setRedHatSubscriptionNumber("12400374");
-    Dimensions dimensions = new Dimensions();
+    Dimension dimensions = new Dimension();
     dimensions.setDimensionName("test_dim_1");
     dimensions.setDimensionValue("5");
     contract.setCurrentDimensions(List.of(dimensions));


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-805

The only way to test this is using test cases. This is because the partner gateway api isn't exposed. We can utilize the api http://localhost:8000/q/swagger-ui/#/default/post_api_rhsm_subscriptions_v1_internal_rpc_partner_contracts in future to send request to controller.

Pass in the json payload as below:
{
  "action" : "contract-updated",
  "redHatSubscriptionNumber" : "12400374",
  "currentDimensions" : [ {
    "dimensionName" : "test_dim_1",
    "dimensionValue" : "5",
    "expirationDate" : "2023-02-15T00:00:00Z"
  }, {
    "dimensionName" : "test_dim_2",
    "dimensionValue" : "10",
    "expirationDate" : "2023-02-15T00:00:00Z"
  } ],
  "cloudIdentifiers" : {
    "awsCustomerId" : "EK57ooq39qs",
    "productCode" : "ek1lel8qbwnqimt2wogc5nmey"
  }
}

Note: The duplicate contract code still needs some attention so, skip that for now. Will be taken care in SWATCH-951 update contract or SWATCH-1014.