### PR TITLE
Pin postgres13 image in podman compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.1'
 services:
   db:
-    image: docker.io/postgres
+    image: docker.io/library/postgres:13
     command: '-c max_connections=5000'
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
If you tear down your postgres pod you deployed with podman-compose, and try to do `podman-compose up -d` again, you start getting permission errors on the public schema.  Seems to be a change with postgres 15, so pinning the docker-compose.yaml file back to postgres-13 as a current working solution to the problem