### PR TITLE
Revert "SWATCH-814: Remove SearchCriteria and SearchOperation classes in favor of Spring Specification search"

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -1026,7 +1026,6 @@ class HostRepositoryTest {
     assertNull(hostToBill.get("i3").getBillingProvider());
   }
 
-  // TODO More tests
   @Transactional
   @ParameterizedTest
   @CsvSource({"'',3", "banana,1", "rang,1", "an,2", "celery,0"})

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import javax.persistence.QueryHint;
-import javax.persistence.criteria.JoinType;
 import javax.validation.constraints.NotNull;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -38,6 +37,7 @@ import org.candlepin.subscriptions.db.model.HostBucketKey_;
 import org.candlepin.subscriptions.db.model.HostTallyBucket_;
 import org.candlepin.subscriptions.db.model.Host_;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyHostView;
 import org.candlepin.subscriptions.db.model.Usage;
@@ -51,7 +51,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /** Provides access to Host database entities. */
@@ -111,7 +110,7 @@ public interface HostRepository
               "((lower(h.displayName) LIKE lower(concat('%', :displayNameSubstring,'%')))) and "
               + "b.cores >= :minCores and b.sockets >= :minSockets",
       // Because we are using a 'fetch join' to avoid having to lazy load each bucket host,
-      // we need to specify how the Page should get its count when the 'limit' parameter
+      // we need to specify how the Page should gets its count when the 'limit' parameter
       // is used.
       countQuery =
           "select count(b) from HostTallyBucket b join b.host h where "
@@ -151,173 +150,68 @@ public interface HostRepository
    *     or empty string to ignore)
    * @param minCores Filter to Hosts with at least this number of cores.
    * @param minSockets Filter to Hosts with at least this number of sockets.
-   * @param month Filter to Hosts with monthly instance totals in provided month
+   * @param month Filter to Hosts with with monthly instance totals in provided month
    * @param referenceUom Uom used when filtering to a specific month.
    * @param pageable the current paging info for this query.
    * @return a page of Host entities matching the criteria.
    */
   @SuppressWarnings("java:S107")
   default Page<Host> findAllBy(
-      String orgId,
-      String productId,
-      ServiceLevel sla,
-      Usage usage,
-      @NotNull String displayNameSubstring,
-      int minCores,
-      int minSockets,
+      @Param("orgId") String orgId,
+      @Param("product") String productId,
+      @Param("sla") ServiceLevel sla,
+      @Param("usage") Usage usage,
+      @NotNull @Param("displayNameSubstring") String displayNameSubstring,
+      @Param("minCores") int minCores,
+      @Param("minSockets") int minSockets,
       String month,
       Uom referenceUom,
       BillingProvider billingProvider,
       String billingAccountId,
       List<HardwareMeasurementType> hardwareMeasurementTypes,
       Pageable pageable) {
-    return findAll(
-        buildSearchSpecification(
-            orgId,
-            productId,
-            sla,
-            usage,
-            displayNameSubstring,
-            minCores,
-            minSockets,
-            month,
-            referenceUom,
-            billingProvider,
-            billingAccountId,
-            hardwareMeasurementTypes),
-        pageable);
-  }
 
-  static Specification<Host> productIdEquals(String productId) {
-    return (root, query, builder) -> {
-      var bucketJoin = root.join(Host_.buckets, JoinType.INNER);
-      var key = bucketJoin.get(HostTallyBucket_.key);
-      return builder.equal(key.get(HostBucketKey_.productId), productId);
-    };
-  }
+    HostSpecification searchCriteria = new HostSpecification();
 
-  static Specification<Host> slaEquals(ServiceLevel sla) {
-    return (root, query, builder) -> {
-      var bucketJoin = root.join(Host_.buckets, JoinType.INNER);
-      var key = bucketJoin.get(HostTallyBucket_.key);
-      return builder.equal(key.get(HostBucketKey_.sla), sla);
-    };
-  }
+    searchCriteria.add(new SearchCriteria(Host_.ORG_ID, orgId, SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(HostBucketKey_.PRODUCT_ID, productId, SearchOperation.EQUAL));
+    searchCriteria.add(new SearchCriteria(HostBucketKey_.SLA, sla, SearchOperation.EQUAL));
+    searchCriteria.add(new SearchCriteria(HostBucketKey_.USAGE, usage, SearchOperation.EQUAL));
 
-  static Specification<Host> usageEquals(Usage usage) {
-    return (root, query, builder) -> {
-      var bucketJoin = root.join(Host_.buckets, JoinType.INNER);
-      var key = bucketJoin.get(HostTallyBucket_.key);
-      return builder.equal(key.get(HostBucketKey_.usage), usage);
-    };
-  }
+    searchCriteria.add(
+        new SearchCriteria(
+            HostBucketKey_.BILLING_PROVIDER, billingProvider, SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(
+            HostBucketKey_.BILLING_ACCOUNT_ID, billingAccountId, SearchOperation.EQUAL));
 
-  static Specification<Host> billingProviderEquals(BillingProvider billingProvider) {
-    return (root, query, builder) -> {
-      var bucketJoin = root.join(Host_.buckets, JoinType.INNER);
-      var key = bucketJoin.get(HostTallyBucket_.key);
-      return builder.equal(key.get(HostBucketKey_.billingProvider), billingProvider);
-    };
-  }
-
-  static Specification<Host> billingAccountIdEquals(String billingAccountId) {
-    return (root, query, builder) -> {
-      var bucketJoin = root.join(Host_.buckets, JoinType.INNER);
-      var key = bucketJoin.get(HostTallyBucket_.key);
-      return builder.equal(key.get(HostBucketKey_.billingAccountId), billingAccountId);
-    };
-  }
-
-  static Specification<Host> orgEquals(String orgId) {
-    return (root, query, builder) -> builder.equal(root.get(Host_.orgId), orgId);
-  }
-
-  static Specification<Host> socketsAndCoresGreaterThanOrEqualTo(int minCores, int minSockets) {
-    return (root, query, builder) -> {
-      var bucketJoin = root.join(Host_.buckets, JoinType.INNER);
-      return builder.and(
-          builder.greaterThanOrEqualTo(bucketJoin.get(HostTallyBucket_.cores), minCores),
-          builder.greaterThanOrEqualTo(bucketJoin.get(HostTallyBucket_.sockets), minSockets));
-    };
-  }
-
-  static Specification<Host> hardwareMeasurementTypeIn(List<HardwareMeasurementType> types) {
-    return (root, query, builder) -> {
-      var bucketJoin = root.join(Host_.buckets, JoinType.INNER);
-      return bucketJoin.get(HostTallyBucket_.measurementType).in(types);
-    };
-  }
-
-  static Specification<Host> monthlyKeyEquals(InstanceMonthlyTotalKey totalKey) {
-    return (root, query, builder) -> {
-      var instanceMonthlyTotalRoot = root.join(Host_.monthlyTotals, JoinType.LEFT);
-      return builder.equal(instanceMonthlyTotalRoot.key(), totalKey);
-    };
-  }
-
-  static Specification<Host> displayNameContains(String displayNameSubstring) {
-    return (root, query, builder) ->
-        builder.like(
-            builder.lower(root.get(Host_.displayName)),
-            "%" + displayNameSubstring.toLowerCase() + "%");
-  }
-
-  @SuppressWarnings("java:S107")
-  default Specification<Host> buildSearchSpecification(
-      String orgId,
-      String productId,
-      ServiceLevel sla,
-      Usage usage,
-      String displayNameSubstring,
-      int minCores,
-      int minSockets,
-      String month,
-      Uom referenceUom,
-      BillingProvider billingProvider,
-      String billingAccountId,
-      List<HardwareMeasurementType> hardwareMeasurementTypes) {
-
-    /* The where call allows us to build a Specification object to operate on even if the
-     * first specification method we call returns null (it won't be null in this case, but it's
-     * good practice to handle it) */
-    var searchCriteria =
-        Specification.where(socketsAndCoresGreaterThanOrEqualTo(minCores, minSockets));
-
-    if (Objects.nonNull(orgId)) {
-      searchCriteria = searchCriteria.and(orgEquals(orgId));
-    }
-    if (Objects.nonNull(productId)) {
-      searchCriteria = searchCriteria.and(productIdEquals(productId));
-    }
-    if (Objects.nonNull(sla)) {
-      searchCriteria = searchCriteria.and(slaEquals(sla));
-    }
-    if (Objects.nonNull(usage)) {
-      searchCriteria = searchCriteria.and(usageEquals(usage));
-    }
-    if (Objects.nonNull(billingProvider)) {
-      searchCriteria = searchCriteria.and(billingProviderEquals(billingProvider));
-    }
-    if (Objects.nonNull(billingAccountId)) {
-      searchCriteria = searchCriteria.and(billingAccountIdEquals(billingAccountId));
-    }
-    if (Objects.nonNull(displayNameSubstring)) {
-      searchCriteria = searchCriteria.and(displayNameContains(displayNameSubstring));
-    }
+    searchCriteria.add(
+        new SearchCriteria(Host_.DISPLAY_NAME, displayNameSubstring, SearchOperation.CONTAINS));
+    searchCriteria.add(
+        new SearchCriteria(HostTallyBucket_.CORES, minCores, SearchOperation.GREATER_THAN_EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(
+            HostTallyBucket_.SOCKETS, minSockets, SearchOperation.GREATER_THAN_EQUAL));
     if (StringUtils.hasText(month)) {
       // Defaulting if null, since we need a UOM in order to properly filter against a given month
       Uom effectiveUom =
           Optional.ofNullable(referenceUom).orElse(getDefaultUomForProduct(productId));
-      if (Objects.nonNull(effectiveUom)) {
-        searchCriteria =
-            searchCriteria.and(monthlyKeyEquals(new InstanceMonthlyTotalKey(month, effectiveUom)));
+      if (effectiveUom != null) {
+        searchCriteria.add(
+            new SearchCriteria(
+                InstanceMonthlyTotalKey_.MONTH,
+                new InstanceMonthlyTotalKey(month, effectiveUom),
+                SearchOperation.EQUAL));
       }
     }
-    if (!ObjectUtils.isEmpty(hardwareMeasurementTypes)) {
-      searchCriteria = searchCriteria.and(hardwareMeasurementTypeIn(hardwareMeasurementTypes));
+    if (Objects.nonNull(hardwareMeasurementTypes) && !hardwareMeasurementTypes.isEmpty()) {
+      searchCriteria.add(
+          new SearchCriteria(
+              HostTallyBucket_.MEASUREMENT_TYPE, hardwareMeasurementTypes, SearchOperation.IN));
     }
 
-    return searchCriteria;
+    return findAll(searchCriteria, pageable);
   }
 
   default Uom getDefaultUomForProduct(String productId) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostSpecification.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostSpecification.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.MapJoin;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostBucketKey_;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.HostTallyBucket_;
+import org.candlepin.subscriptions.db.model.Host_;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
+import org.springframework.data.jpa.domain.Specification;
+
+/** Util class for dynamically building Specification&lt;Host&gt; */
+public class HostSpecification implements Specification<Host> {
+
+  private final transient List<SearchCriteria> list;
+
+  public HostSpecification() {
+    this.list = new ArrayList<>();
+  }
+
+  public void add(SearchCriteria criteria) {
+    list.add(criteria);
+  }
+
+  @Override
+  @SuppressWarnings("java:S3776")
+  public Predicate toPredicate(Root<Host> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+
+    Join<Host, HostTallyBucket> bucketListJoin = root.join(Host_.buckets, JoinType.INNER);
+    MapJoin<Host, InstanceMonthlyTotalKey, Double> instanceMonthlyTotalRoot =
+        root.joinMap(Host_.MONTHLY_TOTALS, JoinType.LEFT);
+
+    List<Predicate> predicates = new ArrayList<>();
+
+    Map<String, Path<?>> rootPaths =
+        Map.of(
+            HostBucketKey_.PRODUCT_ID, bucketListJoin.get(HostTallyBucket_.KEY),
+            HostBucketKey_.SLA, bucketListJoin.get(HostTallyBucket_.KEY),
+            HostBucketKey_.USAGE, bucketListJoin.get(HostTallyBucket_.KEY),
+            HostBucketKey_.BILLING_ACCOUNT_ID, bucketListJoin.get(HostTallyBucket_.KEY),
+            HostBucketKey_.BILLING_PROVIDER, bucketListJoin.get(HostTallyBucket_.KEY),
+            HostTallyBucket_.CORES, bucketListJoin,
+            HostTallyBucket_.SOCKETS, bucketListJoin,
+            HostTallyBucket_.MEASUREMENT_TYPE, bucketListJoin,
+            InstanceMonthlyTotalKey_.MONTH, instanceMonthlyTotalRoot);
+
+    for (SearchCriteria criteria : list) {
+      Path<?> path = rootPaths.getOrDefault(criteria.getKey(), root);
+      if (criteria.getOperation().equals(SearchOperation.GREATER_THAN)) {
+        predicates.add(
+            builder.greaterThan(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.LESS_THAN)) {
+        predicates.add(
+            builder.lessThan(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_EQUAL)) {
+        predicates.add(
+            builder.greaterThanOrEqualTo(
+                path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.LESS_THAN_EQUAL)) {
+        predicates.add(
+            builder.lessThanOrEqualTo(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.NOT_EQUAL)) {
+        predicates.add(builder.notEqual(path.get(criteria.getKey()), criteria.getValue()));
+      } else if (criteria.getOperation().equals(SearchOperation.EQUAL)) {
+        var key =
+            Objects.equals(instanceMonthlyTotalRoot, path)
+                ? instanceMonthlyTotalRoot.key()
+                : path.get(criteria.getKey());
+
+        predicates.add(builder.equal(key, criteria.getValue()));
+
+      } else if (criteria.getOperation().equals(SearchOperation.CONTAINS)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                "%" + criteria.getValue().toString().toLowerCase() + "%"));
+      } else if (criteria.getOperation().equals(SearchOperation.MATCH_END)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                criteria.getValue().toString().toLowerCase() + "%"));
+      } else if (criteria.getOperation().equals(SearchOperation.MATCH_START)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                "%" + criteria.getValue().toString().toLowerCase()));
+      } else if (criteria.getOperation().equals(SearchOperation.IN)) {
+        predicates.add(builder.in(path.get(criteria.getKey())).value(criteria.getValue()));
+      } else if (criteria.getOperation().equals(SearchOperation.NOT_IN)) {
+        predicates.add(builder.not(path.get(criteria.getKey())).in(criteria.getValue()));
+      }
+    }
+
+    return builder.and(predicates.toArray(new Predicate[0]));
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SearchCriteria.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SearchCriteria.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import javax.validation.constraints.NotNull;
+import lombok.*;
+
+/** Representation of a single constraint */
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SearchCriteria {
+
+  @NotNull private String key;
+
+  @NotNull private Object value;
+
+  @NotNull private SearchOperation operation;
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SearchOperation.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SearchOperation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+/** Operations for programatically building queries via specifications */
+public enum SearchOperation {
+  GREATER_THAN,
+  LESS_THAN,
+  GREATER_THAN_EQUAL,
+  LESS_THAN_EQUAL,
+  NOT_EQUAL,
+  EQUAL,
+  CONTAINS,
+  MATCH_START,
+  MATCH_END,
+  IN,
+  NOT_IN,
+  AFTER_OR_ON,
+  BEFORE_OR_ON,
+  IS_NOT_NULL
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import javax.persistence.criteria.JoinType;
 import javax.validation.constraints.NotNull;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyInstanceView;
 import org.candlepin.subscriptions.db.model.TallyInstanceViewKey_;
@@ -40,7 +40,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.util.ObjectUtils;
+import org.springframework.data.repository.query.Param;
 import org.springframework.util.StringUtils;
 
 /** Provides access to TallyInstanceView database entities. */
@@ -49,6 +49,10 @@ public interface TallyInstanceViewRepository
     extends JpaRepository<TallyInstanceView, UUID>,
         JpaSpecificationExecutor<TallyInstanceView>,
         TagProfileLookup {
+
+  @Override
+  Page<TallyInstanceView> findAll(
+      Specification<TallyInstanceView> specification, Pageable pageable);
 
   /**
    * Find all Hosts by bucket criteria and return a page of TallyInstanceView objects. A
@@ -70,174 +74,68 @@ public interface TallyInstanceViewRepository
    */
   @SuppressWarnings("java:S107")
   default Page<TallyInstanceView> findAllBy(
-      String orgId,
-      String productId,
-      ServiceLevel sla,
-      Usage usage,
-      @NotNull String displayNameSubstring,
-      int minCores,
-      int minSockets,
+      @Param("orgId") String orgId,
+      @Param("product") String productId,
+      @Param("sla") ServiceLevel sla,
+      @Param("usage") Usage usage,
+      @NotNull @Param("displayNameSubstring") String displayNameSubstring,
+      @Param("minCores") int minCores,
+      @Param("minSockets") int minSockets,
       String month,
       Uom referenceUom,
       BillingProvider billingProvider,
       String billingAccountId,
       List<HardwareMeasurementType> hardwareMeasurementTypes,
       Pageable pageable) {
-    return findAll(
-        buildSearchSpecification(
-            orgId,
-            productId,
-            sla,
-            usage,
-            displayNameSubstring,
-            minCores,
-            minSockets,
-            month,
-            referenceUom,
-            billingProvider,
-            billingAccountId,
-            hardwareMeasurementTypes),
-        pageable);
-  }
 
-  static Specification<TallyInstanceView> socketsAndCoresGreaterThanOrEqualTo(
-      int minCores, int minSockets) {
-    return (root, query, builder) ->
-        builder.and(
-            builder.greaterThanOrEqualTo(root.get(TallyInstanceView_.cores), minCores),
-            builder.greaterThanOrEqualTo(root.get(TallyInstanceView_.sockets), minSockets));
-  }
+    TallyInstanceViewSpecification searchCriteria = new TallyInstanceViewSpecification();
 
-  static Specification<TallyInstanceView> productIdEquals(String productId) {
-    return (root, query, builder) -> {
-      var key = root.get(TallyInstanceView_.key);
-      return builder.equal(key.get(TallyInstanceViewKey_.productId), productId);
-    };
-  }
-
-  static Specification<TallyInstanceView> slaEquals(ServiceLevel sla) {
-    return (root, query, builder) -> {
-      var key = root.get(TallyInstanceView_.key);
-      return builder.equal(key.get(TallyInstanceViewKey_.sla), sla);
-    };
-  }
-
-  static Specification<TallyInstanceView> usageEquals(Usage usage) {
-    return (root, query, builder) -> {
-      var key = root.get(TallyInstanceView_.key);
-      return builder.equal(key.get(TallyInstanceViewKey_.usage), usage);
-    };
-  }
-
-  static Specification<TallyInstanceView> billingProviderEquals(BillingProvider billingProvider) {
-    return (root, query, builder) -> {
-      var key = root.get(TallyInstanceView_.key);
-      return builder.equal(key.get(TallyInstanceViewKey_.bucketBillingProvider), billingProvider);
-    };
-  }
-
-  static Specification<TallyInstanceView> billingAccountIdEquals(String billingAccountId) {
-    return (root, query, builder) -> {
-      var key = root.get(TallyInstanceView_.key);
-      return builder.equal(key.get(TallyInstanceViewKey_.bucketBillingAccountId), billingAccountId);
-    };
-  }
-
-  static Specification<TallyInstanceView> orgEquals(String orgId) {
-    return (root, query, builder) -> builder.equal(root.get(TallyInstanceView_.orgId), orgId);
-  }
-
-  static Specification<TallyInstanceView> hardwareMeasurementTypeIn(
-      List<HardwareMeasurementType> types) {
-    return (root, query, builder) -> {
-      var key = root.get(TallyInstanceView_.key);
-      return key.get(TallyInstanceViewKey_.measurementType).in(types);
-    };
-  }
-
-  static Specification<TallyInstanceView> uomEquals(Uom effectiveUom) {
-    return (root, query, builder) -> {
-      var key = root.get(TallyInstanceView_.key);
-      return builder.equal(key.get(TallyInstanceViewKey_.uom), effectiveUom);
-    };
-  }
-
-  static Specification<TallyInstanceView> displayNameContains(String displayNameSubstring) {
-    return (root, query, builder) ->
-        builder.like(
-            builder.lower(root.get(TallyInstanceView_.displayName)),
-            "%" + displayNameSubstring.toLowerCase() + "%");
-  }
-
-  static Specification<TallyInstanceView> monthlyKeyEquals(InstanceMonthlyTotalKey totalKey) {
-    return (root, query, builder) -> {
-      var instanceMonthlyTotalRoot = root.join(TallyInstanceView_.monthlyTotals, JoinType.LEFT);
-      return builder.equal(instanceMonthlyTotalRoot.key(), totalKey);
-    };
-  }
-
-  static Specification<TallyInstanceView> distinct() {
-    return (root, query, builder) -> {
-      query.distinct(true);
-      return null;
-    };
-  }
-
-  @SuppressWarnings("java:S107")
-  default Specification<TallyInstanceView> buildSearchSpecification(
-      String orgId,
-      String productId,
-      ServiceLevel sla,
-      Usage usage,
-      String displayNameSubstring,
-      int minCores,
-      int minSockets,
-      String month,
-      Uom referenceUom,
-      BillingProvider billingProvider,
-      String billingAccountId,
-      List<HardwareMeasurementType> hardwareMeasurementTypes) {
     Uom effectiveUom = Optional.ofNullable(referenceUom).orElse(getDefaultUomForProduct(productId));
 
-    /* The where call allows us to build a Specification object to operate on even if the
-     * first specification method we call returns null which is does because we're using the
-     * Specification call to set the query to return distinct results */
-    var searchCriteria = Specification.where(distinct());
-    searchCriteria = searchCriteria.and(socketsAndCoresGreaterThanOrEqualTo(minCores, minSockets));
+    searchCriteria.add(new SearchCriteria(TallyInstanceView_.ORG_ID, orgId, SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(TallyInstanceViewKey_.PRODUCT_ID, productId, SearchOperation.EQUAL));
+    searchCriteria.add(new SearchCriteria(TallyInstanceViewKey_.SLA, sla, SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(TallyInstanceViewKey_.USAGE, usage, SearchOperation.EQUAL));
 
-    if (Objects.nonNull(orgId)) {
-      searchCriteria = searchCriteria.and(orgEquals(orgId));
+    searchCriteria.add(
+        new SearchCriteria(
+            TallyInstanceViewKey_.BUCKET_BILLING_PROVIDER, billingProvider, SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(
+            TallyInstanceViewKey_.BUCKET_BILLING_ACCOUNT_ID,
+            billingAccountId,
+            SearchOperation.EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(
+            TallyInstanceView_.DISPLAY_NAME, displayNameSubstring, SearchOperation.CONTAINS));
+    if (effectiveUom != null) {
+      searchCriteria.add(
+          new SearchCriteria(TallyInstanceViewKey_.UOM, effectiveUom, SearchOperation.EQUAL));
     }
-    if (Objects.nonNull(productId)) {
-      searchCriteria = searchCriteria.and(productIdEquals(productId));
+    searchCriteria.add(
+        new SearchCriteria(TallyInstanceView_.CORES, minCores, SearchOperation.GREATER_THAN_EQUAL));
+    searchCriteria.add(
+        new SearchCriteria(
+            TallyInstanceView_.SOCKETS, minSockets, SearchOperation.GREATER_THAN_EQUAL));
+
+    if (StringUtils.hasText(month) && effectiveUom != null) {
+      searchCriteria.add(
+          new SearchCriteria(
+              InstanceMonthlyTotalKey_.MONTH,
+              new InstanceMonthlyTotalKey(month, effectiveUom),
+              SearchOperation.EQUAL));
     }
-    if (Objects.nonNull(sla)) {
-      searchCriteria = searchCriteria.and(slaEquals(sla));
-    }
-    if (Objects.nonNull(usage)) {
-      searchCriteria = searchCriteria.and(usageEquals(usage));
-    }
-    if (Objects.nonNull(billingProvider)) {
-      searchCriteria = searchCriteria.and(billingProviderEquals(billingProvider));
-    }
-    if (Objects.nonNull(billingAccountId)) {
-      searchCriteria = searchCriteria.and(billingAccountIdEquals(billingAccountId));
-    }
-    if (Objects.nonNull(displayNameSubstring)) {
-      searchCriteria = searchCriteria.and(displayNameContains(displayNameSubstring));
-    }
-    if (Objects.nonNull(effectiveUom)) {
-      searchCriteria = searchCriteria.and(uomEquals(effectiveUom));
-      if (StringUtils.hasText(month)) {
-        searchCriteria =
-            searchCriteria.and(monthlyKeyEquals(new InstanceMonthlyTotalKey(month, effectiveUom)));
-      }
-    }
-    if (!ObjectUtils.isEmpty(hardwareMeasurementTypes)) {
-      searchCriteria = searchCriteria.and(hardwareMeasurementTypeIn(hardwareMeasurementTypes));
+    if (Objects.nonNull(hardwareMeasurementTypes) && !hardwareMeasurementTypes.isEmpty()) {
+      searchCriteria.add(
+          new SearchCriteria(
+              TallyInstanceViewKey_.MEASUREMENT_TYPE,
+              hardwareMeasurementTypes,
+              SearchOperation.IN));
     }
 
-    return searchCriteria;
+    return findAll(searchCriteria, pageable);
   }
 
   default Uom getDefaultUomForProduct(String productId) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewSpecification.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewSpecification.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.MapJoin;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
+import org.candlepin.subscriptions.db.model.TallyInstanceView;
+import org.candlepin.subscriptions.db.model.TallyInstanceViewKey_;
+import org.candlepin.subscriptions.db.model.TallyInstanceView_;
+import org.springframework.data.jpa.domain.Specification;
+
+public class TallyInstanceViewSpecification implements Specification<TallyInstanceView> {
+
+  private final transient List<SearchCriteria> list;
+
+  public TallyInstanceViewSpecification() {
+    this.list = new ArrayList<>();
+  }
+
+  public void add(SearchCriteria criteria) {
+    list.add(criteria);
+  }
+
+  @Override
+  @SuppressWarnings("java:S3776")
+  public Predicate toPredicate(
+      Root<TallyInstanceView> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+
+    query.distinct(true);
+
+    List<Predicate> predicates = new ArrayList<>();
+
+    MapJoin<Host, InstanceMonthlyTotalKey, Double> instanceMonthlyTotalRoot =
+        root.joinMap(TallyInstanceView_.MONTHLY_TOTALS, JoinType.LEFT);
+
+    Map<String, Path<?>> rootPaths =
+        Map.of(
+            TallyInstanceViewKey_.PRODUCT_ID, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.SLA, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.USAGE, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.BUCKET_BILLING_ACCOUNT_ID, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.BUCKET_BILLING_PROVIDER, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.INSTANCE_ID, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.MEASUREMENT_TYPE, root.get(TallyInstanceView_.KEY),
+            TallyInstanceViewKey_.UOM, root.get(TallyInstanceView_.KEY),
+            InstanceMonthlyTotalKey_.MONTH, instanceMonthlyTotalRoot);
+
+    for (SearchCriteria criteria : list) {
+      Path<?> path = rootPaths.getOrDefault(criteria.getKey(), root);
+      if (criteria.getOperation().equals(SearchOperation.GREATER_THAN)) {
+        predicates.add(
+            builder.greaterThan(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.LESS_THAN)) {
+        predicates.add(
+            builder.lessThan(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_EQUAL)) {
+        predicates.add(
+            builder.greaterThanOrEqualTo(
+                path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.LESS_THAN_EQUAL)) {
+        predicates.add(
+            builder.lessThanOrEqualTo(path.get(criteria.getKey()), criteria.getValue().toString()));
+      } else if (criteria.getOperation().equals(SearchOperation.NOT_EQUAL)) {
+        predicates.add(builder.notEqual(path.get(criteria.getKey()), criteria.getValue()));
+      } else if (criteria.getOperation().equals(SearchOperation.EQUAL)) {
+        var key =
+            Objects.equals(instanceMonthlyTotalRoot, path)
+                ? instanceMonthlyTotalRoot.key()
+                : path.get(criteria.getKey());
+
+        predicates.add(builder.equal(key, criteria.getValue()));
+      } else if (criteria.getOperation().equals(SearchOperation.CONTAINS)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                "%" + criteria.getValue().toString().toLowerCase() + "%"));
+      } else if (criteria.getOperation().equals(SearchOperation.MATCH_END)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                criteria.getValue().toString().toLowerCase() + "%"));
+      } else if (criteria.getOperation().equals(SearchOperation.MATCH_START)) {
+        predicates.add(
+            builder.like(
+                builder.lower(path.get(criteria.getKey())),
+                "%" + criteria.getValue().toString().toLowerCase()));
+      } else if (criteria.getOperation().equals(SearchOperation.IN)) {
+        predicates.add(builder.in(path.get(criteria.getKey())).value(criteria.getValue()));
+      } else if (criteria.getOperation().equals(SearchOperation.NOT_IN)) {
+        predicates.add(builder.not(path.get(criteria.getKey())).in(criteria.getValue()));
+      }
+    }
+
+    return builder.and(predicates.toArray(new Predicate[0]));
+  }
+}


### PR DESCRIPTION
Reverts RedHatInsights/rhsm-subscriptions#1862

https://issues.redhat.com/browse/SWATCH-1015

Reverting changes from https://github.com/RedHatInsights/rhsm-subscriptions/pull/1862 in order to reduce  likelihood of OOM issues. The multiple joins to buckets caused an enormous amount of duplicate records to be loaded into memory so this PR is to remove those multiple joins. A follow up PR is needed to stop using 'fetch joins' which is the root cause of the issue.
