### PR TITLE
Adding SKU MW01879S

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -2382,6 +2382,7 @@ objects:
         MW01876MO
         MW01876RN
         MW01876S
+        MW01879S
         MW01882
         MW01882RN
         MW01882S


### PR DESCRIPTION
Adding SKU Red Hat OpenShift Platform Plus with Red Hat OpenShift Data Foundation Advanced (Bare Metal Node), Standard (1-2 sockets up to 64 cores, Academic)