### PR TITLE
SWATCH-1015: Update HostRepository findAllBy to remove fetch joins to prevent OOMs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -36,6 +36,7 @@ import javax.ws.rs.core.UriInfo;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostApiProjection;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyHostView;
@@ -198,9 +199,9 @@ public class HostsResource implements HostsApi {
               null,
               page);
       payload =
-          ((Page<Host>) hosts)
+          ((Page<HostApiProjection>) hosts)
               .getContent().stream()
-                  .map(h -> h.asTallyHostViewApiHost(month))
+                  .map(HostApiProjection::asTallyHostViewApiHost)
                   .collect(Collectors.toList());
     } else {
       if (sort != null) {

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -132,7 +132,7 @@ class HostRepositoryTest {
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  private List<Host> persistHosts(Host... hosts) {
+  List<Host> persistHosts(Host... hosts) {
     List<Host> toSave = Arrays.asList(hosts);
     toSave.stream()
         .filter(h -> h.getDisplayName() == null)
@@ -982,7 +982,7 @@ class HostRepositoryTest {
     String sortValue = HostsResource.INSTANCE_SORT_PARAM_MAPPING.get(sort);
     Pageable page = PageRequest.of(0, 10, Sort.by(sortValue));
 
-    Page<Host> results =
+    Page<HostApiProjection> results =
         repo.findAllBy(
             "ORG_a1",
             COOL_PROD,
@@ -1000,7 +1000,7 @@ class HostRepositoryTest {
     assertEquals(1L, results.getTotalElements());
     assertEquals(BillingProvider.AWS, results.getContent().get(0).getBillingProvider());
 
-    Page<Host> allResults =
+    Page<HostApiProjection> allResults =
         repo.findAllBy(
             "ORG_a1",
             COOL_PROD,
@@ -1016,14 +1016,15 @@ class HostRepositoryTest {
             null,
             page);
     assertEquals(3L, allResults.getTotalElements());
-    Map<String, Host> hostToBill =
-        allResults.stream().collect(Collectors.toMap(Host::getInstanceId, Function.identity()));
+    Map<String, HostApiProjection> hostToBill =
+        allResults.stream()
+            .collect(Collectors.toMap(HostApiProjection::getInventoryId, Function.identity()));
     assertTrue(
         hostToBill.keySet().containsAll(Arrays.asList("i1", "i2", "i3")),
         "Result did not contain expected hosts!");
     assertEquals(BillingProvider.RED_HAT, hostToBill.get("i1").getBillingProvider());
     assertEquals(BillingProvider.AWS, hostToBill.get("i2").getBillingProvider());
-    assertNull(hostToBill.get("i3").getBillingProvider());
+    assertEquals(BillingProvider.EMPTY, hostToBill.get("i3").getBillingProvider());
   }
 
   // TODO More tests
@@ -1110,7 +1111,7 @@ class HostRepositoryTest {
     String sortValue = HostsResource.INSTANCE_SORT_PARAM_MAPPING.get(sort);
     Pageable page = PageRequest.of(0, 10, Sort.by(sortValue));
 
-    Page<Host> results =
+    Page<HostApiProjection> results =
         repo.findAllBy(
             "ORG_a1",
             COOL_PROD,
@@ -1126,11 +1127,9 @@ class HostRepositoryTest {
             List.of(HardwareMeasurementType.VIRTUAL),
             page);
     assertEquals(1L, results.getTotalElements());
-    assertEquals(
-        HardwareMeasurementType.VIRTUAL,
-        results.getContent().get(0).getBuckets().iterator().next().getMeasurementType());
+    assertEquals(HardwareMeasurementType.VIRTUAL, results.getContent().get(0).getMeasurementType());
 
-    Page<Host> allResults =
+    Page<HostApiProjection> allResults =
         repo.findAllBy(
             "ORG_a1",
             COOL_PROD,
@@ -1146,20 +1145,15 @@ class HostRepositoryTest {
             null,
             page);
     assertEquals(3L, allResults.getTotalElements());
-    Map<String, Host> hostToBill =
-        allResults.stream().collect(Collectors.toMap(Host::getInstanceId, Function.identity()));
+    Map<String, HostApiProjection> hostToBill =
+        allResults.stream()
+            .collect(Collectors.toMap(HostApiProjection::getInventoryId, Function.identity()));
     assertTrue(
         hostToBill.keySet().containsAll(Arrays.asList("i1", "i2", "i3")),
         "Result did not contain expected hosts!");
-    assertEquals(
-        HardwareMeasurementType.PHYSICAL,
-        hostToBill.get("i1").getBuckets().iterator().next().getMeasurementType());
-    assertEquals(
-        HardwareMeasurementType.VIRTUAL,
-        hostToBill.get("i2").getBuckets().iterator().next().getMeasurementType());
-    assertEquals(
-        HardwareMeasurementType.HYPERVISOR,
-        hostToBill.get("i3").getBuckets().iterator().next().getMeasurementType());
+    assertEquals(HardwareMeasurementType.PHYSICAL, hostToBill.get("i1").getMeasurementType());
+    assertEquals(HardwareMeasurementType.VIRTUAL, hostToBill.get("i2").getMeasurementType());
+    assertEquals(HardwareMeasurementType.HYPERVISOR, hostToBill.get("i3").getMeasurementType());
   }
 
   @Transactional
@@ -1218,7 +1212,7 @@ class HostRepositoryTest {
     String sortValue = HostsResource.INSTANCE_SORT_PARAM_MAPPING.get(sort);
     Pageable page = PageRequest.of(0, 10, Sort.by(sortValue));
 
-    Page<Host> results =
+    Page<HostApiProjection> results =
         repo.findAllBy(
             "ORG_a1",
             COOL_PROD,
@@ -1234,8 +1228,9 @@ class HostRepositoryTest {
             HardwareMeasurementType.getCloudProviderTypes(),
             page);
     assertEquals(4L, results.getTotalElements());
-    Map<String, Host> hostToBill =
-        results.stream().collect(Collectors.toMap(Host::getInstanceId, Function.identity()));
+    Map<String, HostApiProjection> hostToBill =
+        results.stream()
+            .collect(Collectors.toMap(HostApiProjection::getInventoryId, Function.identity()));
     assertTrue(hostToBill.keySet().containsAll(Arrays.asList("i1", "i2", "i3", "i4")));
   }
 

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -20,35 +20,22 @@
  */
 package org.candlepin.subscriptions.resource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
-import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
-import org.candlepin.subscriptions.db.model.Host;
-import org.candlepin.subscriptions.db.model.HostTallyBucket;
-import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyHostView;
 import org.candlepin.subscriptions.db.model.Usage;
-import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
-import org.candlepin.subscriptions.util.ApplicationClock;
-import org.candlepin.subscriptions.utilization.api.model.HostReport;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 import org.candlepin.subscriptions.utilization.api.model.ProductId;
-import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
-import org.candlepin.subscriptions.utilization.api.model.UsageType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,7 +44,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -381,61 +367,6 @@ class HostsResourceTest {
             0,
             1,
             PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER)));
-  }
-
-  @Test
-  void testProperlySetsCoreHours() {
-    ApplicationClock clock = new FixedClockConfiguration().fixedClock();
-    String may2019 = InstanceMonthlyTotalKey.formatMonthId(clock.now());
-    assertEquals("2019-05", may2019);
-
-    OffsetDateTime juneDate = clock.now().plusMonths(1L);
-    String june2019 = InstanceMonthlyTotalKey.formatMonthId(juneDate);
-    assertEquals("2019-06", june2019);
-
-    HostTallyBucket b1 = new HostTallyBucket();
-    b1.setMeasurementType(HardwareMeasurementType.PHYSICAL);
-
-    Host host = new Host();
-    host.setBuckets(Set.of(b1));
-    host.addToMonthlyTotal(may2019, Measurement.Uom.CORES, 1.0);
-    host.addToMonthlyTotal(june2019, Measurement.Uom.CORES, 3.0);
-
-    Page page = mock(Page.class);
-    when(page.getContent()).thenReturn(List.of(host));
-
-    when(repository.findAllBy(
-            "owner123456",
-            ProductId.OPENSHIFT_DEDICATED_METRICS.toString(),
-            ServiceLevel._ANY,
-            Usage._ANY,
-            SANITIZED_MISSING_DISPLAY_NAME,
-            0,
-            1,
-            june2019,
-            null,
-            BillingProvider._ANY,
-            "_ANY",
-            null,
-            PageRequest.of(0, 1, Sort.by(IMPLICIT_ORDER))))
-        .thenReturn(page);
-
-    HostReport hostReport =
-        resource.getHosts(
-            ProductId.OPENSHIFT_DEDICATED_METRICS,
-            0,
-            1,
-            ServiceLevelType._ANY,
-            UsageType._ANY,
-            Uom.SOCKETS,
-            null,
-            clock.startOfMonth(juneDate),
-            clock.endOfMonth(juneDate),
-            null,
-            null);
-    assertEquals(1, hostReport.getData().size());
-    var hostView = hostReport.getData().get(0);
-    assertEquals(3.0, hostView.getCoreHours());
   }
 
   @ParameterizedTest(name = "testInvalidBeginningAndEndingDates[{index}] {arguments}")

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EntityManagerLookup.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EntityManagerLookup.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import javax.persistence.EntityManager;
+
+public interface EntityManagerLookup {
+  EntityManager getEntityManager();
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EntityManagerLookupImpl.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EntityManagerLookupImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * Repository "mixin" that can provides access to the entity manager. To use, extend
+ * EntityManagerLookup
+ */
+@Component
+public class EntityManagerLookupImpl implements EntityManagerLookup {
+
+  @PersistenceContext private EntityManager entityManager;
+
+  @Override
+  public EntityManager getEntityManager() {
+    return entityManager;
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostApiProjection.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostApiProjection.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class HostApiProjection {
+
+  private String inventoryId;
+  private String insightsId;
+  private String displayName;
+  private String subscriptionManagerId;
+  private Double sockets;
+  private Double cores;
+  private Double coreHours;
+  private Double instanceHours;
+  private HostHardwareType hardwareType;
+  private HardwareMeasurementType measurementType;
+  private Integer numberOfGuests;
+  private OffsetDateTime lastSeen;
+  private Boolean isUnmappedGuest;
+  private Boolean isHypervisor;
+  private String cloudProvider;
+  private BillingProvider billingProvider;
+  private String billingAccountId;
+
+  public org.candlepin.subscriptions.utilization.api.model.Host asTallyHostViewApiHost() {
+    var host = new org.candlepin.subscriptions.utilization.api.model.Host();
+
+    host.inventoryId(getInventoryId());
+    host.insightsId(getInsightsId());
+
+    host.hardwareType(
+        Objects.requireNonNullElse(getHardwareType(), HostHardwareType.PHYSICAL).toString());
+    host.cores(Objects.requireNonNullElse(cores, 0.0).intValue());
+    host.sockets(Objects.requireNonNullElse(sockets, 0.0).intValue());
+
+    host.displayName(getDisplayName());
+    host.subscriptionManagerId(getSubscriptionManagerId());
+    host.numberOfGuests(getNumberOfGuests());
+    host.lastSeen(getLastSeen());
+    host.isUnmappedGuest(getIsUnmappedGuest());
+    host.cloudProvider(getCloudProvider());
+
+    // These generally come off of the TallyHostBuckets, but it's different for the
+    // OpenShift-metrics
+    // and OpenShift-dedicated-metrics products, since they're not using the deprecated unit of
+    // measure
+    // model.  Note there's no asHypervisor here either.
+    host.isHypervisor(getIsHypervisor());
+
+    host.measurementType(
+        Objects.requireNonNullElse(getMeasurementType(), HardwareMeasurementType.PHYSICAL)
+            .toString());
+
+    // Core Hours is currently only applicable to the OpenShift-metrics OpenShift-dedicated-metrics
+    // ProductIDs, and the UI is only query the host api in one month timeframes.  If the
+    // granularity of that API changes in the future, other work will have to be done first to
+    // capture relationships between hosts & snapshots to derive coreHours within dynamic timeframes
+
+    host.coreHours(coreHours);
+    host.instanceHours(instanceHours);
+
+    return host;
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1015

This PR refactors the hostRepository.findAllBy() method to remove the fetch joins that were causing OOM errors on swatch-api. Fetch joins with sorting causes hibernate to load all objects in memory to do the sorting. Instead, now we use a projection to get all the required fields in the query.

Test Steps: 

- Insert test data:
```
insert into account_services (org_id, service_type, account_number) values ('16765430', 'OpenShift Cluster', 'account123');

INSERT INTO public.hosts VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', '', '', '', '16765430', 'automation_ocp_cluster_e25dbe5e-4130-4695-8b37-a087462cb248', '', false, '', 'CLOUD', NULL, '2023-03-03 20:00:00+00', false, false, '', 'OpenShift Cluster', 'e25dbe5e-4130-4695-8b37-a087462cb248', 'aws', '23935ade-41c5-4b53-9600-d70cb4cc3f08');

INSERT INTO public.host_tally_buckets VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', '_ANY', 'OpenShift-metrics', '_ANY', false, 0, 0, 'EMPTY', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', '_ANY', 'OpenShift-metrics', '_ANY', false, 0, 0, 'EMPTY', '_ANY', '23935ade-41c5-4b53-9600-d70cb4cc3f08', 0);
INSERT INTO public.host_tally_buckets VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', '_ANY', 'OpenShift-metrics', '_ANY', false, 0, 0, 'EMPTY', 'aws', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', '_ANY', 'OpenShift-metrics', '_ANY', false, 0, 0, 'EMPTY', 'aws', '23935ade-41c5-4b53-9600-d70cb4cc3f08', 0);
INSERT INTO public.host_tally_buckets VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', 'Production', 'OpenShift-metrics', '_ANY', false, 0, 0, 'EMPTY', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', 'Production', 'OpenShift-metrics', '_ANY', false, 0, 0, 'EMPTY', '_ANY', '23935ade-41c5-4b53-9600-d70cb4cc3f08', 0);
INSERT INTO public.host_tally_buckets VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', 'Production', 'OpenShift-metrics', '_ANY', false, 0, 0, 'EMPTY', 'aws', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', 'Production', 'OpenShift-metrics', '_ANY', false, 0, 0, 'EMPTY', 'aws', '23935ade-41c5-4b53-9600-d70cb4cc3f08', 0);

INSERT INTO public.instance_measurements VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', 'CORES', 1);

INSERT INTO public.instance_monthly_totals VALUES ('8f782362-3348-4f5c-8643-4dc1e65061ae', '2023-03', 'CORES', 0);
```
- Start app with: `DEV_MODE=true ./gradlew :bootRun`
- Run curl command:
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/hosts/products/OpenShift-metrics?limit=50' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJhY2NvdW50X251bWJlciI6ICJhY2NvdW50MTIzIiwKICAgICAgICAidHlwZSI6ICJVc2VyIiwKICAgICAgICAidXNlciIgOiB7CiAgICAgICAgICAgICJpc19vcmdfYWRtaW4iOiB0cnVlCiAgICAgICAgfSwKICAgICAgICAiaW50ZXJuYWwiIDogewogICAgICAgICAgICAib3JnX2lkIjogIjE2NzY1NDMwIgogICAgICAgIH0KICAgIH0KfQ=='
```
- Should get one record back:
```
 {
      "inventory_id": "",
      "insights_id": "",
      "display_name": "automation_ocp_cluster_e25dbe5e-4130-4695-8b37-a087462cb248",
      "subscription_manager_id": "",
      "sockets": 0,
      "cores": 1,
      "core_hours": 0,
      "hardware_type": "CLOUD",
      "measurement_type": "EMPTY",
      "last_seen": "2023-03-03T20:00:00Z",
      "is_unmapped_guest": false,
      "is_hypervisor": false,
      "cloud_provider": ""
    }
```