### PR TITLE
Fix wrong & redundant gradle project properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,9 @@ plugins {
     id 'jacoco'
 }
 
-group = "org.candlepin"
+allprojects {
+    group 'com.redhat.swatch'
+}
 
 dependencies {
     implementation project(':swatch-core')

--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -50,9 +50,6 @@ dependencies {
     annotationProcessor libraries["lombok-mapstruct-binding"]
 }
 
-group 'com.redhat.swatch'
-version 'swatch-contracts'
-
 compileJava.dependsOn tasks.openApiGenerate
 
 openApiGenerate {

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -40,9 +40,6 @@ dependencies {
 
 }
 
-group = 'com.redhat.swatch'
-description = 'swatch-producer-aws'
-
 compileJava.dependsOn tasks.openApiGenerate
 
 openApiGenerate {


### PR DESCRIPTION
Specifically, this sets all gradle subprojects to use `group com.redhat.swatch`.

I also removed a couple of redundant declarations and removed an incorrect `version` declaration in swatch-contracts.

With this change, the subprojects are imported into Intellij in a consistent way. Though it may be helpful to use File -> Project Structure... -> right click -> expand all, then select all and delete to force intellij to forget old module definitions.