### PR TITLE
SWATCH-1019: Fix socket sort on instance api to sort by sockets column of hosts

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -41,6 +41,7 @@ import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyInstanceView;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.utilization.api.model.BillingProviderType;
@@ -79,6 +80,7 @@ public class InstancesResource implements InstancesApi {
           .put(InstanceReportSort.NUMBER_OF_GUESTS, "numOfGuests")
           .put(InstanceReportSort.CATEGORY, "key.measurementType")
           .putAll(getUomSorts())
+          .put(InstanceReportSort.SOCKETS, "sockets")
           .build();
 
   public static final Map<InstanceReportSort, Measurement.Uom> SORT_TO_UOM_MAP =
@@ -308,6 +310,7 @@ public class InstancesResource implements InstancesApi {
             uom ->
                 Arrays.stream(InstanceReportSort.values())
                     .map(InstanceReportSort::toString)
+                    .filter(value -> !value.equals(Uom.SOCKETS.value()))
                     .collect(Collectors.toSet())
                     .contains(uom.value()))
         .collect(


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1019

Test Steps:
- Insert test data:
```
INSERT INTO public.hosts VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '4a1b9879-7304-4d8c-9376-48f295be780e', '11472998', '11472998', 'org123', 'virtual_xuxwxqyn.example.info', 'a66347b2-854b-4cbf-8d07-14852b8300ad', true, NULL, 'VIRTUALIZED', NULL, '2023-02-27 13:21:11.41413+00', true, false, NULL, 'HBI_HOST', '4a1b9879-7304-4d8c-9376-48f295be780e', NULL, NULL);

INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '_ANY', 'RHEL for x86', 'Premium', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '', 'RHEL for x86', 'Premium', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '_ANY', 'RHEL', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '', 'RHEL', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '_ANY', 'RHEL', 'Premium', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '_ANY', 'RHEL Server', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '', 'RHEL', 'Premium', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '', 'RHEL Server', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '', 'RHEL for x86', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '_ANY', 'RHEL for x86', '_ANY', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '', 'RHEL Server', 'Premium', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);
INSERT INTO public.host_tally_buckets VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', '_ANY', 'RHEL Server', 'Premium', true, 2, 1, 'VIRTUAL', '_ANY', '_ANY', 0);

INSERT INTO public.instance_measurements VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', 'SOCKETS', 3);
INSERT INTO public.instance_measurements VALUES ('ba0d9a20-ca1c-4ec6-a22d-78987a228b30', 'CORES', 2);
```
- Start app with: `DEV_MODE=true ./gradlew :bootRun`
- Run curl with socket sort desc: 
```
curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=sockets&sort=sockets&dir=desc'   -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' |jq
```
- Run curl with socket sort asc: 
```
curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/instances/products/RHEL?uom=sockets&sort=sockets&dir=asc'   -H 'accept: application/json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' |jq
```
- Records should be sorted by socket value


