### PR TITLE
adding sku MW01510

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -2242,6 +2242,7 @@ objects:
         MW01502
         MW01502F3
         MW0150761
+        MW01510
         MW01517F3RN
         MW01518F3
         MW01519F3RN


### PR DESCRIPTION
adding sku MW01510 - Standard: Red Hat OpenShift Kubernetes Engine (Bare Metal Node), Standard (1-2 sockets)