### PR TITLE
SWATCH-1051: Contracts: Turn on bean validation for openapi gen

### DIFF
--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -61,11 +61,12 @@ openApiGenerate {
     modelPackage = "com.redhat.swatch.contract.openapi.model"
     invokerPackage = "com.redhat.swatch.contract.openapi"
     groupId = "com.redhat.swatch.contract"
-    configOptions = [sourceFolder : "src/gen/java",
-                     interfaceOnly: "true",
-                     library      : "microprofile",
-                     java8        : "true",
-                     dateLibrary  : "java8",]
+    configOptions = [sourceFolder     : "src/gen/java",
+                     interfaceOnly    : "true",
+                     library          : "microprofile",
+                     java8            : "true",
+                     dateLibrary      : "java8",
+                     useBeanValidation: "true"]
     additionalProperties = [disableMultipart: "true", // see https://github.com/OpenAPITools/openapi-generator/pull/4713#issuecomment-633906581
     ]
 }


### PR DESCRIPTION
Testing
=======

Start the service:

```shell
./gradlew :swatch-contracts:quarkusDev
```

```shell
http :8000/api/swatch-contracts/internal/contracts
```

fails with a 400 response like

```json
{
    "classViolations": [],
    "parameterViolations": [
        {
            "constraintType": "PARAMETER",
            "message": "must not be null",
            "path": "getContract.orgId",
            "value": ""
        }
    ],
    "propertyViolations": [],
    "returnValueViolations": []
}
```