### PR TITLE
SWATCH-952: Implement timestamp filter for GET contracts

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
@@ -160,4 +160,13 @@ public class ContractEntity extends PanacheEntityBase {
   public static Specification<ContractEntity> isActive() {
     return (root, query, builder) -> builder.isNull(root.get(ContractEntity_.endDate));
   }
+
+  public static Specification<ContractEntity> activeOn(OffsetDateTime timestamp) {
+    return (root, query, builder) ->
+        builder.and(
+            builder.lessThanOrEqualTo(root.get(ContractEntity_.startDate), timestamp),
+            builder.or(
+                builder.isNull(root.get(ContractEntity_.endDate)),
+                builder.greaterThan(root.get(ContractEntity_.endDate), timestamp)));
+  }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -83,7 +83,8 @@ public class ContractsTestingResource implements DefaultApi {
       String billingAccountId,
       OffsetDateTime timestamp)
       throws ApiException, ProcessingException {
-    return service.getContracts(orgId, productId, metricId, billingProvider, billingAccountId);
+    return service.getContracts(
+        orgId, productId, metricId, billingProvider, billingAccountId, timestamp);
   }
 
   /**

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -133,7 +133,8 @@ public class ContractService {
       String productId,
       String metricId,
       String billingProvider,
-      String billingAccountId) {
+      String billingAccountId,
+      OffsetDateTime timestamp) {
 
     Specification<ContractEntity> specification = ContractEntity.orgIdEquals(orgId);
 
@@ -148,6 +149,9 @@ public class ContractService {
     }
     if (billingAccountId != null) {
       specification = specification.and(ContractEntity.billingAccountIdEquals(billingAccountId));
+    }
+    if (timestamp != null) {
+      specification = specification.and(ContractEntity.activeOn(timestamp));
     }
 
     return contractRepository.getContracts(specification).stream()

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointIntegrationTest.java
@@ -46,7 +46,7 @@ class ContractsHttpEndpointIntegrationTest {
   void whenGetContract_thenContractShouldBeFound() {
     Contract contract = new Contract();
     contract.setOrgId("org123");
-    when(contractService.getContracts(any(), any(), any(), any(), any()))
+    when(contractService.getContracts(any(), any(), any(), any(), any(), any()))
         .thenReturn(List.of(contract));
     given()
         .contentType(ContentType.JSON)

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -130,7 +130,7 @@ class ContractServiceTest extends BaseUnitTest {
     var spec =
         ContractEntity.orgIdEquals("org123").and(ContractEntity.productIdEquals("BASILISK123"));
     List<Contract> contractList =
-        contractService.getContracts("org123", "BASILISK123", null, null, null);
+        contractService.getContracts("org123", "BASILISK123", null, null, null, null);
     verify(contractRepository).getContracts(any());
     assertEquals(1, contractList.size());
     assertEquals(2, contractList.get(0).getMetrics().size());


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-952

The timestamp query param is used to filter to records active at that timestamp. The start date is treated as inclusive, and the end date as exclusive. In other words, `timestamp==2023-01-01T00:00Z` will match contract records that start on the `2023-01-01T00:00Z`, but not those that end on `2023-01-01T00:00Z`.

Testing
=======

Start the service via `./gradlew swatch-contracts:quarkusDev`

Insert some contracts:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
insert into contracts(uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider,
                      billing_account_id, product_id)
VALUES ('9bf28398-d147-4a4d-97f1-2e3ab46af681', 'subscription123', now(), '2023-01-01T00:00Z', '2023-02-01T00:00Z', 'org123', 'BASILISK', 'aws', '123456', 'BASILISK'),
       ('7e5f1aa2-0805-42df-8254-097efd98cfbd', 'subscription123', now(), '2023-02-01T00:00Z', null, 'org123', 'BASILISK', 'aws', '123456', 'BASILISK');
EOF
```

Try the following use cases:

Prior to any contracts, empty response:
```shell
http :8000/api/swatch-contracts/internal/contracts \
  org_id==org123 \
  timestamp==2022-12-31T11:59Z
```

On the start of the first record, only 9bf28398-d147-4a4d-97f1-2e3ab46af681:
```shell
http :8000/api/swatch-contracts/internal/contracts \
  org_id==org123 \
  timestamp==2023-01-01T00:00Z
```

After the start of the first record, only 9bf28398-d147-4a4d-97f1-2e3ab46af681:
```shell
http :8000/api/swatch-contracts/internal/contracts \
  org_id==org123 \
  timestamp==2023-01-02T00:00Z
```

On the start of the second record, only 7e5f1aa2-0805-42df-8254-097efd98cfbd:
```shell
http :8000/api/swatch-contracts/internal/contracts \
  org_id==org123 \
  timestamp==2023-02-01T00:00Z
```

In the future, showing that null end_date is respected:
```shell
http :8000/api/swatch-contracts/internal/contracts \
  org_id==org123 \
  timestamp==2024-02-01T00:00Z
```