### PR TITLE
Enable swatch-contracts test APIs in stage

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -10,7 +10,7 @@ DATABASE_PASSWORD: ${clowder.database.password:rhsm-subscriptions}
 
 SWATCH_TEST_APIS_ENABLED=true
 # following line to be removed in SWATCH-882
-%stage.SWATCH_TEST_APIS_ENABLED=false
+%stage.SWATCH_TEST_APIS_ENABLED=true
 %prod.SWATCH_TEST_APIS_ENABLED=false
 
 ENABLE_SPLUNK_HEC=true

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -9,7 +9,6 @@ DATABASE_USERNAME: ${clowder.database.username:rhsm-subscriptions}
 DATABASE_PASSWORD: ${clowder.database.password:rhsm-subscriptions}
 
 SWATCH_TEST_APIS_ENABLED=true
-# following line to be removed in SWATCH-882
 %stage.SWATCH_TEST_APIS_ENABLED=true
 %prod.SWATCH_TEST_APIS_ENABLED=false
 


### PR DESCRIPTION
Just to unblock QE testing in stage.  There's more involved work for SWATCH-882