### PR TITLE
SWATCH-954: Cleanup swatch-contracts warnings

### DIFF
--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'swatch.java-conventions'
     id 'io.quarkus'
     id 'org.openapi.generator'
-    id 'swatch.quarkus-rest-client-conventions'
 }
 
 repositories {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
@@ -91,6 +91,7 @@ public class ContractEntity extends PanacheEntityBase {
   @Column(name = "product_id", nullable = false)
   private String productId;
 
+  @Builder.Default
   @OneToMany(
       targetEntity = ContractMetricEntity.class,
       cascade = CascadeType.ALL,
@@ -101,9 +102,10 @@ public class ContractEntity extends PanacheEntityBase {
   public void addMetric(ContractMetricEntity metric) {
     metrics.add(metric);
     metric.setContract(this);
+    metric.setContractUuid(uuid);
   }
 
-  public void remoteMetric(ContractMetricEntity metric) {
+  public void removeMetric(ContractMetricEntity metric) {
     metrics.remove(metric);
     metric.setContract(null);
   }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractMetricEmbeddableId.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractMetricEmbeddableId.java
@@ -29,5 +29,5 @@ public class ContractMetricEmbeddableId implements Serializable {
 
   private UUID contractUuid;
   private String metricId;
-  private int value;
+  private double value;
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractMetricEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractMetricEntity.java
@@ -60,7 +60,7 @@ public class ContractMetricEntity extends PanacheEntityBase {
 
   @Id
   @Column(name = "metric_value", nullable = false)
-  private int value;
+  private double value;
 
   @Exclude
   @ManyToOne(targetEntity = ContractEntity.class, fetch = FetchType.LAZY)

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -232,7 +232,7 @@ public class ContractService {
     ContractEntity entity;
     try {
       // Fill up information from upstream and swatch
-      entity = mapper.reconcileUpstreamContract(contract);
+      entity = mapper.partnerContractToContractEntity(contract);
       collectMissingUpStreamContractDetails(entity, contract);
       if (!isValidEntity(entity)) {
         statusResponse.setMessage("Empty value in non-null fields");

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractMapperTest.java
@@ -87,7 +87,7 @@ class ContractMapperTest {
         dto.getMetrics().stream().map(Metric::getMetricId).toList());
     assertEquals(
         entity.getMetrics().stream().map(ContractMetricEntity::getValue).toList(),
-        dto.getMetrics().stream().map(Metric::getValue).toList());
+        dto.getMetrics().stream().map(Metric::getValue).map(Double::valueOf).toList());
   }
 
   @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-954

Clean up various warnings:

* jandex warning was resolved by removing unneeded jandex plugin.
* mapstruct warnings resolved by refactoring mapstruct usage.
* datatype warning resolved by changing metric value from `int` to `double`.

No testing instructions for this PR since there is no functionality change, only refactoring and build changes.