### PR TITLE
SWATCH-1039: Fix EntityExistsException w/ hypervisor duplicates

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -460,7 +460,9 @@ public class InventoryAccountUsageCollector {
       orgHostsData.collectGuestData(new HashMap<>());
     } else if (system.getSubscriptionManagerId() != null) {
       // this is a potential hypervisor record
-      Host placeholder = orgHostsData.hypervisorHostMap().get(system.getSubscriptionManagerId());
+      // NOTE: remove is used in order to ensure a placeholder is processed only once
+      // (otherwise we end up attempting to apply the buckets to every duplicate hypervisor record).
+      Host placeholder = orgHostsData.hypervisorHostMap().remove(system.getSubscriptionManagerId());
       if (placeholder != null) {
         // this system is a hypervisor, transfer buckets & counts to it
         log.debug("Applying buckets and guest-count from orgHostsData.");


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1039

When there are multiple records for a hypervisor present in HBI, they are processed in order by their inventory IDs.

During tally, we keep buckets derived from guests in a placeholder Host record. Each match of the subscription-manager ID will process those buckets via `Host.addBucket`...

When the first instance encountered is not present in the swatch database, the placeholder bucket is added with its `hostId` value being set to that instance's PK. When a subsequent copy of the record is processed having its data in the swatch database, the same buckets are processed again. Note that the bucket at this point is referenced in three places:
1. On the placeholder Host (referred to later as `placeholder`)
2. On the to-be-created hypervisor Host (referred to later as `createdHost`)
3. On the to-be-updated hypervisor Host (referred to later as `updatedHost`)

The first thing that the `addBucket` method does is change the `hostId`, regardless of whether it ends up being added (this makes the comparison work correctly). Recall that the bucket has already been added to `createdHost`. This means there is a pending persist of the bucket through `createdHost`. Then, the bucket is detected as already present in `updatedHost`. As a result, there are now two (or more) buckets with the `hostId` set to `updatedHost`'s `id`. This causes the transaction to fail with an `EntityExistsException`.

In practice, the order, being based on the inventory IDs, is non-deterministic, and if the to-be-updated hypervisor is processed first, then it doesn't conflict with the to-be-created record's buckets. This makes reproduction of the issue a bit tricky...

The solution chosen for this is to remove placeholder Hosts as they are processed. This will prevent the duplicates from being considered as hypervisors.

Testing
=======

Run the service:

```shell
DEV_MODE=true ./gradlew :bootRun
```

Insert a hypervisor and guest into HBI data:

```shell
bin/insert-mock-hosts \
  --num-hypervisors=1 \
  --num-guests=1 \
  --hbi \
  --org org123 \
  --clear
```

Modify the hypervisor to have the known subman ID (and guest mapping too):

```shell
psql -h localhost -U insights insights <<EOF
update hosts
set canonical_facts=jsonb_set(canonical_facts, '{subscription_manager_id}', '"8a9b361b-a97b-406a-a03b-451fed9dcb9b"'::jsonb)
where system_profile_facts ->> 'infrastructure_type' = 'PHYSICAL';
update hosts
set facts=jsonb_set(facts, '{rhsm,VM_HOST_UUID}', '"8a9b361b-a97b-406a-a03b-451fed9dcb9b"'::jsonb)
where system_profile_facts ->> 'infrastructure_type' != 'PHYSICAL';
EOF
```

Modify the inventory ID of the hypervisor to be a known value:

```shell
psql -h localhost -U insights insights <<EOF
update hosts
set id='b72d09ad-d124-46c0-bc1d-cb7491b9d4e1'
where system_profile_facts ->> 'infrastructure_type' = 'PHYSICAL';
EOF
```

Perform a tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean' \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org123"]'
```

Insert another hypervisor, and change its subman ID to be the same:

```shell
bin/insert-mock-hosts \
  --num-hypervisors=1 \
  --hbi \
  --org org123
psql -h localhost -U insights insights <<EOF
update hosts
set canonical_facts=jsonb_set(canonical_facts, '{subscription_manager_id}', '"8a9b361b-a97b-406a-a03b-451fed9dcb9b"'::jsonb)
where system_profile_facts ->> 'infrastructure_type' = 'PHYSICAL';
EOF
```

Modify its inventory ID to be less than the existing record:

```shell
psql -h localhost -U insights insights <<EOF
update hosts
set id='5dbd9c8f-13f5-4b06-bf0b-490553665f09'
where system_profile_facts ->> 'infrastructure_type' = 'PHYSICAL'
and id != 'b72d09ad-d124-46c0-bc1d-cb7491b9d4e1'
EOF
```

Tally again:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean' \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org123"]'
```

After a few retries, see that it'll throw an EntityExistsException.

Now switch to this branch, and try the tally again, observe the exception is no longer thrown.