### PR TITLE
Define ephemeral quarkus profile for swatch-contracts

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -9,6 +9,7 @@ DATABASE_USERNAME: ${clowder.database.username:rhsm-subscriptions}
 DATABASE_PASSWORD: ${clowder.database.password:rhsm-subscriptions}
 
 SWATCH_TEST_APIS_ENABLED=true
+%ephemeral.SWATCH_TEST_APIS_ENABLED=true
 %stage.SWATCH_TEST_APIS_ENABLED=true
 %prod.SWATCH_TEST_APIS_ENABLED=false
 
@@ -41,6 +42,7 @@ SPLUNK_HEC_INCLUDE_EX=false
 %qa.ENTITLEMENT_GATEWAY_URL=https://ibm-entitlement-gateway.qa.api.redhat.com
 %stage.ENTITLEMENT_GATEWAY_URL=https://ibm-entitlement-gateway.stage.api.redhat.com
 %prod.ENTITLEMENT_GATEWAY_URL=https://ibm-entitlement-gateway.api.redhat.com
+%ephemeral.ENTITLEMENT_GATEWAY_URL=${%stage.ENTITLEMENT_GATEWAY_URL}
 
 # dev-specific config items that don't need to be overridden via env var
 # do not use JSON logs in dev mode


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-882

Testing
=======

```shell
SWATCH_SELF_PSK=placehodler QUARKUS_PROFILE=ephemeral quarkus dev
```

Then visit http://localhost:8000/q/dev/io.quarkus.quarkus-vertx-http/config

Search for both of the set environment variables, see that

```properties
ENTITLEMENT_GATEWAY_URL=${stage.ENTITLEMENT_GATEWAY_URL}
SWATCH_TEST_APIS_ENABLED=true
```