### PR TITLE
SWATCH-839: Add new Admin Api for Contract Sync

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -26,6 +26,7 @@ import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.openapi.resource.ApiException;
 import com.redhat.swatch.contract.openapi.resource.DefaultApi;
+import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.service.ContractService;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -116,6 +117,27 @@ public class ContractsTestingResource implements DefaultApi {
     contract.setUuid(uuid);
 
     return service.updateContract(contract);
+  }
+
+  @Override
+  @Transactional
+  @RolesAllowed({"test"})
+  public StatusResponse syncAllContracts() throws ApiException, ProcessingException {
+    log.info("Syncing All Contracts");
+    var contracts = service.getAllContracts();
+    if (contracts.isEmpty()) {
+      return new StatusResponse().status("No active contract found for the orgIds");
+    }
+    for (ContractEntity org : contracts) {
+      syncContractsByOrg(org.getOrgId());
+    }
+    return new StatusResponse().status("All Contract are Synced");
+  }
+
+  @Override
+  @RolesAllowed({"test"})
+  public StatusResponse syncContractsByOrg(String orgId) throws ApiException, ProcessingException {
+    return service.syncContractByOrgId(orgId);
   }
 
   @Override

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -195,6 +195,52 @@ paths:
       security:
         - test: []
       operationId: createContract
+  /api/swatch-contracts/internal/rpc/sync/contracts/{org_id}:
+    description: "Trigger a contract sync for a given Org ID"
+    post:
+      parameters:
+        - name: org_id
+          description: ""
+          schema:
+            type: string
+          in: path
+          required: true
+      summary: "Sync contracts for given org_id."
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+              examples:
+                status response:
+                  value:
+                    status: 'Success'
+                    message: "Contracts Synced for given org_id"
+          description: success
+
+      security:
+        - test: []
+      operationId: syncContractsByOrg
+  /internal/rpc/syncAllContracts:
+    description: "Trigger a sync for all contracts"
+    post:
+      summary: "Sync all contracts."
+      operationId: syncAllContracts
+      responses:
+        '202':
+          description: "The request for syncing all contracts is successfully running."
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/StatusResponse"
+              examples:
+                status response:
+                  value:
+                    status: 'Success'
+                    message: "All contracts Synced"
+      security:
+        - test: []
   /internal/offerings/{sku}/product_tags:
       description: "Mapping sku to product tags."
       parameters:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
@@ -47,7 +47,7 @@ class RhPartnerClientIntegrationTest {
         partnerApi.getPartnerEntitlements(new QueryPartnerEntitlementV1().rhAccountId("org123"));
     var partnerEntitlements = result.getContent();
     assertNotNull(partnerEntitlements);
-    assertEquals(1, partnerEntitlements.size());
+    assertEquals(2, partnerEntitlements.size());
     var entitlement = partnerEntitlements.get(0);
     assertEquals("org123", entitlement.getRhAccountId());
     assertEquals(SourcePartnerEnum.AWS_MARKETPLACE, entitlement.getSourcePartner());
@@ -66,7 +66,7 @@ class RhPartnerClientIntegrationTest {
     assertNotNull(contract);
     assertEquals(OffsetDateTime.parse("2022-09-23T20:07:51.010445Z"), contract.getStartDate());
     assertNotNull(contract.getDimensions());
-    assertEquals(1, contract.getDimensions().size());
+    assertEquals(2, contract.getDimensions().size());
     var dimension = contract.getDimensions().get(0);
     assertEquals("foobar", dimension.getName());
     assertEquals("1000000", dimension.getValue());

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
@@ -99,6 +99,44 @@ public class WireMockResource
                                               {
                                                 "name": "foobar",
                                                 "value": "1000000"
+                                              },
+                                              {
+                                                "name": "cpu-hours",
+                                                "value": "1000000"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "status": "STATUS",
+                                      "entitlementDates": {
+                                        "startDate": "2023-03-17T12:29:48.569Z",
+                                        "endDate": "2023-03-17T12:29:48.569Z"
+                                      }
+                                    },
+                                    {
+                                      "rhAccountId": "org223",
+                                      "sourcePartner": "aws_marketplace",
+                                      "partnerIdentities": {
+                                        "awsCustomerId": "568056954830",
+                                        "customerAwsAccountId": "568056954830",
+                                        "sellerAccountId": "568056954830"
+                                      },
+                                      "rhEntitlements": [
+                                        {
+                                          "sku": "RH000000",
+                                          "redHatSubscriptionNumber": "121256"
+                                        }
+                                      ],
+                                      "purchase": {
+                                        "vendorProductCode": "1234567890abcdefghijklmno",
+                                        "contracts": [
+                                          {
+                                            "startDate": "2022-09-23T20:07:51.010445Z",
+                                            "dimensions": [
+                                              {
+                                                "name": "foobar",
+                                                "value": "1000000"
                                               }
                                             ]
                                           }


### PR DESCRIPTION
This is to create the Admin API to sync existing contracts and add new contracts if there are not already in the swatch-contract database.

https://issues.redhat.com/browse/SWATCH-839

Testing Steps:

1. Run with with these environment variables:
```
SWATCH_SELF_PSK=placeholder;KEYSTORE_RESOURCE=file:/home/<user>/IdeaProjects/rhsm-subscriptions/config/certs/keystore.jks;ENABLE_SPLUNK_HEC=false;KEYSTORE_PASSWORD=<password>;QUARKUS_PROFILE=stage
```
If you have problems access the Partner API you may need to pull credentials from vault [here](https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=ENT&title=Setting+up+non-prod+credentials)
2. Setup database with test data (both contracts and contract-metrics):
```
INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id) VALUES ('6c849fcb-c59f-41b0-9e82-11d3a33898e9', '12400374', '2023-03-16 21:30:43.808568 +00:00', '2023-03-16 21:30:10.414684 +00:00', '2023-03-16 21:30:43.808568 +00:00', '13468036', 'MW01484', 'aws_marketplace', '896801664647', 'OpenShift-dedicated-metrics');
INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id) VALUES ('eaa10ad4-4466-47d3-a3f4-f003e924a02b', '12400374', '2023-03-16 21:30:52.473337 +00:00', '2023-03-16 21:30:52.473337 +00:00', null, '13468036', 'MW01484', 'aws_marketplace', '896801664647', 'OpenShift-dedicated-metrics');
INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id) VALUES ('9bf28398-d147-4a4d-97f1-2e3ab46af681', 'subscription123', '2023-03-23 19:57:41.369450 +00:00', '2023-01-01 00:00:00.000000 +00:00', '2023-02-01 00:00:00.000000 +00:00', 'org123', 'BASILISK', 'aws', '123456', 'BASILISK');
INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id) VALUES ('7e5f1aa2-0805-42df-8254-097efd98cfbd', 'subscription123', '2023-03-23 19:57:41.369450 +00:00', '2023-02-01 00:00:00.000000 +00:00', null, 'org123', 'BASILISK', 'aws', '123456', 'BASILISK');
INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id) VALUES ('642a3b85-240a-4c1f-ab4e-3ee660935a64', '12400374', '2023-03-16 21:30:52.473337 +00:00', '2023-03-16 21:30:43.808568 +00:00', '2023-03-16 21:30:52.473337 +00:00', '13468036', 'MW01484', 'aws_marketplace', '896801664647', 'OpenShift-dedicated-metrics');
```
```
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('6c849fcb-c59f-41b0-9e82-11d3a33898e9', 'test_dim_1', 5);
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('6c849fcb-c59f-41b0-9e82-11d3a33898e9', 'test_dim_2', 10);
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('642a3b85-240a-4c1f-ab4e-3ee660935a64', 'test_dim_3', 5);
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('642a3b85-240a-4c1f-ab4e-3ee660935a64', 'test_dim_2', 10);
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('eaa10ad4-4466-47d3-a3f4-f003e924a02b', 'test_dim_3', 10);
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('eaa10ad4-4466-47d3-a3f4-f003e924a02b', 'test_dim_2', 10);
```
3. Run `syncContractByOrgId` & `syncAllContracts` in swatch-contract UI:
`http://localhost:8000/q/swagger-ui/#/default/syncContractsByOrg`for UI enter `13468036` or curl command:
```
curl -X 'POST' \
  'http://localhost:8000/api/swatch-contracts/internal/rpc/sync/contracts/13468036' \
  -H 'accept: application/json' \
  -H 'x-rh-swatch-psk: placeholder' \
  -d ''
```
Observe that the status gives you the message that the sync was succuessful & that the Databases is updated in `contract` table.