### PR TITLE
SWATCH-1050 Reformat upstream UMB API mapping

### DIFF
--- a/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
+++ b/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
@@ -22,7 +22,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetPartnerEntitlementsResponse'
+                $ref: '#/components/schemas/PartnerEntitlements'
         400:
           description: Order does not exist
           content:
@@ -38,11 +38,12 @@ paths:
 
 components:
   schemas:
-    GetPartnerEntitlementsResponse:
-      type: object
+    PartnerEntitlements:
       properties:
-        _embedded:
-          $ref: '#/components/schemas/PartnerEntitlements'
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartnerEntitlementV1'
         page:
           type: object
           properties:
@@ -54,12 +55,6 @@ components:
               type: integer
             number:
               type: integer
-    PartnerEntitlements:
-      properties:
-        partnerEntitlements:
-          type: array
-          items:
-            $ref: '#/components/schemas/PartnerEntitlementV1'
     QueryPartnerEntitlementV1:
       properties:
         rhAccountId:
@@ -97,12 +92,25 @@ components:
           type: string
           enum:
             - aws_marketplace
-        status:
-          type: string
         partnerIdentities:
           $ref: '#/components/schemas/PartnerIdentityV1'
+        rhEntitlements:
+          type: array
+          items:
+            $ref: '#/components/schemas/RhEntitlementV1'
         purchase:
           $ref: '#/components/schemas/PurchaseV1'
+        status:
+          type: string
+        entitlementDates:
+          type: object
+          properties:
+            startDate:
+              type: string
+              format: date-time
+            endDate:
+              type: string
+              format: date-time
     PartnerIdentityV1:
       properties:
         awsCustomerId:
@@ -113,11 +121,7 @@ components:
           type: string
     PurchaseV1:
       properties:
-        productCode:
-          type: string
-        sku:
-          type: string
-        subscriptionNumber:
+        vendorProductCode:
           type: string
         contracts:
           type: array
@@ -126,9 +130,6 @@ components:
     SaasContractV1:
       properties:
         startDate:
-          type: string
-          format: date-time
-        endDate:
           type: string
           format: date-time
         dimensions:
@@ -140,6 +141,12 @@ components:
         name:
           type: string
         value:
+          type: string
+    RhEntitlementV1:
+      properties:
+        sku:
+          type: string
+        redHatSubscriptionNumber:
           type: string
     ApiErrorV1:
       properties:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
@@ -45,23 +45,26 @@ class RhPartnerClientIntegrationTest {
     // see WireMockResource for setup details, and canned response JSON
     var result =
         partnerApi.getPartnerEntitlements(new QueryPartnerEntitlementV1().rhAccountId("org123"));
-    var partnerEntitlements = result.getEmbedded().getPartnerEntitlements();
+    var partnerEntitlements = result.getContent();
     assertNotNull(partnerEntitlements);
     assertEquals(1, partnerEntitlements.size());
     var entitlement = partnerEntitlements.get(0);
     assertEquals("org123", entitlement.getRhAccountId());
     assertEquals(SourcePartnerEnum.AWS_MARKETPLACE, entitlement.getSourcePartner());
+
+    var rhEntitlements = entitlement.getRhEntitlements();
+    assertNotNull(rhEntitlements);
+    assertNotNull(rhEntitlements.get(0));
+    assertEquals("RH000000", rhEntitlements.get(0).getSku());
+    assertEquals("123456", rhEntitlements.get(0).getRedHatSubscriptionNumber());
     var purchase = entitlement.getPurchase();
     assertNotNull(purchase);
-    assertEquals("RH000000", purchase.getSku());
-    assertEquals("123456", purchase.getSubscriptionNumber());
-    assertEquals("1234567890abcdefghijklmno", purchase.getProductCode());
+    assertEquals("1234567890abcdefghijklmno", purchase.getVendorProductCode());
     assertNotNull(purchase.getContracts());
     assertEquals(1, purchase.getContracts().size());
     var contract = purchase.getContracts().get(0);
     assertNotNull(contract);
     assertEquals(OffsetDateTime.parse("2022-09-23T20:07:51.010445Z"), contract.getStartDate());
-    assertEquals(OffsetDateTime.parse("2022-10-23T20:07:51.010540Z"), contract.getEndDate());
     assertNotNull(contract.getDimensions());
     assertEquals(1, contract.getDimensions().size());
     var dimension = contract.getDimensions().get(0);

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
@@ -75,44 +75,48 @@ public class WireMockResource
                     .withBody(
                         """
                                 {
-                                "_embedded": {
-                                  "partnerEntitlements": [
+                                  "content": [
                                     {
                                       "rhAccountId": "org123",
                                       "sourcePartner": "aws_marketplace",
                                       "partnerIdentities": {
-                                        "awsCustomerId": "e1dSCLwo6ib",
-                                        "customerAwsAccountId": "896801664647",
+                                        "awsCustomerId": "568056954830",
+                                        "customerAwsAccountId": "568056954830",
                                         "sellerAccountId": "568056954830"
                                       },
-                                      "purchase": {
-                                        "productCode": "1234567890abcdefghijklmno",
-                                        "sku": "RH000000",
-                                        "subscriptionNumber": "123456",
-                                        "contracts": [
+                                      "rhEntitlements": [
                                         {
-                                          "startDate": "2022-09-23T20:07:51.010445Z",
-                                          "endDate": "2022-10-23T20:07:51.01054Z",
-                                          "dimensions": [
-                                            {
-                                              "name": "foobar",
-                                              "value": 1000000
-                                            }
-                                          ]
+                                          "sku": "RH000000",
+                                          "redHatSubscriptionNumber": "123456"
                                         }
+                                      ],
+                                      "purchase": {
+                                        "vendorProductCode": "1234567890abcdefghijklmno",
+                                        "contracts": [
+                                          {
+                                            "startDate": "2022-09-23T20:07:51.010445Z",
+                                            "dimensions": [
+                                              {
+                                                "name": "foobar",
+                                                "value": "1000000"
+                                              }
+                                            ]
+                                          }
                                         ]
                                       },
-                                      "status": "SUBSCRIBED",
-                                      "extra": "this shows we ignore unknown fields"
-                                    }
-                                  ]
-                                  },
-                                      "page": {
-                                          "size": 20,
-                                          "totalElements": 2,
-                                          "totalPages": 1,
-                                          "number": 0
+                                      "status": "STATUS",
+                                      "entitlementDates": {
+                                        "startDate": "2023-03-17T12:29:48.569Z",
+                                        "endDate": "2023-03-17T12:29:48.569Z"
                                       }
+                                    }
+                                  ],
+                                  "page": {
+                                    "size": 0,
+                                    "totalElements": 0,
+                                    "totalPages": 0,
+                                    "number": 0
+                                  }
                                 }
 
                                 """)));

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -283,16 +283,16 @@ class ContractServiceTest extends BaseUnitTest {
 
     PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
         new PartnerEntitlementContractCloudIdentifiers();
-    cloudIdentifiers.setAwsCustomerId("896801664647");
+    cloudIdentifiers.setAwsCustomerId("568056954830");
     contract.setCloudIdentifiers(cloudIdentifiers);
 
     ContractEntity existingContract = new ContractEntity();
     existingContract.setUuid(uuid);
-    existingContract.setBillingAccountId("896801664647");
+    existingContract.setBillingAccountId("568056954830");
     existingContract.setStartDate(offsetDateTime);
     existingContract.setEndDate(null);
     existingContract.setBillingProvider("aws_marketplace");
-    existingContract.setSku("MW01484");
+    existingContract.setSku("RH000000");
     existingContract.setProductId("BASILISK123");
     existingContract.setOrgId("org123");
     existingContract.setLastUpdated(offsetDateTime);


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1050

**Description:**
UMB message structure has changed. This PR takes care of the new structure and also includes changes to accommodate SKU.

**Prereq:**
- `%stage.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8001/api/rhsm-subscriptions/v1`
- Set `server.port=8001` in application.properties or yaml for swatch-core and start the application using ` DEV_MODE=true ./gradlew :bootRun`.
- Set env variable for contract app: ENABLE_SPLUNK_HEC=false; KEYSTORE_PASSWORD=<Password>; KEYSTORE_RESOURCE=file:/home/...../rhsm-subscriptions/config/certs/keystore.jks; QUARKUS_PROFILE=stage;SWATCH_SELF_PSK=<placeholder>
- Authorize using Name: x-rh-swatch-psk as placeholder http://localhost:8000/q/swagger-ui/#/default/createPartnerEntitlementContract

Test steps:
1. Test 1:
    **Request:**
    curl -X 'POST' \
      'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/partner/contracts' \
      -H 'accept: application/json' \
      -H 'x-rh-swatch-psk: placeholder' \
      -H 'Content-Type: application/json' \
      -d '{
      "action": "contract-updated",
      "redHatSubscriptionNumber": "12400374",
      "currentDimensions": [
        {
          "dimensionName": "cpu-hours",
          "dimensionValue": "5",
          "expirationDate": "2018-02-10T09:30Z"
        },
        {
          "dimensionName": "instance-hours",
          "dimensionValue": "10",
          "expirationDate": "2018-02-10T09:30Z"
        }
      ],
      "cloudIdentifiers": {
        "awsCustomerId": "568056954830",
        "productCode": "ek1lel8qbwnqimt2wogc5nmey"
      }
    }'
    
    **Response:**
    {
      "message": "Empty value in non-null fields"
    }