### PR TITLE
SWATCH-1057 Update our schemas and API to include ROSA as a product

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1084,6 +1084,7 @@ components:
         - rhacs
         - rhods
         - BASILISK
+        - rosa
     MetricId:
       type: string
       enum:

--- a/swatch-core/schemas/event.yaml
+++ b/swatch-core/schemas/event.yaml
@@ -136,6 +136,7 @@ properties:
       - rhacs
       - addon-open-data-hub
       - BASILISK
+      - rosa
     required: false
   sla:
     description: Service level for the subject.


### PR DESCRIPTION
Intentionally added instead of renaming BASILISK, to keep things working