### PR TITLE
SWATCH-1082: Fix rosa event role enum

### DIFF
--- a/swatch-core/schemas/event.yaml
+++ b/swatch-core/schemas/event.yaml
@@ -136,7 +136,7 @@ properties:
       - rhacs
       - addon-open-data-hub
       - BASILISK
-      - rosa
+      - moa-hostedcontrolplane
     required: false
   sla:
     description: Service level for the subject.


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1082

Testing
=======

Run the service:

```shell
DEV_MODE=true ./gradlew :bootRun
```

Manually create an event having `role="moa-hostedcontrolplane"`:

```shell
event=`cat <<EOF
[{
  "event_source": "prometheus",
  "event_type": "snapshot_redhat.com:rosa:cluster_hour",
  "org_id": "org123",
  "instance_id": "0688fdc4-5991-4204-8611-74ed0ac0af22",
  "timestamp": "2023-03-28T06:00:00Z",
  "expiration": "2023-03-28T07:00:00Z",
  "display_name": "test",
  "measurements": [{"uom": "Instance-hours", "value": 1}],
  "role": "moa-hostedcontrolplane",
  "sla": "Premium",
  "service_type": "rosa Instance",
  "billing_provider": "aws"
}]
EOF
`
http :9000/hawtio/jolokia \
  mbean=org.candlepin.subscriptions.jmx:name=eventJmxBean,type=EventJmxBean \
  type=exec \
  operation='saveEvents(java.lang.String)' \
  arguments:="[$(echo $event | jq)]"
```