### PR TITLE
SWATCH-1011: Implement rate limiting for RHSM API interactions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,6 +51,7 @@ libraries["quarkus-qpid-jms-bom"] = "io.quarkus.platform:quarkus-qpid-jms-bom:2.
 libraries["quarkus-bom"] = "io.quarkus.platform:quarkus-bom:2.16.5.Final"
 libraries["quarkus-logging-logback"] = "io.quarkiverse.logging.logback:quarkus-logging-logback:0.13.0"
 libraries["quarkus-logging-splunk"] = "io.quarkiverse.logging.splunk:quarkus-logging-splunk:2.5.1"
+libraries["resilience4j-spring-boot2"] = "io.github.resilience4j:resilience4j-spring-boot2:2.0.2"
 libraries["resteasy-client"] = "org.jboss.resteasy:resteasy-client:5.0.6.Final"
 libraries["resteasy-jackson2-provider"] = "org.jboss.resteasy:resteasy-jackson2-provider:5.0.6.Final"
 libraries["resteasy-multipart-provider"] = "org.jboss.resteasy:resteasy-multipart-provider:5.0.6.Final"

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation "org.postgresql:postgresql"
     implementation "io.hawt:hawtio-springboot"
     implementation "org.hibernate.validator:hibernate-validator"
+    implementation libraries["resilience4j-spring-boot2"]
 
     testImplementation "org.springframework.security:spring-security-test"
     testImplementation "org.springframework.kafka:spring-kafka-test"

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -97,6 +97,12 @@ parameters:
     value: '3'
   - name: HOST_LAST_SYNC_THRESHOLD
     value: '30h'
+  - name: RHSM_API_LIMIT_FOR_PERIOD
+    value: '150'
+  - name: RHSM_API_LIMIT_REFRESH_PERIOD
+    value: 100ms
+  - name: RHSM_API_LIMIT_TIMEOUT_DURATION
+    value: 30m
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -279,6 +285,12 @@ objects:
                 secretKeyRef:
                   name: swatch-psks
                   key: self
+            - name: RHSM_API_LIMIT_FOR_PERIOD
+              value: ${RHSM_API_LIMIT_FOR_PERIOD}
+            - name: RHSM_API_LIMIT_REFRESH_PERIOD
+              value: ${RHSM_API_LIMIT_REFRESH_PERIOD}
+            - name: RHSM_API_LIMIT_TIMEOUT_DURATION
+              value: ${RHSM_API_LIMIT_TIMEOUT_DURATION}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -6,6 +6,12 @@ spring:
     import: classpath:swatch-core/application.yaml  # load the common configuration
   profiles:
     active: kafka-queue
+resilience4j.ratelimiter:
+  instances:
+    rhsmApi:
+      limitForPeriod: ${RHSM_API_LIMIT_FOR_PERIOD:15}
+      limitRefreshPeriod: ${RHSM_API_LIMIT_REFRESH_PERIOD:100ms}
+      timeoutDuration: ${RHSM_API_LIMIT_TIMEOUT_DURATION:30m}
 rhsm-conduit:
   rhsm:
     use-stub: ${RHSM_USE_STUB:false}


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1011

This introduces the following template params/env vars:

* `RHSM_API_LIMIT_FOR_PERIOD` - how many RHSM API operations allowed in the rate limit window.
* `RHSM_API_LIMIT_REFRESH_PERIOD` - how often the rate limit should be refreshed.
* `RHSM_API_LIMIT_TIMEOUT_DURATION` - the max time a pending RHSM API interaction should wait before timing out.

These are set by default to values that enforce an effective limit of 150 requests/second:

* limit: 150
* refresh period: 100ms
* timeout duration: 30m

Timeout chosen as 30m, as this corresponds to our kafka max poll interval (if it takes longer than that the kafka message is going to be rejected anyways)

Testing
=======

Run the application with some overrides to test the rate limiting:

```shell
DEV_MODE=true \
  RHSM_USE_STUB=true \
  RHSM_MAX_ATTEMPTS=1 \
  RHSM_API_LIMIT_REFRESH_PERIOD=60s \
  RHSM_API_LIMIT_FOR_PERIOD=1 \
  RHSM_API_LIMIT_TIMEOUT_DURATION=10s \
  ./gradlew :swatch-system-conduit:bootRun
```

Check the metrics for the rate limiter:

```shell
http :9000/metrics/ | grep resilience4j | grep rhsmApi
```

Observe there is a single "permission available" - indicating the rate limit is not yet exhausted.

Next, invoke conduit operations:

```shell
http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg \
  org_id=org123 \
  x-rh-swatch-psk:placeholder
```

Next, consult the metrics and see that there are no remaining permissions available.

Make the above request again, and see that it times out after 10s and responds with HTTP 429.