### PR TITLE
SWATCH-1083: Remove retry from billing usage when missing contracts

### DIFF
--- a/bin/BASILISK.csv
+++ b/bin/BASILISK.csv
@@ -1,8 +1,8 @@
 event_type,account,org_id,instance,timestamp,expiration,role,sla,uom,value,service_type,billing_provider,billing_account_id
-redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,BASILISK,Premium,Storage-gibibytes,0.2,BASILISK Instance,red hat,dummyId
-redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,BASILISK,Premium,Storage-gibibytes,0.5,BASILISK Instance,red hat,dummyId
-redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,BASILISK,Premium,Storage-gibibytes,0.75,BASILISK Instance,red hat,dummyId
-redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,BASILISK,Premium,Storage-gibibytes,1.5,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,BASILISK,Premium,Storage-gibibyte-months,0.2,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,BASILISK,Premium,Storage-gibibyte-months,0.5,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,BASILISK,Premium,Storage-gibibyte-months,0.75,BASILISK Instance,red hat,dummyId
+redhat.com:BASILISK:storage_gb,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T22:00:00Z,2021-10-19T22:00:00Z,BASILISK,Premium,Storage-gibibyte-months,1.5,BASILISK Instance,red hat,dummyId
 redhat.com:BASILISK:cluster_hour,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T19:00:00Z,2021-10-19T19:00:00Z,BASILISK,Premium,Instance-hours,1,BASILISK Instance,red hat,dummyId
 redhat.com:BASILISK:cluster_hour,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T20:00:00Z,2021-10-19T20:00:00Z,BASILISK,Premium,Instance-hours,0,BASILISK Instance,red hat,dummyId
 redhat.com:BASILISK:cluster_hour,account123,org123,c5mu16smf1c22rn8e730,2021-10-18T21:00:00Z,2021-10-19T21:00:00Z,BASILISK,Premium,Instance-hours,1,BASILISK Instance,red hat,dummyId

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -35,6 +35,7 @@ import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
 import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
 import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.Measurement;
@@ -179,13 +180,18 @@ public class BillableUsageController {
     } catch (ExternalServiceException ex) {
       if (usage.getSnapshotDate().isAfter(OffsetDateTime.now().minus(30, ChronoUnit.MINUTES))) {
         log.warn(
-            "Unable to retrieve contract for usage less than {} minutes old. Usage: {}", 30, usage);
-      } else {
-        log.error(
-            "Unable to retrieve contract for usage older than {} minutes old. Usage: {}",
+            "{} - Unable to retrieve contract for usage less than {} minutes old. Usage: {}",
+            ErrorCode.CONTRACT_NOT_AVAILABLE,
             30,
             usage);
-        throw ex;
+        return null;
+      } else {
+        log.error(
+            "{} - Unable to retrieve contract for usage older than {} minutes old. Usage: {}",
+            ErrorCode.CONTRACT_NOT_AVAILABLE,
+            30,
+            usage);
+        return null;
       }
     }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
@@ -54,6 +54,7 @@ public class BillingProducer {
     log.debug("Sending billable usage {} to topic {}", usage, billableUsageTopic);
     if (usage == null) {
       log.warn("Skipping billable usage; see previous errors/warnings.");
+      return;
     }
     billableUsageKafkaTemplate.send(billableUsageTopic, usage);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
@@ -52,6 +52,9 @@ public class BillingProducer {
 
   public void produce(BillableUsage usage) {
     log.debug("Sending billable usage {} to topic {}", usage, billableUsageTopic);
+    if (usage == null) {
+      log.warn("Skipping billable usage; see previous errors/warnings.");
+    }
     billableUsageKafkaTemplate.send(billableUsageTopic, usage);
   }
 }

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -54,7 +54,7 @@ rhsm-subscriptions:
       back-off-initial-interval: ${CONTRACT_CLIENT_BACK_OFF_INITIAL_INTERVAL_MILLIS:1000}
       back-off-max-interval: ${CONTRACT_CLIENT_BACK_OFF_MAX_INTERVAL_MILLIS:64000}
       back-off-multiplier: ${CONTRACT_CLIENT_BACK_OFF_MULTIPLIER:2}
-      max-attempts: ${CONTRACT_CLIENT_MAX_ATTEMPTS:6}
+      max-attempts: ${CONTRACT_CLIENT_MAX_ATTEMPTS:1}
       url: ${SWATCH_CONTRACTS_INTERNAL_SERVICE_URL:http://localhost:8001}
       psk: ${SWATCH_SELF_PSK:placeholder}
   tasks:

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -506,6 +506,6 @@ class BillableUsageControllerTest {
     when(tagProfile.isTagContractEnabled(usage.getProductId())).thenReturn(true);
     when(contractsApi.getContract(any(), any(), any(), any(), any(), any())).thenReturn(List.of());
     controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
-    verify(producer).produce(usage);
+    verify(producer).produce(null);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -85,7 +85,9 @@ public enum ErrorCode {
 
   ACCOUNT_MISSING_ERROR(3002, "Account not present according to RH IT services"),
 
-  OFFERING_MISSING_ERROR(3003, "Sku not present in Offering");
+  OFFERING_MISSING_ERROR(3003, "Sku not present in Offering"),
+
+  CONTRACT_NOT_AVAILABLE(3004, "Expected contract missing");
 
   private static final String CODE_PREFIX = "SUBSCRIPTIONS";
 

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -169,7 +169,7 @@ parameters:
   - name: CONTRACT_CLIENT_BACK_OFF_MULTIPLIER
     value: '2'
   - name: CONTRACT_CLIENT_MAX_ATTEMPTS
-    value: '6'
+    value: '1'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1083

Also

* changed attempts to 1 for contracts retry (effectively no retry).
* fixed `bin/BASLISK.csv` to use proper storage UOM.
* added an error code to the warning/error.

Testing
=======

Run the contracts service on port 8882:

```shell
SERVER_PORT=8882 ./gradlew :swatch-contracts:quarkusDev
```

Run the service:

```shell
SPRING_PROFILES_ACTIVE=worker,kafka-task-queue \
  SWATCH_CONTRACTS_INTERNAL_SERVICE_URL=http://localhost:8882 \
  DEV_MODE=true \
  ./gradlew :bootRun
```

Import some events:

```shell
bin/import-events.py --file bin/BASILISK.csv
```

Trigger an hourly tally:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)' \
  arguments:='["org123", "2021-10-18T22:00:00Z","2021-10-18T23:00:00Z"]'
```

Observe 3 different instances of the warning like:

```
SUBSCRIPTIONS3004: Expected contract missing - Unable to retrieve contract for usage older than 30 minutes old. Usage: org.candlepin.subscriptions.json.BillableUsage@6ab88e89[accountNumber=account123,orgId=org123,id=5340e639-1f81-4ecc-bb4d-69b71702c2e3,billingProvider=red hat,billingAccountId=dummyId,snapshotDate=2021-10-18T22:00Z,productId=BASILISK,sla=Premium,usage=Production,uom=Storage-gibibyte-months,value=1.5,billingFactor=<null>]
```

There is a separate message per metric (BASILISK has 3 metrics).