### PR TITLE
Retally when start date and instance last_seen are equal

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -117,7 +117,8 @@ public class MetricUsageCollector {
     We need to recalculate several things if we are re-tallying, namely monthly totals need to be
     cleared and re-updated for each host record
      */
-    if (newestInstanceTimestamp.isAfter(range.getStartDate())) {
+    if (newestInstanceTimestamp.isAfter(range.getStartDate())
+        || newestInstanceTimestamp.isEqual(range.getStartDate())) {
       effectiveStartDateTime = clock.startOfMonth(range.getStartDate());
       effectiveEndDateTime = clock.endOfCurrentHour();
       log.info(


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1090

Test Steps:

- Insert events:
```
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('c107fada-5223-44c6-9ad5-b538a4fd434a', 'account123', '2023-04-05 11:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "c107fada-5223-44c6-9ad5-b538a4fd434a", "timestamp": "2023-04-05T11:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2023-04-05T12:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('29a25eb8-1fde-4dbd-ab2a-845188d58da4', 'account123', '2023-04-05 11:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "29a25eb8-1fde-4dbd-ab2a-845188d58da4", "timestamp": "2023-04-05T11:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-04-05T12:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.99}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:cluster_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('4e1a54f7-abd0-493d-b737-a15d8c06980c', 'account123', '2023-04-05 12:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "4e1a54f7-abd0-493d-b737-a15d8c06980c", "timestamp": "2023-04-05T12:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2023-04-05T13:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('160ed680-16dd-4276-b45e-4f107e6e5fbc', 'account123', '2023-04-05 12:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "160ed680-16dd-4276-b45e-4f107e6e5fbc", "timestamp": "2023-04-05T12:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-04-05T13:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.99}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:cluster_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('8afb0d5f-5102-4abc-99d7-266a5afae50c', 'account123', '2023-04-05 13:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "8afb0d5f-5102-4abc-99d7-266a5afae50c", "timestamp": "2023-04-05T13:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2023-04-05T14:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('a7c199c7-33cd-4918-8baf-a81dc2686d4f', 'account123', '2023-04-05 13:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "a7c199c7-33cd-4918-8baf-a81dc2686d4f", "timestamp": "2023-04-05T13:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-04-05T14:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.99}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:cluster_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('a97228ff-8004-4495-88bf-18639da2dc5b', 'account123', '2023-04-05 14:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "a97228ff-8004-4495-88bf-18639da2dc5b", "timestamp": "2023-04-05T14:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2023-04-05T15:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('4349a660-38c7-4302-bc93-6bb189a87499', 'account123', '2023-04-05 14:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "4349a660-38c7-4302-bc93-6bb189a87499", "timestamp": "2023-04-05T14:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-04-05T15:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.99}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:cluster_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('c740489e-8d34-41fc-a505-ba4823275257', 'account123', '2023-04-05 15:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "c740489e-8d34-41fc-a505-ba4823275257", "timestamp": "2023-04-05T15:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2023-04-05T16:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('3e7f5f0d-c2e1-474a-b222-ba20b5ee7025', 'account123', '2023-04-05 15:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "3e7f5f0d-c2e1-474a-b222-ba20b5ee7025", "timestamp": "2023-04-05T15:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-04-05T16:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.99}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:cluster_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('4b2619a1-f36b-4d78-97e2-7d8fb0b55760', 'account123', '2023-04-05 16:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "4b2619a1-f36b-4d78-97e2-7d8fb0b55760", "timestamp": "2023-04-05T16:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2023-04-05T17:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
INSERT INTO public.events (id, account_number, "timestamp", data, event_type, event_source, instance_id, org_id) VALUES ('4032dc7a-d330-46e7-b9c9-aa2d70f9706d', 'account123', '2023-04-05 16:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "4032dc7a-d330-46e7-b9c9-aa2d70f9706d", "timestamp": "2023-04-05T16:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-04-05T17:00:00Z", "instance_id": "7e52a0fc-32da-49f0-83f5-ba38034780a5", "display_name": "automation_osd_cluster_7e52a0fc-32da-49f0-83f5-ba38034780a5", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.99}], "service_type": "OpenShift Cluster", "account_number": "account123"}', 'snapshot_redhat.com:openshift_dedicated:cluster_hour', 'prometheus', '7e52a0fc-32da-49f0-83f5-ba38034780a5', 'org123');
```
- Trigger hourly tally which will include all events:
```
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)' \
  arguments:='["org123", "2023-04-02T11:00:00Z","2023-04-05T17:00:00Z"]'
```
- Curl host api and expect to see Cores = 24 and Instance-hours = 11.94
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2023-04-01T00%3A32%3A28Z&ending=2023-04-06T17%3A32%3A28Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
- Trigger hourly tally for final hour in events:
```
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)' \
  arguments:='["org123", "2023-04-05T16:00:00Z","2023-04-05T17:00:00Z"]'
```
- Curl host api again and expect to see Cores = 24 and Instance-hours = 11.94 (previously would have added final event to total values giving you Cores = 28 and Instance-hours = 13.93)
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/hosts/products/OpenShift-dedicated-metrics?beginning=2023-04-01T00%3A32%3A28Z&ending=2023-04-06T17%3A32%3A28Z' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```