### PR TITLE
swatch-949: add missing hashcode and equals

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
@@ -26,6 +26,7 @@ import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -39,6 +40,7 @@ import org.candlepin.subscriptions.json.Measurement;
 @AllArgsConstructor
 @Getter
 @Setter
+@EqualsAndHashCode
 public class TallyInstanceViewKey implements Serializable {
 
   @Column(name = "instance_id")


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-949

Test Steps:
- Start app with ` DEV_MODE=true ./gradlew :bootRun`
- Should not see any logs like: "composite-id class does not override hashCode(): org.candlepin.subscriptions.db.model.TallyInstanceViewKey "