### PR TITLE
SWATCH-1093: Apply otel-enabled nginx image to API deployment

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -54,6 +54,12 @@ parameters:
     value: '1000'
   - name: SPLUNK_HEC_TERMINATION_TIMEOUT
     value: '2000'
+  - name: NGINX_OTEL_IMAGE_TAG
+    value: '1df2c89'
+  - name: OTEL_ENABLED
+    value: 'off'
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: 'http://localhost:4317'
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
@@ -255,7 +261,7 @@ objects:
               enabled: true
               apiPath: rhsm-subscriptions
           podSpec:
-            image: quay.io/app-sre/ubi8-nginx-118
+            image: quay.io/cloudservices/nginx-otel:${NGINX_OTEL_IMAGE_TAG}
             command:
             - nginx
             - "-g"
@@ -263,6 +269,10 @@ objects:
             env:
             - name: DEV_MODE
               value: ${DEV_MODE}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: swatch-api-nginx-proxy
             volumeMounts:
             - name: swatch-api-nginx-conf
               mountPath: /etc/nginx
@@ -295,8 +305,11 @@ objects:
       name: nginx-conf
     data:
       nginx.conf: |-
+        load_module /opt/otel_ngx_module.so;
         events {}
         http {
+          opentelemetry ${OTEL_ENABLED};
+          opentelemetry_config /etc/nginx/otel.toml;
           upstream swatch-api {
             server swatch-api-service:8000;
           }
@@ -309,6 +322,7 @@ objects:
             client_header_buffer_size 46k;
 
             location /healthz {
+                opentelemetry       off;
                 auth_basic          off;
                 allow               all;
                 return              200;
@@ -319,3 +333,14 @@ objects:
             }
           }
         }
+      otel.toml: |-
+        exporter = "otlp"
+        processor = "batch"
+
+        [exporters.otlp]
+        # host and port are set via OTEL_EXPORTER_OTLP_ENDPOINT
+
+        [processors.batch]
+        max_queue_size = 2048
+        schedule_delay_millis = 5000
+        max_export_batch_size = 512


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1093

This adds new template params:

* `NGINX_OTEL_IMAGE_TAG`: used to update the nginx image used
* `OTEL_ENABLED`: default off, used to disable/enable otel instrumentation
* `OTEL_EXPORTER_OTLP_ENDPOINT`: configures the endpoint used to report traces to

Testing
=======

Reserve an ephemeral namespace for testing:

```shell
oc project $(bonfire namespace reserve)
```

Deploy swatch:

```shell
bonfire deploy rhsm
```

Note that without further adjustments the deployment fail. However, this is fine as we only care about a few pods.

Create a jaeger all-in-one configuration:

```shell
cat <<EOF > /tmp/values.yaml
provisionDataStore:
  cassandra: false
allInOne:
  enabled: true
storage:
  type: none
agent:
  enabled: false
collector:
  enabled: false
query:
  enabled: false
EOF
```

Use https://helm.sh to deploy jaeger:

```shell
helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
helm template -f /tmp/values.yaml jaegertracing/jaeger \
  --kube-version=1.21.1 \
  --name-template='test' | oc apply -f -
```

Manually deploy this updated nginx proxy deployment:

```shell
oc process \
  -p OTEL_EXPORTER_OTLP_ENDPOINT=http://test-jaeger-collector:4317 \
  -p OTEL_ENABLED=on \
  -p ENV_NAME=env-$(oc project -q) \
  -f swatch-api/deploy/clowdapp.yaml | oc apply -f -
```

Invoke an HTTP request to the proxy and wait for it to succeed or timeout:

```shell
oc rsh Deployment/swatch-api-nginx-proxy bash -c 'curl http://localhost:8000/test/foo2'
```

Port forward the jaeger UI:

```shell
oc port-forward service/test-jaeger-query 16686
```

View the trace in the jaeger UI at http://localhost:16686.