### PR TITLE
SWATCH-554 Add 'releaseVer' to rhsm-conduit in facts

### DIFF
--- a/clients/rhsm-client/rhsm-api-spec.yaml
+++ b/clients/rhsm-client/rhsm-api-spec.yaml
@@ -125,6 +125,8 @@ components:
           type: string
         sysPurposeUsage:
           type: string
+        releaseVer:
+          type: string
         sysPurposeAddons:
           type: array
           items:

--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -48,6 +48,7 @@ public class StubRhsmApi extends RhsmApi {
     consumer1.setAccountNumber("ACCOUNT_1");
     consumer1.setHypervisorName("hypervisor1.test.com");
     consumer1.setServiceLevel("Premium");
+    consumer1.setReleaseVer("8.0");
     consumer1.getFacts().put("network.fqdn", "host1.test.com");
     consumer1.getFacts().put("dmi.system.uuid", UUID.randomUUID().toString());
     consumer1.getFacts().put("Ip-addresses", "192.168.1.1, 10.0.0.1");

--- a/swatch-system-conduit/schemas/inventory/hbi-system-profile.yaml
+++ b/swatch-system-conduit/schemas/inventory/hbi-system-profile.yaml
@@ -5,6 +5,8 @@ properties:
     $ref: "hbi-system-profile-operating-system.yaml"
   os_release:
     type: string
+  releasever:
+    type: string
   arch:
     type: string
   bios_vendor:

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -171,6 +171,7 @@ public class InventoryController {
     facts.setSysPurposeRole(consumer.getSysPurposeRole());
     facts.setSysPurposeSla(consumer.getServiceLevel());
     facts.setSysPurposeUsage(consumer.getSysPurposeUsage());
+    facts.setReleaseVer(consumer.getReleaseVer());
     facts.setSysPurposeAddons(consumer.getSysPurposeAddons());
     facts.setSysPurposeUnits(rhsmFacts.get(OCM_UNITS));
     facts.setBillingModel(rhsmFacts.get(OCM_BILLING_MODEL));

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -34,7 +34,11 @@ import org.slf4j.LoggerFactory;
 /**
  * Defines operations against the inventory service. This service allows batching host fact updates.
  * Once the maximum fact queue depth is reached, the service will auto flush the updates so that we
- * don't keep too many facts in memory before they are pushed to inventory.
+ * don't keep too many facts in memory before they are pushed to inventory. We have four types of
+ * things stored in HBI hosts. 1. Core information like orgId, IP 2. system_profile_facts json
+ * includes non-core information like os_release, 3. canonical_facts json is important for HBI but,
+ * not for swatch table. 4. facts are all other information. Facts used to store all values
+ * initially and later separated out.
  */
 public abstract class InventoryService {
 
@@ -138,6 +142,7 @@ public abstract class InventoryService {
     systemProfile.setOwnerId(facts.getSubscriptionManagerId());
     systemProfile.setNetworkInterfaces(facts.getNetworkInterfaces());
     systemProfile.setIsMarketplace(facts.getIsMarketplace());
+    systemProfile.setReleasever(facts.getReleaseVer());
     return systemProfile;
   }
 

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -253,6 +253,8 @@ components:
           type: string
         sys_purpose_usage:
           type: string
+        release_ver:
+          type: string
         sys_purpose_addons:
           type: array
           items:

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -492,6 +492,17 @@ class InventoryControllerTest {
   }
 
   @Test
+  void testReleaseverInFacts_WhenReleaseVerPresent() {
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+    consumer.setReleaseVer("8.0");
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals("8.0", conduitFacts.getReleaseVer());
+  }
+
+  @Test
   void testIsMarketplaceFacts_WhenAzureOfferPresent() {
     String azureOfferFact = "azure_offer";
     String azzureOffer = "RHEL";


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-554

**Description:**

1. We have four types of facts stored in HBI hosts. 

 * Core information like orgId, IP 
 * system_profile_facts json includes non-core information like os_release, 
 * canonical_facts json is important for HBI but, not for swatch table. 
 * facts are all other information. Facts used to store all values initially and later separated out.

2. We also have two parts to this kind of card. 

 * conduit changes include ingesting RHSM feed and then publish it to Kafka queue for HBI
 * Rhsm monolith gets the information from HBI table and then store it on our table or send it to analytics team. To pull the information we use InventoryHostFacts and InventoryHost entity. Example https://github.com/RedHatInsights/rhsm-subscriptions/pull/2043
 

3. In order to publish this information to Kafka HBI we see how it is mapped on inventory end. https://github.com/RedHatInsights/inventory-schemas/blob/master/schemas/system_profile/v1.yaml#L317

**Test Steps:**
1. Run with stub
Run: ```RHSM_USE_STUB=true DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun```

2. Run: ```http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg   x-rh-swatch-psk:placeholder   org_id=org123```

3. Result: 
 - New message sent in Kafka queue `platform.inventory.host-ingress`
```
0,3237,Wed Apr 12 09:52:56 EDT 2023,,{"operation":"add_host","data":{"account":"ACCOUNT_1","org_id":"org123","subscription_manager_id":"09156e70-ca25-42d3-a492-2d58d75e8ebf","bios_uuid":"ed355dca-860f-4a77-ad54-8980a537a692","ip_addresses":["192.167.11.2","192.168.1.1","192.168.122.1","10.0.0.1"],"fqdn":"host1.test.com","facts":[{"namespace":"rhsm","facts":{"SYNC_TIMESTAMP":"2023-04-12T13:52:56.964391684Z","IS_VIRTUAL":true,"SYSPURPOSE_SLA":"Premium","MEMORY":32,"ARCHITECTURE":"x86_64","VM_HOST":"hypervisor1.test.com","SYSPURPOSE_UNITS":"Sockets","RH_PROD":["72"],"orgId":"org123","BILLING_MODEL":"standard"}}],"system_profile":{"operating_system":{"major":6,"minor":3,"name":"RHEL"},"os_release":"6.3","releasever":"8.0","arch":"x86_64","cores_per_socket":2,"infrastructure_type":"virtual","system_memory_bytes":33543999488,"number_of_sockets":2,"owner_id":"09156e70-ca25-42d3-a492-2d58d75e8ebf","is_marketplace":true,"network_interfaces":[{"ipv4_addresses":["127.0.0.1"],"mac_address":"00:00:00:00:00:00","name":"lo"}]},"stale_timestamp":"2023-04-14T13:52:56.964391684Z","reporter":"rhsm-conduit"},"platform_metadata":{"request_id":"11b215c6-0a6f-4ea7-b975-f10a739e7163"}}
```