### PR TITLE
SWATCH-554 Add 'releaseVer'

### DIFF
--- a/clients/rhsm-client/rhsm-api-spec.yaml
+++ b/clients/rhsm-client/rhsm-api-spec.yaml
@@ -125,6 +125,8 @@ components:
           type: string
         sysPurposeUsage:
           type: string
+        releaseVer:
+          type: string
         sysPurposeAddons:
           type: array
           items:

--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -48,6 +48,7 @@ public class StubRhsmApi extends RhsmApi {
     consumer1.setAccountNumber("ACCOUNT_1");
     consumer1.setHypervisorName("hypervisor1.test.com");
     consumer1.setServiceLevel("Premium");
+    consumer1.setReleaseVer("8.0");
     consumer1.getFacts().put("network.fqdn", "host1.test.com");
     consumer1.getFacts().put("dmi.system.uuid", UUID.randomUUID().toString());
     consumer1.getFacts().put("Ip-addresses", "192.168.1.1, 10.0.0.1");

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -59,6 +59,7 @@ public class InventoryHostFacts {
   private String syspurposeRole;
   private String syspurposeSla;
   private String syspurposeUsage;
+  private String releaseVer;
   private String syspurposeUnits;
   private String billingModel;
   private String cloudProvider;
@@ -93,6 +94,7 @@ public class InventoryHostFacts {
       String syspurposeRole,
       String syspurposeSla,
       String syspurposeUsage,
+      String releaseVer,
       String syspurposeUnits,
       String billingModel,
       String isVirtual,
@@ -125,6 +127,7 @@ public class InventoryHostFacts {
     this.syspurposeRole = syspurposeRole;
     this.syspurposeSla = syspurposeSla;
     this.syspurposeUsage = syspurposeUsage;
+    this.releaseVer = releaseVer;
     this.syspurposeUnits = syspurposeUnits;
     this.isVirtual = asBoolean(isVirtual);
     this.hypervisorUuid = hypervisorUuid;

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -291,6 +291,7 @@ public class FactNormalizer {
       handleRole(normalizedFacts, hostFacts.getSyspurposeRole());
       handleSla(normalizedFacts, hostFacts, hostFacts.getSyspurposeSla());
       handleUsage(normalizedFacts, hostFacts, hostFacts.getSyspurposeUsage());
+      normalizedFacts.setReleaseVer(hostFacts.getReleaseVer());
     }
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -41,6 +41,7 @@ public class NormalizedFacts {
   private Integer sockets;
   private String orgId;
   private String account;
+  private String releaseVer;
 
   /** Subscription-manager ID (UUID) of the hypervisor for this system */
   private String hypervisorUuid;

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorCollectTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorCollectTest.java
@@ -143,7 +143,8 @@ class InventoryAccountUsageCollectorCollectTest {
   @Test
   void removesDuplicateHostRecords() {
     List<Integer> products = List.of(TEST_PRODUCT_ID);
-    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    InventoryHostFacts host =
+        createRhsmHost(ACCOUNT, ORG_ID, products, "", "", OffsetDateTime.now());
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileSockets(3);
     Host orig =
@@ -182,7 +183,8 @@ class InventoryAccountUsageCollectorCollectTest {
   @Test
   void ensureStaleHostsAreDeleted() {
     List<Integer> products = List.of(TEST_PRODUCT_ID);
-    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    InventoryHostFacts host =
+        createRhsmHost(ACCOUNT, ORG_ID, products, "", "", OffsetDateTime.now());
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileSockets(3);
     Host orig =

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
@@ -200,7 +200,8 @@ class InventoryAccountUsageCollectorTallyTest {
   void physicalSystemTotalsForRHEL() {
     List<Integer> products = List.of(TEST_PRODUCT_ID);
 
-    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    InventoryHostFacts host =
+        createRhsmHost(ACCOUNT, ORG_ID, products, "", "", OffsetDateTime.now());
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileSockets(3);
     mockReportedHypervisors(ORG_ID, new HashMap<>());
@@ -229,15 +230,18 @@ class InventoryAccountUsageCollectorTallyTest {
 
     List<Integer> products = List.of(TEST_PRODUCT_ID);
 
-    InventoryHostFacts host1 = createRhsmHost(account1, orgId1, products, "", OffsetDateTime.now());
+    InventoryHostFacts host1 =
+        createRhsmHost(account1, orgId1, products, "", "", OffsetDateTime.now());
     host1.setSystemProfileCoresPerSocket(1);
     host1.setSystemProfileSockets(4);
 
-    InventoryHostFacts host2 = createRhsmHost(account1, orgId1, products, "", OffsetDateTime.now());
+    InventoryHostFacts host2 =
+        createRhsmHost(account1, orgId1, products, "", "", OffsetDateTime.now());
     host2.setSystemProfileCoresPerSocket(2);
     host2.setSystemProfileSockets(4);
 
-    InventoryHostFacts host3 = createRhsmHost(account2, orgId2, products, "", OffsetDateTime.now());
+    InventoryHostFacts host3 =
+        createRhsmHost(account2, orgId2, products, "", "", OffsetDateTime.now());
     host3.setSystemProfileCoresPerSocket(3);
     host3.setSystemProfileSockets(2);
 
@@ -280,6 +284,7 @@ class InventoryAccountUsageCollectorTallyTest {
             TEST_PRODUCT_ID.toString(),
             ServiceLevel.STANDARD,
             "",
+            "",
             OffsetDateTime.now());
     host1.setSystemProfileCoresPerSocket(1);
     host1.setSystemProfileSockets(6);
@@ -290,6 +295,7 @@ class InventoryAccountUsageCollectorTallyTest {
             ORG_ID,
             TEST_PRODUCT_ID.toString(),
             ServiceLevel.PREMIUM,
+            "",
             "",
             OffsetDateTime.now());
     host2.setSystemProfileCoresPerSocket(1);
@@ -319,6 +325,7 @@ class InventoryAccountUsageCollectorTallyTest {
             ServiceLevel.EMPTY,
             Usage.DEVELOPMENT_TEST,
             "",
+            "",
             OffsetDateTime.now());
     host1.setSystemProfileCoresPerSocket(1);
     host1.setSystemProfileSockets(6);
@@ -330,6 +337,7 @@ class InventoryAccountUsageCollectorTallyTest {
             TEST_PRODUCT_ID.toString(),
             ServiceLevel.EMPTY,
             Usage.PRODUCTION,
+            "",
             "",
             OffsetDateTime.now());
     host2.setSystemProfileCoresPerSocket(1);
@@ -433,11 +441,12 @@ class InventoryAccountUsageCollectorTallyTest {
   @Test
   void testCalculationDoesNotIncludeHostWhenProductDoesntMatch() {
     InventoryHostFacts h1 =
-        createRhsmHost(ACCOUNT, ORG_ID, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+        createRhsmHost(ACCOUNT, ORG_ID, List.of(TEST_PRODUCT_ID), "", "", OffsetDateTime.now());
     h1.setSystemProfileCoresPerSocket(4);
     h1.setSystemProfileSockets(2);
 
-    InventoryHostFacts h2 = createRhsmHost(ACCOUNT, ORG_ID, List.of(32), "", OffsetDateTime.now());
+    InventoryHostFacts h2 =
+        createRhsmHost(ACCOUNT, ORG_ID, List.of(32), "", "", OffsetDateTime.now());
     h2.setSystemProfileCoresPerSocket(12);
     h2.setSystemProfileSockets(14);
 
@@ -464,7 +473,7 @@ class InventoryAccountUsageCollectorTallyTest {
     List<String> orgIds = List.of(orgId1, orgId2);
 
     InventoryHostFacts host1 =
-        createRhsmHost(account1, orgId1, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+        createRhsmHost(account1, orgId1, List.of(TEST_PRODUCT_ID), "", "", OffsetDateTime.now());
     host1.setSystemProfileCoresPerSocket(1);
     host1.setSystemProfileSockets(4);
 
@@ -473,7 +482,7 @@ class InventoryAccountUsageCollectorTallyTest {
     host2.setSystemProfileSockets(4);
 
     InventoryHostFacts host3 =
-        createRhsmHost(account2, orgId2, List.of(TEST_PRODUCT_ID), "", OffsetDateTime.now());
+        createRhsmHost(account2, orgId2, List.of(TEST_PRODUCT_ID), "", "", OffsetDateTime.now());
     host3.setSystemProfileCoresPerSocket(5);
     host3.setSystemProfileSockets(1);
 
@@ -659,7 +668,8 @@ class InventoryAccountUsageCollectorTallyTest {
   @Test
   void accountsWithNullInventoryIdFiltered() {
     List<Integer> products = List.of(TEST_PRODUCT_ID);
-    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    InventoryHostFacts host =
+        createRhsmHost(ACCOUNT, ORG_ID, products, "", "", OffsetDateTime.now());
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileSockets(3);
 
@@ -681,7 +691,8 @@ class InventoryAccountUsageCollectorTallyTest {
   @Test
   void removesDuplicateHostRecords() {
     List<Integer> products = List.of(TEST_PRODUCT_ID);
-    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    InventoryHostFacts host =
+        createRhsmHost(ACCOUNT, ORG_ID, products, "", "", OffsetDateTime.now());
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileSockets(3);
     Host orig =
@@ -720,7 +731,8 @@ class InventoryAccountUsageCollectorTallyTest {
   @Test
   void ensureStaleHostsAreDeleted() {
     List<Integer> products = List.of(TEST_PRODUCT_ID);
-    InventoryHostFacts host = createRhsmHost(ACCOUNT, ORG_ID, products, "", OffsetDateTime.now());
+    InventoryHostFacts host =
+        createRhsmHost(ACCOUNT, ORG_ID, products, "", "", OffsetDateTime.now());
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileSockets(3);
     Host orig =

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -58,22 +58,28 @@ public class InventoryHostFactTestHelper {
       String orgId,
       List<Integer> products,
       String syspurposeRole,
+      String releaseVer,
       OffsetDateTime syncTimestamp) {
     return createRhsmHost(
         account,
         orgId,
         StringUtils.collectionToCommaDelimitedString(products),
         syspurposeRole,
+        releaseVer,
         syncTimestamp);
   }
 
   public static InventoryHostFacts createRhsmHost(
-      List<Integer> products, String syspurposeRole, OffsetDateTime syncTimestamp) {
+      List<Integer> products,
+      String syspurposeRole,
+      String releaseVer,
+      OffsetDateTime syncTimestamp) {
     return createRhsmHost(
         "Account",
         "test_org",
         StringUtils.collectionToCommaDelimitedString(products),
         syspurposeRole,
+        releaseVer,
         syncTimestamp);
   }
 
@@ -82,9 +88,10 @@ public class InventoryHostFactTestHelper {
       String orgId,
       String products,
       String syspurposeRole,
+      String releaseVer,
       OffsetDateTime syncTimeStamp) {
     return createRhsmHost(
-        account, orgId, products, ServiceLevel.EMPTY, syspurposeRole, syncTimeStamp);
+        account, orgId, products, ServiceLevel.EMPTY, syspurposeRole, releaseVer, syncTimeStamp);
   }
 
   public static InventoryHostFacts createRhsmHost(
@@ -93,10 +100,11 @@ public class InventoryHostFactTestHelper {
       String products,
       ServiceLevel sla,
       String syspurposeRole,
+      String releaseVer,
       OffsetDateTime syncTimeStamp) {
 
     return createRhsmHost(
-        account, orgId, products, sla, Usage.EMPTY, syspurposeRole, syncTimeStamp);
+        account, orgId, products, sla, Usage.EMPTY, syspurposeRole, releaseVer, syncTimeStamp);
   }
 
   public static InventoryHostFacts createRhsmHost(
@@ -106,6 +114,7 @@ public class InventoryHostFactTestHelper {
       ServiceLevel sla,
       Usage usage,
       String syspurposeRole,
+      String releaseVer,
       OffsetDateTime syncTimeStamp) {
 
     InventoryHostFacts baseFacts = createBaseHost(account, orgId);
@@ -113,6 +122,7 @@ public class InventoryHostFactTestHelper {
     baseFacts.setSyspurposeRole(syspurposeRole);
     baseFacts.setSyspurposeSla(sla.getValue());
     baseFacts.setSyspurposeUsage(usage.getValue());
+    baseFacts.setReleaseVer(releaseVer);
     baseFacts.setSyncTimestamp(syncTimeStamp.toString());
     return baseFacts;
   }

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -171,6 +171,7 @@ public class InventoryController {
     facts.setSysPurposeRole(consumer.getSysPurposeRole());
     facts.setSysPurposeSla(consumer.getServiceLevel());
     facts.setSysPurposeUsage(consumer.getSysPurposeUsage());
+    facts.setReleaseVer(consumer.getReleaseVer());
     facts.setSysPurposeAddons(consumer.getSysPurposeAddons());
     facts.setSysPurposeUnits(rhsmFacts.get(OCM_UNITS));
     facts.setBillingModel(rhsmFacts.get(OCM_BILLING_MODEL));

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -161,6 +161,7 @@ public abstract class InventoryService {
     addFact(rhsmFactMap, "SYSPURPOSE_ROLE", conduitFacts.getSysPurposeRole());
     addFact(rhsmFactMap, "SYSPURPOSE_SLA", conduitFacts.getSysPurposeSla());
     addFact(rhsmFactMap, "SYSPURPOSE_USAGE", conduitFacts.getSysPurposeUsage());
+    addFact(rhsmFactMap, "RELEASE_VER", conduitFacts.getReleaseVer());
     addFact(rhsmFactMap, "SYSPURPOSE_ADDONS", conduitFacts.getSysPurposeAddons());
     addFact(rhsmFactMap, "SYSPURPOSE_UNITS", conduitFacts.getSysPurposeUnits());
     addFact(rhsmFactMap, "BILLING_MODEL", conduitFacts.getBillingModel());

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -253,6 +253,8 @@ components:
           type: string
         sys_purpose_usage:
           type: string
+        release_ver:
+          type: string
         sys_purpose_addons:
           type: array
           items:


### PR DESCRIPTION
This PR contains changes for both monolith and conduit changes. Conduit changes is used to get RHSM feed and then send it as Kafka message platform.inventory.host-ingress. 
RHSM changes are required to get data from HBI table and then store it on our table or send it to analytics team. To pull the information we use InventoryHostFacts and InventoryHost entity