### PR TITLE
SWATCH-1148: Fix tally snapshot purge job curl command

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -653,7 +653,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge"
+              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:


### PR DESCRIPTION
#References
https://issues.redhat.com/browse/SWATCH-1148

Bug fix for: [SWATCH-1042](https://issues.redhat.com/browse/SWATCH-1042)

# Description
The swatch-tally-service requires the Origin header when requests are made to internal endpoints so that the AntiCsrfFilter allows the request.

This was not detected in EE since the swatch-tally-service is running in DEV_MODE when deployed to EE, and the AntiCsrfFilter is disabled.

When testing locally, even with DEV_MODE disabled, deploying with 'capacity-ingress' profile active (i.e default deploy activates all profiles), the anti CSRF filter is disabled. 



# Testing
No real way to test the job itself other than by merging and deploying.

This is sorta reproducible locally hitting the endpoint manually.

1. Deploy the app with the following profiles.
```
SPRING_PROFILES_ACTIVE="api,worker,kafka-queue" ./gradlew :bootRun
```
**NOTE:** Deploying with all profiles will disable the AntiCsrfFilter since the 'capacity-ingress' profile will be active.

2. Reproduce the 403 that is occuring in stage
```
http POST :8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge x-rh-swatch-psk:placeholder 
```

3. Adding an Origin header matching `*.redhat.com` will allow the request to succeed.
```
http POST :8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge x-rh-swatch-psk:placeholder Origin:localhost.redhat.com
```

