### PR TITLE
SWATCH-1130: Fix NPE due to unboxing w/ marketplace systems

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -221,14 +221,9 @@ public class FactNormalizer {
       return;
     }
 
-    normalizedFacts.setMarketplace(hostFacts.isMarketplace());
-    if (normalizedFacts.getCores() != 0) {
-      normalizedFacts.setCores(0);
-    }
-
-    if (normalizedFacts.getSockets() != 0) {
-      normalizedFacts.setSockets(0);
-    }
+    normalizedFacts.setMarketplace(true);
+    normalizedFacts.setCores(0);
+    normalizedFacts.setSockets(0);
   }
 
   private void defaultNullFacts(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -666,6 +666,18 @@ class FactNormalizerTest {
     assertEquals(0, normalizedFacts.getSockets());
   }
 
+  @Test
+  void testNullSocketsMarketplaceDefaulting() {
+    InventoryHostFacts facts = createRhsmHost(List.of(1), null, clock.now());
+    facts.setMarketplace(true);
+    facts.setSystemProfileSockets(null);
+    facts.setSystemProfileCoresPerSocket(null);
+    NormalizedFacts normalizedFacts = normalizer.normalize(facts, hypervisorData());
+    assertTrue(normalizedFacts.isMarketplace());
+    assertEquals(0, normalizedFacts.getCores());
+    assertEquals(0, normalizedFacts.getSockets());
+  }
+
   private void assertClassification(
       NormalizedFacts check, boolean isHypervisor, boolean isHypervisorUnknown, boolean isVirtual) {
     assertEquals(isHypervisor, check.isHypervisor());


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1130

When a system having a null sockets value or null coresPerSocket value and `is_marketplace=true` is normalized, it caused an NPE because a comparison to 0 triggers unboxing.

Testing
-------

Run the service:

```shell
./gradlew :bootRun
```

Insert a mock aws host:

```shell
bin/insert-mock-hosts --num-aws=1 --hbi --org org123
```

Update the host to have `cores_per_socket=0` and `is_marketplace=true`:

```shell
psql -h localhost -U insights insights <<EOF
  update hosts set system_profile_facts=jsonb_set(system_profile_facts, '{cores_per_socket}', 'null') where system_profile_facts->>'cloud_provider'='AWS';
  update hosts set system_profile_facts=jsonb_set(system_profile_facts, '{is_marketplace}', 'true') where system_profile_facts->>'cloud_provider'='AWS';
EOF
```

Trigger a tally:

```
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean' \
  operation='tallyOrg(java.lang.String)' \
  arguments:='["org123"]'
```

Notice no errors. Redeploy with `main` to reproduce NPE.