### PR TITLE
SWATCH-389: Remove usage of WebSecurityConfigurerAdapter

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -43,7 +43,7 @@ import org.candlepin.subscriptions.registry.RegistryConfiguration;
 import org.candlepin.subscriptions.resource.ApiConfiguration;
 import org.candlepin.subscriptions.rhmarketplace.RhMarketplaceWorkerConfiguration;
 import org.candlepin.subscriptions.security.AuthProperties;
-import org.candlepin.subscriptions.security.SecurityConfig;
+import org.candlepin.subscriptions.security.SecurityConfiguration;
 import org.candlepin.subscriptions.subscription.SubscriptionServiceConfiguration;
 import org.candlepin.subscriptions.subscription.SubscriptionWorkerConfiguration;
 import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
@@ -85,7 +85,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
   OfferingSyncConfiguration.class,
   RegistryConfiguration.class,
   DevModeConfiguration.class,
-  SecurityConfig.class,
+  SecurityConfiguration.class,
   HawtioConfiguration.class,
   MeteringConfiguration.class,
   SubscriptionServiceConfiguration.class,

--- a/src/main/java/org/candlepin/subscriptions/security/OptInChecker.java
+++ b/src/main/java/org/candlepin/subscriptions/security/OptInChecker.java
@@ -26,10 +26,14 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * A simple class to check that the user has opted in. This class is meant to be used from a SpEL
- * expression like so "@optInChecker.checkAccess(authentication, request)". A WebExpressionVoter
- * will then run that expression and based on the result vote +1 or -1 for granting access. That
- * vote will got to the AccessDecisionManager who makes the final access control decision.
+ * A simple class to check that the user has opted in. This class can be used from a SpEL expression
+ * like so "@optInChecker.checkAccess(authentication)".
+ *
+ * <p>Normally, this type of check would be handled via a role, ROLE_OPTED_IN, and Spring Security
+ * would check for the required role on the relevant endpoints. However, we want to return a custom
+ * error message telling the user they need to opt in. If the user is missing a role, Spring
+ * Security just returns a generic "Access Denied" message. So instead of using a role, we have this
+ * custom class in the authorization layer to control the error message returned.
  */
 @Component
 public class OptInChecker {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/BaseExceptionMapper.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.exception.mapper;
 
-import static org.candlepin.subscriptions.security.SecurityConfig.*;
+import static org.candlepin.subscriptions.security.SecurityConfiguration.*;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFailureHandler.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFailureHandler.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.security;
 
-import static org.candlepin.subscriptions.security.SecurityConfig.*;
+import static org.candlepin.subscriptions.security.SecurityConfiguration.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -38,8 +38,8 @@ import org.springframework.util.StringUtils;
  * Spring Security filter responsible for pulling the principal out of the x-rh-identity header.
  *
  * <p>Note that we don't register the filter as a bean anywhere, because if we did it would be
- * registered as a an extraneous ServletFilter in addition to its use in our SpringSecurity config.
- * See https://stackoverflow.com/a/31571715
+ * registered as an extraneous ServletFilter in addition to its use in our SpringSecurity config.
+ * See <a href="https://stackoverflow.com/a/31571715">this StackOverflow answer</a>.
  */
 public class IdentityHeaderAuthenticationFilter extends AbstractPreAuthenticatedProcessingFilter {
   private static final Logger log =

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationFilter.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.security;
 
-import static org.candlepin.subscriptions.security.SecurityConfig.*;
+import static org.candlepin.subscriptions.security.SecurityConfiguration.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/RestAccessDeniedHandler.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.security;
 
-import static org.candlepin.subscriptions.security.SecurityConfig.*;
+import static org.candlepin.subscriptions.security.SecurityConfiguration.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityConfiguration.java
@@ -32,10 +32,10 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @ComponentScan("org.candlepin.subscriptions.security")
-public class SecurityConfig {
+public class SecurityConfiguration {
   public static final Marker SECURITY_STACKTRACE = MarkerFactory.getMarker("SECURITY_STACKTRACE");
 
-  protected SecurityConfig() {
+  protected SecurityConfiguration() {
     // Container class only
   }
 }


### PR DESCRIPTION
*Note to the reviewer*:  I suggest reviewing the commits individually.  One commit is a simple name change of a class, but it can clutter up the diff viewer when viewed with the other commit.  Also, I would recommend using the side-by-side diff view instead of the unified viewer on this PR.  The changes are substantial enough that a unified diff is going to be difficult to parse mentally.

# Testing

## Happy Path
```
./gradlew :bootRun

http :8000/api/rhsm-subscriptions/v1/instances/products/RHEL beginning==2022-01-01T00:00:00.000Z ending==2023-01-10T23:59:59.999Z x-rh-identity:$(echo -n '{"identity":{"account_number":"account123","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w0)
```

## Missing account
```
./gradlew :bootRun

http :8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Cores granularity==Hourly ending==2021-10-31T23:59:59.999Z beginning==2021-10-31T20:00:00.000Z x-rh-identity:$(echo -n '{"identity":{"account_number":"missingAccount","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"missingOrg"}}}' | base64 -w 0)

http -v :9000/hawtio/jolokia type=exec mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean operation="ensureOptInForOrgId(java.lang.String,
boolean,boolean,boolean)" arguments:='["missingOrg", true, true, true]'

# Account is now opted in and the request should be authorized
http :8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Cores granularity==Hourly ending==2021-10-31T23:59:59.999Z beginning==2021-10-31T20:00:00.000Z x-rh-identity:$(echo -n '{"identity":{"account_number":"missingAccount","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"missingOrg"}}}' | base64 -w 0)
```

## Malformed identity header
```
./gradlew :bootRun

http :8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Cores granularity==Hourly ending==2021-10-31T23:59:59.999Z beginning==2021-10-31T20:00:00.000Z x-rh-identity:$(echo -n '{"identity":{"malformed": true' | base64 -w 0)
```

## PSK Auth
```
./gradlew :bootRun --args="--rhsm-subscriptions.auth.swatchPsks.self=secret"
# This will work
http :8000/api/rhsm-subscriptions/v1/internal/offerings/MW01485/product_tags x-rh-swatch-psk:secret
# This won't work
http :8000/api/rhsm-subscriptions/v1/internal/offerings/MW01485/product_tags x-rh-swatch-psk:willnotwork
```

## CSRF
```
# Make sure you aren't running with the capacity-ingress profile
./gradlew :bootRun --args="--rhsm-subscriptions.security.dev-mode=false --spring.profiles.active=api,worker,kafka-queue --rhsm-subscriptions.security.anti-csrf-domain-suffix=foobar --rhsm-subscriptions.security.anti-csrf-port=8000"

# Fails CSRF protection
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org123 x-rh-swatch-psk:secret
# This Jolokia call is a GET but still enforces CSRF protection
http -v :9000/hawtio/jolokia type=exec mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean operation="ensureOptInForOrgId(java.lang.String,boolean,boolean,boolean)" arguments:='["org123", true, true, true]'

# You will see a log message saying "Starting force sync for orgId: org123".
# **NOTE** The subscription service will eventually return an access denied in the logs
# but we are past our security chain at that point
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/org123 x-rh-swatch-psk:secret origin:foobar:8000

# Note we are requesting port 9000 but putting 8000 in the origin header.  Our
# port to verify is statically defined so there's a mismatch here since we
# deploy the Spring actuators on port 9000.  In production, the port is defined
# as 443 which is how the actuators are addressed when you visit them over
# Turnpike
http -v :9000/hawtio/jolokia type=exec mbean=org.candlepin.subscriptions.jmx:name=optInJmxBean,type=OptInJmxBean operation="ensureOptInForOrgId(java.lang.String,boolean,boolean,boolean)" arguments:='["org123", true, true, true]' origin:foobar:8000
```

## Actuators
```
http :9000/info
http :9000/health
http :9000/metrics
```
