### PR TITLE
SWATCH-1164: Use org_id as the message key for tally summary messages

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -70,7 +70,8 @@ public class SnapshotSummaryProducer {
                     summary -> {
                       if (validateTallySummary(summary)) {
                         kafkaRetryTemplate.execute(
-                            ctx -> tallySummaryKafkaTemplate.send(tallySummaryTopic, summary));
+                            ctx ->
+                                tallySummaryKafkaTemplate.send(tallySummaryTopic, orgId, summary));
                         totalTallies.getAndIncrement();
                       }
                     }));

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/TallySummaryMessageConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/TallySummaryMessageConsumer.java
@@ -33,6 +33,9 @@ import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,8 +74,10 @@ public class TallySummaryMessageConsumer extends SeekableKafkaConsumer {
       topics = "#{__listener.topic}",
       containerFactory = "billingProducerKafkaTallySummaryListenerContainerFactory")
   @Transactional
-  public void receive(TallySummary tallySummary) {
-    log.debug("Tally Summary received. Producing billable usage.}");
+  public void receive(
+      @Payload TallySummary tallySummary,
+      @Header(name = KafkaHeaders.RECEIVED_MESSAGE_KEY, required = false) String kafkaMessageKey) {
+    log.debug("Tally Summary received w/ key={}. Producing billable usage.", kafkaMessageKey);
 
     billableUsageMapper
         .fromTallySummary(tallySummary)

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -23,11 +23,10 @@ package org.candlepin.subscriptions.tally;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -105,7 +104,7 @@ class SnapshotSummaryProducerTest {
                 Uom.CORES,
                 22.2)));
     producer.produceTallySummaryMessages(updateMap);
-    verify(kafka, times(2)).send(eq(props.getTopic()), summaryCaptor.capture());
+    verify(kafka, times(2)).send(eq(props.getTopic()), any(), summaryCaptor.capture());
 
     List<TallySummary> summaries = summaryCaptor.getAllValues();
     assertEquals(2, summaries.size());
@@ -184,7 +183,7 @@ class SnapshotSummaryProducerTest {
                 20.4)));
     updateMap.get("a1").get(0).getTallyMeasurements().clear();
     producer.produceTallySummaryMessages(updateMap);
-    verify(kafka, never()).send(anyString(), any());
+    verifyNoInteractions(kafka);
   }
 
   void assertMeasurement(


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-1164

This ensures that the messages for a given org_id are processed by the same consumer in order, reducing the risk of concurrency bugs in billable usage production.

Testing
=======

Start the app with debug logging turned on:

```shell
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_TALLY_BILLING=DEBUG \
  SUBSCRIPTION_USE_STUB=true \
  USER_USE_STUB=true \
  DEV_MODE=true \
  ./gradlew :bootRun
```

Import some events into the DB:

```shell
bin/import-events.py --file bin/events.csv
```

Run the hourly tally for that the test events:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean=org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean \
  operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)' \
  arguments:='["org123", "2021-10-01T00:00Z", "2021-10-30T00:00Z"]'
```

Look for log messages indicating the key used:

```text
2023-04-21 21:20:29,372 [thread=swatch-producer-billing-0-C-1] [DEBUG] [org.candlepin.subscriptions.tally.billing.TallySummaryMessageConsumer] - Tally Summary received w/ key=org123. Producing billable usage.
```

Per [official kafka documentation](https://kafka.apache.org/intro):

> Events with the same event key (e.g., a customer or vehicle ID) are written to the same partition,
> and Kafka guarantees that any consumer of a given topic-partition will always read that partition's events in exactly the same order as they were written.

Therefore, by design, this will ensure that an org's tally summaries will always be emitted to the same partition.