### PR TITLE
SWATCH-773: Remove allowList.allProducts and check DB for existing skus

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/product/SyncResult.java
+++ b/src/main/java/org/candlepin/subscriptions/product/SyncResult.java
@@ -44,7 +44,7 @@ public enum SyncResult {
   }
 
   public static boolean isSynced(SyncResult syncResult) {
-    return !Objects.isNull(syncResult) && SUCCESSFUL_SYNC_RESULTS.contains(syncResult);
+    return Objects.nonNull(syncResult) && SUCCESSFUL_SYNC_RESULTS.contains(syncResult);
   }
 
   @Override

--- a/src/main/java/org/candlepin/subscriptions/product/SyncResult.java
+++ b/src/main/java/org/candlepin/subscriptions/product/SyncResult.java
@@ -20,12 +20,18 @@
  */
 package org.candlepin.subscriptions.product;
 
+import java.util.Objects;
+import java.util.Set;
+
 public enum SyncResult {
   FETCHED_AND_SYNCED("Successfully fetched and synced updated value from upstream"),
   FAILED("Failed to fetch and/or sync"),
   SKIPPED_MATCHING("Upstream matches stored item, did not sync"),
   SKIPPED_NOT_FOUND("Was not found upstream, did not sync"),
   SKIPPED_NOT_ALLOWLISTED("Not in allowlist, did not sync");
+
+  public static final Set<SyncResult> SUCCESSFUL_SYNC_RESULTS =
+      Set.of(FETCHED_AND_SYNCED, SKIPPED_MATCHING);
 
   private final String description;
 
@@ -35,6 +41,10 @@ public enum SyncResult {
 
   public String description() {
     return description;
+  }
+
+  public static boolean isSynced(SyncResult syncResult) {
+    return !Objects.isNull(syncResult) && SUCCESSFUL_SYNC_RESULTS.contains(syncResult);
   }
 
   @Override

--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -64,7 +64,7 @@ public class StubSearchApi extends SearchApi {
         .quantity(1)
         .effectiveStartDate(OffsetDateTime.parse("2011-01-01T01:02:33Z").toEpochSecond() * 1000L)
         .effectiveEndDate(OffsetDateTime.parse("2031-01-01T01:02:33Z").toEpochSecond() * 1000L)
-        .subscriptionProducts(List.of(new SubscriptionProduct().sku("sku")));
+        .subscriptionProducts(List.of(new SubscriptionProduct().sku("MW01485")));
   }
 
   private Subscription createAwsBillingProviderData() {

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
@@ -46,7 +46,11 @@ import org.springframework.retry.support.RetryTemplateBuilder;
   CapacityReconciliationConfiguration.class
 })
 @EnableJms
-@ComponentScan({"org.candlepin.subscriptions.subscription", "org.candlepin.subscriptions.umb"})
+@ComponentScan({
+  "org.candlepin.subscriptions.subscription",
+  "org.candlepin.subscriptions.umb",
+  "org.candlepin.subscriptions.product"
+})
 public class SubscriptionServiceConfiguration {
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorkerConfiguration.java
@@ -34,7 +34,11 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 @Profile("capacity-ingress")
-@ComponentScan(basePackages = "org.candlepin.subscriptions.subscription")
+@ComponentScan(
+    basePackages = {
+      "org.candlepin.subscriptions.subscription",
+      "org.candlepin.subscriptions.product"
+    })
 @Import(SubscriptionServiceConfiguration.class)
 @Configuration
 public class SubscriptionWorkerConfiguration {

--- a/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryTest.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -94,5 +95,17 @@ class OfferingRepositoryTest {
     repository.save(extra);
     var actual = repository.findProductNameBySku("foo");
     assertEquals("test", actual.get());
+  }
+
+  @Test
+  @Transactional
+  void testFindAllDistinctSkus() {
+    var offering1 = Offering.builder().sku("foo").build();
+    var offering2 = Offering.builder().sku("foo2").build();
+    repository.save(offering1);
+    repository.save(offering2);
+    var actual = repository.findAllDistinctSkus();
+    assertTrue(actual.contains(offering1.getSku()));
+    assertTrue(actual.contains(offering2.getSku()));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/files/ProductAllowlistTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductAllowlistTest.java
@@ -23,8 +23,6 @@ package org.candlepin.subscriptions.files;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.capacity.files.ProductAllowlist;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -51,18 +49,6 @@ class ProductAllowlistTest {
   void testDisallowsProductsIsNotInAllowlist() throws IOException {
     ProductAllowlist allowlist = initProductAllowlist("classpath:item_per_line.txt");
     assertFalse(allowlist.productIdMatches("not on the list :-("));
-  }
-
-  @Test
-  void testAllProducts() throws IOException {
-    ProductAllowlist allowlist = initProductAllowlist("classpath:item_per_line.txt");
-    assertEquals(Set.of("I1", "I2", "I3"), allowlist.allProducts());
-  }
-
-  @Test
-  void testAllProductsNoSource() throws IOException {
-    ProductAllowlist allowlist = initProductAllowlist("");
-    assertEquals(Collections.emptySet(), allowlist.allProducts());
   }
 
   private ProductAllowlist initProductAllowlist(String resourceLocation) throws IOException {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
@@ -42,4 +42,7 @@ public interface OfferingRepository extends JpaRepository<Offering, String> {
 
   @Query("select distinct o.productName from Offering o where o.sku = :sku")
   Optional<String> findProductNameBySku(@Param("sku") String sku);
+
+  @Query(value = "select distinct sku from Offering")
+  Set<String> findAllDistinctSkus();
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-773

- Delete offering from db if already existing: `DELETE FROM offering WHERE sku = 'MW01485'`
- Start app with: `DEV_MODE=true PRODUCT_USE_STUB=true SUBSCRIPTION_USE_STUB=true SPRING_PROFILES_ACTIVE=capacity-ingress ./gradlew :bootRun`
- Run syncSubscription: 
```
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.subscription:name=subscriptionJmxBean,type=SubscriptionJmxBean' \
  operation='syncSubscription(java.lang.String)' \
  arguments:='["any"]'
```
- Check db that offering now exists in db: `SELECT * FROM offering WHERE sku = 'MW01485'`
- Run syncAllOfferings:
```
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean' \
  operation='syncAllOfferings()' 
```
- Should give message with number of enqued offerings matching the number of total offerings in the DB.