### PR TITLE
SWATCH-1105: Move PurgeEventRecordsJob to internal metrics resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ cat <<BONFIRE >>  ~/.config/bonfire/config.yaml
       path: /deploy/clowdapp.yaml
       parameters:
         REPLICAS: 1
-        IMAGE: quay.io/cloudservices/rhsm-subscriptions
+        swatch-api/IMAGE: quay.io/cloudservices/rhsm-subscriptions
         RHSM_RBAC_USE_STUB: "true"
 
     - name: swatch-producer-aws

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -56,7 +56,10 @@ import org.springframework.retry.support.RetryTemplate;
   TaskConsumerConfiguration.class,
   MeteringTasksConfiguration.class
 })
-@ComponentScan("org.candlepin.subscriptions.metering.api")
+@ComponentScan({
+  "org.candlepin.subscriptions.metering.api",
+  "org.candlepin.subscriptions.metering.retention"
+})
 public class OpenShiftWorkerProfile {
 
   @Bean(name = "openshiftMetricRetryTemplate")

--- a/src/main/java/org/candlepin/subscriptions/metering/retention/EventRecordsRetentionProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/retention/EventRecordsRetentionProperties.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.retention;
+package org.candlepin.subscriptions.metering.retention;
 
 import java.time.Duration;
 import lombok.Getter;

--- a/src/main/java/org/candlepin/subscriptions/metering/retention/PurgeEventRecordsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/retention/PurgeEventRecordsJob.java
@@ -18,8 +18,9 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.retention;
+package org.candlepin.subscriptions.metering.retention;
 
+import org.candlepin.subscriptions.metering.api.admin.InternalMeteringResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -30,18 +31,18 @@ public class PurgeEventRecordsJob implements Runnable {
 
   private static final Logger log = LoggerFactory.getLogger(PurgeEventRecordsJob.class);
 
-  private final TallyRetentionController retentionController;
+  private final InternalMeteringResource meteringResource;
 
-  public PurgeEventRecordsJob(TallyRetentionController retentionController) {
-    this.retentionController = retentionController;
+  public PurgeEventRecordsJob(InternalMeteringResource meteringResource) {
+    this.meteringResource = meteringResource;
   }
 
   @Override
-  @Scheduled(cron = "${rhsm-subscriptions.jobs.purge-snapshot-schedule}")
+  @Scheduled(cron = "${rhsm-subscriptions.jobs.purge-events-schedule}")
   public void run() {
     log.info("Starting PurgeEventRecordsJob job.");
 
-    retentionController.purgeOldEventRecords();
+    meteringResource.purgeEventRecords();
 
     log.info("PurgeEventRecordsJob complete.");
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,7 +44,8 @@ rhsm-subscriptions:
   jobs:
     capture-hourly-snapshot-schedule: ${CAPTURE_HOURLY_SNAPSHOT_SCHEDULE:0 0 * * * ?}
     capture-snapshot-schedule: ${CAPTURE_SNAPSHOT_SCHEDULE:0 0 1 * * ?}
-    purge-snapshot-schedule: ${PURGE_SNAPSHOT_SCHEDULE:0 0 1 * * ?}
+    purge-snapshot-schedule: ${PURGE_SNAPSHOT-SCHEDULE:0 0 1 * * ?}
+    purge-events-schedule: ${PURGE_EVENTS_SCHEDULE:0 0 1 * * ?}
     metering-schedule: ${METERING_SCHEDULE:0 30 * * * ?}
     subscription-sync-schedule: ${SUBSCRIPTION_SYNC_SCHEDULE:0 0 10 * * ?}
     offering-sync-schedule: ${OFFERING_SYNC_SCHEDULE:0 0 2 * * ?}

--- a/src/main/spec/internal-metering-api-spec.yaml
+++ b/src/main/spec/internal-metering-api-spec.yaml
@@ -4,6 +4,17 @@ info:
   version: 1.0.0
 
 paths:
+  /internal/metering/events:
+    description: 'Purge event records'
+    delete:
+      operationId: purgeEventRecords
+      responses:
+        '200':
+          description: "Purge was successful."
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
   /internal/metering/{productTag}:
     description: 'Operations related to product metering.'
     post:

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -33,8 +33,10 @@ import javax.ws.rs.BadRequestException;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
+import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.ResourceUtil;
+import org.candlepin.subscriptions.metering.retention.EventRecordsRetentionProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.registry.TagProfile;
@@ -54,6 +56,8 @@ class InternalMeteringResourceTest {
   @Mock private PrometheusMetricsTaskManager tasks;
   @Mock private PrometheusMeteringController controller;
   @Mock private AccountConfigRepository accountConfigRepository;
+  @Mock private EventRecordsRetentionProperties eventRecordsRetentionProperties;
+  @Mock private EventRecordRepository eventRecordRepository;
 
   private ApplicationProperties appProps;
   private ResourceUtil util;
@@ -72,7 +76,14 @@ class InternalMeteringResourceTest {
     lenient().when(accountConfigRepository.findOrgByAccountNumber("account1")).thenReturn("org1");
     resource =
         new InternalMeteringResource(
-            util, appProps, tagProfile, tasks, controller, accountConfigRepository);
+            util,
+            appProps,
+            eventRecordsRetentionProperties,
+            tagProfile,
+            tasks,
+            controller,
+            accountConfigRepository,
+            eventRecordRepository);
   }
 
   @Test

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -14,6 +14,10 @@ parameters:
     value: latest
   - name: IMAGE_PULL_SECRET
     value: quay-cloudservices-pull
+  - name: CURL_CRON_IMAGE
+    value: quay.io/app-sre/ubi8-ubi-minimal
+  - name: CURL_CRON_IMAGE_TAG
+    value: latest
   - name: MEMORY_REQUEST
     value: 1000Mi
   - name: MEMORY_LIMIT
@@ -86,6 +90,10 @@ parameters:
     value: '2'
   - name: METERING_SCHEDULE
     value: '30 * * * *'
+  - name: PURGE_EVENTS_SCHEDULE
+    value: '30 4 * * *'
+  - name: EVENT_RECORD_RETENTION
+    value: '90d'
   - name: OPENSHIFT_METERING_RANGE
     value: '60'
   - name: HOURLY_TALLY_OFFSET
@@ -280,6 +288,8 @@ objects:
                     key: psk
               - name: PROM_URL
                 value: ${PROM_URL}
+              - name: EVENT_RECORD_RETENTION
+                value: ${EVENT_RECORD_RETENTION}
               - name: OPENSHIFT_BILLING_MODEL_FILTER
                 value: ${OPENSHIFT_BILLING_MODEL_FILTER}
               - name: USER_HOST
@@ -486,6 +496,32 @@ objects:
             sidecars:
               - name: token-refresher
                 enabled: true
+        - name: purge-events
+          schedule: ${PURGE_EVENTS_SCHEDULE}
+          activeDeadlineSeconds: 1800
+          successfulJobsHistoryLimit: 2
+          restartPolicy: Never
+          podSpec:
+            image: ${CURL_CRON_IMAGE}:${CURL_CRON_IMAGE_TAG}
+            command:
+              - /usr/bin/bash
+              - -c
+              - >
+                /usr/bin/curl --fail -i -H "Origin: https://swatch-metrics-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X DELETE "http://swatch-metrics-service:8000/api/rhsm-subscriptions/v1/internal/metering/events"
+            env:
+              - name: SWATCH_SELF_PSK
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-psks
+                    key: self
+          resources:
+            requests:
+              cpu: ${CURL_CRON_CPU_REQUEST}
+              memory: ${CURL_CRON_MEMORY_REQUEST}
+            limits:
+              cpu: ${CURL_CRON_CPU_LIMIT}
+              memory: ${CURL_CRON_MEMORY_LIMIT}
+
 
   - apiVersion: v1
     kind: Secret

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -99,8 +99,6 @@ parameters:
     value: 0 6 * * *
   - name: CAPTURE_HOURLY_SNAPSHOT_SCHEDULE
     value: '@hourly'
-  - name: EVENT_RECORD_RETENTION
-    value: '90d'
   # TODO after enable individual functionality (see ENT-4487)
   - name: DEV_MODE
     value: 'false'


### PR DESCRIPTION
Invoke the job using a curl container.

See https://issues.redhat.com/browse/SWATCH-1105

---
# Testing

1. Start the application
   ```shell
   ./gradlew :bootRun --args="--spring.profiles.active=api,kafka-queue,worker,metering-jmx,metering-job,rhsm-conduit,openshift-metering-worker --rhsm-subscriptions.auth.swatchPsks.self=secret"
   ```
2. Run the import events script with the default events.  All these events are very old and long past the default retention period.
   ```shell
   bin/import-events.py --file bin/events.csv
   ```
3. Verify the events were created
   ```shell
   % psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c 'select count(*) from events'                                                                      
   count                                                                                                                                                             
   -------
       24
   (1 row)
   ```
4. Run an event purge job
   ```shell
   http DELETE :8000/api/rhsm-subscriptions/v1/internal/metering/events x-rh-swatch-psk:secret
   ```
5. You'll see a message reading "Event record purge completed successfully"
6. All events have been purged
   ```shell
   % psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c 'select count(*) from events'
    count 
   -------
        0
   (1 row)
   ```
7. Run an EE deployment.  How you do this is up to you, but my personal workflow is as follows:
   * `podman login quay.io`
   * `bin/build-images.sh`
   * This pushes the images to my personal quay.io namespace.  The `build-images.sh` script will attempt to push the images to your quay user's namespace (`podman login --get-login quay.io`)
   * Use the command below but replace `awood` with your quay.io login
   ```shell
	VER=$(git rev-parse --short=7 HEAD) ; bonfire deploy rhsm --optional-deps-method=none \
	--no-remove-resources=all \
	-i quay.io/awood/swatch-system-conduit=$VER \
	-i quay.io/awood/swatch-producer-aws=$VER \
	-i quay.io/awood/rhsm-subscriptions=$VER \
	-i quay.io/awood/swatch-contracts=$VER \
	-p swatch-producer-red-hat-marketplace/IMAGE=quay.io/awood/rhsm-subscriptions \
	-p swatch-metrics/IMAGE=quay.io/awood/rhsm-subscriptions \
	-p swatch-subscription-sync/IMAGE=quay.io/awood/rhsm-subscriptions \
	-p swatch-system-conduit/IMAGE=quay.io/awood/rhsm-subscriptions \
	-p swatch-system-conduit/CONDUIT_IMAGE=quay.io/awood/swatch-system-conduit \
	-p swatch-tally/IMAGE=quay.io/awood/rhsm-subscriptions \
	-p swatch-producer-aws/IMAGE=quay.io/awood/swatch-producer-aws \
	-p swatch-api/IMAGE=quay.io/awood/rhsm-subscriptions \
	-p swatch-contracts/IMAGE=quay.io/awood/swatch-contracts
	```
8. Once the deployment is complete, you can kick off a copy of the configured cron job
   ```shell
   oc create job purge-test --from=cj/swatch-metrics-purge-events 
   ```
9. Go to the Jobs tab in the EE web console, click on the `purge-test` job, click on the pods for that job, and review the logs for that pod.  You'll see the job returned a HTTP 200.  Then you can go look at the logs for the `swatch-metrics-service` pod and see that the job completed successfully on that side.