### PR TITLE
Swatch-1094: spring boot OTel instrumentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,6 @@
 
 # allow the build libs for spring-boot based contexts
 !build/libs
+!build/javaagent
 # allow the quarkus-app build folder for quarkus based builds
 !build/quarkus-app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.14-2.1681917140
 
 COPY build/libs/* /deployments/
+COPY build/javaagent/* /opt/
+ENV JAVA_OPTS_APPEND=-javaagent:/opt/splunk-otel-javaagent.jar

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,7 @@ dependencies {
 
     runtimeOnly "org.hsqldb:hsqldb"
 
-    javaagent 'com.splunk:splunk-otel-javaagent:1.22.0'
-
+    javaagent  libraries["splunk-otel-agent"]
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ plugins {
     id 'jacoco'
 }
 
+configurations {
+    javaagent
+}
+
 allprojects {
     group 'com.redhat.swatch'
 }
@@ -50,6 +54,9 @@ dependencies {
     testImplementation project(':swatch-core-test')
 
     runtimeOnly "org.hsqldb:hsqldb"
+
+    javaagent 'com.splunk:splunk-otel-javaagent:1.22.0'
+
 }
 
 allprojects {
@@ -290,12 +297,24 @@ sourceSets.main.java.srcDirs += [
     "${buildDir}/generated/metering/src/gen/java"
 ]
 
+tasks.register("downloadJavaAgent", Copy) {
+    into "$buildDir/javaagent"
+    from {
+        configurations.javaagent
+    }
+    rename { filename ->
+        'splunk-otel-javaagent.jar'
+    }
+}
+
 compileJava {
     dependsOn processResources
     dependsOn(provider {
         tasks.findAll { task -> task.name.startsWith('buildApi') }
     })
 }
+
+assemble.dependsOn(tasks.downloadJavaAgent)
 
 project(":api") {
     apply plugin: "swatch.java-conventions"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -63,3 +63,4 @@ libraries["swagger-annotations"] = "io.swagger:swagger-annotations:1.6.10"
 libraries["swagger-ui"] = "org.webjars:swagger-ui:4.18.2"
 libraries["webjars-locator"] = "org.webjars:webjars-locator:0.46"
 libraries["wiremock-jre8"] = "com.github.tomakehurst:wiremock-jre8:2.35.0"
+libraries["splunk-otel-agent"] = 'com.splunk:splunk-otel-javaagent:1.22.0'

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -54,12 +54,17 @@ parameters:
     value: '1000'
   - name: SPLUNK_HEC_TERMINATION_TIMEOUT
     value: '2000'
+  - name: OTEL_SERVICE_NAME
+    value: swatch-api
   - name: NGINX_OTEL_IMAGE_TAG
     value: '1df2c89'
   - name: OTEL_ENABLED
     value: 'off'
+  - name: OTEL_JAVAAGENT_ENABLED
+    value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
+
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
@@ -123,6 +128,12 @@ objects:
                       secretKeyRef:
                         name: swatch-tally-db
                         key: db.name
+                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                    value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                  - name: OTEL_SERVICE_NAME
+                    value: ${OTEL_SERVICE_NAME}
+                  - name: OTEL_JAVAAGENT_ENABLED
+                    value: ${OTEL_JAVAAGENT_ENABLED}
                 resources:
                   requests:
                     cpu: ${CPU_REQUEST}
@@ -216,6 +227,12 @@ objects:
                 value: ${SPLUNK_HEC_BATCH_SIZE}
               - name: SPLUNK_HEC_TERMINATION_TIMEOUT
                 value: ${SPLUNK_HEC_TERMINATION_TIMEOUT}
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: OTEL_SERVICE_NAME
+                value: ${OTEL_SERVICE_NAME}
+              - name: OTEL_JAVAAGENT_ENABLED
+                value: ${OTEL_JAVAAGENT_ENABLED}
             livenessProbe:
               failureThreshold: 3
               httpGet:

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -109,6 +109,14 @@ parameters:
     value: '3'
   - name: ENABLE_SYNCHRONOUS_OPERATIONS
     value: 'false'
+  - name: OTEL_SERVICE_NAME
+    value: swatch-metrics
+  - name: OTEL_ENABLED
+    value: 'off'
+  - name: OTEL_JAVAAGENT_ENABLED
+    value: 'false'
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: 'http://localhost:4317'
 
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
@@ -320,6 +328,12 @@ objects:
                     key: self
               - name: ENABLE_SYNCHRONOUS_OPERATIONS
                 value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: OTEL_SERVICE_NAME
+                value: ${OTEL_SERVICE_NAME}
+              - name: OTEL_JAVAAGENT_ENABLED
+                value: ${OTEL_JAVAAGENT_ENABLED}
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -480,6 +494,12 @@ objects:
                     key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
               - name: PROM_URL
                 value: ${PROM_URL}
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: OTEL_SERVICE_NAME
+                value: ${OTEL_SERVICE_NAME}
+              - name: OTEL_JAVAAGENT_ENABLED
+                value: ${OTEL_JAVAAGENT_ENABLED}
             resources:
               requests:
                 cpu: ${CPU_REQUEST}

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -111,8 +111,6 @@ parameters:
     value: 'false'
   - name: OTEL_SERVICE_NAME
     value: swatch-metrics
-  - name: OTEL_ENABLED
-    value: 'off'
   - name: OTEL_JAVAAGENT_ENABLED
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -128,8 +128,6 @@ parameters:
     value: '3'
   - name: OTEL_SERVICE_NAME
     value: swatch-producer-red-hat-marketplace
-  - name: OTEL_ENABLED
-    value: 'off'
   - name: OTEL_JAVAAGENT_ENABLED
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -126,6 +126,14 @@ parameters:
     value: '3'
   - name: KAFKA_TALLY_PARTITIONS
     value: '3'
+  - name: OTEL_SERVICE_NAME
+    value: swatch-producer-red-hat-marketplace
+  - name: OTEL_ENABLED
+    value: 'off'
+  - name: OTEL_JAVAAGENT_ENABLED
+    value: 'false'
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: 'http://localhost:4317'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -355,6 +363,12 @@ objects:
               value: ${BILLING_PRODUCER_MAX_ATTEMPTS}
             - name: ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC
               value: ${ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: ${OTEL_JAVAAGENT_ENABLED}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -131,8 +131,6 @@ parameters:
     value: '3'
   - name: OTEL_SERVICE_NAME
     value: swatch-subscription-sync
-  - name: OTEL_ENABLED
-    value: 'off'
   - name: OTEL_JAVAAGENT_ENABLED
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -129,6 +129,14 @@ parameters:
     value: '3'
   - name: KAFKA_SUBSCRIPTIONS_PRUNE_PARTITIONS
     value: '3'
+  - name: OTEL_SERVICE_NAME
+    value: swatch-subscription-sync
+  - name: OTEL_ENABLED
+    value: 'off'
+  - name: OTEL_JAVAAGENT_ENABLED
+    value: 'false'
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: 'http://localhost:4317'
 
 # allow overriding to support independent deploy with bonfire
   - name: DB_POD
@@ -406,6 +414,12 @@ objects:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: ${OTEL_JAVAAGENT_ENABLED}
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -566,6 +580,12 @@ objects:
                 secretKeyRef:
                   name: ${INVENTORY_SECRET_KEY_NAME}
                   key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: ${OTEL_JAVAAGENT_ENABLED}
           resources:
             requests:
               cpu: ${CPU_REQUEST}
@@ -696,6 +716,12 @@ objects:
                 secretKeyRef:
                   name: ${INVENTORY_SECRET_KEY_NAME}
                   key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: ${OTEL_JAVAAGENT_ENABLED}
           resources:
             requests:
               cpu: ${CPU_REQUEST}

--- a/swatch-system-conduit/.dockerignore
+++ b/swatch-system-conduit/.dockerignore
@@ -5,3 +5,5 @@
 !build/libs
 # allow the quarkus-app build folder for quarkus based builds
 !build/quarkus-app
+# allow the build libs for splunk otel java agent
+!build/javaagent

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -2,3 +2,5 @@ FROM registry.access.redhat.com/ubi9/openjdk-17:1.14-2.1681917140
 USER root
 
 COPY build/libs/ /deployments/
+COPY build/javaagent/ /opt/
+ENV JAVA_OPTS_APPEND=-javaagent:/opt/splunk-otel-javaagent.jar

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id "jacoco"
 }
 
+configurations {
+    javaagent
+}
+
 ext {
     api_spec_path = "${projectDir}/src/main/spec/internal-organizations-sync-api-spec.yaml"
     config_file = "${projectDir}/src/main/spec/internal-organizations-sync-api-config.json"
@@ -27,8 +31,19 @@ openApiValidate {
     inputSpec = api_spec_path
 }
 
+tasks.register("downloadJavaAgent", Copy) {
+    into "$buildDir/javaagent"
+    from {
+        configurations.javaagent
+    }
+    rename { filename ->
+        'splunk-otel-javaagent.jar'
+    }
+}
+
 sourceSets.main.java.srcDirs += ["${buildDir}/generated/src/gen/java"]
 compileJava.dependsOn tasks.openApiGenerate
+assemble.dependsOn tasks.downloadJavaAgent
 
 dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
@@ -64,6 +79,8 @@ dependencies {
     runtimeOnly "org.hsqldb:hsqldb"
     runtimeOnly "org.jolokia:jolokia-core"
     runtimeOnly "org.jboss.resteasy:resteasy-jackson2-provider"
+
+    javaagent 'com.splunk:splunk-otel-javaagent:1.22.0'
 }
 
 jsonSchema2Pojo {

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     runtimeOnly "org.jolokia:jolokia-core"
     runtimeOnly "org.jboss.resteasy:resteasy-jackson2-provider"
 
-    javaagent 'com.splunk:splunk-otel-javaagent:1.22.0'
+    javaagent  libraries["splunk-otel-agent"]
 }
 
 jsonSchema2Pojo {

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -103,6 +103,14 @@ parameters:
     value: 100ms
   - name: RHSM_API_LIMIT_TIMEOUT_DURATION
     value: 30m
+  - name: OTEL_SERVICE_NAME
+    value: swatch-system-conduit
+  - name: OTEL_ENABLED
+    value: 'off'
+  - name: OTEL_JAVAAGENT_ENABLED
+    value: 'false'
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: 'http://localhost:4317'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -291,6 +299,12 @@ objects:
               value: ${RHSM_API_LIMIT_REFRESH_PERIOD}
             - name: RHSM_API_LIMIT_TIMEOUT_DURATION
               value: ${RHSM_API_LIMIT_TIMEOUT_DURATION}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: ${OTEL_JAVAAGENT_ENABLED}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -105,8 +105,6 @@ parameters:
     value: 30m
   - name: OTEL_SERVICE_NAME
     value: swatch-system-conduit
-  - name: OTEL_ENABLED
-    value: 'off'
   - name: OTEL_JAVAAGENT_ENABLED
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -180,6 +180,14 @@ parameters:
     value: 350m
   - name: CURL_CRON_CPU_LIMIT
     value: 500m
+  - name: OTEL_SERVICE_NAME
+    value: swatch-tally
+  - name: OTEL_ENABLED
+    value: 'off'
+  - name: OTEL_JAVAAGENT_ENABLED
+    value: 'false'
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: 'http://localhost:4317'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -391,6 +399,12 @@ objects:
               value: ${HOST_LAST_SYNC_THRESHOLD}
             - name: SWATCH_CONTRACTS_INTERNAL_SERVICE_URL
               value: ${SWATCH_CONTRACTS_INTERNAL_SERVICE_URL}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: ${OTEL_JAVAAGENT_ENABLED}
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -521,6 +535,12 @@ objects:
                 secretKeyRef:
                   name: ${INVENTORY_SECRET_KEY_NAME}
                   key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: ${OTEL_JAVAAGENT_ENABLED}
           resources:
             requests:
               cpu: ${CPU_REQUEST}
@@ -625,6 +645,12 @@ objects:
                 secretKeyRef:
                   name: ${INVENTORY_SECRET_KEY_NAME}
                   key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: ${OTEL_JAVAAGENT_ENABLED}
           resources:
             requests:
               cpu: ${CPU_REQUEST}

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -182,8 +182,6 @@ parameters:
     value: 500m
   - name: OTEL_SERVICE_NAME
     value: swatch-tally
-  - name: OTEL_ENABLED
-    value: 'off'
   - name: OTEL_JAVAAGENT_ENABLED
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1094](https://issues.redhat.com/browse/SWATCH-1094)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Enables spring boot apps to send Opentelemetry traces to a collector using the splunk java agent.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Build project and push to quay. Alternatively, use the bonfire config attached which uses an image I uploaded and replace your repo paths. 
[config.zip](https://github.com/RedHatInsights/rhsm-subscriptions/files/11373579/config.zip)

### Steps
<!-- Enter each step of the test below -->
Reserve an ephemeral namespace for testing:

```shell
oc project $(bonfire namespace reserve)
```

Deploy swatch:

```shell
bonfire deploy rhsm --no-remove-resources swatch-contracts --no-remove-resources swatch-api --no-remove-resources swatch-producer-aws --no-remove-resources swatch-producer-red-hat-marketplace --no-remove-resources swatch-metrics --no-remove-resources swatch-subscription-sync --no-remove-resources swatch-system-conduit --no-remove-resources swatch-tally
```

Create a jaeger all-in-one configuration:

```shell
cat <<EOF > /tmp/values.yaml
provisionDataStore:
  cassandra: false
allInOne:
  enabled: true
storage:
  type: none
agent:
  enabled: false
collector:
  enabled: false
query:
  enabled: false
EOF
```

Use https://helm.sh/ to deploy jaeger:

```shell
helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
helm template -f /tmp/values.yaml jaegertracing/jaeger \
  --kube-version=1.21.1 \
  --name-template='test' | oc apply -f -
```

Manually deploy updated deployments, change image and tag if you used your own:

```shell
for SERVICE in swatch-api swatch-tally swatch-producer-red-hat-marketplace swatch-subscription-sync swatch-metrics
do
oc process \
  -p OTEL_EXPORTER_OTLP_ENDPOINT=http://test-jaeger-collector:4317  \
  -p OTEL_JAVAAGENT_ENABLED=true  \
  -p ENV_NAME=env-$(oc project -q) \
  -p IMAGE=quay.io/kflahert/rhsm-subscriptions \
  -p IMAGE_TAG=spring-otel-2  \
  -f $SERVICE/deploy/clowdapp.yaml | oc apply -f -
done

oc process \
  -p OTEL_EXPORTER_OTLP_ENDPOINT=http://test-jaeger-collector:4317  \
  -p OTEL_JAVAAGENT_ENABLED=true  \
  -p ENV_NAME=env-$(oc project -q) \
  -p IMAGE=quay.io/kflahert/rhsm-subscriptions \
  -p CONDUIT_IMAGE=quay.io/kflahert/swatch-system-conduit \
  -p IMAGE_TAG=spring-otel-2  \
  -f swatch-system-conduit/deploy/clowdapp.yaml | oc apply -f -
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
Port forward the jaeger UI:

```shell
oc port-forward service/test-jaeger-query 16686
```

View the trace in the jaeger UI at http://localhost:16686.

Eventually you should have /health traces for all of swatch-api swatch-tally swatch-system-conduit swatch-producer-red-hat-marketplace swatch-subscription-sync.