### PR TITLE
SWATCH-1216: Disable swatch-metrics-purge-events job as it leads to OOM on the pod

### DIFF
--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -497,6 +497,8 @@ objects:
               - name: token-refresher
                 enabled: true
         - name: purge-events
+          disabled: true
+          suspend: true
           schedule: ${PURGE_EVENTS_SCHEDULE}
           activeDeadlineSeconds: 1800
           successfulJobsHistoryLimit: 2


### PR DESCRIPTION
See https://issues.redhat.com/browse/SWATCH-1216


<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1216](https://issues.redhat.com/browse/SWATCH-1216)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
SWATCH-1105 (PR #2093) added a job to purge the events table according to a retention policy.  There are either too many events or the job just isn't efficient enough.  Regardless, invoking the internal API endpoint results in the pod being OOMKilled.  This PR disabled and suspends (see [Clowder documentation](https://consoledot.pages.redhat.com/clowder/dev/api_reference.html#k8s-api-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-job)) the OpenShift cronjob for now until we can get around to fixing the core issue.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Deploy to one of the EEs

### Steps
<!-- Enter each step of the test below -->
1. `oc create job purge-test --from=cj/swatch-metrics-purge-events`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Job fails to create:
   ```
   Error from server (NotFound): cronjobs.batch "swatch-metrics-purge-events" not found
   ```