### PR TITLE
SWATCH-1198: Refactor billable usage conversion to use Quantity class

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingUnit.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingUnit.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.registry.TagMetric;
+import org.candlepin.subscriptions.registry.TagProfile;
+
+/** UOM with the currently configured billingFactor applied. */
+@Getter
+@ToString
+@EqualsAndHashCode
+public class BillingUnit implements Unit {
+  private final double billingFactor;
+
+  public BillingUnit(TagProfile tagProfile, BillableUsage usage) {
+    var tagMetricOptional =
+        tagProfile.getTagMetric(
+            usage.getProductId(), Measurement.Uom.fromValue(usage.getUom().value()));
+    billingFactor =
+        tagMetricOptional
+            .map(TagMetric::getBillingFactor)
+            .orElse(1.0); // get configured billingFactor in tag_profile yaml
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/MetricUnit.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/MetricUnit.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/** Unit representing a measurement in its raw measured value, without a billingFactor applied. */
+@ToString
+@EqualsAndHashCode
+public class MetricUnit implements Unit {
+  @Override
+  public double getBillingFactor() {
+    return 1.0;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/Quantity.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/Quantity.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.registry.TagProfile;
+
+/**
+ * Value with a unit attached. Encapsulates conversions involving billingFactor. Provides some
+ * utility methods for adjustments to amounts.
+ *
+ * @param <U> Unit of the quantity.
+ */
+@Getter
+@ToString
+@EqualsAndHashCode
+public class Quantity<U extends Unit> {
+  private final double value;
+  private final U unit;
+
+  private Quantity(double value, U unit) {
+    this.value = value;
+    this.unit = unit;
+  }
+
+  public Quantity<U> add(Quantity<?> other) {
+    var valueInMetricUnits = value / unit.getBillingFactor();
+    var otherInMetricUnits = other.getValue() / other.getUnit().getBillingFactor();
+    return of(valueInMetricUnits + otherInMetricUnits).to(unit);
+  }
+
+  public Quantity<U> subtract(Quantity<?> other) {
+    var valueInMetricUnits = value / unit.getBillingFactor();
+    var otherInMetricUnits = other.getValue() / other.getUnit().getBillingFactor();
+    return of(valueInMetricUnits - otherInMetricUnits).to(unit);
+  }
+
+  public Quantity<U> ceil() {
+    return new Quantity<>(Math.ceil(value), unit);
+  }
+
+  public Quantity<U> positiveOrZero() {
+    // less-than-equals used to normalize -0.0 to 0.0
+    if (value <= 0) {
+      return new Quantity<>(0.0, unit);
+    }
+    return this;
+  }
+
+  public <T extends Unit> Quantity<T> to(T targetUnit) {
+    var valueInMetricUnits = value / unit.getBillingFactor();
+    var valueInTargetUnits = valueInMetricUnits * targetUnit.getBillingFactor();
+    return new Quantity<>(valueInTargetUnits, targetUnit);
+  }
+
+  public static Quantity<MetricUnit> of(double value) {
+    return new Quantity<>(value, new MetricUnit());
+  }
+
+  public static Quantity<BillingUnit> fromContractCoverage(
+      TagProfile tagProfile, BillableUsage referenceUsage, double value) {
+    return new Quantity<>(value, new BillingUnit(tagProfile, referenceUsage));
+  }
+
+  public static Quantity<RemittanceUnit> fromRemittance(BillableUsageRemittanceEntity remittance) {
+    return new Quantity<>(remittance.getRemittedValue(), new RemittanceUnit(remittance));
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceUnit.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceUnit.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+
+/** Represents the uom recorded on a remittance record */
+@Getter
+@ToString
+@EqualsAndHashCode
+public class RemittanceUnit implements Unit {
+  private final double billingFactor;
+
+  public RemittanceUnit(BillableUsageRemittanceEntity entity) {
+    this.billingFactor = Objects.requireNonNullElse(entity.getBillingFactor(), 1.0);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/Unit.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/Unit.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+/**
+ * Captures what unit a given quantity is in.
+ *
+ * @see Quantity
+ * @see MetricUnit
+ * @see RemittanceUnit
+ * @see BillingUnit
+ */
+public interface Unit {
+  double getBillingFactor();
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/QuantityTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/QuantityTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.json.BillableUsage.Uom;
+import org.candlepin.subscriptions.registry.TagMetric;
+import org.candlepin.subscriptions.registry.TagProfile;
+import org.junit.jupiter.api.Test;
+
+class QuantityTest {
+  TagProfile tagProfile() {
+    var tagProfile = mock(TagProfile.class);
+    when(tagProfile.getTagMetric(any(), any()))
+        .thenReturn(Optional.of(TagMetric.builder().billingFactor(0.25).build()));
+    return tagProfile;
+  }
+
+  @Test
+  void testMetricUnitHasBillingFactorOf1() {
+    var quantity = Quantity.of(1.0);
+    assertEquals(1.0, quantity.getValue());
+    assertEquals(1.0, quantity.getUnit().getBillingFactor());
+  }
+
+  @Test
+  void testMetricUnitToMetricUnitPreservesValue() {
+    var quantity = Quantity.of(1.456);
+    var converted = quantity.to(new MetricUnit());
+    assertEquals(converted, quantity);
+  }
+
+  @Test
+  void testQuantityFromBillableUsage() {
+    var billableUsage = new BillableUsage();
+    billableUsage.setUom(Uom.SOCKETS);
+    billableUsage.setProductId("foo");
+    var billingUnit = new BillingUnit(tagProfile(), billableUsage);
+    assertEquals(0.25, billingUnit.getBillingFactor());
+    var billableQuantity = Quantity.of(4.0).to(billingUnit);
+    assertEquals(billingUnit, billableQuantity.getUnit());
+    assertEquals(1.0, billableQuantity.getValue());
+  }
+
+  @Test
+  void testAddingBillableUnitToMetricUnit() {
+    var quantity = Quantity.of(1.5);
+    var billableUsage = new BillableUsage();
+    billableUsage.setUom(Uom.SOCKETS);
+    billableUsage.setProductId("productId");
+    var billingUnit = new BillingUnit(tagProfile(), billableUsage);
+    var billable = Quantity.of(4.0).to(billingUnit);
+    assertEquals(1.0, billable.getValue());
+    var result = quantity.add(billable);
+    assertEquals(5.5, result.getValue());
+    assertEquals(new MetricUnit(), result.getUnit());
+  }
+
+  @Test
+  void testSubtractingBillableUnitFromMetricUnit() {
+    var quantity = Quantity.of(1.5);
+    var billableUsage = new BillableUsage();
+    billableUsage.setUom(Uom.SOCKETS);
+    billableUsage.setProductId("productId");
+    var billingUnit = new BillingUnit(tagProfile(), billableUsage);
+    var billable = Quantity.of(1.0).to(billingUnit);
+    assertEquals(0.25, billable.getValue());
+    var result = quantity.subtract(billable);
+    assertEquals(0.5, result.getValue());
+    assertEquals(new MetricUnit(), result.getUnit());
+  }
+
+  @Test
+  void testCeil() {
+    assertEquals(1.0, Quantity.of(0.1).ceil().getValue());
+    assertEquals(1.0, Quantity.of(0.9).ceil().getValue());
+  }
+
+  @Test
+  void testPositiveOrZero() {
+    assertEquals(0.0, Quantity.of(-0.0).positiveOrZero().getValue());
+    assertEquals(0.0, Quantity.of(-2.0).positiveOrZero().getValue());
+    assertEquals(0.0, Quantity.of(0.0).positiveOrZero().getValue());
+  }
+
+  @Test
+  void testFromRemittance() {
+    var remittance = new BillableUsageRemittanceEntity();
+    remittance.setBillingFactor(0.25);
+    remittance.setRemittedValue(2.5);
+    var quantity = Quantity.fromRemittance(remittance);
+    assertEquals(0.25, quantity.getUnit().getBillingFactor());
+    assertEquals(2.5, quantity.getValue());
+    assertEquals(10.0, quantity.to(new MetricUnit()).getValue());
+  }
+}


### PR DESCRIPTION
Jira issue: [SWATCH-1198](https://issues.redhat.com/browse/SWATCH-1198)

Description
===========

This helps remove some complexity/confusion by having quantities carry `Units` so that it is more clear what unit is applied to a given number.

Initially, I investigated the javax.measure API and reference implementation, but our needs didn't fit cleanly, so instead, I implemented a couple of classes with interfaces loosely inspired by those in javax.measure, `Unit` representing value's unit and capturing the billingFactor, and `Quantity` representing a (value, `Unit`) tuple.

I moved conversions and a couple of key transformations into the `Quantity` class (namely
 `positiveOrZero` and `ceil`). This makes the code a bit easier to read.

Testing
=======

Follow the instructions in #2119