### PR TITLE
Clean up error message that is masking an exception trace

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -104,8 +104,7 @@ public class TallySnapshotController {
       throw new IllegalArgumentException("A non-null orgId is required for tally operations.");
     }
 
-    String account = accountRepo.findAccountNumberByOrgId(orgId);
-    log.info("Producing snapshots for Org ID {} with Account {}.", orgId, account);
+    log.info("Producing snapshots for Org ID {} ", orgId);
 
     AccountUsageCalculation accountCalc;
     try {
@@ -115,8 +114,7 @@ public class TallySnapshotController {
         attemptCloudigradeEnrichment(accountCalc);
       }
     } catch (Exception e) {
-      log.error(
-          "Could not collect existing usage snapshots for orgId={} account={}", orgId, account, e);
+      log.error("Error collecting existing usage snapshots ", e);
       return;
     }
 


### PR DESCRIPTION
Due to the use of multi-argument error logger it was treating the exception as an argument to the formatter and not a throwable to be logged. 

The MDC logger was already logging the org_id so it was extraneous to include it in the string of the error msg. 

Also removed the call to get the account number which is no longer necessary as we are doing all the calculations by org_id.
