### PR TITLE
SWATCH-1258 Enable sync APIs with support role

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -100,7 +100,7 @@ public class ContractsTestingResource implements DefaultApi {
 
   @Override
   @Transactional
-  @RolesAllowed({"test"})
+  @RolesAllowed({"test", "support"})
   public StatusResponse syncAllContracts() throws ApiException, ProcessingException {
     log.info("Syncing All Contracts");
     var contracts = service.getAllContracts();
@@ -114,7 +114,7 @@ public class ContractsTestingResource implements DefaultApi {
   }
 
   @Override
-  @RolesAllowed({"test"})
+  @RolesAllowed({"test", "support"})
   public StatusResponse syncContractsByOrg(String orgId) throws ApiException, ProcessingException {
     return service.syncContractByOrgId(orgId);
   }

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -274,6 +274,7 @@ paths:
           description: success
 
       security:
+        - support: []
         - test: []
       operationId: syncContractsByOrg
   /internal/rpc/syncAllContracts:
@@ -294,6 +295,7 @@ paths:
                     status: 'Success'
                     message: "All contracts Synced"
       security:
+        - support: []
         - test: []
   /internal/offerings/{sku}/product_tags:
       description: "Mapping sku to product tags."


### PR DESCRIPTION
Jira issue: [SWATCH-1258](https://issues.redhat.com/browse/SWATCH-1258)

## Description
Currently, it's not possible to call the sync APIs because they're set for `test` only. They should be set for `support` and `test` together.

## Testing

### Steps
Run swatch-contract.

Execute: 
```
curl -X 'POST' \
  'http://localhost:8000/api/swatch-contracts/internal/rpc/sync/contracts/123' \
  -H 'accept: application/json' \
  -H 'x-rh-identity: ewogICAgICAgICAgICAgICJpZGVudGl0eSI6IHsKICAgICAgICAgICAgICAgICJ0eXBlIjogIkFzc29jaWF0ZSIsCiAgICAgICAgICAgICAgICAiYXNzb2NpYXRlIiA6IHsKICAgICAgICAgICAgICAgICAgImVtYWlsIjogInRlc3RAZXhhbXBsZS5jb20iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgfQogICAgICAgICAgICB9Cg==' \
  -d ''
```

### Verification
You should be able to authorize and see the below response:

> {
>   "message": "123 not found in table",
>   "status": "FAILED"
> }
