### PR TITLE
SWATCH-1195: anti csrf filtering

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -94,8 +94,8 @@ public class ApiSecurityConfiguration {
   }
 
   // NOTE: intentionally not annotated w/ @Bean; @Bean causes an extra use as an application filter
-  public AntiCsrfFilter antiCsrfFilter(SecurityProperties secProps, ConfigurableEnvironment env) {
-    return new AntiCsrfFilter(secProps, env);
+  public AntiCsrfFilter antiCsrfFilter(SecurityProperties secProps) {
+    return new AntiCsrfFilter(secProps);
   }
 
   // NOTE: intentionally not annotated w/ @Bean; @Bean causes an extra use as an application filter
@@ -201,7 +201,7 @@ public class ApiSecurityConfiguration {
     http.addFilter(identityHeaderAuthenticationFilter(authenticationManager, mapper))
         .addFilterAfter(mdcFilter(), IdentityHeaderAuthenticationFilter.class)
         .addFilterAfter(logPrincipalFilter(), MdcFilter.class)
-        .addFilterAt(antiCsrfFilter(secProps, env), CsrfFilter.class)
+        .addFilterAt(antiCsrfFilter(secProps), CsrfFilter.class)
         .csrf(csrf -> csrf.disable()) // We use our own CSRF filter
         .exceptionHandling(
             handler -> {

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -278,17 +278,20 @@ class InternalSubscriptionResourceTest {
      * if we get a 404 response, it means everything passed security-wise and we just couldn't
      * find the matching resource (because there are no matching RestControllers!).
      */
-    mvc.perform(post(SYNC_ORG_123)).andExpect(status().isNotFound());
+    mvc.perform(post(SYNC_ORG_123).header("Origin", "console.redhat.com"))
+        .andExpect(status().isNotFound());
   }
 
   @Test
   void forceSyncForOrgWorksFailsWithNoPrincipal() throws Exception {
-    mvc.perform(post(SYNC_ORG_123)).andExpect(status().isUnauthorized());
+    mvc.perform(post(SYNC_ORG_123).header("Origin", "console.redhat.com"))
+        .andExpect(status().isUnauthorized());
   }
 
   @Test
   @WithMockRedHatPrincipal("123")
   void forceSyncForOrgWorksFailsWithRhPrincipal() throws Exception {
-    mvc.perform(post(SYNC_ORG_123)).andExpect(status().isForbidden());
+    mvc.perform(post(SYNC_ORG_123).header("Origin", "console.redhat.com"))
+        .andExpect(status().isForbidden());
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/AntiCsrfFilter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/AntiCsrfFilter.java
@@ -30,7 +30,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /** Filter that prevents CSRF by verifying for a valid Origin or Referer header. */
@@ -45,9 +44,8 @@ public class AntiCsrfFilter extends OncePerRequestFilter {
   private final String domainSuffix;
   private final String domainAndPortSuffix;
 
-  public AntiCsrfFilter(SecurityProperties props, ConfigurableEnvironment env) {
-    disabled =
-        props.isDevMode() || Arrays.asList(env.getActiveProfiles()).contains("capacity-ingress");
+  public AntiCsrfFilter(SecurityProperties props) {
+    disabled = props.isDevMode();
     port = props.getAntiCsrfPort();
     domainSuffix = props.getAntiCsrfDomainSuffix();
     domainAndPortSuffix = String.join(":", domainSuffix, Integer.toString(port));

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/GetVerbIncludingAntiCsrfFilter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/GetVerbIncludingAntiCsrfFilter.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.security;
 
 import javax.servlet.http.HttpServletRequest;
-import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
  * This class includes GET requests in the list of HTTP verbs that must have a matching origin or
@@ -30,8 +29,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
  */
 public class GetVerbIncludingAntiCsrfFilter extends AntiCsrfFilter {
 
-  GetVerbIncludingAntiCsrfFilter(SecurityProperties props, ConfigurableEnvironment env) {
-    super(props, env);
+  GetVerbIncludingAntiCsrfFilter(SecurityProperties props) {
+    super(props);
   }
 
   @Override

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/JolokiaActuatorConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/JolokiaActuatorConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointR
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -48,9 +47,8 @@ public class JolokiaActuatorConfiguration {
 
   // NOTE: intentionally *not* annotated with @Bean; @Bean causes an extra use as an application
   // filter
-  public AntiCsrfFilter getVerbIncludingAntiCsrfFilter(
-      SecurityProperties appProps, ConfigurableEnvironment env) {
-    return new GetVerbIncludingAntiCsrfFilter(appProps, env);
+  public AntiCsrfFilter getVerbIncludingAntiCsrfFilter(SecurityProperties appProps) {
+    return new GetVerbIncludingAntiCsrfFilter(appProps);
   }
 
   // NOTE: intentionally *not* annotated w/ @Bean; @Bean causes an *extra* use as an application
@@ -112,7 +110,6 @@ public class JolokiaActuatorConfiguration {
       HttpSecurity http,
       SecurityProperties secProps,
       AuthenticationManager authenticationManager,
-      ConfigurableEnvironment env,
       ObjectMapper mapper)
       throws Exception {
     // See
@@ -121,7 +118,7 @@ public class JolokiaActuatorConfiguration {
     http.requestMatcher(EndpointRequest.to("jolokia"))
         .addFilter(identityHeaderAuthenticationFilter(authenticationManager, mapper))
         .addFilterAfter(mdcFilter(), IdentityHeaderAuthenticationFilter.class)
-        .addFilterAt(getVerbIncludingAntiCsrfFilter(secProps, env), CsrfFilter.class)
+        .addFilterAt(getVerbIncludingAntiCsrfFilter(secProps), CsrfFilter.class)
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(requests -> requests.anyRequest().authenticated());
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1195](https://issues.redhat.com/browse/SWATCH-1195)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Enable anticsrf filter on capacity-ingress API's

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Start app with: `./gradlew :bootRun --args="--rhsm-subscriptions.security.dev-mode=false --spring.profiles.active=capacity-ingress,kafka-queue"`

### Steps
<!-- Enter each step of the test below -->
1. Curl with bad origin should return 403: `http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123 x-rh-swatch-psk:placeholder origin:bad`
1. Curl with correct origin should start sync: `http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123 x-rh-swatch-psk:placeholder origin:console.redhat.com`

