### PR TITLE
Separate building, testing and linting into separate stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,12 +31,25 @@ pipeline {
                 input 'ok to test?'
             }
         }
-        stage('Build/Test/Lint') {
+
+        stage('Assemble'){
             steps {
-                // The build task includes check, test, and assemble.  Linting happens during the check
-                // task and uses the spotless gradle plugin.
                 echo "The ci value is ${env.CI}"
-                sh "./gradlew --no-daemon build"
+                sh "./gradlew --no-daemon assemble"
+            }
+        }
+
+        stage('Test'){
+            steps {
+                echo "The ci value is ${env.CI}"
+                sh "./gradlew --no-daemon test"
+            }
+        }
+
+        stage('Lint'){
+            steps {
+                echo "The ci value is ${env.CI}"
+                sh "./gradlew --no-daemon spotlessCheck"
             }
         }
 


### PR DESCRIPTION
Quality of life change.  It's currently a pain to dig into a bunch of logs when the `Subscription PR Check` jenkins job fails due on the **Build/Test/Lint** step

Check the "Details" link on the continuous-integration/jenkins/pr-merge in the Checks section to the changes.


Before
![image](https://github.com/RedHatInsights/rhsm-subscriptions/assets/19955562/127501f0-0591-4814-b6c2-6bbef1b5439b)


After
![image](https://github.com/RedHatInsights/rhsm-subscriptions/assets/19955562/b6dc8a9f-6cc8-4e2f-8eac-548b5b251405)

