### PR TITLE
 SWATCH-1260 Use vendor specific metric when calling contracts API 

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -150,11 +150,12 @@ public class BillableUsageController {
 
   private BillableUsage produceMonthlyBillable(BillableUsage usage) {
     log.info(
-        "Processing monthly billable usage for orgId={} productId={} uom={} provider={}, snapshotDate={}",
+        "Processing monthly billable usage for orgId={} productId={} uom={} provider={}, billingAccountId={} snapshotDate={}",
         usage.getOrgId(),
         usage.getProductId(),
         usage.getUom(),
         usage.getBillingProvider(),
+        usage.getBillingAccountId(),
         usage.getSnapshotDate());
     log.debug("Usage: {}", usage);
 
@@ -174,15 +175,14 @@ public class BillableUsageController {
               ErrorCode.CONTRACT_NOT_AVAILABLE,
               30,
               usage);
-          return null;
         } else {
           log.error(
               "{} - Unable to retrieve contract for usage older than {} minutes old. Usage: {}",
               ErrorCode.CONTRACT_NOT_AVAILABLE,
               30,
               usage);
-          return null;
         }
+        return null;
       }
     }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/ContractMissingException.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/ContractMissingException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+public class ContractMissingException extends Exception {
+
+  public ContractMissingException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/ContractsController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/ContractsController.java
@@ -80,7 +80,7 @@ public class ContractsController {
     if (ObjectUtils.isEmpty(contractMetricId)) {
       throw new IllegalStateException(
           String.format(
-              "Contract metric ID is not configured for provider=%s product=%s usage=%s",
+              "Contract metric ID is not configured for billingProvider=%s product=%s uom=%s",
               usage.getBillingProvider(), usage.getProductId(), usage.getUom()));
     }
 

--- a/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/registry/TagProfileFactoryTest.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.registry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
@@ -73,6 +74,20 @@ class TagProfileFactoryTest {
   void testCanLookupMetricIdByTagAndUom() {
     assertNotNull(
         tagProfile.rhmMetricIdForTagAndUom(ProductId.OPENSHIFT_METRICS.toString(), Uom.CORES));
+  }
+
+  @Test
+  void testCanLookupAwsDimensionByTagAndUom() {
+    String rosaCoresAwsDimension =
+        tagProfile.awsDimensionForTagAndUom(ProductId.ROSA.toString(), Uom.CORES);
+    assertNotNull(rosaCoresAwsDimension);
+    assertEquals("four_vcpu_hour", rosaCoresAwsDimension);
+  }
+
+  @Test
+  void awsDimensionLookupReturnsNullWhenNotDefined() {
+    assertNull(
+        tagProfile.awsDimensionForTagAndUom(ProductId.OPENSHIFT_METRICS.toString(), Uom.CORES));
   }
 
   @Test

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagProfile.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/registry/TagProfile.java
@@ -62,6 +62,7 @@ public class TagProfile {
 
   private Map<String, Set<String>> tagToEngProductsLookup;
   private Map<ProductUom, String> productUomToRhmMetricIdLookup;
+  private Map<ProductUom, String> productUomToAwsDimensionLookup;
   @Getter private Set<String> tagsWithPrometheusEnabledLookup;
   private Map<String, Set<Uom>> measurementsByTagLookup;
   private Map<String, String> offeringProductNameToTagLookup;
@@ -77,6 +78,7 @@ public class TagProfile {
   public void initLookups() {
     tagToEngProductsLookup = new HashMap<>();
     productUomToRhmMetricIdLookup = new HashMap<>();
+    productUomToAwsDimensionLookup = new HashMap<>();
     tagsWithPrometheusEnabledLookup = new HashSet<>();
     measurementsByTagLookup = new HashMap<>();
     offeringProductNameToTagLookup = new HashMap<>();
@@ -152,6 +154,13 @@ public class TagProfile {
 
     productUomToRhmMetricIdLookup.put(
         new ProductUom(tagMetric.getTag(), tagMetric.getUom().value()), tagMetric.getRhmMetricId());
+
+    if (!ObjectUtils.isEmpty(tagMetric.getAwsDimension())) {
+      productUomToAwsDimensionLookup.put(
+          new ProductUom(tagMetric.getTag(), tagMetric.getUom().value()),
+          tagMetric.getAwsDimension());
+    }
+
     measurementsByTagLookup
         .computeIfAbsent(tagMetric.getTag(), k -> new HashSet<>())
         .add(tagMetric.getUom());
@@ -196,6 +205,10 @@ public class TagProfile {
 
   public String rhmMetricIdForTagAndUom(String tag, TallyMeasurement.Uom uom) {
     return productUomToRhmMetricIdLookup.get(new ProductUom(tag, uom.value()));
+  }
+
+  public String awsDimensionForTagAndUom(String tag, TallyMeasurement.Uom uom) {
+    return productUomToAwsDimensionLookup.get(new ProductUom(tag, uom.value()));
   }
 
   public String tagForOfferingProductName(String offeringProductName) {

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -351,7 +351,7 @@ tagMetrics:
   - tag: rosa
     metricId: redhat.com:rosa:cpu_hour
     rhmMetricId: redhat.com:rosa:cpu_hour
-    awsDimension: four_cpu_hour
+    awsDimension: four_vcpu_hour
     uom: CORES
     billingFactor: 0.25
     billingWindow: MONTHLY


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1260](https://issues.redhat.com/browse/SWATCH-1260)

## Description
The contract service API is expecting the vendor specific metric
(awsDimension/rhmMetricId) as the metric_id when fetching contracts.

Before making the API call, convert the UOM to the vendor metric
ID by consulting the tag profile.

The configured awsDimension for ROSA was incorrect based on existing contracts
and has been adjusted.

Since the Contracts API retruns an empty list when a contract
is not found based on the search criteria, this should not
result in an ExternalServiceException. Instead we now throw
a ContractMissingException which is handled by the
BillableUsageController.

As part of this change, ContractController.getContractCoverage
now returns a Double instead of Optional, ensuring that if the
call succeeds, a value will be returned.


## Testing Steps
### Setup
Clean up any existing data.
```bash
psql -U rhsm-subscriptions rhsm-subscriptions << EOF
-- cleanup the tables
truncate events;
truncate tally_snapshots cascade;
truncate hosts cascade;
truncate billable_usage_remittance;
truncate contracts cascade;
EOF
```

Insert the following data into the DB.
```bash
psql -U rhsm-subscriptions rhsm-subscriptions << EOF
-- contracts
INSERT INTO contracts VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', '12914277', '2023-05-10 15:20:07.717275-03', '2023-05-10 15:20:07.717275-03', NULL, 'org123', 'MW02393', 'aws', 'aws123', 'rosa', 'bcwuzc8ww10vvxfair55mliy8');

-- contract_metrics
INSERT INTO contract_metrics VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', 'control_plane', 7);
INSERT INTO contract_metrics VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', 'premium_support', 9);
INSERT INTO contract_metrics VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', 'four_vcpu_hour', 12);

-- events
INSERT INTO public.events VALUES ('1464d3e9-2cb7-44c6-b0b6-8bef0ecb57d8', 'account123', '2023-05-11 11:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "1464d3e9-2cb7-44c6-b0b6-8bef0ecb57d8", "timestamp": "2023-05-11T14:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-05-11T15:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 2.3333333333333335}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('68f95e47-5751-48e3-89e0-655c8f99fe6d', 'account123', '2023-05-11 11:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "68f95e47-5751-48e3-89e0-655c8f99fe6d", "timestamp": "2023-05-11T14:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-05-11T15:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 0.6666666666666666}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('6fc851d9-6372-42ca-8758-690306d70718', 'account123', '2023-05-11 12:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "6fc851d9-6372-42ca-8758-690306d70718", "timestamp": "2023-05-11T15:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-05-11T16:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('f95c0ea1-5aae-4928-be9a-48e79b200fd5', 'account123', '2023-05-11 12:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "f95c0ea1-5aae-4928-be9a-48e79b200fd5", "timestamp": "2023-05-11T15:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-05-11T16:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('b48da70c-79cd-4504-ad77-ac9b5a31e016', 'account123', '2023-05-11 13:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "b48da70c-79cd-4504-ad77-ac9b5a31e016", "timestamp": "2023-05-11T16:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-05-11T17:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('0d47af0e-2aad-4fef-b7ef-57397bda3b15', 'account123', '2023-05-11 13:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "0d47af0e-2aad-4fef-b7ef-57397bda3b15", "timestamp": "2023-05-11T16:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-05-11T17:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');

EOF
```

### Reproducer
From the **main** branch.

Start the contract service in one console.
```
SERVER_PORT=8882 ./gradlew  :swatch-contracts:quarkusDev
```

Start tally (configured to point at the contracts service) in another console.
```
SPRING_PROFILES_ACTIVE=worker,kafka-task-queue SWATCH_CONTRACTS_INTERNAL_SERVICE_URL=http://localhost:8882 DEV_MODE=true ./gradlew :bootRun
```

Perform a nightly tally that covers the timespan of the Events that we added to the DB.
```
http :9000/hawtio/jolokia type=exec \
mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean' \
operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)' \
arguments:='["org123", "2023-05-01T00:00Z", "2023-05-15T23:00Z"]'
```

You should see a bunch of errors/warning like the following.
```
2023-05-17 15:08:26,401 [thread=swatch-producer-billing-0-C-1] [ERROR] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - SUBSCRIPTIONS3004: Expected contract missing - Unable to retrieve contract for usage older than 30 minutes old. Usage: org.candlepin.subscriptions.json.BillableUsage@3fec1ebc[accountNumber=account123,orgId=org123,id=be578931-e23e-4c5a-a5c9-be8dde1b46b9,billingProvider=aws,billingAccountId=aws123,snapshotDate=2023-05-11T15:00Z,productId=rosa,sla=Premium,usage=Production,uom=Instance-hours,value=1.0,billingFactor=<null>,vendorProductCode=<null>]
2023-05-17 15:08:26,401 [thread=swatch-producer-billing-0-C-1] [WARN ] [org.candlepin.subscriptions.tally.billing.BillingProducer] - Skipping billable usage; see previous errors/warnings.
```

Looking at the **billable_usage_remittance** table, you'll see that there were no records created since the processing was cancelled.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance"
```

### Testing The Fix
Check out the branch for this PR and **deploy the applications as you previously did** and **re-run the tally**.

Looking at the logs, you should see that the billable useage was processed, and that there were no errors like before.
```
2023-05-17 15:24:07,527 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Processing monthly billable usage for orgId=org123 productId=rosa uom=Instance-hours provider=aws, snapshotDate=2023-05-11T15:00Z
2023-05-17 15:24:07,588 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Finished producing monthly billable for orgId=org123 productId=rosa uom=Instance-hours provider=aws, snapshotDate=2023-05-11T15:00Z
2023-05-17 15:24:07,596 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Processing monthly billable usage for orgId=org123 productId=rosa uom=Cores provider=aws, snapshotDate=2023-05-11T15:00Z
2023-05-17 15:24:07,604 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Finished producing monthly billable for orgId=org123 productId=rosa uom=Cores provider=aws, snapshotDate=2023-05-11T15:00Z
2023-05-17 15:24:07,668 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Processing monthly billable usage for orgId=org123 productId=rosa uom=Instance-hours provider=aws, snapshotDate=2023-05-11T14:00Z
2023-05-17 15:24:07,677 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Finished producing monthly billable for orgId=org123 productId=rosa uom=Instance-hours provider=aws, snapshotDate=2023-05-11T14:00Z
2023-05-17 15:24:07,678 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Processing monthly billable usage for orgId=org123 productId=rosa uom=Cores provider=aws, snapshotDate=2023-05-11T14:00Z
2023-05-17 15:24:07,687 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Finished producing monthly billable for orgId=org123 productId=rosa uom=Cores provider=aws, snapshotDate=2023-05-11T14:00Z
2023-05-17 15:24:07,704 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Processing monthly billable usage for orgId=org123 productId=rosa uom=Instance-hours provider=aws, snapshotDate=2023-05-11T16:00Z
2023-05-17 15:24:07,712 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Finished producing monthly billable for orgId=org123 productId=rosa uom=Instance-hours provider=aws, snapshotDate=2023-05-11T16:00Z
2023-05-17 15:24:07,713 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Processing monthly billable usage for orgId=org123 productId=rosa uom=Cores provider=aws, snapshotDate=2023-05-11T16:00Z
2023-05-17 15:24:07,722 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Finished producing monthly billable for orgId=org123 productId=rosa uom=Cores provider=aws, snapshotDate=2023-05-11T16:00Z
```

Finally check the remittance table to make sure that remittance was recorded. The value should be **0** for both metrics since the contract covers the current usage.
```
psql -h localhost -U rhsm-subscriptions -c "select * from billable_usage_remittance"
```
