### PR TITLE
SWATCH-1095: enable otel on quarkus apps

### DIFF
--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-jsonb'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-openshift'
+    implementation 'io.quarkus:quarkus-opentelemetry'
     implementation 'io.quarkus:quarkus-resteasy-jsonb'
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-security'

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -47,6 +47,12 @@ parameters:
     value: swatch-tally
   - name: QUARKUS_PROFILE
     value: prod
+  - name: OTEL_ENABLED
+    value: 'false'
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: 'http://localhost:4317'
+  - name: OTEL_SERVICE_NAME
+    value: swatch-contracts
 
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
@@ -195,6 +201,12 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: metadata.namespace
+              - name: QUARKUS_OPENTELEMETRY_ENABLED
+                value: ${OTEL_ENABLED}
+              - name: QUARKUS_OPENTELEMETRY_TRACER_EXPORTER_OTLP_ENDPOINT
+                value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: QUARKUS_OPENTELEMETRY_SERVICE_NAME
+                value: ${OTEL_SERVICE_NAME}
             volumeMounts:
               - name: logs
                 mountPath: /logs

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-logging-json'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-openshift'
+    implementation 'io.quarkus:quarkus-opentelemetry'
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-smallrye-fault-tolerance'
     implementation 'io.quarkus:quarkus-smallrye-health'

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -60,6 +60,12 @@ parameters:
     value: '3'
   - name: KAFKA_BILLABLE_USAGE_PARTITIONS
     value: '3'
+  - name: OTEL_ENABLED
+    value: 'false'
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: 'http://localhost:4317'
+  - name: OTEL_SERVICE_NAME
+    value: swatch-producer-aws
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -175,6 +181,12 @@ objects:
               value: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP}
             - name: ENABLE_AWS_DRY_RUN
               value: ${ENABLE_AWS_DRY_RUN}
+            - name: QUARKUS_OPENTELEMETRY_ENABLED
+              value: ${OTEL_ENABLED}
+            - name: QUARKUS_OPENTELEMETRY_TRACER_EXPORTER_OTLP_ENDPOINT
+              value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: QUARKUS_OPENTELEMETRY_SERVICE_NAME
+              value: ${OTEL_SERVICE_NAME}
           volumeMounts:
             - name: logs
               mountPath: /logs


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1095](https://issues.redhat.com/browse/SWATCH-1095)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Enables OTel in quarkus apps
## Testing

<!--
When possible, please use commands a developer can directly paste or modify
-->

### Steps
<!-- Enter each step of the test below -->
Reserve an ephemeral namespace for testing:

```shell
oc project $(bonfire namespace reserve)
```

Deploy swatch:

```shell
bonfire deploy rhsm --no-remove-resources swatch-contracts --no-remove-resources swatch-api --no-remove-resources swatch-producer-aws --no-remove-resources swatch-producer-red-hat-marketplace --no-remove-resources swatch-metrics --no-remove-resources swatch-subscription-sync --no-remove-resources swatch-system-conduit --no-remove-resources swatch-tally
```

Create a jaeger all-in-one configuration:

```shell
cat <<EOF > /tmp/values.yaml
provisionDataStore:
  cassandra: false
allInOne:
  enabled: true
storage:
  type: none
agent:
  enabled: false
collector:
  enabled: false
query:
  enabled: false
EOF
```

Use https://helm.sh/ to deploy jaeger:

```shell
helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
helm template -f /tmp/values.yaml jaegertracing/jaeger \
  --kube-version=1.21.1 \
  --name-template='test' | oc apply -f -
```

Manually deploy updated deployments, change image and tag if you used your own:

```shell
oc process  \
-p OTEL_ENABLED=true \
-p OTEL_EXPORTER_OTLP_ENDPOINT=http://test-jaeger-collector:4317 \
-p ENV_NAME=env-$(oc project -q)  \
-p IMAGE=quay.io/kflahert/swatch-producer-aws  \
-p IMAGE_TAG=otel-4 \
-f swatch-producer-aws/deploy/clowdapp.yaml | oc apply -f -


oc process  \
 -p OTEL_EXPORTER_OTLP_ENDPOINT=http://test-jaeger-collector:4317 \
 -p OTEL_ENABLED=true \
 -p ENV_NAME=env-$(oc project -q) \
 -p IMAGE=quay.io/kflahert/swatch-contracts \
 -p IMAGE_TAG=otel-4  \
 -f swatch-contracts/deploy/clowdapp.yaml | oc apply -f -

```

### Verification
<!-- Enter the steps needed to verify the test passed -->
Port forward the jaeger UI:

```shell
oc port-forward service/test-jaeger-query 16686
```
Run a curl command in each of swatch-producer-aws and swatch-contracts in OpenShift terminal (can just be `curl localhost:8000`)

View the trace in the jaeger UI at http://localhost:16686.