### PR TITLE
SWATCH-1105: update TallyReportDataPoint value to int and round up

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1263,8 +1263,8 @@ components:
           type: string
           format: date-time
         value:
-          type: number
-          format: double
+          type: integer
+          format: int32
         has_data:
           type: boolean
     TallyReport:

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapter.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapter.java
@@ -33,7 +33,7 @@ public class TallyReportDataPointAdapter implements ReportFillerAdapter<TallyRep
   @Override
   public TallyReportDataPoint createDefaultItem(
       OffsetDateTime itemDate, TallyReportDataPoint previous, boolean useRunningTotalFormat) {
-    return new TallyReportDataPoint().date(itemDate).hasData(false).value(0.0);
+    return new TallyReportDataPoint().date(itemDate).hasData(false).value(0);
   }
 
   @Override


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1150](https://issues.redhat.com/browse/SWATCH-1150)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Update the value of TallyReportDataPoint to integer and round up from double value.
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1.Insert test data:
```
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('dcf4adc8-9f23-476a-9c94-9a405ce2facd', 'account123', '2021-10-30 20:00:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "dcf4adc8-9f23-476a-9c94-9a405ce2facd", "timestamp": "2021-10-30T20:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-11-01T01:00:00Z", "instance_id": "c5mu16smf1c22rn8e730", "display_name": "c5mu16smf1c22rn8e730", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 1.25}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('4cf4adc8-9f23-476a-9c94-9a405ce2facd', 'account123', '2021-10-30 21:00:00.000000+00:00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "4cf4adc8-9f23-476a-9c94-9a405ce2facd", "timestamp": "2021-10-30T21:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-11-01T01:00:00Z", "instance_id": "c5mu16smf1c22rn8e730", "display_name": "c5mu16smf1c22rn8e730", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 1.5}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('4cf4adc7-9f23-476a-9c94-9a405ee2face', 'account123', '2021-10-30 22:00:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "4cf4adc7-9f23-476a-9c94-9a405ee2face", "timestamp": "2021-10-30T22:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-11-01T00:00:00Z", "instance_id": "c5mu16smf1c22rn8e730", "display_name": "c5mu16smf1c22rn8e730", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 3.6}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('9cf4adc8-9f23-476a-9c94-9a405ce2facd', 'account123', '2021-10-30 23:00:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "9cf4adc8-9f23-476a-9c94-9a405ce2facd", "timestamp": "2021-10-30T23:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2021-11-01T01:00:00Z", "instance_id": "c5mu16smf1c22rn8e730", "display_name": "c5mu16smf1c22rn8e730", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 1.0}], "service_type": "OpenShift Cluster", "account_number": "account123", "billing_provider": "red hat", "billing_account_id": "dummyId"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');
```
1. Run hourlyTallyByOrg curl (async response won't return response):
`curl -X POST -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=org123&start=2021-10-01T00%3A00Z&end=2021-11-01T00%3A00Z"`

### Steps
<!-- Enter each step of the test below -->
1. Curl tally endpoint to check records:
`curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Cores?granularity=Hourly&beginning=2021-10-30T20%3A00%3A00Z&ending=2021-10-31T01%3A00%3A00Z'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' | jq`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. First 4 values should be (2, 2, 4, 1)