### PR TITLE
SWATCH-1266: Modify subscription syncing to remove all stale records

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -58,6 +58,7 @@ public class StubSearchApi extends SearchApi {
 
   private Subscription createData() {
     return new Subscription()
+        .id(235251)
         .subscriptionNumber("2253591")
         .webCustomerId(123)
         .oracleAccountNumber(123)

--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -53,7 +53,7 @@ public class StubSearchApi extends SearchApi {
   @Override
   public List<Subscription> searchSubscriptionsByOrgId(
       String orgId, Integer index, Integer pageSize) throws ApiException {
-    return List.of(createData(), createAwsBillingProviderData());
+    return List.of(createData(), createAwsBillingProviderData(), createRhelData());
   }
 
   private Subscription createData() {
@@ -66,6 +66,18 @@ public class StubSearchApi extends SearchApi {
         .effectiveStartDate(OffsetDateTime.parse("2011-01-01T01:02:33Z").toEpochSecond() * 1000L)
         .effectiveEndDate(OffsetDateTime.parse("2031-01-01T01:02:33Z").toEpochSecond() * 1000L)
         .subscriptionProducts(List.of(new SubscriptionProduct().sku("MW01485")));
+  }
+
+  private Subscription createRhelData() {
+    return new Subscription()
+        .id(235255)
+        .subscriptionNumber("2253594")
+        .webCustomerId(123)
+        .oracleAccountNumber(123)
+        .quantity(1)
+        .effectiveStartDate(OffsetDateTime.parse("2011-01-01T01:02:33Z").toEpochSecond() * 1000L)
+        .effectiveEndDate(OffsetDateTime.parse("2031-01-01T01:02:33Z").toEpochSecond() * 1000L)
+        .subscriptionProducts(List.of(new SubscriptionProduct().sku("RH3413336")));
   }
 
   private Subscription createAwsBillingProviderData() {

--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -30,6 +30,9 @@ import org.candlepin.subscriptions.subscription.api.resources.SearchApi;
 /** Stub version of the SearchApi for the Subscription service for local testing. */
 public class StubSearchApi extends SearchApi {
 
+  public static final String START_DATE = "2011-01-01T01:02:33Z";
+  public static final String END_DATE = "2031-01-01T01:02:33Z";
+
   @Override
   public Subscription getSubscriptionById(String id) throws ApiException {
     if ("789".equals(id)) {
@@ -63,8 +66,8 @@ public class StubSearchApi extends SearchApi {
         .webCustomerId(123)
         .oracleAccountNumber(123)
         .quantity(1)
-        .effectiveStartDate(OffsetDateTime.parse("2011-01-01T01:02:33Z").toEpochSecond() * 1000L)
-        .effectiveEndDate(OffsetDateTime.parse("2031-01-01T01:02:33Z").toEpochSecond() * 1000L)
+        .effectiveStartDate(OffsetDateTime.parse(START_DATE).toEpochSecond() * 1000L)
+        .effectiveEndDate(OffsetDateTime.parse(END_DATE).toEpochSecond() * 1000L)
         .subscriptionProducts(List.of(new SubscriptionProduct().sku("MW01485")));
   }
 
@@ -75,8 +78,8 @@ public class StubSearchApi extends SearchApi {
         .webCustomerId(123)
         .oracleAccountNumber(123)
         .quantity(1)
-        .effectiveStartDate(OffsetDateTime.parse("2011-01-01T01:02:33Z").toEpochSecond() * 1000L)
-        .effectiveEndDate(OffsetDateTime.parse("2031-01-01T01:02:33Z").toEpochSecond() * 1000L)
+        .effectiveStartDate(OffsetDateTime.parse(START_DATE).toEpochSecond() * 1000L)
+        .effectiveEndDate(OffsetDateTime.parse(END_DATE).toEpochSecond() * 1000L)
         .subscriptionProducts(List.of(new SubscriptionProduct().sku("RH3413336")));
   }
 
@@ -92,8 +95,8 @@ public class StubSearchApi extends SearchApi {
         .webCustomerId(123)
         .oracleAccountNumber(123)
         .subscriptionNumber("4243626")
-        .effectiveStartDate(OffsetDateTime.parse("2011-01-01T01:02:33Z").toEpochSecond() * 1000L)
-        .effectiveEndDate(OffsetDateTime.parse("2031-01-01T01:02:33Z").toEpochSecond() * 1000L)
+        .effectiveStartDate(OffsetDateTime.parse(START_DATE).toEpochSecond() * 1000L)
+        .effectiveEndDate(OffsetDateTime.parse(END_DATE).toEpochSecond() * 1000L)
         .putExternalReferencesItem("aws", awsRef)
         .subscriptionProducts(List.of(new SubscriptionProduct().sku("MW01882")));
   }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionJmxBean.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionJmxBean.java
@@ -74,7 +74,7 @@ public class SubscriptionJmxBean {
   public void syncSubscriptionsForOrg(String orgId) {
     Object principal = ResourceUtils.getPrincipal();
     log.info("Sync for org {} triggered over JMX by {}", orgId, principal);
-    subscriptionSyncController.syncAllSubcriptionsForOrg(orgId);
+    subscriptionSyncController.reconcileSubscriptionsWithSubscriptionService(orgId);
   }
 
   @Transactional

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -455,6 +455,7 @@ public class SubscriptionSyncController {
     if (newOrUpdated.getEndDate() != null) {
       entity.setEndDate(newOrUpdated.getEndDate());
     }
+    entity.setSubscriptionNumber(newOrUpdated.getSubscriptionNumber());
     entity.setBillingProvider(newOrUpdated.getBillingProvider());
     entity.setBillingAccountId(newOrUpdated.getBillingAccountId());
     entity.setBillingProviderId(newOrUpdated.getBillingProviderId());

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorkerConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 @Profile("capacity-ingress")
@@ -79,6 +80,7 @@ public class SubscriptionWorkerConfiguration {
     }
     // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
     factory.getContainerProperties().setConsumerRebalanceListener(registry);
+    factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
     return factory;
   }
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionJmxBeanTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionJmxBeanTest.java
@@ -89,7 +89,7 @@ class SubscriptionJmxBeanTest {
   @Test
   void syncSubscriptionForOrgTest() {
     subject.syncSubscriptionsForOrg("123");
-    verify(subscriptionSyncController).syncAllSubcriptionsForOrg("123");
+    verify(subscriptionSyncController).reconcileSubscriptionsWithSubscriptionService("123");
   }
 
   @Test


### PR DESCRIPTION
Jira issue: [SWATCH-1266](https://issues.redhat.com/browse/SWATCH-1266)

Description
===========

Modify subscription syncing to always remove stale subscription and capacity records. Also modify syncing to process all pages of an org at once. Because this process can take quite a while, I changed the kafka acknowledgement to immediate, which means that if there is a restart during a sync, the org in-progress won't be synced again until the next scheduled (nightly sync).

During smoketesting, I found that a large org can take around 30 minutes on a clean database to process locally, this necessitated the acknowledgement change. I did not see a significant difference in memory usage.

Testing
=======

Setup
-----

1. Insert some mock subscription and subscription_capacity records:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
insert into subscription(sku, org_id, subscription_id, quantity, start_date, end_date)
values ('extra', '123', 'sub123', 1, now(), now()),
       ('MW01882', '123', '235252', 1, now(), now()),
       ('MW01485', '123', '235251', 1, now(), now());

insert into subscription_capacity(sku, org_id, subscription_id, product_id, begin_date, end_date, sla, usage)
values ('extra', '123', 'sub123', 'foo', now(), now(), '_ANY', '_ANY'),
       ('MW01882', '123', '235252', 'foo', now(), now(), '_ANY', '_ANY');
EOF
```

2. Ensure org "123" is opted in:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
insert into org_config(org_id, opt_in_type, created, updated) values ('123', 'JMX', now(), now());
EOF
```

3. Set up a denylist:

```shell
echo 'MW01485' > /tmp/denylist
```

4. Start the service:

```shell
PRODUCT_DENYLIST_RESOURCE_LOCATION=file:/tmp/denylist \
  SUBSCRIPTION_USE_STUB=true \
  ./gradlew :bootRun
```

Steps
-----

1. Run the nightly sync job:

```shell
SPRING_PROFILES_ACTIVE=subscription-sync,kafka-queue \
  SUBSCRIPTION_SYNC_ENABLED=true \
  SERVER_PORT=8001 \
  METRICS_SERVER_PORT=9001 \
  ./gradlew :bootRun
```

Verification
------------

1. Query `subscription` table:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
select * from subscription where org_id='123';
EOF
```

* Observe that the denylisted SKU (`MW01485`) records have been removed.
* Observe that the extraneous records w/ SKU `extra` have been removed.
* Observe that the MW01484 record remains.

2. Query `subscription_capacity` table:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
select * from subscription_capacity where org_id='123';
EOF
```

* Observe that the denylisted SKU (`MW01485`) records have been removed.
* Observe that the extraneous records w/ SKU `extra` have been removed.
