### PR TITLE
SWATCH-1190 Subscriptions sync endpoint JMX to REST

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionPruneController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionPruneController.java
@@ -68,6 +68,7 @@ public class SubscriptionPruneController {
     this.pruneSubscriptionsByOrgTaskKafkaTemplate = pruneSubscriptionsByOrgTaskKafkaTemplate;
   }
 
+  @Transactional
   public void pruneAllUnlistedSubscriptions() {
     Timer.Sample enqueueAllTime = Timer.start();
     orgRepository.findSyncEnabledOrgs().forEach(this::enqueueSubscriptionPrune);

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -26,6 +26,59 @@ servers:
         default: rhsm-subscriptions
 
 paths:
+  /internal/subscriptions:
+    description: Save subscriptions manually. Supported only in dev-mode.
+    post:
+      operationId: saveSubscriptions
+      tags:
+        - internalSubscriptions
+      parameters:
+        - name: reconcileCapacity
+          in: query
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: Save a list of subscriptions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionResponse"
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+  /internal/rpc/subscriptions/sync:
+    description: Enqueue all sync-enabled orgs to sync their subscriptions with upstream
+    put:
+      summary: Enqueue all sync-enabled orgs to sync their subscriptions with upstream
+      operationId: syncAllSubscriptions
+      tags:
+        - internalSubscriptions
+      responses:
+        '200':
+          description: The request for syncing all subscriptions is successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultResponse"
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
   /internal/subscriptions/sync/org/{org_id}:
     description: "Force sync of subscriptions for given org_id."
     parameters:
@@ -48,6 +101,28 @@ paths:
               schema:
                 type: string
                 example: Sync started.
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+  /internal/subscriptions/prune:
+    description: Remove subscription and capacity records that are in the denylist.
+    delete:
+      summary: Remove subscription and capacity records that are in the denylist.
+      operationId: pruneUnlistedSubscriptions
+      tags:
+        - internalSubscriptions
+      responses:
+        '200':
+          description: Prune of unlisted subscriptions is successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultResponse"
         '400':
           $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
@@ -201,6 +276,84 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
+  /internal/rpc/offerings/sync/{sku}:
+    description: Sync an offering from the upstream source.
+    parameters:
+      - name: sku
+        in: path
+        required: true
+        schema:
+          type: string
+    put:
+      summary: Sync an offering from the upstream source.
+      operationId: syncOffering
+      responses:
+        '200':
+          description: Sync for offering sku
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OfferingResponse"
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags:
+        - internalSubscriptions
+  /internal/rpc/offerings/sync:
+    description: Syncs all offerings not listed in deny list from the upstream source.
+    put:
+      summary: Syncs all offerings not listed in deny list from the upstream source.
+      operationId: syncAllOfferings
+      tags:
+        - internalSubscriptions
+      responses:
+        '200':
+          description: Enqueued offerings to be synced.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OfferingResponse"
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+  /internal/rpc/offerings/reconcile/{sku}:
+    description: Reconcile capacity for an offering from the upstream source.
+    parameters:
+      - name: sku
+        in: path
+        required: true
+        schema:
+          type: string
+    put:
+      summary: Reconcile capacity for an offering from the upstream source.
+      operationId: forceReconcileOffering
+      responses:
+        '200':
+          description: Capacity Reconciliation for offering sku successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OfferingResponse"
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags:
+        - internalSubscriptions
   /internal/subscriptions/terminate/{subscription_id}:
     description: "Terminate a subscription with a given end date."
     parameters:
@@ -277,6 +430,18 @@ components:
           properties:
             termination_message:
               type: string
+    DefaultResponse:
+      properties:
+        status:
+          type: string
+    SubscriptionResponse:
+      properties:
+        detail:
+          type: string
+    OfferingResponse:
+      properties:
+        detail:
+          type: string
   securitySchemes:
     PskIdentity:
       type: apiKey


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1190](https://issues.redhat.com/browse/SWATCH-1190)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
We are converting the endpoint to REST based endpoints for swatch-subscription-sync

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1.  `DEV_MODE=true SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true PRODUCT_USE_STUB=true PRODUCT_DENYLIST_RESOURCE_LOCATION=file:/tmp/denylist ./gradlew :bootRun`

2. `echo 'MW01485' > /tmp/denylist`

3. 
```
INSERT INTO public.org_config (org_id, opt_in_type, created, updated) VALUES ('123', 'JMX', '2023-05-22 20:12:21.502130 +00:00', '2023-05-22 20:12:21.502130 +00:00');

INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW01485', 'OpenShift Container Platform', 'OpenShift Enterprise', null, null, null, null, null, 'Premium', '', 'Red Hat OpenShift Container Platform (Hourly)', false, null);

INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id) VALUES ('MW01485', '123', '235252', 1, '2023-05-26 15:55:28.636000 +00:00', '2031-01-01 01:02:33.000000 +00:00', null, '123', '4243626', null, null);

INSERT INTO public.subscription_capacity (account_number, product_id, subscription_id, org_id, sockets, hypervisor_sockets, has_unlimited_usage, begin_date, end_date, cores, hypervisor_cores, sku, sla, usage) VALUES ('123', 'Dummy', '235255', '123', 2, null, false, '2011-01-01 01:02:33.000000 +00:00', '2031-01-01 01:02:33.000000 +00:00', 4, null, 'MW01485', '', 'Development/Test');
```

### Steps
<!-- Enter each step of the test below -->
**Test 1: sync-enabled orgs to sync their subscriptions.** 
`http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/subscriptions/sync x-rh-swatch-psk:placeholder`

### Verification
**Response:**
{
    "status": "Success"
}

**Test 2: Save subscriptions manually**
```
curl -X 'POST'   http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions?reconcileCapacity=true   -H 'Content-Type: application/json'   -d '[{
         "id": 1234576,
         "quantity": 2,
         "webCustomerId": 123,
         "effectiveStartDate": 1639002100392,
         "effectiveEndDate": 1639003100392,
         "subscriptionProducts": [
           {
             "sku": "RH3413336"
           }
         ]
      }]' -H 'x-rh-swatch-psk:placeholder'
```

### Verification
**Response:**
{
    "status": "Success"
}

**Test 3: Remove subscription and capacity records that are in the denylist.**
`http DELETE :8000/api/rhsm-subscriptions/v1/internal/subscriptions/prune x-rh-swatch-psk:placeholder`

### Verification
**Response:**
{
    "status": "Success"
}
Notice that the row with sku `MW01485` gets deleted from subscription and subscription_capacity table since its in denylist.

**Test 4: Sync an offering from the upstream source. In this case using stub**
` http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/offerings/sync/MW00330 x-rh-swatch-psk:placeholder`

### Verification
**Response:**
{
    "detail": "syncResult=FETCHED_AND_SYNCED (Successfully fetched and synced updated value from upstream) for offeringSku=\"MW00330\"."
}

You will see and inserted row in Offering table as: `MW00330,"Red Hat OpenShift Container Platform, Standard (16 Cores or 32 vCPUs)",OpenShift Enterprise,16,,,,,Standard,"",Red Hat OpenShift Container Platform for Customer Entitlement qty,false,`

Note: Since we are using StubProductApi it checks for tree-MW00330_attrs-true.json file and mocks the api response.

**Test 5: Syncs all offerings not listed in deny list but are in the upstream source.**
Change the value for cores to 0 for sku MW00330 in Offering table.
`http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/offerings/sync x-rh-swatch-psk:placeholder
`
### Verification
**Response:**
{
    "detail": "Enqueued 1 numProducts offerings to be synced."
}

**Test 6: Reconcile capacity for an offering from the upstream source.**
`http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/offerings/reconcile/RH3413336 x-rh-swatch-psk:placeholder`

### Verification
**Response:**
{
    "status": "Success"
}
