### PR TITLE
SWATCH-1189: Add internal API for swatch-producer-red-hat-marketplace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     implementation "org.liquibase:liquibase-core"
     implementation "org.postgresql:postgresql"
 
+    implementation libraries["mapstruct"]
+    annotationProcessor libraries["mapstruct-processor"]
+    testAnnotationProcessor libraries["mapstruct-processor"]
+
     testImplementation "org.springframework.security:spring-security-test"
     testImplementation "org.springframework.kafka:spring-kafka-test"
     testImplementation project(':swatch-core-test')
@@ -130,6 +134,10 @@ ext {
 
     metering_api_spec_file = "${internal_spec_dir}/internal-metering-api-spec.yaml"
     metering_config_file = "${internal_spec_dir}/internal-metering-api-config.json"
+
+    swatch_producer_rhm_api_spec_file = "${internal_spec_dir}/internal-swatch-producer-red-hat-marketplace-api-spec.yaml"
+    swatch_producer_rhm_config_spec_file = "${internal_spec_dir}/internal-swatch-producer-red-hat-marketplace-api-config.json"
+
 }
 
 tasks.register("buildApiTally", GenerateTask) {
@@ -173,6 +181,18 @@ tasks.register("buildApiMetering", GenerateTask) {
     inputSpec = metering_api_spec_file
     configFile = metering_config_file
     outputDir = "$buildDir/generated/metering"
+    configOptions = [
+            interfaceOnly: "true",
+            generatePom: "false",
+            dateLibrary: "java8",
+    ]
+}
+
+tasks.register("buildApiProducerRHM", GenerateTask) {
+    generatorName = "jaxrs-spec"
+    inputSpec = swatch_producer_rhm_api_spec_file
+    configFile = swatch_producer_rhm_config_spec_file
+    outputDir = "$buildDir/generated/rhm"
     configOptions = [
             interfaceOnly: "true",
             generatePom: "false",
@@ -284,6 +304,17 @@ tasks.register("generateOpenApiJsonMetering", GenerateTask) {
     ]
 }
 
+tasks.register("generateOpenApiJsonProducerRhM", GenerateTask) {
+    generatorName = "openapi"
+    inputSpec = swatch_producer_rhm_api_spec_file
+    outputDir = "$buildDir/openapijson"
+    generateModelTests = false
+    generateApiTests = false
+    configOptions = [
+            outputFileName: "internal-swatch-producer-red-hat-marketplace-openapi.json"
+    ]
+}
+
 processResources {
     from tasks.generateOpenApiJsonTally, tasks.generateOpenApiJsonSubSync, tasks.generateOpenApiJsonBilling, tasks.generateOpenApiJsonMetering
     from tally_api_spec_file, sub_sync_api_spec_file, billing_api_spec_file, metering_api_spec_file
@@ -293,7 +324,8 @@ sourceSets.main.java.srcDirs += [
     "${buildDir}/generated/tally/src/gen/java",
     "${buildDir}/generated/sub-sync/src/gen/java",
     "${buildDir}/generated/billing/src/gen/java",
-    "${buildDir}/generated/metering/src/gen/java"
+    "${buildDir}/generated/metering/src/gen/java",
+    "${buildDir}/generated/rhm/src/gen/java"
 ]
 
 tasks.register("downloadJavaAgent", Copy) {

--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/InternalRhMarkeplaceResource.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/InternalRhMarkeplaceResource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.rhmarketplace.api.admin;
+
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.rhmarketplace.ApiException;
+import org.candlepin.subscriptions.rhmarketplace.RhMarketplaceService;
+import org.candlepin.subscriptions.rhmarketplace.admin.api.InternalApi;
+import org.candlepin.subscriptions.rhmarketplace.admin.api.model.StatusResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class InternalRhMarkeplaceResource implements InternalApi {
+  private final RhMarketplaceService rhMarketplaceService;
+
+  private final StatusResponseMapper statusResponseMapper;
+
+  InternalRhMarkeplaceResource(
+      RhMarketplaceService rhMarketplaceService, StatusResponseMapper statusMapper) {
+
+    this.rhMarketplaceService = rhMarketplaceService;
+    this.statusResponseMapper = statusMapper;
+  }
+
+  @Override
+  public StatusResponse getUsageEventStatus(String batchId) {
+    // NOTE: no need to validate batchId as the RHM API will do that for us
+    StatusResponse response;
+    try {
+      response =
+          statusResponseMapper.clientToApi(rhMarketplaceService.getUsageBatchStatus(batchId));
+    } catch (ApiException e) {
+      // pass-through of the underlying error response, see RhmExceptionMapper
+      throw new RhmException(e);
+    }
+
+    return response;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/RhmException.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/RhmException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.rhmarketplace.api.admin;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.candlepin.subscriptions.rhmarketplace.ApiException;
+
+/** Exception that captures an underlying Marketplace API call failure */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class RhmException extends RuntimeException {
+  private final ApiException cause;
+}

--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/RhmExceptionMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/RhmExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.rhmarketplace.api.admin;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.springframework.stereotype.Component;
+
+/** ExceptionMapper that reconstructs the RHM API exception. */
+@Provider
+@Component
+public class RhmExceptionMapper implements ExceptionMapper<RhmException> {
+  @Override
+  public Response toResponse(RhmException exception) {
+    return Response.status(exception.getCause().getCode())
+        .entity(exception.getCause().getResponseBody())
+        .type(MediaType.APPLICATION_JSON_TYPE)
+        .build();
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/StatusResponseMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/StatusResponseMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.rhmarketplace.api.admin;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+// We have to ignore the mappings for two methods tht the jax-rs generator creates which the java
+// generator skips
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface StatusResponseMapper {
+  org.candlepin.subscriptions.rhmarketplace.admin.api.model.StatusResponse clientToApi(
+      org.candlepin.subscriptions.rhmarketplace.api.model.StatusResponse response);
+}

--- a/src/main/spec/internal-swatch-producer-red-hat-marketplace-api-config.json
+++ b/src/main/spec/internal-swatch-producer-red-hat-marketplace-api-config.json
@@ -1,0 +1,6 @@
+{
+  "invokerPackage": "org.candlepin.subscriptions.rhmarketplace.admin",
+  "apiPackage": "org.candlepin.subscriptions.rhmarketplace.admin.api",
+  "modelPackage": "org.candlepin.subscriptions.rhmarketplace.admin.api.model",
+  "groupId": "org.candlepin"
+}

--- a/src/main/spec/internal-swatch-producer-red-hat-marketplace-api-spec.yaml
+++ b/src/main/spec/internal-swatch-producer-red-hat-marketplace-api-spec.yaml
@@ -1,0 +1,27 @@
+openapi: "3.0.2"
+info:
+  title: "swatch-producer-red-hat-marketplace internal API"
+  version: 1.0.0
+
+paths:
+  /internal/rhm/status/{batch_id}:
+    parameters:
+      - name: batch_id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: "Fetch a usage event status for a given batch"
+      operationId: getUsageEventStatus
+      responses:
+        '200':
+          description: "Found a batch matching the id and was able to retrieve it's status"
+          content:
+            application/json:
+              schema:
+                $ref: "../../../clients/rh-marketplace-client/rh-marketplace-api-spec.yaml#/components/schemas/StatusResponse"
+  /internal-swatch-producer-red-hat-marketplace-openapi.json:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
+  /internal-swatch-producer-red-hat-marketplace-openapi.yaml:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"


### PR DESCRIPTION
Jira issue: [SWATCH-1189](https://issues.redhat.com/browse/SWATCH-1189)

Description
===========

The internal API simply references the RHM API response definition.

Testing
=======

Setup
-----

Start the service (use the URL and key from the marketplace sandbox):

```shell
DEV_MODE=true \
  RH_MARKETPLACE_URL=$FIXME \
  RH_MARKETPLACE_API_KEY=$FIXME \
  ./gradlew :bootRun
```

Steps
-----

1. Query status of an existing batch:

```shell
http :8000/api/rhsm-subscriptions/v1/internal/rhm/status/e36bfad2-dafe-57ff-8834-02b3abc1ef93 \
  x-rh-swatch-psk:placeholder
```

2. Query a non-existent batch

```shell
http :8000/api/rhsm-subscriptions/v1/internal/rhm/status/foobar \
  x-rh-swatch-psk:placeholder
```

Verification
------------

Observe a successful response for the first request, and a properly formatted JSON error (straight from the RHM API) for the second.