### PR TITLE
SWATCH-1270: Make denylist consider suffixes

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/files/ProductDenylistTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/ProductDenylistTest.java
@@ -23,13 +23,20 @@ package org.candlepin.subscriptions.files;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
+import java.util.stream.Stream;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.capacity.files.ProductDenylist;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.core.io.FileSystemResourceLoader;
 
 class ProductDenylistTest {
+
+  public static Stream<String> getSkusWithSuffixes() {
+    return ProductDenylist.getSuffixes().stream().map(suffix -> "I1" + suffix);
+  }
 
   @Test
   void testUnspecifiedLocationAllowsArbitraryProducts() throws IOException {
@@ -45,6 +52,13 @@ class ProductDenylistTest {
     assertTrue(denylist.productIdMatches("I3"));
     assertFalse(denylist.productIdMatches("I111"));
     assertFalse(denylist.productIdMatches("I112"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getSkusWithSuffixes")
+  void testConsidersAllSuffixes(String sku) {
+    ProductDenylist denylist = initProductDenylist("classpath:item_per_line.txt");
+    assertTrue(denylist.productIdMatches(sku));
   }
 
   private ProductDenylist initProductDenylist(String resourceLocation) {


### PR DESCRIPTION
Jira issue: [SWATCH-1270](https://issues.redhat.com/browse/SWATCH-1270)

Description
===========

Make denylist consider suffixes. The algorithm for denylist now first normalizes the SKU by removing suffixes. Removing suffixes tries all defined suffixes in length descending order, which avoids subtle issues when a suffix coincidentally has another suffix in it (e.g. `F3RN` has `F3` and `RN`).

Testing
=======

Setup
-----

1. Create a denylist:

```shell
echo 'ASKEW' > /tmp/denylist
```

2. Start the service w/ the configured denylist:

```shell
DEV_MODE=true \
  PRODUCT_DENYLIST_RESOURCE_LOCATION=file:/tmp/denylist \
  ./gradlew :bootRun
```

Steps
-----

Attempt to sync the offering, but with a suffix:

```shell
http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean' \
  operation='syncOffering(java.lang.String)' \
  arguments:='["ASKEW"]'
```

Verification
------------

Observe the result is `SKIPPED_DENYLISTED`. You can try other suffixes or no suffix as desired.