### PR TITLE
Update billable_usage_remittance to track history

### DIFF
--- a/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/StubContactsApi.java
+++ b/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/StubContactsApi.java
@@ -66,6 +66,7 @@ public class StubContactsApi extends DefaultApi {
         .orgId(orgId)
         .productId(productId)
         .billingProvider(billingProvider)
+        .startDate(OffsetDateTime.now())
         .billingAccountId(billingAccountId)
         .vendorProductCode(vendorProductCode)
         .addMetricsItem(new Metric().metricId(metricId).value(value));

--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,6 +63,7 @@ public class SnapshotSummaryProducer {
     newAndUpdatedSnapshots.forEach(
         (orgId, snapshots) ->
             snapshots.stream()
+                .sorted(Comparator.comparing(TallySnapshot::getSnapshotDate))
                 .map(
                     snapshot ->
                         summaryMapper.mapSnapshots(

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -22,9 +22,9 @@ package org.candlepin.subscriptions.tally.billing;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
@@ -32,6 +32,7 @@ import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.RemittanceSummaryProjection;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
 import org.candlepin.subscriptions.db.model.Usage;
@@ -42,7 +43,6 @@ import org.candlepin.subscriptions.registry.BillingWindow;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 @Slf4j
 @Component
@@ -92,11 +92,38 @@ public class BillableUsageController {
     return toBill;
   }
 
-  public BillableUsageRemittanceEntity getLatestRemittance(BillableUsage billableUsage) {
+  public boolean isReTally(BillableUsage billableUsage) {
     BillableUsageRemittanceEntityPK key = BillableUsageRemittanceEntityPK.keyFrom(billableUsage);
-    return billableUsageRemittanceRepository
-        .findById(key)
-        .orElse(BillableUsageRemittanceEntity.builder().key(key).remittedValue(0.0).build());
+    var filter =
+        BillableUsageRemittanceFilter.builder()
+            .orgId(key.getOrgId())
+            .billingAccountId(key.getBillingAccountId())
+            .billingProvider(key.getBillingProvider())
+            .accumulationPeriod(key.getAccumulationPeriod())
+            .metricId(key.getMetricId())
+            .productId(key.getProductId())
+            .granularity(Granularity.HOURLY)
+            .beginning(billableUsage.getSnapshotDate())
+            .build();
+    return billableUsageRemittanceRepository.existsBy(filter);
+  }
+
+  public double getTotalRemitted(BillableUsage billableUsage) {
+    BillableUsageRemittanceEntityPK key = BillableUsageRemittanceEntityPK.keyFrom(billableUsage);
+    var filter =
+        BillableUsageRemittanceFilter.builder()
+            .orgId(key.getOrgId())
+            .billingAccountId(key.getBillingAccountId())
+            .billingProvider(key.getBillingProvider())
+            .accumulationPeriod(key.getAccumulationPeriod())
+            .metricId(key.getMetricId())
+            .productId(key.getProductId())
+            .granularity(Granularity.HOURLY)
+            .build();
+    return billableUsageRemittanceRepository.getRemittanceSummaries(filter).stream()
+        .findFirst()
+        .map(RemittanceSummaryProjection::getTotalRemittedPendingValue)
+        .orElse(0.0);
   }
 
   /**
@@ -109,15 +136,15 @@ public class BillableUsageController {
    *
    * @param applicableUsage The total amount of measured usage used during the calculation.
    * @param usage The specific event within a given month to determine what need to be billed
-   * @param remittance The previous record amount for remitted amount
+   * @param remittanceTotal The previous record amount for remitted amount
    * @return calculations that are need to bill any un-billed amount and to record any un-billed
    *     amount
    */
   private BillableUsageCalculation calculateBillableUsage(
-      double applicableUsage, BillableUsage usage, BillableUsageRemittanceEntity remittance) {
+      double applicableUsage, BillableUsage usage, double remittanceTotal) {
     Quantity<MetricUnit> totalUsage = Quantity.of(applicableUsage);
-    Quantity<RemittanceUnit> currentRemittance = Quantity.fromRemittance(remittance);
     var billingUnit = new BillingUnit(tagProfile, usage);
+    Quantity<MetricUnit> currentRemittance = Quantity.of(remittanceTotal);
     Quantity<BillingUnit> billableValue =
         totalUsage
             .subtract(currentRemittance)
@@ -128,7 +155,6 @@ public class BillableUsageController {
             // or usage is credited, nothing to bill in either case.
             .positiveOrZero();
 
-    Quantity<BillingUnit> totalRemittance = billableValue.add(currentRemittance);
     log.debug(
         "Running total: {}, already remitted: {}, to be remitted: {}",
         totalUsage,
@@ -137,8 +163,8 @@ public class BillableUsageController {
 
     return BillableUsageCalculation.builder()
         .billableValue(billableValue.getValue())
-        .remittedValue(totalRemittance.getValue())
-        .remittanceDate(clock.now())
+        .remittedValue(billableValue.to(new MetricUnit()).getValue())
+        .remittanceDate(usage.getSnapshotDate())
         .billingFactor(billingUnit.getBillingFactor())
         .build();
   }
@@ -159,9 +185,27 @@ public class BillableUsageController {
         usage.getSnapshotDate());
     log.debug("Usage: {}", usage);
 
-    Double currentlyMeasuredTotal =
-        getCurrentlyMeasuredTotal(
-            usage, clock.startOfMonth(usage.getSnapshotDate()), usage.getSnapshotDate());
+    if (billableUsageRemittanceRepository.existsById(
+        BillableUsageRemittanceEntityPK.keyFrom(usage))) {
+      log.debug("Skipping usage since remittance already exists.");
+      return null;
+    }
+
+    Double currentlyMeasuredTotal;
+
+    // if re-tallying we need to collect total for whole month.
+    if (isReTally(usage)) {
+      log.debug("Re-tallying, using measured total for entire month");
+      currentlyMeasuredTotal =
+          getCurrentlyMeasuredTotal(
+              usage,
+              clock.startOfMonth(usage.getSnapshotDate()),
+              clock.endOfMonth(usage.getSnapshotDate()));
+    } else {
+      currentlyMeasuredTotal =
+          getCurrentlyMeasuredTotal(
+              usage, clock.startOfMonth(usage.getSnapshotDate()), usage.getSnapshotDate());
+    }
 
     Optional<Double> contractValue = Optional.of(0.0);
     if (tagProfile.isTagContractEnabled(usage.getProductId())) {
@@ -194,26 +238,24 @@ public class BillableUsageController {
             .positiveOrZero() // ignore usage less than the contract amount
             .getValue();
 
-    BillableUsageRemittanceEntity remittance = getLatestRemittance(usage);
-    BillableUsageCalculation usageCalc = calculateBillableUsage(applicableUsage, usage, remittance);
+    var totalRemitted = getTotalRemitted(usage);
+    BillableUsageCalculation usageCalc =
+        calculateBillableUsage(applicableUsage, usage, totalRemitted);
 
     log.debug(
         "Processing monthly billable usage: Usage: {}, Applicable: {}, Current total: {}, Current remittance: {}, New billable: {}",
         usage,
         applicableUsage,
         currentlyMeasuredTotal,
-        remittance,
+        totalRemitted,
         usageCalc);
 
     // Update the reported usage value to the newly calculated one.
     usage.setValue(usageCalc.getBillableValue());
     usage.setBillingFactor(usageCalc.getBillingFactor());
 
-    if (updateRemittance(remittance, usage.getOrgId(), usageCalc)) {
-      remittance.setAccountNumber(usage.getAccountNumber());
-      log.debug("Updating remittance: {}", remittance);
-      billableUsageRemittanceRepository.save(remittance);
-    }
+    updateRemittance(usage, usageCalc);
+
     log.info(
         "Finished producing monthly billable for orgId={} productId={} uom={} provider={}, snapshotDate={}",
         usage.getOrgId(),
@@ -224,26 +266,18 @@ public class BillableUsageController {
     return usage;
   }
 
-  private boolean updateRemittance(
-      BillableUsageRemittanceEntity remittance, String orgId, BillableUsageCalculation usageCalc) {
-    boolean updated = false;
-    if (!Objects.equals(remittance.getKey().getOrgId(), orgId) && StringUtils.hasText(orgId)) {
-      remittance.getKey().setOrgId(orgId);
-      updated = true;
-    }
-    if (!Objects.equals(remittance.getRemittedValue(), usageCalc.getRemittedValue())) {
-      remittance.setRemittedValue(usageCalc.getRemittedValue());
-      updated = true;
-    }
-    if (!Objects.equals(remittance.getBillingFactor(), usageCalc.getBillingFactor())) {
-      remittance.setBillingFactor(usageCalc.getBillingFactor());
-      updated = true;
-    }
-    // Only update the date if the remittance was updated.
-    if (updated) {
-      remittance.setRemittanceDate(usageCalc.getRemittanceDate());
-    }
-    return updated;
+  private void updateRemittance(BillableUsage usage, BillableUsageCalculation usageCalc) {
+    var newRemittance =
+        BillableUsageRemittanceEntity.builder()
+            .key(BillableUsageRemittanceEntityPK.keyFrom(usage))
+            .build();
+    // Remitted value should be set to usages metric_value rather than billing_value
+    newRemittance.setRemittedPendingValue(usageCalc.getRemittedValue());
+    newRemittance.getKey().setRemittancePendingDate(usageCalc.getRemittanceDate());
+    newRemittance.setAccountNumber(usage.getAccountNumber());
+    newRemittance.setGranularity(Granularity.HOURLY);
+    log.debug("Creating new remittance for update: {}", newRemittance);
+    billableUsageRemittanceRepository.save(newRemittance);
   }
 
   private Double getCurrentlyMeasuredTotal(

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducer.java
@@ -53,7 +53,7 @@ public class BillingProducer {
   public void produce(BillableUsage usage) {
     log.debug("Sending billable usage {} to topic {}", usage, billableUsageTopic);
     if (usage == null) {
-      log.warn("Skipping billable usage; see previous errors/warnings.");
+      log.debug("Skipping billable usage; see previous errors/warnings.");
       return;
     }
     billableUsageKafkaTemplate.send(billableUsageTopic, usage);

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/Quantity.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/Quantity.java
@@ -84,7 +84,8 @@ public class Quantity<U extends Unit> {
     return new Quantity<>(value, new BillingUnit(tagProfile, referenceUsage));
   }
 
-  public static Quantity<RemittanceUnit> fromRemittance(BillableUsageRemittanceEntity remittance) {
-    return new Quantity<>(remittance.getRemittedValue(), new RemittanceUnit(remittance));
+  public static Quantity<RemittanceUnit> fromRemittance(
+      BillableUsageRemittanceEntity remittance, Double billingFactor) {
+    return new Quantity<>(remittance.getRemittedPendingValue(), new RemittanceUnit(billingFactor));
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceUnit.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceUnit.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 
 /** Represents the uom recorded on a remittance record */
 @Getter
@@ -33,7 +32,7 @@ import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 public class RemittanceUnit implements Unit {
   private final double billingFactor;
 
-  public RemittanceUnit(BillableUsageRemittanceEntity entity) {
-    this.billingFactor = Objects.requireNonNullElse(entity.getBillingFactor(), 1.0);
+  public RemittanceUnit(Double billingFactor) {
+    this.billingFactor = Objects.requireNonNullElse(billingFactor, 1.0);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
@@ -27,6 +27,7 @@ import javax.ws.rs.BadRequestException;
 import org.candlepin.subscriptions.billing.admin.api.InternalApi;
 import org.candlepin.subscriptions.billing.admin.api.model.MonthlyRemittance;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
+import org.candlepin.subscriptions.db.model.Granularity;
 import org.springframework.stereotype.Component;
 
 /** This resource is for exposing administrator REST endpoints for Remittance. */
@@ -68,6 +69,7 @@ public class InternalBillingResource implements InternalApi {
             .billingAccountId(billingAccountId)
             .beginning(beginning)
             .ending(ending)
+            .granularity(Granularity.HOURLY)
             .build();
     return billingController.process(filter);
   }

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -64,6 +64,7 @@ rhsm-subscriptions:
     outgoing:
       topic: ${BILLABLE_USAGE_TOPIC}
     contracts:
+      use-stub: ${CONTRACT_USE_STUB:false}
       back-off-initial-interval: ${CONTRACT_CLIENT_BACK_OFF_INITIAL_INTERVAL_MILLIS:1000}
       back-off-max-interval: ${CONTRACT_CLIENT_BACK_OFF_MAX_INTERVAL_MILLIS:64000}
       back-off-multiplier: ${CONTRACT_CLIENT_BACK_OFF_MULTIPLIER:2}

--- a/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
@@ -23,17 +23,23 @@ package org.candlepin.subscriptions.db;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.util.TimeZone;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
+import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.RemittanceSummaryProjection;
 import org.candlepin.subscriptions.json.BillableUsage.BillingProvider;
 import org.candlepin.subscriptions.json.BillableUsage.Sla;
 import org.candlepin.subscriptions.json.BillableUsage.Uom;
 import org.candlepin.subscriptions.json.BillableUsage.Usage;
 import org.candlepin.subscriptions.util.ApplicationClock;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -49,6 +55,11 @@ class BillableUsageRemittanceRepositoryTest {
 
   @Autowired private BillableUsageRemittanceRepository repository;
   private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+
+  @BeforeEach()
+  public void setUp() {
+    TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+  }
 
   @Test
   void saveAndFetch() {
@@ -85,10 +96,18 @@ class BillableUsageRemittanceRepositoryTest {
   void findByAccount() {
     BillableUsageRemittanceEntity remittance1 =
         remittance(
-            "org123", "product1", BillingProvider.AWS.value(), 12.0, clock.startOfCurrentMonth());
+            "org123",
+            "product1",
+            BillingProvider.AWS.value(),
+            12.0,
+            truncateDate(clock.startOfCurrentMonth()));
     BillableUsageRemittanceEntity remittance2 =
         remittance(
-            "org123", "product1", BillingProvider.AWS.value(), 12.0, clock.endOfCurrentQuarter());
+            "org123",
+            "product1",
+            BillingProvider.AWS.value(),
+            12.0,
+            truncateDate(clock.endOfCurrentQuarter()));
     var accountMonthlyList = List.of(remittance1, remittance2);
     repository.saveAllAndFlush(accountMonthlyList);
     List<BillableUsageRemittanceEntity> found =
@@ -117,12 +136,12 @@ class BillableUsageRemittanceRepositoryTest {
             .sla(Sla.PREMIUM.value())
             .metricId(Uom.CORES.value())
             .accumulationPeriod(InstanceMonthlyTotalKey.formatMonthId(remittanceDate))
+            .remittancePendingDate(remittanceDate)
             .build();
     return BillableUsageRemittanceEntity.builder()
         .key(key)
-        .billingFactor(1.0)
-        .remittanceDate(remittanceDate)
-        .remittedValue(value)
+        .remittedPendingValue(value)
+        .granularity(Granularity.HOURLY)
         .build();
   }
 
@@ -148,21 +167,25 @@ class BillableUsageRemittanceRepositoryTest {
   void findByBillingProvider() {
     BillableUsageRemittanceEntity remittance1 =
         remittance(
-            "org123", "product1", BillingProvider.AWS.value(), 12.0, clock.startOfCurrentMonth());
+            "org123",
+            "product1",
+            BillingProvider.AWS.value(),
+            12.0,
+            truncateDate(clock.startOfCurrentMonth()));
     BillableUsageRemittanceEntity remittance2 =
         remittance(
             "org123",
             "product1",
             BillingProvider.RED_HAT.value(),
             12.0,
-            clock.endOfCurrentQuarter());
+            truncateDate(clock.endOfCurrentQuarter()));
     BillableUsageRemittanceEntity remittance3 =
         remittance(
             "org456",
             "product1",
             BillingProvider.RED_HAT.value(),
             12.0,
-            clock.endOfCurrentQuarter());
+            truncateDate(clock.endOfCurrentQuarter()));
     var accountMonthlyList = List.of(remittance1, remittance2, remittance3);
     repository.saveAllAndFlush(accountMonthlyList);
 
@@ -189,14 +212,18 @@ class BillableUsageRemittanceRepositoryTest {
   void findByBillingAccountId() {
     BillableUsageRemittanceEntity remittance1 =
         remittance(
-            "org123", "product1", BillingProvider.AWS.value(), 12.0, clock.startOfCurrentMonth());
+            "org123",
+            "product1",
+            BillingProvider.AWS.value(),
+            12.0,
+            truncateDate(clock.startOfCurrentMonth()));
     BillableUsageRemittanceEntity remittance2 =
         remittance(
             "org123",
             "product1",
             BillingProvider.RED_HAT.value(),
             12.0,
-            clock.endOfCurrentQuarter());
+            truncateDate(clock.endOfCurrentQuarter()));
     remittance2.getKey().setOrgId("special_org");
 
     var accountMonthlyList = List.of(remittance1, remittance2);
@@ -275,5 +302,118 @@ class BillableUsageRemittanceRepositoryTest {
     List<BillableUsageRemittanceEntity> byDateRangeAndOrgId = repository.filterBy(filter);
     assertEquals(1, byDateRangeAndOrgId.size());
     assertEquals(remittance3, byDateRangeAndOrgId.get(0));
+  }
+
+  @Test
+  void getMonthlySummary() {
+    BillableUsageRemittanceEntity remittance1 =
+        remittance(
+            "org123",
+            "product1",
+            BillingProvider.RED_HAT.value(),
+            12.0,
+            truncateDate(clock.startOfCurrentMonth()));
+    BillableUsageRemittanceEntity remittance2 =
+        remittance(
+            "org123",
+            "product1",
+            BillingProvider.RED_HAT.value(),
+            12.0,
+            truncateDate(clock.startOfCurrentMonth().plusDays(1)));
+    BillableUsageRemittanceEntity remittance3 =
+        remittance(
+            "org456",
+            "product1",
+            BillingProvider.RED_HAT.value(),
+            15.0,
+            truncateDate(clock.endOfCurrentMonth()));
+
+    var accountMonthlyList = List.of(remittance1, remittance2, remittance3);
+    repository.saveAllAndFlush(accountMonthlyList);
+
+    BillableUsageRemittanceFilter filter1 =
+        BillableUsageRemittanceFilter.builder()
+            .productId(remittance1.getKey().getProductId())
+            .build();
+
+    var expectedSummary1 =
+        RemittanceSummaryProjection.builder()
+            .accountNumber(remittance1.getAccountNumber())
+            .accumulationPeriod(
+                getAccumulationPeriod(remittance1.getKey().getRemittancePendingDate()))
+            .billingAccountId(remittance1.getKey().getBillingAccountId())
+            .billingProvider(remittance1.getKey().getBillingProvider())
+            .orgId("org123")
+            .productId(remittance1.getKey().getProductId())
+            .remittancePendingDate(remittance2.getKey().getRemittancePendingDate())
+            .metricId(remittance1.getKey().getMetricId())
+            .totalRemittedPendingValue(24.0)
+            .build();
+
+    var expectedSummary2 =
+        RemittanceSummaryProjection.builder()
+            .accountNumber(remittance3.getAccountNumber())
+            .accumulationPeriod(
+                getAccumulationPeriod(remittance3.getKey().getRemittancePendingDate()))
+            .billingAccountId(remittance3.getKey().getBillingAccountId())
+            .billingProvider(remittance3.getKey().getBillingProvider())
+            .orgId("org456")
+            .productId(remittance3.getKey().getProductId())
+            .remittancePendingDate(remittance3.getKey().getRemittancePendingDate())
+            .metricId(remittance3.getKey().getMetricId())
+            .totalRemittedPendingValue(15.0)
+            .build();
+
+    List<RemittanceSummaryProjection> results = repository.getRemittanceSummaries(filter1);
+    assertEquals(2, results.size());
+    assertTrue(results.containsAll(List.of(expectedSummary1, expectedSummary2)));
+  }
+
+  @Test
+  void getMonthlySummaryForSpecificMonth() {
+    BillableUsageRemittanceEntity remittance1 =
+        remittance(
+            "org123",
+            "product1",
+            BillingProvider.RED_HAT.value(),
+            12.0,
+            truncateDate(clock.startOfCurrentMonth()));
+    BillableUsageRemittanceEntity remittance2 =
+        remittance(
+            "org123",
+            "product1",
+            BillingProvider.RED_HAT.value(),
+            12.0,
+            truncateDate(clock.startOfCurrentMonth().plusDays(1)));
+    // One remittance is out of date accumulation_period and should not be counted
+    BillableUsageRemittanceEntity remittance3 =
+        remittance(
+            "org123",
+            "product1",
+            BillingProvider.RED_HAT.value(),
+            15.0,
+            truncateDate(clock.endOfCurrentMonth().plusDays(1)));
+
+    var accountMonthlyList = List.of(remittance1, remittance2, remittance3);
+    repository.saveAllAndFlush(accountMonthlyList);
+
+    BillableUsageRemittanceFilter filter1 =
+        BillableUsageRemittanceFilter.builder()
+            .accumulationPeriod(
+                getAccumulationPeriod(remittance1.getKey().getRemittancePendingDate()))
+            .build();
+
+    List<RemittanceSummaryProjection> results = repository.getRemittanceSummaries(filter1);
+    assertEquals(1, results.size());
+    assertEquals(24.0, results.get(0).getTotalRemittedPendingValue());
+  }
+
+  // In memory DB does not save same length of decimals so truncate to make sure they equal
+  OffsetDateTime truncateDate(OffsetDateTime date) {
+    return date.truncatedTo(ChronoUnit.MILLIS);
+  }
+
+  public static String getAccumulationPeriod(OffsetDateTime reference) {
+    return InstanceMonthlyTotalKey.formatMonthId(reference);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -23,10 +23,8 @@ package org.candlepin.subscriptions.tally.billing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contracts.api.model.Contract;
@@ -34,6 +32,7 @@ import com.redhat.swatch.contracts.api.model.Metric;
 import com.redhat.swatch.contracts.api.resources.DefaultApi;
 import com.redhat.swatch.contracts.client.ApiException;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,6 +46,7 @@ import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.RemittanceSummaryProjection;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
 import org.candlepin.subscriptions.json.BillableUsage;
@@ -107,11 +107,16 @@ class BillableUsageControllerTest {
   @Test
   void monthlyWindowNoCurrentRemittance() {
     BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 0.0003);
-    when(remittanceRepo.findById(keyFrom(usage))).thenReturn(Optional.empty());
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    summaries.add(RemittanceSummaryProjection.builder().totalRemittedPendingValue(0.0).build());
+
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
+
     mockCurrentSnapshotMeasurementTotal(usage, 0.0003); // from single snapshot
     controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
 
-    BillableUsageRemittanceEntity expectedRemittance = remittance(usage, CLOCK.now(), 1.0);
+    BillableUsageRemittanceEntity expectedRemittance =
+        remittance(usage, usage.getSnapshotDate(), 1.0);
     BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 1.0);
     expectedUsage.setId(usage.getId()); // Id will be regenerated above.
     verify(remittanceRepo).save(expectedRemittance);
@@ -121,13 +126,16 @@ class BillableUsageControllerTest {
   @Test
   void monthlyWindowWithRemittanceUpdate() {
     BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 2.3);
-    BillableUsageRemittanceEntity currentRemittance =
-        remittance(usage, CLOCK.now().minusHours(1), 3.0);
-    when(remittanceRepo.findById(keyFrom(usage))).thenReturn(Optional.of(currentRemittance));
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    summaries.add(RemittanceSummaryProjection.builder().totalRemittedPendingValue(3.0).build());
+
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
+
     mockCurrentSnapshotMeasurementTotal(usage, 4.4); // from multiple snapshots (2.1, 2.3)
     controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
 
-    BillableUsageRemittanceEntity expectedRemittance = remittance(usage, CLOCK.now(), 5.0);
+    BillableUsageRemittanceEntity expectedRemittance =
+        remittance(usage, usage.getSnapshotDate(), 2.0);
     BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 2.0);
     expectedUsage.setId(usage.getId()); // Id will be regenerated above.
     verify(remittanceRepo).save(expectedRemittance);
@@ -135,17 +143,53 @@ class BillableUsageControllerTest {
   }
 
   @Test
+  void monthlyWindowRemittanceMultipleOfBillingFactor() {
+    BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 68.103);
+    usage.setProductId("osd");
+    usage.setUom(Uom.CORES);
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    summaries.add(RemittanceSummaryProjection.builder().totalRemittedPendingValue(996.0).build());
+
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
+
+    TagMetric tag =
+        TagMetric.builder()
+            .tag("OpenShift-dedicated-metrics")
+            .uom(Measurement.Uom.CORES)
+            .billingFactor(0.25)
+            .accountQueryKey("osd")
+            .build();
+
+    when(tagProfile.getTagMetric("osd", Measurement.Uom.CORES)).thenReturn(Optional.of(tag));
+
+    mockCurrentSnapshotMeasurementTotal(usage, 1064.104);
+    controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
+
+    // applicable_usage(68.1) converted to billable_usage as 68.1/4 = 17.025. Rounds to 18. 18 *
+    // 4(Billing_factor) = 72
+    BillableUsageRemittanceEntity expectedRemittance =
+        remittance(usage, usage.getSnapshotDate(), 72.0);
+    BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 18.0);
+    expectedUsage.setId(usage.getId()); // Id will be regenerated above.
+    expectedUsage.setProductId("osd");
+    expectedUsage.setUom(Uom.CORES);
+    expectedUsage.setBillingFactor(0.25);
+    verify(remittanceRepo).save(expectedRemittance);
+    verify(producer).produce(expectedUsage);
+  }
+
+  @Test
   void monthlyWindowWithNoRemittanceUpdate() {
     BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 0.03);
-    BillableUsageRemittanceEntity currentRemittance = remittance(usage, CLOCK.now(), 1.0);
-    when(remittanceRepo.findById(keyFrom(usage))).thenReturn(Optional.of(currentRemittance));
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    summaries.add(RemittanceSummaryProjection.builder().totalRemittedPendingValue(1.0).build());
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
     mockCurrentSnapshotMeasurementTotal(usage, 0.05); // from multiple snapshots (0.02, 0.03)
     controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
 
     BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 0.0); // Nothing billed
     expectedUsage.setId(usage.getId()); // Id will be regenerated above.
     verify(producer).produce(expectedUsage);
-    verifyNoMoreInteractions(remittanceRepo);
   }
 
   @Test
@@ -153,11 +197,10 @@ class BillableUsageControllerTest {
     BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 8.0);
     usage.setProductId("osd");
     usage.setUom(Uom.CORES);
-    BillableUsageRemittanceEntity currentRemittance =
-        remittance(usage, CLOCK.now().minusHours(1), 1.5);
-    currentRemittance.setBillingFactor(0.5);
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    summaries.add(RemittanceSummaryProjection.builder().totalRemittedPendingValue(6.0).build());
 
-    when(remittanceRepo.findById(keyFrom(usage))).thenReturn(Optional.of(currentRemittance));
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
     TagMetric tag =
         TagMetric.builder()
             .tag("OpenShift-dedicated-metrics")
@@ -170,8 +213,8 @@ class BillableUsageControllerTest {
     mockCurrentSnapshotMeasurementTotal(usage, 16.0);
     controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
 
-    BillableUsageRemittanceEntity expectedRemittance = remittance(usage, CLOCK.now(), 4.75);
-    expectedRemittance.setBillingFactor(0.25);
+    BillableUsageRemittanceEntity expectedRemittance =
+        remittance(usage, usage.getSnapshotDate(), 12.0);
     BillableUsage expectedUsage = billable(usage.getSnapshotDate(), usage.getValue());
     expectedUsage.setId(usage.getId()); // Id will be regenerated above.
     expectedUsage.setProductId("osd");
@@ -186,11 +229,12 @@ class BillableUsageControllerTest {
     BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 8.0);
     usage.setProductId("osd");
     usage.setUom(Uom.CORES);
-    BillableUsageRemittanceEntity currentRemittance =
-        remittance(usage, CLOCK.now().minusHours(1), 1.5);
-    currentRemittance.setBillingFactor(0.5);
 
-    when(remittanceRepo.findById(keyFrom(usage))).thenReturn(Optional.of(currentRemittance));
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    summaries.add(RemittanceSummaryProjection.builder().totalRemittedPendingValue(6.0).build());
+
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
+
     TagMetric tag =
         TagMetric.builder()
             .tag("OpenShift-dedicated-metrics")
@@ -203,8 +247,8 @@ class BillableUsageControllerTest {
     mockCurrentSnapshotMeasurementTotal(usage, 32.3);
     controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
 
-    BillableUsageRemittanceEntity expectedRemittance = remittance(usage, CLOCK.now(), 8.75);
-    expectedRemittance.setBillingFactor(0.25);
+    BillableUsageRemittanceEntity expectedRemittance =
+        remittance(usage, usage.getSnapshotDate(), 28.00);
     BillableUsage expectedUsage = billable(usage.getSnapshotDate(), usage.getValue());
     expectedUsage.setId(usage.getId()); // Id will be regenerated above.
     expectedUsage.setProductId("osd");
@@ -226,10 +270,10 @@ class BillableUsageControllerTest {
         //        200 coverage from 2019-05-16T00:00Z onwards
         arguments(startOfUsage, 50.0, 0.0, 0.0, 0.0),
         arguments(startOfUsage.plusDays(5), 150.0, 0.0, 50.0, 50.0),
-        arguments(startOfUsage.plusDays(13), 200.0, 50.0, 100.0, 50.0),
+        arguments(startOfUsage.plusDays(13), 200.0, 50.0, 50.0, 50.0),
         // NOTE: Contract bumps to 200 here.
-        arguments(startOfUsage.plusDays(20), 300.0, 100.0, 100.0, 0.0),
-        arguments(CLOCK.endOfCurrentMonth(), 350.00, 100.0, 150.0, 50.0),
+        arguments(startOfUsage.plusDays(20), 300.0, 100.0, 0.0, 0.0),
+        arguments(CLOCK.endOfCurrentMonth(), 350.00, 100.0, 50.0, 50.0),
         // NOTE: New month so simulate remittance reset, contract remains at 200.
         arguments(CLOCK.startOfCurrentMonth().plusMonths(1), 150.0, 0.0, 0.0, 0.0));
   }
@@ -275,8 +319,8 @@ class BillableUsageControllerTest {
         // billed = ceil(unbilled) * billing_factor
         //        = ceil(0) * 0.5
         //        = 0.0 (billable units)
-        // remitted = billed + current_remittance
-        //          = 0.0 + 0.0
+        // remitted = billed / billable_factor
+        //          = 0.0 / 0.5
         //          = 0.0
         arguments(startOfUsage, 100.0, 0.0, 0.0, 0.0),
 
@@ -285,32 +329,32 @@ class BillableUsageControllerTest {
         // applicable_usage = gtez(current_usage - applicable_contact)
         //                  = gtez(250 - 200)
         //                  = 50 (measurement units)
-        // unbilled = gtez(applicable_usage - (current_remittance / prev_billing_factor))
+        // unbilled = gtez(applicable_usage - (current_remittance / billing_factor))
         //          = gtez(50 - (0.0/0.5))
         //          = 50 (measurement units)
         // billed = ceil(unbilled) * billing_factor
         //        = ceil(50) * 0.5
         //        = 25 (billable units)
-        // remitted = billed + current_remittance
-        //          = 25 + 0.0
-        //          = 25
-        arguments(startOfUsage.plusDays(10), 250.0, 0.0, 25.0, 25.0),
+        // remitted = billed / billing_factor
+        //          = 25 / 0.5
+        //          = 50
+        arguments(startOfUsage.plusDays(10), 250.0, 0.0, 50.0, 25.0),
 
         // contract = 100 (billable_units)
         // applicable_contract = 100 / 0.5 = 200 (measurement units)
         // applicable_usage = gtez(current_usage - applicable_contact)
         //                  = gtez(400 - 200)
         //                  = 200 (measurement units)
-        // unbilled = gtez(applicable_usage - (current_remittance / prev_billing_factor))
-        //          = gtez(200 - (25.0/0.5))
+        // unbilled = gtez(applicable_usage - (current_remittance))
+        //          = gtez(200 - (50))
         //          = 150 (measurement units)
         // billed = ceil(unbilled) * billing_factor
         //        = ceil(150) * 0.5
         //        = 75 (billable units)
-        // remitted = billed + current_remittance
-        //          = 75 + 25.0
+        // remitted = billed / billing_factor
+        //          = 75 / 0.5
         //          = 100
-        arguments(startOfUsage.plusDays(5), 400.0, 25.0, 100.0, 75.0),
+        arguments(startOfUsage.plusDays(5), 400.0, 50.0, 150.0, 75.0),
 
         // NOTE: Contract rolls to 200 here.
         //
@@ -326,10 +370,10 @@ class BillableUsageControllerTest {
         // billed = ceil(unbilled) * billing_factor
         //        = ceil(0) * 0.5
         //        = 0 (billable units)
-        // remitted = billed + current_remittance
-        //          = 0 + 100
-        //          = 100
-        arguments(startOfUsage.plusDays(20), 500.0, 100.0, 100.0, 0.0),
+        // remitted = billed / billing_factor
+        //          = 0 / 0.5
+        //          = 0.0
+        arguments(startOfUsage.plusDays(20), 500.0, 200.0, 0.0, 0.0),
 
         // contract = 200 (billable_units)
         // applicable_contract = 200 / 0.5 = 400 (measurement units)
@@ -343,10 +387,10 @@ class BillableUsageControllerTest {
         // billed = ceil(unbilled) * billing_factor
         //        = ceil(1.25) * 0.5
         //        = 1 (billable units)
-        // remitted = billed + current_remittance
-        //          = 1 + 100
-        //          = 101
-        arguments(CLOCK.endOfCurrentMonth(), 601.25, 100.0, 101.0, 1.0),
+        // remitted = billed / billing_factor
+        //          = 1 / 0.5
+        //          = 2
+        arguments(CLOCK.endOfCurrentMonth(), 601.25, 200.0, 2.0, 1.0),
 
         // NOTE: New billing month so simulate remittance of 0 with 200 contract.
         //
@@ -394,10 +438,10 @@ class BillableUsageControllerTest {
         // arguments(currentUsage, currentRemittance, expectedRemitted, expectedBilledValue)
         // NOTE: currantUsage is the sum of all snapshots, NOT the value from BillableUsage.
         arguments(startOfUsage, 0.5, 0.0, 1.0, 1.0),
-        arguments(startOfUsage.plusDays(5), 1.0, 1.0, 1.0, 0.0),
-        arguments(startOfUsage.plusDays(13), 1.5, 1.0, 2.0, 1.0),
-        arguments(startOfUsage.plusDays(20), 2.0, 2.0, 2.0, 0.0),
-        arguments(CLOCK.endOfCurrentMonth(), 2.5, 2.0, 3.0, 1.0),
+        arguments(startOfUsage.plusDays(5), 1.0, 1.0, 0.0, 0.0),
+        arguments(startOfUsage.plusDays(13), 1.5, 1.0, 1.0, 1.0),
+        arguments(startOfUsage.plusDays(20), 2.0, 2.0, 0.0, 0.0),
+        arguments(CLOCK.endOfCurrentMonth(), 2.5, 2.0, 1.0, 1.0),
         arguments(CLOCK.startOfCurrentMonth().plusMonths(1), 2.5, 0.0, 3.0, 3.0));
   }
 
@@ -425,12 +469,12 @@ class BillableUsageControllerTest {
     return Stream.of(
         // arguments(currentUsage, currentRemittance, expectedRemitted, expectedBilledValue)
         // NOTE: currantUsage is the sum of all snapshots, NOT the value from BillableUsage.
-        arguments(startOfUsage, 0.5, 0.0, 1.0, 1.0),
-        arguments(startOfUsage.plusDays(5), 1.0, 1.0, 1.0, 0.0),
-        arguments(startOfUsage.plusDays(13), 1.5, 1.0, 1.0, 0.0),
-        arguments(startOfUsage.plusDays(20), 2.0, 1.0, 1.0, 0.0),
-        arguments(CLOCK.endOfCurrentMonth(), 2.5, 1.0, 2.0, 1.0),
-        arguments(CLOCK.startOfCurrentMonth().plusMonths(1), 3.0, 0.0, 2.0, 2.0));
+        arguments(startOfUsage, 0.5, 0.0, 2.0, 1.0),
+        arguments(startOfUsage.plusDays(5), 1.0, 1.0, 0.0, 0.0),
+        arguments(startOfUsage.plusDays(13), 1.5, 2.0, 0.0, 0.0),
+        arguments(startOfUsage.plusDays(20), 2.0, 2.0, 0.0, 0.0),
+        arguments(CLOCK.endOfCurrentMonth(), 2.5, 2.0, 2.0, 1.0),
+        arguments(CLOCK.startOfCurrentMonth().plusMonths(1), 3.0, 0.0, 4.0, 2.0));
   }
 
   @ParameterizedTest()
@@ -452,6 +496,43 @@ class BillableUsageControllerTest {
         false);
   }
 
+  @Test
+  void reTallyCalculatesFromEntireMonthsUsage() {
+    BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 60.0);
+
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    summaries.add(RemittanceSummaryProjection.builder().totalRemittedPendingValue(20.0).build());
+
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
+    when(remittanceRepo.existsBy(any())).thenReturn(true);
+
+    TallyMeasurementKey measurementKey =
+        new TallyMeasurementKey(
+            HardwareMeasurementType.PHYSICAL, Measurement.Uom.fromValue(usage.getUom().value()));
+    when(snapshotRepo.sumMeasurementValueForPeriod(
+            usage.getOrgId(),
+            usage.getProductId(),
+            Granularity.HOURLY,
+            ServiceLevel.fromString(usage.getSla().value()),
+            org.candlepin.subscriptions.db.model.Usage.fromString(usage.getUsage().value()),
+            org.candlepin.subscriptions.db.model.BillingProvider.fromString(
+                usage.getBillingProvider().value()),
+            usage.getBillingAccountId(),
+            CLOCK.startOfMonth(usage.getSnapshotDate()),
+            CLOCK.endOfMonth(usage.getSnapshotDate()),
+            measurementKey))
+        .thenReturn(100.0);
+
+    controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
+
+    BillableUsageRemittanceEntity expectedRemittance =
+        remittance(usage, usage.getSnapshotDate(), 80.0);
+    BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 80.0);
+    expectedUsage.setId(usage.getId()); // Id will be regenerated above.
+    verify(remittanceRepo).save(expectedRemittance);
+    verify(producer).produce(expectedUsage);
+  }
+
   private BillableUsage billable(OffsetDateTime date, Double value) {
     return new BillableUsage()
         .withAccountNumber("account123")
@@ -468,7 +549,8 @@ class BillableUsageControllerTest {
         .withValue(value);
   }
 
-  private BillableUsageRemittanceEntityPK keyFrom(BillableUsage billableUsage) {
+  private BillableUsageRemittanceEntityPK keyFrom(
+      BillableUsage billableUsage, OffsetDateTime remittedDate) {
     return BillableUsageRemittanceEntityPK.builder()
         .usage(billableUsage.getUsage().value())
         .orgId(billableUsage.getOrgId())
@@ -478,6 +560,7 @@ class BillableUsageControllerTest {
         .sla(billableUsage.getSla().value())
         .metricId(billableUsage.getUom().value())
         .accumulationPeriod(InstanceMonthlyTotalKey.formatMonthId(billableUsage.getSnapshotDate()))
+        .remittancePendingDate(remittedDate)
         .build();
   }
 
@@ -502,13 +585,12 @@ class BillableUsageControllerTest {
 
   private BillableUsageRemittanceEntity remittance(
       BillableUsage usage, OffsetDateTime remittedDate, Double value) {
-    BillableUsageRemittanceEntityPK remKey = keyFrom(usage);
+    BillableUsageRemittanceEntityPK remKey = keyFrom(usage, remittedDate);
     return BillableUsageRemittanceEntity.builder()
         .key(remKey)
-        .billingFactor(1.0)
-        .remittanceDate(remittedDate)
-        .remittedValue(value)
+        .remittedPendingValue(value)
         .accountNumber(usage.getAccountNumber())
+        .granularity(Granularity.HOURLY)
         .build();
   }
 
@@ -532,9 +614,14 @@ class BillableUsageControllerTest {
 
     BillableUsageRemittanceEntity existingRemittance =
         remittance(usage, CLOCK.now().minusHours(1), currentRemittance);
-    existingRemittance.setBillingFactor(tagMetric.getBillingFactor());
 
-    when(remittanceRepo.findById(keyFrom(usage))).thenReturn(Optional.of(existingRemittance));
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    summaries.add(
+        RemittanceSummaryProjection.builder()
+            .totalRemittedPendingValue(existingRemittance.getRemittedPendingValue())
+            .build());
+
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
 
     mockCurrentSnapshotMeasurementTotal(usage, currentUsage);
 
@@ -544,7 +631,7 @@ class BillableUsageControllerTest {
               usage.getProductId(), TallyMeasurement.Uom.fromValue(usage.getUom().value())))
           .thenReturn(AWS_METRIC_ID);
 
-      mockContactCoverage(
+      mockContractCoverage(
           usage.getOrgId(),
           usage.getProductId(),
           AWS_METRIC_ID,
@@ -558,18 +645,13 @@ class BillableUsageControllerTest {
 
     // Remittance should only be saved when it changes.
     // NOTE: Using argument captors make errors caught by mocks a little easier to debug.
-    if (!currentRemittance.equals(expectedRemitted)) {
-      BillableUsageRemittanceEntity expectedRemittance =
-          remittance(usage, CLOCK.now(), expectedRemitted);
-      expectedRemittance.setBillingFactor(billingFactor);
-      ArgumentCaptor<BillableUsageRemittanceEntity> remitted =
-          ArgumentCaptor.forClass(BillableUsageRemittanceEntity.class);
-      verify(remittanceRepo).save(remitted.capture());
-      BillableUsageRemittanceEntity saved = remitted.getValue();
-      assertEquals(expectedRemittance, saved);
-    } else {
-      verify(remittanceRepo, never()).save(any());
-    }
+    BillableUsageRemittanceEntity expectedRemittance =
+        remittance(usage, usage.getSnapshotDate(), expectedRemitted);
+    ArgumentCaptor<BillableUsageRemittanceEntity> remitted =
+        ArgumentCaptor.forClass(BillableUsageRemittanceEntity.class);
+    verify(remittanceRepo).save(remitted.capture());
+    BillableUsageRemittanceEntity saved = remitted.getValue();
+    assertEquals(expectedRemittance, saved);
 
     BillableUsage expectedUsage = billable(usage.getSnapshotDate(), expectedBilledValue);
     expectedUsage.setId(usage.getId());
@@ -579,7 +661,7 @@ class BillableUsageControllerTest {
     assertEquals(expectedUsage, usageCaptor.getValue());
   }
 
-  private void mockContactCoverage(
+  private void mockContractCoverage(
       String orgId,
       String productId,
       String metric,

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/QuantityTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/QuantityTest.java
@@ -111,9 +111,8 @@ class QuantityTest {
   @Test
   void testFromRemittance() {
     var remittance = new BillableUsageRemittanceEntity();
-    remittance.setBillingFactor(0.25);
-    remittance.setRemittedValue(2.5);
-    var quantity = Quantity.fromRemittance(remittance);
+    remittance.setRemittedPendingValue(2.5);
+    var quantity = Quantity.fromRemittance(remittance, 0.25);
     assertEquals(0.25, quantity.getUnit().getBillingFactor());
     assertEquals(2.5, quantity.getValue());
     assertEquals(10.0, quantity.to(new MetricUnit()).getValue());

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingControllerTest.java
@@ -30,6 +30,7 @@ import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
+import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.BillableUsage.BillingProvider;
@@ -201,11 +202,12 @@ class InternalBillingControllerTest {
             .sla(BillableUsage.Sla.PREMIUM.value())
             .metricId(BillableUsage.Uom.INSTANCE_HOURS.value())
             .accumulationPeriod(InstanceMonthlyTotalKey.formatMonthId(remittanceDate))
+            .remittancePendingDate(remittanceDate)
             .build();
     return BillableUsageRemittanceEntity.builder()
         .key(key)
-        .remittanceDate(remittanceDate)
-        .remittedValue(value)
+        .remittedPendingValue(value)
+        .granularity(Granularity.HOURLY)
         .build();
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
@@ -20,13 +20,14 @@
  */
 package org.candlepin.subscriptions.db.model;
 
-import java.time.OffsetDateTime;
+import java.io.Serializable;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Table;
-import javax.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,26 +39,19 @@ import lombok.NoArgsConstructor;
 @Builder
 @Entity
 @Table(name = "billable_usage_remittance")
-public class BillableUsageRemittanceEntity {
+public class BillableUsageRemittanceEntity implements Serializable {
 
   @EmbeddedId private BillableUsageRemittanceEntityPK key;
 
   @Basic
-  @Column(name = "remitted_value", nullable = false, precision = 0)
-  private Double remittedValue;
-
-  @Basic
-  @Column(name = "remittance_date", nullable = false)
-  private OffsetDateTime remittanceDate;
+  @Column(name = "remitted_pending_value", nullable = false, precision = 0)
+  private Double remittedPendingValue;
 
   @Basic
   @Column(name = "account_number", nullable = true)
   private String accountNumber;
 
-  @Basic
-  @Column(name = "billing_factor")
-  private Double billingFactor;
-
-  // Version to enable optimistic locking
-  @Version @Column private Integer version;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "granularity")
+  private Granularity granularity;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
@@ -61,6 +61,9 @@ public class BillableUsageRemittanceEntityPK implements Serializable {
   @Column(name = "billing_account_id", nullable = false, length = 255)
   private String billingAccountId;
 
+  @Column(name = "remittance_pending_date", nullable = false)
+  private OffsetDateTime remittancePendingDate;
+
   public static BillableUsageRemittanceEntityPK keyFrom(BillableUsage billableUsage) {
     return BillableUsageRemittanceEntityPK.builder()
         .usage(billableUsage.getUsage().value())
@@ -71,6 +74,7 @@ public class BillableUsageRemittanceEntityPK implements Serializable {
         .sla(billableUsage.getSla().value())
         .metricId(billableUsage.getUom().value())
         .accumulationPeriod(getAccumulationPeriod(billableUsage.getSnapshotDate()))
+        .remittancePendingDate(billableUsage.getSnapshotDate())
         .build();
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceSummaryProjection.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceSummaryProjection.java
@@ -18,31 +18,26 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.db;
+package org.candlepin.subscriptions.db.model;
 
 import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import org.candlepin.subscriptions.db.model.Granularity;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-/**
- * A filter used to find {@link org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity}
- * objects via the {@link BillableUsageRemittanceRepository}. Any filter value with a null value
- * will not be checked.
- */
 @Builder
-@Getter
-@Setter
-public class BillableUsageRemittanceFilter {
-  private String productId;
-  private String account;
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RemittanceSummaryProjection {
+  private Double totalRemittedPendingValue;
   private String orgId;
-  private String metricId;
+  private String accountNumber;
+  private String productId;
+  private String accumulationPeriod;
+  private OffsetDateTime remittancePendingDate;
   private String billingProvider;
   private String billingAccountId;
-  private OffsetDateTime beginning;
-  private OffsetDateTime ending;
-  private String accumulationPeriod;
-  private Granularity granularity;
+  private String metricId;
 }


### PR DESCRIPTION
## Testing


### Setup

Prep your DB.
**NOTE** This will truncate/drop some tables.
```
psql -h localhost -U rhsm-subscriptions <<EOF
drop table events;
truncate table hosts cascade;
truncate table tally_snapshots cascade;
truncate table billable_usage_remittance;
EOF
```

Use the attached [remittance-billing-factor-event-data.txt](https://github.com/RedHatInsights/rhsm-subscriptions/files/11407548/remittance-billing-factor-event-data.txt) file to import event metric data into your DB for Feb and March.
```
psql -h localhost -U rhsm-subscriptions < remittance-billing-factor-event-data.txt
```

Start tally worker with stub contract api
```
SPRING_PROFILES_ACTIVE=worker,kafka-task-queue CONTRACT_USE_STUB=true DEV_MODE=true ./gradlew :bootRun
```

Perform a nightly tally across the event date ranges and ensure that snapshot summaries were created for BASILISK Instance-hours and rosa Cores.
```
http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["org123", "2023-02-01T00:00Z", "2023-03-16T00:00Z"]'
```

### Verification

**NOTE** When we are validating the remittance data in the table, we will assume there is nothing currently remitted, and we will base our calculation off of the sum of the the current snapshot values. This is Ok since no matter what snapshot we start at, we will end up with the same remittance.

#### BASILISK Verification
Verify BASILISK Instance-hours remittance first. It is configured with a billing factor of 1.0 (default)

Find the `total_usage` for the single instance under test for Feb and March.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select h.instance_id, t.value from instance_monthly_totals t, hosts h where t.instance_id = h.id and month='2023-03' and h.instance_id::text in (select distinct e.instance_id from events e where e.org_id='org123' and extract(month from e.timestamp) = 3 and e.event_type='snapshot_redhat.com:BASILISK:cluster_hour') order by h.instance_id;"
```
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select h.instance_id, t.value from instance_monthly_totals t, hosts h where t.instance_id = h.id and month='2023-02' and h.instance_id::text in (select distinct e.instance_id from events e where e.org_id='org123' and extract(month from e.timestamp) = 2 and e.event_type='snapshot_redhat.com:BASILISK:cluster_hour') order by h.instance_id;"
```

Verify the correct usage has been remitted. 

```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance where org_id='org123' and product_id='BASILISK' order by accumulation_period;"
```

**Check February**
measured_units = 1064.1067677478911
remitted = ceil(1064.1067677478911) = 1065

**Check March**
measured_units = 16990.061835580877
remitted = ceil(16990.061835580877) = 16991

Curl internal endpoint and get summary for BASILISK should match above remitted:
```
http GET :8000/api/rhsm-subscriptions/v1/internal/remittance/accountRemittances orgId==org123  productId==BASILISK  x-rh-swatch-psk:placeholder
```

#### ROSA Verification
Next verify rosa Cores Instance-hours. It is configured with a billing factor of 0.25 (tag profile)

Find the `total_usage` for the single instance under test for Feb and March.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select h.instance_id, t.value from instance_monthly_totals t, hosts h where t.instance_id = h.id and month='2023-03' and h.instance_id::text in (select distinct e.instance_id from events e where e.org_id='org123' and extract(month from e.timestamp) = 3 and e.event_type='snapshot_redhat.com:rosa:cpu_hour') order by h.instance_id;"
```
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select h.instance_id, t.value from instance_monthly_totals t, hosts h where t.instance_id = h.id and month='2023-02' and h.instance_id::text in (select distinct e.instance_id from events e where e.org_id='org123' and extract(month from e.timestamp) = 2 and e.event_type='snapshot_redhat.com:rosa:cpu_hour') order by h.instance_id;"
```

Verify the correct usage has been remitted.

```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance where org_id='org123' and product_id='rosa' order by accumulation_period;"
```

**Check February**
measured_units = 1064.1067677478911
remitted = ceil(1064.1067677478911) = 1065 (rounded to nearest multiple of billing_factor(4) = 1068)

**Check March**
measured_units = 16990.061835580877
remitted = ceil(16990.061835580877) = 16991 (rounded to nearest multiple of billing_factor(4) = 16992)

Curl internal endpoint and get summary for rosa should match above remitted:
```
http GET :8000/api/rhsm-subscriptions/v1/internal/remittance/accountRemittances orgId==org123  productId==rosa  x-rh-swatch-psk:placeholder
```

### Re-tally testing
**Setup :**
**NOTE** This will truncate some tables.
```
psql -h localhost -U rhsm-subscriptions <<EOF
truncate table events;
truncate table hosts cascade;
truncate table tally_snapshots cascade;
truncate table billable_usage_remittance;
EOF
```
Create event data:
```
psql -h localhost -U rhsm-subscriptions <<EOF
INSERT INTO public.events VALUES ('c77461ca-1949-47cd-b408-da48f6542c30', 'account123', '2023-03-14 23:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "c77461ca-1949-47cd-b408-da48f6542c30", "timestamp": "2023-03-14T23:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-15T00:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 66.3149034729778}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('66d3b513-ff98-4ca2-a8e0-6220d587e481', 'account123', '2023-03-14 05:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "66d3b513-ff98-4ca2-a8e0-6220d587e481", "timestamp": "2023-03-14T05:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T06:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 78.43902161885251}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('1df4b66b-6c38-4dfb-86ba-7f836772c5ed', 'account123', '2023-03-14 07:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "1df4b66b-6c38-4dfb-86ba-7f836772c5ed", "timestamp": "2023-03-14T07:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T08:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 89.71619997683332}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('fa6e942e-60a0-46c8-956f-6d22ad26d8ef', 'account123', '2023-03-14 14:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "fa6e942e-60a0-46c8-956f-6d22ad26d8ef", "timestamp": "2023-03-14T14:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T15:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 50.37548343963122}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('b28612ae-966f-49a6-a471-5b6916ce278e', 'account123', '2023-03-14 03:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "b28612ae-966f-49a6-a471-5b6916ce278e", "timestamp": "2023-03-14T03:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T04:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 42.68440226666289}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('7bd5b681-11be-4653-bc47-c8f629c84ad6', 'account123', '2023-03-14 11:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "7bd5b681-11be-4653-bc47-c8f629c84ad6", "timestamp": "2023-03-14T11:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T12:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 34.2383995282023}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('5d66e3f1-a180-4d75-a5ed-2332f992deb2', 'account123', '2023-03-14 16:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "5d66e3f1-a180-4d75-a5ed-2332f992deb2", "timestamp": "2023-03-14T16:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T17:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 71.48314039307245}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('72a6af24-28f0-4a1a-9fe6-f6636d77301d', 'account123', '2023-03-14 04:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "72a6af24-28f0-4a1a-9fe6-f6636d77301d", "timestamp": "2023-03-14T04:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T05:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 1.2093764882562086}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('256bbc5a-dfa7-41d2-97e6-cb6b159f1c9c', 'account123', '2023-03-14 21:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "256bbc5a-dfa7-41d2-97e6-cb6b159f1c9c", "timestamp": "2023-03-14T21:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T22:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 38.764976832898554}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('0f82bf07-c23d-4a3f-8277-cfc2596bc13b', 'account123', '2023-03-14 22:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "0f82bf07-c23d-4a3f-8277-cfc2596bc13b", "timestamp": "2023-03-14T22:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T23:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 96.84935372226566}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('9f8f0511-bc93-4c43-a6d7-67c7ab9fe97f', 'account123', '2023-03-14 18:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "9f8f0511-bc93-4c43-a6d7-67c7ab9fe97f", "timestamp": "2023-03-14T18:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T19:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 49.023161003774284}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('cc70a3fa-0b1b-4dfa-972d-cae6a271674f', 'account123', '2023-03-14 15:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "cc70a3fa-0b1b-4dfa-972d-cae6a271674f", "timestamp": "2023-03-14T15:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T16:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 95.71927764615205}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('bdbeea80-f00c-4488-9011-417a3edcb46f', 'account123', '2023-03-14 09:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "bdbeea80-f00c-4488-9011-417a3edcb46f", "timestamp": "2023-03-14T09:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T10:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 15.123411369169371}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('e1a1f075-62cb-469d-9793-cb8fd445b47f', 'account123', '2023-03-14 10:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "e1a1f075-62cb-469d-9793-cb8fd445b47f", "timestamp": "2023-03-14T10:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T11:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 37.91220775819097}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('b154f5bc-0a28-496a-b072-549dc26f456c', 'account123', '2023-03-14 19:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "b154f5bc-0a28-496a-b072-549dc26f456c", "timestamp": "2023-03-14T19:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T20:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 19.960434280604055}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('c78e0772-194d-42e2-a7d1-c9afbd640844', 'account123', '2023-03-14 20:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "c78e0772-194d-42e2-a7d1-c9afbd640844", "timestamp": "2023-03-14T20:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T21:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 9.510901762986833}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('86eea9e0-0099-4267-91d7-a4f922aa49e3', 'account123', '2023-03-14 13:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "86eea9e0-0099-4267-91d7-a4f922aa49e3", "timestamp": "2023-03-14T13:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T14:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 54.79963991495147}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('18145e4b-5cbc-474e-b74a-7d90326182da', 'account123', '2023-03-14 06:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "18145e4b-5cbc-474e-b74a-7d90326182da", "timestamp": "2023-03-14T06:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T07:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 7.393575209181202}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('ecbc3710-5995-49f3-afcb-5c66e6d25284', 'account123', '2023-03-14 17:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "ecbc3710-5995-49f3-afcb-5c66e6d25284", "timestamp": "2023-03-14T17:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T18:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 13.34036251053049}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('08257ba9-3dcc-40e7-9e46-1134094d8dd7', 'account123', '2023-03-14 12:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "08257ba9-3dcc-40e7-9e46-1134094d8dd7", "timestamp": "2023-03-14T12:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T13:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 91.98507323220977}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
EOF
```

Run tally:
`http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["org123", "2023-02-01T00:00Z", "2023-03-16T00:00Z"]'`

Note remitted value matches instance_monthly_totals:
```
psql -h localhost -U rhsm-subscriptions <<EOF
select value from instance_monthly_totals where instance_id = '34a86bc5-4b8f-47b6-8d1f-b2c3effbdf51';
EOF

http GET :8000/api/rhsm-subscriptions/v1/internal/remittance/accountRemittances orgId==org123  productId==rosa  x-rh-swatch-psk:placeholder
```
Insert missing event:
```
psql -h localhost -U rhsm-subscriptions <<EOF
INSERT INTO public.events VALUES ('a888e2fe-bdc2-4b8f-bc60-eaf8cc42d367', 'account123', '2023-03-14 08:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "a888e2fe-bdc2-4b8f-bc60-eaf8cc42d367", "timestamp": "2023-03-14T08:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-03-14T09:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 5.558876229410159}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
EOF
```
Run tally again to pick up missing event:
`http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["org123", "2023-02-01T00:00Z", "2023-03-16T00:00Z"]'`

Note remitted value instance_monthly_totals should still match:
```
psql -h localhost -U rhsm-subscriptions <<EOF
select value from instance_monthly_totals where instance_id = '34a86bc5-4b8f-47b6-8d1f-b2c3effbdf51';
EOF

http GET :8000/api/rhsm-subscriptions/v1/internal/remittance/accountRemittances orgId==org123  productId==rosa  x-rh-swatch-psk:placeholder
```
