### PR TITLE
Update delete contracts to actually delete contracts for test cleanup purposes

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -179,28 +179,7 @@ public class ContractService {
   @Transactional
   public void deleteContract(String uuid) {
 
-    updateContractEndDate(uuid, OffsetDateTime.now());
-  }
-
-  /**
-   * Look up a contract via uuid and update the record to have the given end date.
-   *
-   * @param uuid
-   * @param endDate
-   */
-  @Transactional
-  Optional<ContractEntity> updateContractEndDate(String uuid, OffsetDateTime endDate) {
-    var contract = contractRepository.findContract(UUID.fromString(uuid));
-
-    if (Objects.nonNull(contract)) {
-      log.debug("Setting end date to {} for contract {}", endDate, uuid);
-      contract.setEndDate(endDate);
-      contract.setLastUpdated(OffsetDateTime.now());
-      contractRepository.persist(contract);
-      return Optional.of(contract);
-    }
-
-    return Optional.empty();
+    contractRepository.deleteById(UUID.fromString(uuid));
   }
 
   @Transactional

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -130,22 +130,6 @@ class ContractServiceTest extends BaseUnitTest {
   }
 
   @Test
-  void testUpdateContractEndDate() {
-
-    when(contractRepository.findContract(any())).thenReturn(actualContract1);
-
-    var now = OffsetDateTime.now();
-
-    UUID uuid = actualContract1.getUuid();
-
-    var expected = now;
-    var actual = contractService.updateContractEndDate(uuid.toString(), now).get().getEndDate();
-
-    verify(contractRepository, times(1)).findContract(uuid);
-    assertEquals(expected, actual);
-  }
-
-  @Test
   void createPartnerContract_WhenNonNullEntityAndContractNotFoundInDB() {
     var contract = new PartnerEntitlementContract();
     contract.setRedHatSubscriptionNumber("12400374");


### PR DESCRIPTION
We were doing a soft delete before we had a way to update an endDate of a contract.  Since we have a way to do that now, and not deleting test contracts is now making a mess in stage, it's time to reenable true deletion.

More context: https://redhat-internal.slack.com/archives/C01F7QFNATC/p1685546969765389?thread_ts=1685545352.820649&cid=C01F7QFNATC