### PR TITLE
SWATCH-122: Add GCP Marketplace detection to swatch-system-conduit

### DIFF
--- a/bin/fetch-gcp-marketplace-license-codes.py
+++ b/bin/fetch-gcp-marketplace-license-codes.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# NOTE: this script requires the python google-cloud-compute library and
+# to auth GCP API interactions via https://cloud.google.com/docs/authentication/provide-credentials-adc#local-dev
+try:
+    import google.cloud.compute_v1 as compute_v1
+except ImportError:
+    print("Failed to import GCP client, please pip install --user google-cloud-compute")
+    sys.exit(1)
+
+images_client = compute_v1.ImagesClient()
+license_codes = {}
+for project in ['rhel-cloud', 'rhel-sap-cloud']:
+    request = compute_v1.ListImagesRequest(
+        project=project, max_results=100,
+        # NOTE: below argument can be used to limit output if needed in the future
+        # filter="deprecated.state != DEPRECATED"
+    )
+    # NOTE: list method paginates where page size is the `max_results` value from above
+    for image in images_client.list(request=request):
+        family = image.family
+        if family.startswith('rhel') and len(image.license_codes) > 0:
+            license = image.license_codes[0]
+            if license not in license_codes:
+                license_codes[license] = set()
+            license_codes[license].add(family)
+
+for license, families in license_codes.items():
+    print(f'"{license}", // {", ".join(families)}')

--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -37,6 +37,7 @@ public class StubRhsmApi extends RhsmApi {
   private static Logger log = LoggerFactory.getLogger(StubRhsmApi.class);
 
   private static final String MAX_ALLOWED_MEMORY_ORG_ID = "maxAllowedMemoryOrg";
+  private static final String GCP_ORG_ID = "gcpOrg";
 
   @Override
   public OrgInventory getConsumersForOrg(
@@ -106,6 +107,10 @@ public class StubRhsmApi extends RhsmApi {
   private void applyOrgIdUpdates(String orgId, Consumer consumer) {
     if (orgId.equals(MAX_ALLOWED_MEMORY_ORG_ID)) {
       consumer.getFacts().put("memory.memtotal", "8830587505648");
+    }
+    if (orgId.equals(GCP_ORG_ID)) {
+      consumer.getFacts().remove("azure_offer");
+      consumer.getFacts().put("gcp_license_codes", "7883559014960410759");
     }
   }
 }

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/admin/InternalOrganizationSyncResource.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/admin/InternalOrganizationSyncResource.java
@@ -84,8 +84,12 @@ public class InternalOrganizationSyncResource implements InternalOrganizationsAp
   }
 
   @Override
-  public OrgInventory getInventoryForOrg(String orgId, Integer offset, Integer limit) {
-    throw new UnsupportedOperationException();
+  public OrgInventory getInventoryForOrg(String orgId, Integer limit, Integer offset) {
+    try {
+      return controller.getInventoryForOrg(orgId, offset == null ? null : offset.toString());
+    } catch (MissingAccountNumberException ex) {
+      throw new InternalServerErrorException(ex.getMessage());
+    }
   }
 
   @Override

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -562,6 +562,32 @@ class InventoryControllerTest {
   }
 
   @Test
+  void testIsMarketplaceFacts_WhenGcpLicenseCodeIsRhel() {
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+    consumer
+        .getFacts()
+        .put(
+            InventoryController.GCP_LICENSE_CODES,
+            InventoryController.MARKETPLACE_GCP_LICENSE_CODES.stream().findFirst().orElseThrow());
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertTrue(conduitFacts.getIsMarketplace());
+  }
+
+  @Test
+  void testIsMarketplaceFacts_WhenGcpLicenseCodeIsNonRhel() {
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+    consumer.getFacts().put(InventoryController.GCP_LICENSE_CODES, "non-rhel-placeholder");
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertNull(conduitFacts.getIsMarketplace());
+  }
+
+  @Test
   void testTruncatedIpV6AddressIsIgnoredForNics() {
     String factPrefix = "net.interface.virbr0.";
 


### PR DESCRIPTION
Jira issue: [SWATCH-122](https://issues.redhat.com/browse/SWATCH-122)

Description
===========

I implemented the stub for `/internal/organizations/$org/inventory`. I also added a script that can be used to get an updated list of licenseCodes.

Testing
=======

Steps
-----

1. Run the service:

```shell
RHSM_USE_STUB=true \
  DEV_MODE=true \
  ./gradlew swatch-system-conduit:bootRun
```

2. Call the conduit debugging API to see what the value for is_marketplace is:

```shell
http ':8000/api/rhsm-subscriptions/v1/internal/organizations/gcpOrg/inventory?limit=10' \
  x-rh-swatch-psk:placeholder
```

Verification
------------

Observe `is_marketplace=true`.