### PR TITLE
SWATCH-1216: Reenable event purge cronjob

### DIFF
--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -506,8 +506,6 @@ objects:
               - name: token-refresher
                 enabled: true
         - name: purge-events
-          disabled: true
-          suspend: true
           schedule: ${PURGE_EVENTS_SCHEDULE}
           activeDeadlineSeconds: 1800
           successfulJobsHistoryLimit: 2


### PR DESCRIPTION
Revert "Disable swatch-metrics-purge-events job as it leads to OOM on the pod" (https://github.com/RedHatInsights/rhsm-subscriptions/pull/2109)

This reverts commit d4e7be695206be5f8f45d84fdbf2aefd31a76ee1.


<!-- Replace 1216 with the issue number -->
Jira issue: [SWATCH-1216](https://issues.redhat.com/browse/SWATCH-1216)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Reenabling the cron job after confirming that invoking purge event no longer causes OOM pod restarts after previous PR (https://github.com/RedHatInsights/rhsm-subscriptions/pull/2189).