### PR TITLE
Fix path lookups to work for `quarkus test`

### DIFF
--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/PathUtils.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/PathUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract;
+
+import java.nio.file.Paths;
+
+public class PathUtils {
+  public static String PROJECT_DIRECTORY = findRootPath();
+
+  private static String findRootPath() {
+    var path = Paths.get(".").toAbsolutePath();
+    do {
+      var srcDir = Paths.get(path.toString(), "src");
+      if (srcDir.toFile().exists()) {
+        return path.toString();
+      }
+      path = path.getParent();
+    } while (path.getParent() != null);
+    throw new IllegalStateException("Unable to locate project root");
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ConsumerApiSpecEqualityTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ConsumerApiSpecEqualityTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.redhat.swatch.contract.PathUtils;
 import io.smallrye.openapi.runtime.io.Format;
 import io.smallrye.openapi.runtime.io.OpenApiParser;
 import java.io.IOException;
@@ -57,7 +58,8 @@ class ConsumerApiSpecEqualityTest {
 
   private static OpenAPI loadOpenApiDefinition(String path) {
     try {
-      return OpenApiParser.parse(Files.newInputStream(Paths.get(path)), Format.YAML);
+      return OpenApiParser.parse(
+          Files.newInputStream(Paths.get(PathUtils.PROJECT_DIRECTORY, path)), Format.YAML);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
@@ -28,13 +28,16 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.redhat.swatch.contract.PathUtils;
 import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import java.nio.file.Paths;
 import java.util.Map;
 
 public class WireMockResource
     implements QuarkusTestResourceConfigurableLifecycleManager<WireMockTest> {
 
-  private static final String BASE_KEYSTORE_PATH = "../clients-core/src/test/resources";
+  private static final String BASE_KEYSTORE_PATH =
+      Paths.get(PathUtils.PROJECT_DIRECTORY, "../clients-core/src/test/resources").toString();
   private static final String SERVER_KEYSTORE_PATH =
       String.format("%s/server.jks", BASE_KEYSTORE_PATH);
   private static final String CLIENT_KEYSTORE_PATH =


### PR DESCRIPTION
## Description

`quarkus test` runs in a different working directory than when running from Intellij or gradle builds. In order to allow tests to run in either, I implemented a lookup of the project directory by walking up the directory tree looking for `src`.

Before this change, running `quarkus test` doesn't work from the `swatch-contracts` directory, and afterwards it works.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Install the quarkus cli
2. `cd swatch-contracts`

### Steps
<!-- Enter each step of the test below -->
1. `git checkout main`
2. `quarkus test` (see failures)
3. ctrl+c after tests run
4. `git checkout khowell/quarkus_test_fixes`
5. `quarkus test` (see no failures)
6. ctrl+c after tests run

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Observe test failures during the first `quarkus test`
1. Observe no test failures during second `quarkus test`.
