### PR TITLE
Consolidate dependabot PRs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 
 COPY build/libs/* /deployments/
 COPY build/javaagent/* /opt/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 USER root
 WORKDIR /tmp/src
 ADD . /tmp/src

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,7 @@ ext.plugins = [
 ]
 
 libraries["annotation-api"] = "javax.annotation:javax.annotation-api:1.3.2"
-libraries["awssdk-bom"] = "software.amazon.awssdk:bom:2.20.79"
+libraries["awssdk-bom"] = "software.amazon.awssdk:bom:2.20.80"
 libraries["clowder-quarkus-config-source"] = "com.redhat.cloud.common:clowder-quarkus-config-source:1.3.2"
 libraries["guava"] = "com.google.guava:guava:32.0.0-jre"
 libraries["hawtio-springboot"] = "io.hawt:hawtio-springboot:2.17.3"

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 
 ENV LANGUAGE='en_US:en'
 

--- a/swatch-contracts/src/main/docker/Dockerfile.legacy-jar
+++ b/swatch-contracts/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 
 ENV LANGUAGE='en_US:en'
 

--- a/swatch-contracts/src/main/docker/Dockerfile.native
+++ b/swatch-contracts/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/swatch-contracts
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/swatch-producer-aws/src/main/docker/Dockerfile.legacy-jar
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 USER root
 
 COPY build/libs/ /deployments/


### PR DESCRIPTION
Bumps software.amazon.awssdk:bom from 2.20.79 to 2.20.80.
Bump ubi9/openjdk-17-runtime from 1.14-2.1681917142 to 1.15-1 