### PR TITLE
swatch-1342: subscription api capacity bug

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -361,20 +361,20 @@ public class SubscriptionTableController {
     var value = measurement.getValue();
 
     var sockets =
-        (MetricId.SOCKETS.toString().equals(metric) && "PHYSICAL".equals(type))
+        (MetricId.SOCKETS.toString().equalsIgnoreCase(metric) && "PHYSICAL".equals(type))
             ? value.intValue()
             : 0;
     var cores =
-        (MetricId.CORES.toString().equals(metric) && "PHYSICAL".equals(type))
+        (MetricId.CORES.toString().equalsIgnoreCase(metric) && "PHYSICAL".equals(type))
             ? value.intValue()
             : 0;
 
     var hypervisorSockets =
-        (MetricId.SOCKETS.toString().equals(metric) && "HYPERVISOR".equals(type))
+        (MetricId.SOCKETS.toString().equalsIgnoreCase(metric) && "HYPERVISOR".equals(type))
             ? value.intValue()
             : 0;
     var hypervisorCores =
-        (MetricId.CORES.toString().equals(metric) && "HYPERVISOR".equals(type))
+        (MetricId.CORES.toString().equalsIgnoreCase(metric) && "HYPERVISOR".equals(type))
             ? value.intValue()
             : 0;
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -1034,7 +1034,7 @@ class SubscriptionTableControllerTest {
 
       return SubscriptionMeasurement.builder()
           .measurementType(type)
-          .metricId(metric.toString())
+          .metricId(metric.toString().toUpperCase())
           .value(value)
           .build();
     }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1342](https://issues.redhat.com/browse/SWATCH-1342)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Subscription API is not returning capacity for records. The new subscription_measurements are being saved in all uppercase but being compared to the properly cased values of the enums. This PR makes it so we ignore case when checking the capacity.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert test data:
```
INSERT INTO public.offering VALUES ('RH00005', 'RHEL Server', 'Red Hat Enterprise Linux', 1, 2, 1, 1, 'Red Hat Enterprise Linux Server', 'Self-Support', 'Production', 'Red Hat Enterprise Linux Server Entry Level, Self-support', false, '');
INSERT INTO public.subscription VALUES ('RH00005', '16772552', '12497245', 1, '2022-06-03 04:00:00+00', '2023-10-20 11:05:11+00', NULL, '11476445', '12497402', NULL, NULL, false);
INSERT INTO public.subscription VALUES ('RH00005', '16772552', '12497327', 1, '2022-06-03 04:00:00+00', '2024-05-31 12:23:18+00', NULL, '11476445', '12497484', NULL, NULL, false);
INSERT INTO public.subscription VALUES ('RH00005', '16772552', '12497360', 1, '2023-05-30 04:00:00+00', '2024-05-31 13:01:15+00', NULL, '11476445', '12497517', NULL, NULL, false);
INSERT INTO public.subscription VALUES ('RH00005', '16772552', '12501528', 1, '2022-06-10 04:00:00+00', '2024-06-09 04:00:00+00', NULL, '11476445', '12501685', NULL, NULL, false);
INSERT INTO public.subscription_product_ids VALUES ('RHEL', '12497327', '2022-06-03 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL Server', '12497327', '2022-06-03 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL for x86', '12497327', '2022-06-03 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL', '12497245', '2022-06-03 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL Server', '12497245', '2022-06-03 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL for x86', '12497245', '2022-06-03 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL', '12497360', '2023-05-30 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL Server', '12497360', '2023-05-30 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL for x86', '12497360', '2023-05-30 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL for x86', '12501528', '2022-06-10 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL', '12501528', '2022-06-10 04:00:00+00');
INSERT INTO public.subscription_product_ids VALUES ('RHEL Server', '12501528', '2022-06-10 04:00:00+00');
INSERT INTO public.subscription_measurements VALUES ('12497245', '2022-06-03 04:00:00+00', 'SOCKETS', 'PHYSICAL', 2);
INSERT INTO public.subscription_measurements VALUES ('12497327', '2022-06-03 04:00:00+00', 'SOCKETS', 'PHYSICAL', 2);
INSERT INTO public.subscription_measurements VALUES ('12497360', '2023-05-30 04:00:00+00', 'SOCKETS', 'PHYSICAL', 2);
INSERT INTO public.subscription_measurements VALUES ('12501528', '2022-06-10 04:00:00+00', 'SOCKETS', 'PHYSICAL', 2);
```
1. Opt in account:
```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJhY2NvdW50X251bWJlciI6ICIxMTQ3NjQ0NSIsCiAgICAgICAgInR5cGUiOiAiVXNlciIsCiAgICAgICAgInVzZXIiIDogewogICAgICAgICAgICAiaXNfb3JnX2FkbWluIjogdHJ1ZQogICAgICAgIH0sCiAgICAgICAgImludGVybmFsIiA6IHsKICAgICAgICAgICAgIm9yZ19pZCI6ICIxNjc3MjU1MiIKICAgICAgICB9CiAgICB9Cn0='
```

### Steps
<!-- Enter each step of the test below -->
1. Curl subscription endpoint:
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJhY2NvdW50X251bWJlciI6ICIxMTQ3NjQ0NSIsCiAgICAgICAgInR5cGUiOiAiVXNlciIsCiAgICAgICAgInVzZXIiIDogewogICAgICAgICAgICAiaXNfb3JnX2FkbWluIjogdHJ1ZQogICAgICAgIH0sCiAgICAgICAgImludGVybmFsIiA6IHsKICAgICAgICAgICAgIm9yZ19pZCI6ICIxNjc3MjU1MiIKICAgICAgICB9CiAgICB9Cn0='
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Verify capacity and total_capacity = 8
