### PR TITLE
SWATCH-932 Get capacity report by metric id

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -30,6 +30,7 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
+import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.db.HypervisorReportCategory;
 import org.candlepin.subscriptions.db.SubscriptionMeasurementRepository;
 import org.candlepin.subscriptions.db.SubscriptionRepository;
@@ -66,6 +67,7 @@ import org.springframework.stereotype.Component;
 
 /** Capacity API implementation. */
 @Component
+@Slf4j
 public class CapacityResource implements CapacityApi {
   public static final String SOCKETS = MetricId.SOCKETS.toString().toUpperCase();
   public static final String CORES = MetricId.CORES.toString().toUpperCase();
@@ -180,6 +182,13 @@ public class CapacityResource implements CapacityApi {
       ServiceLevelType sla,
       UsageType usage) {
 
+    log.debug(
+        "Get capacity report for product {} by metric {} in range [{}, {}] for category {}",
+        productId,
+        metricId,
+        beginning,
+        ending,
+        reportCategory);
     HypervisorReportCategory hypervisorReportCategory =
         HypervisorReportCategory.mapCategory(reportCategory);
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepository.java
@@ -43,8 +43,6 @@ public interface SubscriptionMeasurementRepository
     extends JpaRepository<SubscriptionMeasurement, SubscriptionMeasurementKey>,
         JpaSpecificationExecutor<SubscriptionMeasurement> {
 
-  String CORES = MetricId.CORES.toString().toUpperCase();
-  String SOCKETS = MetricId.SOCKETS.toString().toUpperCase();
   String SUBSCRIPTION_ALIAS = "subscription";
 
   @SuppressWarnings("java:S107")
@@ -171,16 +169,6 @@ public interface SubscriptionMeasurementRepository
     };
   }
 
-  static Specification<SubscriptionMeasurement> coresCriteria(
-      HypervisorReportCategory hypervisorReportCategory) {
-    return metricsCriteria(hypervisorReportCategory, CORES);
-  }
-
-  static Specification<SubscriptionMeasurement> socketsCriteria(
-      HypervisorReportCategory hypervisorReportCategory) {
-    return metricsCriteria(hypervisorReportCategory, SOCKETS);
-  }
-
   static Specification<SubscriptionMeasurement> metricsCriteria(
       HypervisorReportCategory hypervisorReportCategory, String attribute) {
     return (root, query, builder) -> {
@@ -273,12 +261,8 @@ public interface SubscriptionMeasurementRepository
 
     if (Objects.nonNull(metricId)) {
       searchCriteria =
-          switch (metricId) {
-            case CORES -> searchCriteria.and(coresCriteria(hypervisorReportCategory));
-            case SOCKETS -> searchCriteria.and(socketsCriteria(hypervisorReportCategory));
-            default -> throw new IllegalStateException(
-                metricId + " is not a support metricId for this query");
-          };
+          searchCriteria.and(
+              metricsCriteria(hypervisorReportCategory, metricId.toString().toUpperCase()));
     }
     return searchCriteria;
   }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-932](https://issues.redhat.com/browse/SWATCH-932)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Get the capacity metrics endpoint to support metrics other than sockets/cores

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert into tables:
- INSERT INTO subscription
```
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id, has_unlimited_usage) VALUES ('RH3413336', '123', '1234576', 2, '2021-12-08 22:21:40.392000 +00:00', '2021-12-08 22:38:20.392000 +00:00', null, 'null', null, null, null, false);
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id, has_unlimited_usage) VALUES ('RH3413336', 'org123', '235255', 1, '2011-01-01 01:02:33.000000 +00:00', '2031-01-01 01:02:33.000000 +00:00', null, '123', '2253594', null, null, true);
```

- INSERT INTO subscription_measurements:
```
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('1234576', '2021-12-08 22:21:40.392000 +00:00', 'SOCKETS', 'PHYSICAL', 4);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('235255', '2011-01-01 01:02:33.000000 +00:00', 'SOCKETS', 'PHYSICAL', 2);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('235255', '2011-01-01 01:02:33.000000 +00:00', 'CORES', 'PHYSICAL', 4);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('1234576', '2021-12-08 22:21:40.392000 +00:00', 'CORES', 'PHYSICAL', 8);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('235255', '2011-01-01 01:02:33.000000 +00:00', 'INSTANCE-HOURS', 'PHYSICAL', 4);
```

- INSERT INTO subscription_product_ids
```
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Server', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Workstation', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Desktop', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Server', '1234576', '2021-12-08 22:21:40.392000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Workstation', '1234576', '2021-12-08 22:21:40.392000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Desktop', '1234576', '2021-12-08 22:21:40.392000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '1234576', '2021-12-08 22:21:40.392000 +00:00');
```

2. Execute:  `DEV_MODE=true SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true PRODUCT_USE_STUB=true ./gradlew :bootRun`

### Steps
<!-- Enter each step of the test below -->
**1. Test 1:**
Execute  `curl -X 'GET' 'http://localhost:8000/api/rhsm-subscriptions/v1/capacity/products/RHEL/Sockets?granularity=Daily&beginning=2011-01-01T00%3A32%3A28Z&ending=2011-01-02T17%3A32%3A28Z&category=virtual'  -H 'accept: application/vnd.api+json'  -H 'x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`
 
**Verification**
<!-- Enter the steps needed to verify the test passed -->
Response: `{"data":[{"date":"2011-01-01T00:00:00Z","has_data":false,"value":0,"has_infinite_quantity":false},{"date":"2011-01-02T00:00:00Z","has_data":true,"value":2,"has_infinite_quantity":true}],"meta":{"count":2,"product":"RHEL","metric_id":"Sockets","granularity":"Daily","category":"virtual"}}`

Note for date: 2011-01-02T00:00:00Z it shows value 2

**2. Test 2:**
Execute `curl -X 'GET' 'http://localhost:8000/api/rhsm-subscriptions/v1/capacity/products/RHEL/INSTANCE-HOURS?granularity=Daily&beginning=2011-01-01T00%3A32%3A28Z&ending=2011-01-02T17%3A32%3A28Z&category=virtual'  -H 'accept: application/vnd.api+json'  -H 'x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`

**Verification:**
`{"data":[{"date":"2011-01-01T00:00:00Z","has_data":false,"value":0,"has_infinite_quantity":false},{"date":"2011-01-02T00:00:00Z","has_data":true,"value":4,"has_infinite_quantity":true}],"meta":{"count":2,"product":"RHEL","metric_id":"Instance-hours","granularity":"Daily","category":"virtual"}}`

Note for date: 2011-01-02T00:00:00Z it shows value 4

**3. Test 3:**
Execute ` curl -X 'GET' 'http://localhost:8000/api/rhsm-subscriptions/v1/capacity/products/RHEL/CORE-SECONDS?granularity=Daily&beginning=2011-01-01T00%3A32%3A28Z&ending=2011-01-02T17%3A32%3A28Z&category=virtual'  -H 'accept: application/vnd.api+json'  -H 'x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`

**Verification:**
Response: `{"data":[{"date":"2011-01-01T00:00:00Z","has_data":false,"value":0,"has_infinite_quantity":false},{"date":"2011-01-02T00:00:00Z","has_data":false,"value":0,"has_infinite_quantity":true}],"meta":{"count":2,"product":"RHEL","metric_id":"Core-seconds","granularity":"Daily","category":"virtual"}}`

Note for any date you pass it shows value 0 since there is no such metric_id in table yet.