### PR TITLE
SWATCH-1347 Subscription showing Product Name instead of Offering name

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -272,7 +272,7 @@ public class SubscriptionTableController {
             .findById(sku)
             .orElseThrow(() -> new IllegalStateException("No offering" + " found for sku " + sku));
     inv.setSku(sku);
-    inv.setProductName(offering.getProductName());
+    inv.setProductName(offering.getDescription());
     inv.setServiceLevel(
         Optional.ofNullable(offering.getServiceLevel()).orElse(ServiceLevel.EMPTY).asOpenApiEnum());
     inv.setUsage(Optional.ofNullable(offering.getUsage()).orElse(Usage.EMPTY).asOpenApiEnum());


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1347](https://issues.redhat.com/browse/SWATCH-1347)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
After SWATCH-1202 got deployed the response of getSkuCapacityReport > `api/rhsm-subscriptions/v1/subscriptions/products` is showing Product Name instead of Offering Name in subscription table api.

RH00001 - RHEL Server
RH00004 - RHEL Server

instead we want 
RH00001 - Red Hat Enterprise Linux for Virtual Datacenters, Premium
RH00004 - Red Hat Enterprise Linux Server, Standard (Physical or Virtual Nodes)

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert into tables:
- INSERT INTO subscription

```
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id, has_unlimited_usage) VALUES ('MW01882', '123', '235252', 1, '2011-01-01 01:02:33.000000 +00:00', '2031-01-01 01:02:33.000000 +00:00', null, '123', '4243626', null, null, null);
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id, has_unlimited_usage) VALUES ('BASILISK', 'orgId_asdfasdf', '235252', 1, '2023-04-24 04:00:00.000000 +00:00', '2023-04-24 18:17:02.000000 +00:00', null, 'account123', 'subscriptionNumber_swatch-972', '', null, null);
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id, has_unlimited_usage) VALUES ('RH3413336', '123', '1234576', 2, '2021-12-08 22:21:40.392000 +00:00', '2021-12-08 22:38:20.392000 +00:00', null, 'null', null, null, null, false);
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id, has_unlimited_usage) VALUES ('RH3413336', 'org123', '235255', 1, '2011-01-01 01:02:33.000000 +00:00', '2031-01-01 01:02:33.000000 +00:00', null, '123', '2253594', null, null, true);

```


- INSERT INTO offering 

```
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('BASILISK', 'BASILISK', null, 0, 0, 0, 0, 'BASLISK', 'Premium', 'Production', null, null, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('actual_MW01882', 'OpenShift Streams for Apache Kafka', null, 0, 0, 0, 0, 'rhosak', 'Premium', 'Production', 'Red Hat OpenShift Streams for Apache Kafka (Hourly)', null, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MCT3321F3', 'Ansible Automation Academic', 'Ansible', null, null, null, null, null, 'Standard', '', 'Red Hat Ansible Automation (Academic Edition), Standard (10000 Managed Nodes)', false, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW01882', 'OpenShift Dedicated', null, 0, 0, 0, 0, 'osd', 'Premium', 'Production', 'Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)', null, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW11884', 'OpenShift Dedicated', null, 0, 0, 0, 0, 'osd', 'Premium', 'Production', 'Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)', null, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('RH00001', 'OpenShift Dedicated', '', null, null, null, 2, 'osd', 'Premium', '', 'Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)', false, 'Article_1589801907847034');
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('RH3413336', 'RHEL Developer Workstation', 'Red Hat Enterprise Linux', 4, 2, null, null, null, '', 'Development/Test', 'Red Hat Enterprise Linux Developer Workstation, Enterprise', false, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW01485', 'OpenShift Container Platform', 'OpenShift Enterprise', null, null, null, null, null, 'Premium', '', 'Red Hat OpenShift Container Platform (Hourly)', false, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('RH0180191', 'RHEL Server', 'Red Hat Enterprise Linux', null, 2, null, null, 'Red Hat Enterprise Linux Server', 'Standard', 'Production', 'Red Hat Enterprise Linux Server, Standard (1-2 sockets) (Up to 4 guests) with Smart Management', false, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW00330', 'Red Hat OpenShift Container Platform, Standard (16 Cores or 32 vCPUs)', 'OpenShift Enterprise', 16, null, null, null, null, 'Standard', '', 'Red Hat OpenShift Container Platform for Customer Entitlement qty', false, null);

```

- INSERT INTO subscription_product_ids

```
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Server', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Workstation', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Desktop', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '235255', '2011-01-01 01:02:33.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Server', '1234576', '2021-12-08 22:21:40.392000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Workstation', '1234576', '2021-12-08 22:21:40.392000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL Desktop', '1234576', '2021-12-08 22:21:40.392000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '1234576', '2021-12-08 22:21:40.392000 +00:00');

```

3. Run  `DEV_MODE=true SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true PRODUCT_USE_STUB=true ./gradlew :bootRun`

### Steps
<!-- Enter each step of the test below -->
1. Execute `curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL'   -H 'accept: application/vnd.api+json' -H 'x-rh-identity:eyJpZGVudGl0eSeyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Response: `{"data":[{"sku":"RH3413336","product_name":"Red Hat Enterprise Linux Developer Workstation, Enterprise","service_level":"","usage":"Development/Test","subscriptions":[{"id":"235255","number":"2253594"}],"next_event_date":"2031-01-01T01:02:33Z","next_event_type":"Subscription End","quantity":1,"capacity":4,"hypervisor_capacity":0,"total_capacity":4,"has_infinite_quantity":true,"uom":"cores"}],"meta":{"count":1,"product":"RHEL","subscription_type":"Annual"}}`

Note: In response `"product_name":"Red Hat Enterprise Linux Developer Workstation, Enterprise"` instead of `RHEL Developer Workstation`
