### PR TITLE
SWATCH-1343: Improve performance in SubscriptionTableController

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -136,17 +136,6 @@ public class SubscriptionTableController {
             reportStart,
             reportEnd);
 
-    Map<String, SkuCapacity> inventories = new HashMap<>();
-    for (SubscriptionMeasurement measurement : measurements) {
-      String sku = measurement.getSubscription().getSku();
-      var subscription = measurement.getSubscription();
-      final SkuCapacity inventory =
-          inventories.computeIfAbsent(sku, key -> initializeDefaultSkuCapacity(subscription, uom));
-      calculateNextEvent(subscription, inventory, reportEnd);
-      addSubscriptionInformation(subscription, inventory);
-      addTotalCapacity(measurement, inventory);
-    }
-
     var reportCriteria =
         DbReportCriteria.builder()
             .orgId(orgId)
@@ -156,7 +145,28 @@ public class SubscriptionTableController {
             .beginning(reportStart)
             .ending(reportEnd)
             .build();
-    handleUnlimitedSubs(inventories, uom, reportCriteria);
+    List<Subscription> unlimitedSubs = subscriptionRepository.findUnlimited(reportCriteria);
+
+    var skus =
+        measurements.stream().map(x -> x.getSubscription().getSku()).collect(Collectors.toSet());
+    skus.addAll(unlimitedSubs.stream().map(Subscription::getSku).collect(Collectors.toSet()));
+
+    Map<String, SkuCapacity> inventories = initializeDefaultSkuCapacities(skus, uom);
+
+    for (SubscriptionMeasurement measurement : measurements) {
+      Subscription subscription = measurement.getSubscription();
+      SkuCapacity inventory = inventories.get(subscription.getSku());
+      calculateNextEvent(subscription, inventory, reportEnd);
+      addSubscriptionInformation(subscription, inventory);
+      addTotalCapacity(measurement, inventory);
+    }
+
+    for (Subscription subscription : unlimitedSubs) {
+      SkuCapacity inventory = inventories.get(subscription.getSku());
+      inventory.setHasInfiniteQuantity(true);
+      calculateNextEvent(subscription, inventory, reportCriteria.getEnding());
+      addSubscriptionInformation(subscription, inventory);
+    }
 
     List<SkuCapacity> reportItems = new ArrayList<>(inventories.values());
 
@@ -197,16 +207,33 @@ public class SubscriptionTableController {
                 .product(productId));
   }
 
-  private void handleUnlimitedSubs(
-      Map<String, SkuCapacity> inventories, Uom uom, DbReportCriteria reportCriteria) {
-    var unlimitedSubs = subscriptionRepository.findUnlimited(reportCriteria);
-    for (Subscription s : unlimitedSubs) {
-      SkuCapacity capacity =
-          inventories.computeIfAbsent(s.getSku(), key -> initializeDefaultSkuCapacity(s, uom));
-      capacity.setHasInfiniteQuantity(true);
-      calculateNextEvent(s, capacity, reportCriteria.getEnding());
-      addSubscriptionInformation(s, capacity);
+  private Map<String, SkuCapacity> initializeDefaultSkuCapacities(Set<String> skus, Uom uom) {
+    Map<String, SkuCapacity> capacityTemplates = new HashMap<>();
+    for (Offering offering : offeringRepository.findBySkuIn(skus)) {
+      // No information specific to an engineering product within an offering is added.
+      var inventory = new SkuCapacity();
+      inventory.setSku(offering.getSku());
+      inventory.setProductName(offering.getDescription());
+      inventory.setServiceLevel(
+          Optional.ofNullable(offering.getServiceLevel())
+              .orElse(ServiceLevel.EMPTY)
+              .asOpenApiEnum());
+      inventory.setUsage(
+          Optional.ofNullable(offering.getUsage()).orElse(Usage.EMPTY).asOpenApiEnum());
+
+      // When uom param is set, force all inventories to report capacities for that UoM
+      // (Some products have both sockets and cores)
+      if (uom != null) {
+        inventory.setUom(uom);
+      }
+      inventory.setQuantity(0);
+      inventory.setCapacity(0);
+      inventory.setHypervisorCapacity(0);
+      inventory.setTotalCapacity(0);
+      inventory.setSubscriptions(new ArrayList<>());
+      capacityTemplates.put(offering.getSku(), inventory);
     }
+    return capacityTemplates;
   }
 
   private List<SkuCapacity> paginate(List<SkuCapacity> capacities, Pageable pageable) {
@@ -259,35 +286,6 @@ public class SubscriptionTableController {
           addOnDemandSubscriptionInformation(sub, inventory);
         });
     return inventories.values();
-  }
-
-  public SkuCapacity initializeDefaultSkuCapacity(Subscription subscription, Uom uom) {
-    // If no inventory is associated with the SKU key, then initialize a new inventory
-    // with offering-specific data and default values. No information specific to an
-    // engineering product within an offering is added.
-    var inv = new SkuCapacity();
-    String sku = subscription.getSku();
-    Offering offering =
-        offeringRepository
-            .findById(sku)
-            .orElseThrow(() -> new IllegalStateException("No offering" + " found for sku " + sku));
-    inv.setSku(sku);
-    inv.setProductName(offering.getDescription());
-    inv.setServiceLevel(
-        Optional.ofNullable(offering.getServiceLevel()).orElse(ServiceLevel.EMPTY).asOpenApiEnum());
-    inv.setUsage(Optional.ofNullable(offering.getUsage()).orElse(Usage.EMPTY).asOpenApiEnum());
-
-    // When uom param is set, force all inventories to report capacities for that UoM
-    // (Some products have both sockets and cores)
-    if (uom != null) {
-      inv.setUom(uom);
-    }
-    inv.setQuantity(0);
-    inv.setCapacity(0);
-    inv.setHypervisorCapacity(0);
-    inv.setTotalCapacity(0);
-    inv.setSubscriptions(new ArrayList<>());
-    return inv;
   }
 
   public SkuCapacity initializeOnDemandSkuCapacity(Subscription subscription, Offering offering) {

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -28,11 +28,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.core.Response;
@@ -169,11 +165,15 @@ class SubscriptionTableControllerTest {
   }
 
   private void mockOfferings(MeasurementSpec... specs) {
+    Set<String> skus = new HashSet<>();
+    List<Offering> offerings = new ArrayList<>();
     Arrays.stream(specs)
         .forEach(
-            x ->
-                when(offeringRepository.findById(x.sku))
-                    .thenReturn(Optional.of(x.createOffering())));
+            x -> {
+              skus.add(x.sku);
+              offerings.add(x.createOffering());
+            });
+    when(offeringRepository.findBySkuIn(skus)).thenReturn(offerings);
   }
 
   @Test
@@ -564,13 +564,14 @@ class SubscriptionTableControllerTest {
     var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
     var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
     var expectedMuchOlderSub = stubSubscription("1238", "1237", 5, 24, 6);
+
     var coresSpec1 = RH0180193_CORES.withSub(expectedNewerSub);
     var coresSpec2 = RH0180194_SOCKETS_AND_CORES.withSub(expectedMuchOlderSub);
+    mockOfferings(coresSpec1, coresSpec2);
 
     var socketsSpec1 = RH0180192_SOCKETS.withSub(expectedOlderSub);
     var socketsSpec2 = RH0180194_SOCKETS_AND_CORES.withSub(expectedMuchOlderSub);
-
-    mockOfferings(coresSpec1, coresSpec2, socketsSpec1, socketsSpec2);
+    mockOfferings(socketsSpec1, socketsSpec2);
 
     var capacitiesWithCores = givenCapacities(Org.STANDARD, productId, coresSpec1, coresSpec2);
     var capacitiesWithSockets =

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
@@ -34,6 +34,8 @@ public interface OfferingRepository extends JpaRepository<Offering, String> {
 
   List<Offering> findByProductName(String productName);
 
+  List<Offering> findBySkuIn(Set<String> skus);
+
   @Query(value = "select sku from Offering where :sku member of childSkus")
   Stream<String> findSkusForChildSku(@Param("sku") String sku);
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -31,8 +31,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import lombok.*;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
 
 /**
  * Represents a product Offering that can be provided by a Subscription.
@@ -89,7 +87,6 @@ public class Offering implements Serializable {
   /** Internal identifiers for products that compose an Offering. */
   @Builder.Default
   @ElementCollection
-  @LazyCollection(LazyCollectionOption.FALSE)
   @CollectionTable(name = "sku_child_sku", joinColumns = @JoinColumn(name = "sku"))
   @Column(name = "child_sku")
   private Set<String> childSkus = new HashSet<>();
@@ -106,7 +103,6 @@ public class Offering implements Serializable {
    */
   @Builder.Default
   @ElementCollection
-  @LazyCollection(LazyCollectionOption.FALSE)
   @CollectionTable(name = "sku_oid", joinColumns = @JoinColumn(name = "sku"))
   @Column(name = "oid")
   private Set<Integer> productIds = new HashSet<>();


### PR DESCRIPTION
The old code was fetching the offerings for the SKUs one at a time as we moved through the subscriptions.  Instead of hitting the DB over and over again for one offering at a time, this patch consolidates the queries so that we fetch all the offerings at once.

See https://issues.redhat.com/browse/SWATCH-1343

<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1343](https://issues.redhat.com/browse/SWATCH-1343)

## Description
[SWATCH-1202](https://issues.redhat.com/browse/SWATCH-1202) (PR #2180) introduced a performance regression.  Calls to `api/rhsm-subscriptions/v1/subscriptions/products/{product_id}` were taking a very long time.  Analysis in SignalFx revealed numerous hits to the `offering`, `sku_oid`, and `sku_child_sku` tables over the course of the API call.  This PR consolidates those requests into one batch query for all the offerings.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Import database.  See the private comment on https://issues.redhat.com/browse/SWATCH-1202 for a link to the file.
   ```shell
   createdb -h localhost -U postgres swatch-1343
   zcat swatch-1343-db.dump.gz | psql -h localhost -U rhsm-subscriptions swatch-1343
   ```
1. Deploy main
   ```shell
   DATABASE_DATABASE=swatch-1343 ./gradlew :bootRun --args="--spring.jpa.show-sql=true --spring.jpa.properties.hibernate.format_sql=true"
   ```

### Steps
<!-- Enter each step of the test below -->
1. Make a call to `/subscriptions/products/{product_id}
   ```shell
   http :8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"13269666"}}}' | base64 -w0)
   ```
1. Observe a bunch of queries to `offering`, `sku_oid`, and `sku_child_sku` go flying past.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Deploy this branch.  Run the same `http` call outlined previously.
1. Observe that there's only one call made to `offering` and that the `WHERE` clause looks like 
   ```   
   where
     offering0_.sku in (
         ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ?
     )
   ```
1. Observe that there are no calls to `sku_oid` or `sku_child_sku`.  I set those collections to be lazy loaded instead of eager fetched.