### PR TITLE
SWATCH-1345 Do not filter the contract lookup by metricId

### DIFF
--- a/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/StubContactsApi.java
+++ b/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/StubContactsApi.java
@@ -33,11 +33,12 @@ import java.util.List;
  */
 public class StubContactsApi extends DefaultApi {
 
+  private static final String CONTRACT_METRIC_ID = "four_vcpu_hour";
+
   @Override
   public List<Contract> getContract(
       String orgId,
       String productId,
-      String metricId,
       String vendorProductCode,
       String billingProvider,
       String billingAccountId,
@@ -49,9 +50,21 @@ public class StubContactsApi extends DefaultApi {
 
     return List.of(
         createContract(
-            orgId, productId, metricId, vendorProductCode, billingProvider, billingAccountId, 5),
+            orgId,
+            productId,
+            CONTRACT_METRIC_ID,
+            vendorProductCode,
+            billingProvider,
+            billingAccountId,
+            5),
         createContract(
-            orgId, productId, metricId, vendorProductCode, billingProvider, billingAccountId, 10));
+            orgId,
+            productId,
+            CONTRACT_METRIC_ID,
+            vendorProductCode,
+            billingProvider,
+            billingAccountId,
+            10));
   }
 
   private Contract createContract(

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/ContractsController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/ContractsController.java
@@ -84,15 +84,13 @@ public class ContractsController {
               usage.getBillingProvider(), usage.getProductId(), usage.getUom()));
     }
 
-    log.debug(
-        "Looking up contract information for usage {} using metric ID {}", usage, contractMetricId);
+    log.debug("Looking up contract information for usage {}", usage);
     List<Contract> contracts;
     try {
       contracts =
           contractsApi.getContract(
               usage.getOrgId(),
               usage.getProductId(),
-              contractMetricId,
               usage.getVendorProductCode(),
               usage.getBillingProvider().value(),
               usage.getBillingAccountId(),

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -602,13 +602,7 @@ class BillableUsageControllerTest {
 
     log.info("Second: {}", updatedContract);
     when(contractsApi.getContract(
-            orgId,
-            productId,
-            metric,
-            vendorProductCode,
-            billingProvider,
-            billingAccountId,
-            startDate))
+            orgId, productId, vendorProductCode, billingProvider, billingAccountId, startDate))
         .thenReturn(List.of(contract1, updatedContract));
   }
 
@@ -618,8 +612,7 @@ class BillableUsageControllerTest {
     usage.setSnapshotDate(OffsetDateTime.now());
     usage.setUom(Uom.CORES);
     when(tagProfile.isTagContractEnabled(usage.getProductId())).thenReturn(true);
-    when(contractsApi.getContract(any(), any(), any(), any(), any(), any(), any()))
-        .thenReturn(List.of());
+    when(contractsApi.getContract(any(), any(), any(), any(), any(), any())).thenReturn(List.of());
     when(tagProfile.awsDimensionForTagAndUom(
             usage.getProductId(), TallyMeasurement.Uom.fromValue(usage.getUom().value())))
         .thenReturn(AWS_METRIC_ID);

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/ContractsControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/ContractsControllerTest.java
@@ -96,7 +96,6 @@ class ContractsControllerTest {
     when(contractsApi.getContract(
             usage.getOrgId(),
             usage.getProductId(),
-            CONTRACT_METRIC_ID,
             usage.getVendorProductCode(),
             usage.getBillingProvider().value(),
             usage.getBillingAccountId(),
@@ -109,7 +108,6 @@ class ContractsControllerTest {
         .getContract(
             usage.getOrgId(),
             usage.getProductId(),
-            CONTRACT_METRIC_ID,
             usage.getVendorProductCode(),
             usage.getBillingProvider().toString(),
             usage.getBillingAccountId(),
@@ -133,7 +131,6 @@ class ContractsControllerTest {
     when(contractsApi.getContract(
             usage.getOrgId(),
             usage.getProductId(),
-            CONTRACT_METRIC_ID,
             usage.getVendorProductCode(),
             usage.getBillingProvider().value(),
             usage.getBillingAccountId(),
@@ -146,7 +143,6 @@ class ContractsControllerTest {
         .getContract(
             usage.getOrgId(),
             usage.getProductId(),
-            CONTRACT_METRIC_ID,
             usage.getVendorProductCode(),
             usage.getBillingProvider().toString(),
             usage.getBillingAccountId(),
@@ -204,7 +200,6 @@ class ContractsControllerTest {
     when(contractsApi.getContract(
             usage.getOrgId(),
             usage.getProductId(),
-            CONTRACT_METRIC_ID,
             usage.getVendorProductCode(),
             usage.getBillingProvider().value(),
             usage.getBillingAccountId(),
@@ -233,7 +228,6 @@ class ContractsControllerTest {
     when(contractsApi.getContract(
             usage.getOrgId(),
             usage.getProductId(),
-            CONTRACT_METRIC_ID,
             usage.getVendorProductCode(),
             usage.getBillingProvider().value(),
             usage.getBillingAccountId(),
@@ -284,7 +278,6 @@ class ContractsControllerTest {
     when(contractsApi.getContract(
             usage.getOrgId(),
             usage.getProductId(),
-            CONTRACT_METRIC_ID,
             usage.getVendorProductCode(),
             usage.getBillingProvider().value(),
             usage.getBillingAccountId(),
@@ -305,7 +298,7 @@ class ContractsControllerTest {
         .thenReturn(CONTRACT_METRIC_ID);
     doThrow(ApiException.class)
         .when(contractsApi)
-        .getContract(any(), any(), any(), any(), any(), any(), any());
+        .getContract(any(), any(), any(), any(), any(), any());
     ExternalServiceException e =
         assertThrows(
             ExternalServiceException.class,
@@ -321,7 +314,7 @@ class ContractsControllerTest {
   void throwsContractMissingExceptionWhenNoContractsFound() throws Exception {
     BillableUsage usage = defaultUsage();
     when(tagProfile.isTagContractEnabled(usage.getProductId())).thenReturn(true);
-    when(contractsApi.getContract(any(), any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getContract(any(), any(), any(), any(), any(), any()))
         .thenReturn(new ArrayList<>());
     when(tagProfile.awsDimensionForTagAndUom(any(), any())).thenReturn(CONTRACT_METRIC_ID);
     ContractMissingException e =

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -70,7 +70,6 @@ public class ContractsTestingResource implements DefaultApi {
    *
    * @param orgId
    * @param productId
-   * @param metricId
    * @param billingProvider
    * @param billingAccountId
    * @return List<Contract> dtos
@@ -82,20 +81,13 @@ public class ContractsTestingResource implements DefaultApi {
   public List<Contract> getContract(
       String orgId,
       String productId,
-      String metricId,
       String vendorProductCode,
       String billingProvider,
       String billingAccountId,
       OffsetDateTime timestamp)
       throws ApiException, ProcessingException {
     return service.getContracts(
-        orgId,
-        productId,
-        metricId,
-        billingProvider,
-        billingAccountId,
-        vendorProductCode,
-        timestamp);
+        orgId, productId, billingProvider, billingAccountId, vendorProductCode, timestamp);
   }
 
   @Override

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -129,7 +129,6 @@ public class ContractService {
    *
    * @param orgId
    * @param productId
-   * @param metricId
    * @param billingProvider
    * @param billingAccountId
    * @param vendorProductCode
@@ -138,7 +137,6 @@ public class ContractService {
   public List<Contract> getContracts(
       String orgId,
       String productId,
-      String metricId,
       String billingProvider,
       String billingAccountId,
       String vendorProductCode,
@@ -148,9 +146,6 @@ public class ContractService {
 
     if (productId != null) {
       specification = specification.and(ContractEntity.productIdEquals(productId));
-    }
-    if (metricId != null) {
-      specification = specification.and(ContractEntity.metricIdEquals(metricId));
     }
     if (billingProvider != null) {
       specification = specification.and(ContractEntity.billingProviderEquals(billingProvider));

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -164,14 +164,6 @@ paths:
             type: string
           in: query
         - examples:
-            metric_id:
-              value: Instance-hours
-          name: metric_id
-          description: ""
-          schema:
-            type: string
-          in: query
-        - examples:
             vendor_product_code:
               value: 6n58d3s3qpvk22dgew2gal7w3
           name: vendor_product_code

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointIntegrationTest.java
@@ -49,7 +49,7 @@ class ContractsHttpEndpointIntegrationTest {
   void whenGetContract_thenContractShouldBeFound() {
     Contract contract = new Contract();
     contract.setOrgId("org123");
-    when(contractService.getContracts(any(), any(), any(), any(), any(), any(), any()))
+    when(contractService.getContracts(any(), any(), any(), any(), any(), any()))
         .thenReturn(List.of(contract));
     given()
         .contentType(ContentType.JSON)

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -123,7 +123,7 @@ class ContractServiceTest extends BaseUnitTest {
     var spec =
         ContractEntity.orgIdEquals("org123").and(ContractEntity.productIdEquals("BASILISK123"));
     List<Contract> contractList =
-        contractService.getContracts("org123", "BASILISK123", null, null, null, null, null);
+        contractService.getContracts("org123", "BASILISK123", null, null, null, null);
     verify(contractRepository).getContracts(any());
     assertEquals(1, contractList.size());
     assertEquals(2, contractList.get(0).getMetrics().size());


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1345](https://issues.redhat.com/browse/SWATCH-1345)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Given a pure PAYG contract, which comes across with neither dimensions for vCPUs nor instance hours, the billable usage controller is unable to recognize a contract when trying to send usage to AWS. This should be fixed by not filtering the contract lookup by metricId. For this bug we are changing the method signature in contract and swatch-core.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
Clean up any existing data.
```bash
psql -U rhsm-subscriptions rhsm-subscriptions << EOF
-- cleanup the tables
truncate events;
truncate tally_snapshots cascade;
truncate hosts cascade;
truncate billable_usage_remittance;
truncate contracts cascade;
EOF
```

Insert the following data into the DB.
```bash
psql -U rhsm-subscriptions rhsm-subscriptions << EOF
-- contracts
INSERT INTO contracts VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', '12914277', '2023-05-10 15:20:07.717275-03', '2023-05-10 15:20:07.717275-03', NULL, 'org123', 'MW02393', 'aws', 'aws123', 'rosa', 'bcwuzc8ww10vvxfair55mliy8');

-- events
INSERT INTO public.events VALUES ('1464d3e9-2cb7-44c6-b0b6-8bef0ecb57d8', 'account123', '2023-05-11 11:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "1464d3e9-2cb7-44c6-b0b6-8bef0ecb57d8", "timestamp": "2023-05-11T14:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-05-11T15:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 2.3333333333333335}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('68f95e47-5751-48e3-89e0-655c8f99fe6d', 'account123', '2023-05-11 11:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "68f95e47-5751-48e3-89e0-655c8f99fe6d", "timestamp": "2023-05-11T14:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-05-11T15:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 0.6666666666666666}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('6fc851d9-6372-42ca-8758-690306d70718', 'account123', '2023-05-11 12:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "6fc851d9-6372-42ca-8758-690306d70718", "timestamp": "2023-05-11T15:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-05-11T16:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('f95c0ea1-5aae-4928-be9a-48e79b200fd5', 'account123', '2023-05-11 12:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "f95c0ea1-5aae-4928-be9a-48e79b200fd5", "timestamp": "2023-05-11T15:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-05-11T16:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('b48da70c-79cd-4504-ad77-ac9b5a31e016', 'account123', '2023-05-11 13:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "b48da70c-79cd-4504-ad77-ac9b5a31e016", "timestamp": "2023-05-11T16:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-05-11T17:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.0}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');
INSERT INTO public.events VALUES ('0d47af0e-2aad-4fef-b7ef-57397bda3b15', 'account123', '2023-05-11 13:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "0d47af0e-2aad-4fef-b7ef-57397bda3b15", "timestamp": "2023-05-11T16:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-05-11T17:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');

EOF
```

### Reproducer
From the **main** branch.

Start the contract service in one console.
```
SERVER_PORT=8882 ./gradlew  :swatch-contracts:quarkusDev
```

Start tally (configured to point at the contracts service) in another console.
```
SPRING_PROFILES_ACTIVE=worker,kafka-task-queue SWATCH_CONTRACTS_INTERNAL_SERVICE_URL=http://localhost:8882 DEV_MODE=true ./gradlew :bootRun
```

Perform a nightly tally that covers the timespan of the Events that we added to the DB.
```
http :9000/hawtio/jolokia type=exec \
mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean' \
operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)' \
arguments:='["org123", "2023-05-01T00:00Z", "2023-05-15T23:00Z"]'
```

**Error:**
[ERROR] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - SUBSCRIPTIONS3004: Expected contract missing - Unable to retrieve contract for usage older than 30 minutes old. Usage: org.candlepin.subscriptions.json.BillableUsage@231fbcc[accountNumber=account123,orgId=org123,id=56b454f1-38c9-4635-b983-dce538469341,billingProvider=aws,billingAccountId=aws123,snapshotDate=2023-05-11T16:00Z,productId=rosa,sla=Premium,usage=Production,uom=Cores,value=4.0,billingFactor=<null>,vendorProductCode=<null>]

### ### Testing The Fix Steps
<!-- Enter each step of the test below -->
1. Execute the swatch-contract and swatch-core followed by nightly tally on the current branch.

### Verification
<!-- Enter the steps needed to verify the test passed -->
Response: No errors
