### PR TITLE
Fix incorrect RH_ prefix from some internal roles

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsServiceTest.java
@@ -76,7 +76,7 @@ class IdentityHeaderAuthenticationDetailsServiceTest {
     Authentication auth = new PreAuthenticatedAuthenticationToken(new RhAssociatePrincipal(), null);
     UserDetails userDetails = detailsService.loadUserDetails(auth);
     assertEquals(
-        Collections.singleton(new SimpleGrantedAuthority("ROLE_RH_INTERNAL")),
+        Collections.singleton(new SimpleGrantedAuthority("ROLE_INTERNAL")),
         userDetails.getAuthorities());
     verifyNoInteractions(rbacApi);
   }
@@ -86,7 +86,7 @@ class IdentityHeaderAuthenticationDetailsServiceTest {
     Authentication auth = new PreAuthenticatedAuthenticationToken(new X509Principal(), null);
     UserDetails userDetails = detailsService.loadUserDetails(auth);
     assertEquals(
-        Collections.singleton(new SimpleGrantedAuthority("ROLE_RH_INTERNAL")),
+        Collections.singleton(new SimpleGrantedAuthority("ROLE_INTERNAL")),
         userDetails.getAuthorities());
     verifyNoInteractions(rbacApi);
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
@@ -85,7 +85,7 @@ public class IdentityHeaderAuthenticationDetailsService
     if (principal instanceof InsightsUserPrincipal) {
       userRoles = getUserRoles();
     } else {
-      userRoles = Collections.singleton("RH_INTERNAL");
+      userRoles = Collections.singleton("INTERNAL");
     }
     Collection<? extends GrantedAuthority> userGAs = authMapper.getGrantedAuthorities(userRoles);
 


### PR DESCRIPTION
Description
===========

In some places we were granting `RH_INTERNAL` and in some places simply `INTERNAL`. Because of this, it was not sufficient to auth via x509 cert when using internal endpoints.

Testing
=======

Steps
-----

1. Deploy the service:

```shell
./gradlew :bootRun
```

2. Hit the opt-in endpoint w/ a header mimicing turnpike w/ x509 auth:

```shell
http PUT localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/opt-in \
  org_id==org123 \
  account_number==account123 \
  x-rh-identity:$(echo '{"identity":{"auth_type":"x509","type":"X509","x509":{"subject_dn":"CN=test.example.com"}}}' | base64 -w0) \
  Origin:console.redhat.com
```

With `main`, you'll get a 403, with this change, you'll get a success.