### PR TITLE
SWATCH-1356: Use subscription compound ID as map key in SubscriptionSyncController

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -312,14 +312,14 @@ public class SubscriptionSyncController {
     log.info("Syncing subscriptions for orgId={}", orgId);
     Set<String> seenSubscriptionIds = new HashSet<>();
     Map<SubscriptionCompoundId, org.candlepin.subscriptions.db.model.Subscription>
-        swatchSubscriptions =
-            subscriptionRepository
-                .findByOrgId(orgId)
-                .collect(
-                    Collectors.toMap(
-                        sub ->
-                            new SubscriptionCompoundId(sub.getSubscriptionId(), sub.getStartDate()),
-                        Function.identity()));
+        swatchSubscriptions;
+    try (var subs = subscriptionRepository.findByOrgId(orgId)) {
+      swatchSubscriptions =
+          subs.collect(
+              Collectors.toMap(
+                  sub -> new SubscriptionCompoundId(sub.getSubscriptionId(), sub.getStartDate()),
+                  Function.identity()));
+    }
     subscriptionService.getSubscriptionsByOrgId(orgId).stream()
         .filter(this::shouldSyncSub)
         .forEach(


### PR DESCRIPTION
We can have multiple subscriptions with the same subscription ID.  It's the combination of ID and start date that's unique.  To avoid collisions, this patch uses that tuple for a map key instead of the subscription ID alone.

See https://issues.redhat.com/browse/SWATCH-1356


<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1356](https://issues.redhat.com/browse/SWATCH-1356)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This PR corrects an ongoing issue in stage.  We're seeing stacktraces that look like

```
2023-06-14 09:43:48,468 [thread=http-nio-8000-exec-4] [ERROR] [org.candlepin.subscriptions.exception.mapper.BaseExceptionMapper] self- SUBSCRIPTIONS1000: An internal server error has occurred. Check the server logs for further details. - Duplicate key 12501973 (attempted merging values Subscription(subscriptionId=12501973, subscriptionNumber=12502130, sku=RH00069, orgId=16775631, quantity=1, startDate=2023-06-06T04:00Z, endDate=2027-06-09T04:00Z, billingProviderId=null, billingAccountId=null, accountNumber=11478791, billingProvider=EMPTY, hasUnlimitedUsage=true) and Subscription(subscriptionId=12501973, subscriptionNumber=12502130, sku=RH00069, orgId=16775631, quantity=1, startDate=2023-06-07T04:00Z, endDate=2027-06-11T04:00Z, billingProviderId=null, billingAccountId=null, accountNumber=11478791, billingProvider=EMPTY, hasUnlimitedUsage=true))
java.lang.IllegalStateException: Duplicate key 12501973 (attempted merging values Subscription(subscriptionId=12501973, subscriptionNumber=12502130, sku=RH00069, orgId=16775631, quantity=1, startDate=2023-06-06T04:00Z, endDate=2027-06-09T04:00Z, billingProviderId=null, billingAccountId=null, accountNumber=11478791, billingProvider=EMPTY, hasUnlimitedUsage=true) and Subscription(subscriptionId=12501973, subscriptionNumber=12502130, sku=RH00069, orgId=16775631, quantity=1, startDate=2023-06-07T04:00Z, endDate=2027-06-11T04:00Z, billingProviderId=null, billingAccountId=null, accountNumber=11478791, billingProvider=EMPTY, hasUnlimitedUsage=true))
at java.base/java.util.stream.Collectors.duplicateKeyException(Collectors.java:135)
at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:182)
at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
at org.candlepin.subscriptions.subscription.SubscriptionSyncController.forceSyncSubscriptionsForOrg(SubscriptionSyncController.java:575)
at org.candlepin.subscriptions.subscription.SubscriptionSyncController.findSubscriptionsAndSyncIfNeeded(SubscriptionSyncController.java:641)
at org.candlepin.subscriptions.subscription.SubscriptionSyncController$$FastClassBySpringCGLIB$$27764e9d.invoke(<generated>)
```

This is due to trying to insert different Subscription objects that have the same subscription ID into a map.  It's actually the tuple of beginning date **and** subscription ID that make a Subscription unique.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1.  Insert records
    ```shell
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF                         
    insert into subscription(sku, org_id, subscription_id, quantity, start_date, end_date)
    values ('MW01882', '123', '235252', 1, '2022-02-02T01:02:03Z', '2030-02-02T02:02:02Z'),
          ('MW01882', '123', '235252', 1, now(), '2030-01-01T01:01:01Z');
    EOF
    ```
1. Start the application
   ```shell
   SUBSCRIPTION_USE_STUB=true PRODUCT_USE_STUB=true ./gradlew :bootRun --args="--rhsm-subscriptions.auth.swatchPsks.self=secret" 
   ```

### Steps
<!-- Enter each step of the test below -->
1. Force a sync
   ```shell
   curl -X PUT 'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123' -H 'x-rh-swatch-psk:secret'
   ```
1. Observe the stack trace in the log.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.  Check out this branch.
1.  Rerun the `http` command
1.  Observe there is no stack trace and the sync completes successfully.
