### PR TITLE
swatch-1363: offering hibernate initialization error fix

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/product/OfferingSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingSyncController.java
@@ -94,6 +94,7 @@ public class OfferingSyncController {
    *
    * @param sku the identifier of the marketing operational product
    */
+  @Transactional
   public SyncResult syncOffering(String sku) {
     Timer.Sample syncTime = Timer.start();
 
@@ -193,7 +194,13 @@ public class OfferingSyncController {
   // If there is an existing offering in the DB, and it exactly matches the latest upstream
   // version then return true. False means we should sync with the latest upstream version.
   private boolean alreadySynced(Optional<Offering> persisted, Offering latest) {
-    return persisted.isPresent() && Objects.equals(persisted.get(), latest);
+    return persisted
+        .map(
+            offering ->
+                Objects.equals(offering, latest)
+                    && Objects.equals(offering.getProductIds(), latest.getProductIds())
+                    && Objects.equals(offering.getChildSkus(), latest.getChildSkus()))
+        .orElse(false);
   }
 
   private void enqueueOfferingSyncTask(String sku) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.db.model;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -30,7 +31,13 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * Represents a product Offering that can be provided by a Subscription.
@@ -38,7 +45,6 @@ import lombok.*;
  * <p>Offerings are identified by SKU.
  */
 @Entity
-@EqualsAndHashCode
 @Getter
 @Setter
 @ToString
@@ -145,5 +151,47 @@ public class Offering implements Serializable {
 
   public Boolean getHasUnlimitedUsage() {
     return hasUnlimitedUsage;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Offering)) {
+      return false;
+    }
+    Offering offering = (Offering) o;
+    return Objects.equals(sku, offering.sku)
+        && Objects.equals(productName, offering.productName)
+        && Objects.equals(description, offering.description)
+        && Objects.equals(productFamily, offering.productFamily)
+        && Objects.equals(cores, offering.cores)
+        && Objects.equals(sockets, offering.sockets)
+        && Objects.equals(hypervisorCores, offering.hypervisorCores)
+        && Objects.equals(hypervisorSockets, offering.hypervisorSockets)
+        && Objects.equals(role, offering.role)
+        && serviceLevel == offering.serviceLevel
+        && usage == offering.usage
+        && Objects.equals(hasUnlimitedUsage, offering.hasUnlimitedUsage)
+        && Objects.equals(derivedSku, offering.derivedSku);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        sku,
+        productName,
+        description,
+        productFamily,
+        cores,
+        sockets,
+        hypervisorCores,
+        hypervisorSockets,
+        role,
+        serviceLevel,
+        usage,
+        hasUnlimitedUsage,
+        derivedSku);
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1363](https://issues.redhat.com/browse/SWATCH-1363)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Lazy loaded fields causing initialization error when called without a transaction.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
 Run following curl twice and both requests should be successful:
```
 http :9000/hawtio/jolokia \
  type=exec \
  mbean='org.candlepin.subscriptions.product:name=offeringJmxBean,type=OfferingJmxBean' \
  operation='syncOffering(java.lang.String)' \
  arguments:='["RH00003"]'
```

