### PR TITLE
SWATCH-1364 Add subscription_id index to subscription_measurements

### DIFF
--- a/src/main/resources/liquibase/202306201611-add-subscription-id-index-for-measurements.xml
+++ b/src/main/resources/liquibase/202306201611-add-subscription-id-index-for-measurements.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202306201611-1" author="karshah">
+        <comment>Add an index on subscription_id column in the subscription_measurements table</comment>
+        <createIndex indexName="subscription_id_idx" tableName="subscription_measurements"
+                     unique="false">
+            <column name="subscription_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -104,6 +104,7 @@
     <include file="/liquibase/202302151544-remove-uuid-cast-on-instance-id-in-tally-instance-view.xml"/>
     <include file="/liquibase/202305231247-update-host-pk-for-dup-violation.xml"/>
     <include file="liquibase/202305031403-create-subscription-measurements-table.xml"/>
+    <include file="liquibase/202306201611-add-subscription-id-index-for-measurements.xml"/>
     <!-- Uncomment once subscription-measurements has been verified -->
     <!-- <include file="liquibase/202305251412-drop-subscription-capacity-table.xml"/> -->
 </databaseChangeLog>


### PR DESCRIPTION
This is to improve performance of query when we do GET /subscriptions/products/{product_id}


<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1364](https://issues.redhat.com/browse/SWATCH-1364)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1.Get three tables(subscription, subscription_measurements, subscription_product_ids) from stage and import to local db in the same order:

- For subscription:
`GABI_URL=https://gabi-subscription-watch-stage.apps.crcs02ue1.urby.p1.openshiftapps.com OCP_CONSOLE_TOKEN=$(oc whoami -t) gabitabi -q "SELECT * from subscription;" --sep "," -o "subscription_full_data.csv"`

- For subscription_measurements:
`GABI_URL=https://gabi-subscription-watch-stage.apps.crcs02ue1.urby.p1.openshiftapps.com OCP_CONSOLE_TOKEN=$(oc whoami -t) gabitabi -q "SELECT * from subscription_measurements;" --sep "," -o "subscription_measurements_full_data.csv"`

- For subscription_product_ids:
`GABI_URL=https://gabi-subscription-watch-stage.apps.crcs02ue1.urby.p1.openshiftapps.com OCP_CONSOLE_TOKEN=$(oc whoami -t) gabitabi -q "SELECT * from subscription_product_ids order by subscription_id asc;" --sep "," -o "subscription_product_ids_full_data1.csv"`




### Steps
<!-- Enter each step of the test below -->
1. When you run the below query with main branch you will see higher execution time. You can see it by EXPLAIN ANALYZE
```
EXPLAIN (ANALYZE, BUFFERS)
select subscripti0_.measurement_type    as measurem1_13_0_,
       subscripti0_.metric_id           as metric_i2_13_0_,
       subscripti0_.start_date          as start_da0_13_0_,
       subscripti0_.subscription_id     as subscrip0_13_0_,
       subscripti1_.start_date          as start_da1_12_1_,
       subscripti1_.subscription_id     as subscrip2_12_1_,
       subscripti3_.product_id          as product_1_14_2_,
       subscripti3_.start_date          as start_da0_14_2_,
       subscripti3_.subscription_id     as subscrip0_14_2_,
       subscripti0_.start_date          as start_da4_13_0_,
       subscripti0_.subscription_id     as subscrip5_13_0_,
       subscripti0_.value               as value3_13_0_,
       subscripti1_.account_number      as account_3_12_1_,
       subscripti1_.billing_account_id  as billing_4_12_1_,
       subscripti1_.billing_provider    as billing_5_12_1_,
       subscripti1_.billing_provider_id as billing_6_12_1_,
       subscripti1_.end_date            as end_date7_12_1_,
       subscripti1_.has_unlimited_usage as has_unli8_12_1_,
       subscripti1_.org_id              as org_id9_12_1_,
       subscripti1_.quantity            as quantit10_12_1_,
       subscripti1_.sku                 as sku11_12_1_,
       subscripti1_.subscription_number as subscri12_12_1_,
       subscripti3_.start_date          as start_da2_14_2_,
       subscripti3_.subscription_id     as subscrip3_14_2_,
       subscripti3_.start_date          as start_da2_14_0__,
       subscripti3_.subscription_id     as subscrip3_14_0__,
       subscripti3_.product_id          as product_1_14_0__,
       subscripti3_.start_date          as start_da0_14_0__,
       subscripti3_.subscription_id     as subscrip0_14_0__
from subscription subscripti1_
         inner join subscription_measurements subscripti0_ on subscripti0_.start_date = subscripti1_.start_date and
                                                 subscripti0_.subscription_id = subscripti1_.subscription_id
         inner join subscription_product_ids subscripti3_ on subscripti1_.start_date = subscripti3_.start_date and
                                                             subscripti1_.subscription_id = subscripti3_.subscription_id
where subscripti1_.start_date <= '2023-06-15T12:06:51.904569390Z'
  and subscripti1_.end_date >= '2023-06-15T12:06:51.904575669Z'
  and subscripti1_.org_id = '16767885'
  and subscripti3_.product_id = 'OpenShift Container Platform'
  and subscripti0_.metric_id = 'CORES'
```

- Response:
```
"QUERY PLAN"
"Gather  (cost=11895.49..16612.57 rows=10 width=252) (actual time=320.740..1426.935 rows=54 loops=1)"
"  Workers Planned: 1"
"  Workers Launched: 1"
"  Buffers: shared hit=128646"
"  ->  Nested Loop  (cost=10895.49..15611.57 rows=6 width=252) (actual time=315.223..1359.260 rows=27 loops=2)"
"        Join Filter: ((subscripti0_.start_date = subscripti1_.start_date) AND ((subscripti0_.subscription_id)::text = (subscripti1_.subscription_id)::text))"
"        Buffers: shared hit=128646"
"        ->  Parallel Hash Join  (cost=10895.07..15589.78 rows=4 width=67) (actual time=268.480..459.386 rows=14669 loops=2)"
"              Hash Cond: ((subscripti0_.start_date = subscripti3_.start_date) AND ((subscripti0_.subscription_id)::text = (subscripti3_.subscription_id)::text))"
"              Buffers: shared hit=11378"
"              ->  Parallel Seq Scan on subscription_measurements subscripti0_  (cost=0.00..4595.38 rows=18920 width=40) (actual time=1.418..101.539 rows=16222 loops=2)"
"                    Filter: ((metric_id)::text = 'CORES'::text)"
"                    Rows Removed by Filter: 95742"
"                    Buffers: shared hit=2992"
"              ->  Parallel Hash  (cost=10623.16..10623.16 rows=18127 width=27) (actual time=250.179..250.180 rows=22038 loops=2)"
"                    Buckets: 65536  Batches: 1  Memory Usage: 4192kB"
"                    Buffers: shared hit=8346"
"                    ->  Parallel Bitmap Heap Scan on subscription_product_ids subscripti3_  (cost=2009.58..10623.16 rows=18127 width=27) (actual time=70.340..208.980 rows=22038 loops=2)"
"                          Recheck Cond: ((product_id)::text = 'OpenShift Container Platform'::text)"
"                          Heap Blocks: exact=3938"
"                          Buffers: shared hit=8346"
"                          ->  Bitmap Index Scan on subscription_product_ids_pk  (cost=0.00..1998.70 rows=43504 width=0) (actual time=66.901..66.902 rows=63944 loops=1)"
"                                Index Cond: ((product_id)::text = 'OpenShift Container Platform'::text)"
"                                Buffers: shared hit=980"
"        ->  Index Scan using subscription_pkey on subscription subscripti1_  (cost=0.42..5.43 rows=1 width=110) (actual time=0.060..0.060 rows=0 loops=29338)"
"              Index Cond: (((subscription_id)::text = (subscripti3_.subscription_id)::text) AND (start_date = subscripti3_.start_date) AND (start_date <= '2023-06-15 12:06:51.904569+00'::timestamp with time zone))"
"              Filter: ((end_date >= '2023-06-15 12:06:51.904576+00'::timestamp with time zone) AND ((org_id)::text = '16767885'::text))"
"              Rows Removed by Filter: 1"
"              Buffers: shared hit=117268"
"Planning Time: 1.201 ms"
"Execution Time: 1427.023 ms"

```

2. Now with the current branch
- Execute ` DEV_MODE=true SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true PRODUCT_USE_STUB=true ./gradlew :bootRun`

- Run the above query and observe that the EXECUTION time reduced. This is because instead of `Parallel Seq Scan` it now uses `NESTED LOOP` and also uses the new index `subscription_id_idx`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. 
```
QUERY PLAN                                                                                                                                                                             |

|Gather  (cost=1113.82..11370.89 rows=13 width=262) (actual time=1.387..6.085 rows=40 loops=1)                                                                                          |
|  Workers Planned: 2                                                                                                                                                                   |
|  Workers Launched: 2                                                                                                                                                                  |
|  Buffers: shared hit=1419                                                                                                                                                             |
|  ->  Nested Loop  (cost=113.82..10369.59 rows=5 width=262) (actual time=0.703..1.687 rows=13 loops=3)                                                                                 |
|        Buffers: shared hit=1419                                                                                                                                                       |
|        ->  Nested Loop  (cost=113.39..10253.84 rows=58 width=160) (actual time=0.695..1.572 rows=13 loops=3)                                                                          |
|              Buffers: shared hit=1298                                                                                                                                                 |
|              ->  Parallel Bitmap Heap Scan on subscription subscripti1_  (cost=112.97..6421.42 rows=787 width=120) (actual time=0.688..1.402 rows=22 loops=3)                         |
|                    Recheck Cond: ((org_id)::text = '16767885'::text)                                                                                                                  |
|                    Filter: ((start_date <= '2023-06-15 12:06:51.904569+00'::timestamp with time zone) AND (end_date >= '2023-06-15 12:06:51.904576+00'::timestamp with time zone))    |
|                    Rows Removed by Filter: 2043                                                                                                                                       |
|                    Heap Blocks: exact=814                                                                                                                                             |
|                    Buffers: shared hit=1043                                                                                                                                           |
|                    ->  Bitmap Index Scan on subscription_owner_id_idx  (cost=0.00..112.50 rows=5877 width=0) (actual time=0.622..0.623 rows=6195 loops=1)                             |
|                          Index Cond: ((org_id)::text = '16767885'::text)                                                                                                              |
|                          Buffers: shared hit=7                                                                                                                                        |
|              ->  Index Scan using subscription_id_idx on subscription_measurements subscripti0_  (cost=0.42..4.86 rows=1 width=40) (actual time=0.007..0.007 rows=1 loops=66)         |
|                    Index Cond: ((subscription_id)::text = (subscripti1_.subscription_id)::text)                                                                                       |
|                    Filter: (((metric_id)::text = 'CORES'::text) AND (subscripti1_.start_date = start_date))                                                                           |
|                    Rows Removed by Filter: 0                                                                                                                                          |
|                    Buffers: shared hit=255                                                                                                                                            |
|        ->  Index Only Scan using subscription_product_ids_pk on subscription_product_ids subscripti3_  (cost=0.42..2.00 rows=1 width=27) (actual time=0.008..0.008 rows=1 loops=40)   |
|              Index Cond: ((product_id = 'OpenShift Container Platform'::text) AND (subscription_id = (subscripti0_.subscription_id)::text) AND (start_date = subscripti0_.start_date))|
|              Heap Fetches: 0                                                                                                                                                          |
|              Buffers: shared hit=121                                                                                                                                                  |
|Planning:                                                                                                                                                                              |
|  Buffers: shared hit=48                                                                                                                                                               |
|Planning Time: 1.136 ms                                                                                                                                                                |
|Execution Time: 6.144 ms                                                                                                                                                               
```

Also the` /subscriptions/products/{product_id}` endpoint should return the results quickly.