### PR TITLE
SWATCH-1365: Add FK relationship between Offering and Subscription

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionPruneController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionPruneController.java
@@ -80,12 +80,13 @@ public class SubscriptionPruneController {
     // Associated subscription measurements and product IDs should be removed by cascade
     subscriptions.forEach(
         subscription -> {
-          if (productDenylist.productIdMatches(subscription.getSku())) {
+          var sku = subscription.getOffering().getSku();
+          if (productDenylist.productIdMatches(sku)) {
             log.info(
                 "Removing subscriptionId={} for orgId={} w/ sku={}",
                 subscription.getSubscriptionId(),
                 orgId,
-                subscription.getSku());
+                sku);
             subscriptionRepository.delete(subscription);
           }
         });

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -182,8 +182,10 @@ public class SubscriptionSyncController {
     }
 
     subscriptionOptional.ifPresentOrElse(
-        subscription -> subscription.getOffering().addSubscription(newOrUpdated),
-        () -> offeringRepository.findById(sku).orElseThrow().addSubscription(newOrUpdated));
+        subscription -> newOrUpdated.setOffering(subscription.getOffering()),
+        () ->
+            newOrUpdated.setOffering(
+                offeringRepository.findById(sku).orElseThrow(EntityNotFoundException::new)));
 
     log.debug("Syncing subscription from external service={}", newOrUpdated);
 

--- a/src/main/resources/liquibase/202306151541-add-sku-foreign-key-to-subscription.xml
+++ b/src/main/resources/liquibase/202306151541-add-sku-foreign-key-to-subscription.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202306151541-01" author="awood">
+        <addForeignKeyConstraint constraintName="subscription_sku_fkey"
+            baseTableName="subscription" baseColumnNames="sku"
+            referencedTableName="offering" referencedColumnNames="sku"/>
+    </changeSet>
+    <changeSet id="202306151541-02" author="awood">
+        <comment>This column is present in the offering table</comment>
+        <dropColumn tableName="subscription" columnName="has_unlimited_usage"/>
+    </changeSet>
+</databaseChangeLog>
+    <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -107,5 +107,6 @@
     <include file="liquibase/202306201611-add-subscription-id-index-for-measurements.xml"/>
     <!-- Uncomment once subscription-measurements has been verified -->
     <!-- <include file="liquibase/202305251412-drop-subscription-capacity-table.xml"/> -->
+    <include file="liquibase/202306151541-add-sku-foreign-key-to-subscription.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
@@ -101,7 +101,7 @@ class CapacityReconciliationControllerTest {
             .build();
 
     Subscription newSubscription = createSubscription("456", 10);
-    offering.addSubscription(newSubscription);
+    newSubscription.setOffering(offering);
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(new HashSet<>(productIds));
@@ -140,7 +140,7 @@ class CapacityReconciliationControllerTest {
     SubscriptionProductId subscriptionProductId = new SubscriptionProductId();
     subscriptionProductId.setProductId("RHEL");
     updatedSubscription.addSubscriptionProductId(subscriptionProductId);
-    updatedOffering.addSubscription(updatedSubscription);
+    updatedSubscription.setOffering(updatedOffering);
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(updatedOffering)).thenReturn(productIds);
@@ -176,7 +176,7 @@ class CapacityReconciliationControllerTest {
     SubscriptionProductId subscriptionProductId = new SubscriptionProductId();
     subscriptionProductId.setProductId("RHEL");
     updatedSubscription.addSubscriptionProductId(subscriptionProductId);
-    updatedOffering.addSubscription(updatedSubscription);
+    updatedSubscription.setOffering(updatedOffering);
 
     when(denylist.productIdMatches(any())).thenReturn(true);
     when(capacityProductExtractor.getProducts(updatedOffering)).thenReturn(productIds);
@@ -208,7 +208,7 @@ class CapacityReconciliationControllerTest {
     subscription
         .getSubscriptionMeasurements()
         .add(createMeasurement(subscription, "PHYSICAL", SOCKETS, 15.0));
-    offering.addSubscription(subscription);
+    subscription.setOffering(offering);
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(productIds);

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.*;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.capacity.files.ProductDenylist;
@@ -90,7 +89,6 @@ class CapacityReconciliationControllerTest {
 
   @Test
   void shouldAddNewMeasurementsAndProductIdsIfNotAlreadyExisting() {
-
     List<String> productIds = List.of("RHEL");
     Offering offering =
         Offering.builder()
@@ -103,10 +101,10 @@ class CapacityReconciliationControllerTest {
             .build();
 
     Subscription newSubscription = createSubscription("456", 10);
+    offering.addSubscription(newSubscription);
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(new HashSet<>(productIds));
-    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(offering));
 
     capacityReconciliationController.reconcileCapacityForSubscription(newSubscription);
 
@@ -142,10 +140,10 @@ class CapacityReconciliationControllerTest {
     SubscriptionProductId subscriptionProductId = new SubscriptionProductId();
     subscriptionProductId.setProductId("RHEL");
     updatedSubscription.addSubscriptionProductId(subscriptionProductId);
+    updatedOffering.addSubscription(updatedSubscription);
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(updatedOffering)).thenReturn(productIds);
-    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(updatedOffering));
 
     capacityReconciliationController.reconcileCapacityForSubscription(updatedSubscription);
 
@@ -163,7 +161,6 @@ class CapacityReconciliationControllerTest {
 
   @Test
   void shouldRemoveAllCapacitiesWhenProductIsOnDenylist() {
-
     Set<String> productIds = Set.of("RHEL", "RHEL Workstation");
     Offering updatedOffering =
         Offering.builder().productIds(Set.of(45, 25)).sku("MCT3718").cores(20).sockets(40).build();
@@ -179,10 +176,10 @@ class CapacityReconciliationControllerTest {
     SubscriptionProductId subscriptionProductId = new SubscriptionProductId();
     subscriptionProductId.setProductId("RHEL");
     updatedSubscription.addSubscriptionProductId(subscriptionProductId);
+    updatedOffering.addSubscription(updatedSubscription);
 
     when(denylist.productIdMatches(any())).thenReturn(true);
     when(capacityProductExtractor.getProducts(updatedOffering)).thenReturn(productIds);
-    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(updatedOffering));
 
     capacityReconciliationController.reconcileCapacityForSubscription(updatedSubscription);
 
@@ -192,7 +189,6 @@ class CapacityReconciliationControllerTest {
 
   @Test
   void shouldAddNewCapacitiesAndRemoveAllStaleCapacities() {
-
     Set<String> productIds = Set.of("RHEL");
     Offering offering = Offering.builder().productIds(Set.of(45)).sku("MCT3718").cores(42).build();
     Subscription subscription = createSubscription("456", 10);
@@ -212,10 +208,10 @@ class CapacityReconciliationControllerTest {
     subscription
         .getSubscriptionMeasurements()
         .add(createMeasurement(subscription, "PHYSICAL", SOCKETS, 15.0));
+    offering.addSubscription(subscription);
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(capacityProductExtractor.getProducts(offering)).thenReturn(productIds);
-    when(offeringRepository.findById("MCT3718")).thenReturn(Optional.of(offering));
 
     capacityReconciliationController.reconcileCapacityForSubscription(subscription);
 
@@ -237,7 +233,7 @@ class CapacityReconciliationControllerTest {
     Page<Subscription> subscriptions = mock(Page.class);
     when(subscriptions.hasNext()).thenReturn(true);
 
-    when(subscriptionRepository.findBySku(
+    when(subscriptionRepository.findByOfferingSku(
             "MCT3718", ResourceUtils.getPageable(0, 2, Sort.by("subscriptionId"))))
         .thenReturn(subscriptions);
     capacityReconciliationController.reconcileCapacityForOffering(offering.getSku(), 0, 2);
@@ -261,14 +257,12 @@ class CapacityReconciliationControllerTest {
   }
 
   private Subscription createSubscription(String subId, int quantity) {
-
     return Subscription.builder()
         .orgId("123")
         .subscriptionId(subId)
         .quantity(quantity)
         .startDate(NOW)
         .endDate(NOW.plusDays(30))
-        .sku("MCT3718")
         .build();
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
@@ -88,9 +88,10 @@ class SubscriptionMeasurementRepositoryTest {
     subscription.addSubscriptionProductId(subscriptionProductId);
     physicalCores = createMeasurement("PHYSICAL", MetricId.CORES, 42.0);
     subscription.addSubscriptionMeasurement(physicalCores);
-    offering.addSubscription(subscription);
+    subscription.setOffering(offering);
 
     offeringRepository.saveAndFlush(offering);
+    subscriptionRepository.saveAndFlush(subscription);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
@@ -63,12 +63,19 @@ class SubscriptionMeasurementRepositoryTest {
   @BeforeEach
   void setUp() {
     TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+    var offering =
+        Offering.builder()
+            .sku("premiumproduction")
+            .serviceLevel(ServiceLevel.PREMIUM)
+            .usage(Usage.PRODUCTION)
+            .build();
+
     subscription =
         Subscription.builder()
             .accountNumber("account123")
             .subscriptionId("subscription123")
             .subscriptionNumber("subscriptionNumber123")
-            .sku("premiumproduction")
+            .offering(offering)
             .orgId("org123")
             .billingProvider(BillingProvider.RED_HAT)
             .quantity(10)
@@ -78,18 +85,12 @@ class SubscriptionMeasurementRepositoryTest {
 
     subscriptionProductId = SubscriptionProductId.builder().productId("RHEL").build();
 
-    var offering =
-        Offering.builder()
-            .sku("premiumproduction")
-            .serviceLevel(ServiceLevel.PREMIUM)
-            .usage(Usage.PRODUCTION)
-            .build();
-
     subscription.addSubscriptionProductId(subscriptionProductId);
     physicalCores = createMeasurement("PHYSICAL", MetricId.CORES, 42.0);
     subscription.addSubscriptionMeasurement(physicalCores);
+    offering.addSubscription(subscription);
+
     offeringRepository.saveAndFlush(offering);
-    subscriptionRepository.saveAndFlush(subscription);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -301,7 +301,7 @@ class CapacityResourceTest {
     OffsetDateTime begin = min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1);
     var subscription = datedSubscription(begin, max);
     var offering = Offering.builder().sku("testsku").hasUnlimitedUsage(true).build();
-    offering.addSubscription(subscription);
+    subscription.setOffering(offering);
 
     DbReportCriteria criteria =
         DbReportCriteria.builder()
@@ -792,14 +792,14 @@ class CapacityResourceTest {
     var unlimited = datedSubscription(begin, max);
     unlimited.setSubscriptionId("unlimited123");
     var unlimitedOffering = Offering.builder().sku("unlimitedsku").hasUnlimitedUsage(true).build();
-    unlimitedOffering.addSubscription(unlimited);
+    unlimited.setOffering(unlimitedOffering);
 
     var limited = datedSubscription(begin, max);
     limited.setSubscriptionId("limited123");
     limited.addSubscriptionMeasurements(
         List.of(createMeasurement("PHYSICAL", MetricId.CORES, 4.0)));
     var limitedOffering = Offering.builder().sku("limitedsku").hasUnlimitedUsage(false).build();
-    limitedOffering.addSubscription(limited);
+    limited.setOffering(limitedOffering);
 
     when(repository.findAllBy(
             "owner123456", RHEL.toString(), MetricId.CORES, null, null, null, min, max))

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -34,6 +34,7 @@ import org.candlepin.subscriptions.db.SubscriptionMeasurementRepository;
 import org.candlepin.subscriptions.db.SubscriptionRepository;
 import org.candlepin.subscriptions.db.model.DbReportCriteria;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Subscription;
 import org.candlepin.subscriptions.db.model.SubscriptionMeasurement;
@@ -89,20 +90,16 @@ class CapacityResourceTest {
             .build();
 
     s.addSubscriptionProductId(SubscriptionProductId.builder().productId(RHEL.toString()).build());
-    s.addSubscriptionMeasurement(basicMeasurement());
 
     return s;
   }
 
   private static Subscription enhancedSubscription(List<SubscriptionMeasurement> measurements) {
     Subscription s =
-        Subscription.builder()
-            .startDate(min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1))
-            .endDate(max.truncatedTo(ChronoUnit.DAYS).minusSeconds(1))
-            .orgId("owner123456")
-            .build();
+        datedSubscription(
+            min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1),
+            max.truncatedTo(ChronoUnit.DAYS).minusSeconds(1));
 
-    s.addSubscriptionProductId(SubscriptionProductId.builder().productId(RHEL.toString()).build());
     s.addSubscriptionMeasurements(measurements);
     return s;
   }
@@ -303,7 +300,8 @@ class CapacityResourceTest {
   void testShouldCalculateCapacityWithUnlimitedUsage() {
     OffsetDateTime begin = min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1);
     var subscription = datedSubscription(begin, max);
-    subscription.setHasUnlimitedUsage(true);
+    var offering = Offering.builder().sku("testsku").hasUnlimitedUsage(true).build();
+    offering.addSubscription(subscription);
 
     DbReportCriteria criteria =
         DbReportCriteria.builder()
@@ -788,17 +786,20 @@ class CapacityResourceTest {
     assertEquals(expected, actual.size());
   }
 
+  @Test
   void testReportByMetricIdShouldCalculateCapacityEvenWhenUnlimited() {
     var begin = min.truncatedTo(ChronoUnit.DAYS).minusSeconds(1);
     var unlimited = datedSubscription(begin, max);
-    unlimited.setHasUnlimitedUsage(true);
     unlimited.setSubscriptionId("unlimited123");
+    var unlimitedOffering = Offering.builder().sku("unlimitedsku").hasUnlimitedUsage(true).build();
+    unlimitedOffering.addSubscription(unlimited);
 
     var limited = datedSubscription(begin, max);
-    limited.setHasUnlimitedUsage(false);
     limited.setSubscriptionId("limited123");
-    limited.setSubscriptionMeasurements(
+    limited.addSubscriptionMeasurements(
         List.of(createMeasurement("PHYSICAL", MetricId.CORES, 4.0)));
+    var limitedOffering = Offering.builder().sku("limitedsku").hasUnlimitedUsage(false).build();
+    limitedOffering.addSubscription(limited);
 
     when(repository.findAllBy(
             "owner123456", RHEL.toString(), MetricId.CORES, null, null, null, min, max))

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionPruneControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionPruneControllerTest.java
@@ -84,7 +84,7 @@ class SubscriptionPruneControllerTest {
   void testPruneDoesNothingIfSkuOnNonDenylist() {
     Offering offering = Offering.builder().sku("allowed").build();
     Subscription allowedSub = new Subscription();
-    offering.addSubscription(allowedSub);
+    allowedSub.setOffering(offering);
     when(subscriptionRepo.findByOrgId("up-to-date")).thenReturn(Stream.of(allowedSub));
     SubscriptionMeasurement allowedMeasurement = SubscriptionMeasurement.builder().build();
     allowedSub.addSubscriptionMeasurement(allowedMeasurement);
@@ -97,7 +97,7 @@ class SubscriptionPruneControllerTest {
   void testPruneRemovesDelistedSubscription() {
     Offering offering = Offering.builder().sku("denied").build();
     Subscription staleSub = new Subscription();
-    offering.addSubscription(staleSub);
+    staleSub.setOffering(offering);
     when(subscriptionRepo.findByOrgId("stale-sub")).thenReturn(Stream.of(staleSub));
     controller.pruneUnlistedSubscriptions("stale-sub");
     verify(subscriptionRepo).findByOrgId("stale-sub");

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionPruneControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionPruneControllerTest.java
@@ -31,6 +31,7 @@ import io.micrometer.core.instrument.Timer;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.capacity.files.ProductDenylist;
 import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
 import org.candlepin.subscriptions.db.model.Subscription;
 import org.candlepin.subscriptions.db.model.SubscriptionMeasurement;
@@ -81,8 +82,9 @@ class SubscriptionPruneControllerTest {
 
   @Test
   void testPruneDoesNothingIfSkuOnNonDenylist() {
+    Offering offering = Offering.builder().sku("allowed").build();
     Subscription allowedSub = new Subscription();
-    allowedSub.setSku("allowed");
+    offering.addSubscription(allowedSub);
     when(subscriptionRepo.findByOrgId("up-to-date")).thenReturn(Stream.of(allowedSub));
     SubscriptionMeasurement allowedMeasurement = SubscriptionMeasurement.builder().build();
     allowedSub.addSubscriptionMeasurement(allowedMeasurement);
@@ -93,8 +95,9 @@ class SubscriptionPruneControllerTest {
 
   @Test
   void testPruneRemovesDelistedSubscription() {
+    Offering offering = Offering.builder().sku("denied").build();
     Subscription staleSub = new Subscription();
-    staleSub.setSku("denied");
+    offering.addSubscription(staleSub);
     when(subscriptionRepo.findByOrgId("stale-sub")).thenReturn(Stream.of(staleSub));
     controller.pruneUnlistedSubscriptions("stale-sub");
     verify(subscriptionRepo).findByOrgId("stale-sub");

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -174,7 +174,7 @@ class SubscriptionSyncControllerTest {
   void shouldSyncSubscriptionFromServiceForASubscriptionID() {
     Offering offering = Offering.builder().sku("testSku").build();
     Subscription s = createSubscription("123", "testsku", "456");
-    offering.addSubscription(s);
+    s.setOffering(offering);
     Mockito.when(subscriptionRepository.findActiveSubscription(Mockito.anyString()))
         .thenReturn(Optional.of(s));
     var dto = createDto("456", 10);
@@ -360,9 +360,11 @@ class SubscriptionSyncControllerTest {
     var subList = Arrays.asList(dto1, dto2);
 
     var dao1 = convertDto(dto1);
-    Offering.builder().sku(SubscriptionDtoUtil.extractSku(dto1)).build().addSubscription(dao1);
+    var offering1 = Offering.builder().sku(SubscriptionDtoUtil.extractSku(dto1)).build();
+    dao1.setOffering(offering1);
     var dao2 = convertDto(dto2);
-    Offering.builder().sku(SubscriptionDtoUtil.extractSku(dto2)).build().addSubscription(dao2);
+    var offering2 = Offering.builder().sku(SubscriptionDtoUtil.extractSku(dto2)).build();
+    dao2.setOffering(offering2);
 
     when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(subList);
     when(subscriptionRepository.findByOrgIdAndEndDateAfter(eq("123"), any()))
@@ -564,7 +566,7 @@ class SubscriptionSyncControllerTest {
   void lateTerminateActivePAYGSubscriptionTest() {
     Subscription s = createSubscription("123", "testsku", "456");
     Offering offering = Offering.builder().productName(PAYG_PRODUCT_NAME).build();
-    offering.addSubscription(s);
+    s.setOffering(offering);
     when(offeringRepository.findById("testsku")).thenReturn(Optional.of(offering));
     when(subscriptionRepository.findActiveSubscription("456")).thenReturn(Optional.of(s));
     when(mockProfile.tagForOfferingProductName(PAYG_PRODUCT_NAME))

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerOnDemandTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerOnDemandTest.java
@@ -623,7 +623,7 @@ class SubscriptionTableControllerOnDemandTest {
           .billingProvider(sub.billingProvider)
           .startDate(sub.start)
           .endDate(sub.end)
-          .sku(sku)
+          .offering(toOffering())
           .build();
     }
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -1047,7 +1047,7 @@ class SubscriptionTableControllerTest {
 
       var offering = Offering.builder().sku(sku).hasUnlimitedUsage(hasUnlimitedUsage).build();
 
-      offering.addSubscription(subscription);
+      subscription.setOffering(offering);
       subscription.setOrgId(org.orgId);
       subscription.setAccountNumber(org.accountNumber);
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -1045,8 +1045,9 @@ class SubscriptionTableControllerTest {
         subscription = stubSubscription("sub123", "number123", 1);
       }
 
-      subscription.setSku(sku);
-      subscription.setHasUnlimitedUsage(hasUnlimitedUsage);
+      var offering = Offering.builder().sku(sku).hasUnlimitedUsage(hasUnlimitedUsage).build();
+
+      offering.addSubscription(subscription);
       subscription.setOrgId(org.orgId);
       subscription.setAccountNumber(org.accountNumber);
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -47,7 +47,8 @@ import org.mapstruct.Named;
 @Mapper(
     componentModel = "cdi",
     collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED,
-    builder = @Builder(disableBuilder = true))
+    builder = @Builder(disableBuilder = true),
+    uses = {ContractOfferingMapper.class})
 public interface ContractMapper {
 
   Contract contractEntityToDto(ContractEntity contract);
@@ -68,7 +69,7 @@ public interface ContractMapper {
   @Mapping(target = "accountNumber", ignore = true)
   @Mapping(target = "billingProviderId", ignore = true)
   @Mapping(target = "quantity", constant = "1L")
-  @Mapping(target = "hasUnlimitedUsage", constant = "false")
+  @Mapping(target = "offering", source = ".")
   @Mapping(target = "subscriptionProductIds", source = ".")
   @Mapping(target = "subscriptionMeasurements", source = "metrics")
   void mapContractEntityToSubscriptionEntity(

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractOfferingMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractOfferingMapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.model;
+
+import com.redhat.swatch.contract.repository.ContractEntity;
+import com.redhat.swatch.contract.repository.OfferingEntity;
+import com.redhat.swatch.contract.repository.OfferingRepository;
+import java.util.Objects;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+
+@ApplicationScoped
+public class ContractOfferingMapper {
+  @Inject OfferingRepository offeringRepository;
+
+  public OfferingEntity mapContractToOfferingEntity(ContractEntity contract) {
+    var offering = offeringRepository.findById(contract.getSku());
+    if (Objects.isNull(offering)) {
+      throw new BadRequestException("Could not find sku " + contract.getSku());
+    }
+    return offering;
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingEntity.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.repository;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Represents a product Offering that can be provided by a Subscription.
+ *
+ * <p>Offerings are identified by SKU.
+ */
+@Entity
+@Getter
+@Setter
+@ToString
+@Table(name = "offering")
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class OfferingEntity implements Serializable {
+
+  /**
+   * Unique identifier for the Offering.
+   *
+   * <p>Because we want only a single instance per SKU, we'll use the SKU as the only primary key.
+   *
+   * <p>Note that many types of SKUs exist within Red Hat, Offering will be Marketing SKUs only.
+   */
+  @Id
+  @Column(name = "sku")
+  private String sku;
+
+  /**
+   * Customer-facing name for the offering.
+   *
+   * <p>E.g. Red Hat Enterprise Linux Server
+   */
+  @Column(name = "product_name")
+  private String productName;
+
+  /**
+   * Customer-facing description for the offering.
+   *
+   * <p>E.g. Red Hat Enterprise Linux Server with Smart Management + Satellite, Standard (Physical
+   * or Virtual Nodes)
+   */
+  @Column(name = "description")
+  private String description;
+
+  /**
+   * Category for the offering.
+   *
+   * <p>E.g. "Red Hat Enterprise Linux" or "Ansible"
+   */
+  @Column(name = "product_family")
+  private String productFamily;
+
+  /** Internal identifiers for products that compose an Offering. */
+  @Builder.Default
+  @ElementCollection
+  @CollectionTable(name = "sku_child_sku", joinColumns = @JoinColumn(name = "sku"))
+  @Column(name = "child_sku")
+  private Set<String> childSkus = new HashSet<>();
+
+  /**
+   * Numeric identifiers for Engineering Products provided by the offering.
+   *
+   * <p>Engineering products define a set of installable content.
+   *
+   * <p>See
+   * https://www.candlepinproject.org/docs/candlepin/how_subscriptions_work.html#engineering-products
+   *
+   * <p>Sometimes referred to as "provided products".
+   */
+  @Builder.Default
+  @ElementCollection
+  @CollectionTable(name = "sku_oid", joinColumns = @JoinColumn(name = "sku"))
+  @Column(name = "oid")
+  private Set<Integer> productIds = new HashSet<>();
+
+  /** Effective standard CPU cores capacity per quantity of subscription to this offering. */
+  @Column(name = "cores")
+  private Integer cores;
+
+  /** Effective standard CPU sockets capacity per quantity of subscription to this offering. */
+  @Column(name = "sockets")
+  private Integer sockets;
+
+  /** Effective hypervisor CPU cores capacity per quantity of subscription to this offering. */
+  @Column(name = "hypervisor_cores")
+  private Integer hypervisorCores;
+
+  /** Effective hypervisor CPU sockets capacity per quantity of subscription to this offering. */
+  @Column(name = "hypervisor_sockets")
+  private Integer hypervisorSockets;
+
+  /** Syspurpose Role for the offering */
+  @Column(name = "role")
+  private String role;
+
+  @Column(name = "sla")
+  private ServiceLevel serviceLevel;
+
+  /** Syspurpose Usage for the offering */
+  @Column(name = "usage")
+  private Usage usage;
+
+  // Lombok would name the getter "isHasUnlimitedGuestSockets"
+  @Getter(AccessLevel.NONE)
+  @Column(name = "has_unlimited_usage")
+  private Boolean hasUnlimitedUsage;
+
+  // Derived SKU, needed to track necessary updates when a derived SKU is changed
+  @Column(name = "derived_sku")
+  private String derivedSku;
+
+  public Boolean getHasUnlimitedUsage() {
+    return hasUnlimitedUsage;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof OfferingEntity)) {
+      return false;
+    }
+    OfferingEntity offering = (OfferingEntity) o;
+    return Objects.equals(sku, offering.sku)
+        && Objects.equals(productName, offering.productName)
+        && Objects.equals(description, offering.description)
+        && Objects.equals(productFamily, offering.productFamily)
+        && Objects.equals(cores, offering.cores)
+        && Objects.equals(sockets, offering.sockets)
+        && Objects.equals(hypervisorCores, offering.hypervisorCores)
+        && Objects.equals(hypervisorSockets, offering.hypervisorSockets)
+        && Objects.equals(role, offering.role)
+        && serviceLevel == offering.serviceLevel
+        && usage == offering.usage
+        && Objects.equals(hasUnlimitedUsage, offering.hasUnlimitedUsage)
+        && Objects.equals(derivedSku, offering.derivedSku);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        sku,
+        productName,
+        description,
+        productFamily,
+        cores,
+        sockets,
+        hypervisorCores,
+        hypervisorSockets,
+        role,
+        serviceLevel,
+        usage,
+        hasUnlimitedUsage,
+        derivedSku);
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.repository;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class OfferingRepository implements PanacheSpecificationSupport<OfferingEntity, String> {
+  /* intentionally empty */
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ServiceLevel.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ServiceLevel.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.repository;
+
+import java.util.Map;
+import java.util.Objects;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+/**
+ * System purpose service level
+ *
+ * <p>SLA or service level agreement is defined on a given subscription, and can be set as an
+ * attribute on a system to associate it with a specific SLA requirement.
+ */
+public enum ServiceLevel implements StringValueEnum {
+  EMPTY(""),
+  PREMIUM("Premium"),
+  STANDARD("Standard"),
+  SELF_SUPPORT("Self-Support"),
+  _ANY("_ANY"); // NOSONAR
+
+  private static final Map<String, ServiceLevel> VALUE_ENUM_MAP =
+      StringValueEnum.initializeImmutableMap(ServiceLevel.class);
+
+  private final String value;
+
+  ServiceLevel(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Parse the service level from its string representation (excluding special value _ANY).
+   *
+   * <p>NOTE: this method will not return the special value ANY, and gives UNSPECIFIED for any
+   * invalid value.
+   *
+   * @param value String representation of the SLA, as seen in a host record
+   * @return the ServiceLevel enum; UNSPECIFIED if unparseable.
+   */
+  public static ServiceLevel fromString(String value) {
+    return StringValueEnum.getValueOf(ServiceLevel.class, VALUE_ENUM_MAP, value, EMPTY);
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  /** JPA converter for ServiceLevel */
+  @Converter(autoApply = true)
+  public static class EnumConverter implements AttributeConverter<ServiceLevel, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ServiceLevel attribute) {
+      return Objects.nonNull(attribute) ? attribute.getValue() : null;
+    }
+
+    @Override
+    public ServiceLevel convertToEntityAttribute(String dbData) {
+      return ServiceLevel.fromString(dbData);
+    }
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/StringValueEnum.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/StringValueEnum.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.repository;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/** Interface to reduce duplication of common methods for some enums */
+public interface StringValueEnum {
+  static <T> T getValueOf(
+      Class<T> className, Map<String, T> valueEnumMap, String value, T defaultEnum) {
+    String key = Objects.nonNull(value) ? value.toLowerCase() : null;
+
+    T match = valueEnumMap.get(key);
+
+    if (Objects.nonNull(match)) {
+      return match;
+    } else if (Objects.nonNull(defaultEnum)) {
+      return defaultEnum;
+    } else {
+      throw new IllegalArgumentException(
+          String.format("%s is not a valid value for %s", value, className));
+    }
+  }
+
+  /**
+   * Maps lowercase string values of an enum's .getValue() to the enum itself
+   *
+   * @param enumClass Given enum class to create map for
+   * @param <T> Subclass of StringValueEnum
+   * @return Map where keys are lowercase string value of the given enumClass's value
+   */
+  static <T extends StringValueEnum> Map<String, T> initializeImmutableMap(Class<T> enumClass) {
+    return Arrays.stream(enumClass.getEnumConstants())
+        .collect(Collectors.toMap(t -> t.getValue().toLowerCase(), value -> value));
+  }
+
+  String getValue();
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionEntity.java
@@ -34,6 +34,8 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
@@ -63,8 +65,9 @@ public class SubscriptionEntity implements Serializable {
   @Column(name = "subscription_number")
   private String subscriptionNumber;
 
-  @Column(name = "sku")
-  private String sku;
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "sku")
+  private OfferingEntity offering;
 
   @Column(name = "org_id")
   private String orgId;
@@ -91,24 +94,23 @@ public class SubscriptionEntity implements Serializable {
   @Column(name = "billing_provider")
   private BillingProvider billingProvider;
 
-  @OneToMany(mappedBy = "subscription", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+  @OneToMany(
+      mappedBy = "subscription",
+      fetch = FetchType.EAGER,
+      cascade = CascadeType.ALL,
+      orphanRemoval = true)
   @Builder.Default
   @ToString.Exclude
   private Set<SubscriptionProductIdEntity> subscriptionProductIds = new HashSet<>();
 
-  @OneToMany(mappedBy = "subscription", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @OneToMany(
+      mappedBy = "subscription",
+      fetch = FetchType.LAZY,
+      cascade = CascadeType.ALL,
+      orphanRemoval = true)
   @Builder.Default
   @ToString.Exclude // Excluded to prevent fetching a lazy-loaded collection
   private List<SubscriptionMeasurementEntity> subscriptionMeasurements = new ArrayList<>();
-
-  // Lombok would name the getter "isHasUnlimitedGuestSockets"
-  @Getter(AccessLevel.NONE)
-  @Column(name = "has_unlimited_usage")
-  private Boolean hasUnlimitedUsage;
-
-  public Boolean getHasUnlimitedUsage() {
-    return hasUnlimitedUsage;
-  }
 
   @Override
   public boolean equals(Object o) {
@@ -128,7 +130,6 @@ public class SubscriptionEntity implements Serializable {
 
     return Objects.equals(subscriptionId, sub.getSubscriptionId())
         && Objects.equals(subscriptionNumber, sub.getSubscriptionNumber())
-        && Objects.equals(sku, sub.getSku())
         && Objects.equals(orgId, sub.getOrgId())
         && Objects.equals(quantity, sub.getQuantity())
         && Objects.equals(startDate, sub.getStartDate())
@@ -137,13 +138,25 @@ public class SubscriptionEntity implements Serializable {
         && Objects.equals(billingAccountId, sub.getBillingAccountId())
         && Objects.equals(accountNumber, sub.getAccountNumber())
         && Objects.equals(billingProvider, sub.getBillingProvider())
-        && Objects.equals(hasUnlimitedUsage, sub.getHasUnlimitedUsage())
         && Objects.equals(ourProductIds, otherProductIds);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(subscriptionId, startDate);
+    var ourProductIds =
+        subscriptionProductIds.stream().map(SubscriptionProductIdEntity::getProductId).toList();
+    return Objects.hash(
+        subscriptionId,
+        subscriptionNumber,
+        orgId,
+        quantity,
+        startDate,
+        endDate,
+        billingProviderId,
+        billingAccountId,
+        accountNumber,
+        billingProvider,
+        ourProductIds);
   }
 
   /** Composite ID class for SubscriptionEntity entities. */

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/Usage.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/Usage.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.repository;
+
+import java.util.Map;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+/**
+ * System purpose usage
+ *
+ * <p>Usage represents the class of usage for a given system or subscription.
+ */
+public enum Usage implements StringValueEnum {
+  EMPTY(""),
+  PRODUCTION("Production"),
+  DEVELOPMENT_TEST("Development/Test"),
+  DISASTER_RECOVERY("Disaster Recovery"),
+  _ANY("_ANY"); // NOSONAR
+
+  private static final Map<String, Usage> VALUE_ENUM_MAP =
+      StringValueEnum.initializeImmutableMap(Usage.class);
+
+  private final String value;
+
+  Usage(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Parse the usage from its string representation
+   *
+   * @param value String representation of the Usage, as seen in a host record
+   * @return the Usage enum
+   */
+  public static Usage fromString(String value) {
+    return StringValueEnum.getValueOf(Usage.class, VALUE_ENUM_MAP, value, EMPTY);
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  /** JPA converter for Usage */
+  @Converter(autoApply = true)
+  public static class EnumConverter implements AttributeConverter<Usage, String> {
+    @Override
+    public String convertToDatabaseColumn(Usage attribute) {
+      if (attribute == null) {
+        return null;
+      }
+      return attribute.getValue();
+    }
+
+    @Override
+    public Usage convertToEntityAttribute(String dbData) {
+      return Usage.fromString(dbData);
+    }
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractMapperTest.java
@@ -22,29 +22,33 @@ package com.redhat.swatch.contract.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.openapi.model.Contract;
 import com.redhat.swatch.contract.openapi.model.Metric;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
+import com.redhat.swatch.contract.repository.OfferingEntity;
+import com.redhat.swatch.contract.repository.OfferingRepository;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import java.util.UUID;
+import javax.inject.Inject;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * The fact that we are using @ExtendWith(MockitoExtension.class) prevents this test from launching
  * the entire application. Use @QuarkusTest to launch the entire application with the test if
  * required.
  */
-@ExtendWith(MockitoExtension.class)
+@QuarkusTest
 class ContractMapperTest {
 
-  private final ContractMapper mapper = Mappers.getMapper(ContractMapper.class);
+  @Inject ContractMapper mapper;
+  @InjectMock OfferingRepository offeringRepository;
 
   @Test
   void testEntityToDto() {
@@ -164,12 +168,17 @@ class ContractMapperTest {
 
   @Test
   void testMapContractEntityToSubscriptionEntity() {
+    var offering = new OfferingEntity();
+    offering.setSku("MCT123");
+    when(offeringRepository.findById("MCT123")).thenReturn(offering);
+
     var subscription = new SubscriptionEntity();
     var metric = new ContractMetricEntity();
     metric.setMetricId("Cores");
     metric.setValue(42.0);
+
     var contract = new ContractEntity();
-    contract.setSku("sku");
+    contract.setSku("MCT123");
     contract.setMetrics(Set.of(metric));
     contract.setStartDate(OffsetDateTime.parse("2000-01-01T00:00Z"));
     contract.setEndDate(OffsetDateTime.parse("2020-01-01T00:00Z"));
@@ -178,10 +187,11 @@ class ContractMapperTest {
     contract.setBillingAccountId("12345678");
     contract.setOrgId("org123");
     contract.setProductId("rosa");
+
     mapper.mapContractEntityToSubscriptionEntity(subscription, contract);
     assertEquals(contract.getSubscriptionNumber(), subscription.getSubscriptionNumber());
     assertEquals(1, subscription.getSubscriptionMeasurements().size());
-    assertEquals(contract.getSku(), subscription.getSku());
+    assertEquals(contract.getSku(), subscription.getOffering().getSku());
     assertEquals(contract.getStartDate(), subscription.getStartDate());
     assertEquals(contract.getEndDate(), subscription.getEndDate());
     assertEquals(contract.getBillingProvider(), subscription.getBillingProvider().getValue());

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -37,6 +38,8 @@ import com.redhat.swatch.contract.openapi.model.*;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
 import com.redhat.swatch.contract.repository.ContractRepository;
+import com.redhat.swatch.contract.repository.OfferingEntity;
+import com.redhat.swatch.contract.repository.OfferingRepository;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import io.quarkus.test.junit.QuarkusTest;
@@ -46,6 +49,7 @@ import java.util.*;
 import javax.inject.Inject;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
@@ -56,6 +60,7 @@ import org.mockito.Captor;
 class ContractServiceTest extends BaseUnitTest {
   @Inject ContractService contractService;
   @InjectMock ContractRepository contractRepository;
+  @InjectMock OfferingRepository offeringRepository;
   @InjectMock SubscriptionRepository subscriptionRepository;
 
   @InjectMock SubscriptionSyncService syncService;
@@ -67,6 +72,18 @@ class ContractServiceTest extends BaseUnitTest {
   Contract contractDto;
 
   @Captor ArgumentCaptor<ContractEntity> contractArgumentCaptor;
+
+  @BeforeEach
+  public void setup() {
+    when(offeringRepository.findById(anyString()))
+        .thenAnswer(
+            invocation -> {
+              Object[] args = invocation.getArguments();
+              var offering = new OfferingEntity();
+              offering.setSku((String) args[0]);
+              return offering;
+            });
+  }
 
   @BeforeAll
   public void setupTestData() {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SpringDataUtil.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SpringDataUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.Objects;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Join;
+import javax.persistence.metamodel.SetAttribute;
+import javax.persistence.metamodel.SingularAttribute;
+
+public class SpringDataUtil {
+  private SpringDataUtil() {
+    // Static methods only
+  }
+
+  public static <P, S, T> Join<S, T> fetchJoin(
+      Join<P, S> primaryJoin, SingularAttribute<S, T> attribute, String alias) {
+    // NB: think P for primary, S for secondary, T for tertiary
+    var existing =
+        primaryJoin.getJoins().stream()
+            .filter(join -> Objects.equals(join.getAlias(), alias))
+            .findFirst();
+    return existing
+        .map(join -> (Join<S, T>) join)
+        .orElseGet(
+            () -> {
+              var join = (Join<S, T>) primaryJoin.fetch(attribute);
+              join.alias(alias);
+              return join;
+            });
+  }
+
+  public static <P, S> Join<P, S> fetchJoin(
+      From<P, P> root, SingularAttribute<P, S> attribute, String alias) {
+    // NB: think P for primary, S for secondary
+    var existing =
+        root.getJoins().stream().filter(join -> Objects.equals(join.getAlias(), alias)).findFirst();
+    return existing
+        .map(join -> (Join<P, S>) join)
+        .orElseGet(
+            () -> {
+              var join = (Join<P, S>) root.fetch(attribute);
+              join.alias(alias);
+              return join;
+            });
+  }
+
+  public static <P, S> Join<P, S> fetchJoin(
+      From<?, P> root, SetAttribute<P, S> attribute, String alias) {
+    // NB: think P for primary, S for secondary
+    var existing =
+        root.getJoins().stream().filter(join -> Objects.equals(join.getAlias(), alias)).findFirst();
+    return existing
+        .map(join -> (Join<P, S>) join)
+        .orElseGet(
+            () -> {
+              var join = (Join<P, S>) root.fetch(attribute);
+              join.alias(alias);
+              return join;
+            });
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -21,15 +21,21 @@
 package org.candlepin.subscriptions.db.model;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -96,6 +102,15 @@ public class Offering implements Serializable {
   @CollectionTable(name = "sku_child_sku", joinColumns = @JoinColumn(name = "sku"))
   @Column(name = "child_sku")
   private Set<String> childSkus = new HashSet<>();
+
+  @Builder.Default
+  @ToString.Exclude
+  @OneToMany(
+      mappedBy = "offering",
+      cascade = CascadeType.ALL,
+      orphanRemoval = true,
+      fetch = FetchType.LAZY)
+  private List<Subscription> subscriptions = new ArrayList<>();
 
   /**
    * Numeric identifiers for Engineering Products provided by the offering.
@@ -193,5 +208,22 @@ public class Offering implements Serializable {
         usage,
         hasUnlimitedUsage,
         derivedSku);
+  }
+
+  public void addSubscription(Subscription s) {
+    subscriptions.add(s);
+    s.setOffering(this);
+  }
+
+  public void addSubscriptions(Collection<Subscription> subscriptionCollection) {
+    for (Subscription s : subscriptionCollection) {
+      subscriptions.add(s);
+      s.setOffering(this);
+    }
+  }
+
+  public void removeSubscription(Subscription s) {
+    subscriptions.remove(s);
+    s.setOffering(null);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -21,21 +21,15 @@
 package org.candlepin.subscriptions.db.model;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -102,15 +96,6 @@ public class Offering implements Serializable {
   @CollectionTable(name = "sku_child_sku", joinColumns = @JoinColumn(name = "sku"))
   @Column(name = "child_sku")
   private Set<String> childSkus = new HashSet<>();
-
-  @Builder.Default
-  @ToString.Exclude
-  @OneToMany(
-      mappedBy = "offering",
-      cascade = CascadeType.ALL,
-      orphanRemoval = true,
-      fetch = FetchType.LAZY)
-  private List<Subscription> subscriptions = new ArrayList<>();
 
   /**
    * Numeric identifiers for Engineering Products provided by the offering.
@@ -208,22 +193,5 @@ public class Offering implements Serializable {
         usage,
         hasUnlimitedUsage,
         derivedSku);
-  }
-
-  public void addSubscription(Subscription s) {
-    subscriptions.add(s);
-    s.setOffering(this);
-  }
-
-  public void addSubscriptions(Collection<Subscription> subscriptionCollection) {
-    for (Subscription s : subscriptionCollection) {
-      subscriptions.add(s);
-      s.setOffering(this);
-    }
-  }
-
-  public void removeSubscription(Subscription s) {
-    subscriptions.remove(s);
-    s.setOffering(null);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -50,8 +50,9 @@ public class Subscription implements Serializable {
   @Column(name = "subscription_number")
   private String subscriptionNumber;
 
-  @Column(name = "sku")
-  private String sku;
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "sku")
+  private Offering offering;
 
   @Column(name = "org_id")
   private String orgId;
@@ -78,24 +79,23 @@ public class Subscription implements Serializable {
   @Column(name = "billing_provider")
   private BillingProvider billingProvider;
 
-  @OneToMany(mappedBy = "subscription", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+  @OneToMany(
+      mappedBy = "subscription",
+      fetch = FetchType.EAGER,
+      cascade = CascadeType.ALL,
+      orphanRemoval = true)
   @Builder.Default
   @ToString.Exclude
   private Set<SubscriptionProductId> subscriptionProductIds = new HashSet<>();
 
-  @OneToMany(mappedBy = "subscription", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @OneToMany(
+      mappedBy = "subscription",
+      fetch = FetchType.LAZY,
+      cascade = CascadeType.ALL,
+      orphanRemoval = true)
   @Builder.Default
   @ToString.Exclude // Excluded to prevent fetching a lazy-loaded collection
   private List<SubscriptionMeasurement> subscriptionMeasurements = new ArrayList<>();
-
-  // Lombok would name the getter "isHasUnlimitedGuestSockets"
-  @Getter(AccessLevel.NONE)
-  @Column(name = "has_unlimited_usage")
-  private Boolean hasUnlimitedUsage;
-
-  public Boolean getHasUnlimitedUsage() {
-    return hasUnlimitedUsage;
-  }
 
   @Override
   public boolean equals(Object o) {
@@ -113,7 +113,6 @@ public class Subscription implements Serializable {
 
     return Objects.equals(subscriptionId, sub.getSubscriptionId())
         && Objects.equals(subscriptionNumber, sub.getSubscriptionNumber())
-        && Objects.equals(sku, sub.getSku())
         && Objects.equals(orgId, sub.getOrgId())
         && Objects.equals(quantity, sub.getQuantity())
         && Objects.equals(startDate, sub.getStartDate())
@@ -122,13 +121,25 @@ public class Subscription implements Serializable {
         && Objects.equals(billingAccountId, sub.getBillingAccountId())
         && Objects.equals(accountNumber, sub.getAccountNumber())
         && Objects.equals(billingProvider, sub.getBillingProvider())
-        && Objects.equals(hasUnlimitedUsage, sub.getHasUnlimitedUsage())
         && Objects.equals(ourProductIds, otherProductIds);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(subscriptionId, startDate);
+    var ourProductIds =
+        subscriptionProductIds.stream().map(SubscriptionProductId::getProductId).toList();
+    return Objects.hash(
+        subscriptionId,
+        subscriptionNumber,
+        orgId,
+        quantity,
+        startDate,
+        endDate,
+        billingProviderId,
+        billingAccountId,
+        accountNumber,
+        billingProvider,
+        ourProductIds);
   }
 
   /** Composite ID class for Subscription entities. */

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -145,6 +145,7 @@ public class Subscription implements Serializable {
   /** Composite ID class for Subscription entities. */
   @Getter
   @Setter
+  @ToString
   public static class SubscriptionCompoundId implements Serializable {
     private String subscriptionId;
     private OffsetDateTime startDate;


### PR DESCRIPTION
Adding the FK relationship allows us to remove a cross join that we needed to perform between the offering and subscription tables that had poor performance compared to an inner join.

Also set orphan-removal true on relationship between Subscription and SubscriptionMeasurement.


<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1365](https://issues.redhat.com/browse/SWATCH-1365)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Save the following as `manualJoin.patch`
   ```patch
   diff --git a/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java b/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
   index e624fb98..c47b29d2 100644
   --- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
   +++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
   @@ -39,6 +39,8 @@ import org.candlepin.subscriptions.db.model.Usage;
    import org.candlepin.subscriptions.utilization.api.model.MetricId;
    import org.junit.jupiter.api.BeforeEach;
    import org.junit.jupiter.api.Test;
   +import org.slf4j.Logger;
   +import org.slf4j.LoggerFactory;
    import org.springframework.beans.factory.annotation.Autowired;
    import org.springframework.boot.test.context.SpringBootTest;
    import org.springframework.test.context.ActiveProfiles;
   @@ -92,6 +94,19 @@ class SubscriptionMeasurementRepositoryTest {
        subscriptionRepository.saveAndFlush(subscription);
      }
    
   +  private static final Logger log =
   +      LoggerFactory.getLogger(SubscriptionMeasurementRepositoryTest.class);
   +
   +  @Test
   +  void manualJoinTest() {
   +    var specification =
   +        SubscriptionMeasurementRepository.slaEquals(ServiceLevel.PREMIUM).and(SubscriptionMeasurementRepository.usageEquals(Usage.PRODUCTION));
   +
   +    log.info("BEGIN TEST");
   +    var result = subscriptionMeasurementRepository.findAll(specification);
   +    assertThat(result, contains(physicalCores));
   +  }
   +
      @Test
      void testSimpleFetch() {
        var subscriptionId = new SubscriptionCompoundId();
   diff --git a/swatch-core-test/src/main/resources/application-test.yaml b/swatch-core-test/src/main/resources/application-test.yaml
   index f72bb574..4331148c 100644
   --- a/swatch-core-test/src/main/resources/application-test.yaml
   +++ b/swatch-core-test/src/main/resources/application-test.yaml
   @@ -34,10 +34,14 @@ logging:
      level:
        org:
          candlepin: INFO
   +      hibernate:
   +        type: TRACE
    spring:
      jpa:
   +    show-sql: true
        properties:
          hibernate:
   +        format_sql: true
            jdbc:
              # Force the testing database into UTC to prevent test failures when the database
              # determines the 'current' time in a query. NOTE: This is primarily when tests
   ```

### Steps
<!-- Enter each step of the test below -->
1. `git checkout main && patch -p1 < manualJoin.patch`
1. `./gradlew :test -i --tests=SubscriptionMeasurementRepositoryTest.manualJoinTest`
1. Observe the output after the log line reading `BEGIN TEST`.  The query has **two** cross joins on `offering1_` and `offering2_`.  The wrapping is a bit weird in the Hibernate output but the `cross` directive is associated with the `join` on the subsequent line.
   ```sql
   select
       subscripti0_.measurement_type as measurem1_13_0_,
       subscripti0_.metric_id as metric_i2_13_0_,
       subscripti0_.start_date as start_da0_13_0_,
       subscripti0_.subscription_id as subscrip0_13_0_,
       subscripti3_.start_date as start_da1_12_1_,
       subscripti3_.subscription_id as subscrip2_12_1_,
       subscripti0_.start_date as start_da4_13_0_,
       subscripti0_.subscription_id as subscrip5_13_0_,
       subscripti0_.value as value3_13_0_,
       subscripti3_.account_number as account_3_12_1_,
       subscripti3_.billing_account_id as billing_4_12_1_,
       subscripti3_.billing_provider as billing_5_12_1_,
       subscripti3_.billing_provider_id as billing_6_12_1_,
       subscripti3_.end_date as end_date7_12_1_,
       subscripti3_.has_unlimited_usage as has_unli8_12_1_,
       subscripti3_.org_id as org_id9_12_1_,
       subscripti3_.quantity as quantit10_12_1_,
       subscripti3_.sku as sku11_12_1_,
       subscripti3_.subscription_number as subscri12_12_1_
   from
       subscription_measurements subscripti0_ cross
   join
       offering offering1_ cross
   join
       offering offering2_
   inner join
       subscription subscripti3_
           on subscripti0_.start_date=subscripti3_.start_date
           and subscripti0_.subscription_id=subscripti3_.subscription_id
   where
       subscripti3_.sku=offering1_.sku  
       and offering1_.sla=?
       and subscripti3_.sku=offering2_.sku
       and offering2_.usage=?
   ```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. `git checkout origin/awood/SWATCH-1365-slow-query && patch -p1 < manualJoin.patch`
1. `./gradlew :test -i --tests=SubscriptionMeasurementRepositoryTest.manualJoinTest`
1. The select query is now devoid of any cross joins                                                                                                                             
   ```sql                                                                                                                                                                        
   select                                                                                                                                                                        
       subscripti0_.measurement_type as measurem1_13_0_,                                                                                                                         
       subscripti0_.metric_id as metric_i2_13_0_,                                                                                                                                
       subscripti0_.start_date as start_da0_13_0_,                                                                                                                               
       subscripti0_.subscription_id as subscrip0_13_0_,                                                                                                                                 subscripti1_.start_date as start_da1_12_1_,                                                                                                                               
       subscripti1_.subscription_id as subscrip2_12_1_,                                                                                                                          
       offering2_.sku as sku1_8_2_,                                                                                                                                              
       subscripti0_.start_date as start_da4_13_0_,                                                                                                                               
       subscripti0_.subscription_id as subscrip5_13_0_,                                                                                                                          
       subscripti0_.value as value3_13_0_,                                                                                                                                       
       subscripti1_.account_number as account_3_12_1_,                                                                                                                           
       subscripti1_.billing_account_id as billing_4_12_1_,                                                                                                                       
       subscripti1_.billing_provider as billing_5_12_1_,                                                                                                                         
       subscripti1_.billing_provider_id as billing_6_12_1_,                                                                                                                      
       subscripti1_.end_date as end_date7_12_1_,                                                                                                                                 
       subscripti1_.sku as sku11_12_1_,                                                                                                                                          
       subscripti1_.org_id as org_id8_12_1_,                                                                                                                                     
       subscripti1_.quantity as quantity9_12_1_,                                                                                                                                 
       subscripti1_.subscription_number as subscri10_12_1_,                                                                                                                      
       offering2_.cores as cores2_8_2_,                                                                                                                                          
       offering2_.derived_sku as derived_3_8_2_,                                                                                                                                 
       offering2_.description as descript4_8_2_,                                                                                                                                 
       offering2_.has_unlimited_usage as has_unli5_8_2_,                                                                                                                         
       offering2_.hypervisor_cores as hypervis6_8_2_,                                                                                                                            
       offering2_.hypervisor_sockets as hypervis7_8_2_,                                                                                                                          
       offering2_.product_family as product_8_8_2_,                                                                                                                              
       offering2_.product_name as product_9_8_2_,                                                                                                                                
       offering2_.role as role10_8_2_,                                                                                                                                           
       offering2_.sla as sla11_8_2_,                                                                                                                                             
       offering2_.sockets as sockets12_8_2_,                                                                                                                                     
       offering2_.usage as usage13_8_2_                                                                                                                                          
   from                                                                                                                                                                          
       subscription_measurements subscripti0_                                                                                                                                    
   inner join                                                                                                                                                                    
       subscription subscripti1_                                                                                                                                                 
           on subscripti0_.start_date=subscripti1_.start_date                                                                                                                    
           and subscripti0_.subscription_id=subscripti1_.subscription_id                                                                                                         
   inner join                                                                                                                                                                    
       offering offering2_                                                                                                                                                       
           on subscripti1_.sku=offering2_.sku                                                                                                                                    
   where                                                                                                                                                                         
       offering2_.sla=?                                                                                                                                                          
       and offering2_.usage=?                                                                                                                                                    
   ```