### PR TITLE
SWATCH-865: Implement instances guest api 

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -510,6 +510,14 @@ public interface HostRepository
   Page<Host> getHostsByHypervisor(
       @Param("orgId") String orgId, @Param("hypervisor_id") String hypervisorId, Pageable pageable);
 
+  @Query(
+      "select distinct h1 from Host h1 where "
+          + "h1.orgId = :orgId and "
+          + "h1.hypervisorUuid in (select h2.subscriptionManagerId from Host h2 where "
+          + "h2.instanceId = :instanceId)")
+  Page<Host> getGuestHostsByHypervisorInstanceId(
+      @Param("orgId") String orgId, @Param("instanceId") String instanceId, Pageable pageable);
+
   List<Host> findByAccountNumber(String accountNumber);
 
   Optional<Host> findById(UUID id);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -269,7 +269,7 @@ public class Host implements Serializable {
         .sockets(
             Optional.ofNullable(getMeasurement(Uom.SOCKETS)).map(Double::intValue).orElse(null))
         .displayName(displayName)
-        .hardwareType(hardwareType.toString())
+        .hardwareType(hardwareType == null ? null : hardwareType.toString())
         .insightsId(insightsId)
         .inventoryId(inventoryId)
         .subscriptionManagerId(subscriptionManagerId)


### PR DESCRIPTION

<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-865](https://issues.redhat.com/browse/SWATCH-865)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Implement instances guest API to retrieve a hypervisor's guest instances by the hypervisor's instance_id.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1.Insert mock hypervisor and guest instances: 
`bin/insert-mock-hosts  --num-hypervisors 1   --num-guests 1   --org org123`

### Steps
<!-- Enter each step of the test below -->
1. Find the instance_id of created hypervisor:
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
select instance_id from hosts where org_id='org123' and is_hypervisor=true;
EOF
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Run following curl(replacing with generated instance_id from previous step) and should retrieve guest instance:
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/instances/{hypervisor_instance_id}/guests' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
