### PR TITLE
SWATCH-1298: Add post-deployment API support to sync hourly remittance

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -39,12 +39,14 @@ import org.candlepin.subscriptions.tally.admin.api.model.TallyResendData;
 import org.candlepin.subscriptions.tally.admin.api.model.TallyResponse;
 import org.candlepin.subscriptions.tally.admin.api.model.UuidList;
 import org.candlepin.subscriptions.tally.billing.RemittanceController;
+import org.candlepin.subscriptions.tally.billing.RemittanceSyncAlignmentException;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.DateRange;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.task.TaskRejectedException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 /** This resource is for exposing administrator REST endpoints for Tally. */
@@ -118,8 +120,45 @@ public class InternalTallyResource implements InternalApi {
   }
 
   @Override
+  @Transactional
   public void syncRemittance() {
-    remittanceController.syncRemittance();
+    log.info("REMITTANCE SYNC: Starting");
+
+    remittanceController
+        .findSyncableRemittance()
+        .forEach(
+            remittance -> {
+              try {
+                // Sync the remittance record in a single transaction.
+                // NOTE: syncRemittance must be called here in order to
+                // allow spring boot to roll back single remittance sync
+                // on failure.
+                remittanceController.syncRemittance(remittance);
+              } catch (RemittanceSyncAlignmentException e) {
+                log.warn(e.getMessage());
+                // We let the exception bubble up this far so that the transaction is
+                // rolled back and any remittance records created by the single remittance
+                // sync are not persisted.
+
+                handleSyncAlignmentException(e);
+              } catch (Exception e) {
+                log.error(e.getMessage());
+              }
+            });
+    log.info("REMITTANCE SYNC: Complete");
+  }
+
+  private void handleSyncAlignmentException(RemittanceSyncAlignmentException rsae) {
+    log.debug(
+        "Converting existing monthly remittance to hourly - date={} remittance={}",
+        rsae.getDateOfLatestSnapshot(),
+        rsae.getRemittanceToSync());
+    try {
+      remittanceController.replaceMonthlyRemittance(
+          rsae.getRemittanceToSync(), rsae.getDateOfLatestSnapshot());
+    } catch (Exception ex) {
+      log.error("REMITTANCE SYNC: Failed to convert remittance.", ex);
+    }
   }
 
   @Override

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -102,6 +102,8 @@ public class BillableUsageController {
             .accumulationPeriod(key.getAccumulationPeriod())
             .metricId(key.getMetricId())
             .productId(key.getProductId())
+            .sla(key.getSla())
+            .usage(key.getUsage())
             .granularity(Granularity.HOURLY)
             .beginning(billableUsage.getSnapshotDate())
             .build();
@@ -118,6 +120,8 @@ public class BillableUsageController {
             .accumulationPeriod(key.getAccumulationPeriod())
             .metricId(key.getMetricId())
             .productId(key.getProductId())
+            .sla(key.getSla())
+            .usage(key.getUsage())
             .granularity(Granularity.HOURLY)
             .build();
     return billableUsageRemittanceRepository.getRemittanceSummaries(filter).stream()

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceController.java
@@ -20,21 +20,34 @@
  */
 package org.candlepin.subscriptions.tally.billing;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
-import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.RemittanceSummaryProjection;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.registry.BillingWindow;
 import org.candlepin.subscriptions.registry.TagMetric;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.retention.TallyRetentionPolicy;
 import org.candlepin.subscriptions.tally.TallySummaryMapper;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Component
@@ -47,6 +60,7 @@ public class RemittanceController {
   private final TallySummaryMapper summaryMapper;
   private final BillableUsageMapper billableUsageMapper;
   private final BillableUsageController billableUsageController;
+  private final TallyRetentionPolicy retention;
 
   public RemittanceController(
       ApplicationClock clock,
@@ -55,7 +69,8 @@ public class RemittanceController {
       TallySnapshotRepository snapshotRepository,
       TallySummaryMapper summaryMapper,
       BillableUsageMapper billableUsageMapper,
-      BillableUsageController billableUsageController) {
+      BillableUsageController billableUsageController,
+      TallyRetentionPolicy retention) {
     this.clock = clock;
     this.tagProfile = tagProfile;
     this.remittanceRepository = remittanceRepository;
@@ -63,14 +78,78 @@ public class RemittanceController {
     this.summaryMapper = summaryMapper;
     this.billableUsageMapper = billableUsageMapper;
     this.billableUsageController = billableUsageController;
+    this.retention = retention;
   }
 
-  @Transactional
-  public void syncRemittance() {
-    log.info("Syncing remittance!");
+  public List<BillableUsageRemittanceEntity> findSyncableRemittance() {
+    return remittanceRepository.filterBy(
+        BillableUsageRemittanceFilter.builder().granularity(Granularity.MONTHLY).build());
+  }
 
+  // A monthly remittance can only be synced if all HOURLY snapshots are present.
+  // The hourly retention policy may have deleted snapshots on the monthly boundary,
+  // which makes it impossible to build the corresponding HOURLY remittance.
+  //
+  // Determine the cutoff date based on the Hourly tally retention policy.
+  private OffsetDateTime getRemittanceCutoffDate() {
+    OffsetDateTime hourlyCutoff = retention.getCutoffDate(Granularity.HOURLY);
+    if (hourlyCutoff.equals(clock.startOfMonth(hourlyCutoff))) {
+      return hourlyCutoff;
+    }
+    return clock.startOfMonth(hourlyCutoff.plusMonths(1));
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void syncRemittance(BillableUsageRemittanceEntity rem) {
+    OffsetDateTime earliestRemittanceDate = getRemittanceCutoffDate();
+
+    OffsetDateTime beginning = dateFromAccumulationPeriod(rem.getKey().getAccumulationPeriod());
+    OffsetDateTime ending = clock.endOfMonth(beginning);
+    log.debug("CHECKING FOR BILLABLES: {} --> {}", beginning, ending);
+
+    if (beginning.isBefore(earliestRemittanceDate)) {
+      log.warn(
+          "REMITTANCE SYNC: Remittance is outside the hourly tally snapshot retention window {} so it will be purged. {}",
+          earliestRemittanceDate,
+          rem);
+      remittanceRepository.delete(rem);
+      return;
+    }
+
+    // If there are no associated billables for the remittance, they were deleted as
+    // part of the snapshot purge. If that's the case, then we just delete this remittance
+    // as it is no longer relevant and will be eventually purged.
+    if (!snapshotRepository.hasLatestBillables(
+        rem.getKey().getOrgId(),
+        rem.getKey().getProductId(),
+        ServiceLevel.fromString(rem.getKey().getSla()),
+        Usage.fromString(rem.getKey().getUsage()),
+        BillingProvider.fromString(rem.getKey().getBillingProvider()),
+        rem.getKey().getBillingAccountId(),
+        beginning,
+        ending,
+        new TallyMeasurementKey(
+            HardwareMeasurementType.PHYSICAL, Uom.fromValue(rem.getKey().getMetricId())))) {
+      log.warn(
+          "REMITTANCE SYNC: No hourly billables found for remittance so it will be purged. {}",
+          rem);
+      remittanceRepository.delete(rem);
+      return;
+    }
+
+    AtomicReference<OffsetDateTime> latestBillableDate = new AtomicReference<>();
     snapshotRepository
-        .findLatestBillablesForMonth(clock.now().getMonthValue())
+        .getBillableSnapshots(
+            rem.getKey().getOrgId(),
+            rem.getKey().getProductId(),
+            ServiceLevel.fromString(rem.getKey().getSla()),
+            Usage.fromString(rem.getKey().getUsage()),
+            BillingProvider.fromString(rem.getKey().getBillingProvider()),
+            rem.getKey().getBillingAccountId(),
+            beginning,
+            ending,
+            new TallyMeasurementKey(
+                HardwareMeasurementType.PHYSICAL, Uom.fromValue(rem.getKey().getMetricId())))
         .map(s -> summaryMapper.mapSnapshots(s.getAccountNumber(), s.getOrgId(), List.of(s)))
         .forEach(
             summary ->
@@ -88,19 +167,76 @@ public class RemittanceController {
                         })
                     .forEach(
                         billable -> {
-                          if (remittanceExists(billable)) {
-                            log.debug(
-                                "Remittance already exists! Will not align remittance! {}",
-                                billable);
-                          } else {
-                            log.info("Creating new remittance! {}", billable);
-                            billableUsageController.processBillableUsage(
-                                BillingWindow.MONTHLY, billable);
-                          }
+                          latestBillableDate.set(billable.getSnapshotDate());
+                          billableUsageController.processBillableUsage(
+                              BillingWindow.MONTHLY, billable);
                         }));
+    validateRemittance(rem, latestBillableDate.get());
+    log.info("REMITTANCE SYNC: Successfully synced remittance {}", rem);
   }
 
-  private boolean remittanceExists(BillableUsage billableUsage) {
-    return remittanceRepository.existsById(BillableUsageRemittanceEntityPK.keyFrom(billableUsage));
+  private void validateRemittance(
+      BillableUsageRemittanceEntity rem, OffsetDateTime latestSnapshotDate) {
+    var filter =
+        BillableUsageRemittanceFilter.builder()
+            .orgId(rem.getKey().getOrgId())
+            .billingAccountId(rem.getKey().getBillingAccountId())
+            .billingProvider(rem.getKey().getBillingProvider())
+            .accumulationPeriod(rem.getKey().getAccumulationPeriod())
+            .metricId(rem.getKey().getMetricId())
+            .productId(rem.getKey().getProductId())
+            .sla(rem.getKey().getSla())
+            .usage(rem.getKey().getUsage())
+            .granularity(Granularity.HOURLY)
+            .build();
+    Double hourlyBasedTotal =
+        remittanceRepository.getRemittanceSummaries(filter).stream()
+            .findFirst()
+            .map(RemittanceSummaryProjection::getTotalRemittedPendingValue)
+            .orElse(0.0);
+    if (!rem.getRemittedPendingValue().equals(hourlyBasedTotal)) {
+      throw new RemittanceSyncAlignmentException(rem, hourlyBasedTotal, latestSnapshotDate);
+    } else {
+      log.debug("Remittance validated after sync! Deleting initial remittance record");
+      remittanceRepository.delete(rem);
+    }
+  }
+
+  private OffsetDateTime dateFromAccumulationPeriod(String accumulationPeriod) {
+    if (!StringUtils.hasText(accumulationPeriod)) {
+      throw new IllegalArgumentException("Invalid accumulation period: " + accumulationPeriod);
+    }
+
+    String[] parts = accumulationPeriod.split("-");
+    if (parts.length < 2) {
+      throw new IllegalArgumentException("Invalid accumulation period: " + accumulationPeriod);
+    }
+
+    return clock
+        .startOfCurrentMonth()
+        .withYear(Integer.parseInt(parts[0]))
+        .withMonth(Integer.parseInt(parts[1]));
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void replaceMonthlyRemittance(
+      BillableUsageRemittanceEntity toConvert, OffsetDateTime hourlyDate) {
+    BillableUsageRemittanceEntityPK hourlyKey =
+        BillableUsageRemittanceEntityPK.clone(toConvert.getKey());
+    hourlyKey.setRemittancePendingDate(clock.startOfHour(hourlyDate));
+    hourlyKey.setGranularity(Granularity.HOURLY);
+    remittanceRepository.save(
+        new BillableUsageRemittanceEntity(
+            hourlyKey, toConvert.getRemittedPendingValue(), toConvert.getAccountNumber()));
+
+    BillableUsageRemittanceEntityPK dailyKey =
+        BillableUsageRemittanceEntityPK.clone(toConvert.getKey());
+    dailyKey.setRemittancePendingDate(clock.startOfDay(hourlyDate));
+    dailyKey.setGranularity(Granularity.DAILY);
+    remittanceRepository.save(
+        new BillableUsageRemittanceEntity(
+            dailyKey, toConvert.getRemittedPendingValue(), toConvert.getAccountNumber()));
+
+    remittanceRepository.deleteById(toConvert.getKey());
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceSyncAlignmentException.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceSyncAlignmentException.java
@@ -28,9 +28,9 @@ import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 @Getter
 public class RemittanceSyncAlignmentException extends RuntimeException {
 
-  private Double result;
-  private BillableUsageRemittanceEntity remittanceToSync;
-  private OffsetDateTime dateOfLatestSnapshot;
+  private final Double result;
+  private final BillableUsageRemittanceEntity remittanceToSync;
+  private final OffsetDateTime dateOfLatestSnapshot;
 
   public RemittanceSyncAlignmentException(
       BillableUsageRemittanceEntity remittanceToSync,

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceSyncAlignmentException.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/RemittanceSyncAlignmentException.java
@@ -18,35 +18,30 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.db;
+package org.candlepin.subscriptions.tally.billing;
 
 import java.time.OffsetDateTime;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
-import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 
-/**
- * A filter used to find {@link org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity}
- * objects via the {@link BillableUsageRemittanceRepository}. Any filter value with a null value
- * will not be checked.
- */
-@Builder
+/** An exception that tracks a remittance sync alignment issue. */
 @Getter
-@Setter
-@EqualsAndHashCode
-public class BillableUsageRemittanceFilter {
-  private String productId;
-  private String account;
-  private String orgId;
-  private String usage;
-  private String sla;
-  private String metricId;
-  private String billingProvider;
-  private String billingAccountId;
-  private OffsetDateTime beginning;
-  private OffsetDateTime ending;
-  private String accumulationPeriod;
-  private Granularity granularity;
+public class RemittanceSyncAlignmentException extends RuntimeException {
+
+  private Double result;
+  private BillableUsageRemittanceEntity remittanceToSync;
+  private OffsetDateTime dateOfLatestSnapshot;
+
+  public RemittanceSyncAlignmentException(
+      BillableUsageRemittanceEntity remittanceToSync,
+      Double result,
+      OffsetDateTime dateOfLatestSnapshot) {
+    super(
+        String.format(
+            "REMITTANCE SYNC: Remittance did not align after sync! EXPECTED: %s WAS: %s -- %s",
+            remittanceToSync.getRemittedPendingValue(), result, remittanceToSync));
+    this.result = result;
+    this.remittanceToSync = remittanceToSync;
+    this.dateOfLatestSnapshot = dateOfLatestSnapshot;
+  }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
@@ -345,6 +345,8 @@ class BillableUsageRemittanceRepositoryTest {
             .remittancePendingDate(remittance2.getKey().getRemittancePendingDate())
             .metricId(remittance1.getKey().getMetricId())
             .totalRemittedPendingValue(24.0)
+            .sla(remittance1.getKey().getSla())
+            .usage(remittance1.getKey().getUsage())
             .build();
 
     var expectedSummary2 =
@@ -359,6 +361,8 @@ class BillableUsageRemittanceRepositoryTest {
             .remittancePendingDate(remittance3.getKey().getRemittancePendingDate())
             .metricId(remittance3.getKey().getMetricId())
             .totalRemittedPendingValue(15.0)
+            .sla(remittance3.getKey().getSla())
+            .usage(remittance3.getKey().getUsage())
             .build();
 
     List<RemittanceSummaryProjection> results = repository.getRemittanceSummaries(filter1);

--- a/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallySnapshotRepositoryTest.java
@@ -446,4 +446,54 @@ class TallySnapshotRepositoryTest {
         Uom.CORES,
         2.0);
   }
+
+  @Test
+  void testHasLatestBillablesWhenMetricExists() {
+    TallySnapshot snap =
+        createUnpersisted(
+            "OrgAcme", "Acme Inc.", "rocket-skates", Granularity.HOURLY, 1, 2, 3, NOWISH);
+
+    snap.setMeasurement(HardwareMeasurementType.PHYSICAL, Uom.CORES, 9.0);
+    snap.setMeasurement(HardwareMeasurementType.PHYSICAL, Uom.SOCKETS, 8.0);
+    snap.setMeasurement(HardwareMeasurementType.PHYSICAL, Uom.INSTANCES, 7.0);
+
+    repository.save(snap);
+    repository.flush();
+
+    assertTrue(
+        repository.hasLatestBillables(
+            snap.getOrgId(),
+            snap.getProductId(),
+            snap.getServiceLevel(),
+            snap.getUsage(),
+            snap.getBillingProvider(),
+            snap.getBillingAccountId(),
+            NOWISH,
+            NOWISH,
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.CORES)));
+  }
+
+  @Test
+  void testDoesNotHaveLatestBillablesWhenMetricDoesNotExists() {
+    TallySnapshot snap =
+        createUnpersisted(
+            "OrgAcme", "Acme Inc.", "rocket-skates", Granularity.HOURLY, 1, 2, 3, NOWISH);
+
+    snap.setMeasurement(HardwareMeasurementType.PHYSICAL, Uom.SOCKETS, 8.0);
+
+    repository.save(snap);
+    repository.flush();
+
+    assertFalse(
+        repository.hasLatestBillables(
+            snap.getOrgId(),
+            snap.getProductId(),
+            snap.getServiceLevel(),
+            snap.getUsage(),
+            snap.getBillingProvider(),
+            snap.getBillingAccountId(),
+            NOWISH,
+            NOWISH,
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.CORES)));
+  }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -512,9 +511,9 @@ class RemittanceControllerTest {
     dailyRem.getKey().setGranularity(Granularity.DAILY);
 
     controller.replaceMonthlyRemittance(monthlyRemittance, snapshot.getSnapshotDate());
-    verify(remittanceRepo).save(eq(dailyRem));
-    verify(remittanceRepo).save(eq(hourlyRem));
-    verify(remittanceRepo).deleteById(eq(monthlyRemittance.getKey()));
+    verify(remittanceRepo).save(dailyRem);
+    verify(remittanceRepo).save(hourlyRem);
+    verify(remittanceRepo).deleteById(monthlyRemittance.getKey());
   }
 
   private BillableUsageRemittanceEntity createRemittance(

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
@@ -22,7 +22,11 @@ package org.candlepin.subscriptions.tally.billing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -31,14 +35,17 @@ import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contracts.api.resources.DefaultApi;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
@@ -46,6 +53,7 @@ import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.RemittanceSummaryProjection;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
@@ -57,6 +65,8 @@ import org.candlepin.subscriptions.registry.TagMapping;
 import org.candlepin.subscriptions.registry.TagMetaData;
 import org.candlepin.subscriptions.registry.TagMetric;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.retention.TallyRetentionPolicy;
+import org.candlepin.subscriptions.retention.TallyRetentionPolicyProperties;
 import org.candlepin.subscriptions.tally.TallySummaryMapper;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -66,6 +76,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.kafka.core.KafkaTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -76,6 +87,10 @@ class RemittanceControllerTest {
   @Mock private KafkaTemplate<String, BillableUsage> billableTemplate;
   @Mock private DefaultApi contractApi;
   @Mock private ContractsClientProperties contractsClientProperties;
+
+  @Mock(lenient = true)
+  private TallyRetentionPolicyProperties retentionProperties;
+
   private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
 
   private TagProfile tagProfile;
@@ -92,6 +107,9 @@ class RemittanceControllerTest {
     BillableUsageController usageController =
         new BillableUsageController(
             clock, billingProducer, remittanceRepo, snapshotRepo, tagProfile, contractsController);
+
+    when(retentionProperties.getHourly()).thenReturn(1680); // 70 days
+    TallyRetentionPolicy retentionPolicy = new TallyRetentionPolicy(clock, retentionProperties);
     controller =
         new RemittanceController(
             clock,
@@ -100,12 +118,16 @@ class RemittanceControllerTest {
             snapshotRepo,
             new TallySummaryMapper(),
             new BillableUsageMapper(tagProfile),
-            usageController);
+            usageController,
+            retentionPolicy);
   }
 
   @Test
   void syncRemittance() {
-    List<TallySnapshot> snaps = new ArrayList<>();
+    double snap1Measurement = 15.25;
+    double snap2Measurement = 15.5;
+
+    // Applicable snapshots
     TallySnapshot expectedSnapshot1 =
         buildSnapshot(
             "org123",
@@ -115,27 +137,52 @@ class RemittanceControllerTest {
             Usage.PRODUCTION,
             BillingProvider.AWS,
             Uom.STORAGE_GIBIBYTE_MONTHS,
-            15.25,
+            snap1Measurement,
             clock.startOfCurrentHour());
-    snaps.add(expectedSnapshot1);
 
     TallySnapshot expectedSnapshot2 =
         buildSnapshot(
-            "org345",
+            "org123",
             "rhosak",
             Granularity.HOURLY,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             BillingProvider.AWS,
             Uom.STORAGE_GIBIBYTE_MONTHS,
-            15.5,
-            clock.startOfCurrentHour());
-    snaps.add(expectedSnapshot2);
-    when(snapshotRepo.findLatestBillablesForMonth(clock.now().getMonthValue()))
-        .thenReturn(snaps.stream());
+            snap2Measurement,
+            clock.startOfCurrentHour().plusHours(1));
+
+    BillableUsageRemittanceEntity monthlyRemittanceAfterDbMigration =
+        createRemittance(expectedSnapshot1, 31.0);
+    monthlyRemittanceAfterDbMigration.getKey().setGranularity(Granularity.MONTHLY);
+
+    when(snapshotRepo.hasLatestBillables(
+            expectedSnapshot1.getOrgId(),
+            expectedSnapshot1.getProductId(),
+            expectedSnapshot1.getServiceLevel(),
+            expectedSnapshot1.getUsage(),
+            expectedSnapshot1.getBillingProvider(),
+            expectedSnapshot1.getBillingAccountId(),
+            clock.startOfMonth(expectedSnapshot1.getSnapshotDate()),
+            clock.endOfMonth(expectedSnapshot1.getSnapshotDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(true);
+
+    when(snapshotRepo.getBillableSnapshots(
+            expectedSnapshot1.getOrgId(),
+            expectedSnapshot1.getProductId(),
+            expectedSnapshot1.getServiceLevel(),
+            expectedSnapshot1.getUsage(),
+            expectedSnapshot1.getBillingProvider(),
+            expectedSnapshot1.getBillingAccountId(),
+            clock.startOfMonth(expectedSnapshot1.getSnapshotDate()),
+            clock.endOfMonth(expectedSnapshot1.getSnapshotDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(Stream.of(expectedSnapshot1, expectedSnapshot2));
 
     BillableUsageRemittanceEntity expectedDailyRemittance =
-        createRemittanceAndMockMeasurementValue(expectedSnapshot2, 46);
+        createRemittanceAndMockMeasurementValue(
+            expectedSnapshot2, snap1Measurement + snap2Measurement, 46);
     expectedDailyRemittance.getKey().setGranularity(Granularity.DAILY);
     expectedDailyRemittance
         .getKey()
@@ -145,15 +192,25 @@ class RemittanceControllerTest {
     when(remittanceRepo.findById(any())).thenReturn(Optional.of(expectedDailyRemittance));
 
     BillableUsageRemittanceEntity expectedRemittance1 =
-        createRemittanceAndMockMeasurementValue(expectedSnapshot1, 46.0);
+        createRemittanceAndMockMeasurementValue(expectedSnapshot1, snap1Measurement, 16.0);
+
     BillableUsageRemittanceEntity expectedRemittance2 =
-        createRemittanceAndMockMeasurementValue(expectedSnapshot2, 16.0);
+        createRemittanceAndMockMeasurementValue(
+            expectedSnapshot2, snap1Measurement + snap2Measurement, 15.0);
+
+    mockRemittanceSummaryTotal(
+        monthlyRemittanceAfterDbMigration.getKey(),
+        // Nothing remitted initially, when first snapshot is processed.
+        0.0,
+        expectedRemittance1.getRemittedPendingValue(),
+        // The final summary call will be when the remittance sync validation occurs
+        // so we expect the value of the remittance we are syncing.
+        monthlyRemittanceAfterDbMigration.getRemittedPendingValue());
 
     ArgumentCaptor<BillableUsageRemittanceEntity> savedRemittance =
         ArgumentCaptor.forClass(BillableUsageRemittanceEntity.class);
-    controller.syncRemittance();
+    controller.syncRemittance(monthlyRemittanceAfterDbMigration);
     verify(remittanceRepo, times(4)).save(savedRemittance.capture());
-    var list = savedRemittance.getAllValues();
     assertThat(
         savedRemittance.getAllValues(),
         containsInAnyOrder(
@@ -161,11 +218,12 @@ class RemittanceControllerTest {
             expectedRemittance2,
             expectedDailyRemittance,
             expectedDailyRemittance));
+    verify(remittanceRepo).delete(monthlyRemittanceAfterDbMigration);
   }
 
   @Test
   void syncRemittanceSkipsSnapshotWhenBillingWindowIsNotMonthly() {
-    List<TallySnapshot> snaps = new ArrayList<>();
+
     TallySnapshot snapshot =
         buildSnapshot(
             "org123",
@@ -177,18 +235,53 @@ class RemittanceControllerTest {
             Uom.STORAGE_GIBIBYTE_MONTHS,
             15.25,
             clock.startOfCurrentHour());
-    snaps.add(snapshot);
 
-    when(snapshotRepo.findLatestBillablesForMonth(clock.now().getMonthValue()))
-        .thenReturn(snaps.stream());
+    // Technically, a remittance record should never exist for a product that
+    // doesn't have a monthly billing window, however, there is a safeguard put in
+    // place just in case it ever happened because of future code changes.
+    BillableUsageRemittanceEntity monthlyRemittanceAfterDbMigration =
+        createRemittance(snapshot, 16.0);
+    monthlyRemittanceAfterDbMigration.getKey().setGranularity(Granularity.MONTHLY);
 
-    controller.syncRemittance();
-    verifyNoInteractions(remittanceRepo);
+    when(snapshotRepo.hasLatestBillables(
+            snapshot.getOrgId(),
+            snapshot.getProductId(),
+            snapshot.getServiceLevel(),
+            snapshot.getUsage(),
+            snapshot.getBillingProvider(),
+            snapshot.getBillingAccountId(),
+            clock.startOfMonth(snapshot.getSnapshotDate()),
+            clock.endOfMonth(snapshot.getSnapshotDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(true);
+
+    when(snapshotRepo.getBillableSnapshots(
+            snapshot.getOrgId(),
+            snapshot.getProductId(),
+            snapshot.getServiceLevel(),
+            snapshot.getUsage(),
+            snapshot.getBillingProvider(),
+            snapshot.getBillingAccountId(),
+            clock.startOfMonth(snapshot.getSnapshotDate()),
+            clock.endOfMonth(snapshot.getSnapshotDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(Stream.of(snapshot));
+
+    mockRemittanceSummaryTotal(
+        monthlyRemittanceAfterDbMigration.getKey(),
+        monthlyRemittanceAfterDbMigration.getRemittedPendingValue());
+
+    controller.syncRemittance(monthlyRemittanceAfterDbMigration);
+
+    verify(remittanceRepo).delete(monthlyRemittanceAfterDbMigration);
+
+    // Code path shouldn't get into the BillableUsageController, so no more interactions are
+    // expected with the RemittanceRepository (saves).
+    verifyNoMoreInteractions(remittanceRepo);
   }
 
   @Test
   void syncRemittanceSkipsSnapshotWhenRemittanceExists() {
-    List<TallySnapshot> snaps = new ArrayList<>();
     TallySnapshot snapshot =
         buildSnapshot(
             "org123",
@@ -200,18 +293,228 @@ class RemittanceControllerTest {
             Uom.STORAGE_GIBIBYTE_MONTHS,
             15.25,
             clock.startOfCurrentHour());
-    snaps.add(snapshot);
 
-    when(snapshotRepo.findLatestBillablesForMonth(clock.now().getMonthValue()))
-        .thenReturn(snaps.stream());
+    BillableUsageRemittanceEntity monthlyRemittanceAfterDbMigration =
+        createRemittance(snapshot, 46.0);
+    monthlyRemittanceAfterDbMigration.getKey().setGranularity(Granularity.MONTHLY);
 
     BillableUsageRemittanceEntity remittance = createRemittance(snapshot, 46.0);
     remittance.getKey().setRemittancePendingDate(snapshot.getSnapshotDate());
     when(remittanceRepo.existsById(remittance.getKey())).thenReturn(true);
 
-    controller.syncRemittance();
-    // Should not save remittance.
+    when(snapshotRepo.hasLatestBillables(
+            snapshot.getOrgId(),
+            snapshot.getProductId(),
+            snapshot.getServiceLevel(),
+            snapshot.getUsage(),
+            snapshot.getBillingProvider(),
+            snapshot.getBillingAccountId(),
+            clock.startOfMonth(snapshot.getSnapshotDate()),
+            clock.endOfMonth(snapshot.getSnapshotDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(true);
+
+    when(snapshotRepo.getBillableSnapshots(
+            snapshot.getOrgId(),
+            snapshot.getProductId(),
+            snapshot.getServiceLevel(),
+            snapshot.getUsage(),
+            snapshot.getBillingProvider(),
+            snapshot.getBillingAccountId(),
+            clock.startOfMonth(snapshot.getSnapshotDate()),
+            clock.endOfMonth(snapshot.getSnapshotDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(Stream.of(snapshot));
+
+    mockRemittanceSummaryTotal(
+        monthlyRemittanceAfterDbMigration.getKey(),
+        monthlyRemittanceAfterDbMigration.getRemittedPendingValue());
+
+    controller.syncRemittance(monthlyRemittanceAfterDbMigration);
+
+    // Should not save new remittance but should delete the main remittance since the final
+    // sync totals matched.
+    verify(remittanceRepo).delete(monthlyRemittanceAfterDbMigration);
     verifyNoMoreInteractions(remittanceRepo);
+  }
+
+  // If there are no billable snapshots present for the remittance being synced (
+  // potentially pruned snapshots for older remittance) then the remittance is
+  // considered synced and is deleted.
+  @Test
+  void testRemittanceBeingSyncedIsDeletedIfThereAreNoBillablesPresent() {
+    var remittanceToSync =
+        BillableUsageRemittanceEntity.builder()
+            .key(
+                BillableUsageRemittanceEntityPK.builder()
+                    .orgId("org123")
+                    .accumulationPeriod(
+                        BillableUsageRemittanceEntityPK.getAccumulationPeriod(clock.now()))
+                    .billingAccountId("baid")
+                    .billingProvider("red hat")
+                    .metricId(Uom.STORAGE_GIBIBYTE_MONTHS.value())
+                    .productId("rhosak")
+                    .sla("Premium")
+                    .usage("Production")
+                    .remittancePendingDate(clock.now())
+                    .granularity(Granularity.MONTHLY)
+                    .build())
+            .remittedPendingValue(22.2)
+            .build();
+
+    when(snapshotRepo.hasLatestBillables(
+            remittanceToSync.getKey().getOrgId(),
+            remittanceToSync.getKey().getProductId(),
+            ServiceLevel.fromString(remittanceToSync.getKey().getSla()),
+            Usage.fromString(remittanceToSync.getKey().getUsage()),
+            BillingProvider.fromString(remittanceToSync.getKey().getBillingProvider()),
+            remittanceToSync.getKey().getBillingAccountId(),
+            clock.startOfMonth(remittanceToSync.getKey().getRemittancePendingDate()),
+            clock.endOfMonth(remittanceToSync.getKey().getRemittancePendingDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(false);
+
+    controller.syncRemittance(remittanceToSync);
+
+    // Should not save new remittance but should delete the main remittance since the final
+    // sync totals matched.
+    verify(remittanceRepo).delete(remittanceToSync);
+    verifyNoMoreInteractions(remittanceRepo);
+    verifyNoMoreInteractions(snapshotRepo);
+  }
+
+  @Test
+  void testIllegalStateExceptionWhenRemittanceDoesNotAlignAndSyncedRemittanceIsNotDeleted() {
+    double snapMeasurementValue1 = 15.25;
+    double snapMeasurementValue2 = 1.20;
+
+    // Applicable snapshots
+    TallySnapshot snapshot1 =
+        buildSnapshot(
+            "org123",
+            "rhosak",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            snapMeasurementValue1,
+            clock.startOfCurrentHour());
+
+    // Applicable snapshots
+    TallySnapshot snapshot2 =
+        buildSnapshot(
+            "org123",
+            "rhosak",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            snapMeasurementValue2,
+            clock.startOfCurrentHour().plusHours(1));
+
+    BillableUsageRemittanceEntity monthlyRemittanceAfterDbMigration =
+        createRemittance(snapshot1, 18.0);
+    monthlyRemittanceAfterDbMigration.getKey().setGranularity(Granularity.MONTHLY);
+
+    when(snapshotRepo.hasLatestBillables(
+            snapshot1.getOrgId(),
+            snapshot1.getProductId(),
+            snapshot1.getServiceLevel(),
+            snapshot1.getUsage(),
+            snapshot1.getBillingProvider(),
+            snapshot1.getBillingAccountId(),
+            clock.startOfMonth(snapshot1.getSnapshotDate()),
+            clock.endOfMonth(snapshot1.getSnapshotDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(true);
+
+    when(snapshotRepo.getBillableSnapshots(
+            snapshot1.getOrgId(),
+            snapshot1.getProductId(),
+            snapshot1.getServiceLevel(),
+            snapshot1.getUsage(),
+            snapshot1.getBillingProvider(),
+            snapshot1.getBillingAccountId(),
+            clock.startOfMonth(snapshot1.getSnapshotDate()),
+            clock.endOfMonth(snapshot1.getSnapshotDate()),
+            new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
+        .thenReturn(Stream.of(snapshot1, snapshot2));
+
+    createRemittanceAndMockMeasurementValue(snapshot1, snapMeasurementValue1, 16.0);
+
+    mockRemittanceSummaryTotal(
+        monthlyRemittanceAfterDbMigration.getKey(),
+        // Nothing remitted initially, when first snapshot is processed.
+        0.0,
+        // Mock an incorrect final remittance on validation value to trigger exception.
+        10.0);
+
+    RemittanceSyncAlignmentException ex =
+        assertThrows(
+            RemittanceSyncAlignmentException.class,
+            () -> controller.syncRemittance(monthlyRemittanceAfterDbMigration));
+    assertEquals(monthlyRemittanceAfterDbMigration, ex.getRemittanceToSync());
+    assertEquals(10.0, ex.getResult());
+    assertEquals(snapshot2.getSnapshotDate(), ex.getDateOfLatestSnapshot());
+
+    verify(remittanceRepo, never()).delete(monthlyRemittanceAfterDbMigration);
+  }
+
+  @Test
+  void testRemittanceNotProcessedAndIsDeletedWhenOutsideHourlyTallyRetentionPeriod() {
+    TallySnapshot snapshot =
+        buildSnapshot(
+            "org123",
+            "rhosak",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            12.0,
+            clock.startOfCurrentMonth().minusMonths(5));
+
+    BillableUsageRemittanceEntity monthlyRemittanceAfterDbMigration =
+        createRemittance(snapshot, 12.0);
+    monthlyRemittanceAfterDbMigration.getKey().setGranularity(Granularity.MONTHLY);
+
+    controller.syncRemittance(monthlyRemittanceAfterDbMigration);
+
+    verifyNoInteractions(snapshotRepo);
+    verify(remittanceRepo).delete(monthlyRemittanceAfterDbMigration);
+    verifyNoMoreInteractions(remittanceRepo);
+  }
+
+  @Test
+  void testReplaceMonthlyRemittance() {
+    TallySnapshot snapshot =
+        buildSnapshot(
+            "org123",
+            "rhosak",
+            Granularity.HOURLY,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            Uom.STORAGE_GIBIBYTE_MONTHS,
+            12.0,
+            clock.startOfCurrentMonth());
+
+    BillableUsageRemittanceEntity monthlyRemittance = createRemittance(snapshot, 12.0);
+    monthlyRemittance.getKey().setGranularity(Granularity.MONTHLY);
+
+    BillableUsageRemittanceEntity hourlyRem =
+        createRemittance(snapshot, monthlyRemittance.getRemittedPendingValue());
+
+    BillableUsageRemittanceEntity dailyRem =
+        createRemittance(snapshot, monthlyRemittance.getRemittedPendingValue());
+    dailyRem.getKey().setGranularity(Granularity.DAILY);
+
+    controller.replaceMonthlyRemittance(monthlyRemittance, snapshot.getSnapshotDate());
+    verify(remittanceRepo).save(eq(dailyRem));
+    verify(remittanceRepo).save(eq(hourlyRem));
+    verify(remittanceRepo).deleteById(eq(monthlyRemittance.getKey()));
   }
 
   private BillableUsageRemittanceEntity createRemittance(
@@ -239,7 +542,7 @@ class RemittanceControllerTest {
   }
 
   private BillableUsageRemittanceEntity createRemittanceAndMockMeasurementValue(
-      TallySnapshot snapshot, double remittedValue) {
+      TallySnapshot snapshot, double sumOfSnapMeasurement, double remittedValue) {
     BillableUsageRemittanceEntity remittance = createRemittance(snapshot, remittedValue);
 
     when(snapshotRepo.sumMeasurementValueForPeriod(
@@ -253,7 +556,7 @@ class RemittanceControllerTest {
             clock.startOfMonth(snapshot.getSnapshotDate()),
             snapshot.getSnapshotDate(),
             new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, Uom.STORAGE_GIBIBYTE_MONTHS)))
-        .thenReturn(remittance.getRemittedPendingValue());
+        .thenReturn(sumOfSnapMeasurement);
 
     return remittance;
   }
@@ -322,5 +625,47 @@ class RemittanceControllerTest {
     // Manually invoke @PostConstruct so that the class is properly initialized.
     tagProfile.initLookups();
     return tagProfile;
+  }
+
+  void mockRemittanceSummaryTotal(
+      BillableUsageRemittanceEntityPK key, Double... expectedRemittanceTotal) {
+
+    var filter =
+        BillableUsageRemittanceFilter.builder()
+            .orgId(key.getOrgId())
+            .billingAccountId(key.getBillingAccountId())
+            .billingProvider(key.getBillingProvider())
+            .accumulationPeriod(key.getAccumulationPeriod())
+            .metricId(key.getMetricId())
+            .productId(key.getProductId())
+            .sla(key.getSla())
+            .usage(key.getUsage())
+            .granularity(Granularity.HOURLY)
+            .build();
+
+    List<List<RemittanceSummaryProjection>> returnValues =
+        Arrays.stream(expectedRemittanceTotal)
+            .map(
+                value ->
+                    List.of(
+                        RemittanceSummaryProjection.builder()
+                            .orgId(key.getOrgId())
+                            .billingAccountId(key.getBillingAccountId())
+                            .billingProvider(key.getBillingProvider())
+                            .accumulationPeriod(key.getAccumulationPeriod())
+                            .metricId(key.getMetricId())
+                            .productId(key.getProductId())
+                            .sla(key.getSla())
+                            .usage(key.getUsage())
+                            .totalRemittedPendingValue(value)
+                            .build()))
+            .collect(Collectors.toList());
+
+    OngoingStubbing<List<RemittanceSummaryProjection>> mockCall =
+        when(remittanceRepo.getRemittanceSummaries(filter));
+
+    for (var summaryReturn : returnValues) {
+      mockCall = mockCall.thenReturn(summaryReturn);
+    }
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -31,7 +31,6 @@ import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_TIME_UT
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -263,8 +262,8 @@ class ApplicationClockTest {
   }
 
   private void assertEndOfDay(int year, int month, int day, OffsetDateTime date) {
-    OffsetDateTime max = OffsetDateTime.of(LocalDateTime.MAX, ZoneOffset.UTC)
-        .truncatedTo(ChronoUnit.MICROS);
+    OffsetDateTime max =
+        OffsetDateTime.of(LocalDateTime.MAX, ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
 
     assertDate(
         year, month, day, max.getHour(), max.getMinute(), max.getSecond(), max.getNano(), date);

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -31,7 +31,10 @@ import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_TIME_UT
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -260,7 +263,9 @@ class ApplicationClockTest {
   }
 
   private void assertEndOfDay(int year, int month, int day, OffsetDateTime date) {
-    LocalDateTime max = LocalDateTime.MAX;
+    OffsetDateTime max = OffsetDateTime.of(LocalDateTime.MAX, ZoneOffset.UTC)
+        .truncatedTo(ChronoUnit.MICROS);
+
     assertDate(
         year, month, day, max.getHour(), max.getMinute(), max.getSecond(), max.getNano(), date);
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
@@ -63,6 +63,8 @@ public interface BillableUsageRemittanceRepository
       query.where(predicate);
       query.groupBy(
           key.get(BillableUsageRemittanceEntityPK_.ACCUMULATION_PERIOD),
+          key.get(BillableUsageRemittanceEntityPK_.SLA),
+          key.get(BillableUsageRemittanceEntityPK_.USAGE),
           root.get(BillableUsageRemittanceEntity_.ACCOUNT_NUMBER),
           key.get(BillableUsageRemittanceEntityPK_.BILLING_PROVIDER),
           key.get(BillableUsageRemittanceEntityPK_.BILLING_ACCOUNT_ID),
@@ -78,6 +80,8 @@ public interface BillableUsageRemittanceRepository
             root.get(BillableUsageRemittanceEntity_.ACCOUNT_NUMBER),
             key.get(BillableUsageRemittanceEntityPK_.PRODUCT_ID),
             key.get(BillableUsageRemittanceEntityPK_.ACCUMULATION_PERIOD),
+            key.get(BillableUsageRemittanceEntityPK_.SLA),
+            key.get(BillableUsageRemittanceEntityPK_.USAGE),
             criteriaBuilder.max(key.get(BillableUsageRemittanceEntityPK_.REMITTANCE_PENDING_DATE)),
             key.get(BillableUsageRemittanceEntityPK_.BILLING_PROVIDER),
             key.get(BillableUsageRemittanceEntityPK_.BILLING_ACCOUNT_ID),
@@ -133,6 +137,20 @@ public interface BillableUsageRemittanceRepository
     return (root, query, builder) -> {
       var path = root.get(BillableUsageRemittanceEntity_.key);
       return builder.equal(path.get(BillableUsageRemittanceEntityPK_.granularity), granularity);
+    };
+  }
+
+  static Specification<BillableUsageRemittanceEntity> matchingUsage(String usage) {
+    return (root, query, builder) -> {
+      var path = root.get(BillableUsageRemittanceEntity_.key);
+      return builder.equal(path.get(BillableUsageRemittanceEntityPK_.usage), usage);
+    };
+  }
+
+  static Specification<BillableUsageRemittanceEntity> matchingSla(String sla) {
+    return (root, query, builder) -> {
+      var path = root.get(BillableUsageRemittanceEntity_.key);
+      return builder.equal(path.get(BillableUsageRemittanceEntityPK_.sla), sla);
     };
   }
 
@@ -196,6 +214,12 @@ public interface BillableUsageRemittanceRepository
     }
     if (Objects.nonNull(filter.getGranularity())) {
       searchCriteria = searchCriteria.and(matchingGranularity(filter.getGranularity()));
+    }
+    if (Objects.nonNull(filter.getUsage())) {
+      searchCriteria = searchCriteria.and(matchingUsage(filter.getUsage()));
+    }
+    if (Objects.nonNull(filter.getSla())) {
+      searchCriteria = searchCriteria.and(matchingSla(filter.getSla()));
     }
     return searchCriteria;
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
@@ -36,7 +36,7 @@ import org.candlepin.subscriptions.json.BillableUsage;
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class BillableUsageRemittanceEntityPK implements Serializable {
 
   @Column(name = "org_id", nullable = false, length = 32)
@@ -88,21 +88,6 @@ public class BillableUsageRemittanceEntityPK implements Serializable {
 
   public static BillableUsageRemittanceEntityPK keyFrom(BillableUsage billableUsage) {
     return keyFrom(billableUsage, Granularity.HOURLY);
-  }
-
-  public static BillableUsageRemittanceEntityPK clone(BillableUsageRemittanceEntityPK target) {
-    return BillableUsageRemittanceEntityPK.builder()
-        .usage(target.getUsage())
-        .orgId(target.getOrgId())
-        .billingProvider(target.getBillingProvider())
-        .billingAccountId(target.getBillingAccountId())
-        .productId(target.getProductId())
-        .sla(target.getSla())
-        .metricId(target.getMetricId())
-        .accumulationPeriod(target.getAccumulationPeriod())
-        .remittancePendingDate(target.getRemittancePendingDate())
-        .granularity(target.getGranularity())
-        .build();
   }
 
   public static String getAccumulationPeriod(OffsetDateTime reference) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
@@ -90,6 +90,21 @@ public class BillableUsageRemittanceEntityPK implements Serializable {
     return keyFrom(billableUsage, Granularity.HOURLY);
   }
 
+  public static BillableUsageRemittanceEntityPK clone(BillableUsageRemittanceEntityPK target) {
+    return BillableUsageRemittanceEntityPK.builder()
+        .usage(target.getUsage())
+        .orgId(target.getOrgId())
+        .billingProvider(target.getBillingProvider())
+        .billingAccountId(target.getBillingAccountId())
+        .productId(target.getProductId())
+        .sla(target.getSla())
+        .metricId(target.getMetricId())
+        .accumulationPeriod(target.getAccumulationPeriod())
+        .remittancePendingDate(target.getRemittancePendingDate())
+        .granularity(target.getGranularity())
+        .build();
+  }
+
   public static String getAccumulationPeriod(OffsetDateTime reference) {
     return InstanceMonthlyTotalKey.formatMonthId(reference);
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceSummaryProjection.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceSummaryProjection.java
@@ -36,6 +36,8 @@ public class RemittanceSummaryProjection {
   private String accountNumber;
   private String productId;
   private String accumulationPeriod;
+  private String sla;
+  private String usage;
   private OffsetDateTime remittancePendingDate;
   private String billingProvider;
   private String billingAccountId;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/util/ApplicationClock.java
@@ -80,7 +80,7 @@ public class ApplicationClock {
   }
 
   public OffsetDateTime endOfDay(OffsetDateTime anyDay) {
-    return OffsetDateTime.from(anyDay.with(LocalTime.MAX));
+    return OffsetDateTime.from(anyDay.with(LocalTime.MAX).truncatedTo(ChronoUnit.MICROS));
   }
 
   public OffsetDateTime endOfCurrentWeek() {
@@ -104,7 +104,7 @@ public class ApplicationClock {
   }
 
   public OffsetDateTime endOfMonth(OffsetDateTime anyDayOfMonth) {
-    return OffsetDateTime.from(anyDayOfMonth.with(LocalTime.MAX))
+    return OffsetDateTime.from(anyDayOfMonth.with(LocalTime.MAX).truncatedTo(ChronoUnit.MICROS))
         .with(TemporalAdjusters.lastDayOfMonth());
   }
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1298](https://issues.redhat.com/browse/SWATCH-1298)

## Description
The existing syncRemittance API has been updated to sync any remittance with a MONTHLY granularity into a set of corresponding HOURLY and DAILY remittance records.

**!!! THIS SHOULD BE RUN IMMEDIATELY AFTER WE DEPLOY TO STAGE/PROD and ideally when the hourly tally has been completed !!!**
    
This API is intended to be used post-deployment to sync any existing remittance date now that the schema has been changed.

The goal is to break each MONTHLY remittance record down into a set of HOURLY and DAILY remittance records, which yeild the same total remitted pending value when each are summed. This is achieved by fetching the applicable HOURLY tally snapshots for a given MONTHLY remittance record, and running them through the billable usage process (without sending BillableUsage to the producers).

Syncing a MONTHLY remittance record can result in the following outcomes:

1. Resulting remittance matches - In this case, all is well and we delete the MONTHLY remittance record.
2. No tally snapshots exist that contribute to the MONTHLY remittance record. Since it is not possible to create the associated HOURLY remittance records, we WARN, and remove the MONTHLY remittance record.
3. The MONTHLY remittance record is outside of the hourly tally retention policy (70 days) and associated tally snapshots will already be pruned. In this case we WARN and delete the monthly remittance record.
4. The sum of the HOURLY remittance records does not match the MONTHLY remittance record being synced. In this case, a single HOURLY and single DAILY remittance record mirroring the MONTHLY remittance, but has the remitted pending date set based on the last known hourly tally snapshot processed.

### Note About End Date Precision
Postgresql does timestamp comparison at microsecond precision,
and rounds up when a query is made using a timestamp with
microsecond precision. This can lead to unexpected query results.

The ApplicationClock was using LocalTime.MAX to force dates to
the max time for a day/month which results in microsecond precision,
which often gets passed as DB query parameters.

This change updates the clock to truncate the max time to microsecond
precision, preventing the rounding issue at the DB.

**Example:**
Before change: 2023-03-31T23:59:59.999999999Z
After change: 2023-03-31T23:59:59.999999Z

## Testing

### Setup
#### FROM THE MAIN BRANCH
From the **main** branch, drop the database and recreate it.
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```

Apply the following patch [fix_contract_api_stub.txt](https://github.com/RedHatInsights/rhsm-subscriptions/files/11869294/fix_contract_api_stub.txt) to temporarily fix an issue with the StubContractAPI. This has already been fixed in the feature branch but we need it in place to load test data.
```
git apply fix_contract_api_stub.txt
```

Deploy the app so that a new DB schema is created.
```
SPRING_PROFILES_ACTIVE=worker,kafka-task-queue CONTRACT_USE_STUB=true DEV_MODE=true ./gradlew :bootRun
```

Set up the test data as follows (**NOTE** This will truncate/drop some tables.)
```
psql -h localhost -U rhsm-subscriptions <<EOF
drop table events;
truncate table hosts cascade;
truncate table tally_snapshots cascade;
truncate table billable_usage_remittance;
EOF
```

Use the attached [EVENT_DATA_FOR_REMITTANCE_SYNC_TESTING](https://github.com/RedHatInsights/rhsm-subscriptions/files/11869236/EVENT_DATA_FOR_REMITTANCE_SYNC_TESTING.txt) file to import event metric data into your DB.
```
psql -U rhsm-subscriptions rhsm-subscriptions < EVENT_DATA_FOR_REMITTANCE_SYNC_TESTING.txt
```

Perform a nightly tally, **for both targeted orgs**, across the event date ranges and ensure that snapshot summaries were created for BASILISK Instance-hours and rosa Cores.
```
http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["org123", "2023-04-01T00:00Z", "2023-06-30T00:00Z"]'
```
```
http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["org555", "2023-04-01T00:00Z", "2023-06-30T00:00Z"]'
```

Add a remittance record that does not have any associated snapshots.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "insert into billable_usage_remittance values ('account234', 'org234', 'rosa', 'Cores', '2023-06', 'Premium', 'Production', 'aws', 'mktp-234', 233.0, '2023-06-21 09:25:57.282084-03', 0, 0.25);"
```

Update the remittance record for **org555** so that the remitted value will not match the usage defined by the snaphots.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "update billable_usage_remittance set remitted_value=2.0 where org_id = 'org555'"
```

Take a look at the remittance data to make sure that we have the correct remittance records for the test.

```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance"


psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance"
 account_number | org_id | product_id |   metric_id    | accumulation_period |   sla   |   usage    | billing_provider | billing_account_id | remitted_value |        remittance_date        | version | billing_factor 
----------------+--------+------------+----------------+---------------------+---------+------------+------------------+--------------------+----------------+-------------------------------+---------+----------------
 account123     | org123 | rosa       | Cores          | 2023-06             | Premium | Production | aws              | mktp-123           |           4187 | 2023-06-23 11:38:24.971807-03 |       7 |           0.25
 account123     | org123 | rosa       | Cores          | 2023-05             | Premium | Production | aws              | mktp-123           |            298 | 2023-06-23 11:38:25.626897-03 |       3 |           0.25
 account123     | org123 | rosa       | Cores          | 2023-04             | Premium | Production | aws              | mktp-123           |             20 | 2023-06-23 11:38:25.990432-03 |       2 |           0.25
 account123     | org123 | BASILISK   | Instance-hours | 2023-06             | Premium | Production | aws              | mktp-123           |          16807 | 2023-06-23 11:38:28.131525-03 |       7 |              1
 account123     | org123 | BASILISK   | Instance-hours | 2023-05             | Premium | Production | aws              | mktp-123           |           1249 | 2023-06-23 11:38:28.69089-03  |       3 |              1
 account123     | org123 | BASILISK   | Instance-hours | 2023-04             | Premium | Production | aws              | mktp-123           |            159 | 2023-06-23 11:38:29.012198-03 |       0 |              1
 account234     | org234 | rosa       | Cores          | 2023-06             | Premium | Production | aws              | mktp-234           |            233 | 2023-06-21 09:25:57.282084-03 |       0 |           0.25
 account555     | org555 | rosa       | Cores          | 2023-06             | Premium | Production | aws              | mktp-555           |              2 | 2023-06-23 11:38:34.274779-03 |       0 |           0.25
(8 rows)

```

Revert the changes from the patch you appplied earlier!!
```
git reset --hard
```

#### FROM THIS PR'S BRANCH
**Check out the branch for this PR** (it is already rebased onto the feature branch) and deploy. Grep the logs so that you can isolate them to the sync logs when the operation is run. During the deployment, the billable_usage_remittance table schema will be updated, and each existing remittance record will now contain the raw/metered remitted value (formerly billed value) as well as set the granularity to MONTHLY.

```
SPRING_PROFILES_ACTIVE=worker,kafka-task-queue CONTRACT_USE_STUB=true DEV_MODE=true ./gradlew :bootRun | grep "REMITTANCE SYNC"
```

Take a look at the schema/data changes in the remittance table to make sure that things are set up correctly. Notice that after the schema was migrated, the remitted_pending_value has been converted to RAW/METRIC value AND the granularity for ALL remittance records has been set to MONTHLY.

**********************************************************************
**NOTE: When validating sync results below, use this data for comparison. Copying it somewhere temporarily is a good idea**
**********************************************************************

```
$ psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance"

 account_number | org_id | product_id |   metric_id    | accumulation_period |   sla   |   usage    | billing_provider | billing_account_id | remitted_pending_value |    remittance_pending_date    | granularity 
----------------+--------+------------+----------------+---------------------+---------+------------+------------------+--------------------+------------------------+-------------------------------+-------------
 account123     | org123 | rosa       | Cores          | 2023-06             | Premium | Production | aws              | mktp-123           |                  16748 | 2023-06-23 11:38:24.971807-03 | MONTHLY
 account123     | org123 | rosa       | Cores          | 2023-05             | Premium | Production | aws              | mktp-123           |                   1192 | 2023-06-23 11:38:25.626897-03 | MONTHLY
 account123     | org123 | rosa       | Cores          | 2023-04             | Premium | Production | aws              | mktp-123           |                     80 | 2023-06-23 11:38:25.990432-03 | MONTHLY
 account123     | org123 | BASILISK   | Instance-hours | 2023-06             | Premium | Production | aws              | mktp-123           |                  16807 | 2023-06-23 11:38:28.131525-03 | MONTHLY
 account123     | org123 | BASILISK   | Instance-hours | 2023-05             | Premium | Production | aws              | mktp-123           |                   1249 | 2023-06-23 11:38:28.69089-03  | MONTHLY
 account123     | org123 | BASILISK   | Instance-hours | 2023-04             | Premium | Production | aws              | mktp-123           |                    159 | 2023-06-23 11:38:29.012198-03 | MONTHLY
 account234     | org234 | rosa       | Cores          | 2023-06             | Premium | Production | aws              | mktp-234           |                    932 | 2023-06-21 09:25:57.282084-03 | MONTHLY
 account555     | org555 | rosa       | Cores          | 2023-06             | Premium | Production | aws              | mktp-555           |                      8 | 2023-06-23 11:38:34.274779-03 | MONTHLY
(8 rows)

```

### Steps
Run the remittance sync API. Based on the logs, you should see examples of all three sync scenarios.

```
http POST :8000/api/rhsm-subscriptions/v1/internal/tally/sync-remittance x-rh-swatch-psk:placeholder
```

### Verification
Validate via the logs that:
* 4 remittance syncs were successful
* 2 remittance records were deleted because of the tally snapshot retention policy (1 rosa, 1 BASILISK)
* 1 remittance record was deleted because there were no associated snapshots (org234).
* 1 remittance record did not align correctly (org555)

```log
2023-06-22 13:11:05,972 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.admin.InternalTallyResource] self- REMITTANCE SYNC: Starting
2023-06-22 13:11:08,180 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.billing.RemittanceController] self- REMITTANCE SYNC: Successfully synced remittance BillableUsageRemittanceEntity(key=BillableUsageRemittanceEntityPK(orgId=org123, productId=rosa, metricId=Cores, accumulationPeriod=2023-06, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=mktp-123, remittancePendingDate=2023-06-22T12:59:51.215548Z, granularity=MONTHLY), remittedPendingValue=16748.0, accountNumber=account123)
2023-06-22 13:11:08,284 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.billing.RemittanceController] self- REMITTANCE SYNC: Successfully synced remittance BillableUsageRemittanceEntity(key=BillableUsageRemittanceEntityPK(orgId=org123, productId=rosa, metricId=Cores, accumulationPeriod=2023-05, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=mktp-123, remittancePendingDate=2023-06-22T12:59:51.819672Z, granularity=MONTHLY), remittedPendingValue=1192.0, accountNumber=account123)
2023-06-22 13:11:08,287 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.billing.RemittanceController] self- REMITTANCE SYNC: Remittance is outside the hourly tally snapshot retention window 2023-05-01T00:00Z so it will be purged. BillableUsageRemittanceEntity(key=BillableUsageRemittanceEntityPK(orgId=org123, productId=rosa, metricId=Cores, accumulationPeriod=2023-04, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=mktp-123, remittancePendingDate=2023-06-22T12:59:52.147979Z, granularity=MONTHLY), remittedPendingValue=80.0, accountNumber=account123)
2023-06-22 13:11:10,323 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.billing.RemittanceController] self- REMITTANCE SYNC: Successfully synced remittance BillableUsageRemittanceEntity(key=BillableUsageRemittanceEntityPK(orgId=org123, productId=BASILISK, metricId=Instance-hours, accumulationPeriod=2023-06, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=mktp-123, remittancePendingDate=2023-06-22T12:59:54.547915Z, granularity=MONTHLY), remittedPendingValue=16807.0, accountNumber=account123)
2023-06-22 13:11:10,412 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.billing.RemittanceController] self- REMITTANCE SYNC: Successfully synced remittance BillableUsageRemittanceEntity(key=BillableUsageRemittanceEntityPK(orgId=org123, productId=BASILISK, metricId=Instance-hours, accumulationPeriod=2023-05, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=mktp-123, remittancePendingDate=2023-06-22T12:59:55.446501Z, granularity=MONTHLY), remittedPendingValue=1249.0, accountNumber=account123)
2023-06-22 13:11:10,415 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.billing.RemittanceController] self- REMITTANCE SYNC: Remittance is outside the hourly tally snapshot retention window 2023-05-01T00:00Z so it will be purged. BillableUsageRemittanceEntity(key=BillableUsageRemittanceEntityPK(orgId=org123, productId=BASILISK, metricId=Instance-hours, accumulationPeriod=2023-04, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=mktp-123, remittancePendingDate=2023-06-22T12:59:55.721723Z, granularity=MONTHLY), remittedPendingValue=159.0, accountNumber=account123)
2023-06-22 13:11:10,417 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.billing.RemittanceController] self- REMITTANCE SYNC: No hourly billables found for remittance so it will be purged. BillableUsageRemittanceEntity(key=BillableUsageRemittanceEntityPK(orgId=org234, productId=rosa, metricId=Cores, accumulationPeriod=2023-06, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=mktp-234, remittancePendingDate=2023-06-21T12:25:57.282084Z, granularity=MONTHLY), remittedPendingValue=233.0, accountNumber=account234)
2023-06-22 13:11:10,425 [thread=http-nio-8000-exec-1] [WARN ] [org.candlepin.subscriptions.tally.admin.InternalTallyResource] self- REMITTANCE SYNC: Remittance did not align after sync! EXPECTED: 8.0 WAS: 4.0 -- BillableUsageRemittanceEntity(key=BillableUsageRemittanceEntityPK(orgId=org555, productId=rosa, metricId=Cores, accumulationPeriod=2023-06, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=mktp-555, remittancePendingDate=2023-06-22T13:00:15.811148Z, granularity=MONTHLY), remittedPendingValue=8.0, accountNumber=account555)
2023-06-22 13:11:10,425 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.admin.InternalTallyResource] self- REMITTANCE SYNC: Complete

```

#### Validation
Verify that there are no remaining MONTHLY remittance records after the sync completes.
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from billable_usage_remittance where granularity='MONTHLY'"

 count 
-------
     0
(1 row)
```

Verify that the HOURLY and DAILY remittance records were created correctly when the remittance totals didn't line up. The dates on each should line up with the start of the hour/day depending on the granularity and should align with the last snapshot that was found that applies to this remittance. The sum of either all related HOURLY or DAILY remittance records should be that of the MONTHLY.

Find the latest snapshot date.
```
psql -U rhsm-subscriptions rhsm-subscriptions << EOF
select max(snapshot_date at time zone 'utc') from tally_snapshots s, tally_measurements m where s.id = m.snapshot_id and org_id='org555' and product_id='rosa' and sla='Premium' and usage='Production' and billing_provider='aws' and billing_account_id='mktp-555' and m.measurement_type='PHYSICAL' and m.uom = 'CORES' and granularity='HOURLY' and snapshot_date at time zone 'utc' between '2023-06-01T00:00:00.000000Z' and '2023-06-30T23:59:59.999999Z'
;
EOF

          max           
------------------------
 2023-06-01 06:00:00+00
(1 row)

```

```
PGTZ=UTC psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance where org_id='org555'"

 account_number | org_id | product_id | metric_id | accumulation_period |   sla   |   usage    | billing_provider | billing_account_id | remitted_pending_value | remittance_pending_date | granularity 
----------------+--------+------------+-----------+---------------------+---------+------------+------------------+--------------------+------------------------+-------------------------+-------------
 account555     | org555 | rosa       | Cores     | 2023-06             | Premium | Production | aws              | mktp-555           |                      8 | 2023-06-01 00:00:00+00  | DAILY
 account555     | org555 | rosa       | Cores     | 2023-06             | Premium | Production | aws              | mktp-555           |                      8 | 2023-06-01 06:00:00+00  | HOURLY
(2 rows)


```

Validate the results from the HOURLY/DAILY remittances.

```
psql -U rhsm-subscriptions rhsm-subscriptions << EOF
select accumulation_period, product_id, metric_id, granularity, sum(remitted_pending_value) from billable_usage_remittance where org_id='org123' and sla='Premium' and usage='Production' and billing_provider='aws' and billing_account_id='mktp-123' group by accumulation_period, product_id, metric_id, granularity order by product_id, accumulation_period, granularity;
EOF



 accumulation_period | product_id |   metric_id    | granularity |  sum  
---------------------+------------+----------------+-------------+-------
 2023-05             | BASILISK   | Instance-hours | DAILY       |  1249
 2023-05             | BASILISK   | Instance-hours | HOURLY      |  1249
 2023-06             | BASILISK   | Instance-hours | DAILY       | 16807
 2023-06             | BASILISK   | Instance-hours | HOURLY      | 16807
 2023-05             | rosa       | Cores          | DAILY       |  1192
 2023-05             | rosa       | Cores          | HOURLY      |  1192
 2023-06             | rosa       | Cores          | DAILY       | 16748
 2023-06             | rosa       | Cores          | HOURLY      | 16748
(8 rows)

```

The query results above shows:
1. The sum of the hourly remittances == the sum of the daily remittances (each sum representing the monthly total for accumulation period)
2. The sum of either daily or hourly should match the total for the original monthly remittance that was synced (cross reference the totals with the monthly remittance from the query you performed after the DB migration for this PR).
	1. For example, the sum of (2023-06 | rosa | Cores | HOURLY) records == 16748 and the original remitted value for the month before syncing was 16748.
