### PR TITLE
SWATCH-1399: Round monthlyTotals after summation

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -984,7 +984,7 @@ class TallyResourceTest {
     TallyReportDataPoint expectedTotalMonthly =
         new TallyReportDataPoint()
             .date(OffsetDateTime.parse("2023-03-08T12:35Z"))
-            .value(30)
+            .value(22)
             .hasData(true);
 
     when(repository.findSnapshot(
@@ -1038,7 +1038,7 @@ class TallyResourceTest {
     TallyReportDataPoint expectedTotalMonthly =
         new TallyReportDataPoint()
             .date(OffsetDateTime.parse("2023-03-02T12:35Z"))
-            .value(6)
+            .value(3)
             .hasData(true);
 
     when(repository.findSnapshot(


### PR DESCRIPTION
Jira issue: [SWATCH-1399](https://issues.redhat.com/browse/SWATCH-1399)

Description
===========

Before this change, the logic was summing rounded values, which gave inaccurate numbers for monthly totals.

Testing
=======

Setup
-----

Insert some test data - 6 data points having 2.2 as the value:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
DO $$
    DECLARE id uuid;
    BEGIN
    FOR i IN 0..5 LOOP
    id = gen_random_uuid();
    insert into tally_snapshots(id, product_id, account_number, granularity, org_id, snapshot_date, unit_of_measure, sla)
    values (id, 'OpenShift-metrics', 'account123', 'DAILY', 'org123',
            '2023-06-01T00:00Z'::timestamptz + make_interval(days=>i), null, '_ANY');
    insert into tally_measurements(snapshot_id, measurement_type, uom, value)
    values (id, 'TOTAL', 'INSTANCE_HOURS', 2.2);
    END LOOP;
end;
$$;
EOF
```

(Note: you can use truncate on the tally_snapshots table if you wish to have cleaner DBs).

Start the service:

```shell
DEV_MODE=true ./gradlew :bootRun
```

Opt-in org123:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Steps
-----

Repeat for both `main` and this branch in order to compare outputs:

1. Hit the tally API against the test data:

```shell
http :8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-metrics/Instance-hours \
  beginning==2023-06-01T00:00Z \
  ending==2023-06-30T23:59:59Z \
  granularity==DAILY \
  x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Verification
------------

Verify that the value is `14 = ceil(2.2 * 6) = ceil(13.2)`, rather than `18`. (`main` will erroneously return `18`).