### PR TITLE
SWATCH-1411: Fix constraint violation in host_tally_buckets

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -74,7 +74,7 @@ public interface HostRepository
       left join fetch h.monthlyTotals
       where h.orgId=:orgId
         and h.instanceType='HBI_HOST'
-      order by coalesce(h.hypervisorUuid, h.subscriptionManagerId), h.hypervisorUuid, h.inventoryId
+      order by coalesce(h.hypervisorUuid, h.subscriptionManagerId), h.hypervisorUuid, h.inventoryId, h.id
           """)
   @QueryHints(value = {@QueryHint(name = HINT_FETCH_SIZE, value = "1024")})
   Stream<Host> streamHbiHostsByOrgId(@Param("orgId") String orgId);


### PR DESCRIPTION
Jira issue: [SWATCH-1411](https://issues.redhat.com/browse/SWATCH-1411)

Description
===========

Our JPQL for fetching existing host records has an order by that uses a clause:

```sql
order by
    coalesce(h.hypervisorUuid, h.subscriptionManagerId),
    h.hypervisorUuid,
    h.inventoryId
```

Due to previous bugs, sometimes there are system multiple system records for the same inventory ID. Additionally, the query joins `hosts` with `host_tally_buckets`. Because the `order by` clause does not include a swatch-specific identifier, the rows returned for duplicate system records can be interleaved. This causes some unintuitive behavior. For example, Hibernate builds the buckets collection using contiguous records, and when the interleaving of two swatch systems' data happens, it creates a collection of buckets that is incomplete. Additionally, Hibernate will return the same swatch system multiple times. The fix is quite simple... by adding `id` to the order by clause, we ensure that interleaving doesn't happen, even with bad data.

Testing
=======

Setup
-----

Use

```shell
python import-from-gabi.py --org 16775631 --hbi --systems
```

(from support scripts against stage environment to import data to repro)

Start the service:

```shell
DEV_MODE=true ./gradlew :bootRun
```

Steps
-----

Repeat for both `main` and this branch in order to compare logs:

1. Trigger a nightly tally for 16775631:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/16775631 \
  x-rh-swatch-psk:placeholder
```

Verification
------------

Observe that on `main` the constraint violation happens. On this branch, no such error occurs.