### PR TITLE
SWATCH-1423: Avoid n+1 issues in subscription queries

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -296,6 +296,21 @@ class SubscriptionRepositoryTest {
     assertThat(result, Matchers.containsInAnyOrder(s1, s2));
   }
 
+  @Transactional
+  @Test
+  void testFindByOrgIdAndEndDateAfter() {
+    var s1 = createSubscription("org123", "account123", "sub123", "seller123");
+    var s2 = createSubscription("org123", "account123", "sub321", "seller123");
+    var offering1 = createOffering("testSkuUnlimited", "TestSKUUnlimited", 1066, null, null, null);
+    List.of(s1, s2).forEach(x -> x.setOffering(offering1));
+
+    offeringRepo.save(offering1);
+    subscriptionRepo.saveAllAndFlush(List.of(s1, s2));
+
+    var result = subscriptionRepo.findByOrgIdAndEndDateAfter("org123", OffsetDateTime.now());
+    assertThat(result, Matchers.containsInAnyOrder(s1, s2));
+  }
+
   private Offering createOffering(
       String sku, String productName, int productId, ServiceLevel sla, Usage usage, String role) {
     return Offering.builder()

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -81,7 +81,7 @@ public class Subscription implements Serializable {
 
   @OneToMany(
       mappedBy = "subscription",
-      fetch = FetchType.EAGER,
+      fetch = FetchType.LAZY,
       cascade = CascadeType.ALL,
       orphanRemoval = true)
   @Builder.Default


### PR DESCRIPTION
Jira issue: [SWATCH-1423](https://issues.redhat.com/browse/SWATCH-1423)

Description
===========

Using specifications generates JPQL, and when using JPQL with collections, in order to eagerly fetch an association, there are three options:

1) Do nothing, and let Hibernate fetch collection per-entity (N+1 queries risk). 2) Add an explicit fetch join to the JPQL.
3) Make the association lazy (appropriate if the association doesn't actually need to be read).

I changed the specification building to make `Subscription.offering` always fetch joined, and I changed `Subscription.subscriptionProductIds` to be lazy fetched, as its not actually referenced in code paths having issues currently.

Testing
=======

Setup
-----
Set in config/application.properties:
  
```
logging.level.org.hibernate.SQL=DEBUG
```

Steps
-----

Run the tests:

```shell
./gradlew :test -s --tests=SubscriptionRepositoryTest.testFindByOrgIdAndEndDateAfter
```

Verification
------------

Check logs and see after the inserts (for test setup) only a single select:

```shell
cat build/test-results/test/TEST-org.candlepin.subscriptions.db.SubscriptionRepositoryTest.xml
```
