### PR TITLE
SWATCH-1424: Improve offering/subscription relationship performance

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
@@ -93,7 +93,6 @@ public class CapacityReconciliationController {
 
     reconcileSubscriptionCapacities(subscription);
     reconcileSubscriptionProductIds(subscription);
-    subscriptionRepository.save(subscription);
   }
 
   @Transactional

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -214,6 +214,7 @@ public class SubscriptionSyncController {
       if (existingSubscription.quantityHasChanged(newOrUpdated.getQuantity())) {
         existingSubscription.endSubscription();
         subscriptionRepository.save(existingSubscription);
+        capacityReconciliationController.reconcileCapacityForSubscription(existingSubscription);
         final org.candlepin.subscriptions.db.model.Subscription newSub =
             org.candlepin.subscriptions.db.model.Subscription.builder()
                 .subscriptionId(existingSubscription.getSubscriptionId())
@@ -229,11 +230,12 @@ public class SubscriptionSyncController {
                 .billingProvider(newOrUpdated.getBillingProvider())
                 .build();
         subscriptionRepository.save(newSub);
+        capacityReconciliationController.reconcileCapacityForSubscription(newSub);
       } else {
         updateSubscription(newOrUpdated, existingSubscription);
         subscriptionRepository.save(existingSubscription);
+        capacityReconciliationController.reconcileCapacityForSubscription(existingSubscription);
       }
-      capacityReconciliationController.reconcileCapacityForSubscription(newOrUpdated);
     } else {
       subscriptionRepository.save(newOrUpdated);
       capacityReconciliationController.reconcileCapacityForSubscription(newOrUpdated);

--- a/src/main/resources/liquibase/202306291611-add-extra-index-for-product-ids.xml
+++ b/src/main/resources/liquibase/202306291611-add-extra-index-for-product-ids.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202306291611-1" author="karshah">
+        <comment>Add an index on subscription_id and start_date column in the subscription_product_ids table</comment>
+        <createIndex indexName="subs_id_start_date_idx" tableName="subscription_product_ids"
+                     unique="false">
+            <column name="subscription_id"/>
+            <column name="start_date"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -108,5 +108,6 @@
     <!-- Uncomment once subscription-measurements has been verified -->
     <!-- <include file="liquibase/202305251412-drop-subscription-capacity-table.xml"/> -->
     <include file="liquibase/202306151541-add-sku-foreign-key-to-subscription.xml"/>
+    <include file="liquibase/202306291611-add-extra-index-for-product-ids.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -136,7 +136,7 @@ class SubscriptionSyncControllerTest {
     var dto = createDto("456", 10);
     subscriptionSyncController.syncSubscription(dto);
     verify(subscriptionRepository, Mockito.times(2)).save(Mockito.any(Subscription.class));
-    verify(capacityReconciliationController)
+    verify(capacityReconciliationController, Mockito.times(2))
         .reconcileCapacityForSubscription(Mockito.any(Subscription.class));
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -40,6 +40,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -56,14 +57,19 @@ public interface SubscriptionRepository
   @Query(
       "SELECT s FROM Subscription s where s.endDate > CURRENT_TIMESTAMP "
           + "AND s.subscriptionId = :subscriptionId")
+  @EntityGraph(value = "Subscription.offering")
   Optional<Subscription> findActiveSubscription(@Param("subscriptionId") String subscriptionId);
 
+  @EntityGraph(value = "Subscription.offering")
   Optional<Subscription> findBySubscriptionNumber(String subscriptionNumber);
 
+  @EntityGraph(value = "Subscription.offering")
   Page<Subscription> findByOfferingSku(String sku, Pageable pageable);
 
+  @EntityGraph(value = "Subscription.offering")
   Stream<Subscription> findByOrgId(String orgId);
 
+  @EntityGraph(value = "Subscription.offering")
   List<Subscription> findByOrgIdAndEndDateAfter(String orgId, OffsetDateTime date);
 
   void deleteBySubscriptionId(String subscriptionId);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -41,6 +41,7 @@ import lombok.*;
 @NoArgsConstructor
 @IdClass(Subscription.SubscriptionCompoundId.class)
 @Table(name = "subscription")
+@NamedEntityGraph(name = "Subscription.offering", attributeNodes = @NamedAttributeNode("offering"))
 public class Subscription implements Serializable {
 
   @Id
@@ -79,20 +80,12 @@ public class Subscription implements Serializable {
   @Column(name = "billing_provider")
   private BillingProvider billingProvider;
 
-  @OneToMany(
-      mappedBy = "subscription",
-      fetch = FetchType.LAZY,
-      cascade = CascadeType.ALL,
-      orphanRemoval = true)
+  @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   @ToString.Exclude
   private Set<SubscriptionProductId> subscriptionProductIds = new HashSet<>();
 
-  @OneToMany(
-      mappedBy = "subscription",
-      fetch = FetchType.LAZY,
-      cascade = CascadeType.ALL,
-      orphanRemoval = true)
+  @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   @ToString.Exclude // Excluded to prevent fetching a lazy-loaded collection
   private List<SubscriptionMeasurement> subscriptionMeasurements = new ArrayList<>();
@@ -106,11 +99,6 @@ public class Subscription implements Serializable {
       return false;
     }
 
-    var ourProductIds =
-        subscriptionProductIds.stream().map(SubscriptionProductId::getProductId).toList();
-    var otherProductIds =
-        sub.getSubscriptionProductIds().stream().map(SubscriptionProductId::getProductId).toList();
-
     return Objects.equals(subscriptionId, sub.getSubscriptionId())
         && Objects.equals(subscriptionNumber, sub.getSubscriptionNumber())
         && Objects.equals(orgId, sub.getOrgId())
@@ -120,14 +108,11 @@ public class Subscription implements Serializable {
         && Objects.equals(billingProviderId, sub.getBillingProviderId())
         && Objects.equals(billingAccountId, sub.getBillingAccountId())
         && Objects.equals(accountNumber, sub.getAccountNumber())
-        && Objects.equals(billingProvider, sub.getBillingProvider())
-        && Objects.equals(ourProductIds, otherProductIds);
+        && Objects.equals(billingProvider, sub.getBillingProvider());
   }
 
   @Override
   public int hashCode() {
-    var ourProductIds =
-        subscriptionProductIds.stream().map(SubscriptionProductId::getProductId).toList();
     return Objects.hash(
         subscriptionId,
         subscriptionNumber,
@@ -138,8 +123,7 @@ public class Subscription implements Serializable {
         billingProviderId,
         billingAccountId,
         accountNumber,
-        billingProvider,
-        ourProductIds);
+        billingProvider);
   }
 
   /** Composite ID class for Subscription entities. */


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1424](https://issues.redhat.com/browse/SWATCH-1424)

## Description
Join fetch the offering with the subscription.  We invariably need both.  Also eliminate usage of subscription_product_ids in `equals` on Subscription.  It's not useful and it will end up fetching a lazy-loaded association.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
Download [perf.txt](https://github.com/RedHatInsights/rhsm-subscriptions/files/11910213/perf.txt).  I had to name it `.txt` because GitHub says it accepts `.patch` but then it doesn't when you try to upload one.

### Steps
<!-- Enter each step of the test below -->
1. `git checkout main && patch -p1 < perf.txt`
1. `/gradlew :test -i --tests=Swatch1424OfferingRepositoryPerformanceTest.testFindByOfferingSku`
1. Observe the result is
   ```sql
   Hibernate: 
    select
        subscripti0_.start_date as start_da1_12_,
        subscripti0_.subscription_id as subscrip2_12_,
        subscripti0_.account_number as account_3_12_,
        subscripti0_.billing_account_id as billing_4_12_,
        subscripti0_.billing_provider as billing_5_12_,
        subscripti0_.billing_provider_id as billing_6_12_,
        subscripti0_.end_date as end_date7_12_,
        subscripti0_.sku as sku11_12_,
        subscripti0_.org_id as org_id8_12_,
        subscripti0_.quantity as quantity9_12_,
        subscripti0_.subscription_number as subscri10_12_ 
    from
        subscription subscripti0_ 
    left outer join
        offering offering1_ 
            on subscripti0_.sku=offering1_.sku 
    where
        offering1_.sku=?
   Hibernate: 
    select
        offering0_.sku as sku1_8_0_,
        offering0_.cores as cores2_8_0_,
        offering0_.derived_sku as derived_3_8_0_,
        offering0_.description as descript4_8_0_,
        offering0_.has_unlimited_usage as has_unli5_8_0_,
        offering0_.hypervisor_cores as hypervis6_8_0_,
        offering0_.hypervisor_sockets as hypervis7_8_0_,
        offering0_.product_family as product_8_8_0_,
        offering0_.product_name as product_9_8_0_,
        offering0_.role as role10_8_0_,
        offering0_.sla as sla11_8_0_,
        offering0_.sockets as sockets12_8_0_,
        offering0_.usage as usage13_8_0_ 
    from
        offering offering0_ 
    where
        offering0_.sku=?
   Hibernate: 
    select
        childskus0_.sku as sku1_10_0_,
        childskus0_.child_sku as child_sk2_10_0_ 
    from
        sku_child_sku childskus0_ 
    where
        childskus0_.sku=?
   Hibernate: 
    select
        productids0_.sku as sku1_11_0_,
        productids0_.oid as oid2_11_0_ 
    from
        sku_oid productids0_ 
    where
        productids0_.sku=?
   ```
### Verification
1. `git checkout origin/awood/SWATCH-1424-offering-productid-performance && patch -p1 < perf.txt`
1. `./gradlew :test -i --tests=Swatch1424OfferingRepositoryPerformanceTest.testFindByOfferingSku `
1. Observe the query now joins `offering` and `subscription`:
   ```sql
   Hibernate: 
    select
        subscripti0_.start_date as start_da1_12_0_,
        subscripti0_.subscription_id as subscrip2_12_0_,
        offering1_.sku as sku1_8_1_,
        subscripti0_.account_number as account_3_12_0_,
        subscripti0_.billing_account_id as billing_4_12_0_,
        subscripti0_.billing_provider as billing_5_12_0_,
        subscripti0_.billing_provider_id as billing_6_12_0_,
        subscripti0_.end_date as end_date7_12_0_,
        subscripti0_.sku as sku11_12_0_,
        subscripti0_.org_id as org_id8_12_0_,
        subscripti0_.quantity as quantity9_12_0_,
        subscripti0_.subscription_number as subscri10_12_0_,
        offering1_.cores as cores2_8_1_,
        offering1_.derived_sku as derived_3_8_1_,
        offering1_.description as descript4_8_1_,
        offering1_.has_unlimited_usage as has_unli5_8_1_,
        offering1_.hypervisor_cores as hypervis6_8_1_,
        offering1_.hypervisor_sockets as hypervis7_8_1_,
        offering1_.product_family as product_8_8_1_,
        offering1_.product_name as product_9_8_1_,
        offering1_.role as role10_8_1_,
        offering1_.sla as sla11_8_1_,
        offering1_.sockets as sockets12_8_1_,
        offering1_.usage as usage13_8_1_ 
    from
        subscription subscripti0_ 
    left outer join
        offering offering1_ 
            on subscripti0_.sku=offering1_.sku 
    where
        offering1_.sku=?
   Hibernate: 
    select
        childskus0_.sku as sku1_10_0_,
        childskus0_.child_sku as child_sk2_10_0_ 
    from
        sku_child_sku childskus0_ 
    where
        childskus0_.sku=?
   Hibernate: 
    select
        productids0_.sku as sku1_11_0_,
        productids0_.oid as oid2_11_0_ 
    from
        sku_oid productids0_ 
    where
        productids0_.sku=?
   ```
