### PR TITLE
swatch-928: update existing records if retallying

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/RemittanceControllerTest.java
@@ -280,7 +280,7 @@ class RemittanceControllerTest {
   }
 
   @Test
-  void syncRemittanceSkipsSnapshotWhenRemittanceExists() {
+  void syncRemittanceUpdatesRemittanceWhenRemittanceExists() {
     TallySnapshot snapshot =
         buildSnapshot(
             "org123",
@@ -299,7 +299,9 @@ class RemittanceControllerTest {
 
     BillableUsageRemittanceEntity remittance = createRemittance(snapshot, 46.0);
     remittance.getKey().setRemittancePendingDate(snapshot.getSnapshotDate());
-    when(remittanceRepo.existsById(remittance.getKey())).thenReturn(true);
+
+    when(remittanceRepo.existsBy(any())).thenReturn(true);
+    when(remittanceRepo.findById(remittance.getKey())).thenReturn(Optional.of(remittance));
 
     when(snapshotRepo.hasLatestBillables(
             snapshot.getOrgId(),


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-928](https://issues.redhat.com/browse/SWATCH-928)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Error was occurring on retally where hourly remittances were not being updated.
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert test data:
```
INSERT INTO public.account_config VALUES ('7147504', 'API', '2023-06-30 11:51:29.323066+00', '2023-06-30 14:05:38.597068+00', '14541308');

INSERT INTO public.contracts VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', '12914277', '2023-06-01 18:20:07.717275+00', '2023-06-01 18:20:07.717275+00', NULL, '14541308', 'MW02393', 'aws', 'aws123', 'rosa', 'bcwuzc8ww10vvxfair55mliy8');

INSERT INTO public.contract_metrics VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', 'control_plane', 10);
INSERT INTO public.contract_metrics VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', 'four_vcpu_hour', 10);


INSERT INTO public.events VALUES ('ce64995e-c30e-4efc-b745-52017a63161b', NULL, '2023-06-19 08:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "14541308", "event_id": "ce64995e-c30e-4efc-b745-52017a63161b", "timestamp": "2023-06-19T08:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-06-19T09:00:00Z", "instance_id": "67e89df3-1c74-4613-ae58-708def00fe74", "display_name": "automation_moa-hostedcontrolplane_cluster_67e89df3-1c74-4613-ae58-708def00fe74", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 100.0}], "service_type": "rosa Instance", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', '67e89df3-1c74-4613-ae58-708def00fe74', '14541308');
INSERT INTO public.events VALUES ('2cedd057-dd3f-4801-87bf-4ad9ba20a4b7', NULL, '2023-06-19 08:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "14541308", "event_id": "2cedd057-dd3f-4801-87bf-4ad9ba20a4b7", "timestamp": "2023-06-19T08:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-06-19T09:00:00Z", "instance_id": "67e89df3-1c74-4613-ae58-708def00fe74", "display_name": "automation_moa-hostedcontrolplane_cluster_67e89df3-1c74-4613-ae58-708def00fe74", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 100.0}], "service_type": "rosa Instance", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', '67e89df3-1c74-4613-ae58-708def00fe74', '14541308');
INSERT INTO public.events VALUES ('cdc889cd-3596-4373-b49e-6a02159d0c05', NULL, '2023-06-19 08:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "14541308", "event_id": "cdc889cd-3596-4373-b49e-6a02159d0c05", "timestamp": "2023-06-19T08:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-06-19T09:00:00Z", "instance_id": "34bfe0ae-0761-40b0-bef8-96e98e9a0003", "display_name": "automation_moa-hostedcontrolplane_cluster_34bfe0ae-0761-40b0-bef8-96e98e9a0003", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 100.0}], "service_type": "rosa Instance", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', '34bfe0ae-0761-40b0-bef8-96e98e9a0003', '14541308');
INSERT INTO public.events VALUES ('1be93e94-f23a-4429-abd8-b55312d80b08', NULL, '2023-06-19 08:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "14541308", "event_id": "1be93e94-f23a-4429-abd8-b55312d80b08", "timestamp": "2023-06-19T08:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-06-19T09:00:00Z", "instance_id": "34bfe0ae-0761-40b0-bef8-96e98e9a0003", "display_name": "automation_moa-hostedcontrolplane_cluster_34bfe0ae-0761-40b0-bef8-96e98e9a0003", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 100.0}], "service_type": "rosa Instance", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', '34bfe0ae-0761-40b0-bef8-96e98e9a0003', '14541308');
```
2. Start tally service:
```
SPRING_PROFILES_ACTIVE=worker,kafka-task-queue SWATCH_CONTRACTS_INTERNAL_SERVICE_URL=http://localhost:8882 DEV_MODE=true ./gradlew :bootRun
```
3. Start contracts service:
`SERVER_PORT=8882 ./gradlew  :swatch-contracts:quarkusDev
`
4. Run hourly tally:
```
http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["14541308", "2023-06-19T08:00Z", "2023-06-19T09:00Z"]'
```

### Steps
<!-- Enter each step of the test below -->
1. Add new events within same hour:
```
INSERT INTO public.events VALUES ('901bbfb9-8739-4876-bb69-f39e63e1832d', NULL, '2023-06-19 08:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "14541308", "event_id": "901bbfb9-8739-4876-bb69-f39e63e1832d", "timestamp": "2023-06-19T08:00:00Z", "event_type": "snapshot_redhat.com:rosa:cluster_hour", "expiration": "2023-06-19T09:00:00Z", "instance_id": "df47f68a-55fd-45a1-a325-f76cd1cabc10", "display_name": "automation_moa-hostedcontrolplane_cluster_df47f68a-55fd-45a1-a325-f76cd1cabc10", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 100.0}], "service_type": "rosa Instance", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cluster_hour', 'prometheus', 'df47f68a-55fd-45a1-a325-f76cd1cabc10', '14541308');
INSERT INTO public.events VALUES ('56fd9ca7-8ac6-4385-b647-8bc069589b51', NULL, '2023-06-19 08:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "14541308", "event_id": "56fd9ca7-8ac6-4385-b647-8bc069589b51", "timestamp": "2023-06-19T08:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-06-19T09:00:00Z", "instance_id": "df47f68a-55fd-45a1-a325-f76cd1cabc10", "display_name": "automation_moa-hostedcontrolplane_cluster_df47f68a-55fd-45a1-a325-f76cd1cabc10", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 100.0}], "service_type": "rosa Instance", "billing_provider": "aws", "billing_account_id": "aws123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'df47f68a-55fd-45a1-a325-f76cd1cabc10', '14541308');
```
2. Run hourly tally again:
```
http :9000/hawtio/jolokia   type=exec   mbean='org.candlepin.subscriptions.jmx:name=tallyJmxBean,type=TallyJmxBean'   operation='tallyOrgByHourly(java.lang.String,java.lang.String,java.lang.String)'   arguments:='["14541308", "2023-06-19T08:00Z", "2023-06-19T09:00Z"]'
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Run `Select * from billable_usage_remittances; ` and should get cores=260 and instance-hours=290
