### PR TITLE
Return null usage when ISE occurs gathering contract

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -183,6 +183,12 @@ public class BillableUsageController {
               usage);
         }
         return null;
+      } catch (IllegalStateException ise) {
+        log.error(
+            "Unable to retrieve contract for usage - Usage: {} Reason: {}",
+            usage,
+            ise.getMessage());
+        return null;
       }
     }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally.billing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -619,5 +620,14 @@ class BillableUsageControllerTest {
 
     controller.submitBillableUsage(BillingWindow.MONTHLY, usage);
     verify(producer).produce(null);
+  }
+
+  @Test
+  void noUsageProcessedWhenBillingProviderNotSupportedByContractService() {
+    BillableUsage usage = billable(OffsetDateTime.now(), 1.0);
+    usage.setSnapshotDate(OffsetDateTime.now());
+    usage.setBillingProvider(BillingProvider.GCP);
+    when(tagProfile.isTagContractEnabled(usage.getProductId())).thenReturn(true);
+    assertNull(controller.processBillableUsage(BillingWindow.MONTHLY, usage));
   }
 }


### PR DESCRIPTION
# Description

When processing BillableUsage for a contract enabled product
with an unsupported billing provider, return null usage so that
the process will not be retried and will fail gracefully.

# Testing
Clean the database and set up data
```
psql -h localhost -U rhsm-subscriptions <<EOF
truncate  table events;
truncate table hosts cascade;                                                                                                                                                                 truncate table tally_snapshots cascade;                                                                                                                                                       truncate table billable_usage_remittance;

INSERT INTO public.events VALUES ('1464d3e9-2cb7-44c6-b0b6-8bef0ecb57d8', 'account123', '2023-05-11 11:00:00-03', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "1464d3e9-2cb7-44c6-b0b6-8bef0ecb57d8", "timestamp": "2023-05-11T14:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2023-05-11T15:00:00Z", "instance_id": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "display_name": "c36ffaa0-190a-40d9-86a4-ba35f588e90a", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 2.3333333333333335}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "gcp", "billing_account_id": "gcp123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'c36ffaa0-190a-40d9-86a4-ba35f588e90a', 'org123');

EOF
```

Deploy
```
DEV_MODE=true ./gradlew :bootRun
```

Run hourly tally
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=org123&start=2023-05-01T00:00:00Z&end=2023-07-01T00:00:00Z" x-rh-swatch-psk:placeholder
```

Note the error in the log.
```
Unable to retrieve contract for usage - Usage: org.candlepin.subscriptions.json.BillableUsage@30b46346[accountNumber=account123,orgId=org123,id=ba1a3dec-6696-4d4e-95b8-e9eaeba2629f,billingProvider=gcp,billingAccountId=gcp123,snapshotDate=2023-05-11T14:00Z,productId=rosa,sla=Premium,usage=Production,uom=Cores,value=2.3333333333333335,billingFactor=<null>,vendorProductCode=<null>] Reason: Contract metric ID is not configured for billingProvider=gcp product=rosa uom=Cores
```

There should be no stack trace in the logs that resulted from a hard failure!