### PR TITLE
Add serviceType to swatch-product-configuration files

### DIFF
--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/model/Subscription.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/model/Subscription.java
@@ -57,6 +57,7 @@ public class Subscription {
   private Fingerprint fingerprint;
   private List<Variant> variants;
   private BillingWindow billingWindow;
+  private String serviceType;
   private List<Metric> metrics;
   private Defaults defaults;
 }

--- a/swatch-product-configuration/src/main/resources/OpenShift/OpenShift-dedicated-metrics.yaml
+++ b/swatch-product-configuration/src/main/resources/OpenShift/OpenShift-dedicated-metrics.yaml
@@ -17,6 +17,8 @@ defaults:
 
 billingWindow: MONTHLY
 
+serviceType: OpenShift Cluster
+
 metrics:
   - id: redhat.com:openshift_dedicated:4cpu_hour
     rhm_metric_id: redhat.com:openshift_dedicated:4cpu_hour

--- a/swatch-product-configuration/src/main/resources/OpenShift/OpenShift-metrics.yaml
+++ b/swatch-product-configuration/src/main/resources/OpenShift/OpenShift-metrics.yaml
@@ -17,6 +17,8 @@ defaults:
 
 billingWindow: MONTHLY
 
+serviceType: OpenShift Cluster
+
 metrics:
   - id: redhat.com:openshift_container_platform:cpu_hour
     rhm_metric_id: redhat.com:openshift_container_platform:cpu_hour

--- a/swatch-product-configuration/src/main/resources/OpenShift/basilisk.yaml
+++ b/swatch-product-configuration/src/main/resources/OpenShift/basilisk.yaml
@@ -17,6 +17,8 @@ defaults:
 
 billingWindow: MONTHLY
 
+serviceType: BASILISK Instance
+
 metrics:
   - id: redhat.com:BASILISK:transfer_gb
     rhm_metric_id: redhat.com:BASILISK:transfer_gb

--- a/swatch-product-configuration/src/main/resources/OpenShift/rhacs.yaml
+++ b/swatch-product-configuration/src/main/resources/OpenShift/rhacs.yaml
@@ -16,6 +16,8 @@ defaults:
 
 billingWindow: MONTHLY
 
+serviceType: Rhacs Cluster
+
 metrics:
   - id: redhat.com:rhacs:cpu_hour
     rhm_metric_id: redhat.com:rhacs:cpu_hour

--- a/swatch-product-configuration/src/main/resources/OpenShift/rhods.yaml
+++ b/swatch-product-configuration/src/main/resources/OpenShift/rhods.yaml
@@ -17,6 +17,8 @@ defaults:
 
 billingWindow: MONTHLY
 
+serviceType: Rhods Cluster
+
 metrics:
   - id: redhat.com:openshift_data_science:cpu_hours
     rhm_metric_id: redhat.com:openshift_data_science:cpu_hours

--- a/swatch-product-configuration/src/main/resources/OpenShift/rhosak.yaml
+++ b/swatch-product-configuration/src/main/resources/OpenShift/rhosak.yaml
@@ -16,6 +16,8 @@ defaults:
 
 billingWindow: MONTHLY
 
+serviceType: Kafka Cluster
+
 metrics:
   - id: redhat.com:rhosak:transfer_gb
     rhm_metric_id: redhat.com:rhosak:transfer_gb

--- a/swatch-product-configuration/src/main/resources/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/OpenShift/rosa.yaml
@@ -17,6 +17,8 @@ defaults:
 
 billingWindow: MONTHLY
 
+serviceType: rosa Instance
+
 metrics:
   - id: redhat.com:rosa:cluster_hour
     awsDimension: control_plane


### PR DESCRIPTION
Adding serviceType values from tag_profile.yaml to help with transition between tag profile and the subscription config registry