### PR TITLE
SWATCH-1373 Support event lookup by both UOM and metricID

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -72,11 +73,10 @@ public class EventController {
   public Map<EventKey, Event> mapEventsInTimeRange(
       String orgId,
       String eventSource,
-      List<String> eventType,
+      Set<String> eventType,
       OffsetDateTime begin,
       OffsetDateTime end) {
-    return repo.findByOrgIdAndEventSourceAndEventTypeIsInAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
-            orgId, eventSource, eventType, begin, end)
+    return repo.findEventRecordsByCriteria(orgId, eventSource, eventType, begin, end)
         .map(EventRecord::getEvent)
         .collect(Collectors.toMap(EventKey::fromEvent, Function.identity()));
   }

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -72,10 +72,10 @@ public class EventController {
   public Map<EventKey, Event> mapEventsInTimeRange(
       String orgId,
       String eventSource,
-      String eventType,
+      List<String> eventType,
       OffsetDateTime begin,
       OffsetDateTime end) {
-    return repo.findByOrgIdAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+    return repo.findByOrgIdAndEventSourceAndEventTypeIsInAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
             orgId, eventSource, eventType, begin, end)
         .map(EventRecord::getEvent)
         .collect(Collectors.toMap(EventKey::fromEvent, Function.identity()));

--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -21,9 +21,10 @@
 package org.candlepin.subscriptions.metering;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Event.BillingProvider;
 import org.candlepin.subscriptions.json.Event.Role;
@@ -116,7 +117,7 @@ public class MeteringEventFactory {
       Double measuredValue) {
     toUpdate
         .withEventSource(EVENT_SOURCE)
-        .withEventType(getOldEventType(metricId))
+        .withEventType(getEventType(metricId)) // NOSONAR
         .withServiceType(serviceType)
         .withAccountNumber(accountNumber)
         .withOrgId(orgId)
@@ -134,14 +135,23 @@ public class MeteringEventFactory {
   }
 
   // SWATCH-1374 Remove or update this method
-  public static String getOldEventType(String metricId) {
+  /**
+   * Use getEventType(TagMetric tagMetric) instead
+   *
+   * @deprecated (Since we are going to use uom instead of metricid. SWATCH-1374 Remove or update
+   *     this method)
+   * @param metricId
+   * @return
+   */
+  @Deprecated(since = "https://issues.redhat.com/browse/SWATCH-1373")
+  public static String getEventType(String metricId) {
     return StringUtils.hasText(metricId)
         ? String.format("%s_%s", EVENT_TYPE, metricId)
         : EVENT_TYPE;
   }
 
-  public static List<String> getEventType(TagMetric tagMetric) {
-    List<String> eventTypes = new ArrayList<>();
+  public static Set<String> getEventType(TagMetric tagMetric) {
+    Set<String> eventTypes = new HashSet<>();
     Optional.ofNullable(tagMetric.getMetricId())
         .ifPresent(metricId -> eventTypes.add(String.format("%s_%s", EVENT_TYPE, metricId)));
     Optional.ofNullable(tagMetric.getUom())

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -141,7 +141,7 @@ public class PrometheusMeteringController {
                 eventController.mapEventsInTimeRange(
                     orgId,
                     MeteringEventFactory.EVENT_SOURCE,
-                    MeteringEventFactory.getEventType(tagMetric.get().getMetricId()),
+                    MeteringEventFactory.getEventType(tagMetric.get()),
                     // We need to shift the start and end dates by the step, to account for the
                     // shift in the event start date when it is created. See note about eventDate
                     // below.
@@ -256,7 +256,7 @@ public class PrometheusMeteringController {
         new EventKey(
             orgId,
             MeteringEventFactory.EVENT_SOURCE,
-            MeteringEventFactory.getEventType(metricId),
+            MeteringEventFactory.getOldEventType(metricId),
             instanceId,
             measuredDate);
     Event event = existing.remove(lookupKey);

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -256,7 +256,7 @@ public class PrometheusMeteringController {
         new EventKey(
             orgId,
             MeteringEventFactory.EVENT_SOURCE,
-            MeteringEventFactory.getOldEventType(metricId),
+            MeteringEventFactory.getEventType(metricId), // NOSONAR
             instanceId,
             measuredDate);
     Event event = existing.remove(lookupKey);

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -27,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.FixedClockConfiguration;
@@ -164,10 +165,10 @@ class EventRecordRepositoryTest {
 
     List<EventRecord> found =
         repository
-            .findByOrgIdAndEventSourceAndEventTypeIsInAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+            .findEventRecordsByCriteria(
                 e1.getOrgId(),
                 e1.getEventSource(),
-                List.of(e1.getEventType()),
+                Set.of(e1.getEventType()),
                 OffsetDateTime.now(CLOCK).minusYears(1),
                 OffsetDateTime.now(CLOCK).plusYears(1))
             .collect(Collectors.toList());

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -164,10 +164,10 @@ class EventRecordRepositoryTest {
 
     List<EventRecord> found =
         repository
-            .findByOrgIdAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+            .findByOrgIdAndEventSourceAndEventTypeIsInAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
                 e1.getOrgId(),
                 e1.getEventSource(),
-                e1.getEventType(),
+                List.of(e1.getEventType()),
                 OffsetDateTime.now(CLOCK).minusYears(1),
                 OffsetDateTime.now(CLOCK).plusYears(1))
             .collect(Collectors.toList());

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -78,7 +78,7 @@ class MeteringEventFactoryTest {
     assertEquals(Sla.PREMIUM, event.getSla());
     assertEquals(Usage.PRODUCTION, event.getUsage());
     assertEquals(MeteringEventFactory.EVENT_SOURCE, event.getEventSource());
-    assertEquals(MeteringEventFactory.getEventType(metricId), event.getEventType());
+    assertEquals(MeteringEventFactory.getOldEventType(metricId), event.getEventType());
     assertEquals(serviceType, event.getServiceType());
     assertEquals(1, event.getMeasurements().size());
     Measurement measurement = event.getMeasurements().get(0);
@@ -343,9 +343,9 @@ class MeteringEventFactoryTest {
 
   @Test
   void testEventTypeGeneration() {
-    assertEquals("snapshot_my-metric", MeteringEventFactory.getEventType("my-metric"));
-    assertEquals("snapshot", MeteringEventFactory.getEventType(null));
-    assertEquals("snapshot", MeteringEventFactory.getEventType(""));
+    assertEquals("snapshot_my-metric", MeteringEventFactory.getOldEventType("my-metric"));
+    assertEquals("snapshot", MeteringEventFactory.getOldEventType(null));
+    assertEquals("snapshot", MeteringEventFactory.getOldEventType(""));
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -78,7 +78,7 @@ class MeteringEventFactoryTest {
     assertEquals(Sla.PREMIUM, event.getSla());
     assertEquals(Usage.PRODUCTION, event.getUsage());
     assertEquals(MeteringEventFactory.EVENT_SOURCE, event.getEventSource());
-    assertEquals(MeteringEventFactory.getOldEventType(metricId), event.getEventType());
+    assertEquals(MeteringEventFactory.getEventType(metricId), event.getEventType());
     assertEquals(serviceType, event.getServiceType());
     assertEquals(1, event.getMeasurements().size());
     Measurement measurement = event.getMeasurements().get(0);
@@ -343,9 +343,8 @@ class MeteringEventFactoryTest {
 
   @Test
   void testEventTypeGeneration() {
-    assertEquals("snapshot_my-metric", MeteringEventFactory.getOldEventType("my-metric"));
-    assertEquals("snapshot", MeteringEventFactory.getOldEventType(null));
-    assertEquals("snapshot", MeteringEventFactory.getOldEventType(""));
+    assertEquals("snapshot_my-metric", MeteringEventFactory.getEventType("my-metric"));
+    assertEquals("snapshot", MeteringEventFactory.getEventType(""));
   }
 
   @Test

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.db;
 
 import java.time.OffsetDateTime;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.model.EventRecord;
@@ -77,9 +77,21 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
       findByOrgIdAndEventSourceAndEventTypeIsInAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
           String orgId,
           String eventSource,
-          List<String> eventType,
+          Set<String> eventType,
           OffsetDateTime begin,
           OffsetDateTime end);
+
+  // Wrapper for
+  // findByOrgIdAndEventSourceAndEventTypeIsInAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp
+  default Stream<EventRecord> findEventRecordsByCriteria(
+      String orgId,
+      String eventSource,
+      Set<String> eventType,
+      OffsetDateTime begin,
+      OffsetDateTime end) {
+    return findByOrgIdAndEventSourceAndEventTypeIsInAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+        orgId, eventSource, eventType, begin, end);
+  }
 
   /**
    * Delete old event records given a cutoff date

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/EventRecordRepository.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.db;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.model.EventRecord;
@@ -73,10 +74,10 @@ public interface EventRecordRepository extends JpaRepository<EventRecord, UUID> 
    * @return Stream of EventRecords
    */
   Stream<EventRecord>
-      findByOrgIdAndEventSourceAndEventTypeAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
+      findByOrgIdAndEventSourceAndEventTypeIsInAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestamp(
           String orgId,
           String eventSource,
-          String eventType,
+          List<String> eventType,
           OffsetDateTime begin,
           OffsetDateTime end);
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1373](https://issues.redhat.com/browse/SWATCH-1373)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. To run locally prometheus by pointing to stage follow the steps in: [Connecting  Observatorium to fetch Prometheus ](https://docs.engineering.redhat.com/display/ENT/Connecting+to+Observatorium+to+Fetch+Prometheus+Metrics)
- Copy CLIENT_SECRET and paste it in a file `token-refresher`
- Run: `podman run --name=telemeter-stage --rm -ti -p 8082:8080     quay.io/observatorium/token-refresher:master-2021-02-05-5da9663     --oidc.client-secret=$(cat ~/Downloads/token-refresher)     --oidc.client-id=observatorium-subwatch-staging     --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external     --url=https://observatorium.api.stage.openshift.com`
- Then in separate terminal pointing to the prom_url in the doc run: `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 ./gradlew clean :bootRun`

2. Insert few records in Events table:
```
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('2b16a0a1-8278-488a-a8cd-67178a07a013', null, '2023-07-05 15:54:00.000000 +00:00', '{"sla": "Premium", "role": "BASILISK", "org_id": "16785082", "event_id": "2b16a0a1-8278-488a-a8cd-67178a07a013", "timestamp": "2023-06-07T08:00:00Z", "event_type": "snapshot_redhat.com:BASILISK:transfer_gb", "expiration": "2023-06-07T09:00:00Z", "instance_id": "RSsUTrGhOO", "display_name": "automation_BASILISK_cluster_RSsUTrGhOO", "event_source": "prometheus", "measurements": [{"uom": "Transfer-gibibytes", "value": 1.0}], "service_type": "BASILISK Instance"}', 'snapshot_redhat.com:BASILISK:transfer_gb', 'prometheus', 'RSsUTrGhOO', '16785082');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('112a10c5-1374-4c95-964c-9defb5e4c6f6', null, '2023-07-05 15:54:00.000000 +00:00', '{"sla": "Premium", "role": "rhosak", "org_id": "16785082", "event_id": "112a10c5-1374-4c95-964c-9defb5e4c6f6", "timestamp": "2023-07-05T15:54:00Z", "event_type": "snapshot_rhosak_transfer_gibibytes", "expiration": "2023-07-05T13:54:00Z", "instance_id": "56ad40fe-b9bd-49a5-8c6c-a5478ad98a2e", "display_name": "automation_rhosak_cluster_56ad40fe-b9bd-49a5-8c6c-a5478ad98a2e", "event_source": "prometheus", "measurements": [{"uom": "Transfer-gibibytes", "value": 1.0}], "service_type": "Kafka Cluster", "billing_provider": "red hat", "billing_account_id": "4accf275-7db2-4199-9cb6-e7650bd0aa45"}', 'snapshot_rhosak_transfer-gibibytes', 'prometheus', '56ad40fe-b9bd-49a5-8c6c-a5478ad98a2e', '16785082');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('112a10c5-1374-4c95-964c-9defb5e4c6f3', null, '2023-07-05 15:54:00.000000 +00:00', '{"sla": "Premium", "role": "rhosak", "org_id": "16785082", "event_id": "112a10c5-1374-4c95-964c-9defb5e4c6f3", "timestamp": "2023-07-05T15:54:00Z", "event_type": "snapshot_redhat.com:rhosak:transfer_gb", "expiration": "2023-06-07T06:00:00Z", "instance_id": "56ad40fe-b9bd-49a5-8c6c-a5478ad98a2e", "display_name": "automation_rhosak_cluster_56ad40fe-b9bd-49a5-8c6c-a5478ad98a2e", "event_source": "prometheus", "measurements": [{"uom": "Transfer-gibibytes", "value": 1.0}], "service_type": "Kafka Cluster", "billing_provider": "red hat", "billing_account_id": "4accf275-7db2-4199-9cb6-e7650bd0aa45"}', 'snapshot_redhat.com:rhosak:transfer_gb', 'prometheus', '56ad40fe-b9bd-49a5-8c6c-a5478ad98a2e', '16785082');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('a94e8108-32d4-407f-9a50-d50880b3e0e1', null, '2023-07-05 15:54:00.000000 +00:00', '{"sla": "Premium", "role": "rhosak", "org_id": "16785082", "event_id": "a94e8108-32d4-407f-9a50-d50880b3e0e1", "timestamp": "2023-07-05T15:54:00Z", "event_type": "snapshot_redhat.com:rhosak:transfer_gb", "expiration": "2023-06-07T06:00:00Z", "instance_id": "21a0c030-8706-4b46-9836-5ded5ca9a7cc", "display_name": "automation_rhosak_cluster_21a0c030-8706-4b46-9836-5ded5ca9a7cc", "event_source": "prometheus", "measurements": [{"uom": "Transfer-gibibytes", "value": 1.0}], "service_type": "Kafka Cluster", "billing_provider": "gcp", "billing_account_id": "4accf275-7db2-4199-9cb6-e7650bd0aa45"}', 'snapshot_redhat.com:rhosak:transfer_gb', 'prometheus', '21a0c030-8706-4b46-9836-5ded5ca9a7cc', '16785082');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('7a375596-484c-4736-9c1e-52362d965f17', null, '2023-07-05 15:54:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "16785082", "event_id": "7a375596-484c-4736-9c1e-52362d965f17", "timestamp": "2023-07-05T15:54:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-01T01:00:00Z", "instance_id": "93526e44-1296-4674-89ec-1213d44c5ae9", "display_name": "automation_osd_cluster_93526e44-1296-4674-89ec-1213d44c5ae9", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_redhat.com:openshift_dedicated:cluster_hour', 'prometheus', '93526e44-1296-4674-89ec-1213d44c5ae9', '16785082');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('7a375596-484c-4736-9c1e-52362d965f18', null, '2023-07-05 15:54:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "16785082", "event_id": "7a375596-484c-4736-9c1e-52362d965f18", "timestamp": "2023-07-05T15:54:00Z", "event_type": "snapshot_openshift-dedicated-metrics_instance-hours", "expiration": "2023-05-01T01:00:00Z", "instance_id": "93526e44-1296-4674-89ec-1213d44c5ae9", "display_name": "automation_osd_cluster_93526e44-1296-4674-89ec-1213d44c5ae9", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_openshift-dedicated-metrics_instance-hours', 'prometheus', '93526e44-1296-4674-89ec-1213d44c5ae9', '16785082');
INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('2b16a0a1-8278-488a-a8cd-67178a07a014', null, '2023-07-05 15:54:00.000000 +00:00', '{"sla": "Premium", "role": "BASILISK", "org_id": "16785082", "event_id": "2b16a0a1-8278-488a-a8cd-67178a07a014", "timestamp": "2023-07-05T15:54:00Z", "event_type": "snapshot_basilisk_transfer-gibibytes", "expiration": "2023-06-07T09:00:00Z", "instance_id": "RSsUTrGhOO", "display_name": "automation_BASILISK_cluster_RSsUTrGhOO", "event_source": "prometheus", "measurements": [{"uom": "Transfer-gibibytes", "value": 1.0}], "service_type": "BASILISK Instance"}', 'snapshot_basilisk_transfer-gibibytes', 'prometheus', 'RSsUTrGhOO', '16785082');

```


### Steps
<!-- Enter each step of the test below -->
1. `curl -X POST -H "x-rh-swatch-synchronous-request:true"  -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?orgId=16785082&rangeInMinutes=1200"`


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. In debug mode you will see below logs:
```
2023-07-05 20:33:23,545 [thread=http-nio-8000-exec-1] [DEBUG] [org.hibernate.SQL] self- select eventrecor0_.id as id1_3_, eventrecor0_.account_number as account_2_3_, eventrecor0_.data as data3_3_, eventrecor0_.event_source as event_so4_3_, eventrecor0_.event_type as event_ty5_3_, eventrecor0_.instance_id as instance6_3_, eventrecor0_.org_id as org_id7_3_, eventrecor0_.timestamp as timestam8_3_ from events eventrecor0_ where eventrecor0_.org_id=? and eventrecor0_.event_source=? and (eventrecor0_.event_type in (? , ?)) and eventrecor0_.timestamp>=? and eventrecor0_.timestamp<? order by eventrecor0_.timestamp asc

2023-07-05 20:40:59,529 [thread=http-nio-8000-exec-8] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Deleting 3 stale metric events.
2023-07-05 20:40:59,530 [thread=http-nio-8000-exec-8] [DEBUG] [org.hibernate.SQL] self- delete from events where id=? or id=? or id=?

```
Without any errors it will delete the events that are: `snapshot_rhosak_transfer-gibibytes` and `snapshot_redhat.com:rhosak:transfer_gb`

### Steps
<!-- Enter each step of the test below -->
2. `curl -X POST -H "x-rh-swatch-synchronous-request:true"  -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/OpenShift-dedicated-metrics?orgId=16785082&rangeInMinutes=1200"`

### Verification
<!-- Enter the steps needed to verify the test passed -->
2. Logs as below and it will delete the events with `snapshot_redhat.com:openshift_dedicated:cluster_hour` and `snapshot_openshift-dedicated-metrics_instance-hours`
```
2023-07-05 20:45:16,695 [thread=http-nio-8000-exec-9] [DEBUG] [org.hibernate.SQL] self- select eventrecor0_.id as id1_3_, eventrecor0_.account_number as account_2_3_, eventrecor0_.data as data3_3_, eventrecor0_.event_source as event_so4_3_, eventrecor0_.event_type as event_ty5_3_, eventrecor0_.instance_id as instance6_3_, eventrecor0_.org_id as org_id7_3_, eventrecor0_.timestamp as timestam8_3_ from events eventrecor0_ where eventrecor0_.org_id=? and eventrecor0_.event_source=? and (eventrecor0_.event_type in (? , ?)) and eventrecor0_.timestamp>=? and eventrecor0_.timestamp<? order by eventrecor0_.timestamp asc
2023-07-05 20:45:16,697 [thread=http-nio-8000-exec-9] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Persisted 0 events for OpenShift-dedicated-metrics Instance-hours metrics.
2023-07-05 20:45:16,697 [thread=http-nio-8000-exec-9] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Deleting 2 stale metric events.
2023-07-05 20:45:16,698 [thread=http-nio-8000-exec-9] [DEBUG] [org.hibernate.SQL] self- delete from events where id=? or id=?

```

### Steps
<!-- Enter each step of the test below -->
3. `curl -X POST -H "x-rh-swatch-synchronous-request:true"  -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/BASILISK?orgId=16785082&rangeInMinutes=1200"`

### Verification
<!-- Enter the steps needed to verify the test passed -->
3. It will delete the events with `snapshot_redhat.com:BASILISK:transfer_gb` and `snapshot_basilisk_transfer-gibibytes`

To test on EE:
`curl -X POST -H 'x-rh-swatch-synchronous-request:true' -H 'x-rh-swatch-psk:dummy' -H 'Origin: https://cloud.redhat.com/' "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?orgId=16785082&rangeInMinutes=1200"`