### PR TITLE
SWATCH-598 Add worker for event messages to swatch tally

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -144,12 +145,12 @@ public class EventController {
   }
 
   @Transactional
-  public void persistServiceInstances(List<String> eventJsonList) {
+  public void persistServiceInstances(Set<String> eventJsonList) {
     Map<EventKey, Event> eventsMap = parseEventRecordsToEventsEntityMap(eventJsonList);
     saveAll(eventsMap.values());
   }
 
-  public Map<EventKey, Event> parseEventRecordsToEventsEntityMap(List<String> eventJsonList) {
+  private Map<EventKey, Event> parseEventRecordsToEventsEntityMap(Set<String> eventJsonList) {
     Map<EventKey, Event> eventsMap = new HashMap<>();
     eventJsonList.forEach(
         eventJson -> {
@@ -158,7 +159,9 @@ public class EventController {
             eventsMap.putIfAbsent(EventKey.fromEvent(event), event);
           } catch (Exception e) {
             log.warn(
-                "Issue found {} for the event json {} skipping to next", e.getMessage(), eventJson);
+                String.format(
+                    "Issue found %s for the service instance json skipping to next ",
+                    e.getCause()));
           }
         });
     return eventsMap;

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.event;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -31,19 +32,24 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.db.model.EventKey;
 import org.candlepin.subscriptions.db.model.EventRecord;
+import org.candlepin.subscriptions.db.model.EventRecordConverter;
 import org.candlepin.subscriptions.json.Event;
 import org.springframework.stereotype.Service;
 
 /** Encapsulates interaction with event store. */
 @Service
+@Slf4j
 public class EventController {
   private final EventRecordRepository repo;
+  private final EventRecordConverter eventRecordConverter;
 
-  public EventController(EventRecordRepository repo) {
+  public EventController(EventRecordRepository repo, EventRecordConverter eventRecordConverter) {
     this.repo = repo;
+    this.eventRecordConverter = eventRecordConverter;
   }
 
   /**
@@ -135,5 +141,26 @@ public class EventController {
       String orgId, String serviceType, OffsetDateTime startDate, OffsetDateTime endDate) {
     return repo.existsByOrgIdAndServiceTypeAndTimestampGreaterThanEqualAndTimestampLessThan(
         orgId, serviceType, startDate, endDate);
+  }
+
+  @Transactional
+  public void persistServiceInstances(List<String> eventJsonList) {
+    Map<EventKey, Event> eventsMap = parseEventRecordsToEventsEntityMap(eventJsonList);
+    saveAll(eventsMap.values());
+  }
+
+  public Map<EventKey, Event> parseEventRecordsToEventsEntityMap(List<String> eventJsonList) {
+    Map<EventKey, Event> eventsMap = new HashMap<>();
+    eventJsonList.forEach(
+        eventJson -> {
+          try {
+            Event event = eventRecordConverter.convertToEntityAttribute(eventJson);
+            eventsMap.putIfAbsent(EventKey.fromEvent(event), event);
+          } catch (Exception e) {
+            log.warn(
+                "Issue found {} for the event json {} skipping to next", e.getMessage(), eventJson);
+          }
+        });
+    return eventsMap;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.metering.service.prometheus.config;
 
 import org.candlepin.subscriptions.db.EventRecordRepository;
+import org.candlepin.subscriptions.db.model.EventRecordConverter;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
@@ -60,8 +61,9 @@ public class PrometheusServiceConfiguration {
   }
 
   @Bean
-  EventController prometheusEventController(EventRecordRepository repo) {
-    return new EventController(repo, null);
+  EventController prometheusEventController(
+      EventRecordRepository repo, EventRecordConverter eventRecordConverter) {
+    return new EventController(repo, eventRecordConverter);
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
@@ -61,7 +61,7 @@ public class PrometheusServiceConfiguration {
 
   @Bean
   EventController prometheusEventController(EventRecordRepository repo) {
-    return new EventController(repo);
+    return new EventController(repo, null);
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -233,7 +233,7 @@ public class TallyWorkerConfiguration {
   public TaskQueueProperties serviceInstanceTopicProperties() {
     return new TaskQueueProperties();
   }
-  
+
   @Bean(name = "purgeRemittancesJobExecutor")
   public Executor getPurgeRemittancesJobExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -27,6 +27,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.event.EventController;
@@ -41,6 +43,7 @@ import org.candlepin.subscriptions.task.queue.TaskConsumer;
 import org.candlepin.subscriptions.task.queue.TaskConsumerConfiguration;
 import org.candlepin.subscriptions.task.queue.TaskConsumerFactory;
 import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -49,6 +52,9 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -185,5 +191,46 @@ public class TallyWorkerConfiguration {
     executor.setQueueCapacity(0);
     executor.initialize();
     return executor;
+  }
+
+  @Bean
+  @Qualifier("serviceInstanceConsumerFactory")
+  ConsumerFactory<String, String> serviceInstanceConsumerFactory(
+      KafkaProperties kafkaProperties,
+      @Qualifier("tallyTaskQueueProperties") TaskQueueProperties taskQueueProperties) {
+    var props = kafkaProperties.buildConsumerProperties();
+    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, taskQueueProperties.getMaxPollRecords());
+    return new DefaultKafkaConsumerFactory<>(
+        props, new StringDeserializer(), new StringDeserializer());
+  }
+
+  @Bean
+  ConcurrentKafkaListenerContainerFactory<String, String>
+      kafkaServiceInstanceListenerContainerFactory(
+          @Qualifier("serviceInstanceConsumerFactory")
+              ConsumerFactory<String, String> consumerFactory,
+          KafkaProperties kafkaProperties,
+          KafkaConsumerRegistry registry) {
+
+    var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
+    factory.setConsumerFactory(consumerFactory);
+    factory.setBatchListener(true);
+    // Concurrency should be set to the number of partitions for the target topic.
+    factory.setConcurrency(kafkaProperties.getListener().getConcurrency());
+    if (kafkaProperties.getListener().getIdleEventInterval() != null) {
+      factory
+          .getContainerProperties()
+          .setIdleEventInterval(kafkaProperties.getListener().getIdleEventInterval().toMillis());
+    }
+    // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
+    factory.getContainerProperties().setConsumerRebalanceListener(registry);
+    return factory;
+  }
+
+  @Bean
+  @Qualifier("serviceInstanceTopicProperties")
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.service-instance-ingress.incoming")
+  public TaskQueueProperties serviceInstanceTopicProperties() {
+    return new TaskQueueProperties();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/ServiceInstanceMessageConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/ServiceInstanceMessageConsumer.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.billing;
 
-import java.util.List;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
@@ -54,7 +54,7 @@ public class ServiceInstanceMessageConsumer extends SeekableKafkaConsumer {
       topics = "#{__listener.topic}",
       containerFactory = "kafkaServiceInstanceListenerContainerFactory")
   @Transactional(noRollbackFor = RuntimeException.class)
-  public void receive(@Payload List<String> eventRecords) {
+  public void receive(@Payload Set<String> eventRecords) {
     log.info("Events received w/ event list size={}. Consuming events.", eventRecords.size());
     eventController.persistServiceInstances(eventRecords);
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/ServiceInstanceMessageConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/ServiceInstanceMessageConsumer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class ServiceInstanceMessageConsumer extends SeekableKafkaConsumer {
+
+  @Autowired
+  public ServiceInstanceMessageConsumer(
+      @Qualifier("serviceInstanceTopicProperties")
+          TaskQueueProperties taskServiceInstanceTopicProperties,
+      KafkaConsumerRegistry kafkaConsumerRegistry) {
+    super(taskServiceInstanceTopicProperties, kafkaConsumerRegistry);
+  }
+
+  @KafkaListener(
+      id = "#{__listener.groupId}",
+      topics = "#{__listener.topic}",
+      containerFactory = "kafkaServiceInstanceListenerContainerFactory")
+  @Transactional
+  public void receive(
+      @Payload
+          List<String>
+              events /*, @Header(name = KafkaHeaders.RECEIVED_MESSAGE_KEY, required = false) String kafkaMessageKey*/) {
+    log.info("Events received w/ event list size={}. Consuming events.", events.size());
+  }
+}

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -1,7 +1,7 @@
 TASKS_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.tasks')].name:platform.rhsm-subscriptions.tasks}
 TALLY_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.tally')].name:platform.rhsm-subscriptions.tally}
 BILLABLE_USAGE_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.billable-usage')].name:platform.rhsm-subscriptions.billable-usage}
-
+SERVICE_INSTANCE_INGRESS_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.service-instance-ingress')].name:platform.rhsm-subscriptions.service-instance-ingress}
 rhsm-subscriptions:
   hourlyTallyDurationLimitDays: 90d
   inventory-service:
@@ -36,6 +36,13 @@ rhsm-subscriptions:
     back-off-multiplier: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MULTIPLIER:2}
     max-attempts: ${TALLY_SUMMARY_PRODUCER_MAX_ATTEMPTS:5}
     topic: ${TALLY_TOPIC}
+  service-instance-ingress:
+    incoming:
+      topic: ${SERVICE_INSTANCE_INGRESS_TOPIC}
+      kafka-group-id: swatch-instance-ingress
+      seek-override-end: ${SERVICE_INSTANCE_INGRESS_KAFKA_SEEK_OVERRIDE_END:false}
+      seek-override-timestamp: ${SERVICE_INSTANCE_INGRESS_KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+      max-poll-records: ${SERVICE_INSTANCE_INGRESS_KAFKA_MAX_POLL_RECORDS:500}
   billing-producer:
     back-off-initial-interval: ${BILLING_PRODUCER_BACK_OFF_INITIAL_INTERVAL:1s}
     back-off-max-interval: ${BILLING_PRODUCER_BACK_OFF_MAX_INTERVAL:1m}

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.candlepin.subscriptions.db.EventRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"worker", "test"})
+class EventControllerTest {
+  @Autowired EventController eventController;
+
+  @MockBean private EventRecordRepository eventRecordRepository;
+
+  String eventRecord1;
+  String eventRecord2;
+  String eventRecord3;
+  String eventRecord4;
+  String eventRecord5;
+
+  @BeforeEach
+  void setup() {
+    eventRecord1 =
+        """
+                {
+                   "sla": "Premium",
+                   "role": "osd",
+                   "org_id": "4",
+                   "timestamp": "2023-05-02T00:00:00Z",
+                   "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour",
+                   "expiration": "2023-05-02T01:00:00Z",
+                   "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "event_source": "prometheus",
+                   "measurements": [
+                     {
+                       "uom": "Instance-hours",
+                       "value": 1
+                     }
+                   ],
+                   "service_type": "OpenShift Cluster"
+                 }
+                """;
+    eventRecord2 =
+        """
+                {
+                   "sla": "Premium",
+                   "role": "osd",
+                   "org_id": "6",
+                   "timestamp": "2023-05-02T00:00:00Z",
+                   "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour",
+                   "expiration": "2023-05-02T01:00:00Z",
+                   "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "event_source": "prometheus",
+                   "measurements": [
+                     {
+                       "uom": "Instance-hours",
+                       "value": 1
+                     }
+                   ],
+                   "service_type": "OpenShift Cluster"
+                 }
+                """;
+    eventRecord3 =
+        """
+                {
+                   "sla": "Premium",
+                   "role": "osd",
+                   "org_id": "6",
+                   "timestamp": "2023-05-02T00:00:00Z",
+                   "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour",
+                   "expiration": "2023-05-02T01:00:00Z",
+                   "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "event_source": "prometheus",
+                   "measurements": [
+                     {
+                       "uom": "Instance-hours",
+                       "value": 1
+                     }
+                   ],
+                   "service_type": "OpenShift Cluster"
+                 }
+                """;
+    eventRecord4 =
+        """
+                {
+                   "sla": "Premium1",
+                   "role": "osd",
+                   "org_id": "6",
+                   "timestamp": "2023-05-02T00:00:00Z",
+                   "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour",
+                   "expiration": "2023-05-02T01:00:00Z",
+                   "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "event_source": "prometheus",
+                   "measurements": [
+                     {
+                       "uom": "Instance-hours",
+                       "value": 1
+                     }
+                   ],
+                   "service_type": "OpenShift Cluster"
+                 }
+                """;
+    eventRecord5 =
+        """
+                {
+                   "sla": "Premium",
+                   "role": "osd",
+                   "org_id": "7",
+                   "timestamp": "2023-05-02T00:00:00Z",
+                   "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour",
+                   "expiration": "2023-05-02T01:00:00Z",
+                   "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "event_source": "prometheus",
+                   "measurements": [
+                     {
+                       "uom": "Instance-hours",
+                       "value": 1
+                     }
+                   ],
+                   "service_type": "OpenShift Cluster"
+                 }
+                """;
+  }
+
+  @Test
+  void testPersistServiceInstances_WhenValidPayload() {
+
+    Set<String> eventRecords = new HashSet<>();
+    eventRecords.add(eventRecord1);
+    eventRecords.add(eventRecord2);
+    eventRecords.add(eventRecord3);
+    eventController.persistServiceInstances(eventRecords);
+
+    when(eventRecordRepository.saveAll(any())).thenReturn(new ArrayList<>());
+
+    ArgumentCaptor<Collection> eve = ArgumentCaptor.forClass(Collection.class);
+    verify(eventRecordRepository).saveAll(eve.capture());
+    List events = eve.getAllValues().get(0).stream().toList();
+    assertEquals(2, events.size());
+  }
+
+  @Test
+  void testPersistServiceInstances_ProcessValidPayloadAndSkipInvalidPayload() {
+
+    Set<String> eventRecords = new HashSet<>();
+    eventRecords.add(eventRecord1);
+    eventRecords.add(eventRecord2);
+    eventRecords.add(eventRecord3);
+    eventRecords.add(eventRecord4);
+    eventRecords.add(eventRecord5);
+    eventController.persistServiceInstances(eventRecords);
+
+    when(eventRecordRepository.saveAll(any())).thenReturn(new ArrayList<>());
+    ArgumentCaptor<Collection> eve = ArgumentCaptor.forClass(Collection.class);
+    verify(eventRecordRepository).saveAll(eve.capture());
+    List events = eve.getAllValues().get(0).stream().toList();
+    assertEquals(3, events.size());
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventRecordConverter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventRecordConverter.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 
 /** JPA AttributeConverter which uses Jackson to map to/from Event JSON. */
 @Component
-class EventRecordConverter implements AttributeConverter<Event, String> {
+public class EventRecordConverter implements AttributeConverter<Event, String> {
 
   private static ObjectMapper objectMapper;
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
@@ -38,4 +38,7 @@ public class TaskQueueProperties {
   private boolean seekOverrideEnd = false;
 
   private boolean enabled = true;
+
+  /** Batch size number of records * */
+  private String maxPollRecords = "15";
 }

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -23,6 +23,12 @@ parameters:
     value: 'false'
   - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
     value: ''
+  - name: SERVICE_INSTANCE_INGRESS_KAFKA_SEEK_OVERRIDE_END
+    value: 'false'
+  - name: SERVICE_INSTANCE_INGRESS_KAFKA_SEEK_OVERRIDE_TIMESTAMP
+    value: ''
+  - name: SERVICE_INSTANCE_INGRESS_KAFKA_MAX_POLL_RECORDS
+    value: '500'
   - name: REPLICAS
     value: '1'
   - name: IMAGE
@@ -131,6 +137,10 @@ parameters:
     value: '3'
   - name: KAFKA_BILLABLE_USAGE_PARTITIONS
     value: '3'
+  - name: KAFKA_SERVICE_INSTANCE_REPLICAS
+    value: '3'
+  - name: KAFKA_SERVICE_INSTANCE_PARTITIONS
+    value: '3'
   - name: KAFKA_TALLY_REPLICAS
     value: '3'
   - name: KAFKA_TALLY_PARTITIONS
@@ -219,6 +229,9 @@ objects:
       - replicas: ${{KAFKA_BILLABLE_USAGE_REPLICAS}}
         partitions: ${{KAFKA_BILLABLE_USAGE_PARTITIONS}}
         topicName: platform.rhsm-subscriptions.billable-usage
+      - replicas: ${{KAFKA_SERVICE_INSTANCE_REPLICAS}}
+        partitions: ${{KAFKA_SERVICE_INSTANCE_PARTITIONS}}
+        topicName: platform.rhsm-subscriptions.service-instance-ingress
 
     database:
       # Must specify both a name and a major postgres version
@@ -308,6 +321,12 @@ objects:
               value: ${KAFKA_SEEK_OVERRIDE_END}
             - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
               value: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP}
+            - name: SERVICE_INSTANCE_INGRESS_KAFKA_SEEK_OVERRIDE_END
+              value: ${SERVICE_INSTANCE_INGRESS_KAFKA_SEEK_OVERRIDE_END}
+            - name: SERVICE_INSTANCE_INGRESS_KAFKA_SEEK_OVERRIDE_TIMESTAMP
+              value: ${SERVICE_INSTANCE_INGRESS_KAFKA_SEEK_OVERRIDE_TIMESTAMP}
+            - name: SERVICE_INSTANCE_INGRESS_KAFKA_MAX_POLL_RECORDS
+              value: ${SERVICE_INSTANCE_INGRESS_KAFKA_MAX_POLL_RECORDS}
             - name: DATABASE_CONNECTION_TIMEOUT_MS
               value: ${DATABASE_CONNECTION_TIMEOUT_MS}
             - name: DATABASE_MAX_POOL_SIZE


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-598](https://issues.redhat.com/browse/SWATCH-598)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
- This is an implementation of batch Kafka listener. swatch-tally listens on `platform.rhsm-subscriptions.service-instance-ingress` for event messages, and invokes EventController.saveAll() on them. If the json object is in bad format then we skip and log it as warning and process rest of the event messages in the batch. 
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Clean up the Events table.
2. Execute the below respective payload values mentioned in each step so that it forms a batch and then run the application `DEV_MODE=true ./gradlew clean :bootRun `
3. Use the Big data Tools of Intellij as producer to test the consumer topic `platform.rhsm-subscriptions.service-instance-ingress`. Payloads are as below make sure to check each Test step on which payload to use:
![image](https://github.com/RedHatInsights/rhsm-subscriptions/assets/11471167/03ab9bbf-f1a9-49a9-a980-4fb3947dce6d)


Payload1: `{"sla": "Premium", "role": "osd", "org_id": "1","timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}`

Payload2: `{"sla": "Premium", "role": "osd", "org_id": "2","timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}`

Payload3: `{"sla": "Premium", "role": "osd", "org_id": "3","timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}`

Payload144: `{"sla": "Premium", "role": "osd", "org_id": "144","timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}`

Payload145: `{"sla": "Premium1", "role": "osd", "org_id": "145","timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}`

Payload146: `{"sla": "Premium", "role": "osd", "org_id": "146","timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}`

### Steps
<!-- Enter each step of the test below -->
1. **Step 1: Add new events**
In the value string add payload 1, payload 2, payload 3 one by one and produce.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. New `three` entries created in table if the records don't already exists. Also in the log message you can see batch of three events accepted  `[INFO ] [org.candlepin.subscriptions.tally.billing.ServiceInstanceMessageConsumer] - Events received w/ event list size=3. Consuming events.`

```
fcac0338-15c7-4a74-aadd-a7f28fafab2e,,2023-05-02 00:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""2"", ""event_id"": ""fcac0338-15c7-4a74-aadd-a7f28fafab2e"", ""timestamp"": ""2023-05-02T00:00:00Z"", ""event_type"": ""snapshot_redhat.com:openshift_dedicated:cluster_hour"", ""expiration"": ""2023-05-02T01:00:00Z"", ""instance_id"": ""e3a62bd1-fd00-405c-9401-f2288808588d"", ""display_name"": ""automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d"", ""event_source"": ""prometheus"", ""measurements"": [{""uom"": ""Instance-hours"", ""value"": 1.0}], ""service_type"": ""OpenShift Cluster""}",snapshot_redhat.com:openshift_dedicated:cluster_hour,prometheus,e3a62bd1-fd00-405c-9401-f2288808588d,2
552d14b4-7535-4d5f-9126-3935efa110e3,,2023-05-02 00:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""3"", ""event_id"": ""552d14b4-7535-4d5f-9126-3935efa110e3"", ""timestamp"": ""2023-05-02T00:00:00Z"", ""event_type"": ""snapshot_redhat.com:openshift_dedicated:cluster_hour"", ""expiration"": ""2023-05-02T01:00:00Z"", ""instance_id"": ""e3a62bd1-fd00-405c-9401-f2288808588d"", ""display_name"": ""automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d"", ""event_source"": ""prometheus"", ""measurements"": [{""uom"": ""Instance-hours"", ""value"": 1.0}], ""service_type"": ""OpenShift Cluster""}",snapshot_redhat.com:openshift_dedicated:cluster_hour,prometheus,e3a62bd1-fd00-405c-9401-f2288808588d,3
12e52117-e7bf-4d97-9580-d3d0349cc2a5,,2023-05-02 00:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""1"", ""event_id"": ""12e52117-e7bf-4d97-9580-d3d0349cc2a5"", ""timestamp"": ""2023-05-02T00:00:00Z"", ""event_type"": ""snapshot_redhat.com:openshift_dedicated:cluster_hour"", ""expiration"": ""2023-05-02T01:00:00Z"", ""instance_id"": ""e3a62bd1-fd00-405c-9401-f2288808588d"", ""display_name"": ""automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d"", ""event_source"": ""prometheus"", ""measurements"": [{""uom"": ""Instance-hours"", ""value"": 1.0}], ""service_type"": ""OpenShift Cluster""}",snapshot_redhat.com:openshift_dedicated:cluster_hour,prometheus,e3a62bd1-fd00-405c-9401-f2288808588d,1
```

### Steps
<!-- Enter each step of the test below -->
2. **Step 2: Update events**
Since we want the event_id for this step, in the value string copy the data column from the events table and then change a parameter value in it. I changed the event_source to `cost-management` and then reexecute it.
`{"sla": "Premium", "role": "osd", "org_id": "1", "event_id": "12e52117-e7bf-4d97-9580-d3d0349cc2a5", "timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "cost-management", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}`

### Verification
<!-- Enter the steps needed to verify the test passed -->
2. Updated `one` entry and since the application was already running as soon as Kafka listener received a batch it executed a single payload. `[INFO ] [org.candlepin.subscriptions.tally.billing.ServiceInstanceMessageConsumer] - Events received w/ event list size=1.`

`12e52117-e7bf-4d97-9580-d3d0349cc2a5,,2023-05-02 00:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""1"", ""event_id"": ""12e52117-e7bf-4d97-9580-d3d0349cc2a5"", ""timestamp"": ""2023-05-02T00:00:00Z"", ""event_type"": ""snapshot_redhat.com:openshift_dedicated:cluster_hour"", ""expiration"": ""2023-05-02T01:00:00Z"", ""instance_id"": ""e3a62bd1-fd00-405c-9401-f2288808588d"", ""display_name"": ""automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d"", ""event_source"": ""cost-management"", ""measurements"": [{""uom"": ""Instance-hours"", ""value"": 1.0}], ""service_type"": ""OpenShift Cluster""}",snapshot_redhat.com:openshift_dedicated:cluster_hour,cost-management,e3a62bd1-fd00-405c-9401-f2288808588d,1`

### Steps
<!-- Enter each step of the test below -->
3. **Step 3: Update events like 21 new payloads and see it performs in batch**
Stop application. Update the same payload by changing org_ids and then reexecute the payloads. Once that is done restart the application.

Payload example: `{"sla": "Premium", "role": "osd", "org_id": "20", "event_id": "12e52117-e7bf-4d97-9580-d3d0349cc2a5", "timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "cost-management", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}
`
### Verification
<!-- Enter the steps needed to verify the test passed -->
3. In the log `Events received w/ event list size=15. Consuming events.`

### Steps
<!-- Enter each step of the test below -->
4. **Step 4: Add new events if its valid and skip the bad payloads**
Stop the service. In the value string add payload 144, payload 145, payload 146 one by one and produce. Notice that payload 145 is having bad data in sla as `Premium1`. Rerun the `DEV_MODE=true ./gradlew clean :bootRun `

### Verification
<!-- Enter the steps needed to verify the test passed -->
4. The batch will persist 144,146 payload by adding `two` entries and will log warning for 145 payload. 

Logs 
```
2023-07-11 18:09:30,723 [thread=swatch-instance-ingress-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.ServiceInstanceMessageConsumer] - Events received w/ event list size=3. Consuming events.
2023-07-11 18:09:30,924 [thread=swatch-instance-ingress-0-C-1] [WARN ] [org.candlepin.subscriptions.event.EventController] - Issue found com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of `org.candlepin.subscriptions.json.Event$Sla`, problem: Premium1
 at [Source: (String)"{"sla": "Premium1", "role": "osd", "org_id": "145","timestamp": "2023-05-02T00:00:00Z", "event_type": "snapshot_redhat.com:openshift_dedicated:cluster_hour", "expiration": "2023-05-02T01:00:00Z", "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d", "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}"; line: 1, column: 9] (through reference chain: org.candlepin.subscriptions.json.Event["sla"]) for the service instance json skipping to next
```

Tables with new entries look like below:

```
bd9fefa4-97ae-44f8-85f8-8206da1d37a2,,2023-05-02 00:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""144"", ""event_id"": ""bd9fefa4-97ae-44f8-85f8-8206da1d37a2"", ""timestamp"": ""2023-05-02T00:00:00Z"", ""event_type"": ""snapshot_redhat.com:openshift_dedicated:cluster_hour"", ""expiration"": ""2023-05-02T01:00:00Z"", ""instance_id"": ""e3a62bd1-fd00-405c-9401-f2288808588d"", ""display_name"": ""automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d"", ""event_source"": ""prometheus"", ""measurements"": [{""uom"": ""Instance-hours"", ""value"": 1.0}], ""service_type"": ""OpenShift Cluster""}",snapshot_redhat.com:openshift_dedicated:cluster_hour,prometheus,e3a62bd1-fd00-405c-9401-f2288808588d,144
b9594613-47ae-4ee4-81e7-71f58bd8d8fa,,2023-05-02 00:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""146"", ""event_id"": ""b9594613-47ae-4ee4-81e7-71f58bd8d8fa"", ""timestamp"": ""2023-05-02T00:00:00Z"", ""event_type"": ""snapshot_redhat.com:openshift_dedicated:cluster_hour"", ""expiration"": ""2023-05-02T01:00:00Z"", ""instance_id"": ""e3a62bd1-fd00-405c-9401-f2288808588d"", ""display_name"": ""automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d"", ""event_source"": ""prometheus"", ""measurements"": [{""uom"": ""Instance-hours"", ""value"": 1.0}], ""service_type"": ""OpenShift Cluster""}",snapshot_redhat.com:openshift_dedicated:cluster_hour,prometheus,e3a62bd1-fd00-405c-9401-f2288808588d,146
```