### PR TITLE
SWATCH-1047 Properly filter by cores/sockets in instance API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -155,9 +155,6 @@ public class InstancesResource implements InstancesApi {
     Sort.Order implicitOrder = Sort.Order.by("id");
     Sort sortValue = Sort.by(implicitOrder);
 
-    int minCores = 0;
-    int minSockets = 0;
-
     String orgId = ResourceUtils.getOrgId();
     ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
     Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);
@@ -202,8 +199,6 @@ public class InstancesResource implements InstancesApi {
             sanitizedSla,
             sanitizedUsage,
             sanitizedDisplayNameSubstring,
-            minCores,
-            minSockets,
             month,
             referenceUom,
             sanitizedBillingProvider,
@@ -285,6 +280,8 @@ public class InstancesResource implements InstancesApi {
     for (String uom : measurements) {
       if (Measurement.Uom.SOCKETS.equals(Measurement.Uom.fromValue(uom))) {
         measurementList.add(Double.valueOf(tallyInstanceView.getSockets()));
+      } else if (Measurement.Uom.CORES.equals(Measurement.Uom.fromValue(uom))) {
+        measurementList.add(Double.valueOf(tallyInstanceView.getCores()));
       } else if (!isPAYG
           && tallyInstanceView.getKey().getUom().equals(Measurement.Uom.fromValue(uom))) {
         measurementList.add(Optional.ofNullable(tallyInstanceView.getValue()).orElse(0.0));

--- a/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
@@ -83,24 +83,28 @@ class TallyInstanceViewRepositoryTest {
     Host host8 = createHost("inventory8", "account123");
     Host host9 = createHost("inventory9", "account123");
     Host host10 = createHost("inventory10", "account123");
+    Host host11 = createHost("inventory11", "account123");
 
     for (Uom uom : Uom.values()) {
       host8.addToMonthlyTotal(
           OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC), uom, 100.0);
       host8.setMeasurement(uom, 100.0);
       host9.addToMonthlyTotal(
-          OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC), uom, 0.0);
-      host9.setMeasurement(uom, 0.0);
+          OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC), uom, 20.0);
+      host9.setMeasurement(uom, 20.0);
       host10.addToMonthlyTotal(
+          OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC), uom, 0.0);
+      host10.setMeasurement(uom, 0.0);
+      host11.addToMonthlyTotal(
           OffsetDateTime.of(LocalDateTime.of(2021, 2, 1, 0, 0, 0), ZoneOffset.UTC), uom, 50.0);
-      host10.setMeasurement(uom, 50.0);
+      host11.setMeasurement(uom, 50.0);
     }
 
     addBucketToHost(host8, RHEL, ServiceLevel._ANY, Usage._ANY, HardwareMeasurementType.PHYSICAL);
     addBucketToHost(host9, RHEL, ServiceLevel._ANY, Usage._ANY, HardwareMeasurementType.PHYSICAL);
-    addBucketToHost(host10, RHEL, ServiceLevel._ANY, Usage._ANY, HardwareMeasurementType.PHYSICAL);
+    addBucketToHost(host11, RHEL, ServiceLevel._ANY, Usage._ANY, HardwareMeasurementType.PHYSICAL);
 
-    persistHosts(host8, host9, host10).stream()
+    persistHosts(host8, host9, host10, host11).stream()
         .collect(Collectors.toMap(Host::getInventoryId, Function.identity()));
   }
 
@@ -151,8 +155,6 @@ class TallyInstanceViewRepositoryTest {
             ServiceLevel._ANY,
             Usage._ANY,
             "",
-            0,
-            0,
             "2021-01",
             referenceUom,
             BillingProvider._ANY,
@@ -164,7 +166,7 @@ class TallyInstanceViewRepositoryTest {
 
     if (sortValue.equals("monthlyTotals")) {
       List<TallyInstanceView> payload = results.toList();
-      assertEquals(0.0, payload.get(0).getMonthlyTotals().get(0));
+      assertEquals(20.0, payload.get(0).getMonthlyTotals().get(0));
       assertEquals(100.0, payload.get(1).getMonthlyTotals().get(0));
     }
   }
@@ -235,8 +237,6 @@ class TallyInstanceViewRepositoryTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             "",
-            0,
-            0,
             null,
             Uom.CORES,
             BillingProvider.AWS,
@@ -253,8 +253,6 @@ class TallyInstanceViewRepositoryTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             "",
-            0,
-            0,
             null,
             Uom.CORES,
             BillingProvider._ANY,
@@ -368,8 +366,6 @@ class TallyInstanceViewRepositoryTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             "",
-            0,
-            0,
             null,
             Uom.CORES,
             BillingProvider._ANY,
@@ -428,8 +424,6 @@ class TallyInstanceViewRepositoryTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             "",
-            0,
-            0,
             null,
             Uom.CORES,
             BillingProvider.RED_HAT,
@@ -447,8 +441,6 @@ class TallyInstanceViewRepositoryTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             "",
-            0,
-            0,
             null,
             Uom.CORES,
             BillingProvider.RED_HAT,
@@ -499,8 +491,6 @@ class TallyInstanceViewRepositoryTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             "",
-            0,
-            0,
             null,
             Uom.CORES,
             BillingProvider.RED_HAT,
@@ -566,8 +556,6 @@ class TallyInstanceViewRepositoryTest {
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             "",
-            0,
-            0,
             null,
             Uom.CORES,
             BillingProvider.RED_HAT,


### PR DESCRIPTION
Jira issue: [SWATCH-1047](https://issues.redhat.com/browse/SWATCH-1047)

## Description
No longer use the min cores/socktes value as part of
the instances query to filter by cores/sockets UOM.

This change affects all UOM filtering in that an instance
is only matched when it has a UOM matching the query parameter
and the instance measurement value for that UOM is > 0.

**NOTE:**
It also also uncovered an issue where we were not setting the CORES value correctly from the view. These changes could impact IQE tests based on setup.

## Testing
Drop the database
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```

Load the database from the attached test data file: [bug_data_dump_full.txt](https://github.com/RedHatInsights/rhsm-subscriptions/files/11971683/bug_data_dump_full.txt)
```
psql -U rhsm-subscriptions rhsm-subscriptions < bug_data_dump_full.txt
```

Deploy the app from the main branch.
```
DEV_MODE=true ./gradlew :bootRun
```

Opt in the test org/account
```
http PUT :8000/api/rhsm-subscriptions/v1/opt-in x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

### Reproduce on main branch
Test with cores
```
http GET ':8000/api/rhsm-subscriptions/v1/instances/products/OpenShift%20Container%20Platform?dir=desc&ending=2023-06-30T23:59:59.999Z&limit=100&offset=0&sort=last_seen&beginning=2023-06-01T00:00:00Z&uom=cores' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Observe - count 82
```
{
...
...
    "meta": {
        "count": 82,
        "measurements": [
            "Cores",
            "Sockets"
        ],
        "product": "OpenShift Container Platform"
    }
}
```

Test with sockets
```
http GET ':8000/api/rhsm-subscriptions/v1/instances/products/OpenShift%20Container%20Platform?dir=desc&ending=2023-06-30T23:59:59.999Z&limit=100&offset=0&sort=last_seen&beginning=2023-06-01T00:00:00Z&uom=sockets' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Observe - count 82
```
{
...
...
    "meta": {
        "count": 82,
        "measurements": [
            "Cores",
            "Sockets"
        ],
        "product": "OpenShift Container Platform"
    }
}
```

### Test fix on PR branch

Check out this branch and deploy again.

Test with cores
```
http GET ':8000/api/rhsm-subscriptions/v1/instances/products/OpenShift%20Container%20Platform?dir=desc&ending=2023-06-30T23:59:59.999Z&limit=100&offset=0&sort=last_seen&beginning=2023-06-01T00:00:00Z&uom=cores' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Observe - count 48
```
{
...
...
    "meta": {
        "count": 48,
        "measurements": [
            "Cores",
            "Sockets"
        ],
        "product": "OpenShift Container Platform"
    }
}
```

Test with sockets
```
http GET ':8000/api/rhsm-subscriptions/v1/instances/products/OpenShift%20Container%20Platform?dir=desc&ending=2023-06-30T23:59:59.999Z&limit=100&offset=0&sort=last_seen&beginning=2023-06-01T00:00:00Z&uom=sockets' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Observe - count 34
```
{
...
...
    "meta": {
        "count": 34,
        "measurements": [
            "Cores",
            "Sockets"
        ],
        "product": "OpenShift Container Platform"
    }
}
```
