### PR TITLE
SWATCH-1427: Address excess calls to OfferingRepository.existsById with caching

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -153,6 +153,14 @@ public class SubscriptionSyncController {
     syncSubscription(dtoSku, newOrUpdated, subscriptionOptional);
   }
 
+  /**
+   * Sync a subscription from the subscription service with an internally managed subscription.
+   *
+   * @param sku the SKU for the subscription
+   * @param newOrUpdated a Subscription constructed from a DTO. <strong>This object is not in the
+   *     persistence context</strong>
+   * @param subscriptionOptional optional existing Subscription. Managed in the persistence context.
+   */
   @Transactional
   public void syncSubscription(
       String sku,
@@ -183,9 +191,9 @@ public class SubscriptionSyncController {
 
     subscriptionOptional.ifPresentOrElse(
         subscription -> newOrUpdated.setOffering(subscription.getOffering()),
-        () ->
-            newOrUpdated.setOffering(
-                offeringRepository.findById(sku).orElseThrow(EntityNotFoundException::new)));
+        // Set the offering via a proxy object rather than performing a full lookup.  See
+        // https://thorben-janssen.com/jpa-getreference/
+        () -> newOrUpdated.setOffering(offeringRepository.getReferenceById(sku)));
 
     log.debug("Syncing subscription from external service={}", newOrUpdated);
 
@@ -230,7 +238,7 @@ public class SubscriptionSyncController {
                 .build();
         subscriptionRepository.save(newSub);
       } else {
-        updateSubscription(newOrUpdated, existingSubscription);
+        updateExistingSubscription(newOrUpdated, existingSubscription);
         subscriptionRepository.save(existingSubscription);
       }
       capacityReconciliationController.reconcileCapacityForSubscription(newOrUpdated);
@@ -244,6 +252,8 @@ public class SubscriptionSyncController {
       org.candlepin.subscriptions.db.model.Subscription subscription) {
     if (subscription.getBillingProvider() == null
         || subscription.getBillingProvider().equals(BillingProvider.EMPTY)) {
+      // The offering here is going to be a proxy object created by getReferenceById.  Hibernate
+      // should take care of actually performing the select from the database if one is needed.
       var productTag =
           tagProfile.tagForOfferingProductName(subscription.getOffering().getProductName());
       if (tagProfile.isProductPAYGEligible(productTag)) {
@@ -449,8 +459,10 @@ public class SubscriptionSyncController {
         .build();
   }
 
-  /** Update all subscription fields that we allow to change */
-  protected void updateSubscription(
+  /**
+   * Update all subscription fields in an existing SWATCH Subscription that we are allowed to change
+   */
+  protected void updateExistingSubscription(
       org.candlepin.subscriptions.db.model.Subscription newOrUpdated,
       org.candlepin.subscriptions.db.model.Subscription entity) {
     if (newOrUpdated.getEndDate() != null) {

--- a/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryCachingTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OfferingRepositoryCachingTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.transaction.Transactional;
+import org.candlepin.subscriptions.db.model.Offering;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class OfferingRepositoryCachingTest {
+  public static final String EXISTS_CACHE = "offeringExists";
+  public static final String SKU = "MCT123";
+  public static final String SKU2 = "MCT345";
+  public static final String SKU3 = "MCT456";
+
+  @Autowired OfferingRepository repository;
+  @Autowired CacheManager cacheManager;
+
+  @AfterEach
+  void tearDown() {
+    cacheManager.getCache(EXISTS_CACHE).clear();
+  }
+
+  private <T> Optional<T> getCachedOffering(String sku, String cache, Class<T> type) {
+    return ofNullable(cacheManager.getCache(cache)).map(c -> c.get(sku, type));
+  }
+
+  private Offering createOffering(String s) {
+    var offering1 =
+        Offering.builder()
+            .sku(s)
+            .productName("RHEL")
+            .serviceLevel(ServiceLevel.STANDARD)
+            .usage(Usage.PRODUCTION)
+            .build();
+    var offering = offering1;
+    assertEquals(empty(), getCachedOffering(s, EXISTS_CACHE, Boolean.class));
+    repository.save(offering);
+    // Test to make sure the cache is still empty after a save.  In the future we might want to
+    // annotate the save methods with a @CachePut to pre-populate the cache, but right now we
+    // aren't doing that.
+    assertEquals(empty(), getCachedOffering(s, EXISTS_CACHE, Boolean.class));
+    return offering;
+  }
+
+  @Test
+  @Transactional
+  void testExistsById() {
+    createOffering(SKU);
+    assertTrue(repository.existsById(SKU));
+
+    var cacheHit = getCachedOffering(SKU, EXISTS_CACHE, Boolean.class);
+    assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+  }
+
+  @Test
+  @Transactional
+  void testDeleteAllEvictsEverything() {
+    Stream.of(SKU, SKU2).forEach(this::createOffering);
+    Stream.of(SKU, SKU2).forEach(x -> assertTrue(repository.existsById(x)));
+
+    for (String sku : List.of(SKU, SKU2)) {
+      var cacheHit = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+    }
+
+    repository.deleteAll();
+
+    for (String sku : List.of(SKU, SKU2)) {
+      var cacheMiss = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheMiss.isEmpty());
+    }
+  }
+
+  @Test
+  @Transactional
+  void testDeleteAllInBatchEvictsEverything() {
+    Stream.of(SKU, SKU2).forEach(this::createOffering);
+    Stream.of(SKU, SKU2).forEach(x -> assertTrue(repository.existsById(x)));
+
+    for (String sku : List.of(SKU, SKU2)) {
+      var cacheHit = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+    }
+
+    repository.deleteAllInBatch();
+
+    for (String sku : List.of(SKU, SKU2)) {
+      var cacheMiss = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheMiss.isEmpty());
+    }
+  }
+
+  @Test
+  @Transactional
+  void testDeleteAllIterableEvictsEverything() {
+    var offering1 = createOffering(SKU);
+    var offering2 = createOffering(SKU2);
+    createOffering(SKU3);
+
+    Stream.of(SKU, SKU2, SKU3).forEach(x -> assertTrue(repository.existsById(x)));
+
+    for (String sku : List.of(SKU, SKU2, SKU3)) {
+      var cacheHit = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+    }
+
+    repository.deleteAll(List.of(offering1, offering2));
+
+    for (String sku : List.of(SKU, SKU2, SKU3)) {
+      var cacheMiss = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheMiss.isEmpty());
+    }
+  }
+
+  @Test
+  @Transactional
+  void testDeleteAllByIdEvictsEverything() {
+    Stream.of(SKU, SKU2, SKU3).forEach(this::createOffering);
+    Stream.of(SKU, SKU2, SKU3).forEach(x -> assertTrue(repository.existsById(x)));
+
+    for (String sku : List.of(SKU, SKU2, SKU3)) {
+      var cacheHit = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+    }
+
+    repository.deleteAllById(List.of(SKU, SKU2));
+
+    for (String sku : List.of(SKU, SKU2, SKU3)) {
+      var cacheMiss = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheMiss.isEmpty());
+    }
+  }
+
+  @Test
+  @Transactional
+  void testDeleteAllInBatchIterableEvictsEverything() {
+    var offering1 = createOffering(SKU);
+    var offering2 = createOffering(SKU2);
+    createOffering(SKU3);
+
+    Stream.of(SKU, SKU2, SKU3).forEach(x -> assertTrue(repository.existsById(x)));
+
+    for (String sku : List.of(SKU, SKU2, SKU3)) {
+      var cacheHit = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+    }
+
+    repository.deleteAllInBatch(List.of(offering1, offering2));
+
+    for (String sku : List.of(SKU, SKU2, SKU3)) {
+      var cacheMiss = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheMiss.isEmpty());
+    }
+  }
+
+  @Test
+  @Transactional
+  void testDeleteAllByIdInBatchEvictsEverything() {
+    Stream.of(SKU, SKU2, SKU3).forEach(this::createOffering);
+    Stream.of(SKU, SKU2, SKU3).forEach(x -> assertTrue(repository.existsById(x)));
+
+    for (String sku : List.of(SKU, SKU2, SKU3)) {
+      var cacheHit = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+    }
+
+    repository.deleteAllByIdInBatch(List.of(SKU, SKU2));
+
+    for (String sku : List.of(SKU, SKU2, SKU3)) {
+      var cacheMiss = getCachedOffering(sku, EXISTS_CACHE, Boolean.class);
+      assertTrue(cacheMiss.isEmpty());
+    }
+  }
+
+  @Test
+  @Transactional
+  void testDeleteDoesEvict() {
+    var offering = createOffering(SKU);
+    assertTrue(repository.existsById(SKU));
+
+    var cacheHit = getCachedOffering(SKU, EXISTS_CACHE, Boolean.class);
+    assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+
+    repository.delete(offering);
+
+    var cacheMiss = getCachedOffering(SKU, EXISTS_CACHE, Boolean.class);
+    assertTrue(cacheMiss.isEmpty());
+  }
+
+  @Test
+  @Transactional
+  void testDeleteByIdEvicts() {
+    createOffering(SKU);
+    assertTrue(repository.existsById(SKU));
+
+    var cacheHit = getCachedOffering(SKU, EXISTS_CACHE, Boolean.class);
+    assertTrue(cacheHit.orElseThrow(() -> new AssertionFailedError("Test failed: cache miss!")));
+
+    repository.deleteById(SKU);
+    var cacheMiss = getCachedOffering(SKU, EXISTS_CACHE, Boolean.class);
+    assertTrue(cacheMiss.isEmpty());
+  }
+}

--- a/swatch-core/build.gradle
+++ b/swatch-core/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation "javax.validation:validation-api"
     implementation "org.springframework.boot:spring-boot-starter"
     implementation "org.springframework.boot:spring-boot-actuator-autoconfigure"
+    implementation "org.springframework.boot:spring-boot-starter-cache"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "com.google.guava:guava" // for ip address class
@@ -27,6 +28,7 @@ dependencies {
     implementation "com.jayway.jsonpath:json-path"
     implementation "com.splunk.logging:splunk-library-javalogging"
     implementation "org.codehaus.janino:janino"
+    implementation "com.github.ben-manes.caffeine:caffeine"
     implementation libraries["resteasy-spring-boot-starter"]
 
     testImplementation project(":swatch-core-test")

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingCacheProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingCacheProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.time.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("rhsm-subscriptions.offering-cache")
+public class OfferingCacheProperties {
+  private int size;
+  private Duration ttl;
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
@@ -25,12 +25,69 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.model.Offering;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 /** Repository interface for the Offering entity */
 public interface OfferingRepository extends JpaRepository<Offering, String> {
+  @Override
+  @Cacheable(cacheNames = {"offeringExists"})
+  boolean existsById(String s);
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      allEntries = true)
+  void deleteAll();
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      allEntries = true)
+  void deleteAllInBatch();
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      allEntries = true)
+  // We would want the cache key to be something like "offerings.forEach(x -> x.getSku())" but
+  // there isn't a good way to do that.  Instead, we'll just invalidate the entire cache.  The
+  // deleteAll() method actually just calls delete() in a loop but the CacheEvict annotation on
+  // our overriden declaration of delete doesn't get invoked.
+  void deleteAll(Iterable<? extends Offering> offerings);
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      allEntries = true)
+  void deleteAllById(Iterable<? extends String> skus);
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      allEntries = true)
+  // We would want the cache key to be something like "offerings.forEach(x -> x.getSku())" but
+  // there isn't a good way to do that.  Instead, we'll just invalidate the entire cache.
+  void deleteAllInBatch(Iterable<Offering> offerings);
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      allEntries = true)
+  void deleteAllByIdInBatch(Iterable<String> skus);
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      key = "#offering.sku")
+  void delete(Offering offering);
+
+  @Override
+  @CacheEvict(cacheNames = {"offeringExists"})
+  void deleteById(String s);
 
   List<Offering> findByProductName(String productName);
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
@@ -22,7 +22,6 @@ package org.candlepin.subscriptions.db;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.zaxxer.hikari.HikariDataSource;
-import java.time.Duration;
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -100,12 +99,14 @@ public class RhsmSubscriptionsDataSourceConfiguration {
   }
 
   @Bean
-  public Caffeine caffeine() {
-    return Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofMinutes(30));
+  public Caffeine<Object, Object> caffeine(OfferingCacheProperties offeringCacheProperties) {
+    return Caffeine.newBuilder()
+        .maximumSize(offeringCacheProperties.getSize())
+        .expireAfterWrite(offeringCacheProperties.getTtl());
   }
 
   @Bean
-  public CacheManager offeringCacheManager(Caffeine caffeine) {
+  public CacheManager offeringCacheManager(Caffeine<Object, Object> caffeine) {
     CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
     caffeineCacheManager.setCaffeine(caffeine);
     caffeineCacheManager.setCacheNames(List.of("offeringExists"));

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
@@ -20,7 +20,10 @@
  */
 package org.candlepin.subscriptions.db;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.zaxxer.hikari.HikariDataSource;
+import java.time.Duration;
+import java.util.List;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -28,6 +31,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +48,7 @@ import org.springframework.validation.annotation.Validated;
 /** A class to hold the inventory data source configuration. */
 @Configuration
 @EnableTransactionManagement
+@EnableCaching
 @EnableJpaRepositories(
     basePackages = "org.candlepin.subscriptions.db",
     entityManagerFactoryRef = "rhsmSubscriptionsEntityManagerFactory",
@@ -90,5 +97,19 @@ public class RhsmSubscriptionsDataSourceConfiguration {
   public AccountListSource accountListSource(
       AccountConfigRepository accountConfigRepository, ApplicationClock clock) {
     return new DatabaseAccountListSource(accountConfigRepository);
+  }
+
+  @Bean
+  public Caffeine caffeine() {
+    return Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofMinutes(30));
+  }
+
+  @Bean
+  public CacheManager offeringCacheManager(Caffeine caffeine) {
+    CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+    caffeineCacheManager.setCaffeine(caffeine);
+    caffeineCacheManager.setCacheNames(List.of("offeringExists"));
+
+    return caffeineCacheManager;
   }
 }

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -74,6 +74,9 @@ DATABASE_CONNECTION_TIMEOUT_MS: 30000
 DATABASE_MAX_POOL_SIZE: 10
 POSTGRES_STATEMENT_TIMEOUT: 5min
 
+OFFERING_CACHE_TTL: 30m
+OFFERING_CACHE_SIZE: 10000
+
 FILTER_ORGS:
 
 server:
@@ -148,6 +151,9 @@ hawtio:
   hawtio-base-path: ${HAWTIO_BASE_PATH}
 
 rhsm-subscriptions:
+  offering-cache:
+    ttl: ${OFFERING_CACHE_TTL}
+    size: ${OFFERING_CACHE_SIZE}
   security:
     dev-mode: ${DEV_MODE}
     manual-subscription-editing-enabled: ${DEVTEST_SUBSCRIPTION_EDITING_ENABLED}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1427](https://issues.redhat.com/browse/SWATCH-1427)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
For every subscription during a subscription sync, we were making a call to OfferingRepository.existsById just to see if the subscription exists.  This is a lot of work that we don't need to perform over and over again.  I've added a simple in-memory cache to store the SKUs for 30 minutes.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Testing is covered by the unit tests.
