### PR TITLE
SWATCH-1230: Implement swatch-product-configuration lookup methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,3 +41,11 @@ There are various other tasks, see `./gradlew help tasks | grep liquibase`. Note
 Liquibase Hub or Liquibase Pro.
 
 DB migrations should be written to roll back cleanly (exceptions should be discussed with the team).
+
+-------------
+
+# swatch-product-configuration
+
+Directory structure: `$Platform/$Subscription_Name.yaml` (e.g. RHEL/RHEL_for_x86.yaml).
+
+Use camel case for yaml properties that need to be serialized into the `com.redhat.swatch.configuration.registry` object definitions.

--- a/swatch-product-configuration/build.gradle
+++ b/swatch-product-configuration/build.gradle
@@ -4,11 +4,13 @@ plugins {
 }
 
 dependencies {
-    compileOnly platform(libraries["quarkus-bom"])
-    testCompileOnly platform(libraries["quarkus-bom"])
-    implementation 'org.yaml:snakeyaml'
+    implementation 'org.yaml:snakeyaml:2.0'
+    implementation "org.slf4j:slf4j-api:1.7.36"
     implementation 'javax.validation:validation-api:2.0.1.Final'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
+
+    testImplementation libraries["junit-jupiter"]
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }
 
 description = 'SWATCH library for product configuration'

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/exception/ConfigResourcesLoadingException.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/exception/ConfigResourcesLoadingException.java
@@ -18,13 +18,11 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.configuration.registry;
+package com.redhat.swatch.configuration.exception;
 
-import java.util.Map;
-import lombok.*;
+public class ConfigResourcesLoadingException extends RuntimeException {
 
-@Data
-public class PrometheusMetric {
-  private String queryKey;
-  private Map<String, String> queryParams;
+  public ConfigResourcesLoadingException(Exception e) {
+    super(e);
+  }
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Defaults.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Defaults.java
@@ -23,7 +23,6 @@ package com.redhat.swatch.configuration.registry;
 import lombok.*;
 
 @Data
-@Builder
 public class Defaults {
   private String variant;
   private Sla sla;

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Fingerprint.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Fingerprint.java
@@ -20,6 +20,7 @@
  */
 package com.redhat.swatch.configuration.registry;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.*;
 
@@ -31,8 +32,7 @@ import lombok.*;
  * specific architecture w/ a given subscription.
  */
 @Data
-@Builder
 public class Fingerprint {
-  private List<String> engineeringIds;
-  private List<String> arches;
+  private List<String> engineeringIds = new ArrayList<>();
+  private List<String> arches = new ArrayList<>();
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Metric.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Metric.java
@@ -25,12 +25,11 @@ import javax.validation.constraints.NotNull;
 import lombok.*;
 
 @Data
-@Builder
 public class Metric {
 
   @NotNull @NotEmpty private String id; // required
   private String rhmMetricId;
   private String awsDimension;
-  private PrometheusMetric prometheusMetric;
+  private PrometheusMetric prometheus;
   private Double billingFactor;
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionRegistry.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionRegistry.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.configuration.registry;
+
+import com.redhat.swatch.configuration.exception.ConfigResourcesLoadingException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+/**
+ * Loads yaml files from src/main/resource/subscription_configs into List<Subscription>. Provides
+ * lookup methods for that list.
+ */
+@Slf4j
+class SubscriptionRegistry {
+
+  private static SubscriptionRegistry instance = null;
+
+  @Getter private final List<Subscription> subscriptions;
+
+  public static synchronized SubscriptionRegistry getInstance() {
+    if (instance == null) {
+      instance = new SubscriptionRegistry();
+    }
+    return instance;
+  }
+
+  SubscriptionRegistry() {
+    subscriptions = new ArrayList<>();
+    Constructor constructor = new Constructor(Subscription.class, new LoaderOptions());
+    constructor.getPropertyUtils().setSkipMissingProperties(true);
+
+    Yaml yaml = new Yaml(constructor);
+
+    // Get the class loader
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+    // Get all resources on the classpath under the subscription_configs subdirectory.
+    String resourceDirectory = "subscription_configs";
+    URL resourceUrl = Objects.requireNonNull(classLoader.getResource(resourceDirectory));
+
+    Path directoryPath;
+
+    // Needed to support AppClassLoader for when a fancy Quarkus ClassLoader isn't available
+    if (Objects.equals(resourceUrl.getProtocol(), "jar")) {
+      FileSystem fileSystem;
+      try {
+        fileSystem = FileSystems.newFileSystem(resourceUrl.toURI(), Collections.emptyMap());
+      } catch (IOException | URISyntaxException e) {
+        throw new ConfigResourcesLoadingException(e);
+      }
+      directoryPath = fileSystem.getPath(resourceDirectory);
+    } else {
+      try {
+        directoryPath = Paths.get(resourceUrl.toURI());
+      } catch (URISyntaxException e) {
+        throw new ConfigResourcesLoadingException(e);
+      }
+    }
+
+    log.debug("Attempting to walk directoryPath: {}", directoryPath);
+
+    // List YAML files in the resource directory
+    try (Stream<Path> paths = Files.walk(directoryPath)) {
+      paths
+          .filter(Files::isRegularFile)
+          .filter(file -> file.getFileName().toString().endsWith(".yaml"))
+          .forEach(
+              file -> {
+                try (InputStream inputStream = Files.newInputStream(file)) {
+
+                  var subscriptionFromYaml = yaml.loadAs(inputStream, Subscription.class);
+                  subscriptionFromYaml.getVariants().forEach(variant -> variant.setSubscription(subscriptionFromYaml));
+                  subscriptions.add(subscriptionFromYaml);
+
+                } catch (IOException e) {
+                  throw new ConfigResourcesLoadingException(e);
+                }
+              });
+    } catch (IOException e) {
+      log.error("Error while listing files. {}", e.getMessage());
+      throw new ConfigResourcesLoadingException(e);
+    }
+  }
+}

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionRegistry.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionRegistry.java
@@ -104,7 +104,9 @@ class SubscriptionRegistry {
                 try (InputStream inputStream = Files.newInputStream(file)) {
 
                   var subscriptionFromYaml = yaml.loadAs(inputStream, Subscription.class);
-                  subscriptionFromYaml.getVariants().forEach(variant -> variant.setSubscription(subscriptionFromYaml));
+                  subscriptionFromYaml
+                      .getVariants()
+                      .forEach(variant -> variant.setSubscription(subscriptionFromYaml));
                   subscriptions.add(subscriptionFromYaml);
 
                 } catch (IOException e) {

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
@@ -36,17 +36,13 @@ import lombok.*;
 @Data
 public class Variant {
 
-  /**
-   * Convenience method to easily get the "parent" subscription for a Variant
-   */
-  @ToString.Exclude
-  @NotNull private Subscription subscription;
+  /** Convenience method to easily get the "parent" subscription for a Variant */
+  @ToString.Exclude @NotNull private Subscription subscription;
 
   @NotNull @NotEmpty private String tag; // required
   private List<String> roles = new ArrayList<>();
   private List<String> engineeringIds = new ArrayList<>();
   private List<String> productNames = new ArrayList<>();
-
 
   public static Optional<Variant> findByRole(String role) {
     return Subscription.lookupSubscriptionByRole(role)

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
@@ -20,7 +20,9 @@
  */
 package com.redhat.swatch.configuration.registry;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.*;
@@ -32,11 +34,28 @@ import lombok.*;
  * Variants all have the same billing model.
  */
 @Data
-@Builder
 public class Variant {
 
+  /**
+   * Convenience method to easily get the "parent" subscription for a Variant
+   */
+  @ToString.Exclude
+  @NotNull private Subscription subscription;
+
   @NotNull @NotEmpty private String tag; // required
-  private List<String> roles;
-  private List<String> engineeringIds;
-  private List<String> productNames;
+  private List<String> roles = new ArrayList<>();
+  private List<String> engineeringIds = new ArrayList<>();
+  private List<String> productNames = new ArrayList<>();
+
+
+  public static Optional<Variant> findByRole(String role) {
+    return Subscription.lookupSubscriptionByRole(role)
+        .flatMap(
+            subscription ->
+                subscription.getVariants().stream()
+                    .filter(
+                        variant ->
+                            !variant.getRoles().isEmpty() && variant.getRoles().contains(role))
+                    .findFirst());
+  }
 }

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-dedicated-metrics.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-dedicated-metrics.yaml
@@ -1,13 +1,13 @@
 ---
 platform: OpenShift
 
-id: OpenShift-dedicated-metrics
+id: openshift-dedicated-metrics
 
 variants:
   - tag: OpenShift-dedicated-metrics
     roles:
       - osd
-    product_names:
+    productNames:
       - OpenShift Dedicated
 
 defaults:
@@ -21,19 +21,19 @@ serviceType: OpenShift Cluster
 
 metrics:
   - id: redhat.com:openshift_dedicated:4cpu_hour
-    rhm_metric_id: redhat.com:openshift_dedicated:4cpu_hour
+    rhmMetricId: redhat.com:openshift_dedicated:4cpu_hour
     billingFactor: 0.25
     prometheus:
       queryKey: default
       queryParams:
         product: osd
         metric: cluster:usage:workload:capacity_physical_cpu_hours
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels
   - id: redhat.com:openshift_dedicated:cluster_hour
-    rhm_metric_id: redhat.com:openshift_dedicated:cluster_hour
+    rhmMetricId: redhat.com:openshift_dedicated:cluster_hour
     prometheus:
       queryKey: default
       queryParams:
         product: osd
         metric: cluster:usage:workload:capacity_physical_instance_hours
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-metrics.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-metrics.yaml
@@ -7,7 +7,7 @@ variants:
   - tag: OpenShift-metrics
     roles:
       - ocp
-    product_names:
+    productNames:
       - OpenShift Container Platform
 
 defaults:
@@ -21,10 +21,10 @@ serviceType: OpenShift Cluster
 
 metrics:
   - id: redhat.com:openshift_container_platform:cpu_hour
-    rhm_metric_id: redhat.com:openshift_container_platform:cpu_hour
+    rhmMetricId: redhat.com:openshift_container_platform:cpu_hour
     prometheus:
       queryKey: default
       queryParams:
         product: ocp
         metric: cluster:usage:workload:capacity_physical_cpu_hours
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift_Container_Platform.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift_Container_Platform.yaml
@@ -1,10 +1,10 @@
 ---
 platform: OpenShift
 
-id: OpenShift Container Platform
+id: openshift-container-platform
 
 fingerprint:
-  engineering_ids:
+  engineeringIds:
     - 290  # Red Hat OpenShift Container Platform
 
 variants:

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/basilisk.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/basilisk.yaml
@@ -1,13 +1,13 @@
 ---
 platform: OpenShift
 
-id: basilisk
+id: basilisk-test
 
 variants:
   - tag: basilisk
     roles:
       - BASILISK
-    product_names:
+    productNames:
       - BASILISK
 
 defaults:
@@ -21,26 +21,26 @@ serviceType: BASILISK Instance
 
 metrics:
   - id: redhat.com:BASILISK:transfer_gb
-    rhm_metric_id: redhat.com:BASILISK:transfer_gb
-    aws_dimension: transfer_gb
+    rhmMetricId: redhat.com:BASILISK:transfer_gb
+    awsDimension: transfer_gb
     prometheus:
       queryParams:
         product: BASILISK
         metric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels
   - id: redhat.com:BASILISK:cluster_hour
-    rhm_metric_id: redhat.com:BASILISK:cluster_hour
-    aws_dimension: cluster_hour
+    rhmMetricId: redhat.com:BASILISK:cluster_hour
+    awsDimension: cluster_hour
     prometheus:
       queryParams:
         product: BASILISK
         metric: kafka_id:strimzi_resource_state:max_over_time1h
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels
   - id: redhat.com:BASILISK:storage_gib_months
-    rhm_metric_id: redhat.com:BASILISK:storage_gib_months
-    aws_dimension: storage_gb
+    rhmMetricId: redhat.com:BASILISK:storage_gib_months
+    awsDimension: storage_gb
     prometheus:
       queryParams:
         product: BASILISK
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacs.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacs.yaml
@@ -6,7 +6,7 @@ variants:
   - tag: rhacs
     roles:
       - rhacs
-    product_names:
+    productNames:
       - Advanced Cluster Security - Kubernetes
 
 defaults:
@@ -20,10 +20,10 @@ serviceType: Rhacs Cluster
 
 metrics:
   - id: redhat.com:rhacs:cpu_hour
-    rhm_metric_id: redhat.com:rhacs:cpu_hour
+    rhmMetricId: redhat.com:rhacs:cpu_hour
     awsDimension: vCPU_Hour
     prometheus:
       queryParams:
         product: rhacs
         metric: rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhods.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhods.yaml
@@ -7,7 +7,7 @@ variants:
   - tag: rhods
     roles:
       - addon-open-data-hub
-    product_names:
+    productNames:
       - OpenShift Data Science
 
 defaults:
@@ -21,11 +21,11 @@ serviceType: Rhods Cluster
 
 metrics:
   - id: redhat.com:openshift_data_science:cpu_hours
-    rhm_metric_id: redhat.com:openshift_data_science:cpu_hours
+    rhmMetricId: redhat.com:openshift_data_science:cpu_hours
     awsDimension: cluster_cpu_hour
     prometheus:
       queryKey: addonSamples
       queryParams:
         resourceName: addon-open-data-hub
         metric: cluster:usage:workload:capacity_virtual_cpu_hours
-        metadata_metric: ocm_subscription_resource
+        metadataMetric: ocm_subscription_resource

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhosak.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhosak.yaml
@@ -7,7 +7,7 @@ variants:
   - tag: rhosak
     roles:
       - rhosak
-    product_names:
+    productNames:
       - OpenShift Streams for Apache Kafka
 defaults:
   variant: rhosak
@@ -20,33 +20,33 @@ serviceType: Kafka Cluster
 
 metrics:
   - id: redhat.com:rhosak:transfer_gb
-    rhm_metric_id: redhat.com:rhosak:transfer_gb
-    aws_dimension: transfer_gb
+    rhmMetricId: redhat.com:rhosak:transfer_gb
+    awsDimension: transfer_gb
     prometheus:
       queryParams:
         product: rhosak
         metric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels
   - id: redhat.com:rhosak:cluster_hour
-    rhm_metric_id: redhat.com:rhosak:cluster_hour
-    aws_dimension: cluster_hour
+    rhmMetricId: redhat.com:rhosak:cluster_hour
+    awsDimension: cluster_hour
     prometheus:
       queryParams:
         product: rhosak
         metric: kafka_id:strimzi_resource_state:max_over_time1h
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels
   - id: redhat.com:rhosak:storage_gib_months
-    rhm_metric_id: redhat.com:rhosak:storage_gib_months
-    aws_dimension: storage_gb
+    rhmMetricId: redhat.com:rhosak:storage_gib_months
+    awsDimension: storage_gb
     prometheus:
       queryParams:
         product: rhosak
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels
   - id: redhat.com:rhosak:storage_gb
-    rhm_metric_id: redhat.com:rhosak:storage_gb
+    rhmMetricId: redhat.com:rhosak:storage_gb
     prometheus:
       queryParams:
         product: rhosak
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
@@ -7,7 +7,7 @@ variants:
   - tag: rosa
     roles:
       - moa-hostedcontrolplane
-    product_names:
+    productNames:
       - OpenShift Dedicated
 
 defaults:
@@ -26,7 +26,7 @@ metrics:
       queryParams:
         product: moa-hostedcontrolplane
         metric: cluster:usage:workload:capacity_physical_instance_hours
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels
   - id: redhat.com:rosa:cpu_hour
     awsDimension: four_vcpu_0
     billingFactor: 0.25
@@ -34,4 +34,4 @@ metrics:
       queryParams:
         product: moa-hostedcontrolplane
         metric: cluster:usage:workload:capacity_physical_cpu_hours
-        metadata_metric: subscription_labels
+        metadataMetric: subscription_labels

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_ARM.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_ARM.yaml
@@ -1,10 +1,10 @@
 ---
 platform: RHEL
 
-id: RHEL for ARM
+id: rhel-for-arm
 
 fingerprint:
-  engineering_ids:
+  engineeringIds:
     - 419 # Red Hat Enterprise Linux for ARM 64
   arches:
     - aarch64

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_IBM_Power.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_IBM_Power.yaml
@@ -1,10 +1,10 @@
 ---
 platform: RHEL
 
-id: RHEL for IBM Power
+id: rhel-for-ibm-power
 
 fingerprint:
-  engineering_ids:
+  engineeringIds:
     - 74 # Red Hat Enterprise Linux for Power, big endian
     - 279 # Red Hat Enterprise Linux for Power, little endian
     - 420 # Red Hat Enterprise Linux for Power 9

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_IBM_z.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_IBM_z.yaml
@@ -1,10 +1,10 @@
 ---
 platform: RHEL
 
-id: RHEL for IBM z
+id: rhel-for-ibm-z
 
 fingerprint:
-  engineering_ids:
+  engineeringIds:
     - 72 # Red Hat Enterprise Linux for IBM z Systems
   arches:
     - s390x

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86.yaml
@@ -1,10 +1,10 @@
 ---
 platform: RHEL
 
-id: RHEL for x86
+id: rhel-for-x86
 
 fingerprint:
-  engineering_ids:
+  engineeringIds:
     - 479 # Red Hat Enterprise Linux for x86_64 (RHEL8)
   arches:
     - i386
@@ -12,22 +12,22 @@ fingerprint:
 
 variants:
   - tag: RHEL Desktop
-    engineering_ids:
+    engineeringIds:
       - 68 # Red Hat Enterprise Linux Desktop
     roles:
       - RHEL Desktop
   - tag: RHEL Server
-    engineering_ids:
+    engineeringIds:
       - 69 # Red Hat Enterprise Linux Server
     roles:
       - Red Hat Enterprise Linux Server
   - tag: RHEL Workstation
-    engineering_ids:
+    engineeringIds:
       - 71 # Red Hat Enterprise Linux Workstation
     roles:
       - Red Hat Enterprise Linux Workstation
   - tag: RHEL Compute Node
-    engineering_ids:
+    engineeringIds:
       - 76 # Red Hat Enterprise Linux for Scientific Computing
     roles:
       - Red Hat Enterprise Linux Compute Node

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/Satellite_Capsule.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/Satellite_Capsule.yaml
@@ -1,10 +1,10 @@
 ---
 platform: RHEL
 
-id: Satellite Capsule
+id: satellite-capsule
 
 fingerprint:
-  engineering_ids:
+  engineeringIds:
     - 269 # Red Hat Satellite Capsule
 
 variants:

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/Satellite_Server.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/Satellite_Server.yaml
@@ -1,10 +1,10 @@
 ---
 platform: RHEL
 
-id: Satellite Server
+id: satellite-server
 
 fingerprint:
-  engineering_ids:
+  engineeringIds:
     - 250 # Red Hat Satellite
 
 variants:

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionRegistryTest.java
@@ -20,11 +20,34 @@
  */
 package com.redhat.swatch.configuration.registry;
 
-import java.util.Map;
-import lombok.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@Data
-public class PrometheusMetric {
-  private String queryKey;
-  private Map<String, String> queryParams;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class SubscriptionRegistryTest {
+
+  SubscriptionRegistry subscriptionRegistry;
+
+  @BeforeAll
+  void setup() {
+    subscriptionRegistry = new SubscriptionRegistry();
+  }
+
+  @Test
+  void sanityCheck() {
+    assertTrue(true);
+  }
+
+  @Test
+  void testLoadAllTheThings() {
+
+    var actual = subscriptionRegistry.getSubscriptions().size();
+    var expected = 14;
+
+    assertEquals(actual, expected);
+  }
 }

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.configuration.registry;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class SubscriptionTest {
+
+  @Test
+  void sanityCheck() {
+    assertTrue(true);
+  }
+
+  @Test
+  void testFindServiceTypeMatch() {
+
+    var rosaSub = Subscription.findByServiceType("rosa Instance").get();
+
+    var expected = "rosa";
+    var actual = rosaSub.getId();
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testFindServiceTypeNoMatch() {
+
+    var expected = Optional.empty();
+    var actual = Subscription.findByServiceType("bananas");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testFindByArchNoMatch() {
+
+    var expected = Optional.empty();
+    var actual = Subscription.findByArch("bananas");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetAllServiceTypes() {
+
+    var expected =
+        List.of(
+            "OpenShift Cluster",
+            "OpenShift Cluster",
+            "BASILISK Instance",
+            "Rhacs Cluster",
+            "Rhods Cluster",
+            "Kafka Cluster",
+            "rosa Instance");
+    var actual = Subscription.getAllServiceTypes();
+
+    assertThat(actual, Matchers.containsInAnyOrder(expected.toArray()));
+  }
+
+  @Test
+  void testFindByArchMatch() {
+
+    var rhelForIbmZSub = Subscription.findByArch("s390x").get();
+
+    var expected = "rhel-for-ibm-z";
+    var actual = rhelForIbmZSub.getId();
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetMetricIds() {
+
+    var basiliskSub = Subscription.findById("basilisk-test").get();
+
+    var actual = basiliskSub.getMetricIds();
+    var expected =
+        List.of(
+            "redhat.com:BASILISK:transfer_gb",
+            "redhat.com:BASILISK:cluster_hour",
+            "redhat.com:BASILISK:storage_gib_months");
+
+    assertThat(actual, Matchers.containsInAnyOrder(expected.toArray()));
+  }
+
+  @Test
+  void testGetMetricNoMatch() {
+
+    var basiliskSub = Subscription.findById("basilisk-test").get();
+
+    var expected = Optional.empty();
+    var actual = basiliskSub.getMetric("bananas");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetMetric() {
+
+    var basiliskSub = Subscription.findById("basilisk-test").get();
+
+    var metric = new Metric();
+    metric.setId("redhat.com:BASILISK:cluster_hour");
+    metric.setRhmMetricId("redhat.com:BASILISK:cluster_hour");
+    metric.setAwsDimension("cluster_hour");
+
+    var prometheusMetric = new PrometheusMetric();
+    prometheusMetric.setQueryParams(
+        Map.of(
+            "product",
+            "BASILISK",
+            "metric",
+            "kafka_id:strimzi_resource_state:max_over_time1h",
+            "metadataMetric",
+            "subscription_labels"));
+    metric.setPrometheus(prometheusMetric);
+
+    var expected = Optional.of(metric);
+    var actual = basiliskSub.getMetric("redhat.com:BASILISK:cluster_hour");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetMetricIdsUom() {
+
+    var openshiftContainerPlatformSub = Subscription.findById("openshift-container-platform").get();
+
+    var expected = List.of("SOCKETS", "CORES");
+    var actual = openshiftContainerPlatformSub.getMetricIds();
+
+    assertThat(actual, Matchers.containsInAnyOrder(expected.toArray()));
+  }
+
+  @Test
+  void testFindById() {
+
+    var basiliskSub = Subscription.findById("basilisk-test").get();
+
+    var expected = "basilisk-test";
+    var actual = basiliskSub.getId();
+
+    assertEquals(expected, actual);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"basilisk-test,true", "rhel-for-arm,false"})
+  void testIsPrometheusEnabled(String input, boolean expected) {
+
+    var subscription = Subscription.findById(input).get();
+
+    assertEquals(subscription.isPrometheusEnabled(), expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"basilisk-test,HOURLY", "rhel-for-arm,DAILY"})
+  void testGetFinestGranularity(String input, String expected) {
+    var subscription = Subscription.findById(input).get();
+
+    assertEquals(subscription.getFinestGranularity(), expected);
+  }
+
+  @Test
+  void testGetSupportedGranularityProm() {
+    var basiliskSub = Subscription.findById("basilisk-test").get();
+
+    var actual = basiliskSub.getSupportedGranularity();
+    var expected = List.of("HOURLY", "DAILY", "WEEKLY", "MONTHLY", "QUARTERLY", "YEARLY");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetSupportedGranularityNonProm() {
+    var rhelForArmSub = Subscription.findById("rhel-for-arm").get();
+
+    var actual = rhelForArmSub.getSupportedGranularity();
+    var expected = List.of("DAILY", "WEEKLY", "MONTHLY", "QUARTERLY", "YEARLY");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testFingerprintEngIdLookup() {
+    var satelliteCapsule = Subscription.lookupSubscriptionByEngId("269");
+
+    var expected = "satellite-capsule";
+    var actual = satelliteCapsule.get().getId();
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testVariantEngIdLookup() {
+    var rhelForX86 = Subscription.lookupSubscriptionByEngId("76");
+
+    var expected = "rhel-for-x86";
+    var actual = rhelForX86.get().getId();
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testVariantProductNameLookup() {
+    var openshiftContainerPlatform =
+        Subscription.lookupSubscriptionByProductName("OpenShift Container Platform");
+
+    var expected = "OpenShift-metrics";
+    var actual = openshiftContainerPlatform.get().getId();
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testVariantRoleLookup() {
+    var rosa = Subscription.lookupSubscriptionByRole("moa-hostedcontrolplane");
+
+    var expected = "rosa";
+    var actual = rosa.get().getId();
+
+    assertEquals(expected, actual);
+  }
+}

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
@@ -20,11 +20,34 @@
  */
 package com.redhat.swatch.configuration.registry;
 
-import java.util.Map;
-import lombok.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@Data
-public class PrometheusMetric {
-  private String queryKey;
-  private Map<String, String> queryParams;
+import org.junit.jupiter.api.Test;
+
+class VariantTest {
+
+  @Test
+  void sanityCheck() {
+    assertTrue(true);
+  }
+
+  @Test
+  void testFindByRole() {
+
+    var variant = Variant.findByRole("Red Hat Enterprise Linux Server");
+
+    var expected = "RHEL Server";
+    var actual = variant.get().getTag();
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetParentSubscription() {
+    var variant = Variant.findByRole("RHEL Desktop").get();
+    var expected = "rhel-for-x86";
+    var actual = variant.getSubscription().getId();
+
+    assertEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1230](https://issues.redhat.com/browse/SWATCH-1230)

Very important note: The term "Subscription" in the context of this PR (and swatch-product-configuration module in general) is NOT the same as the term "subscription" in swatch-contracts or swatch-subscription-sync.  The terms in this library mirror terms defined by the product management team.  Please see the doc attached to the epic for this card for more information.  There's also short explanations at the top of the java classes.

## Highlights
Created a List<Subscription> that is populated from the yaml config files, provide some common lookup methods, and ensure that Subscriptions can be looked up from other swatch modules.  We only want to read from the disk to populate this list if we haven't done so already.

Moved "POJO" classes from `com.redhat.swatch.configuration.model` to `com.redhat.swatch.configuration.registry`.  Why?  Added a `SubscriptionConfigRegistry` class that I wanted to be be package private, and accessible from the "POJO" classes.  Also, the Subscription/Variant started to have lookup methods that made the POJOs not really Plain Old Java Objects anymore. (Actually done in PR #2307 )

Introduced the `src/main/resource/subscription_configs` directory.  Why?  I liked the idea of having to check/maintain the classpath for a single `subscription_configs` string for yaml files, instead of maintaining a `List.of("OpenShift", "RHEL")` in the code.

YAML properties changed to camelCase instead of snake_case due to a limitation with Snake YAML library.

## Testing
There isn't a great way to test these lookup methods outside of unit tests.  Below I'll provide some steps to prove out how these lookup methods can be accessed from the other swatch modules.

### Save & apply this git patch
0e9e34.patch
```
diff --git a/swatch-producer-aws/src/main/java/com/redhat/swatch/resource/BillableUsageResource.java b/swatch-producer-aws/src/main/java/com/redhat/swatch/resource/BillableUsageResource.java
index 6ac854b..9f4ae0c 100644
--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/resource/BillableUsageResource.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/resource/BillableUsageResource.java
@@ -20,10 +20,12 @@
  */
 package com.redhat.swatch.resource;
 
+import com.redhat.swatch.configuration.registry.Subscription;
 import com.redhat.swatch.exception.AwsManualSubmissionDisabledException;
 import com.redhat.swatch.openapi.model.BillableUsage;
 import com.redhat.swatch.openapi.resource.DefaultApi;
 import com.redhat.swatch.processors.BillableUsageProducer;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -40,12 +42,16 @@ public class BillableUsageResource implements DefaultApi {
   }
 
   @Override
+  @SneakyThrows
   public void submitBillableUsage(BillableUsage billableUsage) {
     if (!manualSubmissionEnabled) {
       throw new AwsManualSubmissionDisabledException();
     }
+
     log.info("{}", billableUsage);
 
+    log.info("{}", Subscription.findById("basilisk").get());
+
     tallySummaryProducer.queueBillableUsage(billableUsage);
   }
 }
diff --git a/swatch-producer-aws/src/main/resources/application.properties b/swatch-producer-aws/src/main/resources/application.properties
index ab28001..bcd6df7 100644
--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -7,7 +7,7 @@ AWS_MANUAL_SUBMISSION_ENABLED=false
 AWS_SEND_RETRIES=0
 AWS_USAGE_CONTEXT_LOOKUP_RETRIES=0
 AWS_MARKETPLACE_ENDPOINT_OVERRIDE=false
-ENABLE_SPLUNK_HEC=true
+ENABLE_SPLUNK_HEC=false
 SPLUNK_HEC_URL=https://splunk-hec.redhat.com:8088/
 SPLUNK_SOURCE=swatch-producer-aws
 SPLUNK_SOURCE_TYPE=quarkus_service
```

### Start swatch-producer-aws 
`DEV_MODE=true ./gradlew :swatch-producer-aws:quarkusDev`

### Hit this curl command
```bash
curl -X 'POST' \
  'http://localhost:8000/api/swatch-producer-aws/internal/aws/billable_usage' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '{
  "account_number": "string",
  "org_id": "string",
  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "billing_provider": "red hat",
  "billing_account_id": "string",
  "snapshot_date": "2022-03-10T12:15:50-04:00",
  "product_id": "string",
  "sla": "Premium",
  "usage": "Production",
  "uom": "Sockets",
  "value": 0,
  "billing_factor": 0,
  "vendor_product_code": "string"
}'
```

### Note output in log

Side note: You should only see the message "Attempting to walk directoryPath:" the first time you hit the curl command, since we don't want to repeatedly load from the disk every time.

`2023-07-11 12:49:22,934 DEBUG [com.red.swa.con.reg.SubscriptionConfigRegistry] (executor-thread-0) Attempting to walk directoryPath: /home/lburnett/code/rhsm-subscriptions/swatch-product-configuration/build/resources/main/subscription_configs`
`2023-07-11 12:49:22,965 INFO  [com.red.swa.res.BillableUsageResource] (executor-thread-0) Subscription(platform=OpenShift, id=basilisk, parentSubscription=null, includedSubscriptions=[], fingerprint=null, variants=[Variant(tag=basilisk, roles=[BASILISK], engineeringIds=[], productNames=[BASILISK])], billingWindow=MONTHLY, serviceType=BASILISK Instance, metrics=[Metric(id=redhat.com:BASILISK:transfer_gb, rhmMetricId=redhat.com:BASILISK:transfer_gb, awsDimension=transfer_gb, prometheus=PrometheusMetric(queryKey=null, queryParams={product=BASILISK, metric=kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes, metadata_metric=subscription_labels}), billingFactor=null), Metric(id=redhat.com:BASILISK:cluster_hour, rhmMetricId=redhat.com:BASILISK:cluster_hour, awsDimension=cluster_hour, prometheus=PrometheusMetric(queryKey=null, queryParams={product=BASILISK, metric=kafka_id:strimzi_resource_state:max_over_time1h, metadata_metric=subscription_labels}), billingFactor=null), Metric(id=redhat.com:BASILISK:storage_gib_months, rhmMetricId=redhat.com:BASILISK:storage_gib_months, awsDimension=storage_gb, prometheus=PrometheusMetric(queryKey=null, queryParams={product=BASILISK, metric=kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months, metadata_metric=subscription_labels}), billingFactor=null)], defaults=Defaults(variant=basilisk, sla=PREMIUM, usage=PRODUCTION))`