### PR TITLE
SWATCH-1500: Fix inconsistencies with hypervisor UUID ordering

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -124,12 +124,12 @@ import lombok.Setter;
         system_profile.system_profile_product_ids,
         h.stale_timestamp,
         coalesce(
-            h.facts->'rhsm'->>'VM_HOST_UUID',
             h.facts->'satellite'->>'virtual_host_uuid',
+            h.facts->'rhsm'->>'VM_HOST_UUID',
             h.canonical_facts->>'subscription_manager_id') as hardware_subman_id,
         coalesce(
-            h.facts->'rhsm'->>'VM_HOST_UUID',
-            h.facts->'satellite'->>'virtual_host_uuid'
+            h.facts->'satellite'->>'virtual_host_uuid',
+            h.facts->'rhsm'->>'VM_HOST_UUID'
         ) as any_hypervisor_uuid
         from hosts h
         cross join lateral (

--- a/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
@@ -236,10 +236,10 @@ public class InventorySwatchDataCollator {
     public static SortKey fromHbiSystem(InventoryHostFacts system) {
       String hardwareSubmanId;
       String hypervisorUuid;
-      if (StringUtils.hasText(system.getHypervisorUuid())) {
-        hardwareSubmanId = hypervisorUuid = system.getHypervisorUuid();
-      } else if (StringUtils.hasText(system.getSatelliteHypervisorUuid())) {
+      if (StringUtils.hasText(system.getSatelliteHypervisorUuid())) {
         hardwareSubmanId = hypervisorUuid = system.getSatelliteHypervisorUuid();
+      } else if (StringUtils.hasText(system.getHypervisorUuid())) {
+        hardwareSubmanId = hypervisorUuid = system.getHypervisorUuid();
       } else {
         hypervisorUuid = null;
         hardwareSubmanId = system.getSubscriptionManagerId();
@@ -257,7 +257,7 @@ public class InventorySwatchDataCollator {
           Objects.compare(
               hardwareSubmanId,
               other.getHardwareSubmanId(),
-              Comparator.nullsFirst(Comparator.naturalOrder()));
+              Comparator.nullsLast(Comparator.naturalOrder()));
       if (hardwareSubmanIdResult != 0) {
         return hardwareSubmanIdResult;
       }
@@ -265,12 +265,12 @@ public class InventorySwatchDataCollator {
           Objects.compare(
               hypervisorUuid,
               other.getHypervisorUuid(),
-              Comparator.nullsFirst(Comparator.naturalOrder()));
+              Comparator.nullsLast(Comparator.naturalOrder()));
       if (hypervisorUuidResult != 0) {
         return hypervisorUuidResult;
       }
       return Objects.compare(
-          inventoryId, other.getInventoryId(), Comparator.nullsFirst(Comparator.naturalOrder()));
+          inventoryId, other.getInventoryId(), Comparator.nullsLast(Comparator.naturalOrder()));
     }
   }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-1500](https://issues.redhat.com/browse/SWATCH-1500)

Description
===========

There were two inconsistencies causing errors when reconciling HBI system data with swatch.

1. When a host has hypervisor UUID information from both the customer portal and from Satellite, swatch prefers the Satellite-derived reported hypervisor. I updated the sorting accordingly.
2. SortKey comparator was implemented as null-first, and should have been nulls-last instead to be consistent with postgresql.

Testing
=======

See private comment in the Jira issue for repro/testing instructions.