### PR TITLE
SWATCH-1464: Transform to running total format after filling in gap data

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -218,14 +218,16 @@ public class TallyResource implements TallyApi {
       report.setLinks(pageLinkCreator.getPaginationLinks(uriInfo, snapshotPage));
     }
 
+    if (Boolean.TRUE.equals(useRunningTotalsFormat)) {
+      transformToRunningTotalFormat(report, uom);
+    }
+
     // Fill the report gaps if no paging was requested.
     if (reportCriteria.getPageable() == null) {
       ReportFiller<TallyReportDataPoint> reportFiller =
           ReportFillerFactory.getDataPointReportFiller(clock, reportCriteria.getGranularity());
-      report.setData(reportFiller.fillGaps(report.getData(), beginning, ending, false));
-    }
-    if (Boolean.TRUE.equals(useRunningTotalsFormat)) {
-      transformToRunningTotalFormat(report, uom);
+      report.setData(
+          reportFiller.fillGaps(report.getData(), beginning, ending, useRunningTotalsFormat));
     }
 
     // Set the count last since the report may have gotten filled.

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -227,7 +227,11 @@ public class TallyResource implements TallyApi {
       ReportFiller<TallyReportDataPoint> reportFiller =
           ReportFillerFactory.getDataPointReportFiller(clock, reportCriteria.getGranularity());
       report.setData(
-          reportFiller.fillGaps(report.getData(), beginning, ending, useRunningTotalsFormat));
+          reportFiller.fillGaps(
+              report.getData(),
+              beginning,
+              ending,
+              Objects.requireNonNullElse(useRunningTotalsFormat, false)));
     }
 
     // Set the count last since the report may have gotten filled.

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -181,10 +181,6 @@ public class TallyResource implements TallyApi {
                 : reportCriteria.getBillingProvider().asOpenApiEnum());
     report.getMeta().setBillingAcountId(billingAcctId);
 
-    if (Boolean.TRUE.equals(useRunningTotalsFormat)) {
-      transformToRunningTotalFormat(report, uom);
-    }
-
     // NOTE: rather than keep a separate monthly rollup, in order to avoid unnecessary storage and
     // DB round-trips, deserialization, etc., simply aggregate in-memory the monthly totals here.
     // NOTE: In order to avoid incorrect aggregations, if there is not exactly a full month (e.g.
@@ -227,6 +223,9 @@ public class TallyResource implements TallyApi {
       ReportFiller<TallyReportDataPoint> reportFiller =
           ReportFillerFactory.getDataPointReportFiller(clock, reportCriteria.getGranularity());
       report.setData(reportFiller.fillGaps(report.getData(), beginning, ending, false));
+    }
+    if (Boolean.TRUE.equals(useRunningTotalsFormat)) {
+      transformToRunningTotalFormat(report, uom);
     }
 
     // Set the count last since the report may have gotten filled.

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapter.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapter.java
@@ -35,7 +35,7 @@ public class TallyReportDataPointAdapter implements ReportFillerAdapter<TallyRep
   public TallyReportDataPoint createDefaultItem(
       OffsetDateTime itemDate, TallyReportDataPoint previous, boolean useRunningTotalFormat) {
     var point = new TallyReportDataPoint().date(itemDate).hasData(false).value(0);
-    if (useRunningTotalFormat) {
+    if (Boolean.TRUE.equals(useRunningTotalFormat)) {
       point.value(Objects.requireNonNullElse(previous.getValue(), 0));
     }
     return point;

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -1031,6 +1031,10 @@ class TallyResourceTest {
     var secondSnapshot = report.getData().get(1);
     assertEquals(6, secondSnapshot.getValue());
 
+    // Snapshot for day with no usage should still show running total
+    var snapshotWithNoNewUsage = report.getData().get(2);
+    assertEquals(6, snapshotWithNoNewUsage.getValue());
+
     var thirdSnapshot = report.getData().get(7);
     assertEquals(22, thirdSnapshot.getValue());
 

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapterTest.java
@@ -20,29 +20,36 @@
  */
 package org.candlepin.subscriptions.tally.filler;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.time.OffsetDateTime;
-import java.util.Objects;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
+import org.junit.jupiter.api.Test;
 
-public class TallyReportDataPointAdapter implements ReportFillerAdapter<TallyReportDataPoint> {
+class TallyReportDataPointAdapterTest {
 
-  @Override
-  public boolean itemIsLarger(TallyReportDataPoint oldData, TallyReportDataPoint newData) {
-    return newData.getValue() >= oldData.getValue();
+  TallyReportDataPointAdapter adapter = new TallyReportDataPointAdapter();
+
+  @Test
+  void createDefaultItemRunningTotal() {
+    var previous = new TallyReportDataPoint().value(10);
+    var now = OffsetDateTime.now();
+    var point = adapter.createDefaultItem(now, previous, true);
+    assertEquals(10, point.getValue());
   }
 
-  @Override
-  public TallyReportDataPoint createDefaultItem(
-      OffsetDateTime itemDate, TallyReportDataPoint previous, boolean useRunningTotalFormat) {
-    var point = new TallyReportDataPoint().date(itemDate).hasData(false).value(0);
-    if (useRunningTotalFormat) {
-      point.value(Objects.requireNonNullElse(previous.getValue(), 0));
-    }
-    return point;
+  @Test
+  void createDefaultItemNoRunningTotal() {
+    var previous = new TallyReportDataPoint().value(10);
+    var now = OffsetDateTime.now();
+    var point = adapter.createDefaultItem(now, previous, false);
+    assertEquals(0, point.getValue());
   }
 
-  @Override
-  public OffsetDateTime getDate(TallyReportDataPoint item) {
-    return item.getDate();
+  @Test
+  void createDefaultItemNullPrevious() {
+    var now = OffsetDateTime.now();
+    var point = adapter.createDefaultItem(now, null, false);
+    assertEquals(0, point.getValue());
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1464](https://issues.redhat.com/browse/SWATCH-1464)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Tally ROSA API Instances and Cores parameters are not summed when the current day is without usage.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert events into db:
```
INSERT INTO public.events VALUES ('66d3b513-ff98-4ca2-a8e0-6220d587e481', 'account123', '2023-06-19 05:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "66d3b513-ff98-4ca2-a8e0-6220d587e481", "timestamp": "2023-03-14T05:00:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2024-03-14T06:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 78.43902161885251}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
INSERT INTO public.events VALUES ('1df4b66b-6c38-4dfb-86ba-7f836772c5ed', 'account123', '2023-06-21 05:15:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "1df4b66b-6c38-4dfb-86ba-7f836772c5ed", "timestamp": "2023-03-14T05:15:00Z", "event_type": "snapshot_redhat.com:rosa:cpu_hour", "expiration": "2024-03-14T08:00:00Z", "instance_id": "test02", "display_name": "test02", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 89.71619997683332}], "service_type": "rosa Instance", "account_number": "account123", "billing_provider": "aws", "billing_account_id": "mktp-123"}', 'snapshot_redhat.com:rosa:cpu_hour', 'prometheus', 'test02', 'org123');
```
2. Start app with:  
`DEV_MODE=true CONTRACT_USE_STUB=true ./gradlew :bootRun`
3. Run tally hourly:
`http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=org123&start=2023-06-18T08:00:00Z&end=2023-06-23T08:00:00Z" x-rh-swatch-psk:placeholder`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Run curl for tally api and should get values filled in all dates except for first:
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/rosa/Cores?granularity=Daily&beginning=2023-06-18T08%3A00Z&ending=2023-06-23T08%3A00Z&use_running_totals_format=true' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```