### PR TITLE
SWATCH-1517: Remove erroneous trigger from subscription_capacity table

### DIFF
--- a/src/main/resources/liquibase/202305251412-drop-subscription-capacity-table.xml
+++ b/src/main/resources/liquibase/202305251412-drop-subscription-capacity-table.xml
@@ -24,29 +24,13 @@
 
   <changeSet id="202305251412-03" author="awood" dbms="postgresql">
     <sql>
-      DROP TRIGGER subscription_insert ON subscription_capacity;
-    </sql>
-    <rollback changeSetId="202305031403-08" changeSetAuthor="awood"
-    changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
-  </changeSet>
-
-  <changeSet id="202305251412-04" author="awood" dbms="postgresql">
-    <sql>
-      DROP TRIGGER subscription_update ON subscription_capacity;
-    </sql>
-    <rollback changeSetId="202305031403-09" changeSetAuthor="awood"
-    changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
-  </changeSet>
-
-  <changeSet id="202305251412-05" author="awood" dbms="postgresql">
-    <sql>
       DROP TRIGGER subscription_product_id_insert ON subscription_capacity;
     </sql>
     <rollback changeSetId="202305031403-11" changeSetAuthor="awood"
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305251412-06" author="awood" dbms="postgresql">
+  <changeSet id="202305251412-04" author="awood" dbms="postgresql">
     <sql>
       DROP TRIGGER subscription_product_id_update ON subscription_capacity;
     </sql>
@@ -54,23 +38,15 @@
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305251412-07" author="awood" dbms="postgresql">
+  <changeSet id="202305251412-05" author="awood" dbms="postgresql">
     <sql>
       DROP FUNCTION copy_subscription_capacity_sockets_and_cores();
     </sql>
-    <rollback changeSetId="202305031403-03" changeSetAuthor="awood"
+    <rollback changeSetId="202305031403-04" changeSetAuthor="awood"
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305251412-08" author="awood" dbms="postgresql">
-    <sql>
-      DROP FUNCTION copy_subscription_capacity_has_unlimited_usage();
-    </sql>
-    <rollback changeSetId="202305031403-06" changeSetAuthor="awood"
-    changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
-  </changeSet>
-
-  <changeSet id="202305251412-09" author="awood" dbms="postgresql">
+  <changeSet id="202305251412-07" author="awood" dbms="postgresql">
     <sql>
       DROP FUNCTION copy_subscription_product_id();
     </sql>
@@ -78,7 +54,7 @@
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305031403-25" author="awood">
+  <changeSet id="202305031403-08" author="awood">
     <dropTable tableName="subscription_capacity"/>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/202307131511-drop-trigger-on-subscription.xml
+++ b/src/main/resources/liquibase/202307131511-drop-trigger-on-subscription.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202307131511-01" author="awood" dbms="postgresql">
+    <sql>
+      DROP TRIGGER subscription_insert ON subscription_capacity;
+    </sql>
+    <rollback changeSetId="202305031403-08" changeSetAuthor="awood"
+    changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
+  </changeSet>
+
+  <changeSet id="202307131511-02" author="awood" dbms="postgresql">
+    <sql>
+      DROP TRIGGER subscription_update ON subscription_capacity;
+    </sql>
+    <rollback changeSetId="202305031403-09" changeSetAuthor="awood"
+    changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
+  </changeSet>
+
+  <changeSet id="202307131511-03" author="awood" dbms="postgresql">
+    <sql>
+      DROP FUNCTION copy_subscription_capacity_has_unlimited_usage();
+    </sql>
+    <rollback changeSetId="202305031403-07" changeSetAuthor="awood"
+      changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
+  </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -111,5 +111,6 @@
     <!-- <include file="liquibase/202305251412-drop-subscription-capacity-table.xml"/> -->
     <include file="liquibase/202306151541-add-sku-foreign-key-to-subscription.xml"/>
     <include file="liquibase/202306291611-add-extra-index-for-product-ids.xml"/>
+    <include file="liquibase/202307131511-drop-trigger-on-subscription.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1517](https://issues.redhat.com/browse/SWATCH-1517)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
During the first phase of the migration to the subscription_measurements table we had to migrate the has_unlimited_usage column from the subscription_measurements table to the subscriptions table.  As part of this migration, we added a trigger to the subscription_measurements table so that subsequent changes to its has_unlimited_usage column would be reflected in the subscription table.

We then added a foreign key relationship between the offering and subscriptions table (SWATCH-1365).  Part of that effort moved the has_unlimited_usage column from the subscriptions table to the offering table.  In that card we dropped the has_unlimited_usage column off subscription entirely since that column is also on the offering table. However, I forgot to remove the triggers on subscription_capacity. Those triggers were then left trying to insert data into a column that no longer existed.

This patch deletes the incorrect trigger and procedure.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Examine functions
   ```
   % psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c '\df'                      
                                            List of functions
    Schema |                      Name                      | Result data type | Argument data types | Type 
    --------+------------------------------------------------+------------------+---------------------+------
    public | copy_subscription_capacity_has_unlimited_usage | trigger          |                     | func
    public | copy_subscription_capacity_sockets_and_cores   | trigger          |                     | func
    public | copy_subscription_product_id                   | trigger          |                     | func
   ```
1. Examine `subscription_capacity`
   ```
   % psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c '\d subscription_capacity'
   ...
   Triggers:
    subscription_insert BEFORE INSERT ON subscription_capacity FOR EACH ROW EXECUTE FUNCTION copy_subscription_capacity_has_unlimited_usage()
    subscription_measurements_insert BEFORE INSERT ON subscription_capacity FOR EACH ROW EXECUTE FUNCTION copy_subscription_capacity_sockets_and_cores()
    subscription_measurements_update BEFORE UPDATE ON subscription_capacity FOR EACH ROW EXECUTE FUNCTION copy_subscription_capacity_sockets_and_cores()
    subscription_product_id_insert BEFORE INSERT ON subscription_capacity FOR EACH ROW EXECUTE FUNCTION copy_subscription_product_id()
    subscription_product_id_update BEFORE UPDATE ON subscription_capacity FOR EACH ROW EXECUTE FUNCTION copy_subscription_product_id()
    subscription_update BEFORE UPDATE ON subscription_capacity FOR EACH ROW EXECUTE FUNCTION copy_subscription_capacity_has_unlimited_usage()
   ```

### Steps
<!-- Enter each step of the test below -->
1. ` ./gradlew liquibaseUpdate`  

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.  Rerun both postgres commands from above.  `copy_subscription_capacity_has_unlimited_usage` and the triggers `subscription_insert` and `subscription_update` will be gone.
