### PR TITLE
SWATCH-1518: Guard against a null value when calculating running totals

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapter.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapter.java
@@ -35,8 +35,11 @@ public class TallyReportDataPointAdapter implements ReportFillerAdapter<TallyRep
   public TallyReportDataPoint createDefaultItem(
       OffsetDateTime itemDate, TallyReportDataPoint previous, boolean useRunningTotalFormat) {
     var point = new TallyReportDataPoint().date(itemDate).hasData(false).value(0);
-    if (Boolean.TRUE.equals(useRunningTotalFormat)) {
-      point.value(Objects.requireNonNullElse(previous.getValue(), 0));
+    if (useRunningTotalFormat) {
+      // Guard against previous being null and against a previous object with a value field equal
+      // to null
+      var prevValue = (previous == null) ? 0 : Objects.requireNonNullElse(previous.getValue(), 0);
+      point.value(prevValue);
     }
     return point;
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapterTest.java
@@ -49,7 +49,15 @@ class TallyReportDataPointAdapterTest {
   @Test
   void createDefaultItemNullPrevious() {
     var now = OffsetDateTime.now();
-    var point = adapter.createDefaultItem(now, null, false);
+    var point = adapter.createDefaultItem(now, null, true);
+    assertEquals(0, point.getValue());
+  }
+
+  @Test
+  void createDefaultItemNullPreviousValue() {
+    var previous = new TallyReportDataPoint().value(null);
+    var now = OffsetDateTime.now();
+    var point = adapter.createDefaultItem(now, previous, true);
     assertEquals(0, point.getValue());
   }
 }


### PR DESCRIPTION
This patch guards against null TallyReportDataPoints in the TallyReportDataPointAdapter and against TallyReportDataPoints that have a value field of null.

We actually had a test for this but the flag to do running totals was accidentally set to false.

<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1518](https://issues.redhat.com/browse/SWATCH-1518)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Calls to
```
api/rhsm-subscriptions/v1/tally/products/rosa/Cores?endi[…]&use_running_totals_format=true&billing_category=prepaid
```

and similar are throwing `NullPointerExceptions` because the value of `previous` parameter used in the `org.candlepin.subscriptions.tally.filler.TallyReportDataPointAdapter#createDefaultItem` method are null.  We had a check for this but the check was actually testing that the `previous.getValue()` call wasn't null instead of checking that `previous` itself wasn't null.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Testing is covered by the unit tests.
