### PR TITLE
SWATCH-1520: Invalidate the SKU existence cache properly when offerings are saved

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/OfferingRepository.java
@@ -89,6 +89,34 @@ public interface OfferingRepository extends JpaRepository<Offering, String> {
   @CacheEvict(cacheNames = {"offeringExists"})
   void deleteById(String s);
 
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      key = "#offering.sku")
+  /* Unfortunately we can't use the CachePut annotation here.  CachePut would put the entity
+   * itself into the cache and what we want to put is a boolean so that our existsById won't
+   * have to hit the database
+   */
+  <S extends Offering> S save(S offering);
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      key = "#offering.sku")
+  <S extends Offering> S saveAndFlush(S offering);
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      allEntries = true)
+  <S extends Offering> List<S> saveAll(Iterable<S> offerings);
+
+  @Override
+  @CacheEvict(
+      cacheNames = {"offeringExists"},
+      allEntries = true)
+  <S extends Offering> List<S> saveAllAndFlush(Iterable<S> offerings);
+
   List<Offering> findByProductName(String productName);
 
   List<Offering> findBySkuIn(Set<String> skus);


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1520](https://issues.redhat.com/browse/SWATCH-1520)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
During a subscription sync, the following events can occur:

* A check for a SKU is performed.  The SKU is not found
* A value of "false" for that SKU is written to the cache that stores the existence of SKUs
* We save an offering with that SKU
* Another subscription with the same SKU comes along and we make another call to OfferingRepository.existsById
* The cache returns false instead of true because we did not update the offering existence cache after saving the offering

This patch removes a SKU from the SKU existence cache after a save or saveAndFlush operation.  For saveAll or saveAllAndFlush operations, the entire cache is invalidated because there is no way to loop through the iterable of saved entities to extract the SKU from each one.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Testing is covered by the unit tests.