### PR TITLE
SWATCH-1465: query optimizations for tally_instance_view

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -171,9 +171,6 @@ public class InstancesResource implements InstancesApi {
         ResourceUtils.sanitizeBillingProvider(billingProviderType);
     String sanitizedBillingAccountId = ResourceUtils.sanitizeBillingAccountId(billingAccountId);
 
-    String sanitizedDisplayNameSubstring =
-        Objects.nonNull(displayNameContains) ? displayNameContains : "";
-
     List<HardwareMeasurementType> hardwareMeasurementTypes =
         getHardwareMeasurementTypesFromCategory(reportCategory);
 
@@ -207,7 +204,7 @@ public class InstancesResource implements InstancesApi {
             productId.toString(),
             sanitizedSla,
             sanitizedUsage,
-            sanitizedDisplayNameSubstring,
+            displayNameContains,
             minCores,
             minSockets,
             month,

--- a/src/main/resources/liquibase/202307171013-add-indexes-for-tally-instance-view-queries.xml
+++ b/src/main/resources/liquibase/202307171013-add-indexes-for-tally-instance-view-queries.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202306291611-1" author="kflahert">
+        <comment>Add indexes for tally_instance_view queries</comment>
+        <createIndex indexName="idx_instance_id_uom_measure" tableName="instance_measurements">
+            <column name="instance_id"/>
+            <column name="uom"/>
+            <column name="value"/>
+        </createIndex>
+        <createIndex indexName="idx_hosts_view" tableName="hosts">
+            <column name="org_id"/>
+            <column name="id"/>
+            <column name="instance_id"/>
+            <column name="display_name"/>
+            <column name="billing_provider"/>
+            <column name="billing_account_id"/>
+            <column name="last_seen"/>
+            <column name="num_of_guests"/>
+            <column name="subscription_manager_id"/>
+        </createIndex>
+        <createIndex indexName="idx_buckets_pid" tableName="host_tally_buckets">
+            <column name="product_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -112,5 +112,6 @@
     <include file="liquibase/202306151541-add-sku-foreign-key-to-subscription.xml"/>
     <include file="liquibase/202306291611-add-extra-index-for-product-ids.xml"/>
     <include file="liquibase/202307131511-drop-trigger-on-subscription.xml"/>
+    <include file="liquibase/202307171013-add-indexes-for-tally-instance-view-queries.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import javax.persistence.criteria.JoinType;
-import javax.validation.constraints.NotNull;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
@@ -74,7 +73,7 @@ public interface TallyInstanceViewRepository
       String productId,
       ServiceLevel sla,
       Usage usage,
-      @NotNull String displayNameSubstring,
+      String displayNameSubstring,
       int minCores,
       int minSockets,
       String month,
@@ -223,7 +222,7 @@ public interface TallyInstanceViewRepository
     if (Objects.nonNull(billingAccountId)) {
       searchCriteria = searchCriteria.and(billingAccountIdEquals(billingAccountId));
     }
-    if (Objects.nonNull(displayNameSubstring)) {
+    if (StringUtils.hasText(displayNameSubstring)) {
       searchCriteria = searchCriteria.and(displayNameContains(displayNameSubstring));
     }
     if (Objects.nonNull(effectiveUom)) {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1465](https://issues.redhat.com/browse/SWATCH-1465)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Instance API queries are taking over 1s frequently in stage and prod. This PR is to improve those query times with better indexing.
## Testing
Was not able to reproduce the very slow queries locally but these before and after execution plans show that there should be improvements since the parallel seq scan on host_tally_buckets (slowest portion previously) is now an index scan. Query times did improve locally as well but never showed above 500ms:
Before: https://explain.dalibo.com/plan/7dfg3894dage6h1g
After: https://explain.dalibo.com/plan/7a94e9a97e36c7e1

