### PR TITLE
SWATCH-1511: Fix bug where subscriptions persisted without capacity

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -221,8 +221,8 @@ public class SubscriptionSyncController {
       }
       if (existingSubscription.quantityHasChanged(newOrUpdated.getQuantity())) {
         existingSubscription.endSubscription();
-        subscriptionRepository.save(existingSubscription);
         capacityReconciliationController.reconcileCapacityForSubscription(existingSubscription);
+        subscriptionRepository.save(existingSubscription);
         final org.candlepin.subscriptions.db.model.Subscription newSub =
             org.candlepin.subscriptions.db.model.Subscription.builder()
                 .subscriptionId(existingSubscription.getSubscriptionId())
@@ -237,16 +237,16 @@ public class SubscriptionSyncController {
                 .subscriptionNumber(newOrUpdated.getSubscriptionNumber())
                 .billingProvider(newOrUpdated.getBillingProvider())
                 .build();
-        subscriptionRepository.save(newSub);
         capacityReconciliationController.reconcileCapacityForSubscription(newSub);
+        subscriptionRepository.save(newSub);
       } else {
         updateExistingSubscription(newOrUpdated, existingSubscription);
-        subscriptionRepository.save(existingSubscription);
         capacityReconciliationController.reconcileCapacityForSubscription(existingSubscription);
+        subscriptionRepository.save(existingSubscription);
       }
     } else {
-      subscriptionRepository.save(newOrUpdated);
       capacityReconciliationController.reconcileCapacityForSubscription(newOrUpdated);
+      subscriptionRepository.save(newOrUpdated);
     }
   }
 
@@ -486,10 +486,10 @@ public class SubscriptionSyncController {
           .map(this::convertDto)
           .forEach(
               subscription -> {
-                subscriptionRepository.save(subscription);
                 if (reconcileCapacity) {
                   capacityReconciliationController.reconcileCapacityForSubscription(subscription);
                 }
+                subscriptionRepository.save(subscription);
               });
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Error parsing subscriptionsJson", e);


### PR DESCRIPTION
Jira issue: [SWATCH-1511](https://issues.redhat.com/browse/SWATCH-1511)

Description
===========

We were modifying the subscription entity after a call to `SubscriptionRepository.save(...)`. In some cases, this is fine, as hibernate will reconcile any changes to managed entities. However, for some use cases, the reference passed to Hibernate itself does not become managed, but instead Hibernate will create a new instance and return it. For this reason, it is necessary to either:

1. Use the return value of `Repository.save(...)` for any further modifications.
2. Call `Repository.save(...)` at the end.

I'm choosing to change the ordering, because that is easier to remember, and behaves consistently.

Note: I noticed other inefficiencies, namely that we fetch only the active subscriptions to attempt to modify, but those aren't causing the issue, so I'll look to address in a separate PR.

Testing
=======

Steps
-----

Repeat for both `main` and this branch.

1. Clear subscription tables (make a backup if desired):

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
truncate table subscription cascade
EOF
```

2. Run the service:

```shell
OFFERING_USE_STUB=true SUBSCRIPTION_USE_STUB=true DEV_MODE=true ./gradlew :bootRun
```

3. Sync an org:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/org123 \
  x-rh-swatch-psk:placeholder
```

See verification steps...

Verification
------------

1. Query the subscription_measurements table:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
select * from subscription_measurements;
EOF
```

In `main`, see that the table is empty, in this branch it has values.

2. Query the subscription_measurements table:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
select * from subscription_product_ids;
EOF
```

In `main`, see that the table is empty, in this branch it has values.