### PR TITLE
SWATCH-1530: Fix EntityExistsException w capacity reconciliation

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
@@ -172,7 +172,7 @@ public class CapacityReconciliationController {
           && !Objects.equals(existingMeasurement.get().getValue(), measurement.getValue())) {
         existingMeasurement.get().setValue(measurement.getValue());
         measurementsUpdated.increment();
-      } else {
+      } else if (existingMeasurement.isEmpty()) {
         subscription.addSubscriptionMeasurement(measurement);
         measurementsCreated.increment();
       }


### PR DESCRIPTION
Jira issue: [SWATCH-1530](https://issues.redhat.com/browse/SWATCH-1530)

Description
===========

Bug was caused by a small logic error. When a measurement was being processed, if there was no change, the code attempted to make a new (dupe) measurement and add it to the subscription.

Testing
=======

Steps
-----

Repeat for both `main` and this branch.

1. Clear subscription tables (make a backup if desired):

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
truncate table subscription cascade
EOF
```

2. Run the service:

```shell
OFFERING_USE_STUB=true SUBSCRIPTION_USE_STUB=true DEV_MODE=true ./gradlew :bootRun
```

3. Sync an org:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/org123 \
  x-rh-swatch-psk:placeholder
```

4. Now force a reconciliation for the existing data.

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/offerings/reconcile/RH3413336 \
  x-rh-swatch-psk:placeholder
```

This will cause the exception on `main`, but not on this branch.