### PR TITLE
SWATCH-1374 Produce events using UOM-derived eventType

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -141,7 +141,7 @@ public class PrometheusMeteringController {
                 eventController.mapEventsInTimeRange(
                     orgId,
                     MeteringEventFactory.EVENT_SOURCE,
-                    MeteringEventFactory.getEventType(tagMetric.get()),
+                    MeteringEventFactory.getEventTypes(tagMetric.get()), // NOSONAR
                     // We need to shift the start and end dates by the step, to account for the
                     // shift in the event start date when it is created. See note about eventDate
                     // below.
@@ -203,7 +203,8 @@ public class PrometheusMeteringController {
                         billingProvider,
                         billingAccountId,
                         tagMetric.get().getUom(),
-                        value);
+                        value,
+                        tagMetric.get().getTag());
                 events.putIfAbsent(EventKey.fromEvent(event), event);
               }
             }
@@ -251,12 +252,13 @@ public class PrometheusMeteringController {
       String billingProvider,
       String billingAccountId,
       Uom metric,
-      BigDecimal value) {
+      BigDecimal value,
+      String productTag) {
     EventKey lookupKey =
         new EventKey(
             orgId,
             MeteringEventFactory.EVENT_SOURCE,
-            MeteringEventFactory.getEventType(metricId), // NOSONAR
+            MeteringEventFactory.getEventType(metric.value(), productTag), // NOSONAR
             instanceId,
             measuredDate);
     Event event = existing.remove(lookupKey);
@@ -278,7 +280,8 @@ public class PrometheusMeteringController {
         billingProvider,
         billingAccountId,
         metric,
-        value.doubleValue());
+        value.doubleValue(),
+        productTag);
     return event;
   }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.Test;
 
 class MeteringEventFactoryTest {
 
+  private final String productTag = "OpenShift-dedicated-metrics";
+
   @Test
   void testOpenShiftClusterCoresEventCreation() throws Exception {
     String account = "my-account";
@@ -67,7 +69,8 @@ class MeteringEventFactoryTest {
             billingProvider,
             null,
             uom,
-            measuredValue);
+            measuredValue,
+            productTag);
 
     assertEquals(account, event.getAccountNumber());
     assertEquals(orgId, event.getOrgId());
@@ -78,7 +81,7 @@ class MeteringEventFactoryTest {
     assertEquals(Sla.PREMIUM, event.getSla());
     assertEquals(Usage.PRODUCTION, event.getUsage());
     assertEquals(MeteringEventFactory.EVENT_SOURCE, event.getEventSource());
-    assertEquals(MeteringEventFactory.getEventType(metricId), event.getEventType());
+    assertEquals(MeteringEventFactory.getEventType(uom.value(), productTag), event.getEventType());
     assertEquals(serviceType, event.getServiceType());
     assertEquals(1, event.getMeasurements().size());
     Measurement measurement = event.getMeasurements().get(0);
@@ -103,7 +106,8 @@ class MeteringEventFactoryTest {
             "red hat",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertNull(event.getSla());
   }
 
@@ -124,7 +128,8 @@ class MeteringEventFactoryTest {
             "red hat",
             "null",
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertEquals(Sla.__EMPTY__, event.getSla());
   }
 
@@ -145,7 +150,8 @@ class MeteringEventFactoryTest {
             "red hat",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertNull(event.getSla());
   }
 
@@ -166,7 +172,8 @@ class MeteringEventFactoryTest {
             "red hat",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertNull(event.getUsage());
   }
 
@@ -187,7 +194,8 @@ class MeteringEventFactoryTest {
             "red hat",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertNull(event.getUsage());
   }
 
@@ -208,7 +216,8 @@ class MeteringEventFactoryTest {
             "red hat",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertNull(event.getRole());
   }
 
@@ -229,7 +238,8 @@ class MeteringEventFactoryTest {
             "red hat",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertNull(event.getRole());
   }
 
@@ -250,7 +260,8 @@ class MeteringEventFactoryTest {
             "aws",
             "aws_account_123",
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertEquals(BillingProvider.AWS, event.getBillingProvider());
     assertTrue(event.getBillingAccountId().isPresent());
     assertEquals("aws_account_123", event.getBillingAccountId().get());
@@ -273,7 +284,8 @@ class MeteringEventFactoryTest {
             null,
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
     assertTrue(event.getBillingAccountId().isEmpty());
   }
@@ -295,7 +307,8 @@ class MeteringEventFactoryTest {
             "",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
   }
 
@@ -316,7 +329,8 @@ class MeteringEventFactoryTest {
             "invalid provider",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertNull(event.getBillingProvider());
   }
 
@@ -337,14 +351,17 @@ class MeteringEventFactoryTest {
             "red hat",
             null,
             Uom.CORES,
-            12.5);
-    assertEquals("snapshot_metric-id", event.getEventType());
+            12.5,
+            productTag);
+    assertEquals("snapshot_openshift-dedicated-metrics_cores", event.getEventType());
   }
 
   @Test
   void testEventTypeGeneration() {
-    assertEquals("snapshot_my-metric", MeteringEventFactory.getEventType("my-metric"));
-    assertEquals("snapshot", MeteringEventFactory.getEventType(""));
+    assertEquals(
+        "snapshot_openshift-dedicated-metrics_my-metric",
+        MeteringEventFactory.getEventType("my-metric", productTag));
+    assertEquals("snapshot", MeteringEventFactory.getEventType("", ""));
   }
 
   @Test
@@ -364,7 +381,8 @@ class MeteringEventFactoryTest {
             "rhm",
             null,
             Uom.CORES,
-            12.5);
+            12.5,
+            productTag);
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -107,6 +107,7 @@ class PrometheusMeteringControllerTest {
   private final String expectedBillingProvider = "red hat";
   private final String expectedBillingAccountId = "mktp-account";
   private final Uom expectedUom = Uom.CORES;
+  private final String expectedProductTag = "OpenShift-metrics";
 
   private PrometheusMeteringController controller;
   private QueryHelper queries;
@@ -272,7 +273,8 @@ class PrometheusMeteringControllerTest {
                 expectedBillingProvider,
                 expectedBillingAccountId,
                 expectedUom,
-                val1.doubleValue()),
+                val1.doubleValue(),
+                expectedProductTag),
             MeteringEventFactory.createMetricEvent(
                 expectedAccount,
                 expectedOrgId,
@@ -287,7 +289,8 @@ class PrometheusMeteringControllerTest {
                 expectedBillingProvider,
                 expectedBillingAccountId,
                 expectedUom,
-                val2.doubleValue()));
+                val2.doubleValue(),
+                expectedProductTag));
 
     controller.collectMetrics("OpenShift-metrics", Uom.CORES, expectedOrgId, start, end);
 
@@ -354,7 +357,8 @@ class PrometheusMeteringControllerTest {
             expectedBillingProvider,
             expectedBillingAccountId,
             expectedUom,
-            val1.doubleValue());
+            val1.doubleValue(),
+            expectedProductTag);
 
     List<Event> expectedEvents =
         List.of(
@@ -373,7 +377,8 @@ class PrometheusMeteringControllerTest {
                 expectedBillingProvider,
                 expectedBillingAccountId,
                 expectedUom,
-                val2.doubleValue()));
+                val2.doubleValue(),
+                expectedProductTag));
 
     Event purgedEvent =
         MeteringEventFactory.createMetricEvent(
@@ -390,7 +395,8 @@ class PrometheusMeteringControllerTest {
             expectedBillingProvider,
             expectedBillingAccountId,
             expectedUom,
-            val1.doubleValue());
+            val1.doubleValue(),
+            expectedProductTag);
 
     List<Event> existingEvents =
         List.of(
@@ -409,13 +415,14 @@ class PrometheusMeteringControllerTest {
                 expectedBillingProvider,
                 expectedBillingAccountId,
                 expectedUom,
-                144.4),
+                144.4,
+                expectedProductTag),
             // This event should get purged because prometheus did not report this cluster.
             purgedEvent);
     when(eventController.mapEventsInTimeRange(
             expectedOrgId,
             MeteringEventFactory.EVENT_SOURCE,
-            MeteringEventFactory.getEventType(tagMetric),
+            MeteringEventFactory.getEventTypes(tagMetric),
             start,
             end))
         .thenReturn(
@@ -502,7 +509,8 @@ class PrometheusMeteringControllerTest {
             expectedBillingProvider,
             expectedBillingAccountId,
             expectedUom,
-            4.0);
+            4.0,
+            expectedProductTag);
 
     var eventId = UUID.randomUUID();
     updatedEvent.setEventId(eventId);
@@ -524,7 +532,8 @@ class PrometheusMeteringControllerTest {
             expectedBillingProvider,
             expectedBillingAccountId,
             expectedUom,
-            144.4);
+            144.4,
+            expectedProductTag);
     existingEvent.setEventId(eventId);
     List<Event> existingEvents =
         List.of(
@@ -533,7 +542,7 @@ class PrometheusMeteringControllerTest {
     when(eventController.mapEventsInTimeRange(
             expectedOrgId,
             MeteringEventFactory.EVENT_SOURCE,
-            MeteringEventFactory.getEventType(tagMetric),
+            MeteringEventFactory.getEventTypes(tagMetric),
             start,
             end))
         .thenReturn(


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1374](https://issues.redhat.com/browse/SWATCH-1374)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This code will now create and update Events with the new event_type: snapshot_$productId_$uom. This PR also takes care of the data json object in Events table. Please check the test steps with all the details.
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. To run locally prometheus by pointing to stage follow the steps in: [Connecting  Observatorium to fetch Prometheus ](https://docs.engineering.redhat.com/display/ENT/Connecting+to+Observatorium+to+Fetch+Prometheus+Metrics)
- Copy CLIENT_SECRET and paste it in a file `token-refresher`
- Run: `podman run --name=telemeter-stage --rm -ti -p 8082:8080     quay.io/observatorium/token-refresher:master-2021-02-05-5da9663     --oidc.client-secret=$(cat ~/Downloads/token-refresher)     --oidc.client-id=observatorium-subwatch-staging     --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external     --url=https://observatorium.api.stage.openshift.com`
2. Apply the below patch in `application-openshift-metering-worker.yaml` since billing_model="marketplace" won't give results in prometheus in the further steps
```
          diff --git a/src/main/resources/application-openshift-metering-worker.yaml b/src/main/resources/application-openshift-metering-worker.yaml
--- a/src/main/resources/application-openshift-metering-worker.yaml	(revision ce8b242be21cb1b8329d08cfd46f684065e44126)
+++ b/src/main/resources/application-openshift-metering-worker.yaml	(date 1689775711055)
@@ -12,7 +12,7 @@
           default: >-
             #{metric.queryParams[prometheusMetric]}
             * on(_id) group_right
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", support=~"Premium|Standard|Self-Support|None"}[1h])
           addonSamples: >-
             #{metric.queryParams[prometheusMetric]}
             * on(_id) group_right


```

3. Then in separate terminal pointing to the prom_url in the doc run:  `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 ./gradlew clean :bootRun`
4. Go to prometheus url that points to stage from local: `http://localhost:8082/api/metrics/v1/telemeter/graph`
Under graph tab paste the query `cluster:usage:workload:capacity_physical_instance_hours * on(_id) group_right min_over_time(subscription_labels{product="osd", external_organization="6323660", support=~"Premium|Standard|Self-Support|None"}[1h])`
 
- or click on this [link](http://localhost:8082/api/metrics/v1/telemeter/graph?g0.expr=cluster%3Ausage%3Aworkload%3Acapacity_physical_instance_hours%20*%20on(_id)%20group_right%20min_over_time(subscription_labels%7Bproduct%3D%22osd%22%2C%20external_organization%3D%226323660%22%2C%20support%3D~%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D)&g0.tab=0&g0.stacked=0&g0.range_input=2h&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=0&g0.store_matches=%5B%5D&g0.end_input=2023-07-19%2004%3A49%3A17&g0.moment_input=2023-07-19%2004%3A49%3A17) and adjust the timestamps but this is only applicable locally. 

**Note: Don't forget to change UUIDs according to what you want to test since UUIDs will be different.**

### Steps
<!-- Enter each step of the test below -->
1. Run: `curl -X POST -H "x-rh-swatch-synchronous-request:true"  -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/OpenShift-dedicated-metrics?orgId=6323660&rangeInMinutes=1200"`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Depending on if stage prometheus has data you should see bunch of inserts in events table with new event_types in event_type column and in data json blob like below:
```
2d312b2b-1ed9-4a4d-a397-2a8c94a72bc6,1455657,2023-07-19 06:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""6323660"", ""event_id"": ""2d312b2b-1ed9-4a4d-a397-2a8c94a72bc6"", ""timestamp"": ""2023-07-19T06:00:00Z"", ""event_type"": ""snapshot_openshift-dedicated-metrics_instance-hours"", ""expiration"": ""2023-07-19T07:00:00Z"", ""instance_id"": ""a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62"", ""display_name"": ""a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62"", ""event_source"": ""prometheus"", ""measurements"": [{""uom"": ""Instance-hours"", ""value"": 1.0}], ""service_type"": ""OpenShift Cluster"", ""account_number"": ""1455657"", ""billing_provider"": ""red hat"", ""billing_account_id"": null}",snapshot_openshift-dedicated-metrics_instance-hours,prometheus,a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62,6323660
60034ed6-3470-47e3-b2ef-dd72bd375ccb,1455657,2023-07-19 07:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""6323660"", ""event_id"": ""60034ed6-3470-47e3-b2ef-dd72bd375ccb"", ""timestamp"": ""2023-07-19T07:00:00Z"", ""event_type"": ""snapshot_openshift-dedicated-metrics_cores"", ""expiration"": ""2023-07-19T08:00:00Z"", ""instance_id"": ""f287ada8-135b-4d5a-96cc-b6a1621ea630"", ""display_name"": ""f287ada8-135b-4d5a-96cc-b6a1621ea630"", ""event_source"": ""prometheus"", ""measurements"": [{""uom"": ""Cores"", ""value"": 6.0}], ""service_type"": ""OpenShift Cluster"", ""account_number"": ""1455657"", ""billing_provider"": ""red hat"", ""billing_account_id"": null}",snapshot_openshift-dedicated-metrics_cores,prometheus,f287ada8-135b-4d5a-96cc-b6a1621ea630,6323660

```

**Logs:**
`2023-07-19 14:15:38,050 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Persisted 131 events for OpenShift-dedicated-metrics Cores metrics.
`


### Steps 2: Update one of the row manually by changing the event_type column
<!-- Enter each step of the test below -->
2. 
- Change the column as mentioned in above example. Here its changed from new uom value`snapshot_openshift-dedicated-metrics_instance-hours` to old metricId value `snapshot_redhat.com:openshift_dedicated:cluster_hour`. Once we run the curl command it should change back to new uom value:

`UPDATE public.events SET account_number = '1455657', timestamp = '2023-07-19 06:00:00.000000 +00:00', data = '{"sla": "Premium", "role": "osd", "org_id": "6323660", "event_id": "2d312b2b-1ed9-4a4d-a397-2a8c94a72bc6", "timestamp": "2023-07-19T06:00:00Z", "event_type": "snapshot_openshift-dedicated-metrics_instance-hours", "expiration": "2023-07-19T07:00:00Z", "instance_id": "a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62", "display_name": "a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster", "account_number": "1455657", "billing_provider": "red hat", "billing_account_id": null}', event_type = 'snapshot_redhat.com:openshift_dedicated:cluster_hour', event_source = 'prometheus', instance_id = 'a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62', org_id = '6323660' WHERE id = '2d312b2b-1ed9-4a4d-a397-2a8c94a72bc6';`

- Run: `curl -X POST -H "x-rh-swatch-synchronous-request:true"  -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/OpenShift-dedicated-metrics?orgId=6323660&rangeInMinutes=1200"`

### Verification
2. 
- In the table row should have changed back to  new uom value`snapshot_openshift-dedicated-metrics_instance-hours`:

`2d312b2b-1ed9-4a4d-a397-2a8c94a72bc6,1455657,2023-07-19 06:00:00.000000 +00:00,"{""sla"": ""Premium"", ""role"": ""osd"", ""org_id"": ""6323660"", ""event_id"": ""2d312b2b-1ed9-4a4d-a397-2a8c94a72bc6"", ""timestamp"": ""2023-07-19T06:00:00Z"", ""event_type"": ""snapshot_openshift-dedicated-metrics_instance-hours"", ""expiration"": ""2023-07-19T07:00:00Z"", ""instance_id"": ""a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62"", ""display_name"": ""a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62"", ""event_source"": ""prometheus"", ""measurements"": [{""uom"": ""Instance-hours"", ""value"": 1.0}], ""service_type"": ""OpenShift Cluster"", ""account_number"": ""1455657"", ""billing_provider"": ""red hat"", ""billing_account_id"": null}",snapshot_openshift-dedicated-metrics_instance-hours,prometheus,a7d30bea-e5d6-4f7a-8a57-6b4f244f3a62,6323660`

- **Logs:**
2023-07-19 13:49:48,279 [thread=http-nio-8000-exec-6] [DEBUG] [org.hibernate.SQL] self- update events set account_number=?, data=?, event_source=?, event_type=?, instance_id=?, org_id=?, timestamp=? where id=?

**To test on EE:**
```
oc project ephemeral-kx17tr
oc new-app prom/prometheus
oc expose service/prometheus
oc rsh prometheus-69db7b485b-dsrlp
```
- Change the prom_url in openshift
clowder-> cloud apps => swatch-metrics
name: PROM_URL
           value: 'http://prometheus:9090/api/v1'
![image](https://github.com/RedHatInsights/rhsm-subscriptions/assets/11471167/4ae617e3-a8fa-48fe-8e5e-058ca36607b7)

- Go to swatch-metrics-service pod and run the below curl command:
```
curl -X POST -H 'x-rh-swatch-synchronous-request:true' -H 'x-rh-swatch-psk:dummy' -H 'Origin: https://cloud.redhat.com/' "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/rhosak?orgId=org123&rangeInMinutes=1200"
```