### PR TITLE
SWATCH-1519: On running total tallies, report the past as has_data and skip future

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -208,15 +208,26 @@ paths:
           type: boolean
           default:
             false
-        description: "Defines the end of the report period. Defaults to the current time. Dates should be provided in UTC."
+        description: "Whether to report the total for each temporal unit of the report period 
+            individually or as a running total since the beginning of the report period."
       - name: billing_category
         in: query
         schema:
           $ref: '#/components/schemas/BillingCategory'
         description: "Include only report data matching the specified billing_category."
     get:
-      summary: "Fetch tally report data for an account and product. "
-      description: "If page header parameters are omitted, any dates missing data will have an entry with null as the value."
+      summary: "Fetch tally report data for an account and product."
+      description: "If the report is requested in a running total format, each temporal unit of 
+          the report period (days, hours, etc.) will give the running total since the start of the 
+          report period and set the has_data field as true, whether or not there is data that lands
+          in that specific temporal unit.  However, if the report period stretches into the 
+          future, temporal units in the future will have a value of zero and have has_data set to
+          false.
+
+          For example, if we have daily values of 0, 1, 0, 3, 0 and request a running total report 
+          ending two days from now, we'll get back '(0, true), (1, true), (1, true), (4, true), (4, 
+          true), (0, false), (0, false)'.
+      "
       operationId: getTallyReportData
       responses:
         '200':

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
@@ -58,6 +58,6 @@ public class ReportFillerFactory {
   public static ReportFiller<TallyReportDataPoint> getDataPointReportFiller(
       ApplicationClock clock, Granularity granularity) {
     SnapshotTimeAdjuster timeAdjuster = SnapshotTimeAdjuster.getTimeAdjuster(clock, granularity);
-    return new ReportFiller<>(timeAdjuster, new TallyReportDataPointAdapter());
+    return new ReportFiller<>(timeAdjuster, new TallyReportDataPointAdapter(clock));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountConfigRepositoryTest.java
@@ -28,14 +28,15 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.config.AccountConfig;
 import org.candlepin.subscriptions.db.model.config.OptInType;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,10 +44,11 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestClockConfiguration.class)
 class AccountConfigRepositoryTest {
 
   @Autowired private AccountConfigRepository repository;
-  private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  @Autowired private ApplicationClock clock;
 
   @Test
   void saveAndUpdate() {

--- a/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepositoryTest.java
@@ -28,7 +28,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
@@ -37,12 +36,14 @@ import org.candlepin.subscriptions.json.BillableUsage.BillingProvider;
 import org.candlepin.subscriptions.json.BillableUsage.Sla;
 import org.candlepin.subscriptions.json.BillableUsage.Uom;
 import org.candlepin.subscriptions.json.BillableUsage.Usage;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,10 +51,11 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestClockConfiguration.class)
 class BillableUsageRemittanceRepositoryTest {
 
   @Autowired private BillableUsageRemittanceRepository repository;
-  private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  @Autowired private ApplicationClock clock;
 
   @BeforeEach()
   public void setUp() {

--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -30,12 +30,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.EventRecord;
 import org.candlepin.subscriptions.json.Event;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,8 +44,9 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestClockConfiguration.class)
 class EventRecordRepositoryTest {
-  private static final Clock CLOCK = new FixedClockConfiguration().fixedClock().getClock();
+  private static final Clock CLOCK = new TestClockConfiguration().adjustableClock().getClock();
 
   @Autowired private EventRecordRepository repository;
 

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -22,7 +22,6 @@ package org.candlepin.subscriptions.db;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -36,12 +35,13 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.*;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.resource.HostsResource;
 import org.candlepin.subscriptions.resource.InstancesResource;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
+import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 import org.candlepin.subscriptions.utilization.api.model.InstanceReportSort;
 import org.junit.jupiter.api.AfterAll;
@@ -54,6 +54,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -65,14 +66,15 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @TestInstance(Lifecycle.PER_CLASS)
+@Import(TestClockConfiguration.class)
 class HostRepositoryTest {
-  private static final Clock CLOCK = new FixedClockConfiguration().fixedClock().getClock();
   private final String RHEL = "RHEL";
   private final String COOL_PROD = "COOL_PROD";
   private static final String DEFAULT_DISPLAY_NAME = "REDHAT_PWNS";
   private static final String SANITIZED_MISSING_DISPLAY_NAME = "";
 
   @Autowired private HostRepository repo;
+  @Autowired private ApplicationClock clock;
   @Autowired private AccountServiceInventoryRepository accountServiceInventoryRepository;
 
   private Map<String, Host> existingHostsByInventoryId;
@@ -163,7 +165,7 @@ class HostRepositoryTest {
   @Test
   void testTallyHostViewProjection() {
     // Ensure that the TallyHostView is properly projecting values.
-    OffsetDateTime expLastSeen = OffsetDateTime.now(CLOCK);
+    OffsetDateTime expLastSeen = OffsetDateTime.now(clock.getClock());
     String expInventoryId = "INV";
     String expInsightsId = "INSIGHTS_ID";
     String expAccount = "ACCT";

--- a/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/OrgConfigRepositoryTest.java
@@ -24,10 +24,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.util.Arrays;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
 import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.db.model.config.OrgConfig;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,10 +43,11 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestClockConfiguration.class)
 class OrgConfigRepositoryTest {
 
   @Autowired private OrgConfigRepository repository;
-  private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  @Autowired private ApplicationClock clock;
 
   @BeforeAll
   void cleanUpDatabase() {

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -31,15 +31,14 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.*;
 import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
@@ -47,13 +46,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@Import(FixedClockConfiguration.class)
+@Import(TestClockConfiguration.class)
 @ActiveProfiles("test")
 class SubscriptionRepositoryTest {
 
-  @Autowired
-  @Qualifier("fixedClock")
-  ApplicationClock clock;
+  @Autowired ApplicationClock clock;
 
   @Autowired SubscriptionRepository subscriptionRepo;
 

--- a/src/test/java/org/candlepin/subscriptions/db/model/EventKeyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/EventKeyTest.java
@@ -27,14 +27,14 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.json.Event;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.Test;
 
 class EventKeyTest {
 
-  private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  private ApplicationClock clock = new TestClockConfiguration().adjustableClock();
 
   @Test
   void testLookup() {

--- a/src/test/java/org/candlepin/subscriptions/files/CacheTest.java
+++ b/src/test/java/org/candlepin/subscriptions/files/CacheTest.java
@@ -26,7 +26,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import org.candlepin.subscriptions.util.TestClock;
+import org.candlepin.subscriptions.test.TestClock;
 import org.junit.jupiter.api.Test;
 
 class CacheTest {

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -32,7 +32,6 @@ import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.json.Measurement.Uom;
@@ -42,6 +41,7 @@ import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +71,7 @@ class InternalMeteringResourceTest {
   @BeforeEach
   void setupTest() {
     appProps = new ApplicationProperties();
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     util = new ResourceUtil(clock);
     lenient().when(tagProfile.tagIsPrometheusEnabled(VALID_PRODUCT)).thenReturn(true);
     lenient()

--- a/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/job/MeteringJobTest.java
@@ -28,10 +28,10 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +60,7 @@ class MeteringJobTest {
     appProps = new ApplicationProperties();
     appProps.setPrometheusLatencyDuration(Duration.ofHours(6L));
 
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     job = new MeteringJob(tasks, tagProfile, metricProps, retryTemplate);
 
     when(tagProfile.getTagsWithPrometheusEnabledLookup()).thenReturn(Set.of("OpenShift-metrics"));

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.model.EventKey;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
@@ -53,6 +52,7 @@ import org.candlepin.subscriptions.registry.BillingWindow;
 import org.candlepin.subscriptions.registry.TagMetric;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.security.OptInController;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,6 +61,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -72,6 +73,7 @@ import org.springframework.test.context.ActiveProfiles;
 //
 @SpringBootTest
 @ActiveProfiles({"openshift-metering-worker", "test"})
+@Import(TestClockConfiguration.class)
 class PrometheusMeteringControllerTest {
 
   @MockBean private PrometheusService service;
@@ -94,7 +96,7 @@ class PrometheusMeteringControllerTest {
   @Qualifier("openshiftMetricRetryTemplate")
   RetryTemplate openshiftRetry;
 
-  private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  @Autowired private ApplicationClock clock;
 
   private final String expectedAccount = "my-test-account";
   private final String expectedOrgId = "my-test-org";

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMeteringTaskFactoryTest.java
@@ -27,13 +27,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
 import java.time.OffsetDateTime;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.task.MetricsTask;
 import org.candlepin.subscriptions.task.Task;
 import org.candlepin.subscriptions.task.TaskDescriptor;
 import org.candlepin.subscriptions.task.TaskType;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,8 +61,8 @@ class PrometheusMeteringTaskFactoryTest {
   }
 
   @Test
-  void testOpenshiftMetricsTaskCreation() throws Exception {
-    ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  void testOpenshiftMetricsTaskCreation() {
+    ApplicationClock clock = new TestClockConfiguration().adjustableClock();
     OffsetDateTime end = clock.now();
     OffsetDateTime start = end.minusDays(1);
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource;
@@ -38,6 +37,7 @@ import org.candlepin.subscriptions.task.TaskDescriptor;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.TaskType;
 import org.candlepin.subscriptions.task.queue.TaskQueue;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,7 +67,7 @@ class PrometheusMetricsTaskManagerTest {
   void setupTest() {
     when(queueProperties.getTopic()).thenReturn(TASK_TOPIC);
     when(tagProfile.getSupportedMetricsForProduct(any())).thenReturn(Set.of(Uom.CORES));
-    ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+    ApplicationClock clock = new TestClockConfiguration().adjustableClock();
     manager =
         new PrometheusMetricsTaskManager(
             queue,

--- a/src/test/java/org/candlepin/subscriptions/metering/task/MetricsTaskTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/task/MetricsTaskTest.java
@@ -23,10 +23,10 @@ package org.candlepin.subscriptions.metering.task;
 import static org.mockito.Mockito.*;
 
 import java.time.OffsetDateTime;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.prometheus.ApiException;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +40,7 @@ class MetricsTaskTest {
 
   @Test
   void testExecute() throws ApiException {
-    ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+    ApplicationClock clock = new TestClockConfiguration().adjustableClock();
     OffsetDateTime expEnd = clock.now();
     OffsetDateTime expStart = expEnd.minusDays(1);
     String expAccount = "test-account";

--- a/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/OptInResourceTest.java
@@ -24,11 +24,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import jakarta.ws.rs.BadRequestException;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.security.OptInController;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,15 +36,17 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles({"api", "test"})
 @WithMockRedHatPrincipal("123456")
+@Import(TestClockConfiguration.class)
 class OptInResourceTest {
 
-  private ApplicationClock clock;
+  @Autowired private ApplicationClock clock;
 
   @MockBean AccountConfigRepository accountConfigRepository;
 
@@ -54,7 +56,6 @@ class OptInResourceTest {
 
   @BeforeEach
   public void setupTests() {
-    this.clock = new FixedClockConfiguration().fixedClock();
     when(accountConfigRepository.existsByOrgId("owner123456")).thenReturn(true);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
@@ -56,6 +55,7 @@ import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.RoleProvider;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.SnapshotTimeAdjuster;
 import org.candlepin.subscriptions.utilization.api.model.*;
@@ -78,14 +78,13 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles({"api", "test"})
 @WithMockRedHatPrincipal("123456")
-@Import(FixedClockConfiguration.class)
+@Import(TestClockConfiguration.class)
 class TallyResourceTest {
 
   public static final ProductId RHEL_PRODUCT_ID = ProductId.RHEL;
   public static final String INVALID_PRODUCT_ID_VALUE = "bad_product";
   private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
   private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
-  private static ApplicationClock CLOCK = new FixedClockConfiguration().fixedClock();
 
   @MockBean TallySnapshotRepository repository;
   @MockBean BillableUsageRemittanceRepository remittanceRepository;
@@ -93,6 +92,7 @@ class TallyResourceTest {
   @MockBean AccountConfigRepository accountConfigRepository;
   @MockBean CapacityApi capacityApi;
   @Autowired TallyResource resource;
+  @Autowired ApplicationClock applicationClock;
 
   @BeforeEach
   public void setupTests() {
@@ -1394,7 +1394,7 @@ class TallyResourceTest {
           Map<OffsetDateTime, Integer> values) {
     SnapshotTimeAdjuster timeAdjuster =
         SnapshotTimeAdjuster.getTimeAdjuster(
-            CLOCK, Granularity.fromString(granularityType.toString()));
+            applicationClock, Granularity.fromString(granularityType.toString()));
 
     OffsetDateTime start = timeAdjuster.adjustToPeriodStart(reportStart);
     OffsetDateTime end = timeAdjuster.adjustToPeriodEnd(reportEnd);

--- a/src/test/java/org/candlepin/subscriptions/retention/RemittanceRetentionPolicyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/retention/RemittanceRetentionPolicyTest.java
@@ -24,12 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.Test;
 
 class RemittanceRetentionPolicyTest {
-  private ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  private ApplicationClock clock = new TestClockConfiguration().adjustableClock();
 
   public RemittanceRetentionPolicy createTestPolicy(RemittanceRetentionPolicyProperties config) {
     return new RemittanceRetentionPolicy(clock, config);

--- a/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyTest.java
@@ -24,14 +24,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.Test;
 
 class TallyRetentionPolicyTest {
   public TallyRetentionPolicy createTestPolicy(TallyRetentionPolicyProperties config) {
-    ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+    ApplicationClock clock = new TestClockConfiguration().adjustableClock();
     return new TallyRetentionPolicy(clock, config);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/security/OptInControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/security/OptInControllerTest.java
@@ -25,12 +25,12 @@ import static org.mockito.Mockito.*;
 
 import java.time.OffsetDateTime;
 import java.util.TimeZone;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.model.OrgConfigRepository;
 import org.candlepin.subscriptions.db.model.config.AccountConfig;
 import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.db.model.config.OrgConfig;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.user.AccountService;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
@@ -40,12 +40,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(TestClockConfiguration.class)
 class OptInControllerTest {
 
   @Autowired private AccountConfigRepository accountRepo;
@@ -54,12 +56,12 @@ class OptInControllerTest {
 
   @Autowired private AccountService accountService;
 
+  @Autowired private ApplicationClock clock;
+
   private OptInController controller;
-  private ApplicationClock clock;
 
   @BeforeEach
   void setupTest() {
-    clock = new FixedClockConfiguration().fixedClock();
     TimeZone.setDefault(TimeZone.getTimeZone(clock.getClock().getZone()));
     controller = new OptInController(clock, accountRepo, orgRepo, accountService);
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.db.model.*;
 import org.candlepin.subscriptions.event.EventController;
@@ -49,6 +48,7 @@ import org.candlepin.subscriptions.registry.TagMapping;
 import org.candlepin.subscriptions.registry.TagMetaData;
 import org.candlepin.subscriptions.registry.TagMetric;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.DateRange;
 import org.jetbrains.annotations.NotNull;
@@ -69,7 +69,7 @@ class MetricUsageCollectorTest {
 
   @Mock EventController eventController;
 
-  ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  ApplicationClock clock = new TestClockConfiguration().adjustableClock();
 
   static final String SERVICE_TYPE = "SERVICE TYPE";
   static final String RHEL_SERVER_SWATCH_PRODUCT_ID = "RHEL_SERVER";

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -28,13 +28,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.retention.RemittanceRetentionController;
 import org.candlepin.subscriptions.retention.TallyRetentionController;
 import org.candlepin.subscriptions.security.SecurityProperties;
 import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
 import org.candlepin.subscriptions.tally.TallySnapshotController;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.DateRange;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +60,7 @@ class InternalTallyResourceTest {
 
   @BeforeEach
   void setupTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     appProps = new ApplicationProperties();
     resource =
         new InternalTallyResource(

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -43,7 +43,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
@@ -64,6 +63,7 @@ import org.candlepin.subscriptions.json.TallyMeasurement;
 import org.candlepin.subscriptions.registry.BillingWindow;
 import org.candlepin.subscriptions.registry.TagMetric;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,7 +79,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class BillableUsageControllerTest {
 
-  private static ApplicationClock CLOCK = new FixedClockConfiguration().fixedClock();
+  private static ApplicationClock CLOCK = new TestClockConfiguration().adjustableClock();
   private static final String AWS_METRIC_ID = "aws_metric";
 
   @Mock BillingProducer producer;

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/ContractsControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/ContractsControllerTest.java
@@ -34,7 +34,6 @@ import com.redhat.swatch.contracts.client.ApiException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
 import org.candlepin.subscriptions.json.BillableUsage;
@@ -44,6 +43,7 @@ import org.candlepin.subscriptions.json.BillableUsage.Uom;
 import org.candlepin.subscriptions.json.BillableUsage.Usage;
 import org.candlepin.subscriptions.json.TallyMeasurement;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,7 +65,7 @@ class ContractsControllerTest {
 
   @BeforeEach
   void setupTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     controller = new ContractsController(tagProfile, contractsApi, contractsClientProperties);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingControllerTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.billing.admin.api.model.MonthlyRemittance;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
@@ -33,12 +32,14 @@ import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.BillableUsage.BillingProvider;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,11 +47,11 @@ import org.springframework.transaction.annotation.Transactional;
 @AutoConfigureTestDatabase
 @ActiveProfiles("test")
 @Transactional
+@Import(TestClockConfiguration.class)
 class InternalBillingControllerTest {
 
   @Autowired BillableUsageRemittanceRepository remittanceRepo;
-
-  private final ApplicationClock clock = new FixedClockConfiguration().fixedClock();
+  @Autowired private ApplicationClock clock;
 
   InternalBillingController controller;
 

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.HostHardwareType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -45,6 +44,7 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.tally.OrgHostsData;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
@@ -69,7 +69,7 @@ import org.yaml.snakeyaml.constructor.Constructor;
 @TestInstance(Lifecycle.PER_CLASS)
 @SpringBootTest
 @ActiveProfiles("test")
-@Import(FixedClockConfiguration.class)
+@Import(TestClockConfiguration.class)
 class FactNormalizerTest {
 
   private FactNormalizer normalizer;

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/DailyReportFillerTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -39,7 +39,7 @@ class DailyReportFillerTest {
   private ReportFiller filler;
 
   public DailyReportFillerTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     filler = ReportFillerFactory.getInstance(clock, Granularity.DAILY);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/HourlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/HourlyReportFillerTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -39,7 +39,7 @@ class HourlyReportFillerTest {
   private ReportFiller filler;
 
   public HourlyReportFillerTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     filler = ReportFillerFactory.getInstance(clock, Granularity.HOURLY);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/MonthlyReportFillerTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -39,7 +39,7 @@ class MonthlyReportFillerTest {
   private ReportFiller filler;
 
   public MonthlyReportFillerTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     filler = ReportFillerFactory.getInstance(clock, Granularity.MONTHLY);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/QuarterlyReportFillerTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -39,7 +39,7 @@ class QuarterlyReportFillerTest {
   private ReportFiller filler;
 
   public QuarterlyReportFillerTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     filler = ReportFillerFactory.getInstance(clock, Granularity.QUARTERLY);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/TallyReportDataPointAdapterTest.java
@@ -22,42 +22,57 @@ package org.candlepin.subscriptions.tally.filler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.OffsetDateTime;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
+import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
 import org.junit.jupiter.api.Test;
 
 class TallyReportDataPointAdapterTest {
 
-  TallyReportDataPointAdapter adapter = new TallyReportDataPointAdapter();
+  ApplicationClock clock = new TestClockConfiguration().adjustableClock();
+  TallyReportDataPointAdapter adapter = new TallyReportDataPointAdapter(clock);
 
   @Test
-  void createDefaultItemRunningTotal() {
+  void createDefaultItemRunningTotalPast() {
     var previous = new TallyReportDataPoint().value(10);
-    var now = OffsetDateTime.now();
-    var point = adapter.createDefaultItem(now, previous, true);
+    var itemDate = clock.startOfDay(clock.now());
+    var point = adapter.createDefaultItem(itemDate, previous, true);
     assertEquals(10, point.getValue());
+    assertTrue(point.getHasData());
+  }
+
+  @Test
+  void createDefaultItemRunningTotalFuture() {
+    var previous = new TallyReportDataPoint().value(10);
+    var itemDate = clock.startOfDay(clock.now().plusDays(1));
+    var point = adapter.createDefaultItem(itemDate, previous, true);
+    assertEquals(0, point.getValue());
+    assertFalse(point.getHasData());
   }
 
   @Test
   void createDefaultItemNoRunningTotal() {
     var previous = new TallyReportDataPoint().value(10);
-    var now = OffsetDateTime.now();
-    var point = adapter.createDefaultItem(now, previous, false);
+    var itemDate = clock.startOfDay(clock.now());
+    var point = adapter.createDefaultItem(itemDate, previous, false);
     assertEquals(0, point.getValue());
+    assertFalse(point.getHasData());
   }
 
   @Test
   void createDefaultItemNullPrevious() {
-    var now = OffsetDateTime.now();
-    var point = adapter.createDefaultItem(now, null, true);
+    var itemDate = clock.startOfDay(clock.now());
+    var point = adapter.createDefaultItem(itemDate, null, true);
     assertEquals(0, point.getValue());
+    assertFalse(point.getHasData());
   }
 
   @Test
   void createDefaultItemNullPreviousValue() {
     var previous = new TallyReportDataPoint().value(null);
-    var now = OffsetDateTime.now();
-    var point = adapter.createDefaultItem(now, previous, true);
+    var itemDate = clock.startOfDay(clock.now());
+    var point = adapter.createDefaultItem(itemDate, previous, true);
     assertEquals(0, point.getValue());
+    assertFalse(point.getHasData());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/WeeklyReportFillerTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -39,7 +39,7 @@ class WeeklyReportFillerTest {
   private ReportFiller filler;
 
   public WeeklyReportFillerTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     filler = ReportFillerFactory.getInstance(clock, Granularity.WEEKLY);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/YearlyReportFillerTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.TallyReport;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -39,7 +39,7 @@ class YearlyReportFillerTest {
   private ReportFiller filler;
 
   public YearlyReportFillerTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
     filler = ReportFillerFactory.getInstance(clock, Granularity.YEARLY);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManagerTest.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.AccountListSource;
 import org.candlepin.subscriptions.task.TaskDescriptor;
@@ -39,6 +38,7 @@ import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.TaskType;
 import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskQueue;
 import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskQueueConsumerFactory;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.DateRange;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
-@ContextConfiguration(classes = FixedClockConfiguration.class)
+@ContextConfiguration(classes = TestClockConfiguration.class)
 @ActiveProfiles({"worker", "test"})
 class CaptureSnapshotsTaskManagerTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/DailySnapshotRollerTest.java
@@ -20,11 +20,10 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import java.io.IOException;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,19 +40,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
+@Import(TestClockConfiguration.class)
 class DailySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
-
   @Autowired private TagProfile tagProfile;
-
-  private ApplicationClock clock;
+  @Autowired private ApplicationClock clock;
 
   private SnapshotRollerTester<DailySnapshotRoller> tester;
 
   @BeforeAll
-  void setupAllTests() throws IOException {
-    this.clock = new FixedClockConfiguration().fixedClock();
+  void setupAllTests() {
     this.tester =
         new SnapshotRollerTester<>(
             repository, new DailySnapshotRoller(repository, clock, tagProfile));

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/HourlySnapshotRollerTest.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.tally.roller;
 import static org.candlepin.subscriptions.db.model.Granularity.HOURLY;
 
 import java.io.IOException;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -35,7 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ActiveProfiles;
@@ -59,9 +57,7 @@ class HourlySnapshotRollerTest {
   private SnapshotRollerTester<HourlySnapshotRoller> tester;
 
   @TestConfiguration
-  @Import(FixedClockConfiguration.class)
   static class HourlySnapshotRollerTestConfig {
-
     @Bean
     @Primary
     public TagProfile testTagProfile(ResourceLoader resourceLoader) throws IOException {

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/MonthlySnapshotRollerTest.java
@@ -20,11 +20,10 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import java.io.IOException;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,19 +40,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
+@Import(TestClockConfiguration.class)
 class MonthlySnapshotRollerTest {
-
   @Autowired private TallySnapshotRepository repository;
-
   @Autowired private TagProfile tagProfile;
-
-  private ApplicationClock clock;
+  @Autowired private ApplicationClock clock;
 
   private SnapshotRollerTester<MonthlySnapshotRoller> tester;
 
   @BeforeAll
-  void setupAllTests() throws IOException {
-    this.clock = new FixedClockConfiguration().fixedClock();
+  void setupAllTests() {
     this.tester =
         new SnapshotRollerTester<>(
             repository, new MonthlySnapshotRoller(repository, clock, tagProfile));

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/QuarterlySnapshotRollerTest.java
@@ -20,11 +20,10 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import java.io.IOException;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,19 +40,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
+@Import(TestClockConfiguration.class)
 class QuarterlySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
-
   @Autowired private TagProfile tagProfile;
-
-  private ApplicationClock clock;
+  @Autowired private ApplicationClock clock;
 
   private SnapshotRollerTester<QuarterlySnapshotRoller> tester;
 
   @BeforeEach
-  void setupTest() throws IOException {
-    this.clock = new FixedClockConfiguration().fixedClock();
+  void setupTest() {
     this.tester =
         new SnapshotRollerTester<>(
             repository, new QuarterlySnapshotRoller(repository, clock, tagProfile));

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/WeeklySnapshotRollerTest.java
@@ -20,11 +20,10 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import java.io.IOException;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,19 +40,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
+@Import(TestClockConfiguration.class)
 class WeeklySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
 
   @Autowired private TagProfile tagProfile;
-
-  private ApplicationClock clock;
+  @Autowired private ApplicationClock clock;
 
   private SnapshotRollerTester<WeeklySnapshotRoller> tester;
 
   @BeforeAll
-  void setupAllTests() throws IOException {
-    this.clock = new FixedClockConfiguration().fixedClock();
+  void setupAllTests() {
     this.tester =
         new SnapshotRollerTester<>(
             repository, new WeeklySnapshotRoller(repository, clock, tagProfile));

--- a/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/roller/YearlySnapshotRollerTest.java
@@ -20,11 +20,10 @@
  */
 package org.candlepin.subscriptions.tally.roller;
 
-import java.io.IOException;
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,19 +40,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ActiveProfiles({"api", "test"})
 @TestInstance(Lifecycle.PER_CLASS)
+@Import(TestClockConfiguration.class)
 class YearlySnapshotRollerTest {
 
   @Autowired private TallySnapshotRepository repository;
-
   @Autowired private TagProfile tagProfile;
-
-  private ApplicationClock clock;
+  @Autowired private ApplicationClock clock;
 
   private SnapshotRollerTester<YearlySnapshotRoller> tester;
 
   @BeforeEach
-  void setupTest() throws IOException {
-    this.clock = new FixedClockConfiguration().fixedClock();
+  void setupTest() {
     this.tester =
         new SnapshotRollerTester<>(
             repository, new YearlySnapshotRoller(repository, clock, tagProfile));

--- a/src/test/java/org/candlepin/subscriptions/test/ClockResetTestExecutionListener.java
+++ b/src/test/java/org/candlepin/subscriptions/test/ClockResetTestExecutionListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.test;
+
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+
+/**
+ * A test execution listener that resets the ApplicationClock to {@link
+ * TestClockConfiguration#SPRING_TIME_UTC} before every test setup. We do this to allow tests to
+ * modify the ApplicationClock without having to worry about polluting the application context for
+ * other tests.
+ */
+public class ClockResetTestExecutionListener implements TestExecutionListener {
+  @Override
+  public void beforeTestMethod(TestContext testContext) {
+    if (testContext.getApplicationContext().containsBean("adjustableClock")) {
+      ApplicationClock applicationClock =
+          testContext.getApplicationContext().getBean("adjustableClock", ApplicationClock.class);
+      var testClock = (TestClock) applicationClock.getClock();
+      testClock.setInstant(TestClockConfiguration.SPRING_TIME_UTC.toInstant());
+      testClock.setZone(TestClockConfiguration.SPRING_TIME_UTC.getZone());
+    }
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/test/ClockResetTestExecutionListenerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/test/ClockResetTestExecutionListenerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestClockConfiguration.class)
+@TestMethodOrder(OrderAnnotation.class)
+class ClockResetTestExecutionListenerTest {
+  public static final LocalDateTime POLLUTE_TIME = LocalDateTime.of(2001, 10, 1, 17, 25, 0, 0);
+  public static final ZonedDateTime POLLUTE_TIME_JAPAN =
+      POLLUTE_TIME.atZone(ZoneId.of("Asia/Tokyo"));
+  public static final OffsetDateTime DEFAULT_TEST_TIME =
+      TestClockConfiguration.SPRING_TIME_UTC.withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime();
+
+  @Autowired ApplicationClock applicationClock;
+
+  @Test
+  @Order(1)
+  void testSetClockAndAttemptToPolluteContext() {
+    var testClock = (TestClock) applicationClock.getClock();
+    assertEquals(DEFAULT_TEST_TIME, applicationClock.now());
+    testClock.setInstant(POLLUTE_TIME_JAPAN.toInstant());
+    testClock.setZone(ZoneId.of("Asia/Tokyo"));
+    assertEquals("Asia/Tokyo", testClock.getZone().getId());
+    assertEquals("2001-10-01T17:25+09:00", applicationClock.now().toString());
+  }
+
+  @Test
+  @Order(2)
+  void testClockShouldBeReset() {
+    assertEquals(DEFAULT_TEST_TIME, applicationClock.now());
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/test/TestClock.java
+++ b/src/test/java/org/candlepin/subscriptions/test/TestClock.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.util;
+package org.candlepin.subscriptions.test;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -28,7 +28,7 @@ import java.time.ZoneId;
 public class TestClock extends Clock {
 
   private Instant instant;
-  private final ZoneId zone;
+  private ZoneId zone;
 
   public TestClock(Instant instant, ZoneId zone) {
     this.instant = instant;
@@ -37,6 +37,10 @@ public class TestClock extends Clock {
 
   public void setInstant(Instant instant) {
     this.instant = instant;
+  }
+
+  public void setZone(ZoneId zone) {
+    this.zone = zone;
   }
 
   @Override

--- a/src/test/java/org/candlepin/subscriptions/test/TestClockConfiguration.java
+++ b/src/test/java/org/candlepin/subscriptions/test/TestClockConfiguration.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions;
+package org.candlepin.subscriptions.test;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 
 @TestConfiguration
-public class FixedClockConfiguration {
+public class TestClockConfiguration {
   // A zoneless time
   public static final LocalDateTime SPRING_TIME = LocalDateTime.of(2019, 5, 24, 12, 35, 0, 0);
   public static final ZonedDateTime SPRING_TIME_UTC = SPRING_TIME.atZone(ZoneId.of("UTC"));
@@ -53,10 +53,23 @@ public class FixedClockConfiguration {
   // date --utc -d '2019-1-3T14:15:00 EST' +%s
   public static final Long WINTER_EPOCH_EST = 1546542900L;
 
+  /**
+   * An ApplicationClock instance based on a TestClock to allow tests to modify the underlying
+   * Instant. E.g.
+   *
+   * <pre><code>
+   * var testClock = (TestClock) applicationClock.getClock();
+   * testClock.setInstant(WINTER_TIME_UTC.toInstant());
+   * </code></pre>
+   *
+   * <p>Note that you need to perform a cast to TestClock on the call to applicationClock
+   * .getClock()
+   */
   @Bean
   @Primary
-  public ApplicationClock fixedClock() {
-    return new ApplicationClock(Clock.fixed(Instant.from(SPRING_TIME_UTC), ZoneId.of("UTC")));
+  public ApplicationClock adjustableClock() {
+    return new ApplicationClock(
+        new TestClock(SPRING_TIME_UTC.toInstant(), SPRING_TIME_UTC.getZone()));
   }
 
   @Bean(name = "ZuluWinterClock")

--- a/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/ApplicationClockTest.java
@@ -20,21 +20,21 @@
  */
 package org.candlepin.subscriptions.util;
 
-import static org.candlepin.subscriptions.FixedClockConfiguration.SPRING_EPOCH_EDT;
-import static org.candlepin.subscriptions.FixedClockConfiguration.SPRING_EPOCH_UTC;
-import static org.candlepin.subscriptions.FixedClockConfiguration.SPRING_TIME_EDT;
-import static org.candlepin.subscriptions.FixedClockConfiguration.SPRING_TIME_UTC;
-import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_EPOCH_EST;
-import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_EPOCH_UTC;
-import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_TIME_EST;
-import static org.candlepin.subscriptions.FixedClockConfiguration.WINTER_TIME_UTC;
+import static org.candlepin.subscriptions.test.TestClockConfiguration.SPRING_EPOCH_EDT;
+import static org.candlepin.subscriptions.test.TestClockConfiguration.SPRING_EPOCH_UTC;
+import static org.candlepin.subscriptions.test.TestClockConfiguration.SPRING_TIME_EDT;
+import static org.candlepin.subscriptions.test.TestClockConfiguration.SPRING_TIME_UTC;
+import static org.candlepin.subscriptions.test.TestClockConfiguration.WINTER_EPOCH_EST;
+import static org.candlepin.subscriptions.test.TestClockConfiguration.WINTER_EPOCH_UTC;
+import static org.candlepin.subscriptions.test.TestClockConfiguration.WINTER_TIME_EST;
+import static org.candlepin.subscriptions.test.TestClockConfiguration.WINTER_TIME_UTC;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import org.candlepin.subscriptions.FixedClockConfiguration;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -44,7 +44,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@ContextConfiguration(classes = FixedClockConfiguration.class)
+@ContextConfiguration(classes = TestClockConfiguration.class)
 class ApplicationClockTest {
 
   @Autowired

--- a/src/test/java/org/candlepin/subscriptions/util/SnapshotTimeAdjusterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/SnapshotTimeAdjusterTest.java
@@ -22,8 +22,8 @@ package org.candlepin.subscriptions.util;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.junit.jupiter.api.Test;
 
 class SnapshotTimeAdjusterTest {
@@ -31,7 +31,7 @@ class SnapshotTimeAdjusterTest {
   private ApplicationClock clock;
 
   SnapshotTimeAdjusterTest() {
-    clock = new FixedClockConfiguration().fixedClock();
+    clock = new TestClockConfiguration().adjustableClock();
   }
 
   @Test

--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.test.context.TestExecutionListener=\
+org.candlepin.subscriptions.test.ClockResetTestExecutionListener


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1519](https://issues.redhat.com/browse/SWATCH-1519)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
On running total tallies, report the past as has_data and skip future

Right now on calls to /tally/products/{product_id} we are marking days that don't have an associated measurement with has_data=false.  This choice doesn't really make sense with a running total since even if we don't have a measurement, we do still have data.  Therefore, for days in the past, we will set has_data=true and set the value equal to the running total. However, we should keep marking days in the future days with has_data=true.

This PR also makes modifications to how we are handling time in our tests.  I modified the fixedClock that we were using to allow tests to modify the underlying instant so that tests have more flexibility around when they consider "now" to be.  This change touched a lot of files, so the easiest way to review this PR is commit by commit.  Both commits compile, pass tests, and pass spotless.

## Testing

### Setup
1. Unzip and import [swatch-1519.zip](https://github.com/RedHatInsights/rhsm-subscriptions/files/12099880/swatch-1519.zip) (you'll see some insertions error, but just ignore them.  They're just an artifact of my export process)
   ```shell
   zcat swatch-1519.zip | psql -h localhost -U rhsm-subscriptions rhsm-subscriptions
   ```

### Steps
1. `git checkout origin/main`
1. `./gradlew :bootRun`
1. Ask for a tally report
   ```shell
    http :8000/api/rhsm-subscriptions/v1/tally/products/rosa/Instance-hours \
    granularity==Daily \
    beginning==2023-07-01T00:00:00.000Z \
    ending==2023-07-31T23:59:59.999Z \
    use_running_totals_format==true \
    billing_category==prepaid \
    x-rh-identity:$(echo -n '{"identity":{"account_number":"account123","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w 0)
   ```
1. You'll see 31 entries in the report and days without specific measurements will be marked with `has_data: false`.

### Verification
1. `git checkout -t origin/awood/SWATCH-1519-running-total-correction`
1. `./gradlew :bootRun`
1. Ask for a tally report
   ```shell
    http :8000/api/rhsm-subscriptions/v1/tally/products/rosa/Instance-hours \
    granularity==Daily \
    beginning==2023-07-01T00:00:00.000Z \
    ending==2023-07-31T23:59:59.999Z \
    use_running_totals_format==true \
    billing_category==prepaid \
    x-rh-identity:$(echo -n '{"identity":{"account_number":"account123","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w 0)
   ```
1. Since `2023-07-31` is currently in the future, you should see records up to whatever today's date is with `has_data` set to true.  You should see `has_data` marked as false for each day that's in the future.  Additionally, days in the future will have a value of zero.

