### PR TITLE
SWATCH-1538: Add Origin header to conduit cron command

### DIFF
--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -347,7 +347,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://console.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-system-conduit-service:8000/api/rhsm-subscriptions/v1/internal/rpc/syncAllOrgs"
+              /usr/bin/curl --fail -H "Origin: https://swatch-system-conduit-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-system-conduit-service:8000/api/rhsm-subscriptions/v1/internal/rpc/syncAllOrgs"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -347,7 +347,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-system-conduit-service:8000/api/rhsm-subscriptions/v1/internal/rpc/syncAllOrgs"
+              /usr/bin/curl --fail -H "Origin: https://console.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-system-conduit-service:8000/api/rhsm-subscriptions/v1/internal/rpc/syncAllOrgs"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:


### PR DESCRIPTION
Jira issue: [SWATCH-1538](https://issues.redhat.com/browse/SWATCH-1538)

Description
===========

We're hitting 403s due to anti-csrf code. Similar to #2059. Probably happening now because of JMX removal.

Testing
=======

1. Deploy:

```shell
./gradlew swatch-system-conduit:bootRun
```

2. Simulate the command used by the job:

```shell
export SWATCH_SELF_PSK=placeholder
/usr/bin/curl --fail -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/syncAllOrgs"
```

(see failure w/ 403)

3. Try the updated command:

```shell
export SWATCH_SELF_PSK=placeholder
/usr/bin/curl --fail -H "Origin: https://console.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/syncAllOrgs"
```

(see success)