### PR TITLE
SWATCH-1535: Optimize subscription syncing

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -376,27 +376,24 @@ public class SubscriptionSyncController {
     Long startDate = sub.getEffectiveStartDate();
     Long endDate = sub.getEffectiveEndDate();
 
-    // Consider any sub with a null effective date as invalid, it could be an upstream data issue.
-    // Log this sub's info and skip it.
-    if (startDate == null || endDate == null) {
+    // Consider any sub with a null effective start date as invalid, it could be an upstream data
+    // issue. Log this sub's info and skip it.
+    if (startDate == null) {
       log.warn(
-          "subscriptionId={} subscriptionNumber={} for orgId={} has effectiveStartDate={} and "
-              + "effectiveEndDate={} (neither should be null). Subscription data will need fixing "
-              + "in upstream service. Skipping sync.",
+          "subscriptionId={} subscriptionNumber={} for orgId={} has effectiveStartDate null (should not be null). Subscription data will need fixing in upstream service. Skipping sync.",
           sub.getId(),
           sub.getSubscriptionNumber(),
-          sub.getWebCustomerId(),
-          startDate,
-          endDate);
+          sub.getWebCustomerId());
       return false;
     }
 
     long earliestAllowedFutureStartDate =
-        now.plus(properties.getIgnoreStartingLaterThan()).toEpochSecond() * 1000;
+        now.plus(properties.getIgnoreStartingLaterThan()).toInstant().toEpochMilli();
     long latestAllowedExpiredEndDate =
-        now.minus(properties.getIgnoreExpiredOlderThan()).toEpochSecond() * 1000;
+        now.minus(properties.getIgnoreExpiredOlderThan()).toInstant().toEpochMilli();
 
-    return startDate < earliestAllowedFutureStartDate && endDate > latestAllowedExpiredEndDate;
+    return startDate < earliestAllowedFutureStartDate
+        && (endDate == null || endDate > latestAllowedExpiredEndDate);
   }
 
   private void enqueueSubscriptionSync(String orgId) {

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorker.java
@@ -71,7 +71,7 @@ public class SubscriptionWorker extends SeekableKafkaConsumer {
     log.info(
         "Subscription Worker is syncing subs with values: {} ", syncSubscriptionsTask.toString());
     subscriptionSyncController.reconcileSubscriptionsWithSubscriptionService(
-        syncSubscriptionsTask.getOrgId());
+        syncSubscriptionsTask.getOrgId(), false);
   }
 
   @JmsListener(destination = "#{@umbProperties.subscriptionTopic}")

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.db;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -35,6 +36,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.*;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.json.Measurement.Uom;
@@ -64,7 +66,7 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @TestInstance(Lifecycle.PER_CLASS)
 class HostRepositoryTest {
-
+  private static final Clock CLOCK = new FixedClockConfiguration().fixedClock().getClock();
   private final String RHEL = "RHEL";
   private final String COOL_PROD = "COOL_PROD";
   private static final String DEFAULT_DISPLAY_NAME = "REDHAT_PWNS";
@@ -161,7 +163,7 @@ class HostRepositoryTest {
   @Test
   void testTallyHostViewProjection() {
     // Ensure that the TallyHostView is properly projecting values.
-    OffsetDateTime expLastSeen = OffsetDateTime.now();
+    OffsetDateTime expLastSeen = OffsetDateTime.now(CLOCK);
     String expInventoryId = "INV";
     String expInsightsId = "INSIGHTS_ID";
     String expAccount = "ACCT";

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -997,6 +997,7 @@ class HostRepositoryTest {
         BillingProvider._ANY);
 
     Host host3 = createHost("i3", "a1");
+    host3.setBillingProvider(BillingProvider.EMPTY);
     addBucketToHost(
         host3,
         COOL_PROD,

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -296,21 +296,6 @@ class SubscriptionRepositoryTest {
     assertThat(result, Matchers.containsInAnyOrder(s1, s2));
   }
 
-  @Transactional
-  @Test
-  void testFindByOrgIdAndEndDateAfter() {
-    var s1 = createSubscription("org123", "account123", "sub123", "seller123");
-    var s2 = createSubscription("org123", "account123", "sub321", "seller123");
-    var offering1 = createOffering("testSkuUnlimited", "TestSKUUnlimited", 1066, null, null, null);
-    List.of(s1, s2).forEach(x -> x.setOffering(offering1));
-
-    offeringRepo.save(offering1);
-    subscriptionRepo.saveAllAndFlush(List.of(s1, s2));
-
-    var result = subscriptionRepo.findByOrgIdAndEndDateAfter("org123", OffsetDateTime.now());
-    assertThat(result, Matchers.containsInAnyOrder(s1, s2));
-  }
-
   private Offering createOffering(
       String sku, String productName, int productId, ServiceLevel sla, Usage usage, String role) {
     return Offering.builder()

--- a/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
@@ -319,7 +319,7 @@ class TallyInstanceViewRepositoryTest {
         BillingProvider._ANY);
 
     Host host3 = createHost("i3", "a1");
-    host3.setBillingProvider(null);
+    host3.setBillingProvider(BillingProvider.EMPTY);
     addBucketToHost(
         host3,
         COOL_PROD,
@@ -377,10 +377,10 @@ class TallyInstanceViewRepositoryTest {
             null,
             page);
     assertEquals(4L, results.getTotalElements());
-    assertEquals(BillingProvider.EMPTY, results.getContent().get(0).getHostBillingProvider());
-    assertEquals(BillingProvider.RED_HAT, results.getContent().get(1).getHostBillingProvider());
-    assertEquals(BillingProvider.ORACLE, results.getContent().get(2).getHostBillingProvider());
-    assertEquals(BillingProvider.AWS, results.getContent().get(3).getHostBillingProvider());
+    assertEquals(BillingProvider.RED_HAT, results.getContent().get(0).getHostBillingProvider());
+    assertEquals(BillingProvider.ORACLE, results.getContent().get(1).getHostBillingProvider());
+    assertEquals(BillingProvider.AWS, results.getContent().get(2).getHostBillingProvider());
+    assertEquals(BillingProvider.EMPTY, results.getContent().get(3).getHostBillingProvider());
   }
 
   @Transactional

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -152,7 +152,7 @@ class SubscriptionSyncControllerTest {
     var dto = createDto("456", 4);
     subscriptionSyncController.syncSubscription(dto);
     verify(subscriptionRepository, Mockito.times(1)).save(Mockito.any(Subscription.class));
-    verify(capacityReconciliationController)
+    verify(capacityReconciliationController, Mockito.times(2))
         .reconcileCapacityForSubscription(Mockito.any(Subscription.class));
   }
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/BillingProvider.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/BillingProvider.java
@@ -24,6 +24,7 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -75,7 +76,7 @@ public enum BillingProvider {
 
     @Override
     public BillingProvider convertToEntityAttribute(String dbData) {
-      return BillingProvider.fromString(dbData);
+      return Objects.nonNull(dbData) ? BillingProvider.fromString(dbData) : null;
     }
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ServiceLevel.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ServiceLevel.java
@@ -75,7 +75,7 @@ public enum ServiceLevel implements StringValueEnum {
 
     @Override
     public ServiceLevel convertToEntityAttribute(String dbData) {
-      return ServiceLevel.fromString(dbData);
+      return Objects.nonNull(dbData) ? ServiceLevel.fromString(dbData) : null;
     }
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/Usage.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/Usage.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.contract.repository;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * System purpose usage
@@ -72,7 +73,7 @@ public enum Usage implements StringValueEnum {
 
     @Override
     public Usage convertToEntityAttribute(String dbData) {
-      return Usage.fromString(dbData);
+      return Objects.nonNull(dbData) ? Usage.fromString(dbData) : null;
     }
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -61,16 +61,16 @@ public interface SubscriptionRepository
   @Query(
       "SELECT s FROM Subscription s where s.endDate > CURRENT_TIMESTAMP "
           + "AND s.subscriptionId = :subscriptionId")
-  @EntityGraph(value = "Subscription.offering")
+  @EntityGraph(value = "graph.SubscriptionSync")
   Optional<Subscription> findActiveSubscription(@Param("subscriptionId") String subscriptionId);
 
-  @EntityGraph(value = "Subscription.offering")
+  @EntityGraph(value = "graph.SubscriptionSync")
   Optional<Subscription> findBySubscriptionNumber(String subscriptionNumber);
 
-  @EntityGraph(value = "Subscription.offering")
+  @EntityGraph(value = "graph.SubscriptionSync")
   Page<Subscription> findByOfferingSku(String sku, Pageable pageable);
 
-  @EntityGraph(value = "Subscription.offering")
+  @EntityGraph(value = "graph.SubscriptionSync")
   Stream<Subscription> findByOrgId(String orgId);
 
   void deleteBySubscriptionId(String subscriptionId);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -73,9 +73,6 @@ public interface SubscriptionRepository
   @EntityGraph(value = "Subscription.offering")
   Stream<Subscription> findByOrgId(String orgId);
 
-  @EntityGraph(value = "Subscription.offering")
-  List<Subscription> findByOrgIdAndEndDateAfter(String orgId, OffsetDateTime date);
-
   void deleteBySubscriptionId(String subscriptionId);
 
   void deleteByOrgId(String orgId);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillingProvider.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillingProvider.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.db.model;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import java.util.Map;
+import java.util.Objects;
 import org.candlepin.subscriptions.utilization.api.model.BillingProviderType;
 
 /** Billing provider associated with a host. */
@@ -80,7 +81,7 @@ public enum BillingProvider implements StringValueEnum<BillingProviderType> {
 
     @Override
     public BillingProvider convertToEntityAttribute(String dbData) {
-      return BillingProvider.fromString(dbData);
+      return Objects.nonNull(dbData) ? BillingProvider.fromString(dbData) : null;
     }
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/ServiceLevel.java
@@ -82,7 +82,7 @@ public enum ServiceLevel implements StringValueEnum<ServiceLevelType> {
 
     @Override
     public ServiceLevel convertToEntityAttribute(String dbData) {
-      return ServiceLevel.fromString(dbData);
+      return Objects.nonNull(dbData) ? ServiceLevel.fromString(dbData) : null;
     }
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -130,6 +130,7 @@ public class Subscription implements Serializable {
   @Getter
   @Setter
   @ToString
+  @EqualsAndHashCode
   public static class SubscriptionCompoundId implements Serializable {
     private String subscriptionId;
     private OffsetDateTime startDate;
@@ -141,24 +142,6 @@ public class Subscription implements Serializable {
 
     public SubscriptionCompoundId() {
       // default
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof Subscription subscription)) {
-        return false;
-      }
-
-      return Objects.equals(subscriptionId, subscription.getSubscriptionId())
-          && Objects.equals(startDate, subscription.getStartDate());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(subscriptionId, startDate);
     }
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -41,7 +41,17 @@ import lombok.*;
 @NoArgsConstructor
 @IdClass(Subscription.SubscriptionCompoundId.class)
 @Table(name = "subscription")
-@NamedEntityGraph(name = "Subscription.offering", attributeNodes = @NamedAttributeNode("offering"))
+// The below graph fetches all associations needed during subscription sync to avoid n+1 queries
+@NamedEntityGraph(
+    name = "graph.SubscriptionSync",
+    attributeNodes = {
+      @NamedAttributeNode(value = "offering", subgraph = "subgraph.offering"),
+      @NamedAttributeNode("subscriptionMeasurements"),
+      @NamedAttributeNode("subscriptionProductIds")
+    },
+    subgraphs = {
+      @NamedSubgraph(name = "subgraph.offering", attributeNodes = @NamedAttributeNode("productIds"))
+    })
 public class Subscription implements Serializable {
 
   @Id

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Usage.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.db.model;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import java.util.Map;
+import java.util.Objects;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
 
 /**
@@ -81,7 +82,7 @@ public enum Usage implements StringValueEnum<UsageType> {
 
     @Override
     public Usage convertToEntityAttribute(String dbData) {
-      return Usage.fromString(dbData);
+      return Objects.nonNull(dbData) ? Usage.fromString(dbData) : null;
     }
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1535](https://issues.redhat.com/browse/SWATCH-1535)

## Description

The following changes to optimize subscription syncing:

* Fix incorrect equals method in `SubscriptionCompoundId`
* Consolidate subscription syncing methods (there were two with slightly different implementations).
* Refactor measurement and product ID reconciliation so that previously implemented optimizations are used (namely doing nothing if the swatch data is up-to-date).
* Allow subs without end date to be synced (we expect some PAYG subs to not have an end date).
* Fix inconsistent DB <-> enum mappings, this was causing equality checks to fail, causing extra unnecessary work.
* Fetch associations upfront to avoid n+1 queries during org sub sync.

Some additional commentary in code comments and commit messages.

## Testing

1. Deploy with sub/product stubs and with sql logging:

```shell
PRODUCT_USE_STUB=true \
  SUBSCRIPTION_USE_STUB=TRUE \
  DEV_MODE=true \
  ./gradlew \
  :bootRun \
  --args="--spring.jpa.properties.hibernate.format_sql=true --spring.jpa.properties.hibernate.show_sql=true"
```

2. Trigger sync of an org's subscriptions:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123 \
  x-rh-swatch-psk:placeholder
```

3. Trigger another sync:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123 \
  x-rh-swatch-psk:placeholder
```

See that in the logs there is a single DB select this time.

4. Sync by SKU:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/offerings/reconcile/RH3413336 \
  x-rh-swatch-psk:placeholder
```

See that there is a single DB query made.

Quick note: if you attach a debugger, the `toString` can trigger additional queries on `Offering`.