### PR TITLE
SWATCH-1509 Apply capacity to tally report running totals when billing category specified

### DIFF
--- a/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/CapacityApiFactory.java
+++ b/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/CapacityApiFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contracts.client;
+
+import com.redhat.swatch.contracts.api.resources.CapacityApi;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.http.HttpClient;
+import org.candlepin.subscriptions.http.HttpClientProperties;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+public class CapacityApiFactory implements FactoryBean<CapacityApi> {
+
+  private final HttpClientProperties properties;
+  private final IdentityHeaderProvider idHeaderProvider;
+
+  public CapacityApiFactory(
+      HttpClientProperties properties, IdentityHeaderProvider idHeaderProvider) {
+    this.properties = properties;
+    this.idHeaderProvider = idHeaderProvider;
+  }
+
+  @Override
+  public CapacityApi getObject() throws Exception {
+    ApiClient client = new IdentityHeaderApiClient(idHeaderProvider);
+    client.setHttpClient(
+        HttpClient.buildHttpClient(properties, client.getJSON(), client.isDebugging()));
+
+    var url = properties.getUrl();
+    if (StringUtils.hasText(url)) {
+      log.info("Capacity API URL: {}", url);
+      client.setBasePath(url);
+    } else {
+      log.warn("Capacity API URL not set...");
+    }
+
+    return new CapacityApi(client);
+  }
+
+  @Override
+  public Class<?> getObjectType() {
+    return CapacityApi.class;
+  }
+}

--- a/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/IdentityHeaderApiClient.java
+++ b/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/IdentityHeaderApiClient.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contracts.client;
+
+import com.redhat.swatch.contracts.client.auth.ApiKeyAuth;
+import jakarta.ws.rs.core.GenericType;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class IdentityHeaderApiClient extends ApiClient {
+
+  private final IdentityHeaderProvider headerProvider;
+  private final Set<String> applicableAuthNames;
+
+  public IdentityHeaderApiClient(IdentityHeaderProvider headerProvider) {
+    super();
+    this.headerProvider = headerProvider;
+
+    this.applicableAuthNames =
+        getAuthentications().entrySet().stream()
+            .filter(
+                e ->
+                    e.getValue() instanceof ApiKeyAuth
+                        && "x-rh-identity".equals(((ApiKeyAuth) e.getValue()).getParamName()))
+            .map(Entry::getKey)
+            .collect(Collectors.toSet());
+  }
+
+  @Override
+  public <T> T invokeAPI(
+      String path,
+      String method,
+      List<Pair> queryParams,
+      Object body,
+      Map<String, String> headerParams,
+      Map<String, String> cookieParams,
+      Map<String, Object> formParams,
+      String accept,
+      String contentType,
+      String[] authNames,
+      GenericType<T> returnType)
+      throws ApiException {
+
+    for (String authName : authNames) {
+      if (this.applicableAuthNames.contains(authName)
+          && getAuthentication(authName) instanceof ApiKeyAuth) {
+        // Forward the existing identity if it is required.
+        headerParams.put("x-rh-identity", this.headerProvider.get());
+        break;
+      }
+    }
+
+    return super.invokeAPI(
+        path,
+        method,
+        queryParams,
+        body,
+        headerParams,
+        cookieParams,
+        formParams,
+        accept,
+        contentType,
+        authNames,
+        returnType);
+  }
+}

--- a/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/IdentityHeaderProvider.java
+++ b/clients/contracts-client/src/main/java/com/redhat/swatch/contracts/client/IdentityHeaderProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contracts.client;
+
+/** Provides a callback function to get the current x-rh-identity header. */
+@FunctionalInterface
+public interface IdentityHeaderProvider {
+
+  String get();
+}

--- a/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
@@ -20,9 +20,14 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import com.redhat.swatch.contracts.client.CapacityApiFactory;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
+import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
 import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -42,5 +47,17 @@ import org.springframework.context.annotation.Profile;
   TallyWorkerConfiguration.class
 })
 public class ApiConfiguration {
-  /* Intentionally empty */
+
+  @Qualifier("apiCapacityClientProperties")
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.api.capacity.client")
+  @Bean
+  HttpClientProperties capacityHttpClientProperties() {
+    return new HttpClientProperties();
+  }
+
+  @Bean
+  CapacityApiFactory capacityApiFactory(
+      @Qualifier("apiCapacityClientProperties") HttpClientProperties httpClientProperties) {
+    return new CapacityApiFactory(httpClientProperties, () -> ResourceUtils.getCurrentIdentityHeader());
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
@@ -58,7 +58,6 @@ public class ApiConfiguration {
   @Bean
   CapacityApiFactory capacityApiFactory(
       @Qualifier("apiCapacityClientProperties") HttpClientProperties httpClientProperties) {
-    return new CapacityApiFactory(
-        httpClientProperties, () -> ResourceUtils.getCurrentIdentityHeader());
+    return new CapacityApiFactory(httpClientProperties, ResourceUtils::getCurrentIdentityHeader);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
@@ -58,6 +58,7 @@ public class ApiConfiguration {
   @Bean
   CapacityApiFactory capacityApiFactory(
       @Qualifier("apiCapacityClientProperties") HttpClientProperties httpClientProperties) {
-    return new CapacityApiFactory(httpClientProperties, () -> ResourceUtils.getCurrentIdentityHeader());
+    return new CapacityApiFactory(
+        httpClientProperties, () -> ResourceUtils.getCurrentIdentityHeader());
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -29,6 +29,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.db.HypervisorReportCategory;
@@ -456,7 +457,7 @@ public class CapacityResource implements CapacityApi {
     for (SubscriptionMeasurement measurement : matches) {
       var begin = measurement.getSubscription().getStartDate();
       var end = measurement.getSubscription().getEndDate();
-      if (begin.isBefore(date) && end.isAfter(date)) {
+      if (begin.isBefore(date) && (Objects.isNull(end) || end.isAfter(date))) {
         hasData = true;
         if (metricId.toString().toUpperCase().equals(measurement.getMetricId())) {
           if (hypervisorReportCategory.isEmpty()) {

--- a/src/main/resources/application-api.yaml
+++ b/src/main/resources/application-api.yaml
@@ -11,3 +11,7 @@ rhsm-subscriptions:
     url: http://${RHSM_RBAC_HOST}:${RHSM_RBAC_PORT}/api/rbac/v1
     max-connections: ${RHSM_RBAC_MAX_CONNECTIONS:100}
     stub-permissions: ${RHSM_RBAC_STUB_PERMISSIONS:subscriptions:*:*}
+  api:
+    capacity:
+      client:
+        url: ${API_CAPACITY_CLIENT_URL:http://localhost:8000}

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -31,29 +31,47 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.model.*;
 import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.util.ApplicationClock;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@Import(FixedClockConfiguration.class)
 @ActiveProfiles("test")
 class SubscriptionRepositoryTest {
 
-  private static final OffsetDateTime NOW = OffsetDateTime.now();
+  @Autowired
+  @Qualifier("fixedClock")
+  ApplicationClock clock;
 
   @Autowired SubscriptionRepository subscriptionRepo;
 
   @Autowired OfferingRepository offeringRepo;
 
+  private OffsetDateTime NOW;
+
+  @BeforeEach
+  void setup() {
+    NOW = clock.now();
+  }
+
   @Transactional
   @Test
   void canInsertAndRetrieveSubscriptions() {
+    // Because the findActiveSubscription query uses CURRENT_TIMESTAMP,
+    // reset NOW so that it is current and not fixed.
+    NOW = OffsetDateTime.now();
     Subscription subscription = createSubscription("1", "1000", "123", "sellerAcctId");
     Offering offering = createOffering("testSku", "Test SKU", 1066, null, null, null);
     subscription.setOffering(offering);
@@ -294,6 +312,55 @@ class SubscriptionRepositoryTest {
     var criteria = DbReportCriteria.builder().orgId("org123").build();
     var result = subscriptionRepo.findUnlimited(criteria);
     assertThat(result, Matchers.containsInAnyOrder(s1, s2));
+  }
+
+  @Transactional
+  @Test
+  void testSubscriptionIsActive() {
+    // Because the findActiveSubscription query uses CURRENT_TIMESTAMP,
+    // reset NOW so that it is current and not fixed.
+    NOW = OffsetDateTime.now();
+
+    var s1 = createSubscription("org123", "account123", "sub123", "seller123");
+    var s2 = createSubscription("org123", "account123", "sub321", "seller123");
+    s2.setEndDate(null);
+
+    var offering1 = createOffering("testSkuUnlimited", "TestSKUUnlimited", 1066, null, null, null);
+    List.of(s1, s2).forEach(x -> x.setOffering(offering1));
+
+    offeringRepo.save(offering1);
+    subscriptionRepo.saveAllAndFlush(List.of(s1, s2));
+
+    assertTrue(subscriptionRepo.findActiveSubscription(s1.getSubscriptionId()).isPresent());
+    assertTrue(subscriptionRepo.findActiveSubscription(s2.getSubscriptionId()).isPresent());
+  }
+
+  @Transactional
+  @Test
+  void testFindBySpecificationWhenSubscriptionEndDateIsNull() {
+    var s1 = createSubscription("org123", "account123", "sub123", "seller123");
+
+    var s2 = createSubscription("org123", "account123", "sub321", "seller123");
+    s2.setEndDate(null);
+
+    var offering1 = createOffering("testSkuUnlimited", "TestSKUUnlimited", 1066, null, null, null);
+    List.of(s1, s2).forEach(x -> x.setOffering(offering1));
+
+    offeringRepo.save(offering1);
+    subscriptionRepo.saveAllAndFlush(List.of(s1, s2));
+
+    var resultList =
+        subscriptionRepo.findByCriteria(
+            DbReportCriteria.builder()
+                .orgId("org123")
+                .beginning(NOW)
+                .ending(NOW.plusDays(1))
+                .build(),
+            Sort.by(Subscription_.START_DATE).descending());
+    assertEquals(2, resultList.size());
+    assertTrue(resultList.contains(s2));
+    assertTrue(resultList.contains(s1));
+    assertThat(resultList, Matchers.containsInAnyOrder(s1, s2));
   }
 
   private Offering createOffering(

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -1107,6 +1107,8 @@ class TallyResourceTest {
 
   @Test
   void testBadRequestWhenBillingCategorySpecifiedWhenRunningTotalsParamIsNull() {
+    OffsetDateTime beginning = OffsetDateTime.parse("2021-10-01T00:00Z");
+    OffsetDateTime ending = OffsetDateTime.parse("2021-10-30T00:00Z");
     assertThrows(
         BadRequestException.class,
         () -> {
@@ -1114,8 +1116,8 @@ class TallyResourceTest {
               ProductId.RHEL,
               MetricId.CORES,
               GranularityType.DAILY,
-              OffsetDateTime.parse("2021-10-01T00:00Z"),
-              OffsetDateTime.parse("2021-10-30T00:00Z"),
+              beginning,
+              ending,
               null,
               null,
               null,
@@ -1130,6 +1132,8 @@ class TallyResourceTest {
 
   @Test
   void testBadRequestWhenBillingCategorySpecifiedWhenRunningTotalsParamIsFalse() {
+    OffsetDateTime beginning = OffsetDateTime.parse("2021-10-01T00:00Z");
+    OffsetDateTime ending = OffsetDateTime.parse("2021-10-30T00:00Z");
     assertThrows(
         BadRequestException.class,
         () -> {
@@ -1137,8 +1141,8 @@ class TallyResourceTest {
               ProductId.RHEL,
               MetricId.CORES,
               GranularityType.DAILY,
-              OffsetDateTime.parse("2021-10-01T00:00Z"),
-              OffsetDateTime.parse("2021-10-30T00:00Z"),
+              beginning,
+              ending,
               null,
               null,
               null,

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -25,21 +25,31 @@ import static org.junit.jupiter.params.ParameterizedTest.DEFAULT_DISPLAY_NAME;
 import static org.junit.jupiter.params.ParameterizedTest.DISPLAY_NAME_PLACEHOLDER;
 import static org.mockito.Mockito.*;
 
+import com.redhat.swatch.contracts.api.resources.CapacityApi;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.FixedClockConfiguration;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
-import org.candlepin.subscriptions.db.model.*;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.json.Measurement.Uom;
@@ -47,6 +57,7 @@ import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.RoleProvider;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.util.SnapshotTimeAdjuster;
 import org.candlepin.subscriptions.utilization.api.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,6 +91,7 @@ class TallyResourceTest {
   @MockBean BillableUsageRemittanceRepository remittanceRepository;
   @MockBean PageLinkCreator pageLinkCreator;
   @MockBean AccountConfigRepository accountConfigRepository;
+  @MockBean CapacityApi capacityApi;
   @Autowired TallyResource resource;
 
   @BeforeEach
@@ -1094,137 +1106,92 @@ class TallyResourceTest {
   }
 
   @Test
-  void testOnDemandBillingCategory() {
-    TallySnapshot snapshot = new TallySnapshot();
-    snapshot.setAccountNumber("account123");
-    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
-    snapshot.setMeasurement(HardwareMeasurementType.TOTAL, Uom.CORES, 4.0);
-    when(repository.findSnapshot(
-            any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-        .thenReturn(new PageImpl<>(List.of(snapshot)));
-    BillableUsageRemittanceEntity remittance =
-        BillableUsageRemittanceEntity.builder()
-            .remittedPendingValue(3.0)
-            .key(
-                BillableUsageRemittanceEntityPK.builder()
-                    .remittancePendingDate(snapshot.getSnapshotDate())
-                    .build())
-            .build();
-    when(remittanceRepository.filterBy(any())).thenReturn(List.of(remittance));
-    TallyReportData response =
-        resource.getTallyReportData(
-            ProductId.RHEL,
-            MetricId.CORES,
-            GranularityType.DAILY,
-            OffsetDateTime.parse("2021-10-01T00:00Z"),
-            OffsetDateTime.parse("2021-10-30T00:00Z"),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            BillingCategory.ON_DEMAND);
-    assertEquals(
-        3.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+  void testBadRequestWhenBillingCategorySpecifiedWhenRunningTotalsParamIsNull() {
+    assertThrows(
+        BadRequestException.class,
+        () -> {
+          resource.getTallyReportData(
+              ProductId.RHEL,
+              MetricId.CORES,
+              GranularityType.DAILY,
+              OffsetDateTime.parse("2021-10-01T00:00Z"),
+              OffsetDateTime.parse("2021-10-30T00:00Z"),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              BillingCategory.ON_DEMAND);
+        });
   }
 
   @Test
-  void testPrePaidBillingCategory() {
-    TallySnapshot snapshot = new TallySnapshot();
-    snapshot.setAccountNumber("account123");
-    snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
-    snapshot.setMeasurement(HardwareMeasurementType.TOTAL, Uom.CORES, 4.0);
-    when(repository.findSnapshot(
-            any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-        .thenReturn(new PageImpl<>(List.of(snapshot)));
-    BillableUsageRemittanceEntity remittance =
-        BillableUsageRemittanceEntity.builder()
-            .remittedPendingValue(3.0)
-            .key(
-                BillableUsageRemittanceEntityPK.builder()
-                    .remittancePendingDate(snapshot.getSnapshotDate())
-                    .build())
-            .build();
-    when(remittanceRepository.filterBy(any())).thenReturn(List.of(remittance));
-    TallyReportData response =
-        resource.getTallyReportData(
-            ProductId.RHEL,
-            MetricId.CORES,
-            GranularityType.DAILY,
-            OffsetDateTime.parse("2021-10-01T00:00Z"),
-            OffsetDateTime.parse("2021-10-30T00:00Z"),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            BillingCategory.PREPAID);
-    assertEquals(
-        1.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+  void testBadRequestWhenBillingCategorySpecifiedWhenRunningTotalsParamIsFalse() {
+    assertThrows(
+        BadRequestException.class,
+        () -> {
+          resource.getTallyReportData(
+              ProductId.RHEL,
+              MetricId.CORES,
+              GranularityType.DAILY,
+              OffsetDateTime.parse("2021-10-01T00:00Z"),
+              OffsetDateTime.parse("2021-10-30T00:00Z"),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              false,
+              BillingCategory.ON_DEMAND);
+        });
   }
 
   @Test
-  void testRunningTotalForOnDemand() {
-    var snapshot1 =
-        TallySnapshot.builder()
-            .snapshotDate(OffsetDateTime.of(2023, 3, 1, 12, 35, 0, 0, ZoneOffset.UTC))
-            .build();
-    snapshot1.setMeasurement(HardwareMeasurementType.TOTAL, Measurement.Uom.CORES, 2.0);
-    var snapshot2 =
-        TallySnapshot.builder()
-            .snapshotDate(OffsetDateTime.of(2023, 3, 2, 12, 35, 0, 0, ZoneOffset.UTC))
-            .build();
-    snapshot2.setMeasurement(HardwareMeasurementType.TOTAL, Measurement.Uom.CORES, 4.0);
-    var snapshot3 =
-        TallySnapshot.builder()
-            .snapshotDate(OffsetDateTime.of(2023, 3, 8, 12, 35, 0, 0, ZoneOffset.UTC))
-            .build();
-    snapshot3.setMeasurement(HardwareMeasurementType.TOTAL, Measurement.Uom.CORES, 16.0);
+  void testRunningTotalForOnDemand() throws Exception {
+    OffsetDateTime snap1Date = OffsetDateTime.of(2023, 3, 4, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime snap2Date = OffsetDateTime.of(2023, 3, 5, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime snap3Date = OffsetDateTime.of(2023, 3, 6, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime snap4Date = OffsetDateTime.of(2023, 3, 7, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime snap5Date = OffsetDateTime.of(2023, 3, 8, 0, 0, 0, 0, ZoneOffset.UTC);
+
+    List<OffsetDateTime> snapDates = List.of(snap1Date, snap2Date, snap3Date, snap4Date, snap5Date);
+    List<TallySnapshot> snapshots = new LinkedList<>();
+    for (OffsetDateTime nextDate : snapDates) {
+      TallySnapshot snap =
+          TallySnapshot.builder()
+              .productId(ProductId.OPENSHIFT_DEDICATED_METRICS.toString())
+              .snapshotDate(nextDate)
+              .build();
+      snap.setMeasurement(HardwareMeasurementType.TOTAL, Measurement.Uom.CORES, 100.0);
+      snapshots.add(snap);
+    }
 
     when(repository.findSnapshot(
             any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-        .thenReturn(new PageImpl<>(List.of(snapshot1, snapshot2, snapshot3)));
+        .thenReturn(new PageImpl<>(snapshots));
 
-    BillableUsageRemittanceEntity remittance1 =
-        BillableUsageRemittanceEntity.builder()
-            .remittedPendingValue(2.0)
-            .key(
-                BillableUsageRemittanceEntityPK.builder()
-                    .remittancePendingDate(CLOCK.startOfDay(snapshot1.getSnapshotDate()))
-                    .build())
-            .build();
-    when(remittanceRepository.filterBy(any())).thenReturn(List.of(remittance1));
-    BillableUsageRemittanceEntity remittance2 =
-        BillableUsageRemittanceEntity.builder()
-            .remittedPendingValue(0.0)
-            .key(
-                BillableUsageRemittanceEntityPK.builder()
-                    .remittancePendingDate(CLOCK.startOfDay(snapshot2.getSnapshotDate()))
-                    .build())
-            .build();
-    BillableUsageRemittanceEntity remittance3 =
-        BillableUsageRemittanceEntity.builder()
-            .remittedPendingValue(10.0)
-            .key(
-                BillableUsageRemittanceEntityPK.builder()
-                    .remittancePendingDate(CLOCK.startOfDay(snapshot3.getSnapshotDate()))
-                    .build())
-            .build();
-
-    when(remittanceRepository.filterBy(any()))
-        .thenReturn(List.of(remittance1, remittance2, remittance3));
+    mockCapacity(
+        ProductId.OPENSHIFT_DEDICATED_METRICS,
+        MetricId.CORES,
+        GranularityType.DAILY,
+        OffsetDateTime.parse("2023-03-01T00:00Z"),
+        OffsetDateTime.parse("2023-03-31T23:59:59.999Z"),
+        null,
+        null,
+        null,
+        Map.of(
+            snap2Date, 100,
+            snap3Date, 100,
+            snap4Date, 100,
+            snap5Date, 150));
 
     TallyReportDataPoint expectedTotalMonthly =
-        new TallyReportDataPoint()
-            .date(OffsetDateTime.parse("2023-03-08T12:35Z"))
-            .value(22)
-            .hasData(true);
+        new TallyReportDataPoint().date(snap5Date).value(500).hasData(true);
 
     TallyReportData report =
         resource.getTallyReportData(
@@ -1244,74 +1211,69 @@ class TallyResourceTest {
             BillingCategory.ON_DEMAND);
     assertEquals(31, report.getData().size());
 
-    var firstSnapshot = report.getData().get(0);
-    assertEquals(2, firstSnapshot.getValue());
+    int snapshotIndex = 2; //
+    var beforeUsage = report.getData().get(snapshotIndex);
+    assertEquals(0, beforeUsage.getValue());
 
-    var secondSnapshot = report.getData().get(1);
-    assertEquals(2, secondSnapshot.getValue());
+    var noAppliedCapacity = report.getData().get(snapshotIndex + 1);
+    assertEquals(100, noAppliedCapacity.getValue());
 
-    var thirdSnapshot = report.getData().get(7);
-    assertEquals(12, thirdSnapshot.getValue());
+    var firstSnapshot = report.getData().get(snapshotIndex + 2);
+    assertEquals(100, firstSnapshot.getValue());
+
+    var secondSnapshot = report.getData().get(snapshotIndex + 3);
+    assertEquals(200, secondSnapshot.getValue());
+
+    var thirdSnapshot = report.getData().get(snapshotIndex + 4);
+    assertEquals(300, thirdSnapshot.getValue());
+
+    var fourthSnapshot = report.getData().get(snapshotIndex + 5);
+    assertEquals(350, fourthSnapshot.getValue());
 
     assertEquals(expectedTotalMonthly, report.getMeta().getTotalMonthly());
   }
 
   @Test
-  void testRunningTotalForPrePaid() {
-    var snapshot1 =
-        TallySnapshot.builder()
-            .snapshotDate(OffsetDateTime.of(2023, 3, 1, 12, 35, 0, 0, ZoneOffset.UTC))
-            .build();
-    snapshot1.setMeasurement(HardwareMeasurementType.TOTAL, Measurement.Uom.CORES, 2.0);
-    var snapshot2 =
-        TallySnapshot.builder()
-            .snapshotDate(OffsetDateTime.of(2023, 3, 2, 12, 35, 0, 0, ZoneOffset.UTC))
-            .build();
-    snapshot2.setMeasurement(HardwareMeasurementType.TOTAL, Measurement.Uom.CORES, 4.0);
-    var snapshot3 =
-        TallySnapshot.builder()
-            .snapshotDate(OffsetDateTime.of(2023, 3, 8, 12, 35, 0, 0, ZoneOffset.UTC))
-            .build();
-    snapshot3.setMeasurement(HardwareMeasurementType.TOTAL, Measurement.Uom.CORES, 16.0);
+  void testRunningTotalForPrePaid() throws Exception {
+    OffsetDateTime snap1Date = OffsetDateTime.of(2023, 3, 4, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime snap2Date = OffsetDateTime.of(2023, 3, 5, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime snap3Date = OffsetDateTime.of(2023, 3, 6, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime snap4Date = OffsetDateTime.of(2023, 3, 7, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime snap5Date = OffsetDateTime.of(2023, 3, 8, 0, 0, 0, 0, ZoneOffset.UTC);
+
+    List<OffsetDateTime> snapDates = List.of(snap1Date, snap2Date, snap3Date, snap4Date, snap5Date);
+    List<TallySnapshot> snapshots = new LinkedList<>();
+    for (OffsetDateTime nextDate : snapDates) {
+      TallySnapshot snap =
+          TallySnapshot.builder()
+              .productId(ProductId.OPENSHIFT_DEDICATED_METRICS.toString())
+              .snapshotDate(nextDate)
+              .build();
+      snap.setMeasurement(HardwareMeasurementType.TOTAL, Measurement.Uom.CORES, 100.0);
+      snapshots.add(snap);
+    }
 
     when(repository.findSnapshot(
             any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-        .thenReturn(new PageImpl<>(List.of(snapshot1, snapshot2, snapshot3)));
+        .thenReturn(new PageImpl<>(snapshots));
 
-    BillableUsageRemittanceEntity remittance1 =
-        BillableUsageRemittanceEntity.builder()
-            .remittedPendingValue(2.0)
-            .key(
-                BillableUsageRemittanceEntityPK.builder()
-                    .remittancePendingDate(CLOCK.startOfDay(snapshot1.getSnapshotDate()))
-                    .build())
-            .build();
-    when(remittanceRepository.filterBy(any())).thenReturn(List.of(remittance1));
-    BillableUsageRemittanceEntity remittance2 =
-        BillableUsageRemittanceEntity.builder()
-            .remittedPendingValue(0.0)
-            .key(
-                BillableUsageRemittanceEntityPK.builder()
-                    .remittancePendingDate(CLOCK.startOfDay(snapshot2.getSnapshotDate()))
-                    .build())
-            .build();
-    BillableUsageRemittanceEntity remittance3 =
-        BillableUsageRemittanceEntity.builder()
-            .remittedPendingValue(10.0)
-            .key(
-                BillableUsageRemittanceEntityPK.builder()
-                    .remittancePendingDate(CLOCK.startOfDay(snapshot3.getSnapshotDate()))
-                    .build())
-            .build();
-
-    when(remittanceRepository.filterBy(any()))
-        .thenReturn(List.of(remittance1, remittance2, remittance3));
+    mockCapacity(
+        ProductId.OPENSHIFT_DEDICATED_METRICS,
+        MetricId.CORES,
+        GranularityType.DAILY,
+        OffsetDateTime.parse("2023-03-01T00:00Z"),
+        OffsetDateTime.parse("2023-03-31T23:59:59.999Z"),
+        null,
+        null,
+        null,
+        Map.of(
+            snap2Date, 200,
+            snap3Date, 200,
+            snap4Date, 500,
+            snap5Date, 500));
 
     TallyReportDataPoint expectedTotalMonthly =
-        new TallyReportDataPoint()
-            .date(OffsetDateTime.parse("2023-03-08T12:35Z"))
-            .value(22)
-            .hasData(true);
+        new TallyReportDataPoint().date(snap5Date).value(500).hasData(true);
 
     TallyReportData report =
         resource.getTallyReportData(
@@ -1331,15 +1293,123 @@ class TallyResourceTest {
             BillingCategory.PREPAID);
     assertEquals(31, report.getData().size());
 
-    var firstSnapshot = report.getData().get(0);
-    assertEquals(0, firstSnapshot.getValue());
+    int snapshotIndex = 2; //
+    var beforeUsage = report.getData().get(snapshotIndex);
+    assertEquals(0, beforeUsage.getValue());
 
-    var secondSnapshot = report.getData().get(1);
-    assertEquals(4, secondSnapshot.getValue());
+    var noAppliedCapacity = report.getData().get(snapshotIndex + 1);
+    assertEquals(0, noAppliedCapacity.getValue());
 
-    var thirdSnapshot = report.getData().get(7);
-    assertEquals(10, thirdSnapshot.getValue());
+    var firstSnapshot = report.getData().get(snapshotIndex + 2);
+    assertEquals(200, firstSnapshot.getValue());
 
-    assertEquals(expectedTotalMonthly, report.getMeta().getTotalMonthly());
+    var secondSnapshot = report.getData().get(snapshotIndex + 3);
+    assertEquals(200, secondSnapshot.getValue());
+
+    var thirdSnapshot = report.getData().get(snapshotIndex + 4);
+    assertEquals(400, thirdSnapshot.getValue());
+
+    var fourthSnapshot = report.getData().get(snapshotIndex + 5);
+    assertEquals(500, fourthSnapshot.getValue());
+
+    var noUsage2 = report.getData().get(snapshotIndex + 5);
+    assertEquals(500, noUsage2.getValue());
+  }
+
+  private void mockCapacity(
+      ProductId productId,
+      MetricId metricId,
+      GranularityType granularityType,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      ReportCategory category,
+      ServiceLevelType sla,
+      UsageType usageType,
+      Map<OffsetDateTime, Integer> result)
+      throws Exception {
+    com.redhat.swatch.contracts.api.model.MetricId cMetricId =
+        com.redhat.swatch.contracts.api.model.MetricId.valueOf(metricId.name());
+    com.redhat.swatch.contracts.api.model.GranularityType cGranularity =
+        com.redhat.swatch.contracts.api.model.GranularityType.valueOf(granularityType.name());
+    com.redhat.swatch.contracts.api.model.ReportCategory cReportCategory =
+        Optional.ofNullable(category)
+            .map(c -> com.redhat.swatch.contracts.api.model.ReportCategory.valueOf(c.name()))
+            .orElse(null);
+    com.redhat.swatch.contracts.api.model.ServiceLevelType cSla =
+        Optional.ofNullable(sla)
+            .map(s -> com.redhat.swatch.contracts.api.model.ServiceLevelType.valueOf(s.name()))
+            .orElse(null);
+    com.redhat.swatch.contracts.api.model.UsageType cUsage =
+        Optional.ofNullable(usageType)
+            .map(ut -> com.redhat.swatch.contracts.api.model.UsageType.valueOf(ut.name()))
+            .orElse(null);
+
+    when(capacityApi.getCapacityReportByMetricId(
+            eq(com.redhat.swatch.contracts.api.model.ProductId.valueOf(productId.name())),
+            eq(cMetricId),
+            eq(cGranularity),
+            eq(beginning),
+            eq(ending),
+            any(),
+            any(),
+            eq(cReportCategory),
+            eq(cSla),
+            eq(cUsage)))
+        .thenReturn(
+            capacityReport(
+                beginning, ending, cMetricId, cReportCategory, cGranularity, cSla, cUsage, result));
+  }
+
+  private com.redhat.swatch.contracts.api.model.CapacityReportByMetricId capacityReport(
+      OffsetDateTime start,
+      OffsetDateTime end,
+      com.redhat.swatch.contracts.api.model.MetricId metricId,
+      com.redhat.swatch.contracts.api.model.ReportCategory category,
+      com.redhat.swatch.contracts.api.model.GranularityType granularity,
+      com.redhat.swatch.contracts.api.model.ServiceLevelType sla,
+      com.redhat.swatch.contracts.api.model.UsageType usage,
+      Map<OffsetDateTime, Integer> values) {
+    var meta =
+        new com.redhat.swatch.contracts.api.model.CapacityReportByMetricIdMeta()
+            .metricId(metricId)
+            .category(category)
+            .granularity(granularity)
+            .serviceLevel(sla)
+            .usage(usage)
+            .count(values.size());
+    return new com.redhat.swatch.contracts.api.model.CapacityReportByMetricId()
+        .meta(meta)
+        .data(createCapacitySnapshots(start, end, granularity, values));
+  }
+
+  private List<com.redhat.swatch.contracts.api.model.CapacitySnapshotByMetricId>
+      createCapacitySnapshots(
+          OffsetDateTime reportStart,
+          OffsetDateTime reportEnd,
+          com.redhat.swatch.contracts.api.model.GranularityType granularityType,
+          Map<OffsetDateTime, Integer> values) {
+    SnapshotTimeAdjuster timeAdjuster =
+        SnapshotTimeAdjuster.getTimeAdjuster(
+            CLOCK, Granularity.fromString(granularityType.toString()));
+
+    OffsetDateTime start = timeAdjuster.adjustToPeriodStart(reportStart);
+    OffsetDateTime end = timeAdjuster.adjustToPeriodEnd(reportEnd);
+    TemporalAmount offset = timeAdjuster.getSnapshotOffset();
+
+    List<com.redhat.swatch.contracts.api.model.CapacitySnapshotByMetricId> result =
+        new ArrayList<>();
+    OffsetDateTime next = OffsetDateTime.from(start);
+
+    while (next.isBefore(end) || next.isEqual(end)) {
+      Integer value = values.getOrDefault(next, 0);
+      result.add(
+          new com.redhat.swatch.contracts.api.model.CapacitySnapshotByMetricId()
+              .hasData(values.containsKey(next))
+              .date(next)
+              .hasInfiniteQuantity(false)
+              .value(value));
+      next = timeAdjuster.adjustToPeriodStart(next.plus(offset));
+    }
+    return result;
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -66,7 +66,6 @@ public class ResourceUtils {
     return auth != null ? auth.getPrincipal() : null;
   }
 
-  
   /**
    * Get the org ID of the authenticated user.
    *
@@ -185,9 +184,6 @@ public class ResourceUtils {
     if (Objects.isNull(requestAttributes)) {
       return null;
     }
-    return ((ServletRequestAttributes) requestAttributes)
-      .getRequest()
-      .getHeader("x-rh-identity");
+    return ((ServletRequestAttributes) requestAttributes).getRequest().getHeader("x-rh-identity");
   }
-
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/resource/ResourceUtils.java
@@ -37,6 +37,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 /** Functionality common to both capacity and tally resources. */
 public class ResourceUtils {
@@ -63,6 +66,7 @@ public class ResourceUtils {
     return auth != null ? auth.getPrincipal() : null;
   }
 
+  
   /**
    * Get the org ID of the authenticated user.
    *
@@ -175,4 +179,15 @@ public class ResourceUtils {
     }
     return value;
   }
+
+  public static String getCurrentIdentityHeader() {
+    RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+    if (Objects.isNull(requestAttributes)) {
+      return null;
+    }
+    return ((ServletRequestAttributes) requestAttributes)
+      .getRequest()
+      .getHeader("x-rh-identity");
+  }
+
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1509](https://issues.redhat.com/browse/SWATCH-1509)

## Description
When the Tally API generates a tally report with a billing category, capacity is applied to the running total calculations as they are calculated.

The following calculations are applied for the following billing categories:
**PREPAID:** max(running_usage_total_for_date - capacity_for_date, 0)
**ON-DEMAND:** min(running_usage_total_for_date, capacity)

**_NOTE: Testing steps has an example of how this is applied. See below._**

The tally report API now requires use_running_totals_format = true when a billing_category is specified.

### Capacity Client Note
When a request is made for a tally report with a billing category, a Capacity client is used to pull back the capacity report for the product/metric, which is then applied during the running total calculations.

Because the capacity client is already being generated for swatch-contracts, we use this generated client in swatch-api, and point it at localhost. We decided to move this to make changes easier when subscriptions/capacity is moved into the contract service in the future.

An HttpClient extension was added that will add the Red Hat identity header to the request (if it exists and is
required) so that it is forwarded along to the Capacity client's request when the tally report operation is executed.

The IdentityHeaderProvider functional interface prevents dependency creep into the generated clients projects.

### Active Subscriptions
A subscription created via a contract may or may not have an end_date
set. When fetching capacity during a tally, subscriptions with a null
end date were being filtered out and not being included in the
capacity report and therefor not being applied to the tally's running
totals.

This patch updates the SubscriptionRepository to consider a subscription as active when the end_date is null.

## Testing

### Setup
Drop the DB
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```

Launch swatch-tally-worker in console 1
```
SWATCH_CONTRACTS_INTERNAL_SERVICE_URL=http://localhost:8882  DEV_MODE=true ./gradlew :bootRun
```

Insert some event records from the attached [events-setup.txt](https://github.com/RedHatInsights/rhsm-subscriptions/files/12176232/events-setup.txt) file.
```
psql -U rhsm-subscriptions rhsm-subscriptions < events-setup.txt
```

Launch swatch-contracts in console 2
```
SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8000/api/rhsm-subscriptions/v1 SERVER_PORT=8882 ./gradlew  :swatch-contracts:quarkusDev
```

Create an offering for rosa
```
psql -U rhsm-subscriptions rhsm-subscriptions -c "insert into offering values ('MW02393', 'OpenShift Dedicated', 'OpenShift Enterprise', 0, 0, 0, 0, 'rosa', 'Premium', 'Production', 'Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)', false, '');"
```

Create a contract and resulting Subscription data
```
http POST :8882/api/swatch-contracts/internal/contracts \
subscription_number=12345 sku=MW02393 start_date=2023-03-07T00:00:00Z \
org_id=org123 billing_provider=aws billing_account_id=mktp-123 \
product_id=rosa \
vendor_product_code=aws_rosa \
metrics[0][metric_id]=four_vcpu_0 \
metrics[0][value]=250 \
metrics[1][metric_id]=control_plane_0 \
metrics[1][value]=250
```

Verify that the contract service created the subscriptions appropriately. NOTE: The subscription measurements should have been coverted to metric units using the billing factor.

CORES: 250 / 0.25 = 1000
INSTANCE_HOURS: 250 / 1.0 = 250

```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from subscription_measurements;"
```


Run an hourly tally for ```rosa```
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=org123&start=2023-07-01T00:00Z&end=2023-07-31T00:00Z" x-rh-swatch-psk:placeholder
```


Opt-in the test org
```
http PUT :8000/api/rhsm-subscriptions/v1/opt-in x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Determine the baseline usage for rosa - cores. This will show the total usage per day for the month. Based on the events that were imported, we should see a total of **965 cores** each day that had events.
```
http GET ':8000/api/rhsm-subscriptions/v1/tally/products/rosa/cores?metric_id=cores&granularity=daily&ending=2023-07-31T23:59:59.999Z&beginning=2023-07-01T00:00:00Z&use_running_totals_format=false' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```
```
 --- snip ---
        {
            "date": "2023-07-13T00:00:00Z",
            "has_data": false,
            "value": 0
        },
        {
            "date": "2023-07-14T00:00:00Z",
            "has_data": true,
            "value": 965
        },
        {
            "date": "2023-07-15T00:00:00Z",
            "has_data": true,
            "value": 965
        },
        {
            "date": "2023-07-16T00:00:00Z",
            "has_data": true,
            "value": 965
        },
        {
            "date": "2023-07-17T00:00:00Z",
            "has_data": false,
            "value": 0
        },

 --- snip ---
```

Do the same using running totals. You should see the accumulation each day, until the max of 2895 is reached. 
```
http GET ':8000/api/rhsm-subscriptions/v1/tally/products/rosa/cores?metric_id=cores&granularity=daily&ending=2023-07-31T23:59:59.999Z&beginning=2023-07-01T00:00:00Z&use_running_totals_format=true' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```
```
 --- snip ---
         {
            "date": "2023-07-13T00:00:00Z",
            "has_data": false,
            "value": 0
        },
        {
            "date": "2023-07-14T00:00:00Z",
            "has_data": true,
            "value": 965
        },
        {
            "date": "2023-07-15T00:00:00Z",
            "has_data": true,
            "value": 1930
        },
        {
            "date": "2023-07-16T00:00:00Z",
            "has_data": true,
            "value": 2895
        },
        {
            "date": "2023-07-17T00:00:00Z",
            "has_data": false,
            "value": 2895
        },

 --- snip ---
```

Check the capacity for rosa - Cores over the time span we will tally. NOTE: Should result in **1000 per day** for the month.
```
http GET ':8000/api/rhsm-subscriptions/v1/capacity/products/rosa/cores?metric_id=cores&granularity=daily&ending=2023-07-31T23:59:59.999Z&beginning=2023-07-01T00:00:00Z' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

### Verification
Test that when specifying a billing category, use_running_totals_format MUST BE true.
```
http GET ':8000/api/rhsm-subscriptions/v1/tally/products/rosa/cores?metric_id=cores&granularity=daily&ending=2023-07-31T23:59:59.999Z&beginning=2023-07-01T00:00:00Z&billing_category=on-demand&use_running_totals_format=false' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```
```
{
    "errors": [
        {
            "code": "SUBSCRIPTIONS1001",
            "status": "400",
            "title": "When `billing_category` is specified, `use_running_totals_format` must be `true`."
        }
    ]
}

```

Run a tally report for rosa with the on-demand billing category. Note that the capacity amount has been deducted as the running total is calculated.
```
http GET ':8000/api/rhsm-subscriptions/v1/tally/products/rosa/cores?metric_id=cores&granularity=daily&ending=2023-07-31T23:59:59.999Z&beginning=2023-07-01T00:00:00Z&billing_category=on-demand&use_running_totals_format=true' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

```
 --- snip ---
        {
            "date": "2023-07-13T00:00:00Z",
            "has_data": false,
            "value": 0
        },
        {
            "date": "2023-07-14T00:00:00Z",
            "has_data": true,
            "value": 0
        },
        {
            "date": "2023-07-15T00:00:00Z",
            "has_data": true,
            "value": 930
        },
        {
            "date": "2023-07-16T00:00:00Z",
            "has_data": true,
            "value": 1895
        },
        {
            "date": "2023-07-17T00:00:00Z",
            "has_data": false,
            "value": 1895
        },

 --- snip ---
```

**Calculations:**
tally_value = max(running_total_for_date - capacity, 0)
2023-07-14T00:00:00Z: max(965 - 1000, 0) = 0
2023-07-15T00:00:00Z: max(1930 - 1000, 0) = 930
2023-07-16T00:00:00Z:  max(2895 - 1000, 0) = 1895
2023-07-17T00:00:00Z:  max(2895 - 1000, 0) = 1895
...

Run a tally report for rosa with the prepaid billing category. Note that the report only allows a maximum value of the capacity.

```
http GET ':8000/api/rhsm-subscriptions/v1/tally/products/rosa/cores?metric_id=cores&granularity=daily&ending=2023-07-31T23:59:59.999Z&beginning=2023-07-01T00:00:00Z&billing_category=prepaid&use_running_totals_format=true' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```
```
 --- snip ---
         {
            "date": "2023-07-13T00:00:00Z",
            "has_data": false,
            "value": 0
        },
        {
            "date": "2023-07-14T00:00:00Z",
            "has_data": true,
            "value": 965
        },
        {
            "date": "2023-07-15T00:00:00Z",
            "has_data": true,
            "value": 1000
        },
        {
            "date": "2023-07-16T00:00:00Z",
            "has_data": true,
            "value": 1000
        },
        {
            "date": "2023-07-17T00:00:00Z",
            "has_data": false,
            "value": 1000
        },
 --- snip ---
```

**Calculations:**
tally_value = min(running_total_for_date, capacity)
2023-07-14T00:00:00Z: min(965, 1000) = 965
2023-07-15T00:00:00Z: min(1930, 1000) = 1000
2023-07-16T00:00:00Z:  min(2895, 1000) = 1000
2023-07-17T00:00:00Z:  min(2895, 1000) = 1000
