### PR TITLE
SWATCH-1047 Properly filter by cores/sockets in instance API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -164,6 +164,11 @@ public class InstancesResource implements InstancesApi {
 
     int minCores = 0;
     int minSockets = 0;
+    if (uom == MetricId.CORES) {
+      minCores = 1;
+    } else if (uom == MetricId.SOCKETS) {
+      minSockets = 1;
+    }
 
     ServiceLevel sanitizedSla = ResourceUtils.sanitizeServiceLevel(sla);
     Usage sanitizedUsage = ResourceUtils.sanitizeUsage(usage);

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -456,4 +456,134 @@ class InstancesResourceTest {
 
     assertEquals(1, response.getData().size());
   }
+
+  @Test
+  void testMinCoresOneWhenUomIsCores() {
+    BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
+
+    var tallyInstanceView = new TallyInstanceView();
+    tallyInstanceView.setKey(new TallyInstanceViewKey());
+    tallyInstanceView.setDisplayName("rhv.example.com");
+    tallyInstanceView.setNumOfGuests(3);
+    tallyInstanceView.setLastSeen(OffsetDateTime.now());
+    tallyInstanceView.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
+    tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
+    tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
+    tallyInstanceView.getKey().setProductId("RHEL");
+    tallyInstanceView.getKey().setUom(Measurement.Uom.CORES);
+
+    Mockito.when(
+            repository.findAllBy(
+                eq("owner123456"),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyInt(),
+                anyInt(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()))
+        .thenReturn(new PageImpl<>(List.of(tallyInstanceView)));
+
+    resource.getInstancesByProduct(
+        RHEL,
+        null,
+        null,
+        ServiceLevelType.PREMIUM,
+        UsageType.PRODUCTION,
+        MetricId.CORES,
+        BillingProviderType.RED_HAT,
+        null,
+        null,
+        null,
+        OffsetDateTime.now(),
+        OffsetDateTime.now(),
+        InstanceReportSort.DISPLAY_NAME,
+        null);
+
+    verify(repository)
+        .findAllBy(
+            eq("owner123456"),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(1),
+            eq(0),
+            eq(null),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
+
+  @Test
+  void testMinSocketsOneWhenUomIsSockets() {
+    BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
+
+    var tallyInstanceView = new TallyInstanceView();
+    tallyInstanceView.setKey(new TallyInstanceViewKey());
+    tallyInstanceView.setDisplayName("rhv.example.com");
+    tallyInstanceView.setNumOfGuests(3);
+    tallyInstanceView.setLastSeen(OffsetDateTime.now());
+    tallyInstanceView.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
+    tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
+    tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
+    tallyInstanceView.getKey().setProductId("RHEL");
+    tallyInstanceView.getKey().setUom(Measurement.Uom.SOCKETS);
+
+    Mockito.when(
+            repository.findAllBy(
+                eq("owner123456"),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyInt(),
+                anyInt(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()))
+        .thenReturn(new PageImpl<>(List.of(tallyInstanceView)));
+
+    resource.getInstancesByProduct(
+        RHEL,
+        null,
+        null,
+        ServiceLevelType.PREMIUM,
+        UsageType.PRODUCTION,
+        MetricId.SOCKETS,
+        BillingProviderType.RED_HAT,
+        null,
+        null,
+        null,
+        OffsetDateTime.now(),
+        OffsetDateTime.now(),
+        InstanceReportSort.DISPLAY_NAME,
+        null);
+
+    verify(repository)
+        .findAllBy(
+            eq("owner123456"),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(0),
+            eq(1),
+            eq(null),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-1047](https://issues.redhat.com/browse/SWATCH-1047)

## Description
Min cores/sockets was always being passed to the query as 0,
resulting in the same instance results no matter if the UOM was
sockets or cores.

This patch applies logic from the old API to toggle the min value
based on whether the uom is sockets or cores.

## Testing
Drop the database
```
dropdb -U rhsm-subscriptions rhsm-subscriptions && createdb -U rhsm-subscriptions rhsm-subscriptions
```

Load the database from the attached test data file: [bug_data_dump_full.txt](https://github.com/RedHatInsights/rhsm-subscriptions/files/11971683/bug_data_dump_full.txt)
```
psql -U rhsm-subscriptions rhsm-subscriptions < bug_data_dump_full.txt
```

Deploy the app from the main branch.
```
DEV_MODE=true ./gradlew :bootRun
```

Opt in the test org/account
```
http PUT :8000/api/rhsm-subscriptions/v1/opt-in x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

### Reproduce on main branch
Test with cores
```
http GET ':8000/api/rhsm-subscriptions/v1/instances/products/OpenShift%20Container%20Platform?dir=desc&ending=2023-06-30T23:59:59.999Z&limit=100&offset=0&sort=last_seen&beginning=2023-06-01T00:00:00Z&uom=cores' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Observe - count 82
```
{
...
...
    "meta": {
        "count": 82,
        "measurements": [
            "Cores",
            "Sockets"
        ],
        "product": "OpenShift Container Platform"
    }
}
```

Test with sockets
```
http GET ':8000/api/rhsm-subscriptions/v1/instances/products/OpenShift%20Container%20Platform?dir=desc&ending=2023-06-30T23:59:59.999Z&limit=100&offset=0&sort=last_seen&beginning=2023-06-01T00:00:00Z&uom=sockets' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Observe - count 82
```
{
...
...
    "meta": {
        "count": 82,
        "measurements": [
            "Cores",
            "Sockets"
        ],
        "product": "OpenShift Container Platform"
    }
}
```

### Test fix on PR branch

Check out this branch and deploy again.

Test with cores
```
http GET ':8000/api/rhsm-subscriptions/v1/instances/products/OpenShift%20Container%20Platform?dir=desc&ending=2023-06-30T23:59:59.999Z&limit=100&offset=0&sort=last_seen&beginning=2023-06-01T00:00:00Z&uom=cores' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Observe - count 48
```
{
...
...
    "meta": {
        "count": 48,
        "measurements": [
            "Cores",
            "Sockets"
        ],
        "product": "OpenShift Container Platform"
    }
}
```

Test with sockets
```
http GET ':8000/api/rhsm-subscriptions/v1/instances/products/OpenShift%20Container%20Platform?dir=desc&ending=2023-06-30T23:59:59.999Z&limit=100&offset=0&sort=last_seen&beginning=2023-06-01T00:00:00Z&uom=sockets' x-rh-identity:$(echo '{"identity":{"account_number":"account123","type":"User","internal":{"org_id":"org123"}}}'| base64 -w0)
```

Observe - count 34
```
{
...
...
    "meta": {
        "count": 34,
        "measurements": [
            "Cores",
            "Sockets"
        ],
        "product": "OpenShift Container Platform"
    }
}
```
