### PR TITLE
SWATCH-1554 Reduce subscription sync memory use

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.subscriptions.inventory.db;
 
-import static org.hibernate.jpa.QueryHints.HINT_FETCH_SIZE;
-import static org.hibernate.jpa.QueryHints.HINT_READONLY;
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.HibernateHints.HINT_READ_ONLY;
 
 import jakarta.persistence.QueryHint;
 import java.util.Collection;
@@ -42,7 +42,7 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
   @QueryHints(
       value = {
         @QueryHint(name = HINT_FETCH_SIZE, value = "1024"),
-        @QueryHint(name = HINT_READONLY, value = "true")
+        @QueryHint(name = HINT_READ_ONLY, value = "true")
       })
   Stream<InventoryHostFacts> streamFacts(
       @Param("orgId") String orgId, @Param("culledOffsetDays") Integer culledOffsetDays);
@@ -109,7 +109,7 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
   @QueryHints(
       value = {
         @QueryHint(name = HINT_FETCH_SIZE, value = "1024"),
-        @QueryHint(name = HINT_READONLY, value = "true")
+        @QueryHint(name = HINT_READ_ONLY, value = "true")
       })
   Stream<String> streamActiveSubscriptionManagerIds(
       @Param("orgId") String orgId, @Param("culledOffsetDays") Integer culledOffsetDays);

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.subscriptions.inventory.db;
 
-import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
-import static org.hibernate.jpa.HibernateHints.HINT_READ_ONLY;
+import static org.hibernate.jpa.AvailableHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.AvailableHints.HINT_READ_ONLY;
 
 import jakarta.persistence.QueryHint;
 import java.util.Collection;

--- a/src/main/java/org/candlepin/subscriptions/subscription/CustomBatchIterator.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/CustomBatchIterator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription;
+
+import static java.util.Spliterator.ORDERED;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class CustomBatchIterator<T> implements Iterator<List<T>> {
+  private final int batchSize;
+  private List<T> currentBatch;
+  private final Iterator<T> iterator;
+
+  private CustomBatchIterator(Iterator<T> sourceIterator, int batchSize) {
+    this.batchSize = batchSize;
+    this.iterator = sourceIterator;
+  }
+
+  @Override
+  public List<T> next() {
+    prepareNextBatch();
+    return currentBatch;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iterator.hasNext();
+  }
+
+  private void prepareNextBatch() {
+    currentBatch = new ArrayList<>(batchSize);
+    while (iterator.hasNext() && currentBatch.size() < batchSize) {
+      currentBatch.add(iterator.next());
+    }
+  }
+
+  public static <T> Stream<List<T>> batchStreamOf(Stream<T> stream, int batchSize) {
+    return stream(new CustomBatchIterator<>(stream.iterator(), batchSize));
+  }
+
+  private static <T> Stream<T> stream(Iterator<T> iterator) {
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, ORDERED), false);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.hibernate.jpa.QueryHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
 
 import jakarta.persistence.QueryHint;
 import jakarta.persistence.criteria.CriteriaBuilder;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.AvailableHints.HINT_FETCH_SIZE;
 
 import jakarta.persistence.QueryHint;
 import jakarta.persistence.criteria.CriteriaBuilder;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.hibernate.jpa.QueryHints.HINT_FETCH_SIZE;
-import static org.hibernate.jpa.QueryHints.HINT_READONLY;
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.HibernateHints.HINT_READ_ONLY;
 
 import jakarta.persistence.QueryHint;
 import java.util.stream.Stream;
@@ -47,7 +47,7 @@ public interface HostTallyBucketRepository extends CrudRepository<HostTallyBucke
   @QueryHints(
       value = {
         @QueryHint(name = HINT_FETCH_SIZE, value = "1024"),
-        @QueryHint(name = HINT_READONLY, value = "true")
+        @QueryHint(name = HINT_READ_ONLY, value = "true")
       })
-  public Stream<AccountBucketTally> tallyHostBuckets(String orgId, String instanceType);
+  Stream<AccountBucketTally> tallyHostBuckets(String orgId, String instanceType);
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
-import static org.hibernate.jpa.HibernateHints.HINT_READ_ONLY;
+import static org.hibernate.jpa.AvailableHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.AvailableHints.HINT_READ_ONLY;
 
 import jakarta.persistence.QueryHint;
 import java.util.stream.Stream;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -21,7 +21,7 @@
 package org.candlepin.subscriptions.db;
 
 import static org.candlepin.subscriptions.db.HypervisorReportCategory.NON_HYPERVISOR;
-import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.AvailableHints.HINT_FETCH_SIZE;
 
 import jakarta.persistence.QueryHint;
 import jakarta.persistence.criteria.CriteriaBuilder;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -21,7 +21,9 @@
 package org.candlepin.subscriptions.db;
 
 import static org.candlepin.subscriptions.db.HypervisorReportCategory.NON_HYPERVISOR;
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
 
+import jakarta.persistence.QueryHint;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
@@ -48,6 +50,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.util.ObjectUtils;
 
@@ -73,12 +76,12 @@ public interface SubscriptionRepository
       "SELECT s FROM Subscription s WHERE s.subscriptionNumber = :subscriptionNumber ORDER BY s.subscriptionId, s.startDate")
   Optional<Subscription> findBySubscriptionNumber(String subscriptionNumber);
 
-  @EntityGraph(value = "graph.SubscriptionSync")
   // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(
       "SELECT s FROM Subscription s LEFT JOIN FETCH s.offering o WHERE o.sku = :sku ORDER BY s.subscriptionId, s.startDate")
   Page<Subscription> findByOfferingSku(String sku, Pageable pageable);
 
+  @QueryHints(value = {@QueryHint(name = HINT_FETCH_SIZE, value = "1024")})
   @EntityGraph(value = "graph.SubscriptionSync")
   // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
-import static org.hibernate.jpa.HibernateHints.HINT_READ_ONLY;
+import static org.hibernate.jpa.AvailableHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.AvailableHints.HINT_READ_ONLY;
 
 import jakarta.persistence.QueryHint;
 import java.time.OffsetDateTime;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.hibernate.jpa.QueryHints.HINT_FETCH_SIZE;
-import static org.hibernate.jpa.QueryHints.HINT_READONLY;
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
+import static org.hibernate.jpa.HibernateHints.HINT_READ_ONLY;
 
 import jakarta.persistence.QueryHint;
 import java.time.OffsetDateTime;
@@ -143,7 +143,7 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
   @QueryHints(
       value = {
         @QueryHint(name = HINT_FETCH_SIZE, value = "1024"),
-        @QueryHint(name = HINT_READONLY, value = "true")
+        @QueryHint(name = HINT_READ_ONLY, value = "true")
       })
   @Query(
       """

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -49,7 +49,9 @@ import lombok.*;
       @NamedAttributeNode("subscriptionProductIds")
     },
     subgraphs = {
-      @NamedSubgraph(name = "subgraph.offering", attributeNodes = @NamedAttributeNode("productIds"))
+      @NamedSubgraph(
+          name = "subgraph.offering",
+          attributeNodes = {@NamedAttributeNode("childSkus"), @NamedAttributeNode("productIds")})
     })
 public class Subscription implements Serializable {
 
@@ -60,7 +62,7 @@ public class Subscription implements Serializable {
   @Column(name = "subscription_number")
   private String subscriptionNumber;
 
-  @ManyToOne(fetch = FetchType.EAGER)
+  @ManyToOne
   @JoinColumn(name = "sku")
   private Offering offering;
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1554](https://issues.redhat.com/browse/SWATCH-1554)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Old Flow:
- Create a List of all the Subscription dtos for an org from the Subscription Service
- Create a Map of all the Subscrpition entities for an org from the database
- Loop through the dtos, cross referencing the entities map.  Sync or delete corresponding Subscription entity.

New Flow:
- Create a Map of all the Subscription dtos for an org from the Subscription Service
- Stream Subscription entities from the database.  Added a @QueryHint to  `Stream<Subscription> findByOrgId(String orgId)` to fetch in batches.
- Loop over Stream<Subscription> in batches, allowing us to periodically flush `subscriptionRepository` and clear the entity manager to release already processed Subscription entities hanging out in memory.

Misc. Changes: 
- Stop using @EntityGraph when invoking findByOfferingSku, which was the source of `HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory` warning when syncing an offering during capacity reconcilliation.

- Switch `QueryHints` for `HibernateHints` because `QueryHints` is marked as deprecated as of Hibernate 6.

Co-authored-by: Kevin Howell <khowell@redhat.com>


## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Unit tests & IQE/Regression testing mainly.

If you want to play yourself, it's easiest to grab some data off of stage to load up locally.  I used a combination of the **jconsole** profiler as well as the one built into IntelliJ to compare memory usage.

The closest way I've found to replicating the hardware limitations in stage is by assembling the jar and passing some JVM arguments, rather than starting the application with :bootRun like we usually do.  When we started experiencing the crash looping due to OOM, the max memory was set to 800m.  At the time of writing this, it's at 2G.

```bash
./gradlew :assemble

DEV_MODE=true SPRING_PROFILES_ACTIVE=kafka-queue,capacity-ingress java -Xmx800m -XX:ActiveProcessorCount=1 -jar /home/lburnett/code/rhsm-subscriptions/build/libs/rhsm-subscriptions-1.1.0-snapshot.202308031816.uncommitted+lburnett.subscription.sync.memory.2eebc5c.jar
```


### Steps
<!-- Enter each step of the test below -->
1.  Get a bunch of data in your database
2. Start application with `capacity-ingress,kafka-queue` profiles.  Don't use stubs for the product service.
3. Kick of subscription sync for an org
```
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/**orgId** x-rh-swatch-psk:placeholder
```
OR
Kick off a subscription sync for all orgs
```
http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/subscriptions/sync x-rh-swatch-psk:placeholder
```

### Verification
Here are some screenshots of resource usage from before and after the changes.  These were taken with no JVM limitations, and were captured while syncing all orgs (via the http command above).


**main branch**
![image](https://github.com/RedHatInsights/rhsm-subscriptions/assets/19955562/c97d08e9-ef26-4e50-bb46-50c991b9d226)



**this branch**

Note the memory doesn't spike as high, the overall process takes significantly less time, and the CPU/Memory usage are more uniform.  The slow increase in heap usage towards the end is when the service was just sitting idle in the background because I didn't disconnect the profile immediately after it finishing.

![image](https://github.com/RedHatInsights/rhsm-subscriptions/assets/19955562/d8da75c5-8b3e-4426-bc1c-e9cf30840439)

