### PR TITLE
SWATCH-1557: Fix DuplicateKeyException during SubscriptionSyncController.forceSyncSubscriptionsForOrg

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionMeasurementRepositoryTest.java
@@ -163,7 +163,7 @@ class SubscriptionMeasurementRepositoryTest {
   }
 
   @Test
-  void testFindsSubStartingBeforeRangeAndEndingDuringRange() { // *
+  void testFindsSubStartingBeforeRangeAndEndingDuringRange() {
     var specification =
         SubscriptionMeasurementRepository.subscriptionIsActiveBetween(
             START.plusDays(5), END.plusDays(5));
@@ -172,7 +172,7 @@ class SubscriptionMeasurementRepositoryTest {
   }
 
   @Test
-  void testFindsSubStartingBeforeRangeAndEndingAfterRange() { // *
+  void testFindsSubStartingBeforeRangeAndEndingAfterRange() {
     var specification =
         SubscriptionMeasurementRepository.subscriptionIsActiveBetween(
             START.plusDays(5), END.minusDays(5));
@@ -181,7 +181,7 @@ class SubscriptionMeasurementRepositoryTest {
   }
 
   @Test
-  void testFindsSubStartingDuringRangeAndEndingDuringRange() { // *
+  void testFindsSubStartingDuringRangeAndEndingDuringRange() {
     var specification =
         SubscriptionMeasurementRepository.subscriptionIsActiveBetween(
             START.minusDays(5), END.plusDays(5));
@@ -190,7 +190,7 @@ class SubscriptionMeasurementRepositoryTest {
   }
 
   @Test
-  void testFindsSubStartingDuringRangeAndEndingAfterRange() { // *
+  void testFindsSubStartingDuringRangeAndEndingAfterRange() {
     var specification =
         SubscriptionMeasurementRepository.subscriptionIsActiveBetween(
             START.minusDays(5), END.minusDays(5));

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.*;
 import jakarta.ws.rs.core.Response;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.HypervisorReportCategory;
@@ -279,7 +280,7 @@ class CapacityResourceTest {
 
     when(repository.findAllBy(
             "owner123456", RHEL.toString(), ServiceLevel._ANY, Usage.PRODUCTION, begin, end))
-        .thenReturn(subscription.getSubscriptionMeasurements());
+        .thenReturn(new ArrayList<>(subscription.getSubscriptionMeasurements()));
 
     List<CapacitySnapshot> actual =
         resource.getCapacities(
@@ -313,7 +314,7 @@ class CapacityResourceTest {
     when(subscriptionRepository.findUnlimited(criteria)).thenReturn(List.of(subscription));
 
     when(repository.findAllBy("owner123456", RHEL.toString(), null, null, min, max))
-        .thenReturn(subscription.getSubscriptionMeasurements());
+        .thenReturn(new ArrayList<>(subscription.getSubscriptionMeasurements()));
 
     CapacityReport report =
         resource.getCapacityReport(RHEL, GranularityType.DAILY, min, max, null, null, null, null);
@@ -767,7 +768,7 @@ class CapacityResourceTest {
             Usage.PRODUCTION,
             min,
             max))
-        .thenReturn(s.getSubscriptionMeasurements());
+        .thenReturn(new ArrayList<>(s.getSubscriptionMeasurements()));
 
     List<CapacitySnapshotByMetricId> actual =
         resource.getCapacitiesByMetricId(
@@ -803,7 +804,7 @@ class CapacityResourceTest {
 
     when(repository.findAllBy(
             "owner123456", RHEL.toString(), MetricId.CORES, null, null, null, min, max))
-        .thenReturn(limited.getSubscriptionMeasurements());
+        .thenReturn(new ArrayList<>(limited.getSubscriptionMeasurements()));
 
     var criteria =
         DbReportCriteria.builder()

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -20,8 +20,6 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.candlepin.subscriptions.db.SpringDataUtil.*;
-
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
@@ -56,8 +54,6 @@ public interface SubscriptionRepository
     extends JpaRepository<Subscription, Subscription.SubscriptionCompoundId>,
         JpaSpecificationExecutor<Subscription> {
 
-  String OFFERING_ALIAS = "offering";
-
   @Query(
       """
         SELECT s FROM Subscription s
@@ -74,6 +70,7 @@ public interface SubscriptionRepository
   Page<Subscription> findByOfferingSku(String sku, Pageable pageable);
 
   @EntityGraph(value = "graph.SubscriptionSync")
+  @Query("SELECT DISTINCT s FROM Subscription s WHERE s.orgId = :orgId")
   Stream<Subscription> findByOrgId(String orgId);
 
   void deleteBySubscriptionId(String subscriptionId);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -23,10 +23,8 @@ package org.candlepin.subscriptions.db.model;
 import jakarta.persistence.*;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import lombok.*;
@@ -98,7 +96,7 @@ public class Subscription implements Serializable {
   @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   @ToString.Exclude // Excluded to prevent fetching a lazy-loaded collection
-  private List<SubscriptionMeasurement> subscriptionMeasurements = new ArrayList<>();
+  private Set<SubscriptionMeasurement> subscriptionMeasurements = new HashSet<>();
 
   @Override
   public boolean equals(Object o) {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1557](https://issues.redhat.com/browse/SWATCH-1557)

## Description
The call to `SubscriptionRepository.findByOrgId` was returning multiple copies of the same subscription (all with a single product ID on the offering) instead of just a single subscription with multiple product IDs on the offering.  The result was in `reconcileSubscriptionsWithSubscriptionService` we were creating a map of SubscriptionCompoundIds to Subscriptions and looping through all the subscriptions returned would result in creating (and attempting to insert) the same SubscriptionCompoundId into the map.

This behavior was a result of adding the product IDs to the named entity graph defined on the Subscription object.  I was unable to duplicate this behavior in a unit test but I could replicate it with stage data.

<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Configure your deployment to point to the stage subscription service.  You'll need to export the stage keystore and truststore and the truststore password.  I have a script that can assist with this.
1. Add the following to your `config/application.properties`
```
RHSM_TRUSTSTORE=...
RHSM_TRUSTSTORE_PASSWORD=...
RHSM_KEYSTORE=...
RHSM_KEYSTORE_PASSWORD=...
SUBSCRIPTION_KEYSTORE=...
SUBSCRIPTION_KEYSTORE_PASSWORD=...
rhsm-subscription.subscription.use-stub=${SUBSCRIPTION_USE_STUB:false}
rhsm-subscription.subscription.url=${SUBSCRIPTION_URL:https://subscription.stage.api.redhat.com/svcrest/subscription/v5}
rhsm-subscription.subscription.keystore=file:${SUBSCRIPTION_KEYSTORE:}
rhsm-subscription.subscription.keystore-password=${SUBSCRIPTION_KEYSTORE_PASSWORD:changeit}
rhsm-subscription.subscription.truststore=file:${RHSM_TRUSTSTORE:}
rhsm-subscription.subscription.truststore-password=${RHSM_TRUSTSTORE_PASSWORD:changeit}
rhsm-subscription.subscription.enablePaygSubscriptionForceSync=true
```
1. See me for a database with records you can use

### Steps
<!-- Enter each step of the test below -->
1. Start the application with 
   ```
   ./gradlew :bootRun --args="--rhsm-subscriptions.enableSynchronousOperations=true --rhsm-subscriptions.subscription.enablePaygSubscriptionForceSync=true" --debug-jvm
   ```
1. Connect with the debugger and set a breakpoint on line 330 of SubscriptionSyncController.
1. Run
   ```
   http :8000/api/rhsm-subscriptions/v1/internal/subscriptions/rhmUsageContext orgId==16775631 productId=='OpenShift-metrics' sla=='Standard' usage=='Production' date=='2021-01-01T00:00:00Z' 'x-rh-swatch-psk:placeholder'
   ```
1.  At the breakpoint evaluate the following expression: `subs.filter(x -> x.getSubscriptionId().equals("12457789")).toList()`.  You'll see 26 results.  If you inspect those results, you'll notice it's 26 copies of the same object and that the offering on each subscription has only one product ID.

### Verification
1.  Checkout this branch
1. Start the application with 
   ```
   ./gradlew :bootRun --args="--rhsm-subscriptions.enableSynchronousOperations=true --rhsm-subscriptions.subscription.enablePaygSubscriptionForceSync=true" --debug-jvm
   ```
1. Connect with the debugger and set a breakpoint on line 330 of SubscriptionSyncController.
1. Run
   ```
   http :8000/api/rhsm-subscriptions/v1/internal/subscriptions/rhmUsageContext orgId==16775631 productId=='OpenShift-metrics' sla=='Standard' usage=='Production' date=='2021-01-01T00:00:00Z' 'x-rh-swatch-psk:placeholder'
   ```
1.  At the breakpoint evaluate the following expression: `subs.filter(x -> x.getSubscriptionId().equals("12457789")).toList()`.  You'll see **1** result.  If you inspect that result, you'll notice the offering on the subscription has **26** product IDs.

