### PR TITLE
SWATCH-1397 Migrate from subscription_labels to ocm_subscriptions prometheus label

### DIFF
--- a/bin/GeneratingPrometheusMetricData.adoc
+++ b/bin/GeneratingPrometheusMetricData.adoc
@@ -11,16 +11,30 @@ bin/prometheus-mock-data.sh
 ----
 
 == Testing The API
+=== WEB UI
 http://localhost:9090/graph is useful to try PromQL queries.
 
+Query:
+[source]
+kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months * on (_id) group_right min_over_time (ocm_subscription{product="rhosak", external_organization="org123", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+
+Res:
+[source]
+`3600`
+
+Range:
+[source]
+`6h`
+
+=== CURL
 Using ``START_DATE=$(date -d yesterday +%s)`` and ``END_DATE=$(date +%s)`` (last 24 hours) and plug them into the curl commands below.
 
 [source,bash]
 ----
-curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibytes+*+on%28_id%29+group_right+min_over_time%28ocm_subscription%7Bproduct%3D%22rhosak%22%2C+ebs_account%3D%22account123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=${START_DATE}&end=${END_DATE}&step=3600&max_source_resolution=0s'
+curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibyte_months+*+on%28_id%29+group_right+min_over_time%28ocm_subscription%7Bproduct%3D%22rhosak%22%2C+external_organization%3D%22org123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=${START_DATE}&end=${END_DATE}&step=3600&max_source_resolution=0s'
 
 # Example
-curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibytes+*+on%28_id%29+group_right+min_over_time%28ocm_subscription%7Bproduct%3D%22rhosak%22%2C+ebs_account%3D%22account123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=1651449600&end=1651506600&step=3600&max_source_resolution=0s'
+curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibyte_months+*+on%28_id%29+group_right+min_over_time%28ocm_subscription%7Bproduct%3D%22rhosak%22%2C+external_organization%3D%22org123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=1651449600&end=1651506600&step=3600&max_source_resolution=0s'
 ----
 
 == Pointing Subscription Watch At The Local Prometheus

--- a/bin/GeneratingPrometheusMetricData.adoc
+++ b/bin/GeneratingPrometheusMetricData.adoc
@@ -17,10 +17,10 @@ Using ``START_DATE=$(date -d yesterday +%s)`` and ``END_DATE=$(date +%s)`` (last
 
 [source,bash]
 ----
-curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibytes+*+on%28_id%29+group_right+min_over_time%28subscription_labels%7Bproduct%3D%22rhosak%22%2C+ebs_account%3D%22account123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=${START_DATE}&end=${END_DATE}&step=3600&max_source_resolution=0s'
+curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibytes+*+on%28_id%29+group_right+min_over_time%28ocm_subscription%7Bproduct%3D%22rhosak%22%2C+ebs_account%3D%22account123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=${START_DATE}&end=${END_DATE}&step=3600&max_source_resolution=0s'
 
 # Example
-curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibytes+*+on%28_id%29+group_right+min_over_time%28subscription_labels%7Bproduct%3D%22rhosak%22%2C+ebs_account%3D%22account123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=1651449600&end=1651506600&step=3600&max_source_resolution=0s'
+curl 'http://localhost:9090/api/v1/query_range?query=kafka_id%3Akafka_broker_quota_totalstorageusedbytes%3Amax_over_time1h_gibibytes+*+on%28_id%29+group_right+min_over_time%28ocm_subscription%7Bproduct%3D%22rhosak%22%2C+ebs_account%3D%22account123%22%2C+billing_model%3D%22marketplace%22%2C+support%3D%7E%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&dedup=true&partial_response=false&start=1651449600&end=1651506600&step=3600&max_source_resolution=0s'
 ----
 
 == Pointing Subscription Watch At The Local Prometheus

--- a/bin/prometheus-mock-data.sh
+++ b/bin/prometheus-mock-data.sh
@@ -35,8 +35,8 @@ entrypoint() {
   echo "Generating mock data for _id=$CLUSTER_ID,product=$PRODUCT,metrics=$METRICS"
 
   cat <<EOF > $FILE
-# HELP subscription_labels placeholder
-# TYPE subscription_labels counter
+# HELP ocm_subscription placeholder
+# TYPE ocm_subscription counter
 EOF
 
   for METRIC in $METRICS; do
@@ -49,7 +49,7 @@ EOF
   while [ $TIME -lt $NOW ]; do
     TIME=$(($TIME + 300))
     cat <<EOF >> $FILE
-subscription_labels{_id="$CLUSTER_ID",billing_model="marketplace",ebs_account="$ACCOUNT",external_organization="$ORG_ID",support="Premium",billing_provider="$BILLING_PROVIDER",billing_marketplace_account="$MARKETPLACE_ACCOUNT",product="$PRODUCT"} 1.0 $TIME
+ocm_subscription{_id="$CLUSTER_ID",billing_model="marketplace",ebs_account="$ACCOUNT",external_organization="$ORG_ID",support="Premium",billing_provider="$BILLING_PROVIDER",billing_marketplace_account="$MARKETPLACE_ACCOUNT",product="$PRODUCT"} 1.0 $TIME
 EOF
     for METRIC in $METRICS; do
       VALUE=$(($RANDOM % 100))

--- a/src/test/java/org/candlepin/subscriptions/metering/RhacsTagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/RhacsTagProfileTest.java
@@ -77,7 +77,7 @@ class RhacsTagProfileTest {
                         "product", "rhacs",
                         "prometheusMetric",
                             "rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h",
-                        "prometheusMetadataMetric", "subscription_labels"))
+                        "prometheusMetadataMetric", "ocm_subscription"))
                 .build()));
   }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/RhosakTagProfileTest.java
@@ -75,7 +75,7 @@ class RhosakTagProfileTest {
                         "product", "rhosak",
                         "prometheusMetric",
                             "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes",
-                        "prometheusMetadataMetric", "subscription_labels"))
+                        "prometheusMetadataMetric", "ocm_subscription"))
                 .build()),
         Arguments.of(
             "rhosak",
@@ -96,7 +96,7 @@ class RhosakTagProfileTest {
                         "prometheusMetric",
                         "kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes",
                         "prometheusMetadataMetric",
-                        "subscription_labels"))
+                        "ocm_subscription"))
                 .build()),
         Arguments.of(
             "rhosak",
@@ -114,7 +114,7 @@ class RhosakTagProfileTest {
                     Map.of(
                         "product", "rhosak",
                         "prometheusMetric", "kafka_id:strimzi_resource_state:max_over_time1h",
-                        "prometheusMetadataMetric", "subscription_labels"))
+                        "prometheusMetadataMetric", "ocm_subscription"))
                 .build()),
         Arguments.of(
             "rhosak",
@@ -134,7 +134,7 @@ class RhosakTagProfileTest {
                         "prometheusMetric",
                         "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months",
                         "prometheusMetadataMetric",
-                        "subscription_labels"))
+                        "ocm_subscription"))
                 .build()));
   }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -134,7 +134,7 @@ class PrometheusMeteringControllerTest {
     Map<String, String> queryParams = new HashMap<>();
     queryParams.put("product", "ocp");
     queryParams.put("prometheusMetric", "cluster:usage:workload:capacity_physical_cpu_hours");
-    queryParams.put("prometheusMetadataMetric", "subscription_labels");
+    queryParams.put("prometheusMetadataMetric", "ocm_subscription");
     tagMetric =
         TagMetric.builder()
             .tag("OpenShift-metrics")

--- a/src/test/java/org/candlepin/subscriptions/registry/TagProfileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/registry/TagProfileTest.java
@@ -253,7 +253,7 @@ class TagProfileTest {
 
     Map<String, String> params = new HashMap<>();
     params.put("prometheusMetric", "cluster:usage:workload:capacity_physical_cpu_cores:max:5m");
-    params.put("prometheusMetadataMetric", "subscription_labels");
+    params.put("prometheusMetadataMetric", "ocm_subscription");
 
     // Mutable List for purpose of modifying during testing.
     List<TagMetric> tagMetrics = new LinkedList<>();

--- a/src/test/resources/test_tag_profile.yaml
+++ b/src/test/resources/test_tag_profile.yaml
@@ -142,7 +142,7 @@ tagMetrics:
     queryParams:
       product: ocp
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_hours
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
   # OSD metrics
   - tag: OpenShift-dedicated-metrics
@@ -154,7 +154,7 @@ tagMetrics:
     queryParams:
       product: osd
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_hours
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: OpenShift-dedicated-metrics
     metricId: Instance-hours
     uom: INSTANCE_HOURS
@@ -163,7 +163,7 @@ tagMetrics:
     queryParams:
       product: osd
       prometheusMetric: cluster:usage:workload:capacity_physical_instance_hours
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
   # RHOSAK metrics
   - tag: rhosak
@@ -173,7 +173,7 @@ tagMetrics:
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: rhosak
     # when we update this metricId to not mirror RHM ids, make sure GiB is reflected
     metricId: Transfer-gibibytes
@@ -182,7 +182,7 @@ tagMetrics:
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: rhosak
     metricId: Instance-hours
     uom: INSTANCE_HOURS
@@ -190,7 +190,7 @@ tagMetrics:
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:strimzi_resource_state:max_over_time1h
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
 # The tagMetaData section defines additional information around how a tag is tallied.  Most notably,
 # tags need to have their finest granularity defined so that we can create accurate snapshots.  A

--- a/swatch-core/src/main/resources/tag_profile.yaml
+++ b/swatch-core/src/main/resources/tag_profile.yaml
@@ -214,7 +214,7 @@ tagMetrics:
     queryParams:
       product: ocp
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_hours
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
   # OSD metrics
   - tag: OpenShift-dedicated-metrics
@@ -227,7 +227,7 @@ tagMetrics:
     queryParams:
       product: osd
       prometheusMetric:  cluster:usage:workload:capacity_physical_cpu_hours
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: OpenShift-dedicated-metrics
     metricId: Instance-hours
     rhmMetricId: redhat.com:openshift_dedicated:cluster_hour
@@ -237,7 +237,7 @@ tagMetrics:
     queryParams:
       product: osd
       prometheusMetric: cluster:usage:workload:capacity_physical_instance_hours
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
   # RHOSAK metrics
   - tag: rhosak
@@ -248,7 +248,7 @@ tagMetrics:
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: rhosak
     # when we update this metricId to not mirror RHM ids, make sure GiB is reflected
     metricId: Transfer-gibibytes
@@ -259,7 +259,7 @@ tagMetrics:
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: rhosak
     metricId: Instance-hours
     rhmMetricId: redhat.com:rhosak:cluster_hour
@@ -269,7 +269,7 @@ tagMetrics:
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:strimzi_resource_state:max_over_time1h
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: rhosak
     metricId: Storage-gibibyte-months
     awsDimension: storage_gb
@@ -278,7 +278,7 @@ tagMetrics:
     queryParams:
       product: rhosak
       prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
   # RHACS metrics
   - tag: rhacs
@@ -290,7 +290,7 @@ tagMetrics:
     queryParams:
       product: rhacs
       prometheusMetric: rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
    #RHODS metrics
   - tag: rhods
@@ -315,7 +315,7 @@ tagMetrics:
     queryParams:
       product: BASILISK
       prometheusMetric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: BASILISK
     metricId: Instance-hours
     rhmMetricId: redhat.com:BASILISK:cluster_hour
@@ -325,7 +325,7 @@ tagMetrics:
     queryParams:
       product: BASILISK
       prometheusMetric: kafka_id:strimzi_resource_state:max_over_time1h
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: BASILISK
     metricId: Storage-gibibyte-months
     rhmMetricId: redhat.com:BASILISK:storage_gib_months
@@ -335,7 +335,7 @@ tagMetrics:
     queryParams:
       product: BASILISK
       prometheusMetric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
   #ROSA tag metadata
   - tag: rosa
@@ -347,7 +347,7 @@ tagMetrics:
     queryParams:
       product: moa-hostedcontrolplane
       prometheusMetric: cluster:usage:workload:capacity_physical_instance_hours
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
   - tag: rosa
     metricId: Cores
     rhmMetricId: redhat.com:rosa:cpu_hour
@@ -358,7 +358,7 @@ tagMetrics:
     queryParams:
       product: moa-hostedcontrolplane
       prometheusMetric: cluster:usage:workload:capacity_physical_cpu_hours
-      prometheusMetadataMetric: subscription_labels
+      prometheusMetadataMetric: ocm_subscription
 
   # RHEL metrics. This is ugly and we should find a way to consolidate this.
   - tag: RHEL

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-dedicated-metrics.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-dedicated-metrics.yaml
@@ -26,7 +26,7 @@ metrics:
       queryParams:
         product: osd
         metric: cluster:usage:workload:capacity_physical_cpu_hours
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription
   - id: Instance-hours
     rhmMetricId: redhat.com:openshift_dedicated:cluster_hour
     prometheus:
@@ -34,4 +34,4 @@ metrics:
       queryParams:
         product: osd
         metric: cluster:usage:workload:capacity_physical_instance_hours
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-metrics.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-metrics.yaml
@@ -25,4 +25,4 @@ metrics:
       queryParams:
         product: ocp
         metric: cluster:usage:workload:capacity_physical_cpu_hours
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/basilisk.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/basilisk.yaml
@@ -25,7 +25,7 @@ metrics:
       queryParams:
         product: BASILISK
         metric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription
   - id: Instance-hours
     rhmMetricId: redhat.com:BASILISK:cluster_hour
     awsDimension: cluster_hour
@@ -33,7 +33,7 @@ metrics:
       queryParams:
         product: BASILISK
         metric: kafka_id:strimzi_resource_state:max_over_time1h
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription
   - id: Storage-gibibyte-months
     rhmMetricId: redhat.com:BASILISK:storage_gib_months
     awsDimension: storage_gb
@@ -41,4 +41,4 @@ metrics:
       queryParams:
         product: BASILISK
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacs.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacs.yaml
@@ -24,4 +24,4 @@ metrics:
       queryParams:
         product: rhacs
         metric: rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhosak.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhosak.yaml
@@ -25,7 +25,7 @@ metrics:
       queryParams:
         product: rhosak
         metric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription
   - id: Instance-hours
     rhmMetricId: redhat.com:rhosak:cluster_hour
     awsDimension: cluster_hour
@@ -33,7 +33,7 @@ metrics:
       queryParams:
         product: rhosak
         metric: kafka_id:strimzi_resource_state:max_over_time1h
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription
   - id: Storage-gibibyte-months
     rhmMetricId: redhat.com:rhosak:storage_gib_months
     awsDimension: storage_gb
@@ -41,11 +41,11 @@ metrics:
       queryParams:
         product: rhosak
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription
   - id: Storage-gibibytes
     rhmMetricId: redhat.com:rhosak:storage_gb
     prometheus:
       queryParams:
         product: rhosak
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
@@ -24,7 +24,7 @@ metrics:
       queryParams:
         product: moa-hostedcontrolplane
         metric: cluster:usage:workload:capacity_physical_instance_hours
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription
   - id: Cores
     awsDimension: four_vcpu_0
     billingFactor: 0.25
@@ -32,4 +32,4 @@ metrics:
       queryParams:
         product: moa-hostedcontrolplane
         metric: cluster:usage:workload:capacity_physical_cpu_hours
-        metadataMetric: subscription_labels
+        metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
@@ -106,7 +106,7 @@ class SubscriptionDefinitionTest {
             "metric",
             "kafka_id:strimzi_resource_state:max_over_time1h",
             "metadataMetric",
-            "subscription_labels"));
+            "ocm_subscription"));
     metric.setPrometheus(prometheusMetric);
 
     var expected = Optional.of(metric);


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1397](https://issues.redhat.com/browse/SWATCH-1397)

## Description
Use the `ocm_subscriptions` prometheus metric as a meta data metric so that OCM can retire the legacy `subscription_labels`. 

This change will affect the prometheus queries for all metered products that utilize the subscription_labels metric. These include:

* OpenShift-metrics
* OpenShift-dedicated-metrics
* rhosak
* rhacs
* basilisk
* rosa


## Testing

### No more references
Verify that there are no more references to `subscription_labels` in our codebase.
```
git grep subscription_labels
```

### Testing scripts function correctly
Follow the steps in [bin/GeneratingPrometheusMetricData.adoc](https://github.com/RedHatInsights/rhsm-subscriptions/compare/mstead/SWATCH-1397-migrate-from-subscription-labels-to-ocm_subscriptions?expand=1#diff-56534a771a3af252fd27849f189d077fdc7438869b7fca807e0bfa81b50d82f7) to ensure that the testing scripts function correctly.

### Verify metric is available in stage/production prometheus
Verify that the metric is available in the stage/production environments. Visit the links below and use SSO when logging in, and verify that the same results are present for 'ocm_subscription' and 'subscription_labels'.

The links below check for the **moa-hostedcontrolplane** product. You can test that the other metrics are present for other products as well. Look in the tag_profile.xml for:
```
    queryParams:
      product: <USE_THIS_PRODUCT_IN_PROMQL_QUERY>
```

[Stage](https://grafana.app-sre.devshift.net/explore?orgId=1&left=%7B%22datasource%22:%22PFC7968DB0218CE3F%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22PFC7968DB0218CE3F%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22ocm_subscription%7Bproduct%3D%5C%22moa-hostedcontrolplane%5C%22,%20billing_model%3D%5C%22marketplace%5C%22,%20support%3D~%5C%22Premium%7CStandard%7CSelf-Support%7CNone%5C%22%7D%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D&right=%7B%22datasource%22:%22PFC7968DB0218CE3F%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22PFC7968DB0218CE3F%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22subscription_labels%7Bproduct%3D%5C%22moa-hostedcontrolplane%5C%22,%20billing_model%3D%5C%22marketplace%5C%22,%20support%3D~%5C%22Premium%7CStandard%7CSelf-Support%7CNone%5C%22%7D%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D)

[Production](https://grafana.app-sre.devshift.net/explore?orgId=1&left=%7B%22datasource%22:%22PD776AFABBE26000A%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22PD776AFABBE26000A%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22ocm_subscription%7Bproduct%3D%5C%22moa-hostedcontrolplane%5C%22,%20billing_model%3D%5C%22marketplace%5C%22,%20support%3D~%5C%22Premium%7CStandard%7CSelf-Support%7CNone%5C%22%7D%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D&right=%7B%22datasource%22:%22PD776AFABBE26000A%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22PD776AFABBE26000A%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22subscription_labels%7Bproduct%3D%5C%22moa-hostedcontrolplane%5C%22,%20billing_model%3D%5C%22marketplace%5C%22,%20support%3D~%5C%22Premium%7CStandard%7CSelf-Support%7CNone%5C%22%7D%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D)


