### PR TITLE
Add a merge function to Collectors.toMap

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -331,7 +331,8 @@ public class SubscriptionSyncController {
           subs.collect(
               Collectors.toMap(
                   sub -> new SubscriptionCompoundId(sub.getSubscriptionId(), sub.getStartDate()),
-                  Function.identity()));
+                  Function.identity(),
+                  (s1, s2) -> s1));
     }
     subscriptions
         .filter(this::shouldSyncSub)


### PR DESCRIPTION
When there are multiple subscriptions with the same subscription id & start date, the collecting to map throws a Collectors.duplicateKeyException exception.  This merge function will say "take the first one".


<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-XXXX](https://issues.redhat.com/browse/SWATCH-XXXX)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.
