### PR TITLE
Fix billing marketplace mock

### DIFF
--- a/bin/prometheus-mock-data.sh
+++ b/bin/prometheus-mock-data.sh
@@ -49,7 +49,7 @@ EOF
   while [ $TIME -lt $NOW ]; do
     TIME=$(($TIME + 300))
     cat <<EOF >> $FILE
-ocm_subscription{_id="$CLUSTER_ID",billing_model="marketplace",ebs_account="$ACCOUNT",external_organization="$ORG_ID",support="Premium",billing_provider="$BILLING_PROVIDER",billing_marketplace_account="$MARKETPLACE_ACCOUNT",product="$PRODUCT"} 1.0 $TIME
+ocm_subscription{_id="$CLUSTER_ID",billing_model="marketplace",ebs_account="$ACCOUNT",external_organization="$ORG_ID",support="Premium",billing_marketplace="$BILLING_PROVIDER",billing_marketplace_account="$MARKETPLACE_ACCOUNT",product="$PRODUCT"} 1.0 $TIME
 EOF
     for METRIC in $METRICS; do
       VALUE=$(($RANDOM % 100))


### PR DESCRIPTION
## Description

Currently whatever billing_provider you pass to bin/prometheus-mock-data.sh, metering events or instances api always consider it "red hat" default billing provider as it should be `billing_marketplace` in Prometheus/RHOBS.

## Testing

**Before fix:**

export BILLING_PROVIDER=aws and run bin/prometheus-mock-data.sh script, verify billing_provider from events or tally instances.

```
{'id': '234e2e72-46b7-43e0-b3f0-c34fec4e5d13',
  'instance_id': 'test01',
  'display_name': 'test01',
  'billing_provider': 'red hat',   <---------------------
  'billing_account_id': 'mktp-123',
  'measurements': [1216.0],
  'last_seen': datetime.datetime(2023, 8, 3, 12, 0, tzinfo=tzlocal()),
  'number_of_guests': 0,
  '_labeled_measurements': {'Cores': 1216.0}}
```

**After fix:** 

```
{'id': '65bf4456-ff10-4df7-ab55-ca04b532b87b',
  'instance_id': 'nikhil',
  'display_name': 'nikhil',
  'billing_provider': 'aws',      <-------------------
  'billing_account_id': 'mktp-123',
  'measurements': [1121.0],
  'last_seen': datetime.datetime(2023, 8, 3, 12, 0, tzinfo=tzlocal()),
  'number_of_guests': 0,
  '_labeled_measurements': {'Cores': 1121.0}}]
```


### Steps
1. export BILLING_PROVIDER=aws
2. sh bin/mock.sh entrypoint
3. Perform metering and sync tally hourly.

### Verification
1. Verify billing_provider is correct in instances_api/metering events as added in mocking. 
