### PR TITLE
SWATCH-1241 remove tag profile from tally resource

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -472,27 +472,13 @@ public class CapacityResource implements CapacityApi {
     return new CapacitySnapshotByMetricId().date(date).value(value).hasData(hasData);
   }
 
-  void validateGranularity(ProductId productId, Granularity granularity) {
-
-    Variant.findByTag(productId.toString())
-        .ifPresentOrElse(
-            variant -> {
-              boolean isCompatible =
-                  variant
-                      .getSubscription()
-                      .getSupportedGranularity()
-                      .contains(SubscriptionDefinitionGranularity.valueOf(granularity.name()));
-
-              if (!isCompatible) {
-                throw new BadRequestException(
-                    String.format(
-                        "%s does not support any granularity finer than %s",
-                        productId, granularity.getValue()));
-              }
-            },
-            () -> {
-              throw new BadRequestException(
-                  String.format("No granularity configuration found for %s", productId));
-            });
+  private void validateGranularity(ProductId productId, Granularity granularity) {
+    if (!Variant.isGranularityCompatible(
+        productId.toString(), SubscriptionDefinitionGranularity.valueOf(granularity.name()))) {
+      throw new BadRequestException(
+          String.format(
+              "%s does not support any granularity finer than %s",
+              productId, granularity.getValue()));
+    }
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -1163,11 +1163,21 @@ class CapacityResourceTest {
 
   @Test
   void testValidateGranularityIncompatible() {
-
     var thrownException =
         Assertions.assertThrows(
             BadRequestException.class,
-            () -> resource.validateGranularity(RHEL_FOR_ARM, Granularity.HOURLY));
+            () ->
+                resource.getCapacityReportByMetricId(
+                    RHEL_FOR_ARM,
+                    MetricId.CORES,
+                    GranularityType.HOURLY,
+                    min,
+                    max,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null));
 
     assertEquals(
         String.format(
@@ -1178,15 +1188,18 @@ class CapacityResourceTest {
 
   @ParameterizedTest
   @MethodSource("generateFinestGranularityCases")
-  void testValidateGranularity(ProductId productId, Granularity granularity) {
-    assertDoesNotThrow(() -> resource.validateGranularity(productId, granularity));
+  void testValidateGranularity(ProductId productId, GranularityType granularity) {
+    assertDoesNotThrow(
+        () ->
+            resource.getCapacityReportByMetricId(
+                productId, MetricId.CORES, granularity, min, max, null, null, null, null, null));
   }
 
   private static Stream<Arguments> generateFinestGranularityCases() {
     return Stream.of(
-        Arguments.of(BASILISK, Granularity.HOURLY),
-        Arguments.of(RHEL_FOR_ARM, Granularity.YEARLY),
-        Arguments.of(BASILISK, Granularity.YEARLY),
-        Arguments.of(RHEL_FOR_ARM, Granularity.DAILY));
+        Arguments.of(BASILISK, GranularityType.HOURLY),
+        Arguments.of(RHEL_FOR_ARM, GranularityType.YEARLY),
+        Arguments.of(BASILISK, GranularityType.YEARLY),
+        Arguments.of(RHEL_FOR_ARM, GranularityType.DAILY));
   }
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
@@ -85,6 +85,15 @@ public class Variant {
         .findFirst();
   }
 
+  public static boolean isGranularityCompatible(
+      String productId, SubscriptionDefinitionGranularity granularity) {
+    return findByTag(productId).stream()
+        .map(Variant::getSubscription)
+        .anyMatch(
+            subscriptionDefinition ->
+                subscriptionDefinition.getSupportedGranularity().contains(granularity));
+  }
+
   public static Optional<Variant> findByProductName(String productName) {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
         .map(SubscriptionDefinition::getVariants)

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
@@ -58,4 +58,16 @@ class VariantTest {
 
     assertEquals("RHEL for x86", actual.get().getTag());
   }
+
+  @Test
+  void testGranularityCompatibility() {
+    assertTrue(
+        Variant.isGranularityCompatible("RHEL for x86", SubscriptionDefinitionGranularity.DAILY));
+  }
+
+  @Test
+  void testGranularityCompatibilityNotSupported() {
+    assertFalse(
+        Variant.isGranularityCompatible("RHEL for x86", SubscriptionDefinitionGranularity.HOURLY));
+  }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1241](https://issues.redhat.com/browse/SWATCH-1241)

Draft until https://github.com/RedHatInsights/rhsm-subscriptions/pull/2369 merged.
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Remove deprecated tag_profile and use swatch-product-configuration instead in TallyResource.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Start app with : `DEV_MODE=true ./gradlew :bootRun`
1. Ensure account is opted in: 
```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

### Steps
<!-- Enter each step of the test below -->
1. Run curl with Daily granularity and no errrors should be returned:
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20Server/Cores?granularity=Daily&beginning=2023-07-21T17%3A32%3A28Z&ending=2023-07-21T17%3A32%3A28Z&use_running_totals_format=false' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
1. Run curl with Hourly granularity and unsupported granularity error should return:
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20Server/Cores?granularity=Hourly&beginning=2023-07-21T17%3A32%3A28Z&ending=2023-07-21T17%3A32%3A28Z&use_running_totals_format=false' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```