### PR TITLE
SWATCH-1591 swatch-tally opt-in on any incoming events' org IDs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
@@ -30,6 +30,7 @@ import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuild
 import org.candlepin.subscriptions.prometheus.api.ApiProvider;
 import org.candlepin.subscriptions.prometheus.api.ApiProviderFactory;
 import org.candlepin.subscriptions.registry.TagProfile;
+import org.candlepin.subscriptions.security.OptInController;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -62,8 +63,10 @@ public class PrometheusServiceConfiguration {
 
   @Bean
   EventController prometheusEventController(
-      EventRecordRepository repo, EventRecordConverter eventRecordConverter) {
-    return new EventController(repo, eventRecordConverter);
+      EventRecordRepository repo,
+      EventRecordConverter eventRecordConverter,
+      OptInController optInController) {
+    return new EventController(repo, eventRecordConverter, optInController);
   }
 
   @Bean

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.candlepin.subscriptions.db.EventRecordRepository;
+import org.candlepin.subscriptions.security.OptInController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -45,6 +47,7 @@ class EventControllerTest {
   @Autowired EventController eventController;
 
   @MockBean private EventRecordRepository eventRecordRepository;
+  @MockBean private OptInController optInController;
 
   String eventRecord1;
   String eventRecord2;
@@ -169,7 +172,7 @@ class EventControllerTest {
     eventRecords.add(eventRecord2);
     eventRecords.add(eventRecord3);
     eventController.persistServiceInstances(eventRecords);
-
+    verify(optInController, times(2)).optInByOrgId(any(), any());
     when(eventRecordRepository.saveAll(any())).thenReturn(new ArrayList<>());
 
     ArgumentCaptor<Collection> eve = ArgumentCaptor.forClass(Collection.class);
@@ -188,7 +191,7 @@ class EventControllerTest {
     eventRecords.add(eventRecord4);
     eventRecords.add(eventRecord5);
     eventController.persistServiceInstances(eventRecords);
-
+    verify(optInController, times(3)).optInByOrgId(any(), any());
     when(eventRecordRepository.saveAll(any())).thenReturn(new ArrayList<>());
     ArgumentCaptor<Collection> eve = ArgumentCaptor.forClass(Collection.class);
     verify(eventRecordRepository).saveAll(eve.capture());


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1591](https://issues.redhat.com/browse/SWATCH-1591)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Opt-in when we receive an event.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

**Note: Testing is same as in PR for SWATCH-598: https://github.com/RedHatInsights/rhsm-subscriptions/pull/2298**

### Steps
<!-- Enter each step of the test below -->
1. DEV_MODE=true ./gradlew :bootRun
2. Produce Kafka event using Big Data Tool for :`platform.rhsm-subscriptions.service-instance-ingress`
`{"event_id": "06893602-d1f9-414d-8bf6-a90154e844be", "event_source": "cost-management", "event_type": "Snapshot", "account_number": "10001", "org_id": "1234567", "service_type": "RHEL System", "instance_id": "i-55555556", "timestamp": "2023-08-01T07:00:00Z", "expiration": "2023-08-01T08:00:00Z", "measurements": [{"value": "2", "uom": "vCPUs"}], "cloud_provider": "AWS", "hardware_type": "Cloud", "product_ids": ["479", "70"], "role": "Red Hat Enterprise Linux Workstation", "sla": "Self-Support", "usage": "Disaster Recovery", "billing_provider": "aws", "billing_account_id": "9999999999999"}`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Inserted event if doesn't exists already and will add an entry in org_config table:
`1234567,PROMETHEUS,2023-08-08 15:47:00.070621 +00:00,2023-08-08 15:47:00.070621 +00:00`
