### PR TITLE
SWATCH-658: Internal metering API should not support accountNumber.

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -23,7 +23,8 @@ package org.candlepin.subscriptions.metering.api.admin;
 import io.micrometer.core.annotation.Timed;
 import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.Min;
-import jakarta.ws.rs.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
@@ -40,7 +41,6 @@ import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeterin
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.resource.ResourceUtils;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -93,11 +93,11 @@ public class InternalMeteringResource implements InternalApi {
 
   @Override
   public void meterProductForOrgIdAndRange(
-          String productTag,
-          @NotNull String orgId,
-          OffsetDateTime endDate,
-          @Min(0) Integer rangeInMinutes,
-          Boolean xRhSwatchSynchronousRequest) {
+      String productTag,
+      @NotNull String orgId,
+      OffsetDateTime endDate,
+      @Min(0) Integer rangeInMinutes,
+      Boolean xRhSwatchSynchronousRequest) {
     Object principal = ResourceUtils.getPrincipal();
 
     if (Objects.isNull(rangeInMinutes)) {

--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.admin.api.InternalApi;
@@ -50,7 +49,6 @@ public class InternalMeteringResource implements InternalApi {
   private final ApplicationProperties applicationProperties;
   private final PrometheusMetricsTaskManager tasks;
   private final PrometheusMeteringController controller;
-  private final AccountConfigRepository accountConfigRepository;
   private final TagProfile tagProfile;
   private final EventRecordsRetentionProperties eventRecordsRetentionProperties;
   private final EventRecordRepository eventRecordRepository;
@@ -63,7 +61,6 @@ public class InternalMeteringResource implements InternalApi {
       TagProfile tagProfile,
       PrometheusMetricsTaskManager tasks,
       PrometheusMeteringController controller,
-      AccountConfigRepository accountConfigRepository,
       EventRecordRepository eventRecordRepository,
       MetricProperties metricProperties) {
     this.util = util;
@@ -72,7 +69,6 @@ public class InternalMeteringResource implements InternalApi {
     this.tagProfile = tagProfile;
     this.tasks = tasks;
     this.controller = controller;
-    this.accountConfigRepository = accountConfigRepository;
     this.eventRecordRepository = eventRecordRepository;
     this.metricProperties = metricProperties;
   }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
@@ -114,12 +114,6 @@ public class PrometheusMetricsTaskManager {
   }
 
   @Transactional
-  public void updateMetricsForAllAccounts(String productTag, int rangeInMinutes) {
-    updateMetricsForAllAccounts(
-        productTag, rangeInMinutes, RetryTemplate.builder().maxAttempts(1).build());
-  }
-
-  @Transactional
   public void updateMetricsForAllAccounts(
       String productTag, int rangeInMinutes, RetryTemplate retry) {
     OffsetDateTime end =

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
@@ -114,13 +114,6 @@ public class PrometheusMetricsTaskManager {
   }
 
   @Transactional
-  public void updateMetricsForAllAccounts(
-      String productTag, OffsetDateTime start, OffsetDateTime end) {
-    updateMetricsForAllAccounts(
-        productTag, start, end, RetryTemplate.builder().maxAttempts(1).build());
-  }
-
-  @Transactional
   public void updateMetricsForAllAccounts(String productTag, int rangeInMinutes) {
     updateMetricsForAllAccounts(
         productTag, rangeInMinutes, RetryTemplate.builder().maxAttempts(1).build());

--- a/src/main/spec/internal-metering-api-spec.yaml
+++ b/src/main/spec/internal-metering-api-spec.yaml
@@ -18,19 +18,16 @@ paths:
   /internal/metering/{productTag}:
     description: 'Operations related to product metering.'
     post:
-      operationId: meterProductForAccount
+      operationId: meterProductForOrgIdAndRange
       summary: "Perform product metering for account."
       parameters:
-        - name: accountNumber
-          in: query
+        - name: productTag
+          in: path
+          required: true
           schema:
             type: string
         - name: orgId
           in: query
-          schema:
-            type: string
-        - name: productTag
-          in: path
           required: true
           schema:
             type: string
@@ -45,6 +42,8 @@ paths:
           schema:
             type: integer
             minimum: 0
+            description: "Defines the amount of time (in minutes) that will be used to calculate a metric query's start date based on a given end date.
+For example, given an end date of 2021-01-06T00:00:00Z and a rangeInMinutes of 60, the calculated start date will be: 2021-01-05T23:00:00Z.  Default (60) is store in application-metering-job.yaml"
         - name: x-rh-swatch-synchronous-request
           in: header
           required: false

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -90,7 +90,6 @@ class InternalMeteringResourceTest {
             tagProfile,
             tasks,
             controller,
-            accountConfigRepository,
             eventRecordRepository,
             metricProps);
   }

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -123,11 +123,10 @@ class InternalMeteringResourceTest {
     IllegalArgumentException iae1 =
         assertThrows(
             IllegalArgumentException.class,
-            () ->
-                resource.meterProductForOrgIdAndRange(VALID_PRODUCT, null, end, 120, false));
+            () -> resource.meterProductForOrgIdAndRange(VALID_PRODUCT, null, end, 120, false));
     assertEquals("Date must start at top of the hour: 2019-05-24T12:05Z", iae1.getMessage());
     resource.meterProductForOrgIdAndRange(
-        VALID_PRODUCT,"org1", clock.startOfHour(end), 120, false);
+        VALID_PRODUCT, "org1", clock.startOfHour(end), 120, false);
 
     // synchronous
     IllegalArgumentException iae2 =
@@ -138,7 +137,7 @@ class InternalMeteringResourceTest {
 
     // Avoid additional exception by enabling synchronous operations.
     appProps.setEnableSynchronousOperations(true);
-    resource.meterProductForOrgIdAndRange(VALID_PRODUCT,"org1", clock.startOfHour(end), 120, true);
+    resource.meterProductForOrgIdAndRange(VALID_PRODUCT, "org1", clock.startOfHour(end), 120, true);
   }
 
   @Test
@@ -178,7 +177,7 @@ class InternalMeteringResourceTest {
 
     OffsetDateTime endDate = clock.startOfCurrentHour();
     OffsetDateTime startDate = endDate.minusMinutes(120);
-    resource.meterProductForOrgIdAndRange(VALID_PRODUCT,"org1", endDate, 120, false);
+    resource.meterProductForOrgIdAndRange(VALID_PRODUCT, "org1", endDate, 120, false);
     verify(tasks).updateMetricsForOrgId("org1", VALID_PRODUCT, startDate, endDate);
     verifyNoInteractions(controller);
   }
@@ -189,7 +188,7 @@ class InternalMeteringResourceTest {
     IllegalArgumentException ie =
         assertThrows(
             IllegalArgumentException.class,
-            () -> resource.meterProductForOrgIdAndRange(VALID_PRODUCT,"org1", endDate, -1, false));
+            () -> resource.meterProductForOrgIdAndRange(VALID_PRODUCT, "org1", endDate, -1, false));
     assertEquals("Invalid value specified (Must be >= 0): rangeInMinutes", ie.getMessage());
   }
 
@@ -200,7 +199,7 @@ class InternalMeteringResourceTest {
         assertThrows(
             IllegalArgumentException.class,
             () ->
-                resource.meterProductForOrgIdAndRange(VALID_PRODUCT,"org1", endDate, 120, false));
+                resource.meterProductForOrgIdAndRange(VALID_PRODUCT, "org1", endDate, 120, false));
     assertEquals("Date must start at top of the hour: " + endDate, ie.getMessage());
   }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -21,9 +21,7 @@
 package org.candlepin.subscriptions.metering.service.prometheus.task;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -98,34 +98,4 @@ class PrometheusMetricsTaskManagerTest {
     manager.updateMetricsForAccount(orgId, TEST_PROFILE_ID, start, end);
     verify(queue).enqueue(expectedTask);
   }
-
-  @Test
-  void updateForConfiguredAccounts() throws Exception {
-    OffsetDateTime end = OffsetDateTime.now();
-    OffsetDateTime start = end.minusDays(1);
-
-    when(accountSource.getMarketplaceAccounts(eq(TEST_PROFILE_ID), eq(Uom.CORES), any(), any()))
-        .thenReturn(Set.of("org1", "org2"));
-    TaskDescriptor account1Task =
-        TaskDescriptor.builder(TaskType.METRICS_COLLECTION, TASK_TOPIC)
-            .setSingleValuedArg("orgId", "org1")
-            .setSingleValuedArg("productTag", TEST_PROFILE_ID)
-            .setSingleValuedArg("metric", "Cores")
-            .setSingleValuedArg("start", start.toString())
-            .setSingleValuedArg("end", end.toString())
-            .build();
-    TaskDescriptor account2Task =
-        TaskDescriptor.builder(TaskType.METRICS_COLLECTION, TASK_TOPIC)
-            .setSingleValuedArg("orgId", "org2")
-            .setSingleValuedArg("productTag", TEST_PROFILE_ID)
-            .setSingleValuedArg("metric", "Cores")
-            .setSingleValuedArg("start", start.toString())
-            .setSingleValuedArg("end", end.toString())
-            .build();
-
-    manager.updateMetricsForAllAccounts(TEST_PROFILE_ID, start, end);
-    verify(queue).enqueue(account1Task);
-    verify(queue).enqueue(account2Task);
-    verifyNoMoreInteractions(queue);
-  }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-658](https://issues.redhat.com/browse/SWATCH-658)

## Description
From Internal metering API, Stop accepting accountNumber and orgId should be marked as required.

Prior to this PR, it was possible to leave both the accountNumber and orgID empty.  It would then try to find all events for the provided range.  However, that feature wasn't currently working and would later throw an exception for the missing orgId.  This PR makes orgId mandatory.

## Testing
### Setup
1. To run locally prometheus by pointing to stage follow the steps in: [Connecting  Observatorium to fetch Prometheus ](https://docs.engineering.redhat.com/display/ENT/Connecting+to+Observatorium+to+Fetch+Prometheus+Metrics)

* Copy CLIENT_SECRET and paste it in a file `token-refresher`
* Run: `podman run --name=telemeter-stage --rm -ti -p 8082:8080     quay.io/observatorium/token-refresher:master-2021-02-05-5da9663     --oidc.client-secret=$(cat ~/Downloads/token-refresher)     --oidc.client-id=observatorium-subwatch-staging     --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external     --url=https://observatorium.api.stage.openshift.com`

2. Apply the below patch in `application-openshift-metering-worker.yaml` since billing_model="marketplace" won't give results in prometheus in the further steps

```
          diff --git a/src/main/resources/application-openshift-metering-worker.yaml b/src/main/resources/application-openshift-metering-worker.yaml
--- a/src/main/resources/application-openshift-metering-worker.yaml	(revision ce8b242be21cb1b8329d08cfd46f684065e44126)
+++ b/src/main/resources/application-openshift-metering-worker.yaml	(date 1689775711055)
@@ -12,7 +12,7 @@
           default: >-
             #{metric.queryParams[prometheusMetric]}
             * on(_id) group_right
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", support=~"Premium|Standard|Self-Support|None"}[1h])
           addonSamples: >-
             #{metric.queryParams[prometheusMetric]}
             * on(_id) group_right
```

3. Then in separate terminal pointing to the prom_url in the doc run:  `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 ./gradlew clean :bootRun`
4. Go to prometheus url that points to stage from local: `http://localhost:8082/api/metrics/v1/telemeter/graph`
   Under graph tab paste the query `cluster:usage:workload:capacity_physical_instance_hours * on(_id) group_right min_over_time(subscription_labels{product="osd", external_organization="6323660", support=~"Premium|Standard|Self-Support|None"}[1h])`

* or click on this [link](http://localhost:8082/api/metrics/v1/telemeter/graph?g0.expr=cluster%3Ausage%3Aworkload%3Acapacity_physical_instance_hours%20*%20on(_id)%20group_right%20min_over_time(subscription_labels%7Bproduct%3D%22osd%22%2C%20external_organization%3D%226323660%22%2C%20support%3D~%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D)&g0.tab=0&g0.stacked=0&g0.range_input=2h&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=0&g0.store_matches=%5B%5D&g0.end_input=2023-08-08%2004%3A49%3A17&g0.moment_input=2023-08-08%2004%3A49%3A17) and adjust the timestamps but this is only applicable locally.

### Steps
1. Run: `curl -X POST  -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/OpenShift-dedicated-metrics?orgId=6323660&rangeInMinutes=1200"`


### Verification
1. Depending on if stage prometheus has data you should see bunch of inserts in events table with new event_types in event_type column and in data json blob like below:
   `INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('743b86eb-56fa-4b2a-84c0-a243fb844a87', '1455657', '2023-08-08 10:00:00.000000 +00:00', '{"sla": "Premium", "role": "osd", "org_id": "6323660", "event_id": "743b86eb-56fa-4b2a-84c0-a243fb844a87", "timestamp": "2023-08-08T10:00:00Z", "event_type": "snapshot_openshift-dedicated-metrics_cores", "expiration": "2023-08-08T11:00:00Z", "instance_id": "fbe99a5e-9213-4c10-942a-74b7df181ec2", "display_name": "fbe99a5e-9213-4c10-942a-74b7df181ec2", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.666666666666667}], "service_type": "OpenShift Cluster", "account_number": "1455657", "billing_provider": "red hat", "billing_account_id": null}', 'snapshot_openshift-dedicated-metrics_instance-hours', 'prometheus', 'fbe99a5e-9213-4c10-942a-74b7df181ec2', '6323660'); `

**In logs:** `2023-08-08 18:01:13,974 [thread=http-nio-8000-exec-5] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Persisted 77 events for OpenShift-dedicated-metrics Instance-hours metrics. `
