### PR TITLE
Fix errors in insert-mock-hosts

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -54,6 +54,7 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
             }),
             'stale_timestamp': '2030-01-01',
             'reporter': 'rhsm-conduit',
+            'groups': '1',
         }
     else:
         _create_account_service(account, 'HBI_HOST', org)
@@ -142,7 +143,7 @@ def _generate_buckets(host_id, product, sla, usage, as_hypervisor=False, measure
 
 def _generate_measurements(host_id, uom, value):
     measurement_fields = {
-        'instance_id': host_id,
+        'host_id': host_id,
         'uom': uom,
         'value': value,
     }


### PR DESCRIPTION
## Description
This is a fix for the insert-mock-hosts script to use the updated schema.
1. First change: The new host_id column must be populated.  And instance_id is now auto-generated.
1. HBI has a groups field that must be populated

## Testing

### Setup
1. Ensure you have the latest hbi schema
```
podman-compose down
podman-compose up -d 
```

### Verification
1. Verify insert will do the insertion and commit
```
bin/insert-mock-hosts --num-aws=1
```
2. Verify can insert into hbi
```
bin/insert-mock-hosts --num-hypervisors=1 --num-guests=1 --hbi --org org123 --clear
```
