### PR TITLE
SWATCH-1605: Change variant tag name from "RHEL Server" to "RHEL for x86"

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -354,10 +354,10 @@ paths:
                     cloud_cores: 8
                     cloud_sockets: 4
                 links:
-                  first: '/api/rhsm-subscriptions/v1/tally/products/RHEL%20Server?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
-                  last: '/api/rhsm-subscriptions/v1/tally/products/RHEL%20Server?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  first: '/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
+                  last: '/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                   previous: null
-                  next: '/api/rhsm-subscriptions/v1/tally/products/RHEL%20Server?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  next: '/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                 meta:
                   count: 10
                   total_core_hours: 30
@@ -468,10 +468,10 @@ paths:
                     has_data: false
                     value: 0.0
                 links:
-                  first: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
-                  last: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  first: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
+                  last: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                   previous: null
-                  next: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  next: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                 meta:
                   count: 10
                   product: RHEL Server
@@ -579,10 +579,10 @@ paths:
                     hypervisor_sockets: 5
                     has_infinite_quantity: true
                 links:
-                  first: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
-                  last: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  first: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
+                  last: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                   previous: null
-                  next: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  next: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                 meta:
                   count: 10
                   product: RHEL Server
@@ -698,10 +698,10 @@ paths:
                     hardware_type: physical
                     last_seen: 2020-01-01T00:00:00Z
                 links:
-                  first: '/api/rhsm-subscriptions/v1/hosts/RHEL%20Server?sla=Premium&usage=Production&offset=0&limit=5'
-                  last: '/api/rhsm-subscriptions/v1/hosts/RHEL%20Server?sla=Premium&usage=Production&offset=5&limit=5'
+                  first: '/api/rhsm-subscriptions/v1/hosts/RHEL%20for%20x86?sla=Premium&usage=Production&offset=0&limit=5'
+                  last: '/api/rhsm-subscriptions/v1/hosts/RHEL%20for%20x86?sla=Premium&usage=Production&offset=5&limit=5'
                   previous: null
-                  next: '/api/rhsm-subscriptions/v1/hosts/RHEL%20Server?sla=Premium&usage=Production&offset=5&limit=5'
+                  next: '/api/rhsm-subscriptions/v1/hosts/RHEL%20for%20x86?sla=Premium&usage=Production&offset=5&limit=5'
                 meta:
                   count: 10
                   product: RHEL Server
@@ -1141,14 +1141,11 @@ components:
       enum:
         - OpenShift Container Platform
         - RHEL Compute Node
-        - RHEL Desktop
         - RHEL for ARM
         - RHEL for IBM Power
         - RHEL for IBM z
         - RHEL for x86
-        - RHEL Server
         - RHEL Workstation
-        - Satellite
         - Satellite Capsule
         - Satellite Server
         - OpenShift-metrics

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -472,21 +472,27 @@ public class CapacityResource implements CapacityApi {
     return new CapacitySnapshotByMetricId().date(date).value(value).hasData(hasData);
   }
 
-  private void validateGranularity(ProductId productId, Granularity granularity) {
+  void validateGranularity(ProductId productId, Granularity granularity) {
 
-    var compatible =
-        Variant.findByTag(productId.toString()).stream()
-            .map(Variant::getSubscription)
-            .anyMatch(
-                subscriptionDefinition ->
-                    subscriptionDefinition
-                        .getSupportedGranularity()
-                        .contains(SubscriptionDefinitionGranularity.valueOf(granularity.name())));
-    if (!compatible) {
-      throw new BadRequestException(
-          String.format(
-              "%s does not support any granularity finer than %s",
-              productId, granularity.getValue()));
-    }
+    Variant.findByTag(productId.toString())
+        .ifPresentOrElse(
+            variant -> {
+              boolean isCompatible =
+                  variant
+                      .getSubscription()
+                      .getSupportedGranularity()
+                      .contains(SubscriptionDefinitionGranularity.valueOf(granularity.name()));
+
+              if (!isCompatible) {
+                throw new BadRequestException(
+                    String.format(
+                        "%s does not support any granularity finer than %s",
+                        productId, granularity.getValue()));
+              }
+            },
+            () -> {
+              throw new BadRequestException(
+                  String.format("No granularity configuration found for %s", productId));
+            });
   }
 }

--- a/src/main/resources/liquibase/202308211518-rename-rhel-product-ids.xml
+++ b/src/main/resources/liquibase/202308211518-rename-rhel-product-ids.xml
@@ -1,0 +1,43 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="202308211518" author="lburnett">
+    <comment>Consider "RHEL Server" as "RHEL for x86" product id for snapshots.</comment>
+    <update tableName="tally_snapshots">
+      <column name="product_id" value="z_RHEL for x86"/>
+      <where>product_id='RHEL for x86'</where>
+    </update>
+    <update tableName="tally_snapshots">
+      <column name="product_id" value="RHEL for x86"/>
+      <where>product_id='RHEL Server'</where>
+    </update>
+    <update tableName="host_tally_buckets">
+      <column name="product_id" value="z_RHEL for x86"/>
+      <where>product_id='RHEL for x86'</where>
+    </update>
+    <update tableName="host_tally_buckets">
+      <column name="product_id" value="RHEL for x86"/>
+      <where>product_id='RHEL Server'</where>
+    </update>
+    <rollback>
+      <update tableName="tally_snapshots">
+        <column name="product_id" value="RHEL Server"/>
+        <where>product_id='RHEL for x86'</where>
+      </update>
+      <update tableName="tally_snapshots">
+        <column name="product_id" value="RHEL for x86"/>
+        <where>product_id='z_RHEL for x86'</where>
+      </update>
+      <update tableName="host_tally_buckets">
+        <column name="product_id" value="RHEL Server"/>
+        <where>product_id='RHEL for x86'</where>
+      </update>
+      <update tableName="host_tally_buckets">
+        <column name="product_id" value="RHEL for x86"/>
+        <where>product_id='z_RHEL for x86'</where>
+      </update>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -119,5 +119,6 @@
     <!-- Uncomment once the above changeset has landed in prod -->
     <!-- <include file="liquibase/202307051245-drop-instance_id-columns.xml"/> -->
     <include file="liquibase/202308151557-fix-subscription-measurement-metric-id-casing.xml"/>
+    <include file="liquibase/202308211518-rename-rhel-product-ids.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityProductExtractorTest.java
@@ -39,7 +39,7 @@ class CapacityProductExtractorTest {
   public static final String RHEL_x86_ID = "479";
   public static final String RHEL_WORKSTATION_ID = "71";
   public static final String OPENSHIFT_CONTAINER_PLATFORM_ID = "290";
-  public static final String RHEL_SERVER = "RHEL Server";
+  public static final String RHEL_FOR_X_86 = "RHEL for x86";
   public static final String SATELLITE_SERVER = "Satellite Server";
   public static final String OPEN_SHIFT_CONTAINER_PLATFORM = "OpenShift Container Platform";
   private CapacityProductExtractor extractor;
@@ -62,12 +62,12 @@ class CapacityProductExtractorTest {
     return Stream.of(
         Arguments.of(List.of(), Set.of()),
         Arguments.of(List.of("123"), Set.of()),
-        Arguments.of(List.of("123", RHEL_LINUX_ID), Set.of(RHEL_SERVER)),
-        Arguments.of(List.of(RHEL_LINUX_ID), Set.of(RHEL_SERVER)),
+        Arguments.of(List.of("123", RHEL_LINUX_ID), Set.of(RHEL_FOR_X_86)),
+        Arguments.of(List.of(RHEL_LINUX_ID), Set.of(RHEL_FOR_X_86)),
         Arguments.of(List.of(RHEL_LINUX_ID, SATELLITE_SERVER_ID), Set.of(SATELLITE_SERVER)),
         Arguments.of(List.of(RHEL_x86_ID, SATELLITE_SERVER_ID), Set.of(SATELLITE_SERVER)),
         Arguments.of(List.of(RHEL_LINUX_ID, SATELLITE_SERVER_ID), Set.of(SATELLITE_SERVER)),
-        Arguments.of(List.of(RHEL_x86_ID), Set.of(RHEL_SERVER)),
+        Arguments.of(List.of(RHEL_x86_ID), Set.of(RHEL_FOR_X_86)),
         Arguments.of(List.of(RHEL_WORKSTATION_ID, SATELLITE_SERVER_ID), Set.of(SATELLITE_SERVER)),
         Arguments.of(
             List.of(OPENSHIFT_CONTAINER_PLATFORM_ID, RHEL_x86_ID),

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -20,10 +20,12 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import static org.candlepin.subscriptions.utilization.api.model.ProductId.BASILISK;
 import static org.candlepin.subscriptions.utilization.api.model.ProductId.RHEL_FOR_ARM;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
@@ -50,11 +52,16 @@ import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshotByMetricId;
 import org.candlepin.subscriptions.utilization.api.model.GranularityType;
 import org.candlepin.subscriptions.utilization.api.model.MetricId;
+import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -1152,5 +1159,34 @@ class CapacityResourceTest {
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
     assertEquals(4, capacitySnapshot.getValue());
+  }
+
+  @Test
+  void testValidateGranularityIncompatible() {
+
+    var thrownException =
+        Assertions.assertThrows(
+            BadRequestException.class,
+            () -> resource.validateGranularity(RHEL_FOR_ARM, Granularity.HOURLY));
+
+    assertEquals(
+        String.format(
+            "%s does not support any granularity finer than %s",
+            RHEL_FOR_ARM, GranularityType.HOURLY),
+        thrownException.getMessage());
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateFinestGranularityCases")
+  void testValidateGranularity(ProductId productId, Granularity granularity) {
+    assertDoesNotThrow(() -> resource.validateGranularity(productId, granularity));
+  }
+
+  private static Stream<Arguments> generateFinestGranularityCases() {
+    return Stream.of(
+        Arguments.of(BASILISK, Granularity.HOURLY),
+        Arguments.of(RHEL_FOR_ARM, Granularity.YEARLY),
+        Arguments.of(BASILISK, Granularity.YEARLY),
+        Arguments.of(RHEL_FOR_ARM, Granularity.DAILY));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -77,7 +77,7 @@ class HostsResourceTest {
   @SuppressWarnings("indentation")
   void testShouldMapDisplayNameAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -92,7 +92,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -112,7 +112,7 @@ class HostsResourceTest {
   @Test
   void testShouldMapCoresAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -127,7 +127,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -146,7 +146,7 @@ class HostsResourceTest {
   @Test
   void testShouldMapSocketsAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -161,7 +161,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -181,7 +181,7 @@ class HostsResourceTest {
   @Test
   void testShouldMapLastSeenAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -196,7 +196,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -216,7 +216,7 @@ class HostsResourceTest {
   @Test
   void testShouldMapHardwareTypeAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -231,7 +231,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -251,7 +251,7 @@ class HostsResourceTest {
   @Test
   void testShouldDefaultToImplicitOrder() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -266,7 +266,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -280,7 +280,7 @@ class HostsResourceTest {
   @Test
   void testShouldDefaultToAscending() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -295,7 +295,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -315,7 +315,7 @@ class HostsResourceTest {
   @Test
   void testShouldUseMinCoresWhenUomIsCores() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -329,7 +329,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -343,7 +343,7 @@ class HostsResourceTest {
   @Test
   void testShouldUseMinSocketsWhenUomIsSockets() {
     resource.getHosts(
-        ProductId.RHEL_SERVER,
+        ProductId.RHEL_FOR_X86,
         0,
         1,
         null,
@@ -358,7 +358,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_SERVER.toString(),
+            ProductId.RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -226,7 +226,7 @@ class InstancesResourceTest {
 
     var meta = new InstanceMeta();
     meta.setCount(2);
-    meta.setProduct(RHEL_SERVER);
+    meta.setProduct(RHEL_FOR_X86);
     meta.setServiceLevel(ServiceLevelType.PREMIUM);
     meta.setUsage(UsageType.PRODUCTION);
     meta.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
@@ -238,7 +238,7 @@ class InstancesResourceTest {
 
     InstanceResponse report =
         resource.getInstancesByProduct(
-            RHEL_SERVER,
+            RHEL_FOR_X86,
             null,
             null,
             ServiceLevelType.PREMIUM,
@@ -391,7 +391,7 @@ class InstancesResourceTest {
         .thenReturn(new PageImpl<>(List.of(tallyInstanceView)));
 
     resource.getInstancesByProduct(
-        RHEL_SERVER,
+        RHEL_FOR_X86,
         null,
         null,
         ServiceLevelType.PREMIUM,
@@ -490,7 +490,7 @@ class InstancesResourceTest {
         .thenReturn(new PageImpl<>(List.of(tallyInstanceView)));
 
     resource.getInstancesByProduct(
-        RHEL_SERVER,
+        RHEL_FOR_X86,
         null,
         null,
         ServiceLevelType.PREMIUM,
@@ -555,7 +555,7 @@ class InstancesResourceTest {
         .thenReturn(new PageImpl<>(List.of(tallyInstanceView)));
 
     resource.getInstancesByProduct(
-        RHEL_SERVER,
+        RHEL_FOR_X86,
         null,
         null,
         ServiceLevelType.PREMIUM,

--- a/src/test/java/org/candlepin/subscriptions/resource/SubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/SubscriptionResourceTest.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.resource;
 
-import static org.candlepin.subscriptions.utilization.api.model.ProductId.RHEL_SERVER;
+import static org.candlepin.subscriptions.utilization.api.model.ProductId.RHEL_FOR_X86;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.OffsetDateTime;
@@ -50,7 +50,7 @@ class SubscriptionResourceTest {
         AccessDeniedException.class,
         () ->
             subscriptionResource.getSkuCapacityReport(
-                RHEL_SERVER,
+                RHEL_FOR_X86,
                 0,
                 10,
                 null,
@@ -74,7 +74,7 @@ class SubscriptionResourceTest {
         AccessDeniedException.class,
         () ->
             subscriptionResource.getSkuCapacityReport(
-                RHEL_SERVER,
+                RHEL_FOR_X86,
                 0,
                 10,
                 null,

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -88,7 +88,7 @@ class TallyResourceTest {
   public static final OffsetDateTime TEST_DATE =
       OffsetDateTime.ofInstant(MID_MONTH_INSTANT, ZoneOffset.UTC);
 
-  public static final ProductId RHEL_PRODUCT_ID = ProductId.RHEL_SERVER;
+  public static final ProductId RHEL_PRODUCT_ID = ProductId.RHEL_FOR_X86;
 
   private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
   private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
@@ -445,7 +445,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                ProductId.RHEL_SERVER.toString(),
+                ProductId.RHEL_FOR_X86.toString(),
                 Granularity.DAILY,
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
@@ -458,7 +458,7 @@ class TallyResourceTest {
 
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             begin,
@@ -787,7 +787,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -816,7 +816,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -848,7 +848,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -880,7 +880,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -905,7 +905,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -930,7 +930,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-02T00:00Z"),
@@ -954,7 +954,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -978,7 +978,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -1002,7 +1002,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -1036,7 +1036,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot1, snapshot2)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -1075,7 +1075,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot1, snapshot2)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_SERVER,
+            ProductId.RHEL_FOR_X86,
             MetricId.CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -1217,7 +1217,7 @@ class TallyResourceTest {
         BadRequestException.class,
         () -> {
           resource.getTallyReportData(
-              ProductId.RHEL_SERVER,
+              ProductId.RHEL_FOR_X86,
               MetricId.CORES,
               GranularityType.DAILY,
               beginning,
@@ -1242,7 +1242,7 @@ class TallyResourceTest {
         BadRequestException.class,
         () -> {
           resource.getTallyReportData(
-              ProductId.RHEL_SERVER,
+              ProductId.RHEL_FOR_X86,
               MetricId.CORES,
               GranularityType.DAILY,
               beginning,

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -178,7 +178,7 @@ class SubscriptionTableControllerTest {
   void testGetSkuCapacityReportSingleSub() {
     // Given an org with one active sub with a quantity of 4 and has an eng product with a socket
     // capacity of 2,
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedSub = stubSubscription("1234", "1235", 4);
     var spec = RH0180191.withSub(expectedSub);
     givenCapacities(Org.STANDARD, productId, spec);
@@ -211,7 +211,7 @@ class SubscriptionTableControllerTest {
     // Given an org with two active subs with different quantities for the same SKU,
     // and the subs have an eng product with a socket capacity of 2,
     // and the subs have different ending dates,
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
     var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
     var spec1 = RH0180191.withSub(expectedOlderSub);
@@ -259,7 +259,7 @@ class SubscriptionTableControllerTest {
     // Given an org with two active subs with different quantities for different SKUs,
     // and the subs have an eng product with a socket capacity of 2,
     // and the subs have different ending dates,
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
     var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
     var spec1 = RH0180191.withSub(expectedNewerSub);
@@ -332,7 +332,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for an eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            RHEL_SERVER, null, null, null, null, null, null, null, null, null, null);
+            RHEL_FOR_X86, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains no inventory items.
     assertEquals(0, actual.getData().size(), "An empty inventory list should be returned.");
@@ -346,7 +346,7 @@ class SubscriptionTableControllerTest {
     var spec1 = RH0180191.withSub(expectedOlderSub);
     var spec2 = RH0180191.withSub(expectedNewerSub);
 
-    givenCapacities(Org.STANDARD, RHEL_SERVER, spec1, spec2);
+    givenCapacities(Org.STANDARD, RHEL_FOR_X86, spec1, spec2);
 
     when(subscriptionRepository.findAll(Mockito.any(Specification.class)))
         .thenReturn(List.of(expectedNewerSub, expectedOlderSub));
@@ -355,7 +355,7 @@ class SubscriptionTableControllerTest {
 
     SkuCapacityReport report =
         subscriptionTableController.capacityReportBySku(
-            RHEL_SERVER,
+            RHEL_FOR_X86,
             null,
             null,
             null,
@@ -371,7 +371,7 @@ class SubscriptionTableControllerTest {
 
   @Test
   void testShouldUseSlaQueryParam() {
-    ProductId productId = RHEL_SERVER;
+    ProductId productId = RHEL_FOR_X86;
     var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
     var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
     var spec1 = RH0180191.withSub(expectedOlderSub);
@@ -417,7 +417,7 @@ class SubscriptionTableControllerTest {
 
   @Test
   void testShouldUseUsageQueryParam() {
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
     Subscription expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
     var spec1 = RH0180191.withSub(expectedOlderSub);
@@ -463,7 +463,7 @@ class SubscriptionTableControllerTest {
 
   @Test
   void testCountReturnedInMetaIgnoresOffsetAndLimit() {
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var spec1 = RH0180191.withSub(stubSubscription("1236", "1237", 5, 6, 6));
     var spec2 = RH00604F5.withSub(stubSubscription("1234", "1235", 4, 5, 7));
     var rh0060192 =
@@ -525,7 +525,7 @@ class SubscriptionTableControllerTest {
 
   @Test
   void testShouldUseUomQueryParam() {
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
     var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
     var expectedMuchOlderSub = stubSubscription("1238", "1237", 5, 24, 6);
@@ -586,7 +586,7 @@ class SubscriptionTableControllerTest {
             SubscriptionsException.class,
             () ->
                 subscriptionTableController.capacityReportBySku(
-                    RHEL_SERVER,
+                    RHEL_FOR_X86,
                     11,
                     10,
                     null,
@@ -608,7 +608,7 @@ class SubscriptionTableControllerTest {
 
     SkuCapacityReport report =
         subscriptionTableController.capacityReportBySku(
-            RHEL_SERVER,
+            RHEL_FOR_X86,
             null,
             null,
             null,
@@ -650,7 +650,7 @@ class SubscriptionTableControllerTest {
   void testGetSkuCapacityReportUnlimitedQuantity() {
     // Given an org with one active sub with a quantity of 4 and has an eng product with unlimited
     // usage.
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedSub = stubSubscription("1234", "1235", 4);
     var unlimitedSpec = RH0180195_UNLIMITED_USAGE.withSub(expectedSub);
     givenCapacities(Org.STANDARD, productId, unlimitedSpec);
@@ -691,7 +691,7 @@ class SubscriptionTableControllerTest {
     // Given an org with two active subs with different quantities for different SKUs,
     // and the subs have an eng product with a socket capacity of 2,
     // and the subs have different ending dates,
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
     var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
     var spec1 = RH0180191.withSub(expectedNewerSub);
@@ -740,7 +740,7 @@ class SubscriptionTableControllerTest {
     // Given an org with two active subs with different quantities for different SKUs,
     // and the subs have an eng product with a socket capacity of 2,
     // and the subs have different ending dates,
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
     var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
     var spec1 = RH0180191.withSub(expectedNewerSub);
@@ -788,7 +788,7 @@ class SubscriptionTableControllerTest {
   void testGetSkuCapacityReportHypervisorSocketsOnly() {
     // Given an org with one active sub with a quantity of 4 and has an eng product with a
     // hypervisor socket capacity of 2,
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedSub = stubSubscription("1234", "1235", 4);
     var spec1 = RH0180196_HYPERVISOR_SOCKETS.withSub(expectedSub);
     givenCapacities(Org.STANDARD, productId, spec1);
@@ -815,7 +815,7 @@ class SubscriptionTableControllerTest {
   void testGetSkuCapacityReportHypervisorCoresOnly() {
     // Given an org with one active sub with a quantity of 4 and has an eng product with a
     // hypervisor socket capacity of 2,
-    var productId = RHEL_SERVER;
+    var productId = RHEL_FOR_X86;
     var expectedSub = stubSubscription("1234", "1235", 4);
     var spec1 = RH0180197_HYPERVISOR_CORES.withSub(expectedSub);
     givenCapacities(Org.STANDARD, productId, spec1);

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -104,10 +104,10 @@ paths:
                     has_data: false
                     value: 0.0
                 links:
-                  first: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
-                  last: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  first: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=0&limit=5'
+                  last: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                   previous: null
-                  next: '/api/rhsm-subscriptions/v1/capacity/RHEL%20Server/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
+                  next: '/api/rhsm-subscriptions/v1/capacity/RHEL%20for%20x86/Sockets?granularity=DAILY&sla=Premium&beginning=2017-08-01T17%3A32%3A28Z&ending=2017-08-31T17%3A32%3A28Z&offset=5&limit=5'
                 meta:
                   count: 10
                   product: RHEL Server
@@ -525,14 +525,11 @@ components:
       enum:
         - OpenShift Container Platform
         - RHEL Compute Node
-        - RHEL Desktop
         - RHEL for ARM
         - RHEL for IBM Power
         - RHEL for IBM z
         - RHEL for x86
-        - RHEL Server
         - RHEL Workstation
-        - Satellite
         - Satellite Capsule
         - Satellite Server
         - OpenShift-metrics

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86.yaml
@@ -4,7 +4,7 @@ platform: RHEL
 id: rhel-for-x86
 
 variants:
-  - tag: RHEL Server
+  - tag: RHEL for x86
     engineeringIds:
       - 69 # Red Hat Enterprise Linux Server
       - 479 # RHEL for x86 catch-all

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86.yaml
@@ -25,7 +25,7 @@ variants:
 
 
 defaults:
-  variant: RHEL Server
+  variant: RHEL for x86
 
 metrics:
   - id: Sockets

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
@@ -36,7 +36,7 @@ class VariantTest {
 
     var variant = Variant.findByRole("Red Hat Enterprise Linux Server");
 
-    var expected = "RHEL Server";
+    var expected = "RHEL for x86";
     var actual = variant.get().getTag();
 
     assertEquals(expected, actual);
@@ -56,6 +56,6 @@ class VariantTest {
 
     var actual = Variant.findByEngProductId("69");
 
-    assertEquals("RHEL Server", actual.get().getTag());
+    assertEquals("RHEL for x86", actual.get().getTag());
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1605](https://issues.redhat.com/browse/SWATCH-1605)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

### API Updates

Change variant tag name from `RHEL Server` to `RHEL for x86`

Remove `RHEL`, `RHEL Server`, `RHEL Desktop`, and `Satellite` as ProductId enum options.  These correspond to variant tags that were dropped per PM input during TagProfile to swatch-product-configurtion migration.

Keeping `RHEL Compute Node` and `RHEL Workstation` in the api spec, so users can still retrieve data for those Product Ids, although data with these ProductIds will not be shown in the UI.

### Database updates
Update tally records that were assigned `RHEL Server` to `RHEL for x86`.  To prevent duplicates, retire records that were already assigned `RHEL for x86`. This is done with liquibase by:

Update the product_id values in tally_snapshots and host_tally_buckets tables
* `set product_id = 'z_RHEL for x86' where product_id = 'RHEL for x86'`
* `set product_id = 'RHEL for x86' where product_id = 'RHEL Server'`

### Expected Behavior Changes
Any data which has been classified as "RHEL Server" up to this point, will be accessible as "RHEL for x86", and we no longer track all x86 variants combined.

## Testing

Start on the `main` branch.  The fake orgId I'm using for this is `5463739`.

### dump a host into the insights database

`"installed_products": [{"id": "69"}],` is what indicates it's a RHEL Server host

```sql
INSERT INTO public.hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) VALUES ('7f36c225-7e1e-48ae-aca1-0604fd5afdab', '5463739', 'a6cc2fbb-5a68-4d62-9671-73017dfba1f5', '1993-03-26 00:00:00+00', '1993-03-26 00:00:00+00', '{"rhsm": {"orgId": "5463739", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', NULL, '{"insights_id": "a6cc2fbb-5a68-4d62-9671-73017dfba1f5", "subscription_manager_id": "724fdf0f-1e29-4734-a1d0-0c16aac122ad"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "69"}], "infrastructure_type": "PHYSICAL"}', NULL, '2030-01-01 00:00:00+00', 'rhsm-conduit', '{}', '5463739', '1');
```

### start the app
`DEV_MODE=true ./gradlew :bootRun`

### opt-in the org
```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjU0NjM3MzkiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiNTQ2MzczOSJ9fX0='
```
### create a snapshot
```
http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/5463739 x-rh-swatch-psk:placeholder
```

### If you're interested, go ahead and check out the database and look at snapshots

```sql
select * from tally_snapshots where org_id = '5463739';
```

### Retrieve data with API

```bash
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20Server/Cores?granularity=Daily&beginning=2023-08-21T00%3A00%3A00Z&ending=2023-08-22T00%3A00%3A00Z&use_running_totals_format=false' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjU0NjM3MzkiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiNTQ2MzczOSJ9fX0=' | jq
```

```json
{
  "data": [
    {
      "date": "2023-08-21T00:00:00Z",
      "value": 4,
      "has_data": true
    },
    {
      "date": "2023-08-22T00:00:00Z",
      "value": 0,
      "has_data": false
    }
  ],
  "meta": {
    "count": 2,
    "product": "RHEL Server",
    "metric_id": "Cores",
    "granularity": "Daily"
  }
}
```

### switch branches to `lburnett/rhel-variant-configs` & restart the app

```
git checkout lburnett/rhel-variant-configs
DEV_MODE=true ./gradlew :bootRun
```

### examine the database to see the changes liquibase did

```sql
select * from tally_snapshots where org_id = '5463739';
```



### try to retrieve a tally report again

You're going to get a 404 now, because "RHEL Server" isn't a thing.

```bash
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20Server/Cores?granularity=Daily&beginning=2023-08-21T00%3A00%3A00Z&ending=2023-08-22T00%3A00%3A00Z&use_running_totals_format=false' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjU0NjM3MzkiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiNTQ2MzczOSJ9fX0=' | jq
```

### update the product ID in the URL and see you get the same data as before, just now with `RHEL for x86` instead of `RHEL Server`

```bash
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86/Cores?granularity=Daily&beginning=2023-08-21T00%3A00%3A00Z&ending=2023-08-22T00%3A00%3A00Z&use_running_totals_format=false' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjU0NjM3MzkiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiNTQ2MzczOSJ9fX0=' | jq
```

```json
{
  "data": [
    {
      "date": "2023-08-21T00:00:00Z",
      "value": 4,
      "has_data": true
    },
    {
      "date": "2023-08-22T00:00:00Z",
      "value": 0,
      "has_data": false
    }
  ],
  "meta": {
    "count": 2,
    "product": "RHEL for x86",
    "metric_id": "Cores",
    "granularity": "Daily"
  }
}
```



