### PR TITLE
SWATCH-1507: Fix casing on subscription_measurements.metric_id

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
@@ -47,8 +47,8 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class CapacityReconciliationController {
-  private static final String SOCKETS = MetricId.SOCKETS.toString().toUpperCase();
-  private static final String CORES = MetricId.CORES.toString().toUpperCase();
+  private static final String SOCKETS = MetricId.SOCKETS.toString();
+  private static final String CORES = MetricId.CORES.toString();
 
   private final SubscriptionRepository subscriptionRepository;
   private final KafkaTemplate<String, ReconcileCapacityByOfferingTask>

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -71,8 +71,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class CapacityResource implements CapacityApi {
 
-  public static final String SOCKETS = MetricId.SOCKETS.toString().toUpperCase();
-  public static final String CORES = MetricId.CORES.toString().toUpperCase();
+  public static final String SOCKETS = MetricId.SOCKETS.toString();
+  public static final String CORES = MetricId.CORES.toString();
   public static final String PHYSICAL = HardwareMeasurementType.PHYSICAL.toString().toUpperCase();
   public static final String HYPERVISOR =
       HardwareMeasurementType.HYPERVISOR.toString().toUpperCase();
@@ -398,7 +398,7 @@ public class CapacityResource implements CapacityApi {
           var isPhysical = PHYSICAL.equals(measurementType);
           var isHypervisor = HYPERVISOR.equals(measurementType);
 
-          if (CORES.equalsIgnoreCase(measurementKey.getMetricId())) {
+          if (CORES.equals(measurementKey.getMetricId())) {
             var val = measurementValue.intValue();
             cores += val;
             if (isPhysical) {
@@ -406,7 +406,7 @@ public class CapacityResource implements CapacityApi {
             } else if (isHypervisor) {
               hypervisorCores += val;
             }
-          } else if (SOCKETS.equalsIgnoreCase(measurementKey.getMetricId())) {
+          } else if (SOCKETS.equals(measurementKey.getMetricId())) {
             var val = measurementValue.intValue();
             sockets += val;
             if (isPhysical) {

--- a/src/main/resources/liquibase/202308151557-fix-subscription-measurement-metric-id-casing.xml
+++ b/src/main/resources/liquibase/202308151557-fix-subscription-measurement-metric-id-casing.xml
@@ -1,0 +1,26 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="202308151557-1" author="khowell">
+    <comment>Change CORES to Cores.</comment>
+    <update tableName="subscription_measurements">
+      <column name="metric_id" value="Cores"/>
+      <where>metric_id='CORES'</where>
+    </update>
+    <rollback>
+      update subscription_measurements set metric_id='CORES' where metric_id='Cores'
+    </rollback>
+  </changeSet>
+  <changeSet id="202308151557-2" author="khowell">
+    <comment>Change SOCKETS to Sockets.</comment>
+    <update tableName="subscription_measurements">
+      <column name="metric_id" value="Sockets"/>
+      <where>metric_id='SOCKETS'</where>
+    </update>
+    <rollback>
+      update subscription_measurements set metric_id='SOCKETS' where metric_id='Sockets'
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -118,5 +118,6 @@
     <include file="liquibase/202307261851-event-change-event-type-data.xml"/>
     <!-- Uncomment once the above changeset has landed in prod -->
     <!-- <include file="liquibase/202307051245-drop-instance_id-columns.xml"/> -->
+    <include file="liquibase/202308151557-fix-subscription-measurement-metric-id-casing.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/CapacityReconciliationControllerTest.java
@@ -54,8 +54,8 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles({"capacity-ingress", "test"})
 class CapacityReconciliationControllerTest {
-  private static final String SOCKETS = MetricId.SOCKETS.toString().toUpperCase();
-  private static final String CORES = MetricId.CORES.toString().toUpperCase();
+  private static final String SOCKETS = MetricId.SOCKETS.toString();
+  private static final String CORES = MetricId.CORES.toString();
 
   private static final OffsetDateTime NOW = OffsetDateTime.now();
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.subscriptions.db;
 
-import static org.candlepin.subscriptions.db.HypervisorReportCategory.NON_HYPERVISOR;
 import static org.hibernate.jpa.AvailableHints.HINT_FETCH_SIZE;
 
 import jakarta.persistence.QueryHint;
@@ -165,6 +164,10 @@ public interface SubscriptionRepository
   default List<Subscription> findByCriteria(DbReportCriteria dbReportCriteria, Sort sort) {
     return findAll(buildSearchSpecification(dbReportCriteria), sort);
   }
+
+  @Override
+  @EntityGraph(attributePaths = {"subscriptionMeasurements"})
+  List<Subscription> findAll(Specification<Subscription> spec, Sort sort);
 
   private static Specification<Subscription> hasUnlimitedUsage() {
     return (root, query, builder) -> {


### PR DESCRIPTION
Jira issue: [SWATCH-1507](https://issues.redhat.com/browse/SWATCH-1507)

Description
===========

When the capacity API is called for Sockets (e.g.
http://localhost:8000/api/rhsm-subscriptions/v1/capacity/products/RHEL%20for%20x86/Sockets), the generated SQL includes a clause like `where metric_id=?` where the param `?` is populated as `Sockets`.

However, we are recording measurements as `SOCKETS`, so no subscriptions will ever match.

I also fixed a subsequent issue where subscription measurements attempted to lazy-load without an open transaction; instead I changed the repository method to eager fetch subscription measurements.

Testing
=======

Test first with the `main` branch and then with this branch.

1. Truncate subscription tables:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
truncate subscription cascade;
EOF
```

2. Deploy the service:

```shell
DEV_MODE=true \
  SUBSCRIPTION_USE_STUB=true \
  PRODUCT_USE_STUB=true \
  ./gradlew :bootRun
```

3. Sync subscriptions:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123 \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

4. Ensure opted-in:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo -n '{"identity":{"type":"User","user":{"is_org_admin":true},"internal":{"org_id":"123"}}}' | base64 -w0)
```

5. Invoke capacity API for RHEL Server:

```shell
http ":8000/api/rhsm-subscriptions/v1/capacity/products/RHEL Server/Sockets" \
  beginning==2023-01-01T00:00Z \
  ending==2023-01-05T00:00Z \
  granularity==DAILY \
  x-rh-identity:$(echo -n '{"identity":{"type":"User","user":{"is_org_admin":true},"internal":{"org_id":"123"}}}' | base64 -w0)
```

6. Switch to this branch and repeat the above process.

Verification
------------

The capacity call will succeed and give values in this branch.

No errors should be seen in the logs for any of the above calls.