### PR TITLE
SWATCH-659: RhMarketplacePayloadMapper.produceUsageEvent no longer needs to looku…

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -41,7 +41,6 @@ import org.candlepin.subscriptions.rhmarketplace.api.model.UsageEvent;
 import org.candlepin.subscriptions.rhmarketplace.api.model.UsageMeasurement;
 import org.candlepin.subscriptions.rhmarketplace.api.model.UsageRequest;
 import org.candlepin.subscriptions.tally.billing.BillableUsageMapper;
-import org.candlepin.subscriptions.user.AccountService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +57,6 @@ public class RhMarketplacePayloadMapper {
   public static final String OPENSHIFT_DEDICATED_4_CPU_HOUR =
       "redhat.com:openshift_dedicated:4cpu_hour";
 
-  private final AccountService accountService;
   private final BillableUsageMapper billableUsageMapper;
   private final TagProfile tagProfile;
   private final InternalSubscriptionsApi subscriptionsClient;
@@ -67,11 +65,9 @@ public class RhMarketplacePayloadMapper {
   @Autowired
   public RhMarketplacePayloadMapper(
       TagProfile tagProfile,
-      AccountService accountService,
       InternalSubscriptionsApi subscriptionsClient,
       @Qualifier("rhmUsageContextLookupRetryTemplate") RetryTemplate usageContextRetryTemplate) {
     this.tagProfile = tagProfile;
-    this.accountService = accountService;
     this.subscriptionsClient = subscriptionsClient;
     // NOTE(khowell) this dependency is temporary, and instantiating here was easier than
     // refactoring profiles.
@@ -154,10 +150,6 @@ public class RhMarketplacePayloadMapper {
         context -> {
           String accountNumber = billableUsage.getAccountNumber();
           String orgId = billableUsage.getOrgId();
-          if (orgId == null) {
-            orgId = accountService.lookupOrgId(accountNumber);
-          }
-
           try {
             log.debug(
                 "Looking up RHM usage context for orgId={} billableUsage={}", orgId, billableUsage);

--- a/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
@@ -45,7 +45,6 @@ import org.candlepin.subscriptions.json.TallyMeasurement;
 import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.rhmarketplace.api.model.UsageEvent;
 import org.candlepin.subscriptions.rhmarketplace.api.model.UsageMeasurement;
-import org.candlepin.subscriptions.user.AccountService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,8 +66,6 @@ class RhMarketplacePayloadMapperTest {
   @Mock TagProfile tagProfile;
   @Mock InternalSubscriptionsApi subscriptionsApi;
 
-  @Mock AccountService accountService;
-
   RhMarketplacePayloadMapper rhMarketplacePayloadMapper;
 
   @BeforeEach
@@ -77,7 +74,7 @@ class RhMarketplacePayloadMapperTest {
     retry.setBackOffPolicy(new NoBackOffPolicy());
 
     rhMarketplacePayloadMapper =
-        new RhMarketplacePayloadMapper(tagProfile, accountService, subscriptionsApi, retry);
+        new RhMarketplacePayloadMapper(tagProfile, subscriptionsApi, retry);
 
     // Tell Mockito not to complain if some of these mocks aren't used in a particular test
     lenient()
@@ -121,6 +118,7 @@ class RhMarketplacePayloadMapperTest {
     var usage =
         new BillableUsage()
             .withId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
+            .withOrgId(orgId)
             .withAccountNumber(account)
             .withProductId("OpenShift-metrics")
             .withSnapshotDate(snapshotDate)
@@ -130,8 +128,6 @@ class RhMarketplacePayloadMapperTest {
             .withSla(Sla.PREMIUM)
             .withBillingProvider(BillingProvider.RED_HAT)
             .withBillingAccountId("sellerAccountId");
-
-    when(accountService.lookupOrgId(account)).thenReturn(orgId);
 
     var usageMeasurement =
         new UsageMeasurement().value(36.0).metricId("redhat.com:openshift:cpu_hour");
@@ -174,6 +170,7 @@ class RhMarketplacePayloadMapperTest {
             .withId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
             .withAccountNumber(account)
             .withProductId("OpenShift-metrics")
+            .withOrgId(orgId)
             .withSnapshotDate(snapshotDate)
             .withUsage(Usage.PRODUCTION)
             .withUom(Uom.CORES)
@@ -181,8 +178,6 @@ class RhMarketplacePayloadMapperTest {
             .withSla(Sla.PREMIUM)
             .withBillingProvider(BillingProvider.RED_HAT)
             .withBillingAccountId("sellerAccountId");
-
-    when(accountService.lookupOrgId(account)).thenReturn(orgId);
 
     assertNull(rhMarketplacePayloadMapper.produceUsageEvent(usage));
     assertTrue(rhMarketplacePayloadMapper.createUsageRequest(usage).getData().isEmpty());
@@ -283,7 +278,7 @@ class RhMarketplacePayloadMapperTest {
         .thenThrow(ApiException.class);
 
     RhMarketplacePayloadMapper mapper =
-        new RhMarketplacePayloadMapper(tagProfile, accountService, subscriptionsApi, retry);
+        new RhMarketplacePayloadMapper(tagProfile, subscriptionsApi, retry);
 
     BillableUsage billableUsage =
         new BillableUsage()


### PR DESCRIPTION
Jira issue: [SWATCH-659](https://issues.redhat.com/browse/SWATCH-659)

## Description
RhMarketplacePayloadMapper#produceUsageEvent was looking up the orgId if missing.  This is no longer necessary after orgId migration. 
The lookup has been removed.

## Testing
The removed lookup was not being used.  Below are the steps to exercise the code to make sure it still works.

### Setup
1. Start with a clean database.  
```
podman-compose down
podman-compose up -d
```
2. Start the app with: `LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_RHMARKETPLACE=DEBUG  DEV_MODE=true ./gradlew clean :bootRun`
3. Insert Mock data:
```
$ psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "INSERT INTO public.subscription(
        sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id)
        VALUES ('MW01882', 'org123', '12351253', '1', '2012-05-13 16:32:00+00', '2032-05-13 16:32:00+00', '1', 'account123', '1235153', 'red hat', '456');"

$ psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "INSERT INTO public.events (id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('3ee2aec5-9a48-424b-9667-e6d3287557d4', 'account123', '2021-10-18 20:00:00.000000 +00:00', '{\"sla\": \"Premium\", \"role\": \"rhosak\", \"org_id\": \"org123\", \"event_id\": \"3ee2aec5-9a48-424b-9667-e6d3287557d4\", \"timestamp\": \"2021-10-18T20:00:00Z\", \"event_type\": \"snapshot_redhat.com:rhosak:storage_gb\", \"expiration\": \"2021-10-19T20:00:00Z\", \"instance_id\": \"c5mu16smf1c22rn8e730\", \"display_name\": \"c5mu16smf1c22rn8e730\", \"event_source\": \"prometheus\", \"measurements\": [{\"uom\": \"Storage-gibibytes\", \"value\": 0.5}], \"service_type\": \"Kafka Cluster\", \"account_number\": \"account123\", \"billing_provider\": \"red hat\", \"billing_account_id\": \"dummyId\"}', 'snapshot_redhat.com:rhosak:storage_gb', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');"
```

### Verification
1.  Run the   `http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=org123&start=2021-10-01T00:00Z&end=2021-11-01T00:00Z" x-rh-swatch-psk:placeholder`
In the logs with debug enabled, you will see `Looking up RHM usage context for orgId=org123....`.   
After waiting a couple of minutes (~4) it will fail to contact the Redhat Marketplace.  But it has been able to get the orgId by this time.

