### PR TITLE
SWATCH-38: Rename staleHostOffsetInDays to staleHostOffset

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.conduit.inventory;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.*;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -47,12 +48,12 @@ public abstract class InventoryService {
   private static final Logger log = LoggerFactory.getLogger(InventoryService.class);
 
   private int maxQueueDepth;
-  private int staleHostOffset;
+  private Duration staleHostOffset;
   private List<ConduitFacts> factQueue;
 
   protected InventoryService(InventoryServiceProperties serviceProperties, int maxQueueDepth) {
     this.maxQueueDepth = maxQueueDepth;
-    this.staleHostOffset = serviceProperties.getStaleHostOffsetInDays();
+    this.staleHostOffset = serviceProperties.getStaleHostOffset();
     this.factQueue = new LinkedList<>();
   }
 
@@ -106,7 +107,7 @@ public abstract class InventoryService {
 
     // required culling properties
     host.setReporter("rhsm-conduit");
-    host.setStaleTimestamp(syncTimestamp.plusHours(staleHostOffset));
+    host.setStaleTimestamp(syncTimestamp.plus(staleHostOffset));
 
     // canonical facts.
     host.setOrgId(facts.getOrgId());

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryServiceProperties.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryServiceProperties.java
@@ -36,8 +36,10 @@ public class InventoryServiceProperties {
   private String apiKey;
   private String kafkaHostIngressTopic;
   private int apiHostUpdateBatchSize = 50;
-  private int staleHostOffsetInDays = 0;
   private boolean tolerateMissingAccountNumber;
+
+  @DurationUnit(ChronoUnit.HOURS)
+  private Duration staleHostOffset = Duration.ofHours(0);
 
   @DurationUnit(ChronoUnit.HOURS)
   private Duration hostLastSyncThreshold = Duration.ofHours(24);

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -31,8 +31,7 @@ rhsm-conduit:
     api-key: ${INVENTORY_API_KEY:changeit}
     host-last-sync-threshold: ${HOST_LAST_SYNC_THRESHOLD:24h}
     add-uuid-hyphens: ${INVENTORY_ADD_UUID_HYPHENS:false}
-    # FIXME: misnamed, it's actually in hours
-    stale-host-offset-in-days: ${INVENTORY_STALE_HOST_OFFSET_HOURS:48}
+    stale-host-offset: ${INVENTORY_STALE_HOST_OFFSET:48h}
     kafka-host-ingress-topic: ${INVENTORY_HOST_INGRESS_TOPIC}
     tolerate-missing-account-number: ${TOLERATE_MISSING_ACCOUNT_NUMBER:false}
   tasks:

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.*;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -179,7 +180,7 @@ class KafkaEnabledInventoryServiceTest {
     expectedFacts.setAccountNumber("my_account");
 
     InventoryServiceProperties props = new InventoryServiceProperties();
-    props.setStaleHostOffsetInDays(24);
+    props.setStaleHostOffset(Duration.ofHours(24));
 
     KafkaEnabledInventoryService service =
         new KafkaEnabledInventoryService(props, producer, meterRegistry, retryTemplate);


### PR DESCRIPTION
Jira issue: JIRA ticket: https://issues.redhat.com/browse/SWATCH-38

## Description

Change the property `rhsm-conduit.inventory-service.staleHostOffsetInDays` which wrongly states it's in days when it's really in hours, to `rhsm-conduit.inventory-service.staleHostOffset` while now it accepts a duration (so users can use hours, days, minutes, ...). 

## Testing

The test `testStaleTimestampUpdatedBasedOnSyncTimestampAndOffset` already covers this change. 

## Breaking changes

The system property has changed from `INVENTORY_STALE_HOST_OFFSET_HOURS` to `INVENTORY_STALE_HOST_OFFSET`. We can add a logic to make INVENTORY_STALE_HOST_OFFSET_HOURS backward compatible (see comments).