### PR TITLE
SWATCH-1237: Use swatch-product-configuration in subscription syncing

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -38,11 +38,11 @@ import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
 import org.candlepin.subscriptions.utilization.admin.api.InternalApi;
 import org.candlepin.subscriptions.utilization.admin.api.model.AwsUsageContext;
 import org.candlepin.subscriptions.utilization.admin.api.model.DefaultResponse;
+import org.candlepin.subscriptions.utilization.admin.api.model.Metric;
 import org.candlepin.subscriptions.utilization.admin.api.model.OfferingProductTags;
 import org.candlepin.subscriptions.utilization.admin.api.model.OfferingResponse;
 import org.candlepin.subscriptions.utilization.admin.api.model.RhmUsageContext;
 import org.candlepin.subscriptions.utilization.admin.api.model.SubscriptionResponse;
-import org.candlepin.subscriptions.utilization.admin.api.model.TagMetric;
 import org.candlepin.subscriptions.utilization.admin.api.model.TerminationRequest;
 import org.candlepin.subscriptions.utilization.admin.api.model.TerminationRequestData;
 import org.jetbrains.annotations.NotNull;
@@ -62,7 +62,7 @@ public class InternalSubscriptionResource implements InternalApi {
   private final MeterRegistry meterRegistry;
   private final UsageContextSubscriptionProvider awsSubscriptionProvider;
   private final UsageContextSubscriptionProvider rhmSubscriptionProvider;
-  private final TagMetricMapper tagMetricMapper;
+  private final MetricMapper metricMapper;
   private static final String SUCCESS_STATUS = "Success";
 
   public static final String FEATURE_NOT_ENABLED_MESSSAGE =
@@ -76,7 +76,7 @@ public class InternalSubscriptionResource implements InternalApi {
       SubscriptionPruneController subscriptionPruneController,
       OfferingSyncController offeringSync,
       CapacityReconciliationController capacityReconciliationController,
-      TagMetricMapper tagMetricMapper) {
+      MetricMapper metricMapper) {
     this.meterRegistry = meterRegistry;
     this.subscriptionSyncController = subscriptionSyncController;
     this.properties = properties;
@@ -95,7 +95,7 @@ public class InternalSubscriptionResource implements InternalApi {
     this.subscriptionPruneController = subscriptionPruneController;
     this.offeringSync = offeringSync;
     this.capacityReconciliationController = capacityReconciliationController;
-    this.tagMetricMapper = tagMetricMapper;
+    this.metricMapper = metricMapper;
   }
 
   /**
@@ -190,8 +190,8 @@ public class InternalSubscriptionResource implements InternalApi {
   }
 
   @Override
-  public List<TagMetric> getTagMetrics(String tag) {
-    return tagMetricMapper.mapTagMetrics(subscriptionSyncController.getMetricsForTag(tag));
+  public List<Metric> getMetrics(String tag) {
+    return metricMapper.mapMetrics(subscriptionSyncController.getMetricsForTag(tag));
   }
 
   private AwsUsageContext buildAwsUsageContext(Subscription subscription) {

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.capacity.admin;
 
+import com.redhat.swatch.configuration.registry.Variant;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.ws.rs.NotFoundException;
@@ -191,7 +192,7 @@ public class InternalSubscriptionResource implements InternalApi {
 
   @Override
   public List<Metric> getMetrics(String tag) {
-    return metricMapper.mapMetrics(subscriptionSyncController.getMetricsForTag(tag));
+    return metricMapper.mapMetrics(Variant.getMetricsForTag(tag));
   }
 
   private AwsUsageContext buildAwsUsageContext(Subscription subscription) {

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/MetricMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/MetricMapper.java
@@ -22,15 +22,16 @@ package org.candlepin.subscriptions.capacity.admin;
 
 import com.redhat.swatch.configuration.registry.Metric;
 import java.util.List;
-import org.candlepin.subscriptions.utilization.admin.api.model.TagMetric;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
-public interface TagMetricMapper {
+public interface MetricMapper {
 
-  List<TagMetric> mapTagMetrics(List<Metric> metricsForTag);
+  List<org.candlepin.subscriptions.utilization.admin.api.model.Metric> mapMetrics(
+      List<Metric> metricsForTag);
 
   @Mapping(target = "uom", source = "id")
-  TagMetric fromConfigurationMetric(Metric metric);
+  org.candlepin.subscriptions.utilization.admin.api.model.Metric fromConfigurationMetric(
+      Metric metric);
 }

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/TagMetricMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/TagMetricMapper.java
@@ -20,13 +20,17 @@
  */
 package org.candlepin.subscriptions.capacity.admin;
 
+import com.redhat.swatch.configuration.registry.Metric;
 import java.util.List;
-import org.candlepin.subscriptions.registry.TagMetric;
+import org.candlepin.subscriptions.utilization.admin.api.model.TagMetric;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface TagMetricMapper {
 
-  List<org.candlepin.subscriptions.utilization.admin.api.model.TagMetric> mapTagMetrics(
-      List<TagMetric> metricsForTag);
+  List<TagMetric> mapTagMetrics(List<Metric> metricsForTag);
+
+  @Mapping(target = "uom", source = "id")
+  TagMetric fromConfigurationMetric(Metric metric);
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.subscription;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.redhat.swatch.configuration.registry.Metric;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
 import io.micrometer.core.annotation.Timed;
@@ -627,11 +626,7 @@ public class SubscriptionSyncController {
     Assert.isTrue(ServiceLevel._ANY != usageKey.getSla(), "Service Level cannot be _ANY");
 
     String productId = usageKey.getProductId();
-    Set<String> productNames =
-        Variant.findByTag(productId).stream()
-            .map(Variant::getProductNames)
-            .flatMap(List::stream)
-            .collect(Collectors.toSet());
+    Set<String> productNames = Variant.getProductNamesForTag(productId);
     if (productNames.isEmpty()) {
       log.warn("No product names configured for tag: {}", productId);
       return Collections.emptyList();
@@ -708,13 +703,5 @@ public class SubscriptionSyncController {
           null);
     }
     return productTags;
-  }
-
-  public List<Metric> getMetricsForTag(String tag) {
-    return Variant.findByTag(tag).stream()
-        .map(Variant::getSubscription)
-        .map(SubscriptionDefinition::getMetrics)
-        .flatMap(List::stream)
-        .toList();
   }
 }

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -285,17 +285,17 @@ paths:
         schema:
           type: string
     get:
-      summary: "Lookup metrics tags by tag"
-      operationId: getTagMetrics
+      summary: "Lookup metric information by tag"
+      operationId: getMetrics
       responses:
         '200':
-          description: Matching tag metrics
+          description: Matching metrics
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TagMetric'
+                  $ref: '#/components/schemas/Metric'
               example:
                 data:
                   - metric_id: foo
@@ -461,7 +461,7 @@ components:
           type: array
           items:
             type: string
-    TagMetric:
+    Metric:
       properties:
         uom:
           type: string

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -71,7 +71,7 @@ class InternalSubscriptionResourceTest {
   @MockBean OfferingSyncController offeringSync;
 
   @MockBean CapacityReconciliationController capacityReconciliationController;
-  @MockBean TagMetricMapper tagMetricMapper;
+  @MockBean MetricMapper metricMapper;
   @Autowired SecurityProperties properties;
   @Autowired WebApplicationContext context;
   @Autowired InternalSubscriptionResource resource;
@@ -109,7 +109,7 @@ class InternalSubscriptionResourceTest {
             subscriptionPruneController,
             offeringSync,
             capacityReconciliationController,
-            tagMetricMapper);
+            metricMapper);
     when(syncController.findSubscriptionsAndSyncIfNeeded(
             any(), any(), any(), any(), any(), anyBoolean()))
         .thenReturn(Collections.emptyList());
@@ -133,7 +133,7 @@ class InternalSubscriptionResourceTest {
             subscriptionPruneController,
             offeringSync,
             capacityReconciliationController,
-            tagMetricMapper);
+            metricMapper);
     when(syncController.findSubscriptionsAndSyncIfNeeded(
             any(), any(), any(), any(), any(), anyBoolean()))
         .thenReturn(Collections.emptyList());
@@ -157,7 +157,7 @@ class InternalSubscriptionResourceTest {
             subscriptionPruneController,
             offeringSync,
             capacityReconciliationController,
-            tagMetricMapper);
+            metricMapper);
     Subscription sub1 = new Subscription();
     sub1.setBillingProviderId("foo1;foo2;foo3");
     sub1.setEndDate(defaultEndDate);
@@ -188,7 +188,7 @@ class InternalSubscriptionResourceTest {
             subscriptionPruneController,
             offeringSync,
             capacityReconciliationController,
-            tagMetricMapper);
+            metricMapper);
     Subscription sub1 = new Subscription();
     sub1.setBillingProviderId("foo1;foo2;foo3");
     sub1.setEndDate(defaultEndDate);
@@ -336,7 +336,7 @@ class InternalSubscriptionResourceTest {
             subscriptionPruneController,
             offeringSync,
             capacityReconciliationController,
-            tagMetricMapper);
+            metricMapper);
 
     when(syncController.findSubscriptionsAndSyncIfNeeded(
             any(), any(), any(), any(), any(), anyBoolean()))
@@ -366,7 +366,7 @@ class InternalSubscriptionResourceTest {
             subscriptionPruneController,
             offeringSync,
             capacityReconciliationController,
-            tagMetricMapper);
+            metricMapper);
 
     Subscription sub1 = new Subscription();
     sub1.setBillingProviderId("account123");

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformer.java
@@ -53,7 +53,7 @@ public class MeasurementMetricIdTransformer {
                 .findFirst()
                 .map(SubscriptionProductIdEntity::getProductId)
                 .orElseThrow();
-        var metrics = internalSubscriptionsApi.getTagMetrics(tag);
+        var metrics = internalSubscriptionsApi.getMetrics(tag);
         subscription
             .getSubscriptionMeasurements()
             .forEach(

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformerTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.redhat.swatch.clients.swatch.internal.subscription.api.model.TagMetric;
+import com.redhat.swatch.clients.swatch.internal.subscription.api.model.Metric;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi;
 import com.redhat.swatch.contract.repository.BillingProvider;
@@ -65,11 +65,11 @@ class MeasurementMetricIdTransformerTest {
     productId.setProductId("hello");
     subscription.addSubscriptionProductId(productId);
 
-    when(internalSubscriptionsApi.getTagMetrics("hello"))
+    when(internalSubscriptionsApi.getMetrics("hello"))
         .thenReturn(
             List.of(
-                new TagMetric().uom("foo1").awsDimension("foo").billingFactor(0.25),
-                new TagMetric().uom("bar2").awsDimension("bar").billingFactor(1.0)));
+                new Metric().uom("foo1").awsDimension("foo").billingFactor(0.25),
+                new Metric().uom("bar2").awsDimension("bar").billingFactor(1.0)));
     transformer.translateContractMetricIdsToSubscriptionMetricIds(subscription);
     assertEquals(
         List.of("bar2", "foo1"),

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -124,6 +124,11 @@ public class SubscriptionDefinition {
     return granularity;
   }
 
+  public boolean isPaygEnabled() {
+    return metrics.stream()
+        .anyMatch(metric -> metric.getRhmMetricId() != null || metric.getAwsDimension() != null);
+  }
+
   /**
    * An engineering id can be found in either a fingerprint or variant. Check the variant first. If
    * not found, check the fingerprint.

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.*;
 
 /**
@@ -85,5 +87,20 @@ public class Variant {
         .flatMap(List::stream)
         .filter(v -> v.getProductNames().contains(productName))
         .findFirst();
+  }
+
+  public static Set<String> getProductNamesForTag(String productId) {
+    return findByTag(productId).stream()
+        .map(Variant::getProductNames)
+        .flatMap(List::stream)
+        .collect(Collectors.toSet());
+  }
+
+  public static List<Metric> getMetricsForTag(String tag) {
+    return findByTag(tag).stream()
+        .map(Variant::getSubscription)
+        .map(SubscriptionDefinition::getMetrics)
+        .flatMap(List::stream)
+        .toList();
   }
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
@@ -78,4 +78,12 @@ public class Variant {
         .filter(variant -> Objects.equals(variant.getTag(), defaultVariantTag))
         .findFirst();
   }
+
+  public static Optional<Variant> findByProductName(String productName) {
+    return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
+        .map(SubscriptionDefinition::getVariants)
+        .flatMap(List::stream)
+        .filter(v -> v.getProductNames().contains(productName))
+        .findFirst();
+  }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-1237](https://issues.redhat.com/browse/SWATCH-1237)

Description
===========

Subscription syncing used tag profile for the following things:

* Log a warning if a PAYG sub is missing details
* Log a warning if attempting to terminate a PAYG sub more than an hour out
* Lookup the product names used for a PAYG sub lookup
* Provide a lookup for productIds/tags for a SKU.
* Provide a lookup for metrics for a productId/tag.

Testing
=======

1. Deploy the service:

```shell
DEV_MODE=true \
  DEVTEST_EVENT_EDITING_ENABLED=true \
  SUBSCRIPTION_USE_STUB=true \
  PRODUCT_USE_STUB=true \
  ./gradlew :bootRun
```

2. Sync subscriptions:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123 \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

3. Terminate a subscription:

```shell
http POST :8000/api/rhsm-subscriptions/v1/internal/subscriptions/terminate/235251 \
  timestamp==2030-01-01T00:00Z \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

4. Lookup aws usage context:

```shell
http :8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext \
  orgId==123 \
  productId==rosa \
  date==2023-01-01T00:00Z \
  awsAccountId==foo \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

See in the logs a line like:
> No subscription found for account null with criteria DbReportCriteria(accountNumber=null, orgId=123, productTag=null, productNames=[OpenShift Dedicated], productId=null, serviceLevel=EMPTY, usage=_ANY, billingProvider=AWS, billingAccountId=foo, payg=true, beginning=2022-12-31T23:00Z, ending=2023-01-01T00:00Z, metricId=null, hypervisorReportCategory=null)

(Verify that `OpenShift Dedicated` is in `productNames`)

5. Lookup tags for a SKU:

```shell
http :8000/api/rhsm-subscriptions/v1/internal/offerings/MW01485/product_tags \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

(See `OpenShift-metrics` in the response).

6. Lookup metrics for a tag:

```shell
http :8000/api/rhsm-subscriptions/v1/internal/tags/rosa/metrics \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

(Verify `Instance-hours` and `Cores` in the response).

Verification
------------

* Verify warning log when PAYG sub is missing details, message like:
> PAYG eligible subscription with subscriptionId:235251 has no billing provider.

* Verify warning log when attempting to terminate a PAYG sub more than an hour out, message like:
> Subscription 235251 terminated at 2023-08-17T19:50:06.974839779Z with out of range termination date 2030-01-01T00:00Z

Verify api calls succeed w/ non-empty results for lookups.