### PR TITLE
SWATCH-371: Add metric_id to instance_measurements

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -141,10 +141,10 @@ def _generate_buckets(host_id, product, sla, usage, as_hypervisor=False, measure
                 _generate_insert("host_tally_buckets", sla=next_sla, usage=next_usage, **hypervisor_bucket_fields)
 
 
-def _generate_measurements(host_id, uom, value):
+def _generate_measurements(host_id, metric_id, value):
     measurement_fields = {
         'host_id': host_id,
-        'uom': uom,
+        'metric_id': metric_id,
         'value': value,
     }
     _generate_insert("instance_measurements", **measurement_fields)

--- a/src/main/resources/liquibase/202308210806-add-metric-id-instance-measurements.xml
+++ b/src/main/resources/liquibase/202308210806-add-metric-id-instance-measurements.xml
@@ -1,0 +1,129 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202308210806-1" author="jcarvaja" dbms="postgresql">
+    <comment>Rename instance_measurements.uom to metric_id and support both.</comment>
+    <renameColumn tableName="instance_measurements" oldColumnName="uom" newColumnName="metric_id"/>
+    <dropView viewName="tally_instance_view"/>
+    <sql>
+      alter table instance_measurements add column uom varchar(255) generated always as (metric_id) stored
+    </sql>
+    <createView
+            replaceIfExists="true"
+            viewName="tally_instance_view">
+      select
+      distinct org_id,
+      h.id,
+      h.instance_id as instance_id,
+      h.display_name,
+      h.billing_provider as host_billing_provider,
+      h.billing_account_id as host_billing_account_id,
+      b.billing_provider as bucket_billing_provider,
+      b.billing_account_id as bucket_billing_account_id,
+      h.last_seen,
+      coalesce(h.num_of_guests, 0) AS num_of_guests,
+      b.product_id,
+      b.sla,
+      b.usage,
+      coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+      m.metric_id,
+      m.value,
+      b.sockets,
+      b.cores,
+      h.subscription_manager_id
+      from hosts h
+      join host_tally_buckets b on h.id = b.host_id
+      left outer join instance_measurements m on h.id = m.host_id;
+    </createView>
+    <rollback>
+      <dropView viewName="tally_instance_view"/>
+      <sql>
+        alter table instance_measurements drop column uom
+      </sql>
+      <renameColumn tableName="instance_measurements" oldColumnName="metric_id" newColumnName="uom"/>
+      <createView
+              replaceIfExists="true"
+              viewName="tally_instance_view">
+        select
+        distinct org_id,
+        h.id,
+        h.instance_id as instance_id,
+        h.display_name,
+        h.billing_provider as host_billing_provider,
+        h.billing_account_id as host_billing_account_id,
+        b.billing_provider as bucket_billing_provider,
+        b.billing_account_id as bucket_billing_account_id,
+        h.last_seen,
+        coalesce(h.num_of_guests, 0) AS num_of_guests,
+        b.product_id,
+        b.sla,
+        b.usage,
+        coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+        m.uom,
+        m.value,
+        b.sockets,
+        b.cores,
+        h.subscription_manager_id
+        from hosts h
+        join host_tally_buckets b on h.id = b.host_id
+        left outer join instance_measurements m on h.id = m.host_id;
+      </createView>
+    </rollback>
+  </changeSet>
+  <!-- NOTE: below changeset is the hsql alternative (only run for unit tests) -->
+  <changeSet id="202308210806-2" author="jcarvaja" dbms="!postgresql">
+    <comment>Rename instance_measurements.uom to metric_id.</comment>
+    <dropView viewName="tally_instance_view"/>
+    <renameColumn tableName="instance_measurements" oldColumnName="uom" newColumnName="metric_id"/>
+    <createView
+            replaceIfExists="true"
+            viewName="tally_instance_view">
+      select
+      distinct org_id,
+      h.id,
+      h.instance_id as instance_id,
+      h.display_name,
+      h.billing_provider as host_billing_provider,
+      h.billing_account_id as host_billing_account_id,
+      b.billing_provider as bucket_billing_provider,
+      b.billing_account_id as bucket_billing_account_id,
+      h.last_seen,
+      coalesce(h.num_of_guests, 0) AS num_of_guests,
+      b.product_id,
+      b.sla,
+      b.usage,
+      coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+      m.metric_id,
+      m.value,
+      b.sockets,
+      b.cores,
+      h.subscription_manager_id
+      from hosts h
+      join host_tally_buckets b on h.id = b.host_id
+      left outer join instance_measurements m on h.id = m.host_id;
+    </createView>
+  </changeSet>
+
+  <changeSet id="202308210806-3" author="jcarvaja" dbms="postgresql">
+    <comment>Rename instance_monthly_totals.uom to metric_id and support both.</comment>
+    <renameColumn tableName="instance_monthly_totals" oldColumnName="uom" newColumnName="metric_id"/>
+    <sql>
+      alter table instance_monthly_totals add column uom varchar(255) generated always as (metric_id) stored
+    </sql>
+    <rollback>
+      <sql>
+        alter table instance_monthly_totals drop column uom
+      </sql>
+      <renameColumn tableName="instance_monthly_totals" oldColumnName="metric_id" newColumnName="uom"/>
+    </rollback>
+  </changeSet>
+  <!-- NOTE: below changeset is the hsql alternative (only run for unit tests) -->
+  <changeSet id="202308210806-4" author="jcarvaja" dbms="!postgresql">
+    <comment>Rename instance_monthly_totals.uom to metric_id.</comment>
+    <renameColumn tableName="instance_monthly_totals" oldColumnName="uom" newColumnName="metric_id"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/202308210906-drop-uom-column-instance-measurements.xml
+++ b/src/main/resources/liquibase/202308210906-drop-uom-column-instance-measurements.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202308210906-1" author="jcarvaja" dbms="postgresql">
+        <comment>Drop instance_measurements.uom.</comment>
+        <dropColumn tableName="instance_measurements" columnName="uom"/>
+        <rollback>
+            alter table instance_measurements add column uom varchar(255) generated always as (metric_id) stored;
+        </rollback>
+    </changeSet>
+    <changeSet id="202308210906-2" author="jcarvaja" dbms="postgresql">
+        <comment>Drop instance_monthly_totals.uom.</comment>
+        <dropColumn tableName="instance_monthly_totals" columnName="uom"/>
+        <rollback>
+            alter table instance_monthly_totals add column uom varchar(255) generated always as (metric_id) stored;
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -115,9 +115,12 @@
     <include file="liquibase/202307171013-add-indexes-for-tally-instance-view-queries.xml"/>
     <include file="/liquibase/202307131456-remove-granularity-from-billable-usage-remittance.xml"/>
     <include file="liquibase/202307051132-rename-instance_id-to-host_id.xml"/>
-    <include file="liquibase/202307261851-event-change-event-type-data.xml"/>
     <!-- Uncomment once the above changeset has landed in prod -->
     <!-- <include file="liquibase/202307051245-drop-instance_id-columns.xml"/> -->
     <include file="liquibase/202308151557-fix-subscription-measurement-metric-id-casing.xml"/>
+    <include file="liquibase/202307261851-event-change-event-type-data.xml"/>
+    <include file="liquibase/202308210806-add-metric-id-instance-measurements.xml"/>
+    <!-- Uncomment once the above changeset has landed in prod -->
+    <!-- <include file="liquibase/202308210906-drop-uom-column-instance-measurements.xml"/> -->
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -95,7 +95,7 @@ public class Host implements Serializable {
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(name = "instance_measurements", joinColumns = @JoinColumn(name = "host_id"))
   @MapKeyEnumerated(EnumType.STRING)
-  @MapKeyColumn(name = "uom")
+  @MapKeyColumn(name = "metric_id")
   @Column(name = "value")
   private Map<Measurement.Uom, Double> measurements = new EnumMap<>(Measurement.Uom.class);
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/InstanceMonthlyTotalKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/InstanceMonthlyTotalKey.java
@@ -46,7 +46,7 @@ public class InstanceMonthlyTotalKey implements Serializable {
   private String month;
 
   @Enumerated(EnumType.STRING) // ENT-4622 needed to avoid recreating collections
-  @Column(nullable = false)
+  @Column(name = "metric_id", nullable = false)
   private Measurement.Uom uom;
 
   public static String formatMonthId(OffsetDateTime reference) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
@@ -64,6 +64,6 @@ public class TallyInstanceViewKey implements Serializable {
   private HardwareMeasurementType measurementType;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "uom")
+  @Column(name = "metric_id")
   private Measurement.Uom uom;
 }


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/SWATCH-371

## Description
As a swatch developer, I want swatch to write metric_id to instance_measurements, so that I can remove UOM later on.
The solution renames the existing column "uom" to "metric_id", so the primary key and the existing index got updated as well. This is done for the table `instance_measurements` and the view `tally_instance_view`. 

Moreover, the solution creates a temporary computed column "uom" to take the data from "metric_id", so existing services will keep working as usual meanwhile the migration data takes effect.

The solution follows the same pattern as in https://github.com/RedHatInsights/rhsm-subscriptions/pull/2304. 

## Testing

Setup
-----

1. Checkout `main`
2. Ensure that the DB schema is in place:

```shell
./gradlew :liquibaseUpdate
```

3. Insert some test data:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
insert into account_config(org_id, opt_in_type, created, updated) values ('org123', 'JMX', now(), now());
insert into account_services(org_id, service_type) values ('org123', 'HBI_HOST');
insert into hosts(id, inventory_id, account_number, insights_id, org_id, display_name, subscription_manager_id,
                  is_guest, hypervisor_uuid, hardware_type, num_of_guests, last_seen, is_unmapped_guest, is_hypervisor,
                  cloud_provider, instance_id, billing_provider, billing_account_id)
values ('78ef3f29-c900-4b9f-af04-e9aeb0231daf', 'd25b4de0-965a-462e-8f0e-6f51d1fd9590', 'account123', '9efad409-9366-48b1-8079-e33333a4715e', 'org123', 'example', '75dabfd8-c67c-45a2-bb19-9c11bb68c242',
        false, null, 'PHYSICAL', null, now(), false, false,
        null, '44d3e412-b238-4de3-ab02-e4b87ea00466', null, null);
insert into instance_measurements (host_id, metric_id, value)
values ('78ef3f29-c900-4b9f-af04-e9aeb0231daf', 'CORES', 41.5);
insert into instance_monthly_totals(host_id, month, metric_id, value)
  values ('78ef3f29-c900-4b9f-af04-e9aeb0231daf', '2023-07', 'CORES', 42.5);
insert into host_tally_buckets(host_id, product_id, sla, as_hypervisor, measurement_type)
  values ('78ef3f29-c900-4b9f-af04-e9aeb0231daf', 'OpenShift-metrics', '_ANY', false, 'PHYSICAL');
insert into host_tally_buckets(host_id, product_id, sla, as_hypervisor, measurement_type)
  values ('78ef3f29-c900-4b9f-af04-e9aeb0231daf', 'OpenShift Container Platform', '_ANY', false, 'PHYSICAL');
EOF
```

4. Insert some hosts into HBI for testing the nightly tally:

```shell
bin/insert-mock-hosts \
  --num-hypervisors=1 \
  --num-guests=1 \
  --hbi \
  --org org123 \
  --clear
```