### PR TITLE
SWATCH-1571: Skip syncing SaaS-contract subscriptions from IT Subscription Service

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -219,6 +219,16 @@ public class SubscriptionSyncController {
       final org.candlepin.subscriptions.db.model.Subscription existingSubscription =
           subscriptionOptional.get();
       log.debug("Existing subscription in DB={}", existingSubscription);
+      if (Objects.nonNull(existingSubscription.getBillingProvider())
+          && !existingSubscription.getSubscriptionMeasurements().isEmpty()) {
+        // NOTE(khowell): longer term, we should query the partnerEntitlement service for this
+        // subscription on any attempt to sync, but for now we rely on UMB messages from the IT
+        // Partner Entitlement service to update this record outside this process.
+        log.info(
+            "Skipping sync of subscriptionId={} because it has contract-provided capacity",
+            existingSubscription.getSubscriptionId());
+        return;
+      }
       if (existingSubscription.equals(newOrUpdated)) {
         return; // we have nothing to do as the DB and the subs service have the same info
       }


### PR DESCRIPTION
Jira issue: [SWATCH-1571](https://issues.redhat.com/browse/SWATCH-1571)

Description
===========

Subscription syncing currently fetches information only from IT Subscription Service and IT Product Service. (It does not consult the partner subscription API). Contract capacities are recorded only the partner subscription API, so the view from IT Subscription Service is incomplete. This can cause a SaaS-contract subscription to be incorrectly modified during a subscription sync.

Note that the `Subscription.equals` method prevents update of a `Subscription` entity unless one of the following properties changes:

* `subscriptionNumber`
* `quantity`
* `startDate`
* `endDate`
* `billingProviderId`
* `billingAccountId`
* `accountNumber`
* `billingProvider`

Contract service does not record accountNumber, so when the subscription is synced, it'll be considered unequal (null != non-null), and then it'll remove the subscription measurements.

Testing
=======

1. Deploy the service:

```shell
DEV_MODE=true \
  DEVTEST_EVENT_EDITING_ENABLED=true \
  SUBSCRIPTION_USE_STUB=true \
  PRODUCT_USE_STUB=true \
  ./gradlew :bootRun
```

2. Sync subscriptions:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123 \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

3. Update the subscription to look like a SaaS-contract subscription, update capacity too:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
update subscription set billing_provider='aws' where id='235255';
update subscription_measurements set value=100 where id='235255';
EOF
```

4. Sync subscriptions:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123 \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

Verification
------------

See in the logs a line like:
> Skipping sync of subscriptionId=235255 because it has contract-provided capacity

Verify the amounts are unchanged:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
select * from subscription_measurements where subscription_id='235255';
EOF
```