### PR TITLE
Fix deps so jandex 2.x exclusion works everywhere

### DIFF
--- a/buildSrc/src/main/groovy/swatch.spring-boot-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-conventions.gradle
@@ -12,8 +12,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-devtools"
     // This starter pulls in Spring Boot versions that we don't want.  The actual classes that we need are
     // baked into the starter artifact itself which is peculiar but sometimes that's how the cookie crumbles.
-    implementation("org.jboss.resteasy:resteasy-servlet-spring-boot-starter") {
+    implementation(libraries["resteasy-spring-boot-starter"]) {
         exclude group: "org.springframework.boot"
+        exclude group: "org.jboss", module: "jandex"
     }
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/buildSrc/src/main/groovy/swatch.spring-boot-dependencies-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-dependencies-conventions.gradle
@@ -28,11 +28,6 @@ dependencyManagement {
         dependency libraries["swagger-annotations"]
         dependency libraries["swagger-ui"]
         dependency libraries["webjars-locator"]
-        dependency(libraries["resteasy-spring-boot-starter"]) {
-            exclude "org.jboss:jandex"
-        }
-        dependency libraries["resteasy-client"]
-        dependency libraries["resteasy-multipart-provider"]
         dependency libraries["resteasy-validator-provider"]
         dependency libraries["resteasy-jackson2-provider"]
         dependency libraries["guava"]

--- a/buildSrc/src/main/groovy/swatch.spring-boot-rest-client-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-rest-client-conventions.gradle
@@ -44,8 +44,12 @@ openApiGenerate {
 dependencies {
     api project(':clients-core')
     api "jakarta.annotation:jakarta.annotation-api"
-    api "org.jboss.resteasy:resteasy-client"
-    api "org.jboss.resteasy:resteasy-multipart-provider"
+    api (libraries["resteasy-client"]) {
+        exclude group: "org.jboss", module: "jandex"
+    }
+    api (libraries["resteasy-multipart-provider"]) {
+        exclude group: "org.jboss", module: "jandex"
+    }
 
     api "com.fasterxml.jackson.core:jackson-annotations"
     api "com.fasterxml.jackson.core:jackson-databind"

--- a/clients-core/build.gradle
+++ b/clients-core/build.gradle
@@ -4,7 +4,9 @@ plugins {
 }
 
 dependencies {
-    implementation "org.jboss.resteasy:resteasy-client"
+    implementation (libraries["resteasy-client"]) {
+        exclude group: "org.jboss", module: "jandex"
+    }
     implementation "org.springframework:spring-beans"
     implementation "org.slf4j:slf4j-api"
     testImplementation libraries["wiremock-jre8"]

--- a/swatch-core/build.gradle
+++ b/swatch-core/build.gradle
@@ -26,7 +26,9 @@ dependencies {
     implementation "com.jayway.jsonpath:json-path"
     implementation "com.splunk.logging:splunk-library-javalogging"
     implementation "org.codehaus.janino:janino"
-    implementation libraries["resteasy-spring-boot-starter"]
+    implementation (libraries["resteasy-spring-boot-starter"]) {
+        exclude group: "org.jboss", module: "jandex"
+    }
 
     testImplementation project(":swatch-core-test")
     testImplementation "org.springframework:spring-test"


### PR DESCRIPTION
There's some sort of bug where dependencies managed by the `io.spring.dependency-management` gradle plugin don't respect exclusions. Work around by moving select dependencies out of the dependency management section.