### PR TITLE
Remove all non-BOM entries from dependency management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     implementation "org.liquibase:liquibase-core"
     implementation "org.postgresql:postgresql"
-    implementation "com.google.guava:guava"
+    implementation libraries["guava"]
 
     implementation libraries["mapstruct"]
     annotationProcessor libraries["mapstruct-processor"]
@@ -419,8 +419,8 @@ project(":api") {
         implementation "jakarta.annotation:jakarta.annotation-api"
         implementation "com.fasterxml.jackson.core:jackson-annotations"
         implementation "jakarta.validation:jakarta.validation-api"
-        implementation "jakarta.ws.rs:jakarta.ws.rs-api"
-        implementation "io.swagger:swagger-annotations"
+        implementation libraries["jakarta-ws-rs"]
+        implementation libraries["swagger-annotations"]
         implementation libraries["jsr305"]
         implementation libraries["jackson-databind-nullable"]
     }

--- a/buildSrc/src/main/groovy/swatch.spring-boot-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-conventions.gradle
@@ -23,11 +23,11 @@ dependencies {
     implementation "org.springframework.retry:spring-retry"
     implementation "org.springframework:spring-context-support"
     implementation "io.micrometer:micrometer-registry-prometheus"
-    runtimeOnly("org.jboss.resteasy:resteasy-validator-provider") {
+    runtimeOnly(libraries["resteasy-validator-provider"]) {
         exclude group: "org.hibernate" // exclude older hibernate validator
     }
-    implementation "org.webjars:swagger-ui"
-    implementation "org.webjars:webjars-locator"
+    implementation libraries["swagger-ui"]
+    implementation libraries["webjars-locator"]
     implementation "org.hibernate.validator:hibernate-validator"
     implementation "org.yaml:snakeyaml"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

--- a/buildSrc/src/main/groovy/swatch.spring-boot-dependencies-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-dependencies-conventions.gradle
@@ -1,10 +1,13 @@
 // Plugin: swatch.spring-boot-dependencies-conventions
-// uses spring dependency-management to apply spring boot dependencies bom and other constraints
-plugins {
-    id "io.spring.dependency-management"
+// uses enforcedPlatform-management to apply spring boot dependencies bom and other constraints
+repositories {
+    mavenCentral()
 }
 
 dependencies {
+    annotationProcessor enforcedPlatform(libraries["spring-boot-dependencies"])
+    implementation enforcedPlatform(libraries["spring-boot-dependencies"])
+
     // common testing deps, junit + mockito + hamcrest
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.junit.jupiter:junit-jupiter-params"
@@ -12,12 +15,4 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter"
     testImplementation "org.hamcrest:hamcrest"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-}
-
-dependencyManagement {
-    imports {
-        // See https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies to
-        // get listings of the contents of this BOM
-        mavenBom libraries["spring-boot-dependencies"]
-    }
 }

--- a/buildSrc/src/main/groovy/swatch.spring-boot-dependencies-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-dependencies-conventions.gradle
@@ -14,24 +14,10 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
-// Define all versions here so that all projects will use the same versions.
 dependencyManagement {
     imports {
         // See https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies to
         // get listings of the contents of this BOM
         mavenBom libraries["spring-boot-dependencies"]
-    }
-    // adding a library here locks it to a specific version, and allows it to be referenced without
-    // version; this section can also be used to override the spring-boot-dependencies BOM
-    dependencies{
-        dependency libraries["jakarta-ws-rs"]
-        dependency libraries["swagger-annotations"]
-        dependency libraries["swagger-ui"]
-        dependency libraries["webjars-locator"]
-        dependency libraries["resteasy-validator-provider"]
-        dependency libraries["resteasy-jackson2-provider"]
-        dependency libraries["guava"]
-        dependency libraries["splunk-library-javalogging"]
-        dependency libraries["janino"]
     }
 }

--- a/buildSrc/src/main/groovy/swatch.spring-boot-rest-client-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-rest-client-conventions.gradle
@@ -57,13 +57,13 @@ dependencies {
 
     api "org.springframework:spring-context"
     api "org.slf4j:slf4j-api"
-    api "io.swagger:swagger-annotations"
+    api libraries["swagger-annotations"]
     api libraries["jsr305"]
     api libraries["jackson-databind-nullable"]
 
     compileOnly 'org.springframework.boot:spring-boot'
     testImplementation libraries["wiremock-jre8"]
-    testImplementation "com.google.guava:guava"
+    testImplementation libraries["guava"]
 }
 
 sourceSets.main.java.srcDirs += "${buildDir}/generated/src/main/java"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,7 +23,6 @@ ext.plugins = [
         "com.diffplug.spotless:spotless-plugin-gradle:6.20.0",
         "com.netflix.nebula:nebula-release-plugin:17.2.2",
         "io.quarkus:gradle-application-plugin:3.2.0.Final",
-        "io.spring.gradle:dependency-management-plugin:1.1.3",
         // swagger-parser manually upgraded for compatibility with snakeyaml 2.0
         // see https://github.com/OpenAPITools/openapi-generator/issues/15876
         "io.swagger.parser.v3:swagger-parser:2.1.16",
@@ -35,6 +34,11 @@ ext.plugins = [
         "org.springframework.boot:spring-boot-gradle-plugin:3.1.1",
 ]
 
+// BOMs
+libraries["quarkus-bom"] = "io.quarkus.platform:quarkus-bom:3.2.0.Final"
+libraries["spring-boot-dependencies"] = "org.springframework.boot:spring-boot-dependencies:3.1.1"
+
+// Individual libraries
 libraries["annotation-api"] = "jakarta.annotation:jakarta.annotation-api:2.1.1"
 libraries["awssdk-bom"] = "software.amazon.awssdk:bom:2.20.136"
 libraries["clowder-quarkus-config-source"] = "com.redhat.cloud.common:clowder-quarkus-config-source:1.5.0"
@@ -50,7 +54,6 @@ libraries["lombok"] = "org.projectlombok:lombok:1.18.28"
 libraries["lombok-mapstruct-binding"] = "org.projectlombok:lombok-mapstruct-binding:0.2.0"
 libraries["mapstruct"] = "org.mapstruct:mapstruct:1.5.5.Final"
 libraries["mapstruct-processor"] = "org.mapstruct:mapstruct-processor:1.5.5.Final"
-libraries["quarkus-bom"] = "io.quarkus.platform:quarkus-bom:3.2.0.Final"
 libraries["quarkus-logging-logback"] = "io.quarkiverse.logging.logback:quarkus-logging-logback:1.1.2"
 libraries["quarkus-logging-splunk"] = "io.quarkiverse.logging.splunk:quarkus-logging-splunk:2.5.1"
 libraries["resilience4j-spring-boot2"] = "io.github.resilience4j:resilience4j-spring-boot2:2.1.0"
@@ -60,7 +63,6 @@ libraries["resteasy-multipart-provider"] = "org.jboss.resteasy:resteasy-multipar
 libraries["resteasy-spring-boot-starter"] = "org.jboss.resteasy:resteasy-servlet-spring-boot-starter:6.0.3.Final"
 libraries["resteasy-validator-provider"] = "org.jboss.resteasy:resteasy-validator-provider:6.2.4.Final"
 libraries["splunk-library-javalogging"] = "com.splunk.logging:splunk-library-javalogging:1.11.7"
-libraries["spring-boot-dependencies"] = "org.springframework.boot:spring-boot-dependencies:3.1.1"
 libraries["swagger-annotations"] = "io.swagger:swagger-annotations:1.6.11"
 libraries["swagger-ui"] = "org.webjars:swagger-ui:5.4.2"
 libraries["webjars-locator"] = "org.webjars:webjars-locator:0.47"

--- a/swatch-common-config-workaround/build.gradle
+++ b/swatch-common-config-workaround/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    // Intentionally marked as platform rather than enforcedPlatform as this project is a library
     implementation platform(libraries["quarkus-bom"])
     implementation 'org.eclipse.microprofile.config:microprofile-config-api'
 }

--- a/swatch-common-resteasy/build.gradle
+++ b/swatch-common-resteasy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     compileOnly platform(libraries["quarkus-bom"])
-    compileOnly 'jakarta.ws.rs:jakarta.ws.rs-api'
+    compileOnly libraries["jakarta-ws-rs"]
     compileOnly 'org.slf4j:slf4j-api'
 }
 

--- a/swatch-common-resteasy/build.gradle
+++ b/swatch-common-resteasy/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    // Intentionally marked as platform rather than enforcedPlatform as this project is a library
     compileOnly platform(libraries["quarkus-bom"])
     compileOnly libraries["jakarta-ws-rs"]
     compileOnly 'org.slf4j:slf4j-api'

--- a/swatch-core/build.gradle
+++ b/swatch-core/build.gradle
@@ -18,14 +18,14 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-actuator-autoconfigure"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-security"
-    implementation "com.google.guava:guava" // for ip address class
+    implementation libraries["guava"] // for ip address class
     implementation "com.fasterxml.jackson.core:jackson-annotations" // for json generated models
     implementation "com.fasterxml.jackson.core:jackson-databind" // for use of objectmapper in EventRecord
     implementation "org.springframework.kafka:spring-kafka"
     implementation "io.micrometer:micrometer-core"
     implementation "com.jayway.jsonpath:json-path"
-    implementation "com.splunk.logging:splunk-library-javalogging"
-    implementation "org.codehaus.janino:janino"
+    implementation libraries["splunk-library-javalogging"]
+    implementation libraries["janino"]
     implementation (libraries["resteasy-spring-boot-starter"]) {
         exclude group: "org.jboss", module: "jandex"
     }

--- a/swatch-product-configuration/build.gradle
+++ b/swatch-product-configuration/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    // Intentionally marked as platform rather than enforcedPlatform as this project is a library
     implementation platform(libraries["quarkus-bom"])
     implementation 'org.yaml:snakeyaml'
     implementation 'org.slf4j:slf4j-api'

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -91,8 +91,8 @@ dependencies {
     implementation "org.yaml:snakeyaml"
     implementation "org.postgresql:postgresql"
     implementation "org.hibernate.validator:hibernate-validator"
-    implementation "org.webjars:swagger-ui"
-    implementation "org.webjars:webjars-locator"
+    implementation libraries["swagger-ui"]
+    implementation libraries["webjars-locator"]
     implementation libraries["resilience4j-spring-boot2"]
 
     testImplementation "org.springframework.security:spring-security-test"
@@ -100,7 +100,7 @@ dependencies {
     testImplementation project(':swatch-core-test')
 
     runtimeOnly "org.hsqldb:hsqldb"
-    runtimeOnly "org.jboss.resteasy:resteasy-jackson2-provider"
+    runtimeOnly libraries["resteasy-jackson2-provider"]
 
     javaagent  libraries["splunk-otel-agent"]
 }


### PR DESCRIPTION
Having non-BOM entries in dependency management results in transitive dependency exclusions not working properly.  We achieve the intended effect of dependency management (uniform versions of a library across all sub-projects) with the dependencies.gradle file anyway.

Attn @kahowell 