### PR TITLE
SWATCH-1574: Use jackson streaming API to parse the response from prometheus

### DIFF
--- a/clients/prometheus-client/prometheus-api-spec.yaml
+++ b/clients/prometheus-client/prometheus-api-spec.yaml
@@ -39,7 +39,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QueryResult'
+                type: string
+                format: file
 
   /query_range:
     description: " Evaluates an expression query over a range of time"
@@ -83,7 +84,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QueryResult'
+                type: string
+                format: file
 components:
   schemas:
     ResultType:
@@ -126,6 +128,12 @@ components:
                       type: array
                       items:
                         type: number
+                # To force OpenAPI to generate default collections if not provided
+                # This marks the following fields as `@Notnull` and avoid null pointers.
+                required:
+                  - metric
+                  - value
+                  - values
         errorType:
           type: string
         error:

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusService.java
@@ -20,16 +20,33 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus;
 
+import static org.candlepin.subscriptions.prometheus.model.QueryResult.JSON_PROPERTY_DATA;
+import static org.candlepin.subscriptions.prometheus.model.QueryResult.JSON_PROPERTY_ERROR;
+import static org.candlepin.subscriptions.prometheus.model.QueryResult.JSON_PROPERTY_ERROR_TYPE;
+import static org.candlepin.subscriptions.prometheus.model.QueryResult.JSON_PROPERTY_STATUS;
+import static org.candlepin.subscriptions.prometheus.model.QueryResultData.JSON_PROPERTY_RESULT;
+import static org.candlepin.subscriptions.prometheus.model.QueryResultData.JSON_PROPERTY_RESULT_TYPE;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.net.UrlEscapers;
+import java.io.File;
+import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
+import org.candlepin.subscriptions.metering.service.prometheus.model.QuerySummaryResult;
 import org.candlepin.subscriptions.prometheus.ApiException;
 import org.candlepin.subscriptions.prometheus.api.ApiProvider;
-import org.candlepin.subscriptions.prometheus.model.QueryResult;
+import org.candlepin.subscriptions.prometheus.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /** Wraps prometheus specific API calls to make them more application specific. */
 @Component
@@ -37,14 +54,21 @@ public class PrometheusService {
 
   private static final Logger log = LoggerFactory.getLogger(PrometheusService.class);
 
-  private ApiProvider apiProvider;
+  private final ApiProvider apiProvider;
+  private final JsonFactory factory;
 
-  public PrometheusService(ApiProvider prometheusApiProvider) {
+  public PrometheusService(ApiProvider prometheusApiProvider, ObjectMapper objectMapper) {
     this.apiProvider = prometheusApiProvider;
+    this.factory = new JsonFactory(objectMapper);
   }
 
-  public QueryResult runRangeQuery(
-      String promQL, OffsetDateTime start, OffsetDateTime end, Integer step, Integer timeout)
+  public QuerySummaryResult runRangeQuery(
+      String promQL,
+      OffsetDateTime start,
+      OffsetDateTime end,
+      Integer step,
+      Integer timeout,
+      Consumer<QueryResultDataResultInner> resultDataItemConsumer)
       throws ExternalServiceException {
     log.info("Fetching metrics from prometheus: {} -> {} [Step: {}]", start, end, step);
     try {
@@ -55,25 +79,35 @@ public class PrometheusService {
           end.toEpochSecond(),
           step,
           query);
-      return apiProvider
-          .queryRangeApi()
-          .queryRange(
-              query, start.toEpochSecond(), end.toEpochSecond(), Integer.toString(step), timeout);
+      File data =
+          apiProvider
+              .queryRangeApi()
+              .queryRange(
+                  query,
+                  start.toEpochSecond(),
+                  end.toEpochSecond(),
+                  Integer.toString(step),
+                  timeout);
+      return parseQueryResult(data, resultDataItemConsumer);
     } catch (ApiException apie) {
       throw new ExternalServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR, formatErrorMessage(apie), apie);
     }
   }
 
-  public QueryResult runQuery(String promQL, OffsetDateTime time, Integer timeout)
+  public QuerySummaryResult runQuery(
+      String promQL,
+      OffsetDateTime time,
+      Integer timeout,
+      Consumer<QueryResultDataResultInner> itemConsumer)
       throws ExternalServiceException {
     log.debug("Fetching metrics from prometheus: {}", time);
     try {
       String query = sanitizeQuery(promQL);
       log.debug("Running prometheus query: Time: {}, Query: {}", time.toEpochSecond(), query);
-      return apiProvider.queryApi().query(query, time, timeout);
+      File data = apiProvider.queryApi().query(query, time, timeout);
+      return parseQueryResult(data, itemConsumer);
     } catch (ApiException apie) {
-
       throw new ExternalServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR, formatErrorMessage(apie), apie);
     }
@@ -89,5 +123,88 @@ public class PrometheusService {
   private String formatErrorMessage(ApiException apie) {
     return String.format(
         "Prometheus API Error! CODE: %s MESSAGE: %s", apie.getCode(), apie.getMessage());
+  }
+
+  /**
+   * Parse the response. See <a
+   * href="https://prometheus.io/docs/prometheus/latest/querying/api/#format-overview">Prometheus
+   * HTTP API format overview</a>
+   */
+  private QuerySummaryResult parseQueryResult(
+      File data, Consumer<QueryResultDataResultInner> itemConsumer) {
+
+    var builder = QuerySummaryResult.builder();
+    try (JsonParser parser = factory.createParser(data)) {
+      while (isNot(parser.nextToken(), JsonToken.END_OBJECT)) {
+        if (JSON_PROPERTY_STATUS.equals(parser.getCurrentName())) {
+          set(parser, StatusType::fromValue, builder::status);
+        } else if (JSON_PROPERTY_ERROR_TYPE.equals(parser.getCurrentName())) {
+          set(parser, builder::errorType);
+        } else if (JSON_PROPERTY_ERROR.equals(parser.getCurrentName())) {
+          set(parser, builder::error);
+        } else if (JSON_PROPERTY_DATA.equals(parser.getCurrentName())) {
+          parseQueryData(parser, builder, itemConsumer);
+        }
+      }
+    } catch (IOException ex) {
+      throw new ExternalServiceException(
+          ErrorCode.REQUEST_PROCESSING_ERROR, "Error parsing the Prometheus response", ex);
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Parse the data property. See "data section of the query result" at <a
+   * href="https://prometheus.io/docs/prometheus/latest/querying/api/">Prometheus HTTP API</a>
+   */
+  private void parseQueryData(
+      JsonParser parser,
+      QuerySummaryResult.QuerySummaryResultBuilder builder,
+      Consumer<QueryResultDataResultInner> itemConsumer)
+      throws IOException {
+    while (isNot(parser.nextToken(), JsonToken.END_OBJECT)) {
+      if (JSON_PROPERTY_RESULT_TYPE.equals(parser.getCurrentName())) {
+        set(parser, ResultType::fromValue, builder::resultType);
+      } else if (JSON_PROPERTY_RESULT.equals(parser.getCurrentName())) {
+        parseDataResultArray(parser, builder, itemConsumer);
+      }
+    }
+  }
+
+  /**
+   * Parse the data.result array. See <a
+   * href="https://prometheus.io/docs/prometheus/latest/querying/api/#expression-query-result-formats">Prometheus
+   * query result formats</a>
+   */
+  private void parseDataResultArray(
+      JsonParser parser,
+      QuerySummaryResult.QuerySummaryResultBuilder builder,
+      Consumer<QueryResultDataResultInner> itemConsumer)
+      throws IOException {
+    int numOfResults = 0;
+    while (isNot(parser.nextToken(), JsonToken.END_ARRAY)) {
+      parser.nextToken();
+      itemConsumer.accept(parser.readValueAs(QueryResultDataResultInner.class));
+      numOfResults++;
+    }
+
+    builder.numOfResults(numOfResults);
+  }
+
+  private void set(JsonParser parser, Consumer<String> consumer) throws IOException {
+    set(parser, Function.identity(), consumer);
+  }
+
+  private <T> void set(JsonParser parser, Function<String, T> transform, Consumer<T> consumer)
+      throws IOException {
+    String str = parser.nextTextValue();
+    if (StringUtils.hasText(str)) {
+      consumer.accept(transform.apply(str));
+    }
+  }
+
+  private boolean isNot(JsonToken token, JsonToken status) {
+    return token != JsonToken.VALUE_NULL && token != status;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.db.model.EventRecordConverter;
 import org.candlepin.subscriptions.event.EventController;
@@ -56,8 +57,8 @@ public class PrometheusServiceConfiguration {
   }
 
   @Bean
-  public PrometheusService prometheusService(ApiProvider provider) {
-    return new PrometheusService(provider);
+  public PrometheusService prometheusService(ApiProvider provider, ObjectMapper objectMapper) {
+    return new PrometheusService(provider, objectMapper);
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/model/QuerySummaryResult.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/model/QuerySummaryResult.java
@@ -18,18 +18,19 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.prometheus.api;
+package org.candlepin.subscriptions.metering.service.prometheus.model;
 
-import java.io.File;
-import java.time.OffsetDateTime;
-import org.candlepin.subscriptions.prometheus.ApiException;
-import org.candlepin.subscriptions.prometheus.resources.QueryApi;
+import lombok.Builder;
+import lombok.Data;
+import org.candlepin.subscriptions.prometheus.model.ResultType;
+import org.candlepin.subscriptions.prometheus.model.StatusType;
 
-/** A class that stubs out the QueryAPI endpoint calls. */
-public class StubQueryApi extends QueryApi {
-
-  @Override
-  public File query(String query, OffsetDateTime time, Integer timeout) throws ApiException {
-    return PrometheusStubLocator.getStubFile();
-  }
+@Data
+@Builder
+public class QuerySummaryResult {
+  private final StatusType status;
+  private final ResultType resultType;
+  @Builder.Default private final long numOfResults = 0;
+  private final String errorType;
+  private final String error;
 }

--- a/src/main/java/org/candlepin/subscriptions/prometheus/api/PrometheusStubLocator.java
+++ b/src/main/java/org/candlepin/subscriptions/prometheus/api/PrometheusStubLocator.java
@@ -21,15 +21,24 @@
 package org.candlepin.subscriptions.prometheus.api;
 
 import java.io.File;
-import java.time.OffsetDateTime;
-import org.candlepin.subscriptions.prometheus.ApiException;
-import org.candlepin.subscriptions.prometheus.resources.QueryApi;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.webjars.NotFoundException;
 
-/** A class that stubs out the QueryAPI endpoint calls. */
-public class StubQueryApi extends QueryApi {
+/** Utility class to locate the prometheus json file used for stubs. */
+public final class PrometheusStubLocator {
 
-  @Override
-  public File query(String query, OffsetDateTime time, Integer timeout) throws ApiException {
-    return PrometheusStubLocator.getStubFile();
+  public static final URL STUB =
+      PrometheusStubLocator.class.getResource("/prometheus-stub-data/success.json");
+
+  private PrometheusStubLocator() {}
+
+  public static File getStubFile() {
+    try {
+      return new File(STUB.toURI());
+    } catch (URISyntaxException e) {
+      throw new NotFoundException(
+          "The '/prometheus-stub-data/success.json' file could not be loaded");
+    }
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/prometheus/api/StubQueryRangeApi.java
+++ b/src/main/java/org/candlepin/subscriptions/prometheus/api/StubQueryRangeApi.java
@@ -20,21 +20,14 @@
  */
 package org.candlepin.subscriptions.prometheus.api;
 
-import java.util.Arrays;
-import org.candlepin.subscriptions.prometheus.ApiException;
-import org.candlepin.subscriptions.prometheus.model.QueryResult;
-import org.candlepin.subscriptions.prometheus.model.QueryResultData;
-import org.candlepin.subscriptions.prometheus.model.StatusType;
+import java.io.File;
 import org.candlepin.subscriptions.prometheus.resources.QueryRangeApi;
 
 /** A class that stubs out the QueryRangeAPI endpoint calls. */
 public class StubQueryRangeApi extends QueryRangeApi {
 
   @Override
-  public QueryResult queryRange(String query, Long start, Long end, String step, Integer timeout)
-      throws ApiException {
-    return new QueryResult()
-        .status(StatusType.SUCCESS)
-        .data(new QueryResultData().result(Arrays.asList()));
+  public File queryRange(String query, Long start, Long end, String step, Integer timeout) {
+    return PrometheusStubLocator.getStubFile();
   }
 }

--- a/src/main/resources/prometheus-stub-data/success.json
+++ b/src/main/resources/prometheus-stub-data/success.json
@@ -1,0 +1,1 @@
+{ "status": "success" }

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusQueryWiremockExtension.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusQueryWiremockExtension.java
@@ -22,7 +22,9 @@ package org.candlepin.subscriptions.metering.service.prometheus;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.junit.jupiter.api.Assertions.fail;
+import static wiremock.com.google.common.net.HttpHeaders.CONTENT_TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -154,6 +156,12 @@ public class PrometheusQueryWiremockExtension
                 .willSetStateTo(nextState));
         currentState = nextState;
       }
+    }
+
+    public void stubQueryRangeWithFile(String file) {
+      extension.prometheusServer.stubFor(
+          get(urlPathEqualTo(QUERY_RANGE_PATH))
+              .willReturn(ok().withHeader(CONTENT_TYPE, APPLICATION_JSON).withBodyFile(file)));
     }
 
     public void verifyQueryRangeWasCalled(int times) {

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
@@ -21,11 +21,15 @@
 package org.candlepin.subscriptions.metering.service.prometheus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
+import org.candlepin.subscriptions.metering.service.prometheus.model.QuerySummaryResult;
 import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
+import org.candlepin.subscriptions.prometheus.model.ResultType;
+import org.candlepin.subscriptions.prometheus.model.StatusType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +54,7 @@ class PrometheusServiceTest {
 
     String expectedQuery = queries.expectedQuery("OpenShift-metrics", Map.of("orgId", "o1"));
     QueryResult expectedResult = new QueryResult();
+    expectedResult.status(StatusType.SUCCESS);
 
     OffsetDateTime end = OffsetDateTime.now();
     OffsetDateTime start = end.minusDays(2);
@@ -59,9 +64,10 @@ class PrometheusServiceTest {
     prometheusServer.stubQueryRange(
         expectedQuery, start, end, expectedStep, expectedTimeout, expectedResult);
 
-    QueryResult result =
-        service.runRangeQuery(expectedQuery, start, end, expectedStep, expectedTimeout);
-    assertEquals(expectedResult, result);
+    QuerySummaryResult result =
+        service.runRangeQuery(expectedQuery, start, end, expectedStep, expectedTimeout, item -> {});
+    assertEquals(expectedResult.getStatus(), result.getStatus());
+    assertEquals(0, result.getNumOfResults());
   }
 
   @Test
@@ -72,10 +78,31 @@ class PrometheusServiceTest {
     int expectedTimeout = 1;
     OffsetDateTime expectedTime = OffsetDateTime.now();
     QueryResult expectedResult = new QueryResult();
+    expectedResult.status(StatusType.ERROR);
+    expectedResult.error(null);
 
     prometheusServer.stubQuery(expectedQuery, expectedTimeout, expectedTime, expectedResult);
 
-    QueryResult result = service.runQuery(expectedQuery, expectedTime, expectedTimeout);
-    assertEquals(expectedResult, result);
+    QuerySummaryResult result =
+        service.runQuery(expectedQuery, expectedTime, expectedTimeout, item -> {});
+    assertEquals(expectedResult.getStatus(), result.getStatus());
+  }
+
+  @Test
+  void testRangeQueryApiWithSmallDataset(
+      PrometheusQueryWiremockExtension.PrometheusQueryWiremock prometheusServer) {
+    prometheusServer.stubQueryRangeWithFile("prometheus_small.json");
+
+    QueryHelper queries = new QueryHelper(queryBuilder);
+    String query = queries.expectedQuery("OpenShift-metrics", Map.of("orgId", "o1"));
+
+    OffsetDateTime end = OffsetDateTime.now();
+    OffsetDateTime start = end.minusDays(2);
+
+    QuerySummaryResult result = service.runRangeQuery(query, start, end, 3600, 1, r -> {});
+    assertNotNull(result);
+    assertEquals(StatusType.SUCCESS, result.getStatus());
+    assertEquals(ResultType.VECTOR, result.getResultType());
+    assertEquals(5, result.getNumOfResults());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/prometheus/api/ApiProviderFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/prometheus/api/ApiProviderFactoryTest.java
@@ -20,9 +20,9 @@
  */
 package org.candlepin.subscriptions.prometheus.api;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +36,8 @@ class ApiProviderFactoryTest {
     ApiProviderFactory factory = new ApiProviderFactory(props);
     ApiProvider api = factory.getObject();
     assertTrue(api instanceof StubApiProvider);
+    assertStubFile(api.queryApi().query(null, null, null));
+    assertStubFile(api.queryRangeApi().queryRange(null, null, null, null, null));
   }
 
   @Test
@@ -46,5 +48,10 @@ class ApiProviderFactoryTest {
     ApiProviderFactory factory = new ApiProviderFactory(props);
     ApiProvider api = factory.getObject();
     assertTrue(api instanceof ApiProviderImpl);
+  }
+
+  private void assertStubFile(File file) {
+    assertNotNull(file);
+    assertTrue(file.exists());
   }
 }

--- a/src/test/resources/__files/prometheus_small.json
+++ b/src/test/resources/__files/prometheus_small.json
@@ -1,0 +1,48 @@
+{
+    "status" : "success",
+    "data" : {
+      "resultType" : "vector",
+      "result" : [
+        {
+          "metric" : {
+            "__name__" : "up",
+            "job" : "prometheus",
+            "instance" : "localhost:9090"
+          },
+          "value": [ 1435781451.781, "1" ]
+        },
+        {
+          "metric" : {
+            "__name__" : "up",
+            "job" : "node",
+            "instance" : "localhost:9100"
+          },
+          "value" : [ 1435781451.781, "0" ]
+        },
+        {
+          "metric" : {
+            "__name__" : "up",
+            "job" : "prometheus",
+            "instance" : "localhost:9090"
+          },
+          "value": [ 1435781451.781, "1" ]
+        },
+        {
+          "metric" : {
+            "__name__" : "up",
+            "job" : "node",
+            "instance" : "localhost:9100"
+          },
+          "value" : [ 1435781451.781, "0" ]
+        },
+        {
+          "metric" : {
+            "__name__" : "up",
+            "job" : "prometheus",
+            "instance" : "localhost:9090"
+          },
+          "value": [ 1435781451.781, "1" ]
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
Jira issue: [SWATCH-1574](https://issues.redhat.com/browse/SWATCH-1574)

## Description
When using a Prometheus dataset with up to 53760 metrics, we were holding up to 129 MB in memory. 
These changes use the Jackson streaming API to process the metrics individually, so it won't ever hold this amount of data. 

I made the following decisions:
- I used the Consumer Java API instead of a more complicated API like the Future API which would require creating threads that would lead to performance penalties.
- I didn't include the scenario to process a large dataset because the file size was too large (up to 20MB). 
- I didn't modify the generation of the Prometheus client API on purpose, because this must match with what the real Prometheus returns (speaking about the QueryResult generated class). Instead, I created a new QuerySummaryResult that we'll be using in the Prometheus service. 
- Ideally, I wanted to use directly the Response input stream from the Prometheus response, however the generated Prometheus client by OpenAPI only gave us two options to get the Prometheus response: either an array of bytes or a File. I chose the File over the array of bytes to avoid holding the amount of data of the bytes in memory. 

## Testing
For testing, I modified the new file `prometheus_small.json` to add 53760 metrics and confirm that the memory heap of the running process is not altered when processing these metrics. 