### PR TITLE
SWATCH-430: Add metric_id to tally_measurements

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/admin/HardwareMeasurementMigration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/HardwareMeasurementMigration.java
@@ -39,19 +39,19 @@ public class HardwareMeasurementMigration extends DataMigration {
       new SqlRowSetResultSetExtractor();
 
   public static final String INSERT_SQL =
-      "insert into tally_measurements(snapshot_id, measurement_type, uom, value)\n"
+      "insert into tally_measurements(snapshot_id, measurement_type, metric_id, value)\n"
           + "values (?, ?, ?, ?)";
 
   public static final String UPDATE_SQL =
-      "update tally_measurements set value=? where snapshot_id=? and measurement_type=? and uom=?";
+      "update tally_measurements set value=? where snapshot_id=? and measurement_type=? and metric_id=?";
 
   private static final String HARDWARE_MEASUREMENT_QUERY =
       "select h.snapshot_id, h.measurement_type, sockets, cores, s.value as s_value, c.value as c_value\n"
           + "from hardware_measurements h\n"
           + "         left join tally_measurements s\n"
-          + "                   on s.snapshot_id = h.snapshot_id and s.measurement_type = h.measurement_type and s.uom = 'SOCKETS'\n"
+          + "                   on s.snapshot_id = h.snapshot_id and s.measurement_type = h.measurement_type and s.metric_id = 'SOCKETS'\n"
           + "         left join tally_measurements c\n"
-          + "                   on c.snapshot_id = h.snapshot_id and c.measurement_type = h.measurement_type and c.uom = 'CORES'\n"
+          + "                   on c.snapshot_id = h.snapshot_id and c.measurement_type = h.measurement_type and c.metric_id = 'CORES'\n"
           + "where ?::uuid is null\n"
           + "   or h.snapshot_id > ?::uuid\n"
           + "order by h.snapshot_id\n"

--- a/src/main/resources/liquibase/202308231356-add-metric-id-tally-measurements.xml
+++ b/src/main/resources/liquibase/202308231356-add-metric-id-tally-measurements.xml
@@ -1,0 +1,28 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202308231356-1" author="jcarvaja" dbms="postgresql">
+    <comment>Rename tally_measurements.uom to metric_id and support both.</comment>
+    <renameColumn tableName="tally_measurements" oldColumnName="uom" newColumnName="metric_id"/>
+    <sql>
+      alter table tally_measurements add column uom varchar(255) generated always as (metric_id) stored
+    </sql>
+    <rollback>
+      <sql>
+        alter table tally_measurements drop column uom
+      </sql>
+      <renameColumn tableName="tally_measurements" oldColumnName="metric_id" newColumnName="uom"/>
+    </rollback>
+  </changeSet>
+  <!-- NOTE: below changeset is the hsql alternative (only run for unit tests) -->
+  <changeSet id="202308231356-2" author="jcarvaja" dbms="!postgresql">
+    <comment>Rename tally_measurements.uom to metric_id.</comment>
+    <renameColumn tableName="tally_measurements" oldColumnName="uom" newColumnName="metric_id"/>
+    <rollback>
+      <renameColumn tableName="tally_measurements" oldColumnName="metric_id" newColumnName="uom"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/202308231456-drop-uom-column-tally-measurements.xml
+++ b/src/main/resources/liquibase/202308231456-drop-uom-column-tally-measurements.xml
@@ -1,0 +1,14 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202308231456-1" author="jcarvaja" dbms="postgresql">
+    <comment>Drop tally_measurements.uom column.</comment>
+    <dropColumn tableName="tally_measurements" columnName="uom"/>
+    <rollback>
+      alter table tally_measurements add column uom varchar(255) generated always as (metric_id) stored;
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -123,5 +123,8 @@
     <include file="liquibase/202308210806-add-metric-id-instance-measurements.xml"/>
     <!-- Uncomment once the above changeset has landed in prod -->
     <!-- <include file="liquibase/202308210906-drop-uom-column-instance-measurements.xml"/> -->
+    <include file="liquibase/202308231356-add-metric-id-tally-measurements.xml"/>
+    <!-- Uncomment once the above changeset has landed in prod -->
+    <!-- <include file="liquibase/202308231456-drop-uom-column-tally-measurements.xml"/> -->
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurementKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurementKey.java
@@ -41,6 +41,7 @@ public class TallyMeasurementKey implements Serializable {
   private HardwareMeasurementType measurementType;
 
   @Enumerated(EnumType.STRING)
+  @Column(name = "metric_id")
   private Measurement.Uom uom;
 
   public TallyMeasurementKey() {

--- a/swatch-producer-aws/README.adoc
+++ b/swatch-producer-aws/README.adoc
@@ -122,7 +122,7 @@ curl --request POST \
       "tally_measurements": [
         {
           "hardware_measurement_type": "string",
-          "uom": "Cores",
+          "metric_id": "Cores",
           "value": 0
         }
       ]


### PR DESCRIPTION
Jira issue: [SWATCH-430](https://issues.redhat.com/browse/SWATCH-430)

## Description

As a swatch developer, I want swatch to write metric_id to instance_measurements, so that I can remove UOM later on.
The solution renames the existing column "uom" to "metric_id", so the primary key and the existing index got updated as well. 

Moreover, the solution creates a temporary computed column "uom" to take the data from "metric_id", so existing services will keep working as usual meanwhile the migration data takes effect.

The solution follows the same pattern as in https://github.com/RedHatInsights/rhsm-subscriptions/pull/2304.

## Testing

1.- Start infrastructure: `podman-compose up`
2.- Ensure the database is migrated: `./gradlew :liquibaseUpdate`
3.- Ensure the apps start ok using: `./gradlew :bootRun`
4.- Check both columns `uom` and `metric_id` are present in the table `tally_measurements` using a db client
5.- Ensure the rollback works: `./gradlew :liquibaseRollbackCount -PliquibaseCommandValue=2`
