### PR TITLE
SWATCH-1462: Correct mismatch in monthly and running totals

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -496,8 +496,7 @@ public class TallyResource implements TallyApi {
           double newValue = runningTotals.getOrDefault(uom, 0.0) + snapshotTotal;
 
           double snapshotValue = newValue;
-          double capacity =
-              (double) capacityByDate.getOrDefault(clock.startOfDay(snapshot.date()), 0);
+          double capacity = capacityByDate.getOrDefault(clock.startOfDay(snapshot.date()), 0);
           if (BillingCategory.PREPAID.equals(billingCategory)) {
             snapshotValue = Math.min(newValue, capacity);
           } else if (BillingCategory.ON_DEMAND.equals(billingCategory)) {

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -49,6 +50,7 @@ import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.tally.filler.ReportFiller;
 import org.candlepin.subscriptions.tally.filler.ReportFillerFactory;
+import org.candlepin.subscriptions.tally.filler.UnroundedTallyReportDataPoint;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.*;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
@@ -163,13 +165,12 @@ public class TallyResource implements TallyApi {
     List<org.candlepin.subscriptions.db.model.TallySnapshot> snapshots =
         snapshotPage.stream().collect(Collectors.toList());
 
-    List<TallyReportDataPoint> snaps =
+    List<UnroundedTallyReportDataPoint> snaps =
         snapshots.stream()
-            .map(snapshot -> dataPointFromSnapshot(uom, category, snapshot))
+            .map(snapshot -> unroundedDataPointFromSnapshot(uom, category, snapshot))
             .collect(Collectors.toList());
 
     TallyReportData report = new TallyReportData();
-    report.setData(snaps);
     report.setMeta(new TallyReportDataMeta());
     report.getMeta().setGranularity(reportCriteria.getGranularity().asOpenApiEnum());
     report.getMeta().setProduct(productId);
@@ -222,20 +223,24 @@ public class TallyResource implements TallyApi {
     }
 
     if (Boolean.TRUE.equals(useRunningTotalsFormat)) {
-      transformToRunningTotalFormat(report, uom, billingCategory, capacityByDate);
+      snaps = transformToRunningTotalFormat(snaps, uom, billingCategory, capacityByDate);
     }
 
     // Fill the report gaps if no paging was requested.
+    List<UnroundedTallyReportDataPoint> dataPointsToConvert;
     if (reportCriteria.getPageable() == null) {
-      ReportFiller<TallyReportDataPoint> reportFiller =
+      ReportFiller<UnroundedTallyReportDataPoint> reportFiller =
           ReportFillerFactory.getDataPointReportFiller(clock, reportCriteria.getGranularity());
-      report.setData(
+      dataPointsToConvert =
           reportFiller.fillGaps(
-              report.getData(),
-              beginning,
-              ending,
-              Objects.requireNonNullElse(useRunningTotalsFormat, false)));
+              snaps, beginning, ending, Objects.requireNonNullElse(useRunningTotalsFormat, false));
+    } else {
+      dataPointsToConvert = snaps;
     }
+    report.setData(
+        dataPointsToConvert.stream()
+            .map(UnroundedTallyReportDataPoint::toRoundedDataPoint)
+            .toList());
 
     // Set the count last since the report may have gotten filled.
     report.getMeta().setCount(report.getData().size());
@@ -344,21 +349,12 @@ public class TallyResource implements TallyApi {
         .build();
   }
 
-  private TallyReportDataPoint dataPointFromSnapshot(
+  private UnroundedTallyReportDataPoint unroundedDataPointFromSnapshot(
       Uom uom,
       ReportCategory category,
       org.candlepin.subscriptions.db.model.TallySnapshot snapshot) {
-    return new TallyReportDataPoint()
-        .date(snapshot.getSnapshotDate())
-        .value(extractValue(uom, category, snapshot))
-        .hasData(true);
-  }
-
-  private int extractValue(
-      Uom uom,
-      ReportCategory category,
-      org.candlepin.subscriptions.db.model.TallySnapshot snapshot) {
-    return (int) Math.ceil(extractRawValue(uom, category, snapshot));
+    return new UnroundedTallyReportDataPoint(
+        snapshot.getSnapshotDate(), extractRawValue(uom, category, snapshot), true);
   }
 
   private Double extractRawValue(
@@ -487,31 +483,32 @@ public class TallyResource implements TallyApi {
             });
   }
 
-  private void transformToRunningTotalFormat(
-      TallyReportData report,
+  private List<UnroundedTallyReportDataPoint> transformToRunningTotalFormat(
+      List<UnroundedTallyReportDataPoint> snaps,
       Uom uom,
       BillingCategory billingCategory,
       Map<OffsetDateTime, Integer> capacityByDate) {
-    Map<Uom, Integer> runningTotals = new EnumMap<>(Measurement.Uom.class);
-    report
-        .getData()
-        .forEach(
-            snapshot -> {
-              int snapshotTotal = Optional.ofNullable(snapshot.getValue()).orElse(0);
-              Integer newValue = runningTotals.getOrDefault(uom, 0) + snapshotTotal;
+    Map<Uom, Double> runningTotals = new EnumMap<>(Measurement.Uom.class);
+    List<UnroundedTallyReportDataPoint> runningTotalSnaps = new ArrayList<>();
+    snaps.forEach(
+        snapshot -> {
+          double snapshotTotal = Optional.ofNullable(snapshot.value()).orElse(0.0);
+          double newValue = runningTotals.getOrDefault(uom, 0.0) + snapshotTotal;
 
-              int snapshotValue = newValue;
-              Integer capacity =
-                  Optional.ofNullable(capacityByDate.get(clock.startOfDay(snapshot.getDate())))
-                      .orElse(0);
-              if (BillingCategory.PREPAID.equals(billingCategory)) {
-                snapshotValue = Math.min(newValue, capacity);
-              } else if (BillingCategory.ON_DEMAND.equals(billingCategory)) {
-                snapshotValue = Math.max(newValue - capacity, 0);
-              }
+          double snapshotValue = newValue;
+          double capacity =
+              (double) capacityByDate.getOrDefault(clock.startOfDay(snapshot.date()), 0);
+          if (BillingCategory.PREPAID.equals(billingCategory)) {
+            snapshotValue = Math.min(newValue, capacity);
+          } else if (BillingCategory.ON_DEMAND.equals(billingCategory)) {
+            snapshotValue = Math.max(newValue - capacity, 0);
+          }
 
-              snapshot.setValue(snapshotValue);
-              runningTotals.put(uom, newValue);
-            });
+          runningTotalSnaps.add(
+              new UnroundedTallyReportDataPoint(
+                  snapshot.date(), snapshotValue, snapshot.hasData()));
+          runningTotals.put(uom, newValue);
+        });
+    return runningTotalSnaps;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/ContractsClientProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/ContractsClientProperties.java
@@ -21,9 +21,13 @@
 package org.candlepin.subscriptions.tally.billing;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 
 @Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class ContractsClientProperties extends HttpClientProperties {
   /** How many attempts before giving up. */
   private Integer maxAttempts;

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/ReportFillerFactory.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.tally.filler;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.SnapshotTimeAdjuster;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
 import org.candlepin.subscriptions.utilization.api.model.TallySnapshot;
 
 /** Responsible for creating ReportFiller objects based on granularity. */
@@ -55,9 +54,9 @@ public class ReportFillerFactory {
    * @param granularity the target granularity
    * @return a ReportFiller instance for the specified granularity.
    */
-  public static ReportFiller<TallyReportDataPoint> getDataPointReportFiller(
+  public static ReportFiller<UnroundedTallyReportDataPoint> getDataPointReportFiller(
       ApplicationClock clock, Granularity granularity) {
     SnapshotTimeAdjuster timeAdjuster = SnapshotTimeAdjuster.getTimeAdjuster(clock, granularity);
-    return new ReportFiller<>(timeAdjuster, new TallyReportDataPointAdapter(clock));
+    return new ReportFiller<>(timeAdjuster, new UnroundedTallyReportDataPointAdapter(clock));
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/filler/UnroundedTallyReportDataPoint.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/filler/UnroundedTallyReportDataPoint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.filler;
+
+import java.time.OffsetDateTime;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
+
+public record UnroundedTallyReportDataPoint(OffsetDateTime date, Double value, Boolean hasData) {
+  public TallyReportDataPoint toRoundedDataPoint() {
+    return new TallyReportDataPoint().hasData(hasData).date(date).value((int) Math.ceil(value));
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -1200,11 +1200,13 @@ class TallyResourceTest {
             null);
     assertEquals(31, report.getData().size());
 
+    // Each running total entry should be the Math.ceil of all the total previous snapshot values
+    // Rounding should only occur after the total has been calculated
     var firstSnapshot = report.getData().get(0);
-    assertEquals(2, firstSnapshot.getValue());
+    assertEquals((int) Math.ceil(1.3), firstSnapshot.getValue());
 
     var secondSnapshot = report.getData().get(1);
-    assertEquals(4, secondSnapshot.getValue());
+    assertEquals((int) Math.ceil(1.3 + 1.3), secondSnapshot.getValue());
 
     assertEquals(expectedTotalMonthly, report.getMeta().getTotalMonthly());
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/filler/UnroundedTallyReportDataPointAdapterTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/filler/UnroundedTallyReportDataPointAdapterTest.java
@@ -24,55 +24,53 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
-import org.candlepin.subscriptions.utilization.api.model.TallyReportDataPoint;
 import org.junit.jupiter.api.Test;
 
-class TallyReportDataPointAdapterTest {
-
+class UnroundedTallyReportDataPointAdapterTest {
   ApplicationClock clock = new TestClockConfiguration().adjustableClock();
-  TallyReportDataPointAdapter adapter = new TallyReportDataPointAdapter(clock);
+  UnroundedTallyReportDataPointAdapter adapter = new UnroundedTallyReportDataPointAdapter(clock);
 
   @Test
   void createDefaultItemRunningTotalPast() {
-    var previous = new TallyReportDataPoint().value(10);
+    var previous = new UnroundedTallyReportDataPoint(null, 10.0, null);
     var itemDate = clock.startOfDay(clock.now());
     var point = adapter.createDefaultItem(itemDate, previous, true);
-    assertEquals(10, point.getValue());
-    assertTrue(point.getHasData());
+    assertEquals(10.0, point.value());
+    assertTrue(point.hasData());
   }
 
   @Test
   void createDefaultItemRunningTotalFuture() {
-    var previous = new TallyReportDataPoint().value(10);
+    var previous = new UnroundedTallyReportDataPoint(null, 10.0, null);
     var itemDate = clock.startOfDay(clock.now().plusDays(1));
     var point = adapter.createDefaultItem(itemDate, previous, true);
-    assertEquals(0, point.getValue());
-    assertFalse(point.getHasData());
+    assertEquals(0.0, point.value());
+    assertFalse(point.hasData());
   }
 
   @Test
   void createDefaultItemNoRunningTotal() {
-    var previous = new TallyReportDataPoint().value(10);
+    var previous = new UnroundedTallyReportDataPoint(null, 10.0, null);
     var itemDate = clock.startOfDay(clock.now());
     var point = adapter.createDefaultItem(itemDate, previous, false);
-    assertEquals(0, point.getValue());
-    assertFalse(point.getHasData());
+    assertEquals(0.0, point.value());
+    assertFalse(point.hasData());
   }
 
   @Test
   void createDefaultItemNullPrevious() {
     var itemDate = clock.startOfDay(clock.now());
     var point = adapter.createDefaultItem(itemDate, null, true);
-    assertEquals(0, point.getValue());
-    assertFalse(point.getHasData());
+    assertEquals(0.0, point.value());
+    assertFalse(point.hasData());
   }
 
   @Test
   void createDefaultItemNullPreviousValue() {
-    var previous = new TallyReportDataPoint().value(null);
+    var previous = new UnroundedTallyReportDataPoint(null, null, null);
     var itemDate = clock.startOfDay(clock.now());
     var point = adapter.createDefaultItem(itemDate, previous, true);
-    assertEquals(0, point.getValue());
-    assertFalse(point.getHasData());
+    assertEquals(0.0, point.value());
+    assertFalse(point.hasData());
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1462](https://issues.redhat.com/browse/SWATCH-1462)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Create a clean database
   ```shell
   createdb -h localhost -U postgres -O rhsm-subscriptions swatch-1462
   ```
2.  Download [SWATCH-1462.zip](https://github.com/RedHatInsights/rhsm-subscriptions/files/12432199/SWATCH-1462.zip) and import it into your database
    ```shell
    zcat SWATCH-1462.zip | psql -h localhost -U rhsm-subscriptions swatch-1462
    ```

### Steps
<!-- Enter each step of the test below -->
1.  Deploy the `main` branch with 
    ```shell
    DATABASE_DATABASE=swatch-1462 ./gradlew :bootRun
    ```
2.  I didn't export the `instance_monthly_total` records, but the underlying instances look like
   ```json
    {"data": [
    {
      "id": "1dce12a3-369f-4b4b-aea6-afb119c4f57c",
      "instance_id": "a7730436-5e1c-4122-ad93-a7316ab8fb46",
      "display_name": "automation_moa-hostedcontrolplane_cluster_a7730436-5e1c-4122-ad93-a7316ab8fb46",
      "billing_provider": "aws",
      "billing_account_id": "dom",
      "measurements": [
        3.09,
        12.93
      ],
      "last_seen": "2023-08-08T15:00:00Z",
      "number_of_guests": 0
    },
    {
      "id": "46faea67-b62e-44a3-9055-64171d5f6b8b",
      "instance_id": "191aa496-8f30-4f59-ab60-b341ecbde21f",
      "display_name": "automation_moa-hostedcontrolplane_cluster_191aa496-8f30-4f59-ab60-b341ecbde21f",
      "billing_provider": "aws",
      "billing_account_id": "dom",
      "measurements": [
        3.09,
        12.93
      ],
      "last_seen": "2023-08-02T11:00:00Z",
      "number_of_guests": 0
    },
    {
      "id": "6c09d816-e3b6-401a-92f4-9797edec5a3a",
      "instance_id": "55973b10-6cfe-435b-b33f-e99e1a7a224c",
      "display_name": "automation_moa-hostedcontrolplane_cluster_55973b10-6cfe-435b-b33f-e99e1a7a224c",
      "billing_provider": "aws",
      "billing_account_id": "dom",
      "measurements": [
        3.99,
        2.93
      ],
      "last_seen": "2023-08-07T15:00:00Z",
      "number_of_guests": 0
    },
    {
      "id": "81bd5ea1-f504-4385-95af-7087a1e42552",
      "instance_id": "9968f68a-885d-411c-a4b0-b1c0242b7f91",
      "display_name": "automation_moa-hostedcontrolplane_cluster_9968f68a-885d-411c-a4b0-b1c0242b7f91",
      "billing_provider": "aws",
      "billing_account_id": "dom",
      "measurements": [
        3.09,
        12.93
      ],
      "last_seen": "2023-08-09T13:00:00Z",
      "number_of_guests": 0
    }
  ],
  "meta": {
    "count": 4,
    "product": "rosa",
    "measurements": [
      "Cores",
      "Instance-hours"
    ]
  }}
   ```
3.  Gather a tally report
    ```shell
    http :8000/api/rhsm-subscriptions/v1/tally/products/rosa/Cores \
    granularity==Daily \
    beginning==2023-08-01T00:00:00.000Z \
    ending==2023-08-31T23:59:59.999Z \
    use_running_totals_format==true \
    x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16788750"}}}' | base64 -w 0) 
    ```
4. Observe that the final running total value is 16 while the monthly total in the meta section is 14.  You get 16 if you run a `Math.ceil` on each cores measurement and 14 if you only run it after totaling all the measurements together.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.  Deploy the `awood/SWATCH-1462-total-mismatch` branch with 
    ```shell
    DATABASE_DATABASE=swatch-1462 ./gradlew :bootRun
    ```
2.  Run the tally report
    ```shell
    http :8000/api/rhsm-subscriptions/v1/tally/products/rosa/Cores \
    granularity==Daily \
    beginning==2023-08-01T00:00:00.000Z \
    ending==2023-08-31T23:59:59.999Z \
    use_running_totals_format==true \
    x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16788750"}}}' | base64 -w 0) 
    ```
3. Observe that the final running total matches the monthly total.

