### PR TITLE
SWATCH-1234 Refactor prometheus integration to use swatch-product-configuration

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -27,7 +27,6 @@ import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService
 import org.candlepin.subscriptions.metering.service.prometheus.config.PrometheusServiceConfiguration;
 import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.metering.task.MeteringTasksConfiguration;
-import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.security.OptInController;
 import org.candlepin.subscriptions.task.queue.TaskConsumerConfiguration;
 import org.candlepin.subscriptions.task.queue.TaskProducerConfiguration;
@@ -85,8 +84,7 @@ public class OpenShiftWorkerProfile {
       QueryBuilder queryBuilder,
       EventController eventController,
       @Qualifier("openshiftMetricRetryTemplate") RetryTemplate openshiftRetryTemplate,
-      OptInController optInController,
-      TagProfile tagProfile) {
+      OptInController optInController) {
     return new PrometheusMeteringController(
         clock,
         mProps,
@@ -94,7 +92,6 @@ public class OpenShiftWorkerProfile {
         queryBuilder,
         eventController,
         openshiftRetryTemplate,
-        optInController,
-        tagProfile);
+        optInController);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/config/PrometheusServiceConfiguration.java
@@ -29,7 +29,6 @@ import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService
 import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.prometheus.api.ApiProvider;
 import org.candlepin.subscriptions.prometheus.api.ApiProviderFactory;
-import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.security.OptInController;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -52,7 +51,7 @@ public class PrometheusServiceConfiguration {
   }
 
   @Bean
-  public MetricProperties metricProperties(TagProfile tagProfile) {
+  public MetricProperties metricProperties() {
     return new MetricProperties();
   }
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -51,7 +51,7 @@ public class QueryBuilder {
   }
 
   public String build(QueryDescriptor queryDescriptor) {
-    String templateKey = queryDescriptor.getMetric().getQueryKey();
+    String templateKey = queryDescriptor.getMetric().getPrometheus().getQueryKey();
     Optional<String> template = metricProperties.getQueryTemplate(templateKey);
 
     if (template.isEmpty()) {
@@ -63,7 +63,9 @@ public class QueryBuilder {
   }
 
   public String buildAccountLookupQuery(QueryDescriptor queryDescriptor) {
-    String templateKey = queryDescriptor.getMetric().getAccountQueryKey();
+    // At some point templateKey here should read either "default" or "addonSamples" with a property
+    // added in application.yaml
+    String templateKey = DEFAULT_METRIC_QUERY_KEY;
     Optional<String> template = metricProperties.getAccountQueryTemplate(templateKey);
     if (template.isEmpty()) {
       throw new IllegalArgumentException(

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -63,8 +63,8 @@ public class QueryBuilder {
   }
 
   public String buildAccountLookupQuery(QueryDescriptor queryDescriptor) {
-    // At some point templateKey here should read either "default" or "addonSamples" with a property
-    // added in application.yaml
+    // SWATCH-1629 At some point templateKey here should read either "default" or "addonSamples"
+    // with a property added in application.yaml
     String templateKey = DEFAULT_METRIC_QUERY_KEY;
     Optional<String> template = metricProperties.getAccountQueryTemplate(templateKey);
     if (template.isEmpty()) {

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryDescriptor.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryDescriptor.java
@@ -20,10 +20,10 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus.promql;
 
+import com.redhat.swatch.configuration.registry.Metric;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
-import org.candlepin.subscriptions.registry.TagMetric;
 
 /**
  * Describes the variables to be applied to a query template. Within a template, these variables can
@@ -35,12 +35,12 @@ import org.candlepin.subscriptions.registry.TagMetric;
 public class QueryDescriptor {
 
   /** Any variables that should be provided by the tag configuration. */
-  private TagMetric metric;
+  private Metric metric;
 
   /** Any variable that are specified at runtime. */
   private Map<String, String> runtime;
 
-  public QueryDescriptor(TagMetric metric) {
+  public QueryDescriptor(Metric metric) {
     this.metric = metric;
     this.runtime = new HashMap<>();
   }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManager.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.metering.service.prometheus.task;
 
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.stream.Stream;
@@ -27,7 +28,6 @@ import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource;
-import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.task.TaskDescriptor;
 import org.candlepin.subscriptions.task.TaskDescriptor.TaskDescriptorBuilder;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
@@ -54,8 +54,6 @@ public class PrometheusMetricsTaskManager {
 
   private PrometheusAccountSource accountSource;
 
-  private TagProfile tagProfile;
-
   private ApplicationClock clock;
 
   private ApplicationProperties appProps;
@@ -66,7 +64,6 @@ public class PrometheusMetricsTaskManager {
       @Qualifier("meteringTaskQueueProperties") TaskQueueProperties queueProps,
       PrometheusAccountSource accountSource,
       AccountConfigRepository accountConfigRepository,
-      TagProfile tagProfile,
       ApplicationClock clock,
       ApplicationProperties appProps) {
     this.accountConfigRepository = accountConfigRepository;
@@ -74,7 +71,6 @@ public class PrometheusMetricsTaskManager {
     this.queue = queue;
     this.topic = queueProps.getTopic();
     this.accountSource = accountSource;
-    this.tagProfile = tagProfile;
     this.clock = clock;
     this.appProps = appProps;
   }
@@ -91,14 +87,19 @@ public class PrometheusMetricsTaskManager {
 
   public void updateMetricsForOrgId(
       String orgId, String productTag, OffsetDateTime start, OffsetDateTime end) {
-    tagProfile
-        .getSupportedMetricsForProduct(productTag)
-        .forEach(
-            metric -> {
-              log.info("Queuing {} {} metric updates for orgId={}.", productTag, metric, orgId);
-              queueMetricUpdateForOrgId(orgId, productTag, metric, start, end);
-              log.info("Done queuing updates of {} {} metric", productTag, metric);
-            });
+    var subDefOptional = SubscriptionDefinition.lookupSubscriptionByTag(productTag);
+    subDefOptional.ifPresent(
+        subDef ->
+            subDef
+                .getMetricIds() // No null check required here since metrics will always be present
+                .forEach(
+                    metric -> {
+                      log.info(
+                          "Queuing {} {} metric updates for orgId={}.", productTag, metric, orgId);
+                      queueMetricUpdateForOrgId(
+                          orgId, productTag, Uom.fromValue(metric), start, end);
+                      log.info("Done queuing updates of {} {} metric", productTag, metric);
+                    }));
   }
 
   private void queueMetricUpdateForOrgId(
@@ -126,15 +127,19 @@ public class PrometheusMetricsTaskManager {
   private void updateMetricsForAllAccounts(
       String productTag, OffsetDateTime start, OffsetDateTime end, RetryTemplate retry) {
     log.info("Queuing {} metric updates for range: [{}, {})", productTag, start, end);
-    tagProfile
-        .getSupportedMetricsForProduct(productTag)
-        .forEach(
-            metric ->
-                retry.execute(
-                    context -> {
-                      queueMetricUpdateForAllAccounts(productTag, metric, start, end);
-                      return null;
-                    }));
+    var subDefOptional = SubscriptionDefinition.lookupSubscriptionByTag(productTag);
+    subDefOptional.ifPresent(
+        subDef ->
+            subDef
+                .getMetricIds() // No null check required here since metrics will always be present
+                .forEach(
+                    metric ->
+                        retry.execute(
+                            context -> {
+                              queueMetricUpdateForAllAccounts(
+                                  productTag, Uom.fromValue(metric), start, end);
+                              return null;
+                            })));
   }
 
   private void queueMetricUpdateForAllAccounts(

--- a/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
@@ -29,7 +29,6 @@ import org.candlepin.subscriptions.metering.service.prometheus.PrometheusService
 import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMeteringTaskFactory;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
-import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.task.TaskFactory;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.queue.TaskConsumer;
@@ -54,11 +53,8 @@ public class MeteringTasksConfiguration {
 
   @Bean
   PrometheusAccountSource accountSource(
-      PrometheusService service,
-      MetricProperties metricProperties,
-      QueryBuilder queryBuilder,
-      TagProfile tagProfile) {
-    return new PrometheusAccountSource(service, metricProperties, queryBuilder, tagProfile);
+      PrometheusService service, MetricProperties metricProperties, QueryBuilder queryBuilder) {
+    return new PrometheusAccountSource(service, metricProperties, queryBuilder);
   }
 
   // Qualify this bean so that a new instance is created in the case that another
@@ -76,11 +72,10 @@ public class MeteringTasksConfiguration {
       @Qualifier("meteringTaskQueueProperties") TaskQueueProperties queueProps,
       PrometheusAccountSource accountSource,
       AccountConfigRepository accountConfigRepository,
-      TagProfile tagProfile,
       ApplicationClock clock,
       ApplicationProperties appProps) {
     return new PrometheusMetricsTaskManager(
-        queue, queueProps, accountSource, accountConfigRepository, tagProfile, clock, appProps);
+        queue, queueProps, accountSource, accountConfigRepository, clock, appProps);
   }
 
   // The following beans are defined for the worker profile only allowing

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -10,13 +10,13 @@ rhsm-subscriptions:
       metric:
         queryTemplates:
           default: >-
-            #{metric.queryParams[prometheusMetric]}
+            #{metric.prometheus.queryParams[metric]}
             * on(_id) group_right
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product="#{metric.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           addonSamples: >-
-            #{metric.queryParams[prometheusMetric]}
+            #{metric.prometheus.queryParams[metric]}
             * on(_id) group_right
-            min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{resource_type="addon",resource_name="#{metric.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
         backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ rhsm-subscriptions:
       metric:
         accountQueryTemplates:
           default: >-
-            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.queryParams[prometheusMetadataMetric]}{product='#{metric.queryParams[product]}', external_organization != '', billing_model='marketplace'}[1h]))
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product='#{metric.prometheus.queryParams[product]}', external_organization != '', billing_model='marketplace'}[1h]))
             by (external_organization)}
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:0h}
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -26,11 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
-import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.db.EventRecordRepository;
@@ -40,7 +38,6 @@ import org.candlepin.subscriptions.metering.retention.EventRecordsRetentionPrope
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
-import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.hamcrest.Matchers;
@@ -55,7 +52,6 @@ class InternalMeteringResourceTest {
 
   private static final String VALID_PRODUCT = "rhosak";
 
-  @Mock private TagProfile tagProfile;
   @Mock private PrometheusMetricsTaskManager tasks;
   @Mock private PrometheusMeteringController controller;
   @Mock private AccountConfigRepository accountConfigRepository;
@@ -73,10 +69,6 @@ class InternalMeteringResourceTest {
     appProps = new ApplicationProperties();
     clock = new TestClockConfiguration().adjustableClock();
     util = new ResourceUtil(clock);
-    lenient().when(tagProfile.tagIsPrometheusEnabled(VALID_PRODUCT)).thenReturn(true);
-    lenient()
-        .when(tagProfile.getSupportedMetricsForProduct(VALID_PRODUCT))
-        .thenReturn(Set.of(Uom.INSTANCE_HOURS));
     lenient().when(accountConfigRepository.findOrgByAccountNumber("account1")).thenReturn("org1");
 
     metricProps = new MetricProperties();
@@ -87,7 +79,6 @@ class InternalMeteringResourceTest {
             util,
             appProps,
             eventRecordsRetentionProperties,
-            tagProfile,
             tasks,
             controller,
             eventRecordRepository,
@@ -97,7 +88,6 @@ class InternalMeteringResourceTest {
   @Test
   void ensureBadRequestIfProductTagIsInvalid() {
     String productId = "test-product";
-    when(tagProfile.tagIsPrometheusEnabled(productId)).thenReturn(false);
 
     OffsetDateTime end = clock.startOfCurrentHour();
     assertThrows(

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -50,7 +50,6 @@ import org.candlepin.subscriptions.prometheus.model.ResultType;
 import org.candlepin.subscriptions.prometheus.model.StatusType;
 import org.candlepin.subscriptions.registry.BillingWindow;
 import org.candlepin.subscriptions.registry.TagMetric;
-import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.security.OptInController;
 import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.ApplicationClock;
@@ -86,8 +85,6 @@ class PrometheusMeteringControllerTest {
   @Autowired private MetricProperties metricProperties;
 
   @Autowired private QueryBuilder queryBuilder;
-
-  @Autowired private TagProfile tagProfile;
 
   @MockBean private OptInController optInController;
 
@@ -125,10 +122,9 @@ class PrometheusMeteringControllerTest {
             queryBuilder,
             eventController,
             openshiftRetry,
-            optInController,
-            tagProfile);
+            optInController);
 
-    queries = new QueryHelper(tagProfile, queryBuilder);
+    queries = new QueryHelper(queryBuilder);
 
     Map<String, String> queryParams = new HashMap<>();
     queryParams.put("product", "ocp");

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusServiceTest.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 import org.candlepin.subscriptions.metering.service.prometheus.promql.QueryBuilder;
 import org.candlepin.subscriptions.prometheus.model.QueryResult;
-import org.candlepin.subscriptions.registry.TagProfile;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,12 +43,10 @@ class PrometheusServiceTest {
 
   @Autowired private QueryBuilder queryBuilder;
 
-  @Autowired private TagProfile tagProfile;
-
   @Test
   void testRangeQueryApi(
       PrometheusQueryWiremockExtension.PrometheusQueryWiremock prometheusServer) {
-    QueryHelper queries = new QueryHelper(tagProfile, queryBuilder);
+    QueryHelper queries = new QueryHelper(queryBuilder);
 
     String expectedQuery = queries.expectedQuery("OpenShift-metrics", Map.of("orgId", "o1"));
     QueryResult expectedResult = new QueryResult();
@@ -69,7 +66,7 @@ class PrometheusServiceTest {
 
   @Test
   void testQueryApi(PrometheusQueryWiremockExtension.PrometheusQueryWiremock prometheusServer) {
-    QueryHelper queries = new QueryHelper(tagProfile, queryBuilder);
+    QueryHelper queries = new QueryHelper(queryBuilder);
 
     String expectedQuery = queries.expectedQuery("OpenShift-metrics", Map.of("orgId", "o1"));
     int expectedTimeout = 1;

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/task/PrometheusMetricsTaskManagerTest.java
@@ -25,12 +25,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
-import java.util.Set;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
-import org.candlepin.subscriptions.json.Measurement.Uom;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusAccountSource;
-import org.candlepin.subscriptions.registry.TagProfile;
 import org.candlepin.subscriptions.task.TaskDescriptor;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.TaskType;
@@ -47,15 +44,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class PrometheusMetricsTaskManagerTest {
 
   private static final String TASK_TOPIC = "metrics-tasks-topic";
-  private static final String TEST_PROFILE_ID = "OpenShift";
+  private static final String TEST_PROFILE_ID = "OpenShift-dedicated-metrics";
 
   @Mock private TaskQueue queue;
 
   @Mock private TaskQueueProperties queueProperties;
 
   @Mock private PrometheusAccountSource accountSource;
-
-  @Mock private TagProfile tagProfile;
 
   @Mock private AccountConfigRepository accountConfigRepository;
 
@@ -64,7 +59,6 @@ class PrometheusMetricsTaskManagerTest {
   @BeforeEach
   void setupTest() {
     when(queueProperties.getTopic()).thenReturn(TASK_TOPIC);
-    when(tagProfile.getSupportedMetricsForProduct(any())).thenReturn(Set.of(Uom.CORES));
     ApplicationClock clock = new TestClockConfiguration().adjustableClock();
     manager =
         new PrometheusMetricsTaskManager(
@@ -72,7 +66,6 @@ class PrometheusMetricsTaskManagerTest {
             queueProperties,
             accountSource,
             accountConfigRepository,
-            tagProfile,
             clock,
             new ApplicationProperties());
   }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -178,4 +178,22 @@ public class SubscriptionDefinition {
     return metrics.stream()
         .anyMatch(metric -> metric.getRhmMetricId() != null || metric.getAwsDimension() != null);
   }
+
+  /**
+   * Looks for tag matching a variant
+   *
+   * @param tag
+   * @return Optional<Subscription>
+   */
+  public static Optional<SubscriptionDefinition> lookupSubscriptionByTag(
+      @NotNull @NotEmpty String tag) {
+
+    return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
+        .filter(subscription -> !subscription.getVariants().isEmpty())
+        .filter(
+            subscription ->
+                subscription.getVariants().stream()
+                    .anyMatch(variant -> Objects.equals(tag, variant.getTag())))
+        .findFirst();
+  }
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -214,23 +214,6 @@ public class SubscriptionDefinition {
         .anyMatch(metric -> metric.getRhmMetricId() != null || metric.getAwsDimension() != null);
   }
 
-  /**
-   * Looks for tag matching a variant
-   *
-   * @param tag
-   * @return Optional<Subscription>
-   */
-  public static Optional<SubscriptionDefinition> lookupSubscriptionByTag(
-      @NotNull @NotEmpty String tag) {
-
-    return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
-        .filter(subscription -> !subscription.getVariants().isEmpty())
-        .filter(
-            subscription ->
-                subscription.getVariants().stream()
-                    .anyMatch(variant -> Objects.equals(tag, variant.getTag())))
-        .findFirst();
-
   public static String getAwsDimension(String productId, String metricId) {
     return lookupSubscriptionByTag(productId)
         .flatMap(subscriptionDefinition -> subscriptionDefinition.getMetric(metricId))

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/basilisk.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/basilisk.yaml
@@ -22,6 +22,7 @@ metrics:
     rhmMetricId: redhat.com:BASILISK:transfer_gb
     awsDimension: transfer_gb
     prometheus:
+      queryKey: default
       queryParams:
         product: BASILISK
         metric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
@@ -30,6 +31,7 @@ metrics:
     rhmMetricId: redhat.com:BASILISK:cluster_hour
     awsDimension: cluster_hour
     prometheus:
+      queryKey: default
       queryParams:
         product: BASILISK
         metric: kafka_id:strimzi_resource_state:max_over_time1h
@@ -38,6 +40,7 @@ metrics:
     rhmMetricId: redhat.com:BASILISK:storage_gib_months
     awsDimension: storage_gb
     prometheus:
+      queryKey: default
       queryParams:
         product: BASILISK
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacs.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacs.yaml
@@ -21,6 +21,7 @@ metrics:
     rhmMetricId: redhat.com:rhacs:cpu_hour
     awsDimension: vCPU_Hour
     prometheus:
+      queryKey: default
       queryParams:
         product: rhacs
         metric: rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhosak.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhosak.yaml
@@ -22,6 +22,7 @@ metrics:
     rhmMetricId: redhat.com:rhosak:transfer_gb
     awsDimension: transfer_gb
     prometheus:
+      queryKey: default
       queryParams:
         product: rhosak
         metric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
@@ -30,6 +31,7 @@ metrics:
     rhmMetricId: redhat.com:rhosak:cluster_hour
     awsDimension: cluster_hour
     prometheus:
+      queryKey: default
       queryParams:
         product: rhosak
         metric: kafka_id:strimzi_resource_state:max_over_time1h
@@ -38,6 +40,7 @@ metrics:
     rhmMetricId: redhat.com:rhosak:storage_gib_months
     awsDimension: storage_gb
     prometheus:
+      queryKey: default
       queryParams:
         product: rhosak
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
@@ -45,6 +48,7 @@ metrics:
   - id: Storage-gibibytes
     rhmMetricId: redhat.com:rhosak:storage_gb
     prometheus:
+      queryKey: default
       queryParams:
         product: rhosak
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
@@ -21,6 +21,7 @@ metrics:
   - id: Instance-hours
     awsDimension: control_plane_0
     prometheus:
+      queryKey: default
       queryParams:
         product: moa-hostedcontrolplane
         metric: cluster:usage:workload:capacity_physical_instance_hours
@@ -29,6 +30,7 @@ metrics:
     awsDimension: four_vcpu_0
     billingFactor: 0.25
     prometheus:
+      queryKey: default
       queryParams:
         product: moa-hostedcontrolplane
         metric: cluster:usage:workload:capacity_physical_cpu_hours

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
@@ -99,6 +99,7 @@ class SubscriptionDefinitionTest {
     metric.setAwsDimension("cluster_hour");
 
     var prometheusMetric = new PrometheusMetric();
+    prometheusMetric.setQueryKey("default");
     prometheusMetric.setQueryParams(
         Map.of(
             "product",


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1234](https://issues.redhat.com/browse/SWATCH-1234)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Refactor prometheus integration to use swatch-product-configuration

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. To run locally prometheus by pointing to stage follow the steps in: [Connecting  Observatorium to fetch Prometheus ](https://docs.engineering.redhat.com/display/ENT/Connecting+to+Observatorium+to+Fetch+Prometheus+Metrics)
- Copy CLIENT_SECRET and paste it in a file `token-refresher`
- Run: `podman run --name=telemeter-stage --rm -ti -p 8082:8080     quay.io/observatorium/token-refresher:master-2021-02-05-5da9663     --oidc.client-secret=$(cat ~/Downloads/token-refresher)     --oidc.client-id=observatorium-subwatch-staging     --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external     --url=https://observatorium.api.stage.openshift.com`
2. Apply the below patch in `application-openshift-metering-worker.yaml` since billing_model="marketplace" won't give results in prometheus in the further steps
```

diff --git a/src/main/resources/application-openshift-metering-worker.yaml b/src/main/resources/application-openshift-metering-worker.yaml
--- a/src/main/resources/application-openshift-metering-worker.yaml	(revision f53e559df23efbc7ba6b5028b1db2f26e3f29570)
+++ b/src/main/resources/application-openshift-metering-worker.yaml	(date 1692902103848)
@@ -12,7 +12,7 @@
           default: >-
             #{metric.prometheus.queryParams[metric]}
             * on(_id) group_right
-            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", support=~"Premium|Standard|Self-Support|None"}[1h])
           addonSamples: >-
             #{metric.prometheus.queryParams[metric]}
             * on(_id) group_right
```

3. Then in separate terminal pointing to the prom_url in the doc run:  `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 ./gradlew clean :bootRun`

### Steps
<!-- Enter each step of the test below -->
1. Run: `curl -X POST -H "x-rh-swatch-synchronous-request:true"  -H "x-rh-swatch-psk: placeholder" "http://localhost:8000/api/rhsm-subscriptions/v1/internal/metering/OpenShift-dedicated-metrics?orgId=6323660&rangeInMinutes=1200"`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Depending on if stage prometheus has data you should see bunch of inserts in events table with new event_types in event_type column and logs as below:

**First time if the data doesn't exists then you get below logs:**
```
2023-08-24 18:35:35,983 [thread=http-nio-8000-exec-1] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Found 0 existing events.
2023-08-24 18:35:36,310 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Persisted 130 events for OpenShift-dedicated-metrics Instance-hours metrics.
```

**Second time when data is already present in table then you should see below message:**
```
2023-08-24 18:36:39,677 [thread=http-nio-8000-exec-2] [DEBUG] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Found 130 existing events.
2023-08-24 18:36:39,682 [thread=http-nio-8000-exec-2] [INFO ] [org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController] self- Persisted 130 events for OpenShift-dedicated-metrics Instance-hours metrics.
```
