### PR TITLE
Configure users as superusers

### DIFF
--- a/init_dbs.sh
+++ b/init_dbs.sh
@@ -6,5 +6,6 @@ for db in rhsm-subscriptions insights; do
       CREATE USER "$db";
       CREATE DATABASE "$db";
       GRANT ALL PRIVILEGES ON DATABASE "$db" TO "$db";
+      ALTER USER "$db" WITH SUPERUSER;
 EOSQL
 done


### PR DESCRIPTION
This is required to load scripts via pqsl using the COPY command.
