### PR TITLE
SWATCH-1569: Remove force sync logic from billing producers

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProvider.java
@@ -26,7 +26,6 @@ import jakarta.ws.rs.core.Response.Status;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -76,8 +75,8 @@ public class UsageContextSubscriptionProvider {
     // Set start date one hour in past to pickup recently terminated subscriptions
     var start = subscriptionDate.minusHours(1);
     List<Subscription> subscriptions =
-        subscriptionSyncController.findSubscriptionsAndSyncIfNeeded(
-            accountNumber, Optional.ofNullable(orgId), usageKey, start, subscriptionDate, true);
+        subscriptionSyncController.findSubscriptions(
+            accountNumber, Optional.ofNullable(orgId), usageKey, start, subscriptionDate);
 
     var existsRecentlyTerminatedSubscription =
         subscriptions.stream()
@@ -90,7 +89,7 @@ public class UsageContextSubscriptionProvider {
                 subscription ->
                     subscription.getEndDate().isAfter(subscriptionDate)
                         || subscription.getEndDate().equals(subscriptionDate))
-            .collect(Collectors.toList());
+            .toList();
 
     if (subscriptions.isEmpty()) {
       missingSubscriptionCounter.increment();

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -110,8 +110,7 @@ class InternalSubscriptionResourceTest {
             offeringSync,
             capacityReconciliationController,
             metricMapper);
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(Collections.emptyList());
     assertThrows(
         NotFoundException.class,
@@ -134,8 +133,7 @@ class InternalSubscriptionResourceTest {
             offeringSync,
             capacityReconciliationController,
             metricMapper);
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(Collections.emptyList());
     assertThrows(
         NotFoundException.class,
@@ -164,8 +162,7 @@ class InternalSubscriptionResourceTest {
     Subscription sub2 = new Subscription();
     sub2.setBillingProviderId("bar1;bar2;bar3");
     sub2.setEndDate(defaultEndDate);
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
@@ -195,8 +192,7 @@ class InternalSubscriptionResourceTest {
     Subscription sub2 = new Subscription();
     sub2.setBillingProviderId("bar1;bar2;bar3");
     sub2.setEndDate(defaultEndDate);
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
@@ -214,8 +210,7 @@ class InternalSubscriptionResourceTest {
     Subscription sub1 = new Subscription();
     sub1.setBillingProviderId("foo1;foo2;foo3");
     sub1.setEndDate(endDate);
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1));
 
     var lookupDate = endDate.plusMinutes(30);
@@ -238,8 +233,7 @@ class InternalSubscriptionResourceTest {
     Subscription sub1 = new Subscription();
     sub1.setBillingProviderId("foo1;foo2;foo3");
     sub1.setEndDate(endDate);
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1));
 
     var lookupDate = endDate.plusMinutes(30);
@@ -265,8 +259,7 @@ class InternalSubscriptionResourceTest {
     Subscription sub2 = new Subscription();
     sub2.setBillingProviderId("bar1;bar2;bar3");
     sub2.setEndDate(endDate.plusMinutes(45));
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
     var lookupDate = endDate.plusMinutes(30);
     AwsUsageContext awsUsageContext =
@@ -286,8 +279,7 @@ class InternalSubscriptionResourceTest {
     Subscription sub2 = new Subscription();
     sub2.setBillingProviderId("bar1;bar2;bar3");
     sub2.setEndDate(endDate.plusMinutes(45));
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
     var lookupDate = endDate.plusMinutes(30);
     AwsUsageContext awsUsageContext =
@@ -338,8 +330,7 @@ class InternalSubscriptionResourceTest {
             capacityReconciliationController,
             metricMapper);
 
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(Collections.emptyList());
 
     OffsetDateTime now = OffsetDateTime.now();
@@ -378,8 +369,7 @@ class InternalSubscriptionResourceTest {
     sub2.setStartDate(OffsetDateTime.now());
     sub2.setEndDate(sub2.getStartDate().plusMonths(1));
 
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
 
     RhmUsageContext rhmUsageContext =

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProviderTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.Counter;
@@ -74,8 +73,7 @@ class UsageContextSubscriptionProviderTest {
 
   @Test
   void incrementsMissingCounter_WhenAccounNumberPresent() {
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(Collections.emptyList());
     assertThrows(
         NotFoundException.class,
@@ -88,8 +86,7 @@ class UsageContextSubscriptionProviderTest {
 
   @Test
   void incrementsMissingCounter_WhenOrgIdPresent() {
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(Collections.emptyList());
     assertThrows(
         NotFoundException.class,
@@ -112,8 +109,7 @@ class UsageContextSubscriptionProviderTest {
     sub2.setBillingProviderId("bar1;bar2;bar3");
     sub2.setEndDate(defaultEndDate);
 
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
 
     Optional<Subscription> subscription =
@@ -137,8 +133,7 @@ class UsageContextSubscriptionProviderTest {
     sub2.setBillingProviderId("bar1;bar2;bar3");
     sub2.setEndDate(defaultEndDate);
 
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
 
     Optional<Subscription> subscription =
@@ -157,8 +152,7 @@ class UsageContextSubscriptionProviderTest {
     Subscription sub1 = new Subscription();
     sub1.setBillingProviderId("foo1;foo2;foo3");
     sub1.setEndDate(endDate);
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1));
 
     var lookupDate = endDate.plusMinutes(30);
@@ -181,8 +175,7 @@ class UsageContextSubscriptionProviderTest {
     Subscription sub1 = new Subscription();
     sub1.setBillingProviderId("foo1;foo2;foo3");
     sub1.setEndDate(endDate);
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1));
 
     var lookupDate = endDate.plusMinutes(30);
@@ -211,8 +204,7 @@ class UsageContextSubscriptionProviderTest {
     sub2.setBillingProviderId("bar1;bar2;bar3");
     sub2.setEndDate(endDate.plusMinutes(45));
 
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
     var lookupDate = endDate.plusMinutes(30);
 
@@ -233,8 +225,7 @@ class UsageContextSubscriptionProviderTest {
     sub2.setBillingProviderId("bar1;bar2;bar3");
     sub2.setEndDate(endDate.plusMinutes(45));
 
-    when(syncController.findSubscriptionsAndSyncIfNeeded(
-            any(), any(), any(), any(), any(), anyBoolean()))
+    when(syncController.findSubscriptions(any(), any(), any(), any(), any()))
         .thenReturn(List.of(sub1, sub2));
 
     var lookupDate = endDate.plusMinutes(30);

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -395,13 +394,13 @@ class SubscriptionSyncControllerTest {
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            subscriptionSyncController.findSubscriptionsAndSyncIfNeeded(
-                "1000", orgId, key1, rangeStart, rangeEnd, false));
+            subscriptionSyncController.findSubscriptions(
+                "1000", orgId, key1, rangeStart, rangeEnd));
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            subscriptionSyncController.findSubscriptionsAndSyncIfNeeded(
-                "1000", orgId, key2, rangeStart, rangeEnd, false));
+            subscriptionSyncController.findSubscriptions(
+                "1000", orgId, key2, rangeStart, rangeEnd));
   }
 
   @Test
@@ -421,13 +420,11 @@ class SubscriptionSyncControllerTest {
     s.setBillingProviderId("xyz");
     List<Subscription> result = Collections.singletonList(s);
 
-    when(subscriptionRepository.findByCriteria(any(), any()))
-        .thenReturn(new ArrayList<>())
-        .thenReturn(result);
+    when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(result);
 
     List<Subscription> actual =
-        subscriptionSyncController.findSubscriptionsAndSyncIfNeeded(
-            "1000", Optional.of("org1000"), key, rangeStart, rangeEnd, false);
+        subscriptionSyncController.findSubscriptions(
+            "1000", Optional.of("org1000"), key, rangeStart, rangeEnd);
     assertEquals(1, actual.size());
     assertEquals("xyz", actual.get(0).getBillingProviderId());
   }
@@ -448,13 +445,11 @@ class SubscriptionSyncControllerTest {
     s.setBillingProviderId("xyz");
     List<Subscription> result = Collections.singletonList(s);
 
-    when(subscriptionRepository.findByCriteria(any(), any()))
-        .thenReturn(new ArrayList<>())
-        .thenReturn(result);
+    when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(result);
 
     List<Subscription> actual =
-        subscriptionSyncController.findSubscriptionsAndSyncIfNeeded(
-            null, Optional.of("org1000"), key, rangeStart, rangeEnd, false);
+        subscriptionSyncController.findSubscriptions(
+            null, Optional.of("org1000"), key, rangeStart, rangeEnd);
     assertEquals(1, actual.size());
     assertEquals("xyz", actual.get(0).getBillingProviderId());
   }
@@ -476,13 +471,11 @@ class SubscriptionSyncControllerTest {
     s.setBillingProviderId("xyz");
     List<Subscription> result = Collections.singletonList(s);
 
-    when(subscriptionRepository.findByCriteria(any(), any()))
-        .thenReturn(new ArrayList<>())
-        .thenReturn(result);
+    when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(result);
 
     List<Subscription> actual =
-        subscriptionSyncController.findSubscriptionsAndSyncIfNeeded(
-            "account123", Optional.empty(), key, rangeStart, rangeEnd, false);
+        subscriptionSyncController.findSubscriptions(
+            "account123", Optional.empty(), key, rangeStart, rangeEnd);
     assertEquals(1, actual.size());
     assertEquals("xyz", actual.get(0).getBillingProviderId());
   }
@@ -509,34 +502,6 @@ class SubscriptionSyncControllerTest {
     when(offeringRepository.findProductNameBySku("sku")).thenReturn(Optional.of("placeholder"));
     OfferingProductTags productTags2 = subscriptionSyncController.findProductTags("sku");
     assertNull(productTags2.getData());
-  }
-
-  @Test
-  void memoizesSubscriptionId() {
-    UsageCalculation.Key key =
-        new Key(
-            "OpenShift-metrics",
-            ServiceLevel.STANDARD,
-            Usage.PRODUCTION,
-            BillingProvider.RED_HAT,
-            "abc");
-    Subscription s = new Subscription();
-    s.setStartDate(OffsetDateTime.now().minusDays(7));
-    s.setEndDate(OffsetDateTime.now().plusDays(7));
-    s.setBillingProvider(BillingProvider.RED_HAT);
-    s.setBillingProviderId("abc");
-    List<Subscription> result = Collections.singletonList(s);
-
-    when(subscriptionRepository.findByCriteria(any(), any()))
-        .thenReturn(new ArrayList<>())
-        .thenReturn(result);
-
-    List<Subscription> actual =
-        subscriptionSyncController.findSubscriptionsAndSyncIfNeeded(
-            "1000", Optional.of("org1000"), key, rangeStart, rangeEnd, false);
-    assertEquals(1, actual.size());
-    assertEquals("abc", actual.get(0).getBillingProviderId());
-    verify(subscriptionService, times(1)).getSubscriptionsByOrgId("org1000");
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1569](https://issues.redhat.com/browse/SWATCH-1569)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
 
Removes logic to sync subscriptions when not found in the billing producers (aws and RH marketplace). 

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Create subscriptions for testing:
```
cat <<EOF | psql -h localhost -U rhsm-subscriptions                                                                                                                                                INSERT INTO offering(
    sku, product_name, product_family, sla, usage, description, has_unlimited_usage)
    VALUES ('MW01882', 'OpenShift Streams for Apache Kafka', 'JBoss', 'Premium', 'Production', 'Red Hat OpenShift Streams for Apache Kafka (Hourly)', false);

INSERT INTO subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id) values ('MW01882', 'org123', 'sub-id-ocp', 30, '2023-03-26T04:00:00Z', '2024-03-26T04:00:00Z', 'marketPlaceSubsriptionId-1', 'account123', '123456', 'red hat', '');

INSERT INTO subscription(
        sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id)
        VALUES ('MW01882', 'org123', '12351256', '1', '2012-05-13 16:32:00+00', '2032-05-13 16:32:00+00', 'testProductCode123;customer123;sellerAccount123', 'account123', '1235153', 'aws', '123');
EOF
```
1. Start app with `DEV_MODE=true ./gradlew :bootRun`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Test AWS endpoint:
```
'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext?orgId=org123&date=2022-01-01T00%3A00Z&productId=rhosak&sla=Premium&usage=Production&awsAccountId=123'   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'
```
1. Test AWS endpoint should give 404 without force sync (No log like "Syncing subscriptions for account {} using orgId {}:")
```
'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext?orgId=org123&date=2022-01-01T00%3A00Z&productId=rhosak&sla=Premium&usage=Production&awsAccountId=NA'   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'
```
1. Test RH marketplace endpoint:
```
http GET :8000/api/rhsm-subscriptions/v1/internal/subscriptions/rhmUsageContext x-rh-swatch-psk:placeholder productId=='rhosak' date=='2023-05-01T03:59:59.999Z' orgId=='org123' accountNumber=='account123' sla=='Premium'
```
1. Test  RH marketplace endpoint should give 404 without force sync  (No log like "Syncing subscriptions for account {} using orgId {}:"):
```
http GET :8000/api/rhsm-subscriptions/v1/internal/subscriptions/rhmUsageContext x-rh-swatch-psk:placeholder productId=='rhosak' date=='2023-05-01T03:59:59.999Z' orgId=='org123' accountNumber=='account123' sla=='Standard'
```