### PR TITLE
[HOTFIX] Disable RHEL {Server,for x86} migration

### DIFF
--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -118,7 +118,8 @@
     <!-- Uncomment once the above changeset has landed in prod -->
     <!-- <include file="liquibase/202307051245-drop-instance_id-columns.xml"/> -->
     <include file="liquibase/202308151557-fix-subscription-measurement-metric-id-casing.xml"/>
-    <include file="liquibase/202308211518-rename-rhel-product-ids.xml"/>
+    <!-- Disabling below due to issues during prod deploy on 2023-08-29 -->
+    <!-- <include file="liquibase/202308211518-rename-rhel-product-ids.xml"/> -->
     <include file="liquibase/202307261851-event-change-event-type-data.xml"/>
     <include file="liquibase/202308210806-add-metric-id-instance-measurements.xml"/>
     <!-- Uncomment once the above changeset has landed in prod -->


### PR DESCRIPTION
We hit issues trying to get this migration to run during production deploy