### PR TITLE
SWATCH-1621: Throw BadRequestException if error during request body validation

### DIFF
--- a/src/main/spec/internal-tally-api-spec.yaml
+++ b/src/main/spec/internal-tally-api-spec.yaml
@@ -197,6 +197,26 @@ paths:
           application/json:
             schema:
               type: string
+            examples:
+              EventDetail:
+                value:
+                  - event_id: 0998c49b-9552-463f-b363-0a4b046dd6e9
+                    event_source: prometheus
+                    event_type: 'snapshot_redhat.com:BASILISK:storage_gb'
+                    account_number: account123
+                    org_id: org123
+                    service_type: BASILISK Instance
+                    instance_id: c5mu16smf1c22rn8e730
+                    timestamp: '2021-10-18T22:00:00Z'
+                    expiration: '2021-10-19T22:00:00Z'
+                    display_name: c5mu16smf1c22rn8e730
+                    measurements:
+                      - value: 1.5
+                        uom: Storage-gibibyte-months
+                    role: BASILISK
+                    sla: Premium
+                    billing_provider: red hat
+                    billing_account_id: placeholderId
       responses:
         '200':
           description: Save a list of events


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1621](https://issues.redhat.com/browse/SWATCH-1621)

## Description
If a bad billing provider (or any other invalid enumeration) got sent to POST `/internal/rpc/tally/event`, a jackson error would occur, resulting in application/server errors and a stacktrace in the logs.

We want to treat validation of the request body as a client error, and put a WARN in the logs instead - without the whole stacktrace spam.

## Testing
### main branch

Reproduce the exception & stack trace 
```
DEV_MODE=true ./gradlew :bootRun
```

```
curl -X 'POST'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/events' -H  'x-rh-swatch-psk:placeholder'   -H 'accept: application/json'   -H 'Content-Type: application/json'   -d '[{"event_id":"0998c49b-9552-463f-b363-0a4b046dd6e9","event_source":"prometheus","event_type":"snapshot_redhat.com:BASILISK:storage_gb","account_number":"account123","org_id":"org123","service_type":"BASILISK Instance","instance_id":"c5mu16smf1c22rn8e730","timestamp":"2021-10-18T22:00:00Z","expiration":"2021-10-19T22:00:00Z","display_name":"c5mu16smf1c22rn8e730","measurements":[{"value":1.5,"uom":"Storage-gibibyte-months"}],"role":"BASILISK","sla":"Premium","billing_provider":"blue hat","billing_account_id":"dummyId"}]'
```

Response:
```
{"detail":"Error saving events"}
```

### this branch
Switch branches, run the application again
```
git checkout lburnett/invalid-billing-producer-exceptio
DEV_MODE=true ./gradlew :bootRun
```
```
curl -X 'POST'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/events' -H  'x-rh-swatch-psk:placeholder'   -H 'accept: application/json'   -H 'Content-Type: application/json'   -d '[{"event_id":"0998c49b-9552-463f-b363-0a4b046dd6e9","event_source":"prometheus","event_type":"snapshot_redhat.com:BASILISK:storage_gb","account_number":"account123","org_id":"org123","service_type":"BASILISK Instance","instance_id":"c5mu16smf1c22rn8e730","timestamp":"2021-10-18T22:00:00Z","expiration":"2021-10-19T22:00:00Z","display_name":"c5mu16smf1c22rn8e730","measurements":[{"value":1.5,"uom":"Storage-gibibyte-months"}],"role":"BASILISK","sla":"Premium","billing_provider":"blue hat","billing_account_id":"dummyId"}]'
```

Note that the logs now have the exception message at the WARN level, and the response from the curl command is now
```
{"errors":[{"status":"400","code":"SUBSCRIPTIONS1001","title":"Cannot construct instance of `org.candlepin.subscriptions.json.Event$BillingProvider`, problem: blue hat\n at [Source: (String)\"[{\"event_id\":\"0998c49b-9552-463f-b363-0a4b046dd6e9\",\"event_source\":\"prometheus\",\"event_type\":\"snapshot_redhat.com:BASILISK:storage_gb\",\"account_number\":\"account123\",\"org_id\":\"org123\",\"service_type\":\"BASILISK Instance\",\"instance_id\":\"c5mu16smf1c22rn8e730\",\"timestamp\":\"2021-10-18T22:00:00Z\",\"expiration\":\"2021-10-19T22:00:00Z\",\"display_name\":\"c5mu16smf1c22rn8e730\",\"measurements\":[{\"value\":1.5,\"uom\":\"Storage-gibibyte-months\"}],\"role\":\"BASILISK\",\"sla\":\"Premium\",\"billing_provider\":\"blue hat\",\"billing_\"[truncated 23 chars]; line: 1, column: 481] (through reference chain: java.util.ArrayList[0]->org.candlepin.subscriptions.json.Event[\"billing_provider\"])"}]}
```