### PR TITLE
[CI] Do not ask "ok to verify?" for some known users

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,28 @@ pipeline {
                 expression { env.CHANGE_FORK }
                 not {
                   anyOf {
+                    // Kevin Howell
+                    changeRequest author: "kahowell"
+                    // Lindsey Burnett
+                    changeRequest author: "lindseyburnett"
+                    // Alex Wood
+                    changeRequest author: "awood"
+                    // Michael Stead
+                    changeRequest author: "mstead"
+                    // Kevin Flaherty
+                    changeRequest author: "kflahert"
+                    // Barnaby Court
+                    changeRequest author: "barnabycourt"
+                    // Nikhil Kathole
+                    changeRequest author: "ntkathole"
                     // Jose Carvajal
                     changeRequest author: "Sgitario"
+                    // Kenny Synvrit
+                    changeRequest author: "ksynvrit"
+                    // Kartik Shah
+                    changeRequest author: "kartikshahc"
+                    // Vanessa Busch
+                    changeRequest author: "vbusch"
                   }
                }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,12 @@ pipeline {
             when {
                 beforeInput true
                 expression { env.CHANGE_FORK }
+                not {
+                  anyOf {
+                    // Jose Carvajal
+                    changeRequest author: "Sgitario"
+                  }
+               }
             }
             steps {
                 input 'ok to test?'


### PR DESCRIPTION
The idea is to register the users that more contribute to the project and not to ask "ok to verify?" to trigger the Jenkins job.

I also checked whether there was a way to check the user organization instead, but I could not find any way.

I took the list of users from the swatch-dev-team slack group and the ones with more contributions.