### PR TITLE
SWATCH-1613: Fully drop uom column from instance measurements table

### DIFF
--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -122,8 +122,7 @@
     <!-- <include file="liquibase/202308211518-rename-rhel-product-ids.xml"/> -->
     <include file="liquibase/202307261851-event-change-event-type-data.xml"/>
     <include file="liquibase/202308210806-add-metric-id-instance-measurements.xml"/>
-    <!-- Uncomment once the above changeset has landed in prod -->
-    <!-- <include file="liquibase/202308210906-drop-uom-column-instance-measurements.xml"/> -->
+    <include file="liquibase/202308210906-drop-uom-column-instance-measurements.xml"/>
     <include file="liquibase/202308231356-add-metric-id-tally-measurements.xml"/>
     <!-- Uncomment once the above changeset has landed in prod -->
     <!-- <include file="liquibase/202308231456-drop-uom-column-tally-measurements.xml"/> -->


### PR DESCRIPTION
Jira issue: [SWATCH-1613](https://issues.redhat.com/browse/SWATCH-1613)

## Description
After https://issues.redhat.com/browse/SWATCH-371 is released, we need to fully drop the uom column from the instance measurements.

## Testing
1.- Run the migration using: `./gradlew :liquibaseUpdate`. The column `uom` should have been dropped from the tables `instance_measurements` and `instance_monthly_totals`.
2.- Test the rollback by calling twice: `./gradlew :liquibaseRollbackCount -PliquibaseCommandValue=2`. The column `uom` should have been back to the tables `instance_measurements` and `instance_monthly_totals`.
