### PR TITLE
SWATCH-1630: Make the instance identifier configurable

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -58,6 +58,7 @@ import org.springframework.util.StringUtils;
 public class PrometheusMeteringController {
 
   private static final Logger log = LoggerFactory.getLogger(PrometheusMeteringController.class);
+  private static final String PROMETHEUS_QUERY_PARAM_INSTANCE_KEY = "instanceKey";
 
   private final PrometheusService prometheusService;
   private final EventController eventController;
@@ -108,6 +109,9 @@ public class PrometheusMeteringController {
           String.format("Unable to determine service type for tag %s.", tag));
     }
 
+    // Get the instance key from the prometheus query params.
+    String instanceKey = getPrometheusInstanceKeyFromMetric(tag, tagMetric.get());
+
     /* Adjust the range for the prometheus range query API. Range query returns a data point at the
     startDate, and then an additional data point for each increment of `step` that is <= endDate.
     Because our prometheus queries use a range vector (look back) of 1h, we need to add an hour to
@@ -151,7 +155,7 @@ public class PrometheusMeteringController {
                     metricProperties.getQueryTimeout(),
                     item -> {
                       Map<String, String> labels = item.getMetric();
-                      String clusterId = labels.get("_id");
+                      String clusterId = labels.get(instanceKey);
                       String sla = labels.get("support");
                       String usage = labels.get("usage");
 
@@ -207,7 +211,8 @@ public class PrometheusMeteringController {
             if (StatusType.ERROR.equals(metricData.getStatus())) {
               throw new MeteringException(
                   String.format(
-                      "Unable to fetch %s %s metrics: %s", tag, metric, metricData.getError()));
+                      "Unable to fetch %s %s %s metrics: %s",
+                      tag, instanceKey, metric, metricData.getError()));
             }
 
             eventController.saveAll(events.values());
@@ -218,8 +223,9 @@ public class PrometheusMeteringController {
             return null;
           } catch (Exception e) {
             log.warn(
-                "Exception thrown while updating {} {} metrics. [Attempt: {}]: {}",
+                "Exception thrown while updating {} {} {} metrics. [Attempt: {}]: {}",
                 tag,
+                instanceKey,
                 metric,
                 context.getRetryCount() + 1,
                 e.getMessage());
@@ -304,5 +310,21 @@ public class PrometheusMeteringController {
     QueryDescriptor descriptor = new QueryDescriptor(tagMetric);
     descriptor.addRuntimeVar("orgId", orgId);
     return prometheusQueryBuilder.build(descriptor);
+  }
+
+  private String getPrometheusInstanceKeyFromMetric(String productTag, Metric metric) {
+    String instanceKey = null;
+    if (metric.getPrometheus() != null && metric.getPrometheus().getQueryParams() != null) {
+      instanceKey =
+          metric.getPrometheus().getQueryParams().get(PROMETHEUS_QUERY_PARAM_INSTANCE_KEY);
+    }
+
+    if (!StringUtils.hasText(instanceKey)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Could not find the `instanceKey` prometheus query param for %s-%s metric. ",
+              productTag, metric.getId()));
+    }
+    return instanceKey;
   }
 }

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -11,11 +11,11 @@ rhsm-subscriptions:
         queryTemplates:
           default: >-
             #{metric.prometheus.queryParams[metric]}
-            * on(_id) group_right
+            * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           addonSamples: >-
             #{metric.prometheus.queryParams[metric]}
-            * on(_id) group_right
+            * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-dedicated-metrics.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-dedicated-metrics.yaml
@@ -24,6 +24,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: osd
         metric: cluster:usage:workload:capacity_physical_cpu_hours
         metadataMetric: ocm_subscription
@@ -32,6 +33,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: osd
         metric: cluster:usage:workload:capacity_physical_instance_hours
         metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-metrics.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift-metrics.yaml
@@ -23,6 +23,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: ocp
         metric: cluster:usage:workload:capacity_physical_cpu_hours
         metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/basilisk.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/basilisk.yaml
@@ -26,6 +26,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: BASILISK
         metric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
         metadataMetric: ocm_subscription
@@ -35,6 +36,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: BASILISK
         metric: kafka_id:strimzi_resource_state:max_over_time1h
         metadataMetric: ocm_subscription
@@ -44,6 +46,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: BASILISK
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
         metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacs.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacs.yaml
@@ -23,6 +23,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: rhacs
         metric: rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h
         metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhods.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhods.yaml
@@ -24,6 +24,7 @@ metrics:
     prometheus:
       queryKey: addonSamples
       queryParams:
+        instanceKey: _id
         resourceName: addon-open-data-hub
         metric: cluster:usage:workload:capacity_virtual_cpu_hours
         metadataMetric: ocm_subscription_resource

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhosak.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhosak.yaml
@@ -24,6 +24,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: rhosak
         metric: kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
         metadataMetric: ocm_subscription
@@ -33,6 +34,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: rhosak
         metric: kafka_id:strimzi_resource_state:max_over_time1h
         metadataMetric: ocm_subscription
@@ -42,6 +44,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: rhosak
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
         metadataMetric: ocm_subscription
@@ -50,6 +53,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: rhosak
         metric: kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
         metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
@@ -25,6 +25,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: moa-hostedcontrolplane
         metric: cluster:usage:workload:capacity_physical_instance_hours
         metadataMetric: ocm_subscription
@@ -34,6 +35,7 @@ metrics:
     prometheus:
       queryKey: default
       queryParams:
+        instanceKey: _id
         product: moa-hostedcontrolplane
         metric: cluster:usage:workload:capacity_physical_cpu_hours
         metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
@@ -100,6 +100,8 @@ class SubscriptionDefinitionTest {
     prometheusMetric.setQueryKey("default");
     prometheusMetric.setQueryParams(
         Map.of(
+            "instanceKey",
+            "_id",
             "product",
             "BASILISK",
             "metric",


### PR DESCRIPTION
Jira issue: [SWATCH-1630](https://issues.redhat.com/browse/SWATCH-1630)

## Description
 I want the subscription watch to allow the instance ID to be configurable so that I can change it depending on the product tag and the metric.

## Testing
1.- podman-compose up
2.- createdb -h localhost -U postgres -O rhsm-subscriptions swatch-1630
3.- DATABASE_DATABASE=swatch-1630 ./gradlew :bootRun
4.- Once the migration is finished, stop all the application that started in step 3.
5.- Mock the prometheus server at localhost:

Create the stub directory:
`mkdir stub`

Add a stub file to return some data: `stub/__files/swatch-1630.json`

```
cat > stub/__files/swatch-1630.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : [
        {
          "metric" : {
            "_id" : "cluster id",
            "support" : "sla",
            "usage" : "usage",
            "product" : "product",
            "billing_marketplace" : "billing_marketplace",
            "billing_marketplace_account" : "billing_marketplace_account",
            "ebs_account" : "account"
          },
          "values": [[ $(date +%s), "1" ]]
        }
      ]
    }
}
EOF
```

Add a stub file to return no data: `stub/__files/empty.json`

```
cat > stub/__files/empty.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : []
    }
}
EOF
```

Run wiremock:
`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock wiremock/wiremock:2.32.0 --verbose`

Configure stubbing for prometheus:

- this is to return some data when asking for instance-hours:
`curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/api/v1/query_range", "method": "GET", "queryParameters": {"query": {"contains":"instance_hours"}}}, "response": { "status": 200, "bodyFileName": "swatch-1630.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

- this is to return no data otherwise:
`curl -X POST --data '{ "priority": 5, "request": { "urlPath": "/api/v1/query_range", "method": "GET" }, "response": { "status": 200, "bodyFileName": "empty.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

6.- Start the swatch metrics app: `DATABASE_DATABASE=swatch-1630 PROM_URL="http://localhost:8101/api/v1/" SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true RHSM_RBAC_USE_STUB=true SUBSCRIPTION_SYNC_ENABLED=true ENABLE_SYNCHRONOUS_OPERATIONS=true SPRING_PROFILES_ACTIVE=openshift-metering-worker,kafka-queue ./gradlew :bootRun`

7.- Trigger the metrics from prometheus:
```
http POST :8000/api/rhsm-subscriptions/v1/internal/metering/rosa?orgId=16790890 \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder \
x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16790890"}}}' | base64 -w 0)
```

8.- Wait some time, so the service consumes all the events from the topic, and then query the `events` table:

Connect to the database:
`psql -h localhost -U rhsm-subscriptions swatch-1630`

Create an existing event for orgId=16790890

`SELECT * FROM EVENTS;`

And you should see only one event. And the "instance_id" column should be "cluster id". This column is populated from the field "_id" (see stub swatch-1630.json) and can be changed in 'subscription_configs/OpenShift/rosa.yaml', see the "queryParams.instanceKey" value (as part of this test, we used 'rosa' and the 'instance-hours' metrics)
