### PR TITLE
SWATCH-1629: Include addonSamples as a template for accountQueryTemplate

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -301,13 +301,6 @@ public class PrometheusMeteringController {
   }
 
   private String buildPromQLForMetering(String orgId, Metric tagMetric) {
-
-    // Default the query template if the swatch-product-configuration library didn't specify one.
-    if (Objects.nonNull(tagMetric.getPrometheus())
-        && !StringUtils.hasText(tagMetric.getPrometheus().getQueryKey())) {
-      tagMetric.getPrometheus().setQueryKey(QueryBuilder.DEFAULT_METRIC_QUERY_KEY);
-    }
-
     QueryDescriptor descriptor = new QueryDescriptor(tagMetric);
     descriptor.addRuntimeVar("orgId", orgId);
     return prometheusQueryBuilder.build(descriptor);

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -36,14 +36,6 @@ public class QueryBuilder {
 
   private static final Logger log = LoggerFactory.getLogger(QueryBuilder.class);
 
-  /**
-   * The default metric query key. A query with this key must be defined in the config file as a
-   * query template.
-   *
-   * @see MetricProperties
-   */
-  public static final String DEFAULT_METRIC_QUERY_KEY = "default";
-
   private final MetricProperties metricProperties;
 
   public QueryBuilder(MetricProperties metricProperties) {
@@ -63,9 +55,7 @@ public class QueryBuilder {
   }
 
   public String buildAccountLookupQuery(QueryDescriptor queryDescriptor) {
-    // SWATCH-1629 At some point templateKey here should read either "default" or "addonSamples"
-    // with a property added in application.yaml
-    String templateKey = DEFAULT_METRIC_QUERY_KEY;
+    String templateKey = queryDescriptor.getMetric().getPrometheus().getQueryKey();
     Optional<String> template = metricProperties.getAccountQueryTemplate(templateKey);
     if (template.isEmpty()) {
       throw new IllegalArgumentException(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,6 +58,9 @@ rhsm-subscriptions:
           default: >-
             ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product='#{metric.prometheus.queryParams[product]}', external_organization != '', billing_model='marketplace'}[1h]))
             by (external_organization)}
+          addonSamples: >-
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon", resource_name='#{metric.prometheus.queryParams[resourceName]}', external_organization != '', billing_model='marketplace'}[1h]))
+            by (external_organization)}
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:0h}
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:1h}

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/PrometheusMetric.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/PrometheusMetric.java
@@ -21,12 +21,14 @@
 package com.redhat.swatch.configuration.registry;
 
 import java.util.Map;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class PrometheusMetric {
-  private String queryKey;
+  private String queryKey = "default";
   private Map<String, String> queryParams;
 }


### PR DESCRIPTION
Jira issue: [SWATCH-1629](https://issues.redhat.com/browse/SWATCH-1629)

## Description
Currently, Rhods contains "addonSamples", but application.yaml does not have a template for it. Therefore, it reads everything by "default" using default query and filters it later in the code. 

Now, we have properly configured the "addonSamples" query profile that includes the resource_type and resource_name filters directly in the prometheus query. 

## Testing
I've verified these changes via:

### a. Using the new prometheus promql script:

1.- Run the script:
```
bin/metering-promql.py --product rhods --url https://grafana.app-sre.devshift.net
```

2.- It will generate the following output:

```
Accounts: https://grafana.app-sre.devshift.net/explore?orgId=1&left=%7B%22queries%22%3A+%5B%7B%22refId%22%3A+%22A%22%2C+%22editorMode%22%3A+%22code%22%2C+%22expr%22%3A+%22group%28min_over_time%28ocm_subscription_resource%7Bresource_type%3D%5C%22addon%5C%22%2C+resource_name%3D%27addon-open-data-hub%27%2C+external_organization+%21%3D+%27%27%2C+billing_model%3D%27marketplace%27%7D%5B1h%5D%29%29+by+%28external_organization%29%22%2C+%22legendFormat%22%3A+%22__auto%22%2C+%22range%22%3A+true%2C+%22instant%22%3A+true%2C+%22interval%22%3A+%223600%22%7D%5D%2C+%22range%22%3A+%7B%22from%22%3A+%22now-12h%22%2C+%22to%22%3A+%22now%22%7D%7D
  Cores: https://grafana.app-sre.devshift.net/explore?orgId=1&left=%7B%22queries%22%3A+%5B%7B%22refId%22%3A+%22A%22%2C+%22editorMode%22%3A+%22code%22%2C+%22expr%22%3A+%22cluster%3Ausage%3Aworkload%3Acapacity_virtual_cpu_hours+%2A+on%28_id%29+group_right+min_over_time%28ocm_subscription_resource%7Bresource_type%3D%5C%22addon%5C%22%2Cresource_name%3D%5C%22addon-open-data-hub%5C%22%2C+external_organization%3D~%5C%22.%2A%5C%22%2C+billing_model%3D%5C%22marketplace%5C%22%2C+support%3D~%5C%22Premium%7CStandard%7CSelf-Support%7CNone%5C%22%7D%5B1h%5D%29%22%2C+%22legendFormat%22%3A+%22__auto%22%2C+%22range%22%3A+true%2C+%22instant%22%3A+true%2C+%22interval%22%3A+%223600%22%7D%5D%2C+%22range%22%3A+%7B%22from%22%3A+%22now-12h%22%2C+%22to%22%3A+%22now%22%7D%7D
```

Checking the `Accounts` link, you can confirm that the query is now: `group(min_over_time(ocm_subscription_resource{resource_type="addon", resource_name='addon-open-data-hub', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)`

Before these changes, the filters were `group(min_over_time(ocm_subscription_resource{product='rhods', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)`.

### b. Using the service

1.- podman-compose up
2.- Mock the prometheus server at localhost:

Create the stub directory:
`mkdir -p stub/__files`

Add a stub file to return no data: `stub/__files/empty.json`

```
cat > stub/__files/empty.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : []
    }
}
EOF
```

Run wiremock:
`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

Configure stubbing for prometheus:

- this is to return no data otherwise:
`curl -X POST --data '{ "priority": 5, "request": { "urlPath": "/api/v1/query_range", "method": "GET" }, "response": { "status": 200, "bodyFileName": "empty.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

3.- Start the swatch metrics app: `PROM_URL="http://localhost:8101/api/v1/" SPRING_PROFILES_ACTIVE=metering-job,kafka-queue ./gradlew :bootRun`

And wait until the app terminates.

5.- Check the prometheus logs (you started the wiremock server using --verbose) and confirm you received:

```
10.0.2.100 - GET /api/v1/query_range?query=group%28min_over_time%28ocm_subscription_resource%7Bresource_type%3D%22addon%22%2C%20resource_name%3D%27addon-open-data-hub%27%2C%20external_organization%20%21%3D%20%27%27%2C%20billing_model%3D%27marketplace%27%7D%5B1h%5D%29%29%20by%20%28external_organization%29&start=1694073600&end=1694073600&step=3600&timeout=10000
```

Which now it contains the `resource_name=addon-open-data-hub` and `resource_type=addon`.

Before these changes, the query was:

```
2023-09-07 07:57:27.105 Request received:
10.0.2.100 - GET /api/v1/query_range?query=group%28min_over_time%28ocm_subscription_resource%7Bproduct%3D%27%27%2C%20external_organization%20%21%3D%20%27%27%2C%20billing_model%3D%27marketplace%27%7D%5B1h%5D%29%29%20by%20%28external_organization%29&start=1694070000&end=1694070000&step=3600&timeout=10000
```