### PR TITLE
SWATCH-969: Replace ProductId enum with class that checks against product-config

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -135,13 +135,13 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/ProductId'
         description: "The product to fetch graph data for"
       - name: metric_id
         in: path
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/MetricId'
         description: "The metric ID to fetch graph data for"
       - name: category
         in: query
@@ -253,7 +253,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/ProductId"
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -383,13 +383,13 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/ProductId"
         description: "The ID for the product we wish to query"
       - name: metric_id
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/MetricId"
         description: "The metric ID for the product we wish to query"
       - name: offset
         in: query
@@ -494,7 +494,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/ProductId"
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -605,7 +605,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/ProductId"
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -840,7 +840,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/ProductId"
       - name: offset
         in: query
         schema:
@@ -937,7 +937,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/ProductId"
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -1965,6 +1965,12 @@ components:
             - count
             - product
             - subscription_type
+    ProductId:
+      type: string
+      format: ProductId
+    MetricId:
+      type: string
+      format: MetricId
 
 security:
   - 3ScaleIdentity: []

--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -135,7 +135,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/ProductId'
+          type: string
         description: "The product to fetch graph data for"
       - name: metric_id
         in: path
@@ -253,7 +253,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/ProductId'
+          type: string
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -383,7 +383,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/ProductId'
+          type: string
         description: "The ID for the product we wish to query"
       - name: metric_id
         in: path
@@ -494,7 +494,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/ProductId'
+          type: string
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -605,7 +605,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/ProductId'
+          type: string
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -840,7 +840,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/ProductId'
+          type: string
       - name: offset
         in: query
         schema:
@@ -937,7 +937,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/ProductId'
+          type: string
         description: "The ID for the product we wish to query"
       - name: offset
         in: query
@@ -1136,25 +1136,6 @@ components:
     BillingProviderType:
       type: string
       enum: [ "", red hat, aws, gcp, azure, oracle, _ANY ]
-    ProductId:
-      type: string
-      enum:
-        - OpenShift Container Platform
-        - RHEL Compute Node
-        - RHEL for ARM
-        - RHEL for IBM Power
-        - RHEL for IBM z
-        - RHEL for x86
-        - RHEL Workstation
-        - Satellite Capsule
-        - Satellite Server
-        - OpenShift-metrics
-        - OpenShift-dedicated-metrics
-        - rhosak
-        - rhacs
-        - rhods
-        - BASILISK
-        - rosa
     ReportCategory:
       type: string
       enum:
@@ -1294,7 +1275,7 @@ components:
             total_monthly:
               $ref: "#/components/schemas/TallyReportDataPoint"
             product:
-              $ref: '#/components/schemas/ProductId'
+              type: string
             metric_id:
               type: string
             service_level:
@@ -1348,7 +1329,7 @@ components:
               type: number
               format: double
             product:
-              $ref: '#/components/schemas/ProductId'
+              type: string
             service_level:
               $ref: '#/components/schemas/ServiceLevelType'
             usage:
@@ -1469,7 +1450,7 @@ components:
             count:
               type: integer
             product:
-              $ref: '#/components/schemas/ProductId'
+              type: string
             granularity:
               $ref: '#/components/schemas/GranularityType'
             service_level:
@@ -1494,7 +1475,7 @@ components:
             count:
               type: integer
             product:
-              $ref: '#/components/schemas/ProductId'
+              type: string
             metric_id:
               type: string
             granularity:
@@ -1602,7 +1583,7 @@ components:
             count:
               type: integer
             product:
-              $ref: '#/components/schemas/ProductId'
+              type: string
             service_level:
               $ref: '#/components/schemas/ServiceLevelType'
             usage:
@@ -1702,7 +1683,7 @@ components:
           format: int32
           type: integer
         product:
-          $ref: '#/components/schemas/ProductId'
+          type: string
         service_level:
           $ref: '#/components/schemas/ServiceLevelType'
         usage:
@@ -1969,7 +1950,7 @@ components:
             count:
               type: integer
             product:
-              $ref: '#/components/schemas/ProductId'
+              type: string
             service_level:
               $ref: '#/components/schemas/ServiceLevelType'
             usage:

--- a/build.gradle
+++ b/build.gradle
@@ -388,6 +388,14 @@ project(":api") {
             dateLibrary: "java8",
             useJakartaEe: "true",
         ]
+        importMappings = [
+            "MetricId": "com.redhat.swatch.configuration.registry.MetricId",
+            "ProductId": "com.redhat.swatch.configuration.registry.ProductId",
+        ]
+        typeMappings = [
+            "string+MetricId": "MetricId",
+            "string+ProductId": "ProductId",
+        ]
     }
 
     tasks.register("validateApiSpec", ValidateTask) {
@@ -416,6 +424,7 @@ project(":api") {
     }
 
     dependencies {
+        implementation project(":swatch-product-configuration")
         implementation "jakarta.annotation:jakarta.annotation-api"
         implementation "com.fasterxml.jackson.core:jackson-annotations"
         implementation "jakarta.validation:jakarta.validation-api"

--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -100,7 +100,7 @@ public class CapacityResource implements CapacityApi {
   @Deprecated(since = "https://issues.redhat.com/browse/ENT-4384")
   @ReportingAccessRequired
   public CapacityReport getCapacityReport(
-      String productIdValue,
+      ProductId productId,
       @NotNull GranularityType granularityType,
       @NotNull OffsetDateTime beginning,
       @NotNull OffsetDateTime ending,
@@ -108,13 +108,6 @@ public class CapacityResource implements CapacityApi {
       @Min(1) Integer limit,
       ServiceLevelType sla,
       UsageType usage) {
-    ProductId productId;
-    try {
-      productId = ProductId.fromString(productIdValue);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e);
-    }
-
     // capacity records do not include _ANY rows
     ServiceLevel sanitizedServiceLevel = ResourceUtils.sanitizeServiceLevel(sla);
     if (sanitizedServiceLevel == ServiceLevel._ANY) {
@@ -174,8 +167,8 @@ public class CapacityResource implements CapacityApi {
   @Override
   @ReportingAccessRequired
   public CapacityReportByMetricId getCapacityReportByMetricId(
-      String productIdValue,
-      String metricIdValue,
+      ProductId productId,
+      MetricId metricId,
       @NotNull GranularityType granularityType,
       @NotNull OffsetDateTime beginning,
       @NotNull OffsetDateTime ending,
@@ -185,14 +178,6 @@ public class CapacityResource implements CapacityApi {
       ServiceLevelType sla,
       UsageType usage) {
 
-    ProductId productId;
-    MetricId metricId;
-    try {
-      productId = ProductId.fromString(productIdValue);
-      metricId = MetricId.fromString(metricIdValue);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e);
-    }
     log.debug(
         "Get capacity report for product {} by metric {} in range [{}, {}] for category {}",
         productId,

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -22,10 +22,12 @@ package org.candlepin.subscriptions.resource;
 
 import com.google.common.collect.ImmutableMap;
 import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
 import java.time.OffsetDateTime;
@@ -52,7 +54,6 @@ import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
 import org.candlepin.subscriptions.utilization.api.model.HypervisorGuestReport;
 import org.candlepin.subscriptions.utilization.api.model.MetaCount;
 import org.candlepin.subscriptions.utilization.api.model.PageLinks;
-import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
@@ -126,7 +127,7 @@ public class HostsResource implements HostsApi {
   @ReportingAccessRequired
   @Override
   public HostReport getHosts(
-      ProductId productId,
+      String productIdValue,
       Integer offset,
       @Min(1) @Max(100) Integer limit,
       ServiceLevelType sla,
@@ -138,6 +139,12 @@ public class HostsResource implements HostsApi {
       HostReportSort sort,
       SortDirection dir) {
 
+    ProductId productId;
+    try {
+      productId = ProductId.fromString(productIdValue);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e);
+    }
     Sort.Direction dirValue = Sort.Direction.ASC;
     if (dir == SortDirection.DESC) {
       dirValue = Sort.Direction.DESC;
@@ -242,7 +249,7 @@ public class HostsResource implements HostsApi {
         .meta(
             new HostReportMeta()
                 .count((int) hosts.getTotalElements())
-                .product(productId)
+                .product(productId.toString())
                 .serviceLevel(sla)
                 .usage(usage)
                 .uom(uom))

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -27,7 +27,6 @@ import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
 import java.time.OffsetDateTime;
@@ -127,7 +126,7 @@ public class HostsResource implements HostsApi {
   @ReportingAccessRequired
   @Override
   public HostReport getHosts(
-      String productIdValue,
+      ProductId productId,
       Integer offset,
       @Min(1) @Max(100) Integer limit,
       ServiceLevelType sla,
@@ -139,12 +138,6 @@ public class HostsResource implements HostsApi {
       HostReportSort sort,
       SortDirection dir) {
 
-    ProductId productId;
-    try {
-      productId = ProductId.fromString(productIdValue);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e);
-    }
     Sort.Direction dirValue = Sort.Direction.ASC;
     if (dir == SortDirection.DESC) {
       dirValue = Sort.Direction.DESC;

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.resource;
 
 import com.google.common.collect.ImmutableMap;
 import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
 import jakarta.ws.rs.BadRequestException;
@@ -58,7 +59,6 @@ import org.candlepin.subscriptions.utilization.api.model.InstanceReportSort;
 import org.candlepin.subscriptions.utilization.api.model.InstanceResponse;
 import org.candlepin.subscriptions.utilization.api.model.MetaCount;
 import org.candlepin.subscriptions.utilization.api.model.PageLinks;
-import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
@@ -133,7 +133,7 @@ public class InstancesResource implements InstancesApi {
   @Override
   @Transactional(readOnly = true)
   public InstanceResponse getInstancesByProduct(
-      ProductId productId,
+      String productIdValue,
       Integer offset,
       Integer limit,
       ServiceLevelType sla,
@@ -147,6 +147,13 @@ public class InstancesResource implements InstancesApi {
       OffsetDateTime ending,
       InstanceReportSort sort,
       SortDirection dir) {
+
+    ProductId productId;
+    try {
+      productId = ProductId.fromString(productIdValue);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e);
+    }
 
     String orgId = ResourceUtils.getOrgId();
 
@@ -249,7 +256,7 @@ public class InstancesResource implements InstancesApi {
         .meta(
             new InstanceMeta()
                 .count((int) instances.getTotalElements())
-                .product(productId)
+                .product(productId.toString())
                 .serviceLevel(sla)
                 .usage(usage)
                 .billingProvider(billingProviderType)

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -133,7 +133,7 @@ public class InstancesResource implements InstancesApi {
   @Override
   @Transactional(readOnly = true)
   public InstanceResponse getInstancesByProduct(
-      String productIdValue,
+      ProductId productId,
       Integer offset,
       Integer limit,
       ServiceLevelType sla,
@@ -147,13 +147,6 @@ public class InstancesResource implements InstancesApi {
       OffsetDateTime ending,
       InstanceReportSort sort,
       SortDirection dir) {
-
-    ProductId productId;
-    try {
-      productId = ProductId.fromString(productIdValue);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e);
-    }
 
     String orgId = ResourceUtils.getOrgId();
 

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionResource.java
@@ -20,7 +20,9 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import com.redhat.swatch.configuration.registry.ProductId;
 import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.utilization.api.model.*;
@@ -40,7 +42,7 @@ public class SubscriptionResource implements SubscriptionsApi {
   @ReportingAccessRequired
   @Override
   public SkuCapacityReport getSkuCapacityReport(
-      ProductId productId,
+      String productIdValue,
       @Min(0) Integer offset,
       @Min(1) Integer limit,
       ReportCategory category,
@@ -54,6 +56,12 @@ public class SubscriptionResource implements SubscriptionsApi {
       SkuCapacityReportSort sort,
       SortDirection dir) {
 
+    ProductId productId;
+    try {
+      productId = ProductId.fromString(productIdValue);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e);
+    }
     return subscriptionTableController.capacityReportBySku(
         productId,
         offset,

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionResource.java
@@ -22,7 +22,6 @@ package org.candlepin.subscriptions.resource;
 
 import com.redhat.swatch.configuration.registry.ProductId;
 import jakarta.validation.constraints.Min;
-import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.utilization.api.model.*;
@@ -42,7 +41,7 @@ public class SubscriptionResource implements SubscriptionsApi {
   @ReportingAccessRequired
   @Override
   public SkuCapacityReport getSkuCapacityReport(
-      String productIdValue,
+      ProductId productId,
       @Min(0) Integer offset,
       @Min(1) Integer limit,
       ReportCategory category,
@@ -56,12 +55,6 @@ public class SubscriptionResource implements SubscriptionsApi {
       SkuCapacityReportSort sort,
       SortDirection dir) {
 
-    ProductId productId;
-    try {
-      productId = ProductId.fromString(productIdValue);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e);
-    }
     return subscriptionTableController.capacityReportBySku(
         productId,
         offset,

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.resource;
 
 import static org.candlepin.subscriptions.resource.ResourceUtils.*;
 
+import com.redhat.swatch.configuration.registry.ProductId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
 import jakarta.transaction.Transactional;
@@ -247,7 +248,7 @@ public class SubscriptionTableController {
                 .usage(usage)
                 .uom(uom)
                 .reportCategory(category)
-                .product(productId));
+                .product(productId.toString()));
   }
 
   private Map<String, SkuCapacity> initializeDefaultSkuCapacities(Set<String> skus, Uom uom) {

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -96,8 +96,8 @@ public class TallyResource implements TallyApi {
   @Override
   @ReportingAccessRequired
   public TallyReportData getTallyReportData(
-      String productIdValue,
-      String metricIdValue,
+      ProductId productId,
+      MetricId metricId,
       GranularityType granularityType,
       OffsetDateTime beginning,
       OffsetDateTime ending,
@@ -116,14 +116,6 @@ public class TallyResource implements TallyApi {
           "When `billing_category` is specified, `use_running_totals_format` must be `true`.");
     }
 
-    ProductId productId;
-    MetricId metricId;
-    try {
-      productId = ProductId.fromString(productIdValue);
-      metricId = MetricId.fromString(metricIdValue);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e);
-    }
     ReportCriteria reportCriteria =
         extractReportCriteria(
             productId,
@@ -390,7 +382,7 @@ public class TallyResource implements TallyApi {
   @Override
   @ReportingAccessRequired
   public TallyReport getTallyReport(
-      String productIdValue,
+      ProductId productId,
       @NotNull GranularityType granularityType,
       @NotNull OffsetDateTime beginning,
       @NotNull OffsetDateTime ending,
@@ -399,12 +391,6 @@ public class TallyResource implements TallyApi {
       ServiceLevelType sla,
       UsageType usageType,
       Boolean useRunningTotalsFormat) {
-    ProductId productId;
-    try {
-      productId = ProductId.fromString(productIdValue);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e);
-    }
     ReportCriteria reportCriteria =
         extractReportCriteria(
             productId,

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -20,12 +20,11 @@
  */
 package org.candlepin.subscriptions.resource;
 
-import static org.candlepin.subscriptions.utilization.api.model.ProductId.BASILISK;
-import static org.candlepin.subscriptions.utilization.api.model.ProductId.RHEL_FOR_ARM;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 import java.time.OffsetDateTime;
@@ -52,7 +51,6 @@ import org.candlepin.subscriptions.utilization.api.model.CapacityReportByMetricI
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshot;
 import org.candlepin.subscriptions.utilization.api.model.CapacitySnapshotByMetricId;
 import org.candlepin.subscriptions.utilization.api.model.GranularityType;
-import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
@@ -76,6 +74,8 @@ class CapacityResourceTest {
 
   private static final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
   private static final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
+  private static final String BASILISK = "BASILISK";
+  private static final String RHEL_FOR_ARM = "RHEL for ARM";
   private static final String METRIC_ID_CORES = "Cores";
   private static final String METRIC_ID_SOCKETS = "Sockets";
 
@@ -100,7 +100,7 @@ class CapacityResourceTest {
             .build();
 
     var newProductIds = s.getSubscriptionProductIds();
-    newProductIds.add(RHEL_FOR_ARM.toString());
+    newProductIds.add(RHEL_FOR_ARM);
     s.setSubscriptionProductIds(newProductIds);
 
     return s;
@@ -141,7 +141,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -167,7 +167,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel.PREMIUM)
             .usage(Usage._ANY)
             .beginning(min)
@@ -200,7 +200,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(min)
@@ -226,7 +226,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -259,7 +259,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -303,7 +303,7 @@ class CapacityResourceTest {
                           .endDate(max.truncatedTo(ChronoUnit.DAYS).minusSeconds(1))
                           .orgId("owner123456")
                           .build();
-                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM.toString());
+                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM);
                   s.getSubscriptionMeasurements().putAll(m);
                   return s;
                 })
@@ -312,7 +312,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
@@ -350,7 +350,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -405,7 +405,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(begin)
@@ -418,7 +418,7 @@ class CapacityResourceTest {
     List<CapacitySnapshot> actual =
         resource.getCapacities(
             "owner123456",
-            RHEL_FOR_ARM,
+            ProductId.fromString(RHEL_FOR_ARM),
             ServiceLevel.STANDARD,
             Usage.PRODUCTION,
             Granularity.WEEKLY,
@@ -440,7 +440,7 @@ class CapacityResourceTest {
     DbReportCriteria criteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .beginning(min)
             .ending(max)
             .build();
@@ -449,7 +449,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(min)
@@ -473,7 +473,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -510,7 +510,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel.PREMIUM)
             .usage(Usage._ANY)
             .beginning(min)
@@ -546,7 +546,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(min)
@@ -582,7 +582,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -618,7 +618,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -672,7 +672,7 @@ class CapacityResourceTest {
                           .endDate(max.truncatedTo(ChronoUnit.DAYS).minusSeconds(1))
                           .orgId("owner123456")
                           .build();
-                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM.toString());
+                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM);
                   s.getSubscriptionMeasurements().putAll(m);
                   return s;
                 })
@@ -681,7 +681,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
@@ -725,7 +725,7 @@ class CapacityResourceTest {
                           .endDate(max.truncatedTo(ChronoUnit.DAYS).minusSeconds(1))
                           .orgId("owner123456")
                           .build();
-                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM.toString());
+                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM);
                   s.getSubscriptionMeasurements().putAll(m);
                   return s;
                 })
@@ -734,7 +734,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
@@ -855,7 +855,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
@@ -899,7 +899,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
@@ -944,7 +944,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
@@ -1000,7 +1000,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -1075,7 +1075,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(min)
@@ -1092,7 +1092,7 @@ class CapacityResourceTest {
     List<CapacitySnapshotByMetricId> actual =
         resource.getCapacitiesByMetricId(
             "owner123456",
-            RHEL_FOR_ARM,
+            ProductId.fromString(RHEL_FOR_ARM),
             MetricId.fromString(METRIC_ID_CORES),
             HypervisorReportCategory.HYPERVISOR,
             ServiceLevel.STANDARD,
@@ -1126,7 +1126,7 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
@@ -1140,7 +1140,7 @@ class CapacityResourceTest {
     var criteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM.toString())
+            .productId(RHEL_FOR_ARM)
             .beginning(min)
             .ending(max)
             .build();
@@ -1195,7 +1195,16 @@ class CapacityResourceTest {
     assertDoesNotThrow(
         () ->
             resource.getCapacityReportByMetricId(
-                productId, METRIC_ID_CORES, granularity, min, max, null, null, null, null, null));
+                productId.toString(),
+                METRIC_ID_CORES,
+                granularity,
+                min,
+                max,
+                null,
+                null,
+                null,
+                null,
+                null));
   }
 
   private static Stream<Arguments> generateFinestGranularityCases() {
@@ -1214,6 +1223,24 @@ class CapacityResourceTest {
             resource.getCapacityReportByMetricId(
                 RHEL_FOR_ARM,
                 "NotAMetricId",
+                GranularityType.DAILY,
+                min,
+                max,
+                null,
+                null,
+                ReportCategory.PHYSICAL,
+                null,
+                null));
+  }
+
+  @Test()
+  void testGetCapacityReportByMetricIdThrowsExceptionForUnknownProductId() {
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            resource.getCapacityReportByMetricId(
+                "NotARealProduct",
+                METRIC_ID_CORES,
                 GranularityType.DAILY,
                 min,
                 max,

--- a/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/CapacityResourceTest.java
@@ -74,10 +74,10 @@ class CapacityResourceTest {
 
   private static final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
   private static final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
-  private static final String BASILISK = "BASILISK";
-  private static final String RHEL_FOR_ARM = "RHEL for ARM";
-  private static final String METRIC_ID_CORES = "Cores";
-  private static final String METRIC_ID_SOCKETS = "Sockets";
+  private static final ProductId BASILISK = ProductId.fromString("BASILISK");
+  private static final ProductId RHEL_FOR_ARM = ProductId.fromString("RHEL for ARM");
+  private static final MetricId METRIC_ID_CORES = MetricId.fromString("Cores");
+  private static final MetricId METRIC_ID_SOCKETS = MetricId.fromString("Sockets");
 
   @MockBean SubscriptionRepository subscriptionRepository;
   @MockBean PageLinkCreator pageLinkCreator;
@@ -100,7 +100,7 @@ class CapacityResourceTest {
             .build();
 
     var newProductIds = s.getSubscriptionProductIds();
-    newProductIds.add(RHEL_FOR_ARM);
+    newProductIds.add(RHEL_FOR_ARM.toString());
     s.setSubscriptionProductIds(newProductIds);
 
     return s;
@@ -132,7 +132,7 @@ class CapacityResourceTest {
   }
 
   private Map<SubscriptionMeasurementKey, Double> basicMeasurement() {
-    return createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 42.0);
+    return createMeasurement("PHYSICAL", METRIC_ID_CORES, 42.0);
   }
 
   @Test
@@ -141,7 +141,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -167,7 +167,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel.PREMIUM)
             .usage(Usage._ANY)
             .beginning(min)
@@ -200,7 +200,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(min)
@@ -226,7 +226,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -259,7 +259,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -281,17 +281,17 @@ class CapacityResourceTest {
 
   @Test
   void testShouldCalculateCapacityBasedOnMultipleSubscriptions() {
-    var hypSock1 = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 5.0);
-    var hypSock2 = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 7.0);
+    var hypSock1 = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 5.0);
+    var hypSock2 = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 7.0);
 
-    var hypCore1 = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 20.0);
-    var hypCore2 = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 14.0);
+    var hypCore1 = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 20.0);
+    var hypCore2 = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 14.0);
 
-    var sock1 = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 2.0);
-    var sock2 = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 11.0);
+    var sock1 = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 2.0);
+    var sock2 = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 11.0);
 
-    var cores1 = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 8.0);
-    var cores2 = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 22.0);
+    var cores1 = createMeasurement("PHYSICAL", METRIC_ID_CORES, 8.0);
+    var cores2 = createMeasurement("PHYSICAL", METRIC_ID_CORES, 22.0);
 
     var subs =
         Stream.of(sock1, sock2, cores1, cores2, hypSock1, hypSock2, hypCore1, hypCore2)
@@ -303,7 +303,7 @@ class CapacityResourceTest {
                           .endDate(max.truncatedTo(ChronoUnit.DAYS).minusSeconds(1))
                           .orgId("owner123456")
                           .build();
-                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM);
+                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM.toString());
                   s.getSubscriptionMeasurements().putAll(m);
                   return s;
                 })
@@ -312,7 +312,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
@@ -350,7 +350,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
@@ -405,7 +405,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(begin)
@@ -418,7 +418,7 @@ class CapacityResourceTest {
     List<CapacitySnapshot> actual =
         resource.getCapacities(
             "owner123456",
-            ProductId.fromString(RHEL_FOR_ARM),
+            RHEL_FOR_ARM,
             ServiceLevel.STANDARD,
             Usage.PRODUCTION,
             Granularity.WEEKLY,
@@ -440,7 +440,7 @@ class CapacityResourceTest {
     DbReportCriteria criteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .beginning(min)
             .ending(max)
             .build();
@@ -449,7 +449,7 @@ class CapacityResourceTest {
     DbReportCriteria dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(min)
@@ -473,13 +473,13 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
             .ending(max)
             .hypervisorReportCategory(HypervisorReportCategory.NON_HYPERVISOR)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     Subscription s = new Subscription();
@@ -510,12 +510,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel.PREMIUM)
             .usage(Usage._ANY)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     Subscription s = new Subscription();
@@ -546,12 +546,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     Subscription s = new Subscription();
@@ -582,12 +582,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     Subscription s = new Subscription();
@@ -618,12 +618,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     Subscription s = new Subscription();
@@ -650,17 +650,17 @@ class CapacityResourceTest {
 
   @Test
   void testReportByMetricIdShouldCalculateCapacityBasedOnMultipleSubscriptions() {
-    var hypSock1 = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 5.0);
-    var hypSock2 = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 7.0);
+    var hypSock1 = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 5.0);
+    var hypSock2 = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 7.0);
 
-    var hypCore1 = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 20.0);
-    var hypCore2 = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 14.0);
+    var hypCore1 = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 20.0);
+    var hypCore2 = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 14.0);
 
-    var sock1 = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 2.0);
-    var sock2 = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 11.0);
+    var sock1 = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 2.0);
+    var sock2 = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 11.0);
 
-    var cores1 = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 8.0);
-    var cores2 = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 22.0);
+    var cores1 = createMeasurement("PHYSICAL", METRIC_ID_CORES, 8.0);
+    var cores2 = createMeasurement("PHYSICAL", METRIC_ID_CORES, 22.0);
 
     var subs =
         Stream.of(sock1, sock2, cores1, cores2, hypSock1, hypSock2, hypCore1, hypCore2)
@@ -672,7 +672,7 @@ class CapacityResourceTest {
                           .endDate(max.truncatedTo(ChronoUnit.DAYS).minusSeconds(1))
                           .orgId("owner123456")
                           .build();
-                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM);
+                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM.toString());
                   s.getSubscriptionMeasurements().putAll(m);
                   return s;
                 })
@@ -681,12 +681,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     when(subscriptionRepository.findByCriteria(dbReportCriteria, Sort.unsorted())).thenReturn(subs);
@@ -710,10 +710,10 @@ class CapacityResourceTest {
 
   @Test
   void testReportByMetricIdShouldCalculateCapacityAllSockets() {
-    var hypSock = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 5.0);
-    var hypCore = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 20.0);
-    var sock = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 2.0);
-    var cores = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 8.0);
+    var hypSock = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 5.0);
+    var hypCore = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 20.0);
+    var sock = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 2.0);
+    var cores = createMeasurement("PHYSICAL", METRIC_ID_CORES, 8.0);
 
     var subs =
         Stream.of(hypSock, hypCore, sock, cores)
@@ -725,7 +725,7 @@ class CapacityResourceTest {
                           .endDate(max.truncatedTo(ChronoUnit.DAYS).minusSeconds(1))
                           .orgId("owner123456")
                           .build();
-                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM);
+                  s.getSubscriptionProductIds().add(RHEL_FOR_ARM.toString());
                   s.getSubscriptionMeasurements().putAll(m);
                   return s;
                 })
@@ -734,12 +734,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_SOCKETS)
+            .metricId(METRIC_ID_SOCKETS.toString())
             .build();
 
     when(subscriptionRepository.findByCriteria(dbReportCriteria, Sort.unsorted())).thenReturn(subs);
@@ -763,10 +763,10 @@ class CapacityResourceTest {
 
   @Test
   void testReportByMetricIdShouldCalculateCapacityVirtualSockets() {
-    var hypSock = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 5.0);
-    var hypCore = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 20.0);
-    var sock = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 2.0);
-    var cores = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 8.0);
+    var hypSock = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 5.0);
+    var hypCore = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 20.0);
+    var sock = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 2.0);
+    var cores = createMeasurement("PHYSICAL", METRIC_ID_CORES, 8.0);
 
     var newMeasurements = new HashMap<SubscriptionMeasurementKey, Double>();
 
@@ -783,7 +783,7 @@ class CapacityResourceTest {
             .beginning(min)
             .ending(max)
             .hypervisorReportCategory(HypervisorReportCategory.NON_HYPERVISOR)
-            .metricId(METRIC_ID_SOCKETS)
+            .metricId(METRIC_ID_SOCKETS.toString())
             .build();
 
     when(subscriptionRepository.findByCriteria(dbReportCriteria, Sort.unsorted()))
@@ -808,10 +808,10 @@ class CapacityResourceTest {
 
   @Test
   void testReportByMetricIdShouldCalculateCapacityPhysicalSockets() {
-    var hypSock = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 5.0);
-    var hypCore = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 20.0);
-    var sock = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 2.0);
-    var cores = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 8.0);
+    var hypSock = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 5.0);
+    var hypCore = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 20.0);
+    var sock = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 2.0);
+    var cores = createMeasurement("PHYSICAL", METRIC_ID_CORES, 8.0);
 
     var newMeasurements = new HashMap<SubscriptionMeasurementKey, Double>();
 
@@ -841,10 +841,10 @@ class CapacityResourceTest {
 
   @Test
   void testReportByMetricIdShouldCalculateCapacityAllCores() {
-    var hypSock = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 5.0);
-    var hypCore = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 20.0);
-    var sock = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 2.0);
-    var cores = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 8.0);
+    var hypSock = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 5.0);
+    var hypCore = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 20.0);
+    var sock = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 2.0);
+    var cores = createMeasurement("PHYSICAL", METRIC_ID_CORES, 8.0);
 
     var newMeasurements = new HashMap<SubscriptionMeasurementKey, Double>();
 
@@ -855,12 +855,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     when(subscriptionRepository.findByCriteria(dbReportCriteria, Sort.unsorted()))
@@ -885,10 +885,10 @@ class CapacityResourceTest {
 
   @Test
   void testReportByMetricIdShouldCalculateCapacityVirtualCores() {
-    var hypSock = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 5.0);
-    var hypCore = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 20.0);
-    var sock = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 2.0);
-    var cores = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 8.0);
+    var hypSock = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 5.0);
+    var hypCore = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 20.0);
+    var sock = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 2.0);
+    var cores = createMeasurement("PHYSICAL", METRIC_ID_CORES, 8.0);
 
     var newMeasurements = new HashMap<SubscriptionMeasurementKey, Double>();
 
@@ -899,13 +899,13 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
             .ending(max)
             .hypervisorReportCategory(HypervisorReportCategory.NON_HYPERVISOR)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     when(subscriptionRepository.findByCriteria(dbReportCriteria, Sort.unsorted()))
@@ -930,10 +930,10 @@ class CapacityResourceTest {
 
   @Test
   void testReportByMetricIdShouldCalculateCapacityPhysicalCores() {
-    var hypSock = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_SOCKETS), 5.0);
-    var hypCore = createMeasurement("HYPERVISOR", MetricId.fromString(METRIC_ID_CORES), 20.0);
-    var sock = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_SOCKETS), 2.0);
-    var cores = createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 8.0);
+    var hypSock = createMeasurement("HYPERVISOR", METRIC_ID_SOCKETS, 5.0);
+    var hypCore = createMeasurement("HYPERVISOR", METRIC_ID_CORES, 20.0);
+    var sock = createMeasurement("PHYSICAL", METRIC_ID_SOCKETS, 2.0);
+    var cores = createMeasurement("PHYSICAL", METRIC_ID_CORES, 8.0);
 
     var newMeasurements = new HashMap<SubscriptionMeasurementKey, Double>();
 
@@ -944,13 +944,13 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
             .ending(max)
             .hypervisorReportCategory(HypervisorReportCategory.NON_HYPERVISOR)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     when(subscriptionRepository.findByCriteria(dbReportCriteria, Sort.unsorted()))
@@ -1000,12 +1000,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage._ANY)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     Subscription s = new Subscription();
@@ -1075,13 +1075,13 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(ServiceLevel._ANY)
             .usage(Usage.PRODUCTION)
             .beginning(min)
             .ending(max)
             .hypervisorReportCategory(HypervisorReportCategory.HYPERVISOR)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     s.setSubscriptionMeasurements(basicMeasurement());
@@ -1092,8 +1092,8 @@ class CapacityResourceTest {
     List<CapacitySnapshotByMetricId> actual =
         resource.getCapacitiesByMetricId(
             "owner123456",
-            ProductId.fromString(RHEL_FOR_ARM),
-            MetricId.fromString(METRIC_ID_CORES),
+            RHEL_FOR_ARM,
+            METRIC_ID_CORES,
             HypervisorReportCategory.HYPERVISOR,
             ServiceLevel.STANDARD,
             Usage.PRODUCTION,
@@ -1117,8 +1117,7 @@ class CapacityResourceTest {
     var limited = datedSubscription(begin, max);
     limited.setSubscriptionId("limited123");
 
-    limited.setSubscriptionMeasurements(
-        createMeasurement("PHYSICAL", MetricId.fromString(METRIC_ID_CORES), 4.0));
+    limited.setSubscriptionMeasurements(createMeasurement("PHYSICAL", METRIC_ID_CORES, 4.0));
 
     var limitedOffering = Offering.builder().sku("limitedsku").hasUnlimitedUsage(false).build();
     limited.setOffering(limitedOffering);
@@ -1126,12 +1125,12 @@ class CapacityResourceTest {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .serviceLevel(null)
             .usage(null)
             .beginning(min)
             .ending(max)
-            .metricId(METRIC_ID_CORES)
+            .metricId(METRIC_ID_CORES.toString())
             .build();
 
     when(subscriptionRepository.findByCriteria(dbReportCriteria, Sort.unsorted()))
@@ -1140,7 +1139,7 @@ class CapacityResourceTest {
     var criteria =
         DbReportCriteria.builder()
             .orgId("owner123456")
-            .productId(RHEL_FOR_ARM)
+            .productId(RHEL_FOR_ARM.toString())
             .beginning(min)
             .ending(max)
             .build();
@@ -1195,16 +1194,7 @@ class CapacityResourceTest {
     assertDoesNotThrow(
         () ->
             resource.getCapacityReportByMetricId(
-                productId.toString(),
-                METRIC_ID_CORES,
-                granularity,
-                min,
-                max,
-                null,
-                null,
-                null,
-                null,
-                null));
+                productId, METRIC_ID_CORES, granularity, min, max, null, null, null, null, null));
   }
 
   private static Stream<Arguments> generateFinestGranularityCases() {
@@ -1213,41 +1203,5 @@ class CapacityResourceTest {
         Arguments.of(RHEL_FOR_ARM, GranularityType.YEARLY),
         Arguments.of(BASILISK, GranularityType.YEARLY),
         Arguments.of(RHEL_FOR_ARM, GranularityType.DAILY));
-  }
-
-  @Test()
-  void testGetCapacityReportByMetricIdThrowsExceptionForUnknownMetricId() {
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            resource.getCapacityReportByMetricId(
-                RHEL_FOR_ARM,
-                "NotAMetricId",
-                GranularityType.DAILY,
-                min,
-                max,
-                null,
-                null,
-                ReportCategory.PHYSICAL,
-                null,
-                null));
-  }
-
-  @Test()
-  void testGetCapacityReportByMetricIdThrowsExceptionForUnknownProductId() {
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            resource.getCapacityReportByMetricId(
-                "NotARealProduct",
-                METRIC_ID_CORES,
-                GranularityType.DAILY,
-                min,
-                max,
-                null,
-                null,
-                ReportCategory.PHYSICAL,
-                null,
-                null));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -20,8 +20,10 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
@@ -33,7 +35,6 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
-import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
 import org.junit.jupiter.api.Assertions;
@@ -53,10 +54,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles({"api", "test"})
 @WithMockRedHatPrincipal("123456")
 class HostsResourceTest {
-
   static final Sort.Order IMPLICIT_ORDER = new Sort.Order(Sort.Direction.ASC, "id");
   private static final String SANITIZED_MISSING_DISPLAY_NAME = "";
   private static final OffsetDateTime NULL_BEGINNING_ENDING_PARAM = null;
+  private static final String RHEL_FOR_X86 = "RHEL for x86";
 
   @MockBean HostRepository repository;
   @MockBean PageLinkCreator pageLinkCreator;
@@ -77,7 +78,7 @@ class HostsResourceTest {
   @SuppressWarnings("indentation")
   void testShouldMapDisplayNameAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -92,7 +93,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -112,7 +113,7 @@ class HostsResourceTest {
   @Test
   void testShouldMapCoresAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -127,7 +128,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -146,7 +147,7 @@ class HostsResourceTest {
   @Test
   void testShouldMapSocketsAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -161,7 +162,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -181,7 +182,7 @@ class HostsResourceTest {
   @Test
   void testShouldMapLastSeenAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -196,7 +197,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -216,7 +217,7 @@ class HostsResourceTest {
   @Test
   void testShouldMapHardwareTypeAppropriately() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -231,7 +232,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -251,7 +252,7 @@ class HostsResourceTest {
   @Test
   void testShouldDefaultToImplicitOrder() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -266,7 +267,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -280,7 +281,7 @@ class HostsResourceTest {
   @Test
   void testShouldDefaultToAscending() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -295,7 +296,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -315,7 +316,7 @@ class HostsResourceTest {
   @Test
   void testShouldUseMinCoresWhenUomIsCores() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -329,7 +330,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -343,7 +344,7 @@ class HostsResourceTest {
   @Test
   void testShouldUseMinSocketsWhenUomIsSockets() {
     resource.getHosts(
-        ProductId.RHEL_FOR_X86,
+        RHEL_FOR_X86,
         0,
         1,
         null,
@@ -358,7 +359,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            ProductId.RHEL_FOR_X86.toString(),
+            RHEL_FOR_X86,
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -388,5 +389,24 @@ class HostsResourceTest {
   void testValidBeginningAndEndingDates(OffsetDateTime beginning, OffsetDateTime ending) {
     Assertions.assertDoesNotThrow(
         () -> resource.validateBeginningAndEndingDates(beginning, ending));
+  }
+
+  @Test()
+  void testGetCapacityReportByMetricIdThrowsExceptionForUnknownProductId() {
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            resource.getHosts(
+                "NotARealProduct",
+                0,
+                1,
+                null,
+                null,
+                Uom.SOCKETS,
+                null,
+                NULL_BEGINNING_ENDING_PARAM,
+                NULL_BEGINNING_ENDING_PARAM,
+                null,
+                null));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/HostsResourceTest.java
@@ -20,10 +20,9 @@
  */
 package org.candlepin.subscriptions.resource;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-import jakarta.ws.rs.BadRequestException;
+import com.redhat.swatch.configuration.registry.ProductId;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
@@ -57,7 +56,7 @@ class HostsResourceTest {
   static final Sort.Order IMPLICIT_ORDER = new Sort.Order(Sort.Direction.ASC, "id");
   private static final String SANITIZED_MISSING_DISPLAY_NAME = "";
   private static final OffsetDateTime NULL_BEGINNING_ENDING_PARAM = null;
-  private static final String RHEL_FOR_X86 = "RHEL for x86";
+  private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
 
   @MockBean HostRepository repository;
   @MockBean PageLinkCreator pageLinkCreator;
@@ -93,7 +92,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -128,7 +127,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -162,7 +161,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -197,7 +196,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -232,7 +231,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -267,7 +266,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -296,7 +295,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -330,7 +329,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -359,7 +358,7 @@ class HostsResourceTest {
     verify(repository, only())
         .getTallyHostViews(
             "owner123456",
-            RHEL_FOR_X86,
+            RHEL_FOR_X86.toString(),
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -389,24 +388,5 @@ class HostsResourceTest {
   void testValidBeginningAndEndingDates(OffsetDateTime beginning, OffsetDateTime ending) {
     Assertions.assertDoesNotThrow(
         () -> resource.validateBeginningAndEndingDates(beginning, ending));
-  }
-
-  @Test()
-  void testGetCapacityReportByMetricIdThrowsExceptionForUnknownProductId() {
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            resource.getHosts(
-                "NotARealProduct",
-                0,
-                1,
-                null,
-                null,
-                Uom.SOCKETS,
-                null,
-                NULL_BEGINNING_ENDING_PARAM,
-                NULL_BEGINNING_ENDING_PARAM,
-                null,
-                null));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -63,8 +63,8 @@ import org.springframework.test.context.ActiveProfiles;
 @WithMockRedHatPrincipal("123456")
 class InstancesResourceTest {
 
-  private static final String RHOSAK = "rhosak";
-  private static final String RHEL_FOR_X86 = "RHEL for x86";
+  private static final ProductId RHOSAK = ProductId.fromString("rhosak");
+  private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
   @MockBean TallyInstanceViewRepository repository;
   @MockBean HostRepository hostRepository;
   @MockBean PageLinkCreator pageLinkCreator;
@@ -130,7 +130,7 @@ class InstancesResourceTest {
 
     var meta = new InstanceMeta();
     meta.setCount(1);
-    meta.setProduct(RHOSAK);
+    meta.setProduct(RHOSAK.toString());
     meta.setServiceLevel(ServiceLevelType.PREMIUM);
     meta.setUsage(UsageType.PRODUCTION);
     meta.setMeasurements(expectUom);
@@ -228,7 +228,7 @@ class InstancesResourceTest {
 
     var meta = new InstanceMeta();
     meta.setCount(2);
-    meta.setProduct(RHEL_FOR_X86);
+    meta.setProduct(RHEL_FOR_X86.toString());
     meta.setServiceLevel(ServiceLevelType.PREMIUM);
     meta.setUsage(UsageType.PRODUCTION);
     meta.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
@@ -318,7 +318,7 @@ class InstancesResourceTest {
 
     var meta = new InstanceMeta();
     meta.setCount(1);
-    meta.setProduct(RHOSAK);
+    meta.setProduct(RHOSAK.toString());
     meta.setServiceLevel(ServiceLevelType.PREMIUM);
     meta.setUsage(UsageType.PRODUCTION);
     meta.setMeasurements(expectUom);
@@ -355,11 +355,10 @@ class InstancesResourceTest {
     var dayInFebruary = OffsetDateTime.of(2023, 2, 23, 10, 0, 0, 0, ZoneOffset.UTC);
 
     // RHOSAK is a PAYG product
-    var rhosak = ProductId.fromString(RHOSAK);
-    resource.validateBeginningAndEndingDates(rhosak, dayInJanuary, laterDayInJanuary);
+    resource.validateBeginningAndEndingDates(RHOSAK, dayInJanuary, laterDayInJanuary);
     assertThrows(
         BadRequestException.class,
-        () -> resource.validateBeginningAndEndingDates(rhosak, dayInJanuary, dayInFebruary));
+        () -> resource.validateBeginningAndEndingDates(RHOSAK, dayInJanuary, dayInFebruary));
   }
 
   @Test
@@ -603,28 +602,6 @@ class InstancesResourceTest {
                 ServiceLevelType.PREMIUM,
                 UsageType.PRODUCTION,
                 "NotAMetricId",
-                BillingProviderType.RED_HAT,
-                null,
-                null,
-                null,
-                null,
-                null,
-                InstanceReportSort.DISPLAY_NAME,
-                null));
-  }
-
-  @Test()
-  void testGetInstancesByProductThrowsExceptionForUnknownProductId() {
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            resource.getInstancesByProduct(
-                "NotAProductId",
-                null,
-                null,
-                ServiceLevelType.PREMIUM,
-                UsageType.PRODUCTION,
-                "Sockets",
                 BillingProviderType.RED_HAT,
                 null,
                 null,

--- a/src/test/java/org/candlepin/subscriptions/resource/SubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/SubscriptionResourceTest.java
@@ -23,7 +23,7 @@ package org.candlepin.subscriptions.resource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-import jakarta.ws.rs.BadRequestException;
+import com.redhat.swatch.configuration.registry.ProductId;
 import java.time.OffsetDateTime;
 import org.candlepin.subscriptions.db.AccountConfigRepository;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
@@ -41,7 +41,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles({"api", "test", "capacity-ingress"})
 @WithMockRedHatPrincipal("123456")
 class SubscriptionResourceTest {
-  private static final String RHEL_FOR_X86 = "RHEL for x86";
+  private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
   private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
   private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
 
@@ -85,27 +85,6 @@ class SubscriptionResourceTest {
         () ->
             subscriptionResource.getSkuCapacityReport(
                 RHEL_FOR_X86,
-                0,
-                10,
-                null,
-                null,
-                UsageType.PRODUCTION,
-                null,
-                null,
-                min,
-                max,
-                null,
-                SkuCapacityReportSort.SKU,
-                null));
-  }
-
-  @Test
-  void testCapacityByProductThrowsExceptionForUnknownProductId() {
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            subscriptionResource.getSkuCapacityReport(
-                "NotARealProductId",
                 0,
                 10,
                 null,

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -92,11 +92,12 @@ class TallyResourceTest {
   private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
   private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
 
-  public static final String RHEL_PRODUCT_ID = "RHEL for x86";
-  public static final String OPENSHIFT_DEDICATED_METRICS = "OpenShift-dedicated-metrics";
-  public static final String RHEL_FOR_X86 = RHEL_PRODUCT_ID;
-  private static final String METRIC_ID_CORES = "Cores";
-  private static final String METRIC_ID_SOCKETS = "Sockets";
+  public static final ProductId RHEL_PRODUCT_ID = ProductId.fromString("RHEL for x86");
+  public static final ProductId OPENSHIFT_DEDICATED_METRICS =
+      ProductId.fromString("OpenShift-dedicated-metrics");
+  public static final ProductId RHEL_FOR_X86 = RHEL_PRODUCT_ID;
+  private static final MetricId METRIC_ID_CORES = MetricId.fromString("Cores");
+  private static final MetricId METRIC_ID_SOCKETS = MetricId.fromString("Sockets");
 
   @MockBean TallySnapshotRepository repository;
   @MockBean BillableUsageRemittanceRepository remittanceRepository;
@@ -137,7 +138,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel._ANY),
                 Mockito.eq(Usage.PRODUCTION),
@@ -165,7 +166,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID,
+            RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel._ANY,
             Usage.PRODUCTION,
@@ -177,7 +178,7 @@ class TallyResourceTest {
 
     assertMetadata(
         report.getMeta(),
-        RHEL_PRODUCT_ID,
+        RHEL_PRODUCT_ID.toString(),
         null,
         UsageType.PRODUCTION,
         GranularityType.DAILY,
@@ -209,7 +210,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage._ANY),
@@ -236,7 +237,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID,
+            RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage._ANY,
@@ -248,7 +249,7 @@ class TallyResourceTest {
 
     assertMetadata(
         report.getMeta(),
-        RHEL_PRODUCT_ID,
+        RHEL_PRODUCT_ID.toString(),
         ServiceLevelType.PREMIUM,
         null,
         GranularityType.DAILY,
@@ -264,7 +265,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.EMPTY),
                 Mockito.eq(Usage.PRODUCTION),
@@ -292,7 +293,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID,
+            RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.EMPTY,
             Usage.PRODUCTION,
@@ -304,7 +305,7 @@ class TallyResourceTest {
 
     assertMetadata(
         report.getMeta(),
-        RHEL_PRODUCT_ID,
+        RHEL_PRODUCT_ID.toString(),
         ServiceLevelType.EMPTY,
         UsageType.PRODUCTION,
         GranularityType.DAILY,
@@ -319,7 +320,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.EMPTY),
@@ -347,7 +348,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID,
+            RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage.EMPTY,
@@ -359,7 +360,7 @@ class TallyResourceTest {
 
     assertMetadata(
         report.getMeta(),
-        RHEL_PRODUCT_ID,
+        RHEL_PRODUCT_ID.toString(),
         ServiceLevelType.PREMIUM,
         UsageType.EMPTY,
         GranularityType.DAILY,
@@ -374,7 +375,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
@@ -402,7 +403,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID,
+            RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -414,7 +415,7 @@ class TallyResourceTest {
 
     assertMetadata(
         report.getMeta(),
-        RHEL_PRODUCT_ID,
+        RHEL_PRODUCT_ID.toString(),
         ServiceLevelType.PREMIUM,
         UsageType.PRODUCTION,
         GranularityType.DAILY,
@@ -450,7 +451,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                RHEL_FOR_X86,
+                RHEL_FOR_X86.toString(),
                 Granularity.DAILY,
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
@@ -538,7 +539,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                OPENSHIFT_DEDICATED_METRICS,
+                OPENSHIFT_DEDICATED_METRICS.toString(),
                 Granularity.DAILY,
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
@@ -581,7 +582,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
@@ -609,7 +610,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID,
+            RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -628,7 +629,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID),
+                Mockito.eq(RHEL_PRODUCT_ID.toString()),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
@@ -657,7 +658,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID,
+            RHEL_PRODUCT_ID.toString(),
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -692,7 +693,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                RHEL_PRODUCT_ID,
+                RHEL_PRODUCT_ID.toString(),
                 Granularity.DAILY,
                 ServiceLevel._ANY,
                 Usage._ANY,
@@ -738,7 +739,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                RHEL_PRODUCT_ID,
+                RHEL_PRODUCT_ID.toString(),
                 Granularity.DAILY,
                 ServiceLevel._ANY,
                 Usage._ANY,
@@ -1279,7 +1280,7 @@ class TallyResourceTest {
     for (OffsetDateTime nextDate : snapDates) {
       TallySnapshot snap =
           TallySnapshot.builder()
-              .productId(OPENSHIFT_DEDICATED_METRICS)
+              .productId(OPENSHIFT_DEDICATED_METRICS.toString())
               .snapshotDate(nextDate)
               .build();
       snap.setMeasurement(HardwareMeasurementType.TOTAL, MetricIdUtils.getCores(), 100.0);
@@ -1291,8 +1292,8 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(snapshots));
 
     mockCapacity(
-        ProductId.fromString(OPENSHIFT_DEDICATED_METRICS),
-        MetricId.fromString(METRIC_ID_CORES),
+        OPENSHIFT_DEDICATED_METRICS,
+        METRIC_ID_CORES,
         GranularityType.DAILY,
         OffsetDateTime.parse("2023-03-01T00:00Z"),
         OffsetDateTime.parse("2023-03-31T23:59:59.999Z"),
@@ -1361,7 +1362,7 @@ class TallyResourceTest {
     for (OffsetDateTime nextDate : snapDates) {
       TallySnapshot snap =
           TallySnapshot.builder()
-              .productId(OPENSHIFT_DEDICATED_METRICS)
+              .productId(OPENSHIFT_DEDICATED_METRICS.toString())
               .snapshotDate(nextDate)
               .build();
       snap.setMeasurement(HardwareMeasurementType.TOTAL, MetricIdUtils.getCores(), 100.0);
@@ -1373,8 +1374,8 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(snapshots));
 
     mockCapacity(
-        ProductId.fromString(OPENSHIFT_DEDICATED_METRICS),
-        MetricId.fromString(METRIC_ID_CORES),
+        OPENSHIFT_DEDICATED_METRICS,
+        METRIC_ID_CORES,
         GranularityType.DAILY,
         OffsetDateTime.parse("2023-03-01T00:00Z"),
         OffsetDateTime.parse("2023-03-31T23:59:59.999Z"),
@@ -1429,54 +1430,6 @@ class TallyResourceTest {
 
     var noUsage2 = report.getData().get(snapshotIndex + 5);
     assertEquals(500, noUsage2.getValue());
-  }
-
-  @Test()
-  void testGetTallyReportDataThrowsExceptionForUnknownMetricId() {
-    var beginning = OffsetDateTime.parse("2023-03-01T00:00Z");
-    var ending = OffsetDateTime.parse("2023-03-31T23:59:59.999Z");
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            resource.getTallyReportData(
-                OPENSHIFT_DEDICATED_METRICS,
-                "NotAMetricId",
-                GranularityType.DAILY,
-                beginning,
-                ending,
-                null,
-                null,
-                null,
-                BillingProviderType.RED_HAT,
-                null,
-                null,
-                null,
-                true,
-                BillingCategory.PREPAID));
-  }
-
-  @Test()
-  void testGetTallyReportDataThrowsExceptionForUnknownProductId() {
-    var beginning = OffsetDateTime.parse("2023-03-01T00:00Z");
-    var ending = OffsetDateTime.parse("2023-03-31T23:59:59.999Z");
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            resource.getTallyReportData(
-                "NotAProductId",
-                METRIC_ID_SOCKETS,
-                GranularityType.DAILY,
-                beginning,
-                ending,
-                null,
-                null,
-                null,
-                BillingProviderType.RED_HAT,
-                null,
-                null,
-                null,
-                true,
-                BillingCategory.PREPAID));
   }
 
   private void mockCapacity(

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.params.ParameterizedTest.DISPLAY_NAME_PLACEHOLDE
 import static org.mockito.Mockito.*;
 
 import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
 import com.redhat.swatch.contracts.api.resources.CapacityApi;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
@@ -88,11 +89,12 @@ class TallyResourceTest {
   public static final OffsetDateTime TEST_DATE =
       OffsetDateTime.ofInstant(MID_MONTH_INSTANT, ZoneOffset.UTC);
 
-  public static final ProductId RHEL_PRODUCT_ID = ProductId.RHEL_FOR_X86;
-
   private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
   private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
 
+  public static final String RHEL_PRODUCT_ID = "RHEL for x86";
+  public static final String OPENSHIFT_DEDICATED_METRICS = "OpenShift-dedicated-metrics";
+  public static final String RHEL_FOR_X86 = RHEL_PRODUCT_ID;
   private static final String METRIC_ID_CORES = "Cores";
   private static final String METRIC_ID_SOCKETS = "Sockets";
 
@@ -135,7 +137,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(RHEL_PRODUCT_ID),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel._ANY),
                 Mockito.eq(Usage.PRODUCTION),
@@ -163,7 +165,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID.toString(),
+            RHEL_PRODUCT_ID,
             Granularity.DAILY,
             ServiceLevel._ANY,
             Usage.PRODUCTION,
@@ -185,7 +187,7 @@ class TallyResourceTest {
 
   private void assertMetadata(
       TallyReportMeta meta,
-      ProductId expectedProduct,
+      String expectedProduct,
       ServiceLevelType expectedSla,
       UsageType expectedUsage,
       GranularityType expectedGranularity,
@@ -207,7 +209,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(RHEL_PRODUCT_ID),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage._ANY),
@@ -234,7 +236,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID.toString(),
+            RHEL_PRODUCT_ID,
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage._ANY,
@@ -262,7 +264,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(RHEL_PRODUCT_ID),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.EMPTY),
                 Mockito.eq(Usage.PRODUCTION),
@@ -290,7 +292,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID.toString(),
+            RHEL_PRODUCT_ID,
             Granularity.DAILY,
             ServiceLevel.EMPTY,
             Usage.PRODUCTION,
@@ -317,7 +319,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(RHEL_PRODUCT_ID),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.EMPTY),
@@ -345,7 +347,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID.toString(),
+            RHEL_PRODUCT_ID,
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage.EMPTY,
@@ -372,7 +374,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(RHEL_PRODUCT_ID),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
@@ -400,7 +402,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID.toString(),
+            RHEL_PRODUCT_ID,
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -448,7 +450,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                ProductId.RHEL_FOR_X86.toString(),
+                RHEL_FOR_X86,
                 Granularity.DAILY,
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
@@ -461,7 +463,7 @@ class TallyResourceTest {
 
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             begin,
@@ -536,7 +538,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                ProductId.OPENSHIFT_DEDICATED_METRICS.toString(),
+                OPENSHIFT_DEDICATED_METRICS,
                 Granularity.DAILY,
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
@@ -549,7 +551,7 @@ class TallyResourceTest {
 
     TallyReport report =
         resource.getTallyReport(
-            ProductId.OPENSHIFT_DEDICATED_METRICS,
+            OPENSHIFT_DEDICATED_METRICS,
             GranularityType.DAILY,
             begin,
             end,
@@ -579,7 +581,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(RHEL_PRODUCT_ID),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
@@ -607,7 +609,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID.toString(),
+            RHEL_PRODUCT_ID,
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -626,7 +628,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 Mockito.eq("owner123456"),
-                Mockito.eq(RHEL_PRODUCT_ID.toString()),
+                Mockito.eq(RHEL_PRODUCT_ID),
                 Mockito.eq(Granularity.DAILY),
                 Mockito.eq(ServiceLevel.PREMIUM),
                 Mockito.eq(Usage.PRODUCTION),
@@ -655,7 +657,7 @@ class TallyResourceTest {
     Mockito.verify(repository)
         .findSnapshot(
             "owner123456",
-            RHEL_PRODUCT_ID.toString(),
+            RHEL_PRODUCT_ID,
             Granularity.DAILY,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
@@ -690,7 +692,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                RHEL_PRODUCT_ID.toString(),
+                RHEL_PRODUCT_ID,
                 Granularity.DAILY,
                 ServiceLevel._ANY,
                 Usage._ANY,
@@ -736,7 +738,7 @@ class TallyResourceTest {
     Mockito.when(
             repository.findSnapshot(
                 "owner123456",
-                RHEL_PRODUCT_ID.toString(),
+                RHEL_PRODUCT_ID,
                 Granularity.DAILY,
                 ServiceLevel._ANY,
                 Usage._ANY,
@@ -790,7 +792,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -819,7 +821,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -851,7 +853,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -883,7 +885,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -908,7 +910,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-10-01T00:00Z"),
@@ -933,7 +935,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-02T00:00Z"),
@@ -957,7 +959,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -981,7 +983,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -1005,7 +1007,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of()));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -1039,7 +1041,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot1, snapshot2)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -1078,7 +1080,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(List.of(snapshot1, snapshot2)));
     TallyReportData response =
         resource.getTallyReportData(
-            ProductId.RHEL_FOR_X86,
+            RHEL_FOR_X86,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2021-11-01T00:00Z"),
@@ -1128,7 +1130,7 @@ class TallyResourceTest {
 
     TallyReportData report =
         resource.getTallyReportData(
-            ProductId.OPENSHIFT_DEDICATED_METRICS,
+            OPENSHIFT_DEDICATED_METRICS,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2023-03-01T00:00Z"),
@@ -1187,7 +1189,7 @@ class TallyResourceTest {
 
     TallyReportData report =
         resource.getTallyReportData(
-            ProductId.OPENSHIFT_DEDICATED_METRICS,
+            OPENSHIFT_DEDICATED_METRICS,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2023-03-01T00:00Z"),
@@ -1222,7 +1224,7 @@ class TallyResourceTest {
         BadRequestException.class,
         () -> {
           resource.getTallyReportData(
-              ProductId.RHEL_FOR_X86,
+              RHEL_FOR_X86,
               METRIC_ID_CORES,
               GranularityType.DAILY,
               beginning,
@@ -1247,7 +1249,7 @@ class TallyResourceTest {
         BadRequestException.class,
         () -> {
           resource.getTallyReportData(
-              ProductId.RHEL_FOR_X86,
+              RHEL_FOR_X86,
               METRIC_ID_CORES,
               GranularityType.DAILY,
               beginning,
@@ -1277,7 +1279,7 @@ class TallyResourceTest {
     for (OffsetDateTime nextDate : snapDates) {
       TallySnapshot snap =
           TallySnapshot.builder()
-              .productId(ProductId.OPENSHIFT_DEDICATED_METRICS.toString())
+              .productId(OPENSHIFT_DEDICATED_METRICS)
               .snapshotDate(nextDate)
               .build();
       snap.setMeasurement(HardwareMeasurementType.TOTAL, MetricIdUtils.getCores(), 100.0);
@@ -1289,7 +1291,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(snapshots));
 
     mockCapacity(
-        ProductId.OPENSHIFT_DEDICATED_METRICS,
+        ProductId.fromString(OPENSHIFT_DEDICATED_METRICS),
         MetricId.fromString(METRIC_ID_CORES),
         GranularityType.DAILY,
         OffsetDateTime.parse("2023-03-01T00:00Z"),
@@ -1308,7 +1310,7 @@ class TallyResourceTest {
 
     TallyReportData report =
         resource.getTallyReportData(
-            ProductId.OPENSHIFT_DEDICATED_METRICS,
+            OPENSHIFT_DEDICATED_METRICS,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2023-03-01T00:00Z"),
@@ -1359,7 +1361,7 @@ class TallyResourceTest {
     for (OffsetDateTime nextDate : snapDates) {
       TallySnapshot snap =
           TallySnapshot.builder()
-              .productId(ProductId.OPENSHIFT_DEDICATED_METRICS.toString())
+              .productId(OPENSHIFT_DEDICATED_METRICS)
               .snapshotDate(nextDate)
               .build();
       snap.setMeasurement(HardwareMeasurementType.TOTAL, MetricIdUtils.getCores(), 100.0);
@@ -1371,7 +1373,7 @@ class TallyResourceTest {
         .thenReturn(new PageImpl<>(snapshots));
 
     mockCapacity(
-        ProductId.OPENSHIFT_DEDICATED_METRICS,
+        ProductId.fromString(OPENSHIFT_DEDICATED_METRICS),
         MetricId.fromString(METRIC_ID_CORES),
         GranularityType.DAILY,
         OffsetDateTime.parse("2023-03-01T00:00Z"),
@@ -1390,7 +1392,7 @@ class TallyResourceTest {
 
     TallyReportData report =
         resource.getTallyReportData(
-            ProductId.OPENSHIFT_DEDICATED_METRICS,
+            OPENSHIFT_DEDICATED_METRICS,
             METRIC_ID_CORES,
             GranularityType.DAILY,
             OffsetDateTime.parse("2023-03-01T00:00Z"),
@@ -1437,8 +1439,32 @@ class TallyResourceTest {
         BadRequestException.class,
         () ->
             resource.getTallyReportData(
-                ProductId.OPENSHIFT_DEDICATED_METRICS,
+                OPENSHIFT_DEDICATED_METRICS,
                 "NotAMetricId",
+                GranularityType.DAILY,
+                beginning,
+                ending,
+                null,
+                null,
+                null,
+                BillingProviderType.RED_HAT,
+                null,
+                null,
+                null,
+                true,
+                BillingCategory.PREPAID));
+  }
+
+  @Test()
+  void testGetTallyReportDataThrowsExceptionForUnknownProductId() {
+    var beginning = OffsetDateTime.parse("2023-03-01T00:00Z");
+    var ending = OffsetDateTime.parse("2023-03-31T23:59:59.999Z");
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            resource.getTallyReportData(
+                "NotAProductId",
+                METRIC_ID_SOCKETS,
                 GranularityType.DAILY,
                 beginning,
                 ending,
@@ -1480,7 +1506,7 @@ class TallyResourceTest {
             .orElse(null);
 
     when(capacityApi.getCapacityReportByMetricId(
-            eq(com.redhat.swatch.contracts.api.model.ProductId.valueOf(productId.name())),
+            eq(productId.getValue()),
             eq(metricId.getValue()),
             eq(cGranularity),
             eq(beginning),

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerOnDemandTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerOnDemandTest.java
@@ -20,12 +20,12 @@
  */
 package org.candlepin.subscriptions.subscription;
 
-import static org.candlepin.subscriptions.utilization.api.model.ProductId.RHOSAK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.configuration.registry.ProductId;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,7 +44,6 @@ import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.tally.AccountListSourceException;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.utilization.api.model.BillingProviderType;
-import org.candlepin.subscriptions.utilization.api.model.ProductId;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.SkuCapacity;
 import org.candlepin.subscriptions.utilization.api.model.SkuCapacityReport;
@@ -64,6 +63,7 @@ import org.springframework.test.context.ActiveProfiles;
 @WithMockRedHatPrincipal("123456")
 class SubscriptionTableControllerOnDemandTest {
 
+  private static final ProductId RHOSAK = ProductId.fromString("rhosak");
   private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
   private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.subscriptions.subscription;
 
-import static org.candlepin.subscriptions.utilization.api.model.ProductId.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,6 +27,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.core.Response;
 import java.time.OffsetDateTime;
@@ -61,6 +61,7 @@ import org.springframework.test.context.ActiveProfiles;
 @WithMockRedHatPrincipal("123456")
 class SubscriptionTableControllerTest {
 
+  private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
   @MockBean SubscriptionRepository subscriptionRepository;
   @MockBean OfferingRepository offeringRepository;
   @MockBean AccountListSource accountListSource;
@@ -632,7 +633,7 @@ class SubscriptionTableControllerTest {
 
     SkuCapacityReport report =
         subscriptionTableController.capacityReportBySku(
-            OPENSHIFT_METRICS,
+            ProductId.fromString("OpenShift-metrics"),
             null,
             null,
             null,

--- a/swatch-common-resteasy/build.gradle
+++ b/swatch-common-resteasy/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compileOnly platform(libraries["quarkus-bom"])
     compileOnly libraries["jakarta-ws-rs"]
     compileOnly 'org.slf4j:slf4j-api'
+    implementation project(":swatch-product-configuration")
 }
 
 description = 'SWATCH common library for RESTEasy configuration & utilities'

--- a/swatch-common-resteasy/src/main/java/com/redhat/swatch/common/resteasy/MetricIdParamConverterProvider.java
+++ b/swatch-common-resteasy/src/main/java/com/redhat/swatch/common/resteasy/MetricIdParamConverterProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.resteasy;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+/** ParamConverterProvider to validate MetricId values against configuration. */
+@Provider
+public class MetricIdParamConverterProvider implements ParamConverterProvider {
+
+  @SuppressWarnings("linelength")
+  @Override
+  public <T> ParamConverter<T> getConverter(
+      Class<T> rawType, Type genericType, Annotation[] annotations) {
+    if (rawType.isAssignableFrom(MetricId.class)) {
+      return (ParamConverter<T>) new MetricIdParamConverter();
+    }
+    return null;
+  }
+
+  /** ParamConverter that converts strings to configured MetricId values */
+  public static class MetricIdParamConverter implements ParamConverter<MetricId> {
+
+    @Override
+    public MetricId fromString(String value) {
+      if (Objects.isNull(value)) {
+        return null;
+      }
+      return MetricId.fromString(value);
+    }
+
+    @Override
+    public String toString(MetricId value) {
+      return value.toString();
+    }
+  }
+}

--- a/swatch-common-resteasy/src/main/java/com/redhat/swatch/common/resteasy/ProductIdParamConverterProvider.java
+++ b/swatch-common-resteasy/src/main/java/com/redhat/swatch/common/resteasy/ProductIdParamConverterProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.resteasy;
+
+import com.redhat.swatch.configuration.registry.ProductId;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+/** ParamConverterProvider to validate ProductId values against configuration. */
+@Provider
+public class ProductIdParamConverterProvider implements ParamConverterProvider {
+  public static final String INVALID_VALUE_EXCEPTION_MSG = "%s is not a valid value for %s";
+
+  @SuppressWarnings("linelength")
+  @Override
+  public <T> ParamConverter<T> getConverter(
+      Class<T> rawType, Type genericType, Annotation[] annotations) {
+    if (rawType.isAssignableFrom(ProductId.class)) {
+      return (ParamConverter<T>) new ProductIdParamConverter();
+    }
+    return null;
+  }
+
+  /** ParamConverter that converts strings to configured ProductId values */
+  public static class ProductIdParamConverter implements ParamConverter<ProductId> {
+
+    @Override
+    public ProductId fromString(String value) {
+      if (Objects.isNull(value)) {
+        return null;
+      }
+      return ProductId.fromString(value);
+    }
+
+    @Override
+    public String toString(ProductId value) {
+      return value.toString();
+    }
+  }
+}

--- a/swatch-common-resteasy/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/swatch-common-resteasy/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,2 +1,4 @@
 com.redhat.swatch.common.resteasy.EnumParamConverterProvider
+com.redhat.swatch.common.resteasy.MetricIdParamConverterProvider
 com.redhat.swatch.common.resteasy.OffsetDateTimeParamConverterProvider
+com.redhat.swatch.common.resteasy.ProductIdParamConverterProvider

--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-amqp'
     implementation 'io.smallrye.reactive:smallrye-reactive-messaging-in-memory'
     implementation project(':clients:quarkus:rbac-client')
+    implementation project(':swatch-product-configuration')
     annotationProcessor enforcedPlatform(libraries["quarkus-bom"])
     annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen"
     testImplementation 'io.quarkus:quarkus-junit5'
@@ -90,6 +91,14 @@ openApiGenerate {
                      useJakartaEE: "true",
     ]
     additionalProperties = [disableMultipart: "true", // see https://github.com/OpenAPITools/openapi-generator/pull/4713#issuecomment-633906581
+    ]
+    importMappings = [
+        "MetricId": "com.redhat.swatch.configuration.registry.MetricId",
+        "ProductId": "com.redhat.swatch.configuration.registry.ProductId",
+    ]
+    typeMappings = [
+        "string+MetricId": "MetricId",
+        "string+ProductId": "ProductId",
     ]
 }
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/CapacityResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/CapacityResource.java
@@ -20,6 +20,8 @@
  */
 package com.redhat.swatch.contract.resource;
 
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
 import com.redhat.swatch.contract.openapi.model.CapacityReportByMetricId;
 import com.redhat.swatch.contract.openapi.model.GranularityType;
 import com.redhat.swatch.contract.openapi.model.ReportCategory;
@@ -39,8 +41,8 @@ public class CapacityResource implements CapacityApi {
   @Override
   @RolesAllowed({"customer"})
   public CapacityReportByMetricId getCapacityReportByMetricId(
-      String productId,
-      String metricId,
+      ProductId productId,
+      MetricId metricId,
       GranularityType granularity,
       OffsetDateTime beginning,
       OffsetDateTime ending,

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/CapacityResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/CapacityResource.java
@@ -22,7 +22,6 @@ package com.redhat.swatch.contract.resource;
 
 import com.redhat.swatch.contract.openapi.model.CapacityReportByMetricId;
 import com.redhat.swatch.contract.openapi.model.GranularityType;
-import com.redhat.swatch.contract.openapi.model.ProductId;
 import com.redhat.swatch.contract.openapi.model.ReportCategory;
 import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
 import com.redhat.swatch.contract.openapi.model.UsageType;
@@ -40,7 +39,7 @@ public class CapacityResource implements CapacityApi {
   @Override
   @RolesAllowed({"customer"})
   public CapacityReportByMetricId getCapacityReportByMetricId(
-      ProductId productId,
+      String productId,
       String metricId,
       GranularityType granularity,
       OffsetDateTime beginning,

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -19,7 +19,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/ProductId'
+          type: string
         description: "The ID for the product we wish to query"
       - name: metric_id
         in: path
@@ -520,25 +520,6 @@ components:
           type: string
         message:
           type: string
-    ProductId:
-      type: string
-      enum:
-        - OpenShift Container Platform
-        - RHEL Compute Node
-        - RHEL for ARM
-        - RHEL for IBM Power
-        - RHEL for IBM z
-        - RHEL for x86
-        - RHEL Workstation
-        - Satellite Capsule
-        - Satellite Server
-        - OpenShift-metrics
-        - OpenShift-dedicated-metrics
-        - rhosak
-        - rhacs
-        - rhods
-        - BASILISK
-        - rosa
     # Schemas ending in "Type" are intentionally named to prevent naming conflicts with db model classes
     GranularityType:
       description: "Describes the significance of each date in the snapshot list. For example if the
@@ -577,7 +558,7 @@ components:
             count:
               type: integer
             product:
-              $ref: '#/components/schemas/ProductId'
+              type: string
             metric_id:
               type: string
             granularity:

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -19,13 +19,13 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/ProductId"
         description: "The ID for the product we wish to query"
       - name: metric_id
         in: path
         required: true
         schema:
-          type: string
+          $ref: "#/components/schemas/MetricId"
         description: "The metric ID for the product we wish to query"
       - name: offset
         in: query
@@ -607,6 +607,12 @@ components:
       required:
         - first
         - last
+    ProductId:
+      type: string
+      format: ProductId
+    MetricId:
+      type: string
+      format: MetricId
   responses:
     ErrorResponse:
       description: "Error handling request"

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
@@ -65,6 +65,8 @@ public class MetricId {
         .collect(Collectors.toSet());
   }
 
+  // NOTE: intentionally overriding the toString() from @Data, so users can use getValue() and
+  // toString() interchangeably without introducing errors
   public String toString() {
     return getValue();
   }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/ProductId.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/ProductId.java
@@ -53,6 +53,8 @@ public class ProductId {
                     String.format("ProductId: %s not found in configuration", value)));
   }
 
+  // NOTE: intentionally overriding the toString() from @Data, so users can use getValue() and
+  // toString() interchangeably without introducing errors
   public String toString() {
     return getValue();
   }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/ProductId.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/ProductId.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.configuration.registry;
+
+import java.util.Collection;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+// constructor is private so that the factory method is the only way to get a MetricId
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductId {
+  private final String value;
+
+  /**
+   * Creates a ProductId from a String.
+   *
+   * @param value String value for the ProductId
+   * @return a validated ProductId
+   * @throws IllegalArgumentException if the productId is not defined in configuration
+   */
+  public static ProductId fromString(String value) {
+    // NOTE: if the volume of data becomes large enough, we can pre-cache these values.
+    return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
+        .map(SubscriptionDefinition::getVariants)
+        .flatMap(Collection::stream)
+        .map(Variant::getTag)
+        .filter(productId -> productId.equalsIgnoreCase(value))
+        .findFirst()
+        .map(ProductId::new)
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    String.format("ProductId: %s not found in configuration", value)));
+  }
+
+  public String toString() {
+    return getValue();
+  }
+}


### PR DESCRIPTION
Jira issue: [SWATCH-969](https://issues.redhat.com/browse/SWATCH-969)

Description
===========

Remove productId enum in favor of a class that validates against product-config (extremely similar
to #2464). I made these changes on top of that PR in order to avoid merge conflicts, so #2464 must
land first.

Testing
=======

Setup
-----

1. Deploy the service:

```shell
DEV_MODE=true \
  ./gradlew :bootRun
```

2. Ensure opted in:

```shell
http PUT :8000/api/rhsm-subscriptions/v1/opt-in \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

Verification - Happy Path
-------------------------

Try the following APIs, expecting successful responses...

capacity (deprecated):

```shell
http ':8000/api/rhsm-subscriptions/v1/capacity/products/RHEL for x86' \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

capacity:

```shell
http ':8000/api/rhsm-subscriptions/v1/capacity/products/RHEL for x86/Sockets' \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

hosts:

```shell
http ':8000/api/rhsm-subscriptions/v1/hosts/products/RHEL for x86' \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

instances:

```shell
http ':8000/api/rhsm-subscriptions/v1/instances/products/RHEL for x86' \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

subscriptions:

```shell
http ':8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL for x86' \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

tally (deprecated):

```shell
http ':8000/api/rhsm-subscriptions/v1/tally/products/RHEL for x86' \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

tally:

```shell
http ':8000/api/rhsm-subscriptions/v1/tally/products/RHEL for x86/Sockets' \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

Verification - Bad Requests
---------------------------

Try the following APIs, expected 404 w/ an error message explaining the missing productId...

capacity (deprecated):

```shell
http :8000/api/rhsm-subscriptions/v1/capacity/products/NotAProduct \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

capacity:

```shell
http :8000/api/rhsm-subscriptions/v1/capacity/products/NotAProduct/Cores \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

hosts:

```shell
http :8000/api/rhsm-subscriptions/v1/hosts/products/NotAProduct \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

instances:

```shell
http :8000/api/rhsm-subscriptions/v1/instances/products/NotAProduct \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

subscriptions:

```shell
http :8000/api/rhsm-subscriptions/v1/subscriptions/products/NotAProduct \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

tally (deprecated):

```shell
http :8000/api/rhsm-subscriptions/v1/tally/products/NotAProduct \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

tally:

```shell
http :8000/api/rhsm-subscriptions/v1/tally/products/NotAProduct/Cores \
  granularity==Daily \
  beginning==2023-07-21T17:32:28Z \
  ending==2023-07-22T17:32:28Z \
  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"org123"}}}' | base64 -w0)
```

Draft until #2464 lands.