### PR TITLE
SWATCH-665:Remove Unneeded orgs check for TallyTaskFactory

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallyTaskFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyTaskFactory.java
@@ -66,13 +66,9 @@ public class TallyTaskFactory implements TaskFactory {
   @Override
   public Task build(TaskDescriptor taskDescriptor) {
     if (taskDescriptor.getTaskType() == TaskType.UPDATE_SNAPSHOTS) {
-      if (taskDescriptor.hasArg("orgs")) {
-        log.debug("Task created for processing orgs");
-        return new UpdateOrgSnapshotsTask(snapshotController, taskDescriptor.getArg("orgs"));
-      } else {
-        log.error("Task descriptor with argument orgs is missing {}", taskDescriptor);
-        throw new IllegalArgumentException("Incorrect task descriptor");
-      }
+      // We can assume that the task messages will have orgs arg going forward.
+      log.debug("Task created for processing orgs");
+      return new UpdateOrgSnapshotsTask(snapshotController, taskDescriptor.getArg("orgs"));
     }
 
     if (taskDescriptor.getTaskType() == TaskType.UPDATE_HOURLY_SNAPSHOTS) {

--- a/src/test/java/org/candlepin/subscriptions/tally/tasks/TallyTaskFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/tasks/TallyTaskFactoryTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.subscriptions.tally.TallyTaskFactory;
 import org.candlepin.subscriptions.task.TaskDescriptor;
-import org.candlepin.subscriptions.task.TaskType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,17 +35,6 @@ import org.springframework.test.context.ActiveProfiles;
 class TallyTaskFactoryTest {
 
   @Autowired private TallyTaskFactory factory;
-
-  @Test
-  void ensureFactoryBuildsUpdateAccountSnapshotTask() {
-    TaskDescriptor task =
-        TaskDescriptor.builder(TaskType.UPDATE_SNAPSHOTS, "accounts", null).build();
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          factory.build(task);
-        });
-  }
 
   @Test
   void ensureIllegalArgumentExceptionWhenTaskTypeIsNull() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-665](https://issues.redhat.com/browse/SWATCH-665)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This is a part of post org-id clean up and  remove logic to check if a orgId exist in the tally task, as 'orgId' is expected to be given moving forward after the org-Id migration 

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
This is regression testing only, so only need to test that non of the process is affected by the removal.
