### PR TITLE
SWATCH-1657: Fully drop uom column from tally measurements table

### DIFF
--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -124,7 +124,6 @@
     <include file="liquibase/202308210806-add-metric-id-instance-measurements.xml"/>
     <include file="liquibase/202308210906-drop-uom-column-instance-measurements.xml"/>
     <include file="liquibase/202308231356-add-metric-id-tally-measurements.xml"/>
-    <!-- Uncomment once the above changeset has landed in prod -->
-    <!-- <include file="liquibase/202308231456-drop-uom-column-tally-measurements.xml"/> -->
+    <include file="liquibase/202308231456-drop-uom-column-tally-measurements.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: [SWATCH-1657](https://issues.redhat.com/browse/SWATCH-1657)

## Description
After https://issues.redhat.com/browse/SWATCH-430 is released, we need to fully drop the uom column from the instance measurements.

## Testing
1.- Run the migration using: `./gradlew :liquibaseUpdate`. The column `uom` should have been dropped from the table `tally_measurements`.
2.- Test the rollback by calling twice: `./gradlew :liquibaseRollbackCount -PliquibaseCommandValue=2`. The column `uom` should have been back to the table `tally_measurements`.