### PR TITLE
SWATCH-1652: Conduit: Set cloud_provider: gcp for GCP systems

### DIFF
--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -110,6 +110,7 @@ public class StubRhsmApi extends RhsmApi {
     }
     if (orgId.equals(GCP_ORG_ID)) {
       consumer.getFacts().remove("azure_offer");
+      consumer.getFacts().put("dmi.bios.vendor", "Google");
       consumer.getFacts().put("gcp_license_codes", "7883559014960410759");
     }
   }

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -234,7 +234,7 @@ public class InventoryController {
     if (assetTag.equals("7783-7084-3265-9085-8269-3286-77")) {
       return "azure";
     } else if (biosVendor.toLowerCase().contains("google")) {
-      return "google";
+      return "gcp";
     } else if (biosVersion.toLowerCase().contains("amazon")) {
       return "aws";
     } else if (systemManufacturer.toLowerCase().contains("alibaba")) {

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -908,7 +908,7 @@ class InventoryControllerTest {
     negative.getFacts().put("dmi.bios.vendor", "foobar");
 
     ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
-    assertEquals("google", conduitFacts.getCloudProvider());
+    assertEquals("gcp", conduitFacts.getCloudProvider());
 
     ConduitFacts conduitFactsNegative = controller.getFactsFromConsumer(negative);
     assertNull(conduitFactsNegative.getCloudProvider());


### PR DESCRIPTION
Jira issue: [SWATCH-1652](https://issues.redhat.com/browse/SWATCH-1652)

Description
===========

This changes the value emitted for cloud_provider from "google" to "gcp" when processing GCP-hosted systems.

Testing
=======

Setup
-----

Deploy the service:

```shell
RHSM_USE_STUB=true ./gradlew swatch-system-conduit:bootRun
```

Verification
------------

Check the output of our debugging output to see what conduit sets for cloud provider for the mocked GCP system:

```shell
http :8000/api/rhsm-subscriptions/v1/internal/organizations/gcpOrg/inventory \
  limit=100 \
  x-rh-swatch-psk:placeholder \
  Origin:console.redhat.com
```

Notice `"cloud_provider": "gcp"`