### PR TITLE
SWATCH-1653: Tally should categorise hosts coming from HBI with cloud provider "gcp" as CLOUD

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -186,6 +186,10 @@ parser.add_argument('--num-aws',
                     type=int,
                     default=0,
                     help='Insert a number of mock aws instances')
+parser.add_argument('--num-gcp',
+                    type=int,
+                    default=0,
+                    help='Insert a number of mock gcp instances')
 parser.add_argument('--unmapped-guests',
                     default=False,
                     help='Are the guests to be created unmapped?')
@@ -273,6 +277,14 @@ for i in range(args.num_accounts):
                       product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
                       is_hbi=args.is_hbi, num_of_guests=args.num_guests,
                       cloud_provider='AWS', is_marketplace=args.is_marketplace, host_type=args.host_type,
+                      billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
+                      uom=args.uom)
+
+    for i in range(args.num_gcp):
+        generate_host(account_number=account, org_id=args.org, hardware_type='VIRTUALIZED', measurement_type='GOOGLE',
+                      product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
+                      is_hbi=args.is_hbi, num_of_guests=args.num_guests,
+                      cloud_provider='GCP', is_marketplace=args.is_marketplace, host_type=args.host_type,
                       billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
                       uom=args.uom)
 

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -370,7 +370,7 @@ public class MetricUsageCollector {
     if (instance.getCloudProvider() == null) {
       throw new IllegalArgumentException("Hardware type cloud, but no cloud provider specified");
     }
-    return HardwareMeasurementType.valueOf(instance.getCloudProvider());
+    return HardwareMeasurementType.fromString(instance.getCloudProvider());
   }
 
   private HardwareMeasurementType getCloudProvider(Event.CloudProvider cloudProvider) {

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -187,8 +187,7 @@ public class FactNormalizer {
       NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
     String cloudProvider = hostFacts.getCloudProvider();
     if (HardwareMeasurementType.isSupportedCloudProvider(cloudProvider)) {
-      normalizedFacts.setCloudProviderType(
-          HardwareMeasurementType.valueOf(cloudProvider.toUpperCase()));
+      normalizedFacts.setCloudProviderType(HardwareMeasurementType.fromString(cloudProvider));
     }
     if (hostFacts.getSystemProfileSockets() != 0) {
       normalizedFacts.setSockets(hostFacts.getSystemProfileSockets());

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -423,6 +423,17 @@ class FactNormalizerTest {
     assertEquals(HardwareMeasurementType.AWS, normalized.getCloudProviderType());
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"google", "gcp"})
+  void testThatGoogleCloudProviderIsSet(String expectedCloudProvider) {
+    InventoryHostFacts baseFacts = createBaseHost("A1", "O1");
+    baseFacts.setCloudProvider(expectedCloudProvider);
+
+    NormalizedFacts normalized = normalizer.normalize(baseFacts, hypervisorData());
+    assertNotNull(normalized.getCloudProviderType());
+    assertEquals(HardwareMeasurementType.GOOGLE, normalized.getCloudProviderType());
+  }
+
   @Test
   void testThatCloudProviderIsNotSetIfNull() {
     NormalizedFacts normalized = normalizer.normalize(createBaseHost("A1", "O1"), hypervisorData());

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HardwareMeasurementType.java
@@ -34,25 +34,46 @@ public enum HardwareMeasurementType {
   // integration
   @Deprecated
   AWS_CLOUDIGRADE,
-  GOOGLE,
+  GOOGLE("GCP"),
   ALIBABA,
   AZURE,
   EMPTY;
+
+  private final String[] aliases;
+
+  HardwareMeasurementType() {
+    this.aliases = new String[0];
+  }
+
+  HardwareMeasurementType(String... aliases) {
+    this.aliases = aliases;
+  }
 
   public static boolean isSupportedCloudProvider(String name) {
     if (name == null || name.isEmpty()) {
       return false;
     }
 
-    try {
-      return getCloudProviderTypes().contains(HardwareMeasurementType.valueOf(name.toUpperCase()));
-    } catch (IllegalArgumentException e) {
-      // Passed an invalid type string, consider it not supported.
-      return false;
-    }
+    return getCloudProviderTypes().contains(fromString(name));
   }
 
   public static List<HardwareMeasurementType> getCloudProviderTypes() {
     return Arrays.asList(AWS, GOOGLE, AZURE, ALIBABA);
+  }
+
+  public static HardwareMeasurementType fromString(String name) {
+    for (HardwareMeasurementType measurementType : HardwareMeasurementType.values()) {
+      if (measurementType.name().equalsIgnoreCase(name)) {
+        return measurementType;
+      }
+
+      for (String alias : measurementType.aliases) {
+        if (alias.equalsIgnoreCase(name)) {
+          return measurementType;
+        }
+      }
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-1653](https://issues.redhat.com/browse/SWATCH-1653)

## Description
Given a host in HBI with cloud_provider=gcp, after a tally for the org, the report for `category=cloud` should increase.

## Testing
1.- podman-compose up
2.- Create hosts for orgId=16790890 in Insights database

```
./bin/insert-mock-hosts --num-gcp 1 --hbi --clear --org 16790890 --account account123
```
3.- createdb -h localhost -U postgres -O rhsm-subscriptions swatch-1653
4.- DEV_MODE=true SUBSCRIPTION_SYNC_ENABLED=true ENABLE_SYNCHRONOUS_OPERATIONS=true DATABASE_DATABASE=swatch-1653 ./gradlew :bootRun
5.- Perform tally snapshot:

```bash
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/16790890" \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder \
x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16790890"}}}' | base64 -w 0)
```

7.- Check hardware_type for generated host:

Connect to the database:
`psql -h localhost -U rhsm-subscriptions swatch-1653`

Create an existing event for orgId=16790890

`SELECT hardware_type FROM hosts;`

It should be CLOUD. Before these changes, it was PHYSICAL.