### PR TITLE
SWATCH-1332: Enable a liquibase script to drop the subscription_capacity table

### DIFF
--- a/src/main/resources/liquibase/202309111412-drop-subscription-capacity-table.xml
+++ b/src/main/resources/liquibase/202309111412-drop-subscription-capacity-table.xml
@@ -5,8 +5,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-
-  <changeSet id="202305251412-01" author="awood" dbms="postgresql">
+  <changeSet id="202309111412-01" author="awood" dbms="postgresql">
     <sql>
       DROP TRIGGER subscription_measurements_insert ON subscription_capacity;
     </sql>
@@ -14,7 +13,7 @@
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305251412-02" author="awood" dbms="postgresql">
+  <changeSet id="202309111412-02" author="awood" dbms="postgresql">
     <sql>
       DROP TRIGGER subscription_measurements_update ON subscription_capacity;
     </sql>
@@ -22,7 +21,7 @@
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305251412-03" author="awood" dbms="postgresql">
+  <changeSet id="202309111412-03" author="awood" dbms="postgresql">
     <sql>
       DROP TRIGGER subscription_product_id_insert ON subscription_capacity;
     </sql>
@@ -30,7 +29,7 @@
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305251412-04" author="awood" dbms="postgresql">
+  <changeSet id="202309111412-04" author="awood" dbms="postgresql">
     <sql>
       DROP TRIGGER subscription_product_id_update ON subscription_capacity;
     </sql>
@@ -38,7 +37,7 @@
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305251412-05" author="awood" dbms="postgresql">
+  <changeSet id="202309111412-05" author="awood" dbms="postgresql">
     <sql>
       DROP FUNCTION copy_subscription_capacity_sockets_and_cores();
     </sql>
@@ -46,7 +45,7 @@
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305251412-07" author="awood" dbms="postgresql">
+  <changeSet id="202309111412-07" author="awood" dbms="postgresql">
     <sql>
       DROP FUNCTION copy_subscription_product_id();
     </sql>
@@ -54,7 +53,7 @@
     changeSetPath="liquibase/202305031403-create-subscription-measurements-table.xml" />
   </changeSet>
 
-  <changeSet id="202305031403-08" author="awood">
+  <changeSet id="202309111412-08" author="awood">
     <dropTable tableName="subscription_capacity"/>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -101,19 +101,17 @@
     <include file="liquibase/202212161446-add-derived-sku-to-offering.xml"/>
     <include file="liquibase/202301311609-update-tally-instance-view-default-num-of-guest-add-subscription_manager_id.xml"/>
     <include file="liquibase/202302141154-add-basilisk-product.xml"/>
-    <include file="/liquibase/202302151544-remove-uuid-cast-on-instance-id-in-tally-instance-view.xml"/>
-    <include file="/liquibase/202305231003-update-remittance-table-for-history.xml"/>
+    <include file="liquibase/202302151544-remove-uuid-cast-on-instance-id-in-tally-instance-view.xml"/>
+    <include file="liquibase/202305231003-update-remittance-table-for-history.xml"/>
     <!--    <include file="/liquibase/202305261600-rollback-update-remittance-table-for-history.xml" />-->
-    <include file="/liquibase/202305231247-update-host-pk-for-dup-violation.xml"/>
+    <include file="liquibase/202305231247-update-host-pk-for-dup-violation.xml"/>
     <include file="liquibase/202305031403-create-subscription-measurements-table.xml"/>
     <include file="liquibase/202306201611-add-subscription-id-index-for-measurements.xml"/>
-    <!-- Uncomment once subscription-measurements has been verified -->
-    <!-- <include file="liquibase/202305251412-drop-subscription-capacity-table.xml"/> -->
     <include file="liquibase/202306151541-add-sku-foreign-key-to-subscription.xml"/>
     <include file="liquibase/202306291611-add-extra-index-for-product-ids.xml"/>
     <include file="liquibase/202307131511-drop-trigger-on-subscription.xml"/>
     <include file="liquibase/202307171013-add-indexes-for-tally-instance-view-queries.xml"/>
-    <include file="/liquibase/202307131456-remove-granularity-from-billable-usage-remittance.xml"/>
+    <include file="liquibase/202307131456-remove-granularity-from-billable-usage-remittance.xml"/>
     <include file="liquibase/202307051132-rename-instance_id-to-host_id.xml"/>
     <!-- Uncomment once the above changeset has landed in prod -->
     <!-- <include file="liquibase/202307051245-drop-instance_id-columns.xml"/> -->
@@ -125,5 +123,6 @@
     <include file="liquibase/202308210906-drop-uom-column-instance-measurements.xml"/>
     <include file="liquibase/202308231356-add-metric-id-tally-measurements.xml"/>
     <include file="liquibase/202308231456-drop-uom-column-tally-measurements.xml"/>
+    <include file="liquibase/202309111412-drop-subscription-capacity-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
The subscription_capacity table was superseded several months ago by the subscription_measurements table.

<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1332](https://issues.redhat.com/browse/SWATCH-1332)

## Note to reviewer
Please also review https://github.com/RedHatInsights/rhsm-subscriptions-egress/pull/28 as the same time as this PR

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
Be forewarned, there's no rolling back from dropping a table.  If you want to test this on an alternate schema, you can copy your database with

```
createdb -h localhost -U postgres -O rhsm-subscriptions -T rhsm-subscriptions scratch
```

and then modify the `buildSrc/src/main/groovy/swatch.liquibase-conventions.gradle` file to point to `scratch` instead of `rhsm-subscription`.

### Setup
1. `psql -h localhost -U rhsm-subscriptions scratch -c '\dt` will show the `subscription_capacity` table
1. `psql -h localhost -U rhsm-subscriptions scratch -c '\df'` will show the `copy_subscription_*` stored procedures

### Steps
<!-- Enter each step of the test below -->
1. `./gradlew liquibaseUpdate`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Run the `psql` commands again and observe that the table and stored procedures are gone.
