### PR TITLE
Use uppercase value for TallyMeasurementKey MetricId for backwards co…

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -199,7 +199,7 @@ class SnapshotSummaryProducerTest {
     TallyMeasurement measurement = optionalTotal.get().get(0);
 
     assertEquals(hardwareType, measurement.getHardwareMeasurementType());
-    assertEquals(metricId.getValue(), measurement.getUom());
+    assertEquals(metricId.getValue().toUpperCase(), measurement.getUom());
     assertEquals(value, measurement.getValue());
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurementKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurementKey.java
@@ -48,7 +48,7 @@ public class TallyMeasurementKey implements Serializable {
 
   public TallyMeasurementKey(HardwareMeasurementType hardwareMeasurementType, String metricId) {
     this.measurementType = hardwareMeasurementType;
-    this.metricId = metricId;
+    this.metricId = metricId.toUpperCase();
   }
 
   @Override


### PR DESCRIPTION
…mpatibility


<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-XXXX](https://issues.redhat.com/browse/SWATCH-XXXX)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
Follow steps outlined here: https://github.com/RedHatInsights/rhsm-subscriptions/pull/2311

If you run on main and then switch to this branch, the API call to get the data will not return values because the records will be incorrectly cased. After you switch to this branch and run steps again then you should get correct results.
