### PR TITLE
SWATCH-1704: Uppercase MetricId on tally_measurements and instance_measurements

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -170,10 +170,10 @@ public class InstancesResource implements InstancesApi {
 
     int minCores = 0;
     int minSockets = 0;
-    if (metricIdOptional.map(metricId -> metricId.getValue().equals("Cores")).orElse(false)) {
+    if (metricIdOptional.map(metricId -> metricId.equals(MetricIdUtils.getCores())).orElse(false)) {
       minCores = 1;
     } else if (metricIdOptional
-        .map(metricId -> metricId.getValue().equals("Sockets"))
+        .map(metricId -> metricId.equals(MetricIdUtils.getSockets()))
         .orElse(false)) {
       minSockets = 1;
     }
@@ -312,7 +312,7 @@ public class InstancesResource implements InstancesApi {
     for (String metric : measurements) {
       if (MetricIdUtils.getSockets().equals(MetricId.fromString(metric))) {
         measurementList.add(Double.valueOf(tallyInstanceView.getSockets()));
-      } else if (!isPAYG && tallyInstanceView.getKey().getMetricId().equals(metric)) {
+      } else if (!isPAYG && tallyInstanceView.getKey().getMetricId().equalsIgnoreCase(metric)) {
         measurementList.add(Optional.ofNullable(tallyInstanceView.getValue()).orElse(0.0));
       } else {
         measurementList.add(

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -341,12 +341,13 @@ public class InventoryAccountUsageCollector {
 
     if (normalizedFacts.getCores() != null) {
       host.getMeasurements()
-          .put(MetricIdUtils.getCores().getValue(), normalizedFacts.getCores().doubleValue());
+          .put(MetricIdUtils.getCores().toUpperCase(), normalizedFacts.getCores().doubleValue());
     }
 
     if (normalizedFacts.getSockets() != null) {
       host.getMeasurements()
-          .put(MetricIdUtils.getSockets().getValue(), normalizedFacts.getSockets().doubleValue());
+          .put(
+              MetricIdUtils.getSockets().toUpperCase(), normalizedFacts.getSockets().doubleValue());
     }
 
     host.setHypervisor(normalizedFacts.isHypervisor());

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -43,7 +43,6 @@ import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.db.model.*;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.json.Event;
-import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.util.ApplicationClock;
 import org.candlepin.subscriptions.util.DateRange;
 import org.slf4j.Logger;
@@ -215,7 +214,7 @@ public class MetricUsageCollector {
 
                 if (event.getMeasurements() != null) {
                   event.getMeasurements().stream()
-                      .map(Measurement::getUom)
+                      .map(measurement -> measurement.getUom().toUpperCase())
                       .forEach(seenMetricIds::add);
                 }
               });

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -966,7 +966,7 @@ class SubscriptionTableControllerTest {
 
       SubscriptionMeasurementKey key = new SubscriptionMeasurementKey();
       key.setMeasurementType(type);
-      key.setMetricId(metric.toString().toUpperCase());
+      key.setMetricId(metric.toUpperCase());
 
       return Map.of(key, value);
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -199,7 +199,7 @@ class SnapshotSummaryProducerTest {
     TallyMeasurement measurement = optionalTotal.get().get(0);
 
     assertEquals(hardwareType, measurement.getHardwareMeasurementType());
-    assertEquals(metricId.getValue(), measurement.getUom());
+    assertEquals(metricId.toUpperCase(), measurement.getUom());
     assertEquals(value, measurement.getValue());
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -156,7 +156,8 @@ public interface TallyInstanceViewRepository
   static Specification<TallyInstanceView> uomEquals(MetricId effectiveUom) {
     return (root, query, builder) -> {
       var key = root.get(TallyInstanceView_.key);
-      return builder.equal(key.get(TallyInstanceViewKey_.metricId), effectiveUom.toString());
+      return builder.equal(
+          key.get(TallyInstanceViewKey_.metricId), effectiveUom.toUpperCase());
     };
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -156,8 +156,7 @@ public interface TallyInstanceViewRepository
   static Specification<TallyInstanceView> uomEquals(MetricId effectiveUom) {
     return (root, query, builder) -> {
       var key = root.get(TallyInstanceView_.key);
-      return builder.equal(
-          key.get(TallyInstanceViewKey_.metricId), effectiveUom.toUpperCase());
+      return builder.equal(key.get(TallyInstanceViewKey_.metricId), effectiveUom.toUpperCase());
     };
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -230,7 +230,8 @@ public interface TallyInstanceViewRepository
       if (StringUtils.hasText(month)) {
         searchCriteria =
             searchCriteria.and(
-                monthlyKeyEquals(new InstanceMonthlyTotalKey(month, effectiveUom.toString())));
+                monthlyKeyEquals(
+                    new InstanceMonthlyTotalKey(month, effectiveUom.toString().toUpperCase())));
       }
     }
     if (!ObjectUtils.isEmpty(hardwareMeasurementTypes)) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -161,11 +161,11 @@ public class Host implements Serializable {
   }
 
   public Double getMeasurement(String metricId) {
-    return measurements.get(metricId);
+    return measurements.get(metricId.toUpperCase());
   }
 
   public void setMeasurement(String metricId, Double value) {
-    measurements.put(metricId, value);
+    measurements.put(metricId.toUpperCase(), value);
   }
 
   public HostTallyBucket addBucket( // NOSONAR
@@ -218,12 +218,7 @@ public class Host implements Serializable {
   }
 
   public Double getMonthlyTotal(String monthId, MetricId metricId) {
-    var key = new InstanceMonthlyTotalKey(monthId, metricId.toString());
-    return monthlyTotals.get(key);
-  }
-
-  public Double getMonthlyTotal(OffsetDateTime reference, MetricId metricId) {
-    var key = new InstanceMonthlyTotalKey(reference, metricId.toString());
+    var key = new InstanceMonthlyTotalKey(monthId, metricId.getValue());
     return monthlyTotals.get(key);
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/InstanceMonthlyTotalKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/InstanceMonthlyTotalKey.java
@@ -25,14 +25,12 @@ import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Key for instance monthly totals */
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @Embeddable
 public class InstanceMonthlyTotalKey implements Serializable {
   private static final DateTimeFormatter MONTH_ID_FORMATTER =
@@ -49,8 +47,13 @@ public class InstanceMonthlyTotalKey implements Serializable {
     return reference.format(MONTH_ID_FORMATTER);
   }
 
+  public InstanceMonthlyTotalKey(String month, String metricId) {
+    this.month = month;
+    this.metricId = metricId.toUpperCase();
+  }
+
   public InstanceMonthlyTotalKey(OffsetDateTime reference, String metricId) {
     this.month = formatMonthId(reference);
-    this.metricId = metricId;
+    this.metricId = metricId.toUpperCase();
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurementKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurementKey.java
@@ -48,7 +48,7 @@ public class TallyMeasurementKey implements Serializable {
 
   public TallyMeasurementKey(HardwareMeasurementType hardwareMeasurementType, String metricId) {
     this.measurementType = hardwareMeasurementType;
-    this.metricId = metricId;
+    this.metricId = metricId.toUpperCase();
   }
 
   @Override

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
@@ -74,5 +74,4 @@ public class MetricId {
   public String toUpperCase() {
     return getValue().toUpperCase();
   }
-
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
@@ -70,4 +70,9 @@ public class MetricId {
   public String toString() {
     return getValue();
   }
+
+  public String toUpperCase() {
+    return getValue().toUpperCase();
+  }
+
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1704](https://issues.redhat.com/browse/SWATCH-1704)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Recent changes to replace UOM with MetricId caused an issue where new values in instance_measurements and tally_measurements were being saved in regular case instead of all upper cased. This PR sets them to all UpperCase again.

## Testing
Follow steps outlined here: https://github.com/RedHatInsights/rhsm-subscriptions/pull/2311

If you run on main and then switch to this branch, the API call to get the data will not return values because the records will be incorrectly cased. After you switch to this branch and run steps again then you should get correct results.

