### PR TITLE
SWATCH-1734: Support integration tests with Postgresql

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,24 @@
+# Integration tests require Docker environment which is not supported by our Jenkins environment yet
+# So, we need to run the integration tests in GitHub.
+# To be deleted once the Jenkins environment support Docker.
+name: "PR build"
+on:
+  - pull_request
+jobs:
+  integration-tests:
+    name: Verify integration tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 17 ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'gradle'
+      - name: Build and Run integration tests
+        run: |
+          ./gradlew clean build -DincludeTags=integration

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,10 @@ pipeline {
                 // The build task includes check, test, and assemble.  Linting happens during the check
                 // task and uses the spotless gradle plugin.
                 echo "The ci value is ${env.CI}"
-                sh "./gradlew --no-daemon build"
+                // Integration tests require Docker environment which is not supported by our Jenkins environment yet
+                // The actual problem is that the podman socket is not listening.
+                // We need to run "systemctl --user enable podman.socket --now" when spawning the node.
+                sh "./gradlew --no-daemon build -DexcludeTags=integration"
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 
     testImplementation "org.springframework.security:spring-security-test"
     testImplementation "org.springframework.kafka:spring-kafka-test"
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation libraries["wiremock"]
     testImplementation libraries["awaitility"]
     testImplementation project(':swatch-core-test')

--- a/buildSrc/src/main/groovy/swatch.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.java-conventions.gradle
@@ -48,7 +48,17 @@ compileTestJava {
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        String iTags = System.getProperty("includeTags")
+        if (iTags != null) {
+            includeTags(iTags)
+        }
+
+        String eTags = System.getProperty("excludeTags")
+        if (eTags != null) {
+            excludeTags(eTags)
+        }
+    }
     if (System.getenv("DOCKER_HOST") == null) {
         String UID = 'id -u'.execute().text.strip()
         environment "DOCKER_HOST", "unix:///run/user/$UID/podman/podman.sock"

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/MeteringMetricsFromPrometheusToDatabaseIT.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/MeteringMetricsFromPrometheusToDatabaseIT.java
@@ -44,29 +44,17 @@ import org.candlepin.subscriptions.prometheus.model.QueryResultData;
 import org.candlepin.subscriptions.prometheus.model.QueryResultDataResultInner;
 import org.candlepin.subscriptions.prometheus.model.ResultType;
 import org.candlepin.subscriptions.prometheus.model.StatusType;
+import org.candlepin.subscriptions.test.BaseIT;
 import org.candlepin.subscriptions.util.MetricIdUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(
-    properties = {
-      PrometheusQueryWiremockExtension.PROM_URL,
-      "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
-      // In tests, messages may be sent before the listener has been assigned the topic
-      // so we ensure that when the listener comes online it starts from first message.
-      "spring.kafka.consumer.auto-offset-reset=earliest"
-    })
-@ActiveProfiles({"openshift-metering-worker", "worker", "test"})
-@ExtendWith(PrometheusQueryWiremockExtension.class)
-@EmbeddedKafka(
-    partitions = 1,
-    topics = {"${rhsm-subscriptions.service-instance-ingress.incoming.topic}"})
-class MeteringMetricsFromPrometheusToDatabaseIT {
+@SpringBootTest
+@ActiveProfiles({"openshift-metering-worker", "worker", "test-inventory"})
+class MeteringMetricsFromPrometheusToDatabaseIT extends BaseIT {
 
   private static final int NUM_METRICS_TO_SEND = 5;
   private static final Duration TIMEOUT_TO_WAIT_FOR_METRICS = Duration.ofSeconds(5);

--- a/src/test/java/org/candlepin/subscriptions/resteasy/HttpServerMetricsTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resteasy/HttpServerMetricsTest.java
@@ -26,7 +26,6 @@ import static org.candlepin.subscriptions.security.IdentityHeaderAuthenticationF
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,7 +47,6 @@ import org.springframework.test.context.ActiveProfiles;
       // use a random port in management server
       "management.server.port=0",
     })
-@Tag("integration")
 @ActiveProfiles({"api", "test"})
 class HttpServerMetricsTest {
 

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.candlepin.subscriptions.metering.MeteringEventFactory.EVENT_SOURCE;
+import static org.candlepin.subscriptions.metering.MeteringEventFactory.getEventType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.candlepin.subscriptions.db.EventRecordRepository;
+import org.candlepin.subscriptions.db.model.EventRecord;
+import org.candlepin.subscriptions.json.Event;
+import org.candlepin.subscriptions.json.Measurement;
+import org.candlepin.subscriptions.resource.OptInResource;
+import org.candlepin.subscriptions.resource.TallyResource;
+import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
+import org.candlepin.subscriptions.test.BaseIT;
+import org.candlepin.subscriptions.util.ApplicationClock;
+import org.candlepin.subscriptions.util.DateRange;
+import org.candlepin.subscriptions.utilization.api.model.GranularityType;
+import org.candlepin.subscriptions.utilization.api.model.TallyReportData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(properties = "CONTRACT_USE_STUB=true")
+@ActiveProfiles(value = {"worker", "kafka-queue", "api", "test-inventory"})
+class TallySnapshotControllerIT extends BaseIT {
+  static final String METRIC = "Cores";
+  static final String USER_ID = "123";
+  static final String ORG_ID = "owner" + USER_ID;
+  static final String ACCOUNT_NUMBER = "account" + USER_ID;
+  static final String PRODUCT_TAG = "rosa";
+
+  @Autowired TallySnapshotController controller;
+  @Autowired TallyResource tallyResource;
+
+  @Autowired ApplicationClock clock;
+
+  @Autowired EventRecordRepository eventRecordRepository;
+  @Autowired OptInResource optInResource;
+
+  OffsetDateTime start;
+  OffsetDateTime end;
+  List<Event> events = new ArrayList<>();
+
+  @BeforeEach
+  public void setup() {
+    events.clear();
+  }
+
+  @WithMockRedHatPrincipal(value = USER_ID)
+  @Test
+  void test() throws Exception {
+    givenOrgAndAccountInConfig();
+    givenFiveDaysOfRangeForReport();
+
+    givenEventAtDay(1, 78.4390);
+    givenEventAtDay(3, 89.716);
+
+    whenProduceHourlySnapshotsForOrg();
+
+    assertTallyReportData();
+  }
+
+  private void givenFiveDaysOfRangeForReport() {
+    start = clock.startOfCurrentHour().minusMonths(1);
+    end = start.plusDays(5L);
+  }
+
+  private void givenOrgAndAccountInConfig() {
+    optInResource.putOptInConfig();
+  }
+
+  private void givenEventAtDay(int dayAt, double value) {
+    Event event = new Event();
+    event.setEventId(UUID.randomUUID());
+    event.setAccountNumber(ACCOUNT_NUMBER);
+    event.setTimestamp(start.plusDays(dayAt));
+    event.setSla(Event.Sla.PREMIUM);
+    event.setRole(Event.Role.MOA_HOSTEDCONTROLPLANE);
+    event.setOrgId(ORG_ID);
+    event.setEventType(getEventType(METRIC, PRODUCT_TAG));
+    event.setInstanceId("test");
+    event.setEventSource(EVENT_SOURCE);
+    event.setExpiration(Optional.of(event.getTimestamp().plusHours(5)));
+    event.setMeasurements(List.of(measurement(value)));
+    event.setServiceType("rosa Instance");
+    event.setBillingProvider(Event.BillingProvider.AWS);
+    event.setBillingAccountId(Optional.of("mktp-123"));
+
+    eventRecordRepository.save(new EventRecord(event));
+
+    events.add(event);
+  }
+
+  private void whenProduceHourlySnapshotsForOrg() {
+    controller.produceHourlySnapshotsForOrg(ORG_ID, new DateRange(start, end));
+  }
+
+  private void assertTallyReportData() {
+    TallyReportData report =
+        tallyResource.getTallyReportData(
+            ProductId.fromString(PRODUCT_TAG),
+            MetricId.fromString(METRIC),
+            GranularityType.DAILY,
+            start,
+            end,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true,
+            null);
+    // assert events
+    double accumulatedValue = 0;
+    for (var point : report.getData()) {
+      for (Event event : events) {
+        if (point.getDate().toLocalDate().equals(event.getTimestamp().toLocalDate())) {
+          for (var measurement : event.getMeasurements()) {
+            accumulatedValue += measurement.getValue();
+          }
+        }
+      }
+
+      int expectedValue = (int) Math.ceil(accumulatedValue);
+      assertEquals(
+          expectedValue,
+          point.getValue(),
+          "Unexpected value in data point at '"
+              + point.getDate()
+              + "'. Expected was "
+              + expectedValue
+              + ". Report was: "
+              + report);
+    }
+
+    // assert days, end day is inclusive, so we need to add one day more.
+    assertEquals((int) Duration.between(start, end).toDays() + 1, report.getMeta().getCount());
+  }
+
+  private Measurement measurement(Double value) {
+    Measurement measurement = new Measurement();
+    measurement.setUom(METRIC);
+    measurement.setValue(value);
+    return measurement;
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/test/BaseIT.java
+++ b/src/test/java/org/candlepin/subscriptions/test/BaseIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.test;
+
+import static org.awaitility.Awaitility.await;
+
+import org.awaitility.core.ThrowingRunnable;
+import org.candlepin.subscriptions.metering.service.prometheus.PrometheusQueryWiremockExtension;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.test.context.TestSecurityContextHolder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * BaseIT includes the setup and integration of the following services: - Postgresql database
+ * instance for Swatch Tally - Prometheus mock by Wiremock
+ *
+ * <p>These services are automatically configured to work with the services with no additional
+ * configuration.
+ */
+@DirtiesContext
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EmbeddedKafka(
+    partitions = 1,
+    topics = {
+      "${rhsm-subscriptions.tasks.topic}",
+      "${rhsm-subscriptions.subscription.tasks.topic}",
+      "${rhsm-subscriptions.billing-producer.incoming.topic}",
+      "${rhsm-subscriptions.billing-producer.outgoing.topic}",
+      "${rhsm-subscriptions.service-instance-ingress.incoming.topic}"
+    })
+@ExtendWith(PrometheusQueryWiremockExtension.class)
+@Tag("integration")
+public abstract class BaseIT {
+  @Container static SwatchPostgreSQLContainer database = new SwatchPostgreSQLContainer();
+
+  @DynamicPropertySource
+  static void registerPgProperties(DynamicPropertyRegistry registry) {
+    registry.add("DATABASE_HOST", () -> database.getHost());
+    registry.add("DATABASE_PORT", () -> database.getFirstMappedPort());
+    registry.add(
+        "rhsm-subscriptions.metering.prometheus.client.url",
+        () -> "http://localhost:${WIREMOCK_PORT:8101}");
+    registry.add("spring.kafka.bootstrap-servers", () -> "${spring.embedded.kafka.brokers}");
+    // In tests, messages may be sent before the listener has been assigned the topic
+    // so we ensure that when the listener comes online it starts from first message.
+    registry.add("spring.kafka.consumer.auto-offset-reset", () -> "earliest");
+  }
+
+  protected void untilAsserted(final ThrowingRunnable assertion) {
+    SecurityContext context = TestSecurityContextHolder.getContext();
+    await()
+        .untilAsserted(
+            () -> {
+              TestSecurityContextHolder.setContext(context);
+              assertion.run();
+            });
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/test/SwatchPostgreSQLContainer.java
+++ b/src/test/java/org/candlepin/subscriptions/test/SwatchPostgreSQLContainer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.test;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class SwatchPostgreSQLContainer extends PostgreSQLContainer<SwatchPostgreSQLContainer> {
+
+  /**
+   * This image is a replacement for the official one "docker.io/library/postgres:13" but in Quay.io
+   * to avoid Docker Hub exceed limit issues.
+   */
+  private static final String IMAGE = "quay.io/jcarvaja/postgres:13";
+
+  private static final String DATABASE = "rhsm-subscriptions";
+
+  public SwatchPostgreSQLContainer() {
+    super(DockerImageName.parse(IMAGE).asCompatibleSubstituteFor("postgres"));
+    withEnv("POSTGRES_HOST_AUTH_METHOD", "trust");
+    withDatabaseName(DATABASE);
+    withUsername(DATABASE);
+    withPassword(DATABASE);
+  }
+}

--- a/swatch-core-test/src/main/resources/application-test-inventory.yaml
+++ b/swatch-core-test/src/main/resources/application-test-inventory.yaml
@@ -1,0 +1,40 @@
+rhsm-subscriptions:
+  inventory-service.datasource:
+    url: jdbc:hsqldb:mem:inventory-testdb
+    username: test
+    password: test
+    driver-class-name: org.hsqldb.jdbc.JDBCDriver
+    platform: hsqldb
+  account-batch-size: 2
+  subscription-sync-enabled: true
+  subscription:
+    use-stub: true
+    tasks:
+      topic: platform.rhsm-subscriptions.subscription-sync
+      kafka-group-id: subscription-worker
+    enable-payg-subscription-force-sync: true
+  capacity:
+    tasks:
+      topic: platform.rhsm-subscriptions.capacity-reconcile
+      kafka-group-id: capacity-reconciliation-worker
+  user-service:
+    use-stub: true
+  product:
+    use-stub: true
+    tasks:
+      topic: platform.rhsm-subscriptions.offering-sync
+      kafka-group-id: offering-worker
+logging:
+  level:
+    org:
+      candlepin: INFO
+spring:
+  jpa:
+    database: postgresql
+    properties:
+      hibernate:
+        jdbc:
+          # Force the testing database into UTC to prevent test failures when the database
+          # determines the 'current' time in a query. NOTE: This is primarily when tests
+          # are run in a local environment and the DB is running in local time zone.
+          time_zone: UTC


### PR DESCRIPTION
Jira issue: [SWATCH-1734](https://issues.redhat.com/browse/SWATCH-1734)

## Description
These changes add a `BaseIT` class that allows writing integration tests using Postgresql and Kafka. Moreover, it brings some other utilities and testing facilities like integration between Spring Boot Security Testing and Awailitily. 
