### PR TITLE
SWATCH-1527: Add SAP x86 as a configured product for non-metered subs…

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_SAP_x86.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_SAP_x86.yaml
@@ -1,0 +1,17 @@
+---
+platform: RHEL
+
+id: rhel-for-sap-x86
+
+variants:
+  - tag: rhel-for-sap-x86
+    engineeringIds:
+      - 388 # RHEL for SAP Update Services for SAP Solutions
+      - 241 # Red Hat Enterprise Linux 8 for x86_64 - SAP Solutions
+      - 146 # Red Hat Enterprise Linux for SAP
+
+defaults:
+  variant: rhel-for-sap-x86
+
+metrics:
+  - id: Sockets

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
@@ -46,8 +46,8 @@ class SubscriptionDefinitionRegistryTest {
   void testLoadAllTheThings() {
 
     var actual = subscriptionDefinitionRegistry.getSubscriptions().size();
-    var expected = 15;
+    var expected = 16;
 
-    assertEquals(actual, expected);
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
…criptions


Jira issue: [SWATCH-1527](https://issues.redhat.com/browse/SWATCH-1527)

## Description
This PR sets up the configuration to count traditional subscriptions of RHEL for SAP systems in subscription watch. These system are identified via engineering products 388, 241, and 146. 

## Testing
Add SKU RH02323 (SAP VDC) 
Install a new RHEL for SAP system and register to HBI. 
Run a tally. 
Look for subscriptions & products matching the id "rhel-for-sap-x86". 

