### PR TITLE
SWATCH-1739: Fix startup errors

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -20,13 +20,11 @@
  */
 package org.candlepin.subscriptions.resteasy;
 
-import org.jboss.resteasy.springboot.ResteasyAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -36,7 +34,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * <p>Should be imported by any component that needs to serve an API.
  */
 @Configuration
-@Import(ResteasyAutoConfiguration.class)
 @ComponentScan(
     basePackages = {
       "org.candlepin.subscriptions.exception.mapper",

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/BadRequestExceptionMapper.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/BadRequestExceptionMapper.java
@@ -27,14 +27,18 @@ import org.candlepin.subscriptions.utilization.api.model.Error;
 import org.jboss.resteasy.spi.BadRequestException;
 import org.springframework.stereotype.Component;
 
-/** This handler catches RESTEasy BadRequestException. */
+/**
+ * This handler catches RESTEasy BadRequestException. Note that {@link
+ * jakarta.ws.rs.BadRequestException} (which is what our application code generally throws) is
+ * <em>not</em> handled by this mapper but instead by the WebApplicationExceptionMapper.
+ */
 @Component
 @Provider
 public class BadRequestExceptionMapper extends BaseExceptionMapper<BadRequestException> {
   @Override
   protected Error buildError(BadRequestException exception) {
     return new Error()
-        .code(ErrorCode.VALIDATION_FAILED_ERROR.getCode())
+        .code(ErrorCode.REQUEST_PROCESSING_ERROR.getCode())
         .status(String.valueOf(Response.Status.BAD_REQUEST.getStatusCode()))
         .title("Bad Request")
         .detail(exception.getCause().getMessage());

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyProviderRegistrar.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyProviderRegistrar.java
@@ -24,6 +24,7 @@ import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.plugins.spring.SpringBeanProcessor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ResteasyProviderRegistrar {
   @Bean
+  @ConditionalOnClass(name = "org.springframework.boot.test.mock.mockito.MockitoPostProcessor")
   public SpringBeanProcessor registerBuiltInProviders(
       @Qualifier("resteasySpringBeanProcessor") BeanFactoryPostProcessor postProcessor) {
     var springBeanProcessor = (SpringBeanProcessor) postProcessor;

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -100,6 +100,7 @@ management:
 spring:
   # general hibernate configurations
   jpa:
+    open-in-view: false
     properties:
       hibernate:
         jdbc:

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -153,8 +153,6 @@ rhsm-subscriptions:
 logging:
   level:
     org:
-      hibernate:
-        type: trace
       candlepin:
         subscriptions:
           resteasy:


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1739](https://issues.redhat.com/browse/SWATCH-1739)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This PR fixes a few issues:
* The "open session in view" warning that Spring prints.
* The warnings about `@Provider`s being registered twice
* Some debug logging that slipped in
* A few comments and correction in semantics for the `BadRequestExceptionMapper`

There are two outstanding issues:
* `RESTEASY004687: Closing a class org.jboss.resteasy.client.jaxrs.engines.ManualClosingApacheHttpClient43Engine$CleanupAction instance for you. Please close clients yourself.`  I have no idea what's causing this error.  It's not even getting logged in the main thread.  It's getting logged in a `Cleaner` thread.

   My best guess is that when we create the various API clients for subscription service, user service, etc, the generated `ApiClient` classes are opening a connection but not closing it.  That's just speculation though.
* `HHH015011: Unable to locate static metamodel field : org.candlepin.subscriptions.db.model.EventRecord_#event; this may or may not indicate a problem with the static metamodel`.  This error is caused by the `data` column [not being mapped](https://stackoverflow.com/a/59002364) to a type in Hibernate.  Instead the type is mapped with a JPA `AttributeConverter`.

   One solution mentioned in that SO link above is to make the class Serializable; however, that won't work for us since the class has `Optional` fields and `Optional` is not serializable.  In my opinion, those fields should not be `Optional`.  Instead, the getters should be return the field wrapped in an `Optional` but I don't believe we have that much control over the generated glass.
   
   The [hypersistence-utils](https://github.com/vladmihalcea/hypersistence-utils#json) project offers a `JsonType` that can be used with the `@Type` annotation, but I considered that change to be a bridge too far for a minor quality of life pull request.

## Testing
Start the application on `main` and on this branch.  The warnings about the "2nd registration" and the open session in view are now gone.