### PR TITLE
SWATCH-382: Aggregate code coverage from sub projects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,8 @@ pipeline {
                 // Integration tests require Docker environment which is not supported by our Jenkins environment yet
                 // The actual problem is that the podman socket is not listening.
                 // We need to run "systemctl --user enable podman.socket --now" when spawning the node.
-                sh "./gradlew --no-daemon build -DexcludeTags=integration"
+                // TODO: https://issues.redhat.com/browse/SWATCH-1750
+                sh "./gradlew --no-daemon build jacocoTestReport -DexcludeTags=integration"
             }
         }
 
@@ -75,7 +76,7 @@ pipeline {
             }
             steps {
                 withSonarQubeEnv('sonarcloud.io') {
-                    sh "./gradlew --no-daemon sonar -x test -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.token=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                    sh "./gradlew --no-daemon sonar -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.token=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
                 }
             }
         }
@@ -87,7 +88,7 @@ pipeline {
             }
             steps {
                 withSonarQubeEnv('sonarcloud.io') {
-                    sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.token=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                    sh "./gradlew --no-daemon sonar -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.token=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
             }
             steps {
                 withSonarQubeEnv('sonarcloud.io') {
-                    sh "./gradlew --no-daemon sonar -x test -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                    sh "./gradlew --no-daemon sonar -x test -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.token=${SONAR_AUTH_TOKEN} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
                 }
             }
         }
@@ -87,7 +87,7 @@ pipeline {
             }
             steps {
                 withSonarQubeEnv('sonarcloud.io') {
-                    sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
+                    sh "./gradlew --no-daemon sonarqube -Duser.home=/tmp -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.token=${SONAR_AUTH_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.organization=rhsm -Dsonar.projectKey=rhsm-subscriptions"
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -126,9 +126,6 @@ jacocoTestReport {
     }
 }
 
-project.tasks["sonarqube"].dependsOn "test"
-project.tasks["sonarqube"].dependsOn "jacocoTestReport"
-
 /* TODO - The directives below to generate the API classes are duplicates of the
  * the directives we use for the api module.  We need to DRY this up but that is
  * going to require a little Gradle-fu that I don't currently possess.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ plugins {
     id "swatch.spring-boot-conventions"
     id "org.sonarqube"
     id "com.netflix.nebula.release"
-    id 'jacoco'
     id 'swatch.liquibase-conventions'
 }
 
@@ -117,12 +116,6 @@ allprojects {
             }
             println JsonOutput.toJson(allDeps.sort { "${it.group}:${it.name}:${it.version}" })
         }
-    }
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
     }
 }
 

--- a/buildSrc/src/main/groovy/swatch.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.java-conventions.gradle
@@ -4,6 +4,7 @@ plugins {
     id "java"
     id "com.diffplug.spotless"
     id 'com.adarshr.test-logger'
+    id 'jacoco'
 }
 
 repositories {
@@ -72,4 +73,10 @@ test {
 tasks.withType(Jar).configureEach {
     // Here to address https://youtrack.jetbrains.com/issue/IDEA-305759
     duplicatesStrategy = DuplicatesStrategy.WARN
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+    }
 }

--- a/buildSrc/src/main/groovy/swatch.quarkus-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.quarkus-conventions.gradle
@@ -1,0 +1,30 @@
+// Plugin: swatch.quarkus-conventions
+// gradle config common to any swatch component implemented as a Quarkus app
+plugins {
+    id "swatch.java-conventions"
+    id 'io.quarkus'
+}
+
+dependencies {
+    implementation enforcedPlatform(libraries["quarkus-bom"])
+    implementation 'io.quarkus:quarkus-arc'
+    implementation 'io.quarkus:quarkus-config-yaml'
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.quarkus:quarkus-junit5-mockito'
+    testImplementation 'io.quarkus:quarkus-jacoco'
+}
+
+test {
+    finalizedBy jacocoTestReport
+    jacoco {
+        excludeClassLoaders = ["*QuarkusClassLoader"]
+        destinationFile = layout.buildDirectory.file("jacoco-quarkus.exec").get().asFile
+    }
+    jacocoTestReport.enabled = false
+}
+
+sonarqube {
+    properties {
+        property 'sonar.coverage.jacoco.xmlReportPaths', "${projectDir}/build/jacoco-report/jacoco.xml"
+    }
+}

--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -120,3 +120,9 @@ tasks.register("wiremock", JavaExec) {
     classpath = sourceSets.test.runtimeClasspath
     mainClass = "com.redhat.swatch.contract.resource.WireMockResource"
 }
+
+sonarqube {
+    properties {
+        property 'sonar.coverage.jacoco.xmlReportPaths', "${projectDir}/build/jacoco-report/jacoco.xml"
+    }
+}

--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -1,7 +1,6 @@
 plugins {
-    id 'swatch.java-conventions'
+    id 'swatch.quarkus-conventions'
     id 'swatch.liquibase-conventions'
-    id 'io.quarkus'
     id 'org.openapi.generator'
 }
 
@@ -21,9 +20,6 @@ liquibase {
 
 dependencies {
     compileOnly libraries["lombok"]
-    implementation enforcedPlatform(libraries["quarkus-bom"])
-    implementation 'io.quarkus:quarkus-arc'
-    implementation 'io.quarkus:quarkus-config-yaml'
     implementation 'io.quarkus:quarkus-hibernate-validator'
     implementation 'io.quarkus:quarkus-jsonb'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
@@ -48,9 +44,6 @@ dependencies {
     implementation project(':swatch-product-configuration')
     annotationProcessor enforcedPlatform(libraries["quarkus-bom"])
     annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen"
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.quarkus:quarkus-junit5-mockito'
-    testImplementation 'io.quarkus:quarkus-jacoco'
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.testcontainers:junit-jupiter'
@@ -119,10 +112,4 @@ tasks.register("wiremock", JavaExec) {
     description = "Run mock REST services for this service"
     classpath = sourceSets.test.runtimeClasspath
     mainClass = "com.redhat.swatch.contract.resource.WireMockResource"
-}
-
-sonarqube {
-    properties {
-        property 'sonar.coverage.jacoco.xmlReportPaths', "${projectDir}/build/jacoco-report/jacoco.xml"
-    }
 }

--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation 'io.quarkus:quarkus-arc'
     implementation 'io.quarkus:quarkus-config-yaml'
     implementation 'io.quarkus:quarkus-hibernate-validator'
-    implementation 'io.quarkus:quarkus-jacoco'
     implementation 'io.quarkus:quarkus-jsonb'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-openshift'
@@ -51,6 +50,7 @@ dependencies {
     annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen"
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.quarkus:quarkus-junit5-mockito'
+    testImplementation 'io.quarkus:quarkus-jacoco'
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/swatch-core/build.gradle
+++ b/swatch-core/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id "swatch.java-library-conventions"
     id "swatch.spring-boot-dependencies-conventions"
     id 'jsonschema2pojo'
-    id 'jacoco'
 }
 
 dependencies {
@@ -52,10 +51,4 @@ description = 'SWATCH Core Library'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
 }

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'swatch.java-conventions'
     id 'io.quarkus'
     id 'org.openapi.generator'
+    id 'jacoco'
 }
 
 dependencies {
@@ -30,9 +31,9 @@ dependencies {
     implementation project(":clients:swatch-internal-subscription-client")
     implementation project(":swatch-common-resteasy")
     implementation project(":swatch-product-configuration")
-    testImplementation 'io.quarkus:quarkus-jacoco'
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.quarkus:quarkus-junit5-mockito'
+    testImplementation 'io.quarkus:quarkus-jacoco'
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.testcontainers:junit-jupiter'
@@ -87,3 +88,9 @@ tasks.register("wiremock", JavaExec) {
 
 quarkusDev.dependsOn(configureQuarkusBuild)
 quarkusBuild.dependsOn(configureQuarkusBuild)
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+    }
+}

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -1,16 +1,11 @@
 plugins {
-    id 'swatch.java-conventions'
-    id 'io.quarkus'
+    id 'swatch.quarkus-conventions'
     id 'org.openapi.generator'
-    id 'jacoco'
 }
 
 dependencies {
     compileOnly libraries["lombok"]
-    implementation enforcedPlatform(libraries["quarkus-bom"])
     implementation platform(libraries["awssdk-bom"])
-    implementation 'io.quarkus:quarkus-arc'
-    implementation 'io.quarkus:quarkus-config-yaml'
     implementation 'io.quarkus:quarkus-hibernate-validator'
     implementation 'io.quarkus:quarkus-jsonb'
     implementation 'io.quarkus:quarkus-logging-json'
@@ -31,9 +26,6 @@ dependencies {
     implementation project(":clients:swatch-internal-subscription-client")
     implementation project(":swatch-common-resteasy")
     implementation project(":swatch-product-configuration")
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.quarkus:quarkus-junit5-mockito'
-    testImplementation 'io.quarkus:quarkus-jacoco'
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.testcontainers:junit-jupiter'
@@ -88,9 +80,3 @@ tasks.register("wiremock", JavaExec) {
 
 quarkusDev.dependsOn(configureQuarkusBuild)
 quarkusBuild.dependsOn(configureQuarkusBuild)
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     implementation 'io.quarkus:quarkus-arc'
     implementation 'io.quarkus:quarkus-config-yaml'
     implementation 'io.quarkus:quarkus-hibernate-validator'
-    implementation 'io.quarkus:quarkus-jacoco'
     implementation 'io.quarkus:quarkus-jsonb'
     implementation 'io.quarkus:quarkus-logging-json'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
@@ -31,6 +30,7 @@ dependencies {
     implementation project(":clients:swatch-internal-subscription-client")
     implementation project(":swatch-common-resteasy")
     implementation project(":swatch-product-configuration")
+    testImplementation 'io.quarkus:quarkus-jacoco'
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.quarkus:quarkus-junit5-mockito'
     testImplementation 'io.rest-assured:rest-assured'

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/TestContainerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/TestContainerTest.java
@@ -24,12 +24,14 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.Assert;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Disabled("This placeholder test shows how to setup an integration test w/ DB & Kafka")
 @QuarkusTest
-@QuarkusTestResource(PostgresResource.class)
-@QuarkusTestResource(KafkaResource.class)
+@QuarkusTestResource(value = PostgresResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = KafkaResource.class, restrictToAnnotatedClass = true)
+@Tag("integration")
 class TestContainerTest {
 
   @Test

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/com/redhat/swatch/processors/BillableUsageProcessorTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/com/redhat/swatch/processors/BillableUsageProcessorTest.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.com.redhat.swatch.processors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -41,17 +42,17 @@ import com.redhat.swatch.processors.AwsMarketplaceMeteringClientFactory;
 import com.redhat.swatch.processors.BillableUsageProcessor;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Optional;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.marketplacemetering.MarketplaceMeteringClient;
 import software.amazon.awssdk.services.marketplacemetering.model.BatchMeterUsageRequest;
 import software.amazon.awssdk.services.marketplacemetering.model.BatchMeterUsageResponse;
@@ -60,7 +61,7 @@ import software.amazon.awssdk.services.marketplacemetering.model.UsageRecord;
 import software.amazon.awssdk.services.marketplacemetering.model.UsageRecordResult;
 import software.amazon.awssdk.services.marketplacemetering.model.UsageRecordResultStatus;
 
-@ExtendWith(MockitoExtension.class)
+@QuarkusTest
 class BillableUsageProcessorTest {
 
   private static final String INSTANCE_HOURS = "Instance-hours";
@@ -101,23 +102,20 @@ class BillableUsageProcessorTest {
                   .build())
           .build();
 
-  @Mock InternalSubscriptionsApi internalSubscriptionsApi;
-  @Mock AwsMarketplaceMeteringClientFactory clientFactory;
-  @Mock MarketplaceMeteringClient meteringClient;
+  @InjectMock @RestClient InternalSubscriptionsApi internalSubscriptionsApi;
+  @InjectMock AwsMarketplaceMeteringClientFactory clientFactory;
+  MarketplaceMeteringClient meteringClient;
 
-  MeterRegistry meterRegistry;
+  @Inject MeterRegistry meterRegistry;
   Counter acceptedCounter;
   Counter rejectedCounter;
-  BillableUsageProcessor processor;
+  @Inject BillableUsageProcessor processor;
 
   @BeforeEach
   void setup() {
-    meterRegistry = new SimpleMeterRegistry();
     acceptedCounter = meterRegistry.counter("swatch_aws_marketplace_batch_accepted_total");
     rejectedCounter = meterRegistry.counter("swatch_aws_marketplace_batch_rejected_total");
-    processor =
-        new BillableUsageProcessor(
-            meterRegistry, internalSubscriptionsApi, clientFactory, Optional.of(false));
+    meteringClient = mock(MarketplaceMeteringClient.class);
   }
 
   @Test
@@ -198,6 +196,7 @@ class BillableUsageProcessorTest {
 
   @Test
   void shouldIncrementFailureCounterIfUnprocessed() throws ApiException {
+    double current = rejectedCounter.count();
     when(internalSubscriptionsApi.getAwsUsageContext(
             any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
@@ -208,11 +207,12 @@ class BillableUsageProcessorTest {
                 .unprocessedRecords(UsageRecord.builder().build())
                 .build());
     processor.process(RHOSAK_INSTANCE_HOURS_RECORD);
-    assertEquals(1.0, rejectedCounter.count());
+    assertEquals(current + 1, rejectedCounter.count());
   }
 
   @Test
   void shouldIncrementFailureCounterOnError() throws ApiException {
+    double current = rejectedCounter.count();
     when(internalSubscriptionsApi.getAwsUsageContext(
             any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
@@ -220,7 +220,7 @@ class BillableUsageProcessorTest {
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
         .thenThrow(MarketplaceMeteringException.class);
     processor.process(RHOSAK_INSTANCE_HOURS_RECORD);
-    assertEquals(1.0, rejectedCounter.count());
+    assertEquals(current + 1, rejectedCounter.count());
   }
 
   @Test

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id "swatch.spring-boot-conventions"
     id "org.openapi.generator"
     id 'jsonschema2pojo'
-    id "jacoco"
 }
 
 configurations {
@@ -119,12 +118,6 @@ jsonSchema2Pojo {
     includeSetters = true
     inclusionLevel = 'USE_DEFAULTS'
     useJakartaValidation = true
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
 }
 
 springBoot {


### PR DESCRIPTION
Jira issue: [SWATCH-382](https://issues.redhat.com/browse/SWATCH-382)

# Description

The pull request includes the following changes:
- Change scope of quarkus-jacoco to test
- Replace the deprecated `sonar.login` to `sonar.token`

Sonar was alerting that `sonar.login` is deprecated and is going to be removed.

- fix code coverage for subprojects

The main issue was that by having: `project.tasks["sonarqube"].dependsOn "jacocoTestReport"` only in the parent build.gradle file, the sub projects were generating the jacoco report. 

I fixed that by appending the tasks directly to the gradle command. 
The problem with the Quarkus projects was caused by a wrong location of the jacoco report and missing the Jacoco plugin. 