### PR TITLE
Workaround issue with testcontainers and podman

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/test/SwatchPostgreSQLContainer.java
+++ b/src/test/java/org/candlepin/subscriptions/test/SwatchPostgreSQLContainer.java
@@ -39,5 +39,8 @@ public class SwatchPostgreSQLContainer extends PostgreSQLContainer<SwatchPostgre
     withDatabaseName(DATABASE);
     withUsername(DATABASE);
     withPassword(DATABASE);
+    // SMELL: Workaround for https://github.com/testcontainers/testcontainers-java/issues/7539
+    // This is because testcontainers randomly fails to start a container when using Podman socket.
+    withStartupAttempts(3);
   }
 }


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
Configure podman-docker and socket using:

```
sudo dnf install podman podman-docker
systemctl --user enable podman.socket --now
podman system service --time=0
```

Check podman socket is listening:
```
podman info | grep -A2 'remoteSocket' 
```
This command should print:
```
remoteSocket:
  exists: true
  path: /path/to/podman.sock
```

And configure testcontainers to connect to the podman socket:
``` 
export DOCKER_HOST=unix:///run/user/${UID}/podman/podman.sock
export TESTCONTAINERS_RYUK_DISABLED=true
``` 

And then run the tests using `./gradlew clean build`. Eventually, any of the integration tests that use SwatchPostgreSQLContainer will fail with `Broken pipe when creating container`. 