### PR TITLE
SWATCH-1716: Make the instance identifier configurable for prometheus integrations during hourly job

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,10 +56,10 @@ rhsm-subscriptions:
       metric:
         accountQueryTemplates:
           default: >-
-            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product='#{metric.prometheus.queryParams[product]}', external_organization != '', billing_model='marketplace'}[1h]))
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:on(#{metric.prometheus.queryParams[instanceKey]}) group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product='#{metric.prometheus.queryParams[product]}', external_organization != '', billing_model='marketplace'}[1h]))
             by (external_organization)}
           addonSamples: >-
-            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon", resource_name='#{metric.prometheus.queryParams[resourceName]}', external_organization != '', billing_model='marketplace'}[1h]))
+            ${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:on(#{metric.prometheus.queryParams[instanceKey]}) group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon", resource_name='#{metric.prometheus.queryParams[resourceName]}', external_organization != '', billing_model='marketplace'}[1h]))
             by (external_organization)}
   prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:0h}
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}


### PR DESCRIPTION
Jira issue: [SWATCH-1716](https://issues.redhat.com/browse/SWATCH-1716)

## Description
We started this already with [SWATCH-1630](https://issues.redhat.com/browse/SWATCH-1630), but it was only applied to the openshift-metering-worker profile.

It needs to be applied to the template in application.yaml in order to be used by the metering-job profile as well.

## Testing
1.- podman-compose up
2.- Mock the prometheus server at localhost:

Create the stub directory:
`mkdir -p stub/__files`

Add a stub file to return no data: `stub/__files/empty.json`

```
cat > stub/__files/empty.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : []
    }
}
EOF
```

Run wiremock:
`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

Configure stubbing for prometheus:

- this is to return no data otherwise:
`curl -X POST --data '{ "priority": 5, "request": { "urlPath": "/api/v1/query_range", "method": "GET" }, "response": { "status": 200, "bodyFileName": "empty.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

3.- Start the swatch metrics app: `PROM_URL="http://localhost:8101/api/v1/" SPRING_PROFILES_ACTIVE=metering-job,kafka-queue ./gradlew :bootRun`

And wait until the app terminates.

5.- Check the prometheus logs (you started the wiremock server using --verbose) and confirm you received:

```
GET /api/v1/query_range?query=on%28_id%29%20group%28min_over_time%28ocm_subscription%7Bproduct%3D%27ocp%27%2C%20external_organization%20%21%3D%20%27%27%2C%20billing_model%3D%27marketplace%27%7D%5B1h%5D%29%29%20by%20%28external_organization%29&start=1695200400&end=1695200400&step=3600&timeout=10000
```

Which now it contains the `on(_id)` part which is configurable.

Before these changes, the query was:

```
GET /api/v1/query_range?query=group%28min_over_time%28ocm_subscription_resource%7Bresource_type%3D%22addon%22%2C%20resource_name%3D%27addon-open-data-hub%27%2C%20external_organization%20%21%3D%20%27%27%2C%20billing_model%3D%27marketplace%27%7D%5B1h%5D%29%29%20by%20%28external_organization%29&start=1694073600&end=1694073600&step=3600&timeout=10000
```