### PR TITLE
SWATCH-1751 Properly configure Event kafka consumer factory

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -189,7 +189,7 @@ public class TallyWorkerConfiguration {
   @Qualifier("serviceInstanceConsumerFactory")
   ConsumerFactory<String, String> serviceInstanceConsumerFactory(
       KafkaProperties kafkaProperties,
-      @Qualifier("tallyTaskQueueProperties") TaskQueueProperties taskQueueProperties) {
+      @Qualifier("serviceInstanceTopicProperties") TaskQueueProperties taskQueueProperties) {
     var props = kafkaProperties.buildConsumerProperties();
     props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, taskQueueProperties.getMaxPollRecords());
     return new DefaultKafkaConsumerFactory<>(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/TaskQueueProperties.java
@@ -40,5 +40,5 @@ public class TaskQueueProperties {
   private boolean enabled = true;
 
   /** Batch size number of records * */
-  private String maxPollRecords = "15";
+  private String maxPollRecords = "500";
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1751](https://issues.redhat.com/browse/SWATCH-1751)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
The wrong qualifier name was being used and the default value (15) for max poll records was getting applied instead of the configured value (500).

I also changed the default value in the configuration class to be 500 since that's the kafka default.

## Testing
To test, we need to send a lot of Event messages to the topic all at once and verify that batching happens correctly. The attached python script can help with this.

### Setup
<!-- Add any steps required to set up the test case -->
1. Download the attached python script and rename to push-events.py
[push-events.py.txt](https://github.com/RedHatInsights/rhsm-subscriptions/files/12685043/push-events.py.txt)

1. Install the python kafka library. 
```
python -m pip install kafka-python --user
```

### Steps
#### Reproduce
1. Make sure that the app is NOT running.
1. Push 1000 event messages to kafka
```
python push-events.py 1000
```
3. Start the application and watch the logs to see what the incoming events are being batched at.
```
SPRING_PROFILES_ACTIVE=api,worker,kafka-task-queue CONTRACT_USE_STUB=true DEV_MODE=true ./gradlew :bootRun
```
4. The default as set in the application-worker.yaml for this topic's consumer is 500. You should see a max batch size of 15.

**NOTE:** The timing of events being received by the broker affect the batch size, so you may see that we don't always process the max batch size.
```
[org.candlepin.subscriptions.tally.billing.ServiceInstanceMessageConsumer] - Events received w/ event list size=15. Consuming events.
```



### Verification
1. Update the application-worker.yaml file to set the max-poll-records property to 250
```
  service-instance-ingress:
    incoming:
      ...
      max-poll-records: ${SERVICE_INSTANCE_INGRESS_KAFKA_MAX_POLL_RECORDS:250}
```
2. `python push-events.py 1000`
3. Run the app and watch the log to ensure a batch size of 250.

```
[org.candlepin.subscriptions.tally.billing.ServiceInstanceMessageConsumer] - Events received w/ event list size=250. Consuming events.
```


**NOTE:** The timing of events being received by the broker affect the batch size, so you may see that we don't always process the max batch size.
