### PR TITLE
SWATCH-1717 & SWATCH-1718: Create metering-rhel and metering-rhel-job profiles, and define ClowdApps

### DIFF
--- a/bin/validate-topics.py
+++ b/bin/validate-topics.py
@@ -34,6 +34,12 @@ class TopicReference:
     def __repr__(self):
         return f"{self.topic} clowdapp={self.clowdapp_template} properties={self.properties_path}"
 
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    def __hash__(self):
+        return hash(str(self))
+
 
 def find_clowdapp_templates():
     templates = []

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/MeteringJobProfile.java
@@ -39,7 +39,7 @@ import org.springframework.retry.support.RetryTemplateBuilder;
 
 /** Defines the beans for the metering-job profile. */
 @Configuration
-@Profile("metering-job")
+@Profile({"metering-job", "metrics-rhel-job"})
 @Import({
   PrometheusServiceConfiguration.class,
   MeteringTasksConfiguration.class,

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -60,7 +60,7 @@ import org.springframework.retry.support.RetryTemplate;
 /** Defines the beans for the openshift-metering-worker profile. */
 @EnableRetry
 @Configuration
-@Profile("openshift-metering-worker")
+@Profile({"openshift-metering-worker", "metrics-rhel"})
 @Import({
   PrometheusServiceConfiguration.class,
   TaskConsumerConfiguration.class,

--- a/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/task/MeteringTasksConfiguration.java
@@ -82,14 +82,14 @@ public class MeteringTasksConfiguration {
   // separation of producer/consumers in profiles (if required).
   @Bean
   @Qualifier("prometheusTaskFactory")
-  @Profile("openshift-metering-worker")
+  @Profile({"openshift-metering-worker", "metrics-rhel"})
   TaskFactory meteringTaskFactory(PrometheusMeteringController controller) {
     return new PrometheusMeteringTaskFactory(controller);
   }
 
   @Bean
   @Qualifier("openshiftMeteringTaskConsumer")
-  @Profile("openshift-metering-worker")
+  @Profile({"openshift-metering-worker", "metrics-rhel"})
   public TaskConsumer meteringTaskProcessor(
       @Qualifier("meteringTaskQueueProperties") TaskQueueProperties taskQueueProperties,
       TaskConsumerFactory<? extends TaskConsumer> taskConsumerFactory,

--- a/src/main/resources/application-metering-job.yaml
+++ b/src/main/resources/application-metering-job.yaml
@@ -11,6 +11,6 @@ rhsm-subscriptions:
         jobMaxAttempts: ${METERING_JOB_MAX_ATTEMPTS:3}
         jobBackOffMaxInterval: ${METERING_JOB_BACK_OFF_MAX_INTERVAL:50000}
         jobBackOffInitialInterval: ${METERING_JOB_BACK_OFF_INITIAL_INTERVAL:1000}
-        jobBackOffMultiplier: ${METERING_JOB_BACK_OFF_MULTIPLIER:1.5}
+        backOffMultiplier: ${METERING_JOB_BACK_OFF_MULTIPLIER:1.5}
     tasks:
       topic: ${METERING_TASK_TOPIC}

--- a/src/main/resources/application-metrics-rhel-job.yaml
+++ b/src/main/resources/application-metrics-rhel-job.yaml
@@ -1,0 +1,14 @@
+METERING_RHEL_TASK_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.metering-rhel-tasks')].name:platform.rhsm-subscriptions.metering-rhel-tasks}
+
+rhsm-subscriptions:
+  account-batch-size: 1
+  metering:
+    prometheus:
+      metric:
+        rangeInMinutes: ${METRICS_RHEL_METERING_RANGE:60}
+        jobMaxAttempts: 3
+        jobBackOffMaxInterval: 50000
+        jobBackOffInitialInterval: 1000
+        backOffMultiplier: 1.5
+    tasks:
+      topic: ${METERING_RHEL_TASK_TOPIC}

--- a/src/main/resources/application-metrics-rhel.yaml
+++ b/src/main/resources/application-metrics-rhel.yaml
@@ -1,0 +1,33 @@
+METERING_RHEL_TASK_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.metering-rhel-tasks')].name:platform.rhsm-subscriptions.metering-rhel-tasks}
+SERVICE_INSTANCE_INGRESS_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.service-instance-ingress')].name:platform.rhsm-subscriptions.service-instance-ingress}
+
+rhsm-subscriptions:
+  account-batch-size: 1
+
+  metering:
+    prometheus:
+      metric:
+        queryTemplates:
+          default: >-
+            #{metric.prometheus.queryParams[metric]}
+            * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
+            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+          addonSamples: >-
+            #{metric.prometheus.queryParams[metric]}
+            * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
+            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+        maxAttempts: 50
+        backOffMaxInterval: 50000
+        backOffInitialInterval: 1000
+        backOffMultiplier: 1.5
+    tasks:
+      topic: ${METERING_RHEL_TASK_TOPIC}
+      kafka-group-id: swatch-metrics-rhel
+      seek-override-end: ${METRICS_RHEL_KAFKA_SEEK_OVERRIDE_END:false}
+      seek-override-timestamp: ${METRICS_RHEL_KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+    events:
+      topic: ${SERVICE_INSTANCE_INGRESS_TOPIC}
+      kafka-group-id: swatch-instance-ingress
+      seek-override-end: false
+      seek-override-timestamp:
+      max-poll-records: 500

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -692,6 +692,8 @@ objects:
                 value: ${DATABASE_CONNECTION_TIMEOUT_MS}
               - name: DATABASE_MAX_POOL_SIZE
                 value: ${DATABASE_MAX_POOL_SIZE}
+              - name: EVENT_SOURCE
+                value: 'rhelemeter'
               - name: PROM_URL
                 value: ${PROM_URL}
               - name: OPENSHIFT_BILLING_MODEL_FILTER

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -11,6 +11,8 @@ parameters:
     value: env-swatch-metrics
   - name: REPLICAS
     value: '1'
+  - name: METRICS_RHEL_REPLICAS
+    value: '1'
   - name: IMAGE
     value: quay.io/cloudservices/rhsm-subscriptions
   - name: IMAGE_TAG
@@ -28,6 +30,14 @@ parameters:
   - name: CPU_REQUEST
     value: 350m
   - name: CPU_LIMIT
+    value: 1500m
+  - name: METRICS_RHEL_MEMORY_REQUEST
+    value: 1000Mi
+  - name: METRICS_RHEL_MEMORY_LIMIT
+    value: 1400Mi
+  - name: METRICS_RHEL_CPU_REQUEST
+    value: 350m
+  - name: METRICS_RHEL_CPU_LIMIT
     value: 1500m
   - name: DEV_MODE
     value: 'false'
@@ -53,7 +63,11 @@ parameters:
     value: WARN
   - name: LOGGING_LEVEL
     value: INFO
+  - name: METRICS_RHEL_LOGGING_LEVEL
+    value: INFO
   - name: METRICS_CRON_LOGGING_LEVEL
+    value: INFO
+  - name: METRICS_RHEL_JOB_LOGGING_LEVEL
     value: INFO
   - name: KAFKA_MESSAGE_THREADS
     value: '24'
@@ -61,7 +75,11 @@ parameters:
     value: '3600000'
   - name: KAFKA_SEEK_OVERRIDE_END
     value: 'false'
+  - name: METRICS_RHEL_KAFKA_SEEK_OVERRIDE_END
+    value: 'false'
   - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
+    value: ''
+  - name: METRICS_RHEL_KAFKA_SEEK_OVERRIDE_TIMESTAMP
     value: ''
   - name: PROM_URL
     value: http://localhost:8082
@@ -89,6 +107,8 @@ parameters:
     value: '2'
   - name: METERING_SCHEDULE
     value: '30 * * * *'
+  - name: RHEL_METERING_SCHEDULE
+    value: '30 * * * *'
   - name: PURGE_EVENTS_SCHEDULE
     value: '30 4 * * *'
   - name: EVENT_RECORD_RETENTION
@@ -96,6 +116,8 @@ parameters:
   - name: OPENSHIFT_METERING_RANGE
     value: '60'
   - name: HOURLY_TALLY_OFFSET
+    value: '60'
+  - name: METRICS_RHEL_METERING_RANGE
     value: '60'
 # nonprod secret keys have different syntax than prod/stage
   - name: INVENTORY_SECRET_KEY_NAME
@@ -118,7 +140,6 @@ parameters:
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
-
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
@@ -126,8 +147,7 @@ objects:
       name: swatch-metrics
       labels:
         prometheus: rhsm
-    spec:
-      # The name of the ClowdEnvironment providing the services
+    spec: # The name of the ClowdEnvironment providing the services
       envName: ${ENV_NAME}
 
       database:
@@ -530,8 +550,346 @@ objects:
             limits:
               cpu: ${CURL_CRON_CPU_LIMIT}
               memory: ${CURL_CRON_MEMORY_LIMIT}
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    metadata:
+      name: swatch-metrics-rhel
+      labels:
+        prometheus: rhsm
+    spec:
+      envName: ${ENV_NAME}
+      database:
+        sharedDbAppName: swatch-tally
+      dependencies:
+        - swatch-tally
 
+      kafkaTopics:
+        - replicas: ${{KAFKA_METERING_TASKS_REPLICAS}}
+          partitions: ${{KAFKA_METERING_TASKS_PARTITIONS}}
+          topicName: platform.rhsm-subscriptions.metering-rhel-tasks
+        - replicas: ${{KAFKA_SERVICE_INSTANCE_REPLICAS}}
+          partitions: ${{KAFKA_SERVICE_INSTANCE_PARTITIONS}}
+          topicName: platform.rhsm-subscriptions.service-instance-ingress
 
+      pullSecrets:
+        name: ${IMAGE_PULL_SECRET}
+      deployments:
+        - name: service
+          webServices:
+            public:
+              enabled: true
+            metrics:
+              enabled: true
+          replicas: ${{METRICS_RHEL_REPLICAS}}
+          podSpec:
+            metadata:
+              annotations:
+                ignore-check.kube-linter.io/no-liveness-probe: The token refresher sidecar container doesn't have a liveness probe instrumented but the service container does
+                ignore-check.kube-linter.io/no-readiness-probe: The token refresher sidecar container doesn't have a readiness probe instrumented but the service container does
+            image: ${IMAGE}:${IMAGE_TAG}
+            command:
+            sidecars:
+              - name: token-refresher
+                enabled: true
+            initContainers:
+              - env:
+                  - name: JAVA_DEBUG
+                    value: ${JAVA_DEBUG}
+                  - name: SPRING_PROFILES_ACTIVE
+                    value: liquibase-only
+                inheritEnv: true
+                resources:
+                  requests:
+                    cpu: ${METRICS_RHEL_CPU_REQUEST}
+                    memory: ${METRICS_RHEL_MEMORY_REQUEST}
+                  limits:
+                    cpu: ${METRICS_RHEL_CPU_LIMIT}
+                    memory: ${METRICS_RHEL_MEMORY_LIMIT}
+            env:
+              - name: JAVA_DEBUG
+                value: ${JAVA_DEBUG}
+              - name: SPRING_LIQUIBASE_ENABLED
+                value: 'false'
+              - name: ENABLE_SPLUNK_HEC
+                value: ${ENABLE_SPLUNK_HEC}
+              - name: SPLUNKMETA_namespace
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: SPLUNKMETA_host
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+              - name: SPLUNK_HEC_URL
+                value: ${SPLUNK_HEC_URL}
+              - name: SPLUNK_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: SPLUNK_SOURCE
+                value: ${SPLUNK_SOURCE}
+              - name: SPLUNK_SOURCE_TYPE
+                value: ${SPLUNK_SOURCE_TYPE}
+              - name: SPLUNK_MESSAGE_FORMAT
+                value: ${SPLUNK_MESSAGE_FORMAT}
+              - name: SPLUNK_HEC_CONNECT_TIMEOUT
+                value: ${SPLUNK_HEC_CONNECT_TIMEOUT}
+              - name: SPLUNK_HEC_BATCH_SIZE
+                value: ${SPLUNK_HEC_BATCH_SIZE}
+              - name: SPLUNK_HEC_TERMINATION_TIMEOUT
+                value: ${SPLUNK_HEC_TERMINATION_TIMEOUT}
+              - name: SPRING_PROFILES_ACTIVE
+                value: metrics-rhel,kafka-queue
+              - name: SERVER_MAX_HTTP_HEADER_SIZE
+                value: ${SERVER_MAX_HTTP_HEADER_SIZE}
+              - name: LOG_FILE
+                value: /logs/server.log
+              - name: JAVA_MAX_MEM_RATIO
+                value: '85'
+              - name: GC_MAX_METASPACE_SIZE
+                value: '256'
+              - name: LOGGING_LEVEL_ROOT
+                value: ${LOGGING_LEVEL_ROOT}
+              - name: LOGGING_LEVEL_ORG_CANDLEPIN
+                value: ${METRICS_RHEL_LOGGING_LEVEL}
+              - name: KAFKA_MESSAGE_THREADS
+                value: ${KAFKA_MESSAGE_THREADS}
+              - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
+                value: ${KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS}
+              - name: METRICS_RHEL_KAFKA_SEEK_OVERRIDE_END
+                value: ${METRICS_RHEL_KAFKA_SEEK_OVERRIDE_END}
+              - name: METRICS_RHEL_KAFKA_SEEK_OVERRIDE_TIMESTAMP
+                value: ${METRICS_RHEL_KAFKA_SEEK_OVERRIDE_TIMESTAMP}
+              - name: DATABASE_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.host
+              - name: DATABASE_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.port
+              - name: DATABASE_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.user
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.password
+              - name: DATABASE_DATABASE
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.name
+              - name: DATABASE_CONNECTION_TIMEOUT_MS
+                value: ${DATABASE_CONNECTION_TIMEOUT_MS}
+              - name: DATABASE_MAX_POOL_SIZE
+                value: ${DATABASE_MAX_POOL_SIZE}
+              - name: PROM_URL
+                value: ${PROM_URL}
+              - name: OPENSHIFT_BILLING_MODEL_FILTER
+                value: ${OPENSHIFT_BILLING_MODEL_FILTER}
+              - name: USER_HOST
+                value: ${USER_HOST}
+              - name: USER_MAX_CONNECTIONS
+                value: ${USER_MAX_CONNECTIONS}
+              - name: USER_MAX_ATTEMPTS
+                value: ${USER_MAX_ATTEMPTS}
+              - name: USER_BACK_OFF_MAX_INTERVAL
+                value: ${USER_BACK_OFF_MAX_INTERVAL}
+              - name: USER_BACK_OFF_INITIAL_INTERVAL
+                value: ${USER_BACK_OFF_INITIAL_INTERVAL}
+              - name: USER_BACK_OFF_MULTIPLIER
+                value: ${USER_BACK_OFF_MULTIPLIER}
+              - name: RHSM_KEYSTORE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: tls
+                    key: keystore_password
+              - name: RHSM_KEYSTORE
+                value: /pinhead/keystore.jks
+              - name: DEV_MODE
+                value: ${DEV_MODE}
+              - name: SWATCH_SELF_PSK
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-psks
+                    key: self
+              - name: ENABLE_SYNCHRONOUS_OPERATIONS
+                value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: OTEL_SERVICE_NAME
+                value: swatch-metrics-rhel
+              - name: OTEL_JAVAAGENT_ENABLED
+                value: ${OTEL_JAVAAGENT_ENABLED}
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /health/liveness
+                port: 9000
+                scheme: HTTP
+              initialDelaySeconds: 15
+              periodSeconds: 20
+              successThreshold: 1
+              timeoutSeconds: 5
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /health
+                port: 9000
+                scheme: HTTP
+              initialDelaySeconds: 15
+              periodSeconds: 20
+              successThreshold: 1
+              timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: ${METRICS_RHEL_CPU_REQUEST}
+                memory: ${METRICS_RHEL_MEMORY_REQUEST}
+              limits:
+                cpu: ${METRICS_RHEL_CPU_LIMIT}
+                memory: ${METRICS_RHEL_MEMORY_LIMIT}
+            volumeMounts:
+              - name: logs
+                mountPath: /logs
+              - name: pinhead
+                mountPath: /pinhead
+            volumes:
+              - name: logs
+                emptyDir:
+              - name: pinhead
+                secret:
+                  secretName: pinhead
+
+      jobs:
+        - name: sync
+          schedule: ${RHEL_METERING_SCHEDULE}
+          activeDeadlineSeconds: 1800
+          successfulJobsHistoryLimit: 2
+          restartPolicy: Never
+          podSpec:
+            image: ${IMAGE}:${IMAGE_TAG}
+            initContainers:
+              - env:
+                  - name: JAVA_DEBUG
+                    value: ${JAVA_DEBUG}
+                  - name: SPRING_PROFILES_ACTIVE
+                    value: liquibase-only
+                inheritEnv: true
+                resources:
+                  requests:
+                    cpu: ${METRICS_RHEL_CPU_REQUEST}
+                    memory: ${METRICS_RHEL_MEMORY_REQUEST}
+                  limits:
+                    cpu: ${METRICS_RHEL_CPU_LIMIT}
+                    memory: ${METRICS_RHEL_MEMORY_LIMIT}
+            env:
+              - name: JAVA_DEBUG
+                value: ${JAVA_DEBUG}
+              - name: ENABLE_SPLUNK_HEC
+                value: ${ENABLE_SPLUNK_HEC}
+              - name: SPLUNKMETA_namespace
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: SPLUNKMETA_host
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+              - name: SPLUNK_HEC_URL
+                value: ${SPLUNK_HEC_URL}
+              - name: SPLUNK_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: SPLUNK_SOURCE
+                value: ${SPLUNK_SOURCE}
+              - name: SPLUNK_SOURCE_TYPE
+                value: ${SPLUNK_SOURCE_TYPE}
+              - name: SPLUNK_MESSAGE_FORMAT
+                value: ${SPLUNK_MESSAGE_FORMAT}
+              - name: SPLUNK_HEC_CONNECT_TIMEOUT
+                value: ${SPLUNK_HEC_CONNECT_TIMEOUT}
+              - name: SPLUNK_HEC_BATCH_SIZE
+                value: ${SPLUNK_HEC_BATCH_SIZE}
+              - name: SPLUNK_HEC_TERMINATION_TIMEOUT
+                value: ${SPLUNK_HEC_TERMINATION_TIMEOUT}
+              - name: SPRING_PROFILES_ACTIVE
+                value: metrics-rhel-job,kafka-queue
+              - name: JAVA_MAX_MEM_RATIO
+                value: '85'
+              - name: GC_MAX_METASPACE_SIZE
+                value: '256'
+              - name: LOG_FILE
+                value: /logs/server.log
+              - name: LOGGING_LEVEL_ROOT
+                value: ${LOGGING_LEVEL_ROOT}
+              - name: LOGGING_LEVEL_ORG_CANDLEPIN
+                value: ${METRICS_RHEL_JOB_LOGGING_LEVEL}
+              - name: METRICS_RHEL_METERING_RANGE
+                value: ${METRICS_RHEL_METERING_RANGE}
+              - name: HOURLY_TALLY_OFFSET
+                value: ${HOURLY_TALLY_OFFSET}
+              - name: DATABASE_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.host
+              - name: DATABASE_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.port
+              - name: DATABASE_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.user
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.password
+              - name: DATABASE_DATABASE
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-db
+                    key: db.name
+              - name: PROM_URL
+                value: ${PROM_URL}
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: OTEL_SERVICE_NAME
+                value: swatch-metrics-rhel-job
+              - name: OTEL_JAVAAGENT_ENABLED
+                value: ${OTEL_JAVAAGENT_ENABLED}
+            resources:
+              requests:
+                cpu: ${METRICS_RHEL_CPU_REQUEST}
+                memory: ${METRICS_RHEL_MEMORY_REQUEST}
+              limits:
+                cpu: ${METRICS_RHEL_CPU_LIMIT}
+                memory: ${METRICS_RHEL_MEMORY_LIMIT}
+            volumeMounts:
+              - name: logs
+                mountPath: /logs
+            volumes:
+              - name: logs
+                emptyDir:
+            sidecars:
+              - name: token-refresher
+                enabled: true
   - apiVersion: v1
     kind: Secret
     metadata:


### PR DESCRIPTION
Jira issue: [SWATCH-1718](https://issues.redhat.com/browse/SWATCH-1718)

## Description

Defining a new ClowdApp to deploy another instance of swatch-metrics, named swatch-metrics-rhel, that connects to RHEL telemeter instance instead of openshift telemeter instance.  There is no need for a separate purge events job, so I omitted it from the swatch-metrics-rhel definition.

This includes creating separate profiles.  This is necessary to allow each deployment to bind to its dedicated kafka topic, and enable the deployments to scale independently.

The part that "points" to the rhel telemeter instance is actually environment variables on the token-refresher sidecar.  These environment variables are set via vault secrets.

## Testing

What we're looking to verify here is that the `swatch-metrics-rhel-*` pods deploy, start up using the appropriate spring profile, connect to the appropriate topic, and the token refresher container uses the swatch-metrics-rhel secret.

The only other thing we can try for verification is hitting the internal endpoint for metrics sync and confirm there are no http errors in the log.  Until there is a product configured in swatch that has data available regularly available in rhel telemeter, we won't actually be able to see swatch consume anything and save it to the database.


## checkout this branch
```bash
git checkout lburnett/metering-rhel-profiles
```

## reserve namespace & enable token refresher sidecar

```bash
export NAMESPACE=$(bonfire namespace reserve -f)

```

```
oc patch env env-$NAMESPACE -p '{"spec":{"providers":{"sidecars":{"tokenRefresher":{"enabled":true}}}}}' --type=merge
```

## deploy swatch-metrics component to namespace

Note about terminology:  "swatch-metrics" is still the name of the component, as defined by our resourceTemplate entry in app-interface.  Up until this point, our clowdapps & components were 1 to 1 in regards to naming.  Now, our "swatch-metrics" component contains two clowdapps - swatch-metrics and swatch-metrics-rhel.  Eventually (out of scope), the swatch-metrics components will be named "swatch-metrics-openshift" and "swatch-metrics-rhel".

This command assumes that the PR has already built and pushed a image to quay for this githash.

```bash
VER=$(git rev-parse --short=7 HEAD); bonfire deploy -n $NAMESPACE rhsm --optional-deps-method=none \
-C swatch-metrics \
-C swatch-tally \
--no-remove-resources=all \
--no-release-on-fail \
-i quay.io/cloudservices/rhsm-subscriptions=pr-2557-$VER \
-p swatch-metrics/IMAGE=quay.io/cloudservices/rhsm-subscriptions \
-p swatch-tally/IMAGE=quay.io/cloudservices/rhsm-subscriptions
```


## verification

EE have the following pods deployed successfully:

* swatch-metrics-service
* swatch-metrics-sync
* swatch-metrics-purge-events
* swatch-metrics-rhel-service
* swatch-metrics-rhel-sync

What we're looking for in each pod

**swatch-metrics-service**
* has a token refresher container.  its environment variables list `swatch-metrics-token-refresher` secrets still
* application logs say `The following 2 profiles are active: "openshift-metering-worker", "kafka-queue"`
* application log says `Initializing metering manager. Topic: platform.rhsm-subscriptions.metering-tasks`

**swatch-metrics-sync**
tip: if there isn't a pod yet (because scheduling), you can make one manually with 
`oc create job --from=cronjob/swatch-metrics-sync swatch-metrics-sync-manual`

* application log says `The following 2 profiles are active: "metering-job", "kafka-queue"`
* application log says `Initializing metering manager. Topic: platform.rhsm-subscriptions.metering-tasks`
* no http errors in application log

**swatch-metrics-rhel-service**
* has a token refresher container.  its environment variables list `swatch-metrics-rhel-token-refresher` secrets
* application logs say `The following 2 profiles are active: "metrics-rhel", "kafka-queue"`
* application logs say `Initializing metering manager. Topic: platform.rhsm-subscriptions.metering-rhel-tasks`


**swatch-metrics-rhel-sync**
tip: if there isn't a pod yet (because scheduling), you can make one manually with 
`oc create job --from=cronjob/swatch-metrics-rhel-sync swatch-metrics-rhel-sync-manual`

* application logs say `The following 2 profiles are active: "metrics-rhel-job", "kafka-queue"`
* application logs say `Initializing metering manager. Topic: platform.rhsm-subscriptions.metering-rhel-tasks`
* no http errors in logs
