### PR TITLE
Fix MetridId comparisons in RHM and Billing Unit

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.rhmarketplace;
 import com.redhat.swatch.clients.internal.subscriptions.api.client.ApiException;
 import com.redhat.swatch.clients.internal.subscriptions.api.model.RhmUsageContext;
 import com.redhat.swatch.clients.internal.subscriptions.api.resources.InternalSubscriptionsApi;
+import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -175,7 +176,8 @@ public class RhMarketplacePayloadMapper {
   protected UsageMeasurement produceUsageMeasurement(BillableUsage billableUsage) {
 
     String rhmMarketplaceMetricId =
-        SubscriptionDefinition.getRhmMetricId(billableUsage.getProductId(), billableUsage.getUom());
+        SubscriptionDefinition.getRhmMetricId(
+            billableUsage.getProductId(), MetricId.fromString(billableUsage.getUom()).getValue());
 
     Double value = billableUsage.getValue();
 

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingUnit.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingUnit.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.tally.billing;
 
 import com.redhat.swatch.configuration.registry.Metric;
+import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.Variant;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -38,7 +39,10 @@ public class BillingUnit implements Unit {
     var metricOptional =
         Variant.findByTag(usage.getProductId())
             .map(Variant::getSubscription)
-            .flatMap(subscriptionDefinition -> subscriptionDefinition.getMetric(usage.getUom()));
+            .flatMap(
+                subscriptionDefinition ->
+                    subscriptionDefinition.getMetric(
+                        MetricId.fromString(usage.getUom()).getValue()));
     billingFactor =
         metricOptional
             .map(Metric::getBillingFactor)

--- a/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
@@ -99,7 +99,7 @@ class RhMarketplacePayloadMapperTest {
             .withProductId("OpenShift-metrics")
             .withSnapshotDate(snapshotDate)
             .withUsage(Usage.PRODUCTION)
-            .withUom(MetricIdUtils.getCores().getValue())
+            .withUom(MetricIdUtils.getCores().toUpperCaseFormatted())
             .withValue(36.0)
             .withSla(Sla.PREMIUM)
             .withBillingProvider(BillingProvider.RED_HAT)

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntityPK.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import com.redhat.swatch.configuration.registry.MetricId;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
@@ -73,7 +74,7 @@ public class BillableUsageRemittanceEntityPK implements Serializable {
         .billingAccountId(billableUsage.getBillingAccountId())
         .productId(billableUsage.getProductId())
         .sla(billableUsage.getSla().value())
-        .metricId(billableUsage.getUom())
+        .metricId(MetricId.fromString(billableUsage.getUom()).getValue())
         .accumulationPeriod(getAccumulationPeriod(billableUsage.getSnapshotDate()))
         .remittancePendingDate(remittancePendingDate)
         .build();


### PR DESCRIPTION
-MetricId on BillableUsage is all uppercase using hyphens. We need to reformat when doing comparisons to the original metricId values in product-config

## Testing
Regression

### Setup
1. Start the app with: `LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_RHMARKETPLACE=DEBUG  DEV_MODE=true ./gradlew clean :bootRun`
2. Insert Mock data:
```
$ psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "INSERT INTO public.subscription(
        sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id)
        VALUES ('MW01882', 'org123', '12351253', '1', '2012-05-13 16:32:00+00', '2032-05-13 16:32:00+00', '1', 'account123', '1235153', 'red hat', '456');"

$ psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "INSERT INTO public.events (event_id, account_number, timestamp, data, event_type, event_source, instance_id, org_id) VALUES ('3ee2aec5-9a48-424b-9667-e6d3287557d4', 'account123', '2021-10-18 20:00:00.000000 +00:00', '{\"sla\": \"Premium\", \"role\": \"rhosak\", \"org_id\": \"org123\", \"event_id\": \"3ee2aec5-9a48-424b-9667-e6d3287557d4\", \"timestamp\": \"2021-10-18T20:00:00Z\", \"event_type\": \"snapshot_redhat.com:rhosak:storage_gb\", \"expiration\": \"2021-10-19T20:00:00Z\", \"instance_id\": \"c5mu16smf1c22rn8e730\", \"display_name\": \"c5mu16smf1c22rn8e730\", \"event_source\": \"prometheus\", \"measurements\": [{\"uom\": \"Storage-gibibytes\", \"value\": 0.5}], \"service_type\": \"Kafka Cluster\", \"account_number\": \"account123\", \"billing_provider\": \"red hat\", \"billing_account_id\": \"dummyId\"}', 'snapshot_redhat.com:rhosak:storage_gb', 'prometheus', 'c5mu16smf1c22rn8e730', 'org123');"
```

### Verification
1.  Run the   `http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=org123&start=2021-10-01T00:00Z&end=2021-11-01T00:00Z" x-rh-swatch-psk:placeholder`
In the logs with debug enabled, you will see 

```
UsageRequest class UsageRequest {
    data: [class UsageEvent {
        start: 1634587200000
        end: 1634590800000
        subscriptionId: 1
        eventId: abcf2358-8a7e-4f0a-8a8c-e2d78e58c18c
        additionalAttributes: {}
        measuredUsage: [class UsageMeasurement {
            chargeId: null
            metricId: redhat.com:rhosak:storage_gb
            value: 1.0
        }]
    }]
```   


