### PR TITLE
SWATCH-382-followup: Incorporate coverage for transitive dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ spec:
                 // The build task includes check, test, and assemble.  Linting happens during the check
                 // task and uses the spotless gradle plugin.
                 echo "The ci value is ${env.CI}"
-                sh "./gradlew --no-daemon build jacocoTestReport"
+                sh "./gradlew --no-daemon build testCodeCoverageReport"
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ plugins {
     id "org.sonarqube"
     id "com.netflix.nebula.release"
     id 'swatch.liquibase-conventions'
+    id 'jacoco-report-aggregation'
+    id 'jvm-test-suite'
 }
 
 configurations {
@@ -73,6 +75,13 @@ dependencies {
     runtimeOnly "org.hsqldb:hsqldb"
 
     javaagent  libraries["splunk-otel-agent"]
+
+    subprojects.findAll { !Set.of(
+            project(':clients'),
+            project(':clients:quarkus')
+    ).contains(it)}.each {
+        jacocoAggregation it
+    }
 }
 
 allprojects {
@@ -430,4 +439,12 @@ project(":api") {
 
     sourceSets.main.java.srcDirs += ["${buildDir}/generated/src/gen/java"]
     compileJava.dependsOn tasks.openApiGenerate
+}
+
+tasks.check.dependsOn tasks.testCodeCoverageReport
+
+sonarqube {
+    properties {
+        property "sonar.coverage.jacoco.xmlReportPaths", "${rootProject.projectDir}/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"
+    }
 }

--- a/buildSrc/src/main/groovy/swatch.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.java-conventions.gradle
@@ -77,6 +77,6 @@ tasks.withType(Jar).configureEach {
 
 jacocoTestReport {
     reports {
-        xml.required = true
+        xml.required = false
     }
 }

--- a/buildSrc/src/main/groovy/swatch.quarkus-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.quarkus-conventions.gradle
@@ -22,9 +22,3 @@ test {
     }
     jacocoTestReport.enabled = false
 }
-
-sonarqube {
-    properties {
-        property 'sonar.coverage.jacoco.xmlReportPaths', "${projectDir}/build/jacoco-report/jacoco.xml"
-    }
-}


### PR DESCRIPTION
Jira issue: [SWATCH-382](https://issues.redhat.com/browse/SWATCH-382)

## Description
This is a follow-up task of https://github.com/RedHatInsights/rhsm-subscriptions/pull/2533 that will fully address https://issues.redhat.com/browse/SWATCH-382. 

Here, we're configuring the `jacoco-report-aggregation` for a multi-module project. This way, the sub modules will aggregate all the report in a single report to then submit it to sonar. 

More information about the Jacoco Report Aggregation plugin: https://docs.gradle.org/current/userguide/jacoco_report_aggregation_plugin.html

With these changes, the code coverage increased to almost 70%:

![Captura de pantalla de 2023-09-26 16-29-25](https://github.com/RedHatInsights/rhsm-subscriptions/assets/6310047/e0d6f7e1-0291-48cb-9656-3b7d6a97d58f)

As you can see, some modules like `swatch-core` have up to 65% of code coverage. 

Something for the future: to exclude the swatch-core-test and swatch-common-testcontainers.



