### PR TITLE
SWATCH-1521 & SWATCH-1775: Configure Rhel for EUS For Swatch

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -497,10 +497,11 @@ public class MetricUsageCollector {
 
     var engIds = Optional.ofNullable(event.getProductIds()).orElse(Collections.emptyList());
     for (String engId : engIds) {
-      SubscriptionDefinition.lookupSubscriptionByEngId(engId)
-          .filter(SubscriptionDefinition::isPaygEligible)
-          .flatMap(s -> s.findVariantForEngId(engId).map(Variant::getTag))
-          .ifPresent(productIds::add);
+      productIds.addAll(
+          SubscriptionDefinition.lookupSubscriptionByEngId(engId).stream()
+              .filter(SubscriptionDefinition::isPaygEligible)
+              .flatMap(s -> s.findVariantForEngId(engId).map(Variant::getTag).stream())
+              .toList());
     }
 
     return productIds;

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -174,7 +174,8 @@ public class TallySnapshotController {
   private AccountUsageCalculation performTally(String orgId) {
     retryTemplate.execute(
         context -> {
-          usageCollector.reconcileSystemDataWithHbi(orgId, SubscriptionDefinition.getAllTags());
+          usageCollector.reconcileSystemDataWithHbi(
+              orgId, SubscriptionDefinition.getAllNonPaygTags());
           return null;
         });
     return usageCollector.tally(orgId);

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -24,6 +24,7 @@ import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -245,10 +246,13 @@ public class FactNormalizer {
 
     for (String productId : productIds) {
       try {
-        var subscription = SubscriptionDefinition.lookupSubscriptionByEngId(productId);
-        if (subscription.isPresent()) {
-          var variant = subscription.get().findVariantForEngId(productId);
-          variant.ifPresent(v -> normalizedFacts.getProducts().add(v.getTag()));
+        var subscriptions = SubscriptionDefinition.lookupSubscriptionByEngId(productId);
+        if (Objects.nonNull(subscriptions)) {
+          subscriptions.forEach(
+              subscriptionDefinition ->
+                  subscriptionDefinition
+                      .findVariantForEngId(productId)
+                      .ifPresent(v -> normalizedFacts.getProducts().add(v.getTag())));
         }
       } catch (NumberFormatException e) {
         log.debug("Skipping non-numeric productId: {}", productId);

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -165,8 +165,9 @@ public class SubscriptionDefinition {
             });
   }
 
-  public static Set<String> getAllTags() {
+  public static Set<String> getAllNonPaygTags() {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
+        .filter(subscriptionDefinition -> !subscriptionDefinition.isPaygEligible())
         .map(SubscriptionDefinition::getVariants)
         .flatMap(Collection::stream)
         .map(Variant::getTag)
@@ -180,14 +181,14 @@ public class SubscriptionDefinition {
    * @param engProductId
    * @return Optional<Subscription> subscription
    */
-  public static Optional<SubscriptionDefinition> lookupSubscriptionByEngId(String engProductId) {
+  public static Set<SubscriptionDefinition> lookupSubscriptionByEngId(String engProductId) {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
         .filter(subscription -> !subscription.getVariants().isEmpty())
         .filter(
             subscription ->
                 subscription.getVariants().stream()
                     .anyMatch(variant -> variant.getEngineeringIds().contains(engProductId)))
-        .collect(MoreCollectors.toOptional());
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   /**

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_EUS.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_EUS.yaml
@@ -1,0 +1,18 @@
+---
+platform: RHEL
+
+id: rhel-for-x86-eus
+# TODO: https://issues.redhat.com/browse/SWATCH-1692 keep this commented out until UI updates are in place.
+#includedSubscriptions:
+#  - rhel-for-x86
+
+variants:
+  - tag: rhel-for-x86-eus
+    engineeringIds:
+      - 70 # Red Hat Enterprise Linux For EUS
+
+defaults:
+  variant: rhel-for-x86-eus
+
+metrics:
+  - id: Sockets

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
@@ -46,7 +46,7 @@ class SubscriptionDefinitionRegistryTest {
   void testLoadAllTheThings() {
 
     var actual = subscriptionDefinitionRegistry.getSubscriptions().size();
-    var expected = 16;
+    var expected = 17;
 
     assertEquals(expected, actual);
   }

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
@@ -198,9 +198,9 @@ class SubscriptionDefinitionTest {
     var satelliteCapsule = SubscriptionDefinition.lookupSubscriptionByEngId("269");
 
     var expected = "satellite-capsule";
-    var actual = satelliteCapsule.orElseThrow().getId();
-
-    assertEquals(expected, actual);
+    var actual = satelliteCapsule.stream().findFirst();
+    actual.ifPresent(
+        subscriptionDefinition -> assertEquals(expected, subscriptionDefinition.getId()));
   }
 
   @Test
@@ -208,9 +208,10 @@ class SubscriptionDefinitionTest {
     var rhelForX86 = SubscriptionDefinition.lookupSubscriptionByEngId("76");
 
     var expected = "rhel-for-x86";
-    var actual = rhelForX86.orElseThrow().getId();
+    var actual = rhelForX86.stream().findFirst();
 
-    assertEquals(expected, actual);
+    actual.ifPresent(
+        subscriptionDefinition -> assertEquals(expected, subscriptionDefinition.getId()));
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1521](https://issues.redhat.com/browse/SWATCH-1521) & Jira issue: [SWATCH-1775](https://issues.redhat.com/browse/SWATCH-1775)
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This is to configure `Rhel for x86 EUS` for traditional subscriptions so it may be queried . Effectively, anywhere you can query/interact with `RHEL for x86`. 
Since the eng ids are same i.e `70` for `Rhel for x86 EUS Payg` and `non-payg` we want to make sure the correct product gets pulled when we do hourly tally and nightly tally. Hence there are two instructions one for nightly tally shouldn't pull payg products and other hourly tally should pull payg products.

## Testing instructions for nightly tally.
<!--
When possible, please use commands a developer can directly paste or modify
-->
1. Add host to Insight DB:
```
INSERT INTO public.hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id) VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "70"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123');

```
2. Run nightly Tally using command below:
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
Observe that Tables in `TallySnapsots`, `Host_Tally_Bucket` & `Instance_measurements` has the configured value: `RHEL for x86 EUS` and it configured MetricId : `SOCKETS`

## Testing instructions for Hourly tally- The steps will be same as [PR SWATCH-1690](https://github.com/RedHatInsights/rhsm-subscriptions/pull/2560)
1. Insert an event manually in Events table. You can follow some steps in SWATCH-1547 to create events using Kafka.
`INSERT INTO public.events (event_id, account_number, timestamp, data, event_type, event_source, instance_id, org_id,  metering_batch_id, record_date) VALUES ('16893602-d1f9-414d-8bf6-a90154e844bf', '10001', '2023-09-01 08:00:00.000000 +00:00', '{"sla": "Self-Support", "role": "Red Hat Enterprise Linux Workstation", "usage": "Disaster Recovery", "org_id": "1234567", "event_id": "16893602-d1f9-414d-8bf6-a90154e844bf", "timestamp": "2023-09-01T08:00:00Z", "event_type": "Snapshot2", "expiration": "2023-08-01T08:00:00Z", "instance_id": "i-55555558", "product_ids": ["479", "70"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 3.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "account_number": "10001", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "9999999999999"}', 'Snapshot2', 'cost-management', 'i-55555558', '1234567', null, '2023-09-01 08:00:00.000000 +00:00');`

2. Insert a record manually in `Contracts` table and `Contract_metrics` table. If you don't do this then you won't be able to test sending usage to AWS. You also need a Subscription and Offering that are not available. In prod and stage a contract should come from API gateway in UMB message.
- `INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id, vendor_product_code) VALUES ('a3a5e8b7-6260-48f4-a9eb-63a584763ce8', '12914276', '2023-05-10 18:20:07.717275 +00:00', '2023-05-10 18:20:07.717275 +00:00', null, '1234567', 'MW02393', 'aws', '9999999999999', 'rhel-for-x86-eus-payg', 'bcwuzc8ww10vvxfair55mliy8');`

- `INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('a3a5e8b7-6260-48f4-a9eb-63a584763ce8', 'VCPUS', 10);`


### Steps
<!-- Enter each step of the test below -->
1.Run in separate terminals.
**Tally:**
`RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE_URL=http://localhost:8882 SERVER_PORT=8001 ./gradlew clean :bootRun
`

**Swatch-contract:**
`SERVER_PORT=8882 ./gradlew  :swatch-contracts:quarkusDev
`

**Swatch-aws-producer:**
`SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8001/api/rhsm-subscriptions/v1 ./gradlew swatch-producer-aws:quarkusDev
`

**Execute hourly tally:**
`http POST ":8001/api/rhsm-subscriptions/v1/internal/tally/hourly?org=1234567&start=2023-09-01T08:00Z&end=2023-09-01T09:00Z" x-rh-swatch-psk:placeholder
`
### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Logs:
- Successfully creates usage
```
2023-09-25 11:53:20,547 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Finished producing monthly billable for orgId=1234567 productId=rhel-for-x86-eus-payg uom=VCPUS provider=aws, snapshotDate=2023-09-01T08:00Z
2023-09-25 11:53:20,547 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillingProducer] - Sending billable usage org.candlepin.subscriptions.json.BillableUsage@7b5b059a[accountNumber=10001,orgId=1234567,id=d9e5484a-e52e-409b-bf0e-c0f7dec2837a,billingProvider=aws,billingAccountId=9999999999999,snapshotDate=2023-09-01T08:00Z,productId=rhel-for-x86-eus-payg,sla=Self-Support,usage=Disaster Recovery,uom=VCPUS,value=0.0,billingFactor=1.0,vendorProductCode=<null>] to topic platform.rhsm-subscriptions.billable-usage
```

- Since this is not for Rh-marketplace:
`2023-09-25 11:53:20,549 [thread=swatch-producer-rh-marketplace-0-C-1] [WARN ] [org.candlepin.subscriptions.rhmarketplace.RhMarketplacePayloadMapper] - Skipping invalid billable usage org.candlepin.subscriptions.json.BillableUsage@205146a0[accountNumber=10001,orgId=1234567,id=d9e5484a-e52e-409b-bf0e-c0f7dec2837a,billingProvider=aws,billingAccountId=9999999999999,snapshotDate=2023-09-01T08:00Z,productId=rhel-for-x86-eus-payg,sla=Self-Support,usage=Disaster Recovery,uom=VCPUS,value=0.0,billingFactor=1.0,vendorProductCode=<null>]`

- For AWS we have log messages as debug in code but, if we change the log level to DEBUG you should see other logs where it attempts to send usage but, fails because of no subscription and offering.

- No subscription and offering so will see this message.
`2023-09-25 11:53:20,930 [thread=http-nio-8001-exec-6] [ERROR] [org.candlepin.subscriptions.subscription.SubscriptionSyncController] self- No subscription found for account 10001 with criteria DbReportCriteria(accountNumber=null, orgId=1234567, productTag=null, productNames=[RHEL EUS COST PLACEHOLDER], productId=null, serviceLevel=SELF_SUPPORT, usage=_ANY, billingProvider=AWS, billingAccountId=9999999999999, payg=true, beginning=2023-09-01T07:00Z, ending=2023-09-01T08:00Z, metricId=null, hypervisorReportCategory=null)`
