### PR TITLE
Use different config key for disabling otel

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -169,10 +169,10 @@ FILTER_ORGS=
 quarkus.container-image.group=cloudservices
 
 # otel config
-quarkus.otel.enabled=false
-%ephemeral.quarkus.otel.enabled=false
-%stage.quarkus.otel.enabled=true
-%prod.quarkus.otel.enabled=true
+quarkus.otel.sdk.disabled=true
+%ephemeral.quarkus.otel.sdk.disabled=true
+%stage.quarkus.otel.sdk.disabled=false
+%prod.quarkus.otel.sdk.disabled=false
 
 quarkus.otel.exporter.otlp.endpoint=http://splunk-otel-collector:4317
 

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -110,9 +110,9 @@ quarkus.log.handler.splunk.include-exception=${SPLUNK_HEC_INCLUDE_EX:false}
 quarkus.container-image.group=cloudservices
 
 # otel config
-quarkus.otel.enabled=false
-%ephemeral.quarkus.otel.enabled=false
-%stage.quarkus.otel.enabled=true
-%prod.quarkus.otel.enabled=true
+quarkus.otel.sdk.disabled=true
+%ephemeral.quarkus.otel.sdk.disabled=true
+%stage.quarkus.otel.sdk.disabled=false
+%prod.quarkus.otel.sdk.disabled=false
 
 quarkus.otel.exporter.otlp.endpoint=http://splunk-otel-collector:4317


### PR DESCRIPTION
quarkus.otel.enabled is marked deprecated and fixed at build time

https://github.com/quarkusio/quarkus/blob/49c5fdbf1895d96924e33211d5234e39b3f2b7e2/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/OTelBuildConfig.java#L33

