### PR TITLE
SWATCH-1745: Make "event_source" configurable when saving to the events

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -50,7 +50,8 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class EventController {
 
-  private static final String PROMETHEUS = "prometheus";
+  private static final Set<String> EXCLUDE_LOG_FOR_EVENT_SOURCES =
+      Set.of("prometheus", "rhelemeter");
   private final EventRecordRepository repo;
   private final ObjectMapper objectMapper;
   private final OptInController optInController;
@@ -148,7 +149,7 @@ public class EventController {
         eventJson -> {
           try {
             BaseEvent baseEvent = objectMapper.readValue(eventJson, BaseEvent.class);
-            if (!PROMETHEUS.equals(baseEvent.getEventSource())) {
+            if (!EXCLUDE_LOG_FOR_EVENT_SOURCES.contains(baseEvent.getEventSource())) {
               log.info("Event processing in batch: " + baseEvent);
             }
 

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -20,8 +20,6 @@
  */
 package org.candlepin.subscriptions.event;
 
-import static org.candlepin.subscriptions.metering.MeteringEventFactory.EVENT_SOURCE;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
@@ -51,6 +49,8 @@ import org.springframework.util.StringUtils;
 @Service
 @Slf4j
 public class EventController {
+
+  private static final String PROMETHEUS = "prometheus";
   private final EventRecordRepository repo;
   private final ObjectMapper objectMapper;
   private final OptInController optInController;
@@ -148,7 +148,7 @@ public class EventController {
         eventJson -> {
           try {
             BaseEvent baseEvent = objectMapper.readValue(eventJson, BaseEvent.class);
-            if (!EVENT_SOURCE.equals(baseEvent.getEventSource())) {
+            if (!PROMETHEUS.equals(baseEvent.getEventSource())) {
               log.info("Event processing in batch: " + baseEvent);
             }
 

--- a/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/MeteringEventFactory.java
@@ -40,8 +40,6 @@ import org.springframework.util.StringUtils;
 public class MeteringEventFactory {
 
   private static final Logger log = LoggerFactory.getLogger(MeteringEventFactory.class);
-
-  public static final String EVENT_SOURCE = "prometheus";
   private static final String EVENT_TYPE = "snapshot";
 
   private MeteringEventFactory() {
@@ -70,6 +68,7 @@ public class MeteringEventFactory {
       String serviceLevel,
       String usage,
       String role,
+      String eventSource,
       OffsetDateTime measuredTime,
       OffsetDateTime expired,
       String serviceType,
@@ -88,6 +87,7 @@ public class MeteringEventFactory {
         serviceLevel,
         usage,
         role,
+        eventSource,
         measuredTime,
         expired,
         serviceType,
@@ -106,6 +106,7 @@ public class MeteringEventFactory {
    *
    * @param orgId the organization id.
    * @param eventType the event type.
+   * @param eventSource the event source.
    * @param start the start time window.
    * @param end the end time window.
    * @param meteringBatchId Metering batch ID that identifies which process generated the event.
@@ -114,12 +115,13 @@ public class MeteringEventFactory {
   public static CleanUpEvent createCleanUpEvent(
       String orgId,
       String eventType,
+      String eventSource,
       OffsetDateTime start,
       OffsetDateTime end,
       UUID meteringBatchId) {
     CleanUpEvent event = new CleanUpEvent();
     event.setOrgId(orgId);
-    event.setEventSource(MeteringEventFactory.EVENT_SOURCE);
+    event.setEventSource(eventSource);
     event.setEventType(eventType);
     event.setMeteringBatchId(meteringBatchId);
     event.setStart(start);
@@ -136,6 +138,7 @@ public class MeteringEventFactory {
       String serviceLevel,
       String usage,
       String role,
+      String eventSource,
       OffsetDateTime measuredTime,
       OffsetDateTime expired,
       String serviceType,
@@ -158,7 +161,7 @@ public class MeteringEventFactory {
         .withMeasurements(
             List.of(new Measurement().withUom(measuredMetric.getValue()).withValue(measuredValue)))
         .withRole(getRole(role, accountNumber, instanceId))
-        .withEventSource(EVENT_SOURCE)
+        .withEventSource(eventSource)
         .withEventType(MeteringEventFactory.getEventType(measuredMetric.getValue(), productTag))
         .withOrgId(orgId)
         .withInstanceId(instanceId)

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
@@ -85,6 +85,9 @@ public class MetricProperties {
   /** Retry backoff interval of the MeteringJob. */
   private Duration jobBackOffMaxInterval;
 
+  /** The event source type. */
+  private String eventSource;
+
   public Optional<String> getQueryTemplate(String templateKey) {
     return queryTemplates.containsKey(templateKey)
         ? Optional.of(queryTemplates.get(templateKey))

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringController.java
@@ -263,6 +263,7 @@ public class PrometheusMeteringController {
         createCleanUpEvent(
             orgId,
             MeteringEventFactory.getEventType(tagMetric.getId(), productTag),
+            metricProperties.getEventSource(),
             start,
             end,
             meteringBatchId));
@@ -304,6 +305,7 @@ public class PrometheusMeteringController {
         sla,
         usage,
         role,
+        metricProperties.getEventSource(),
         measuredDate,
         expired,
         serviceType,

--- a/src/main/resources/application-metering-job.yaml
+++ b/src/main/resources/application-metering-job.yaml
@@ -12,6 +12,5 @@ rhsm-subscriptions:
         jobBackOffMaxInterval: ${METERING_JOB_BACK_OFF_MAX_INTERVAL:50000}
         jobBackOffInitialInterval: ${METERING_JOB_BACK_OFF_INITIAL_INTERVAL:1000}
         backOffMultiplier: ${METERING_JOB_BACK_OFF_MULTIPLIER:1.5}
-        eventSource: ${EVENT_SOURCE}
     tasks:
       topic: ${METERING_TASK_TOPIC}

--- a/src/main/resources/application-metering-job.yaml
+++ b/src/main/resources/application-metering-job.yaml
@@ -12,5 +12,6 @@ rhsm-subscriptions:
         jobBackOffMaxInterval: ${METERING_JOB_BACK_OFF_MAX_INTERVAL:50000}
         jobBackOffInitialInterval: ${METERING_JOB_BACK_OFF_INITIAL_INTERVAL:1000}
         backOffMultiplier: ${METERING_JOB_BACK_OFF_MULTIPLIER:1.5}
+        eventSource: ${EVENT_SOURCE}
     tasks:
       topic: ${METERING_TASK_TOPIC}

--- a/src/main/resources/application-metrics-rhel.yaml
+++ b/src/main/resources/application-metrics-rhel.yaml
@@ -20,6 +20,7 @@ rhsm-subscriptions:
         backOffMaxInterval: 50000
         backOffInitialInterval: 1000
         backOffMultiplier: 1.5
+        eventSource: ${EVENT_SOURCE}
     tasks:
       topic: ${METERING_RHEL_TASK_TOPIC}
       kafka-group-id: swatch-metrics-rhel

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -21,6 +21,7 @@ rhsm-subscriptions:
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
         backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}
         backOffMultiplier: ${OPENSHIFT_BACK_OFF_MULTIPLIER:1.5}
+        eventSource: ${EVENT_SOURCE}
     tasks:
       topic: ${METERING_TASK_TOPIC}
       kafka-group-id: ${METERING_TASK_GROUP_ID:metering-task-processor}

--- a/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/MeteringEventFactoryTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.Test;
 
 class MeteringEventFactoryTest {
 
+  private static final String EVENT_SOURCE = "any";
+
   private final String productTag = "OpenShift-dedicated-metrics";
 
   @Test
@@ -64,6 +66,7 @@ class MeteringEventFactoryTest {
             sla,
             usage,
             role,
+            EVENT_SOURCE,
             measuredTime,
             expiry,
             serviceType,
@@ -82,7 +85,7 @@ class MeteringEventFactoryTest {
     assertEquals(Optional.of(clusterId), event.getDisplayName());
     assertEquals(Sla.PREMIUM, event.getSla());
     assertEquals(Usage.PRODUCTION, event.getUsage());
-    assertEquals(MeteringEventFactory.EVENT_SOURCE, event.getEventSource());
+    assertEquals(EVENT_SOURCE, event.getEventSource());
     assertEquals(
         MeteringEventFactory.getEventType(uom.getValue(), productTag), event.getEventType());
     assertEquals(serviceType, event.getServiceType());
@@ -103,6 +106,7 @@ class MeteringEventFactoryTest {
             null,
             "Production",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -125,6 +129,7 @@ class MeteringEventFactoryTest {
             "None",
             "Production",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -147,6 +152,7 @@ class MeteringEventFactoryTest {
             "UNKNOWN_SLA",
             "Production",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -169,6 +175,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "UNKNOWN_USAGE",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -191,6 +198,7 @@ class MeteringEventFactoryTest {
             "Premium",
             null,
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -213,6 +221,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "Production",
             "UNKNOWN_ROLE",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -235,6 +244,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "Production",
             null,
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -257,6 +267,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "Production",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -281,6 +292,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "Production",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -304,6 +316,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "Production",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -326,6 +339,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "Production",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -348,6 +362,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "Production",
             null,
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",
@@ -378,6 +393,7 @@ class MeteringEventFactoryTest {
             "Premium",
             "Production",
             "ocp",
+            EVENT_SOURCE,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "service_type",

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/PrometheusMeteringControllerTest.java
@@ -64,11 +64,17 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(properties = PrometheusQueryWiremockExtension.PROM_URL)
+@SpringBootTest(
+    properties = {
+      PrometheusQueryWiremockExtension.PROM_URL,
+      "EVENT_SOURCE=" + PrometheusMeteringControllerTest.PROMETHEUS
+    })
 @ActiveProfiles({"openshift-metering-worker", "test"})
 @Import(TestClockConfiguration.class)
 @ExtendWith(PrometheusQueryWiremockExtension.class)
 class PrometheusMeteringControllerTest {
+
+  static final String PROMETHEUS = "prometheus";
 
   @MockBean private PrometheusEventsProducer eventsProducer;
 
@@ -231,6 +237,7 @@ class PrometheusMeteringControllerTest {
                 expectedSla,
                 expectedUsage,
                 expectedRole,
+                PROMETHEUS,
                 clock.dateFromUnix(time1).minusSeconds(metricProperties.getStep()),
                 clock.dateFromUnix(time1),
                 expectedServiceType,
@@ -247,6 +254,7 @@ class PrometheusMeteringControllerTest {
                 expectedSla,
                 expectedUsage,
                 expectedRole,
+                PROMETHEUS,
                 clock.dateFromUnix(time2).minusSeconds(metricProperties.getStep()),
                 clock.dateFromUnix(time2),
                 expectedServiceType,
@@ -259,6 +267,7 @@ class PrometheusMeteringControllerTest {
             MeteringEventFactory.createCleanUpEvent(
                 expectedOrgId,
                 getEventType(expectedMetricId.toString(), expectedProductTag),
+                PROMETHEUS,
                 start,
                 end,
                 expectedSpanId));
@@ -303,6 +312,7 @@ class PrometheusMeteringControllerTest {
             expectedSla,
             expectedUsage,
             expectedRole,
+            PROMETHEUS,
             clock.dateFromUnix(time1).minusSeconds(metricProperties.getStep()),
             clock.dateFromUnix(time1),
             expectedServiceType,
@@ -323,6 +333,7 @@ class PrometheusMeteringControllerTest {
                 expectedSla,
                 expectedUsage,
                 expectedRole,
+                PROMETHEUS,
                 clock.dateFromUnix(time2).minusSeconds(metricProperties.getStep()),
                 clock.dateFromUnix(time2),
                 expectedServiceType,
@@ -335,6 +346,7 @@ class PrometheusMeteringControllerTest {
             MeteringEventFactory.createCleanUpEvent(
                 expectedOrgId,
                 getEventType(expectedMetricId.toString(), expectedProductTag),
+                PROMETHEUS,
                 start,
                 end,
                 expectedSpanId));
@@ -388,6 +400,7 @@ class PrometheusMeteringControllerTest {
             "Standard",
             expectedUsage,
             expectedRole,
+            PROMETHEUS,
             clock.dateFromUnix(1616787308L).minusSeconds(metricProperties.getStep()),
             clock.dateFromUnix(1616787308L),
             expectedServiceType,
@@ -404,6 +417,7 @@ class PrometheusMeteringControllerTest {
             MeteringEventFactory.createCleanUpEvent(
                 expectedOrgId,
                 getEventType(expectedMetricId.toString(), expectedProductTag),
+                PROMETHEUS,
                 start,
                 end,
                 expectedSpanId));

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.subscriptions.tally;
 
-import static org.candlepin.subscriptions.metering.MeteringEventFactory.EVENT_SOURCE;
 import static org.candlepin.subscriptions.metering.MeteringEventFactory.getEventType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -53,6 +52,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(properties = "CONTRACT_USE_STUB=true")
 @ActiveProfiles(value = {"worker", "kafka-queue", "api", "test-inventory"})
 class TallySnapshotControllerIT extends BaseIT {
+  static final String PROMETHEUS = "prometheus";
   static final String METRIC = "Cores";
   static final String USER_ID = "123";
   static final String ORG_ID = "owner" + USER_ID;
@@ -108,8 +108,8 @@ class TallySnapshotControllerIT extends BaseIT {
     event.setRole(Event.Role.MOA_HOSTEDCONTROLPLANE);
     event.setOrgId(ORG_ID);
     event.setEventType(getEventType(METRIC, PRODUCT_TAG));
-    event.setInstanceId("test");
-    event.setEventSource(EVENT_SOURCE);
+    event.setInstanceId(PROMETHEUS);
+    event.setEventSource("any");
     event.setExpiration(Optional.of(event.getTimestamp().plusHours(5)));
     event.setMeasurements(List.of(measurement(value)));
     event.setServiceType("rosa Instance");

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -113,6 +113,8 @@ parameters:
     value: '30 4 * * *'
   - name: EVENT_RECORD_RETENTION
     value: '90d'
+  - name: EVENT_SOURCE
+    value: 'prometheus'
   - name: OPENSHIFT_METERING_RANGE
     value: '60'
   - name: HOURLY_TALLY_OFFSET
@@ -305,6 +307,8 @@ objects:
                   secretKeyRef:
                     name: ${INVENTORY_SECRET_KEY_NAME}
                     key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
+              - name: EVENT_SOURCE
+                value: ${EVENT_SOURCE}
               - name: PROM_URL
                 value: ${PROM_URL}
               - name: EVENT_RECORD_RETENTION
@@ -501,6 +505,8 @@ objects:
                   secretKeyRef:
                     name: ${INVENTORY_SECRET_KEY_NAME}
                     key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
+              - name: EVENT_SOURCE
+                value: ${EVENT_SOURCE}
               - name: PROM_URL
                 value: ${PROM_URL}
               - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -113,8 +113,6 @@ parameters:
     value: '30 4 * * *'
   - name: EVENT_RECORD_RETENTION
     value: '90d'
-  - name: EVENT_SOURCE
-    value: 'prometheus'
   - name: OPENSHIFT_METERING_RANGE
     value: '60'
   - name: HOURLY_TALLY_OFFSET
@@ -308,7 +306,7 @@ objects:
                     name: ${INVENTORY_SECRET_KEY_NAME}
                     key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
               - name: EVENT_SOURCE
-                value: ${EVENT_SOURCE}
+                value: 'prometheus'
               - name: PROM_URL
                 value: ${PROM_URL}
               - name: EVENT_RECORD_RETENTION
@@ -505,8 +503,6 @@ objects:
                   secretKeyRef:
                     name: ${INVENTORY_SECRET_KEY_NAME}
                     key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
-              - name: EVENT_SOURCE
-                value: ${EVENT_SOURCE}
               - name: PROM_URL
                 value: ${PROM_URL}
               - name: OTEL_EXPORTER_OTLP_ENDPOINT


### PR DESCRIPTION
Jira issue: [SWATCH-1745](https://issues.redhat.com/browse/SWATCH-1745)

## Description
The "event_source" column should be configured as an env var, set in the [clowdapp](https://github.com/RedHatInsights/rhsm-subscriptions/blob/main/swatch-metrics/deploy/clowdapp.yaml#L181) file, and the configured value saves in the "events" table appropriately

## Testing
1.- podman-compose up
2.- Mock the prometheus server at localhost:

Create the stub directory:
`mkdir -p stub/__files`

Add a stub file to return some data: `stub/__files/swatch-1745.json`

```
cat > stub/__files/swatch-1745.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : [
        {
          "metric" : {
            "_id" : "cluster id",
            "support" : "sla",
            "usage" : "usage",
            "product" : "product",
            "billing_marketplace" : "billing_marketplace",
            "billing_marketplace_account" : "billing_marketplace_account",
            "ebs_account" : "account"
          },
          "values": [[ $(date +%s), "1" ]]
        }
      ]
    }
}
EOF
```

Add a stub file to return no data: `stub/__files/empty.json`

```
cat > stub/__files/empty.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : []
    }
}
EOF
```

Run wiremock:
`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

Configure stubbing for prometheus:

- this is to return some data when asking for instance-hours:
`curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/api/v1/query_range", "method": "GET", "queryParameters": {"query": {"contains":"instance_hours"}}}, "response": { "status": 200, "bodyFileName": "swatch-1745.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

- this is to return no data otherwise:
`curl -X POST --data '{ "priority": 5, "request": { "urlPath": "/api/v1/query_range", "method": "GET" }, "response": { "status": 200, "bodyFileName": "empty.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

3.- Start the swatch metrics app: `EVENT_SOURCE=prometheus PROM_URL="http://localhost:8101/api/v1/" SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true RHSM_RBAC_USE_STUB=true SUBSCRIPTION_SYNC_ENABLED=true ENABLE_SYNCHRONOUS_OPERATIONS=true SPRING_PROFILES_ACTIVE=openshift-metering-worker,kafka-queue ./gradlew :bootRun`

4.- Trigger the metrics from prometheus:
```
http POST :8000/api/rhsm-subscriptions/v1/internal/metering/rosa?orgId=16790890 \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder \
x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16790890"}}}' | base64 -w 0)
```

5.- Confirm the events have been produced in the Kafka topic "platform.rhsm-subscriptions.service-instance-ingress".

You should see at least two events in http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.service-instance-ingress/:

```
Key 16790890
Value
event_source prometheus
event_type snapshot_rosa_instance-hours
account_number account
org_id 16790890
service_type rosa Instance
instance_id cluster id
display_name cluster id
measurements [ [object Object] ]
billing_account_id billing_marketplace_account

Key 16790890
Value
event_source prometheus
event_type cleanup-snapshot_rosa_instance-hours
org_id 16790890
timestamp 2023-08-31T06:00:00Z
```

Note that both events should use "prometheus" as event_source, proving that the EVENT_SOURCE environment property works as expected and this field is configurable. 
