### PR TITLE
Add empty template for swatch-producer-azure

### DIFF
--- a/swatch-producer-azure/deploy/clowdapp.yaml
+++ b/swatch-producer-azure/deploy/clowdapp.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: swatch-producer-azure
+parameters: []
+objects: []


### PR DESCRIPTION
So that CI can "deploy" swatch-producer-azure.

This will fix bonfire deploy failures in recent PR checks.