### PR TITLE
SWATCH-664 Remove account_config table

### DIFF
--- a/src/main/resources/liquibase/202310131200-remove-account-config.xml
+++ b/src/main/resources/liquibase/202310131200-remove-account-config.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+
+  <changeSet id="202310131000-01" author="vbusch">
+    <comment>Drop account_config table.  org_config is used instead.</comment>
+    <dropTable tableName="account_config"/>
+    <rollback>
+      <createTable tableName="account_config">
+        <column name="account_number" type="VARCHAR(255)">
+                <constraints nullable="true" unique="true" uniqueConstraintName="account_config_account_number_unq"/>
+        </column>
+        <column name="opt_in_type" type="VARCHAR(255)">
+          <constraints nullable="false" />
+        </column>
+        <column name="created" type="TIMESTAMP WITH TIME ZONE">
+          <constraints nullable="false" />
+        </column>
+        <column name="updated" type="TIMESTAMP WITH TIME ZONE">
+          <constraints nullable="false" />
+        </column>
+        <column name="org_id" type="varchar(32)">
+          <constraints primaryKey="true" primaryKeyName="account_config_pkey" />
+        </column>
+      </createTable>
+
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202310031000-02" author="vbusch">
+    <comment>Drop account_number column from subscription table</comment>
+    <dropColumn tableName="subscription" columnName="account_number"/>
+
+    <rollback>
+      <addColumn tableName="subscription"> <column name="account_number" type="varchar(255)"/> </addColumn>
+
+      <createIndex tableName="subscription" indexName="subscription_account_number_sku_idx">
+        <column name="account_number"/>
+        <column name="sku"/>
+      </createIndex>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202310031000-03" author="vbusch">
+    <comment>Drop account_number column from hosts table</comment>
+    <dropColumn tableName="hosts" columnName="account_number"/>
+
+    <rollback>
+      <addColumn tableName="hosts"> <column name="account_number" type="varchar(255)"/> </addColumn>
+
+      <createIndex indexName="account_idx" tableName="hosts">
+        <column name="account_number"/>
+      </createIndex>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202310031000-04" author="vbusch" dbms="postgresql">
+    <comment>Drop account_number column from events table</comment>
+    <dropColumn tableName="events" columnName="account_number"/>
+
+    <rollback>
+      <addColumn tableName="events"> <column name="account_number" type="varchar(255)"/> </addColumn>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202310031000-05" author="vbusch">
+    <comment>Drop account_number column from tally_snapshots table</comment>
+    <dropColumn tableName="tally_snapshots" columnName="account_number"/>
+
+    <rollback>
+      <addColumn tableName="tally_snapshots"> <column name="account_number" type="varchar(255)"/> </addColumn>
+
+      <createIndex indexName="acct_prod_sla_gran_usage_idx" tableName="tally_snapshots"
+                   unique="false">
+        <column name="account_number"/>
+        <column name="product_id"/>
+        <column name="sla"/>
+        <column name="usage"/>
+        <column name="granularity"/>
+      </createIndex>
+      <createIndex indexName="acct_prod_sla_granularity_idx" tableName="tally_snapshots"
+                   unique="false">
+        <column name="account_number"/>
+        <column name="product_id"/>
+        <column name="sla"/>
+        <column name="granularity"/>
+      </createIndex>
+      <createIndex indexName="acct_and_product_idx" tableName="tally_snapshots"
+                   unique="false">
+        <column name="account_number"/>
+        <column name="product_id"/>
+      </createIndex>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -132,5 +132,6 @@
     <include file="liquibase/202310041633-fix-placeholder-values-for-rosa.xml"/>
     <!-- Need to fix duplicate key issue -->
     <!-- <include file="liquibase/202309181629-fix-measurement-metric-id-formatting.xml"/> -->
+    <include file="/liquibase/202310131200-remove-account-config.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: [SWATCH-664](https://issues.redhat.com/browse/SWATCH-664)

* This PR is dependent on https://github.com/RedHatInsights/rhsm-subscriptions/pull/2632 being released.   With rolling updates, we need the removed references deployed, before deleting the table.

## Description
- Deletes the account_config table which is no longer being used.
- Deletes the account_number column in:
- - subscription: unused as of SWATCH-667
- - host: unused as of SWATCH-661
- - events: unused as of SWATCH-667 
- - tally_snapshot: unused as of SWATCH-667

## Testing
Unit tests & Regression