### PR TITLE
Randomize testcontainer network aliases

### DIFF
--- a/swatch-common-testcontainers/src/main/java/org/candlepin/testcontainers/SwatchPostgreSQLContainer.java
+++ b/swatch-common-testcontainers/src/main/java/org/candlepin/testcontainers/SwatchPostgreSQLContainer.java
@@ -23,6 +23,7 @@ package org.candlepin.testcontainers;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
@@ -47,7 +48,7 @@ public class SwatchPostgreSQLContainer extends PostgreSQLContainer<SwatchPostgre
     withDatabaseName(database);
     withUsername(database);
     withPassword(database);
-    withNetworkAliases(database);
+    withNetworkAliases(UUID.randomUUID().toString());
     // SMELL: Workaround for https://github.com/testcontainers/testcontainers-java/issues/7539
     // This is because testcontainers randomly fails to start a container when using Podman socket.
     withStartupAttempts(3);


### PR DESCRIPTION
Otherwise we get strange behaviors due to kubedock behavior.

Notably,

> Kubedock flattens all networking, which basicly means that everything will run in the same namespace.
> When a network alias is present, it will create a service exposing all ports that have been exposed by the container.

I *think* this will fix recent ci test failures.