### PR TITLE
SWATCH-1624: Remove qpc_certs from HBI query

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -57,7 +57,6 @@ import lombok.Setter;
             @ColumnResult(name = "system_profile_arch"),
             @ColumnResult(name = "is_marketplace"),
             @ColumnResult(name = "qpc_products"),
-            @ColumnResult(name = "qpc_product_ids"),
             @ColumnResult(name = "system_profile_product_ids"),
             @ColumnResult(name = "syspurpose_role"),
             @ColumnResult(name = "syspurpose_sla"),
@@ -120,7 +119,6 @@ import lombok.Setter;
         h.canonical_facts->>'insights_id' as insights_id,
         rhsm_products.products,
         qpc_prods.qpc_products,
-        qpc_certs.qpc_product_ids,
         system_profile.system_profile_product_ids,
         h.stale_timestamp,
         coalesce(
@@ -138,9 +136,6 @@ import lombok.Setter;
         cross join lateral (
             select string_agg(items, ',') as qpc_products
             from jsonb_array_elements_text(h.facts->'qpc'->'rh_products_installed') as items) qpc_prods
-        cross join lateral (
-            select string_agg(items, ',') as qpc_product_ids
-            from jsonb_array_elements_text(h.facts->'qpc'->'rh_product_certs') as items) qpc_certs
         cross join lateral (
             select string_agg(items->>'id', ',') as system_profile_product_ids
             from jsonb_array_elements(h.system_profile_facts->'installed_products') as items) system_profile

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -54,7 +54,6 @@ public class InventoryHostFacts {
   private String subscriptionManagerId;
   private String insightsId;
   private Set<String> qpcProducts;
-  private Set<String> qpcProductIds;
   private Set<String> systemProfileProductIds;
   private String syspurposeRole;
   private String syspurposeSla;
@@ -88,7 +87,6 @@ public class InventoryHostFacts {
       String systemProfileArch,
       String isMarketplace,
       String qpcProducts,
-      String qpcProductIds,
       String systemProfileProductIds,
       String syspurposeRole,
       String syspurposeSla,
@@ -114,7 +112,6 @@ public class InventoryHostFacts {
     this.orgId = orgId;
     this.products = asStringSet(products);
     this.qpcProducts = asStringSet(qpcProducts);
-    this.qpcProductIds = asStringSet(qpcProductIds);
     this.syncTimestamp = StringUtils.hasText(syncTimestamp) ? syncTimestamp : "";
     this.systemProfileInfrastructureType = systemProfileInfrastructureType;
     this.systemProfileCoresPerSocket = asInt(systemProfileCores);
@@ -174,10 +171,6 @@ public class InventoryHostFacts {
 
   public void setQpcProducts(String qpcProducts) {
     this.qpcProducts = asStringSet(qpcProducts);
-  }
-
-  public void setQpcProductIds(String qpcProductIds) {
-    this.qpcProductIds = asStringSet(qpcProductIds);
   }
 
   public void setSystemProfileProductIds(String productIds) {

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -331,7 +331,6 @@ public class FactNormalizer {
     if (hostFacts.getQpcProducts() != null && hostFacts.getQpcProducts().contains("RHEL")) {
       normalizedFacts.addProduct("RHEL");
     }
-    getProductsFromProductIds(normalizedFacts, hostFacts.getQpcProductIds());
   }
 
   /**

--- a/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
+++ b/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
@@ -70,7 +70,6 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
   private static final String INSIGHTS_ID = "INSIGHTS_ID test";
   private static final Set<String> RH_PROD = Set.of("a1", "a2", "a3");
   private static final Set<String> RH_PRODUCTS_INSTALLED = Set.of("b1", "b2", "b3");
-  private static final Set<String> RH_PRODUCT_CERTS = Set.of("c1", "c2", "c3");
   private static final Set<Map<String, String>> INSTALLED_PRODUCTS =
       Set.of(Map.of("id", "d1"), Map.of("id", "d2"));
   private static final int CUT_OFF_DAYS = 3;
@@ -117,7 +116,6 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
     assertEquals(VIRTUAL_HOST_UUID, fact.getHardwareSubmanId());
     assertEquals(RH_PROD, fact.getProducts());
     assertEquals(RH_PRODUCTS_INSTALLED, fact.getQpcProducts());
-    assertEquals(RH_PRODUCT_CERTS, fact.getQpcProductIds());
     assertEquals(Set.of("d1", "d2"), fact.getSystemProfileProductIds());
   }
 
@@ -195,13 +193,7 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
                 "system_purpose_usage",
                 SYSTEM_PURPOSE_USAGE),
             "qpc",
-            of(
-                "IS_RHEL",
-                "true",
-                "rh_products_installed",
-                RH_PRODUCTS_INSTALLED,
-                "rh_product_certs",
-                RH_PRODUCT_CERTS)),
+            of("IS_RHEL", "true", "rh_products_installed", RH_PRODUCTS_INSTALLED)),
         of("subscription_manager_id", SUBSCRIPTION_MANAGER_ID, "insights_id", INSIGHTS_ID),
         of(
             "infrastructure_type",


### PR DESCRIPTION
Jira issue: [SWATCH-1624](https://issues.redhat.com/browse/SWATCH-1624)

## Description
Because Discovery now populates the products elsewhere, it's no longer necessary to look at the qpc_certs fact/field.

## Testing
There is an integration test covering that the updated query to HBI keeps working. 