### PR TITLE
Add prometheus query params to rhel-for-x86-eus-payg product config

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_eus_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_eus_payg.yaml
@@ -33,4 +33,4 @@ metrics:
         instanceKey: _id
         product: rhel-for-x86-eus-payg-placeholder-role
         metric: system_cpu_logical_count
-        metadataMetric: subscription_labels
+        metadataMetric: system_cpu_logical_count

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_eus_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_eus_payg.yaml
@@ -12,6 +12,8 @@ variants:
       - 70
     productNames:
       - RHEL EUS COST PLACEHOLDER # when external service creates a sku offering manager definition. This is to differentiate between skus.
+    roles:
+      - rhel-for-x86-eus-payg-placeholder-role
 
 defaults:
   variant: rhel-for-x86-eus-payg
@@ -25,3 +27,10 @@ contractEnabled: true #test to see when they create aws listing
 metrics:
   - id: vCPUs
     awsDimension: vCPU_Hour # PLACEHOLDER when external service sends an aws dimension
+    prometheus:
+      queryKey: default
+      queryParams:
+        instanceKey: _id
+        product: rhel-for-x86-eus-payg-placeholder-role
+        metric: system_cpu_logical_count
+        metadataMetric: subscription_labels


### PR DESCRIPTION
This enables the swatch-metrics-rhel service to actually receive results from rhelemeter after [HMS-2713 - [SWATCH] create clients to regularly send data](https://issues.redhat.com/browse/HMS-2713) is completed.  Which ultimately will make the swatch/rhelemeter integration testable.