### PR TITLE
SWATCH-1801: Use simple solution to replace SPeL expression parser

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/MetricProperties.java
@@ -70,12 +70,6 @@ public class MetricProperties {
 
   private Map<String, String> accountQueryTemplates = new HashMap<>();
 
-  /**
-   * SPEL templates do not support nested expressions so the QueryBuilder will apply template
-   * parameters a set number of times to prevent recursion.
-   */
-  private int templateParameterDepth = 3;
-
   /** How many attempts before giving up on the MeteringJob. */
   private Integer jobMaxAttempts;
 

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -48,9 +48,6 @@ public class QueryBuilder {
           "#{metric.prometheus.queryKey}",
               descriptor -> descriptor.getMetric().getPrometheus().getQueryKey());
   private static final String KEY_VALUE_CLOSE_TAG = "]}";
-  private static final String SYSTEM_PROPERTY_OPEN_TAG = "${";
-  private static final String SYSTEM_PROPERTY_CLOSE_TAG = "}";
-  private static final String SYSTEM_PROPERTY_DEFAULT_TAG = ":";
 
   private final MetricProperties metricProperties;
 
@@ -82,25 +79,6 @@ public class QueryBuilder {
   }
 
   private String buildQuery(String query, QueryDescriptor descriptor) {
-    // Support of system properties binding in the format of "${KEY:default value}"
-    if (query.contains(SYSTEM_PROPERTY_OPEN_TAG)) {
-      String rawKey =
-          StringUtils.substringBetween(query, SYSTEM_PROPERTY_OPEN_TAG, SYSTEM_PROPERTY_CLOSE_TAG);
-      String key = rawKey;
-      String defaultValue = null;
-      if (rawKey.contains(SYSTEM_PROPERTY_DEFAULT_TAG)) {
-        String[] keyParts = rawKey.split(SYSTEM_PROPERTY_DEFAULT_TAG);
-        key = keyParts[0];
-        defaultValue = keyParts[1];
-      }
-
-      query =
-          query.replace(
-              SYSTEM_PROPERTY_OPEN_TAG + rawKey + SYSTEM_PROPERTY_CLOSE_TAG,
-              getSystemProperty(key, defaultValue));
-      return buildQuery(query, descriptor);
-    }
-
     // Support of key-value properties that use a map as collection. The expected format is:
     // "#{map[key]}"
     for (var rule : KEY_VALUE_RULES.entrySet()) {
@@ -124,17 +102,5 @@ public class QueryBuilder {
 
     log.debug("PromQL: {}", query);
     return query;
-  }
-
-  private static String getSystemProperty(String key, String defaultValue) {
-    String value = System.getProperty(key);
-    if (value == null) {
-      value = System.getenv(key);
-    }
-
-    if (value == null) {
-      value = defaultValue;
-    }
-    return value;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilder.java
@@ -24,17 +24,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /** Builds PromQL queries based on a configured template. */
+@Slf4j
 @Component
 public class QueryBuilder {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(QueryBuilder.class);
   private static final Map<String, BiFunction<QueryDescriptor, String, String>> KEY_VALUE_RULES =
       Map.of(
           "#{metric.prometheus.queryParams[",
@@ -67,7 +66,7 @@ public class QueryBuilder {
       throw new IllegalArgumentException(
           String.format("Unable to find query template for key: %s", templateKey));
     }
-    LOGGER.debug("Building metric lookup PromQL.");
+    log.debug("Building metric lookup PromQL.");
     return buildQuery(template.get(), queryDescriptor);
   }
 
@@ -78,7 +77,7 @@ public class QueryBuilder {
       throw new IllegalArgumentException(
           String.format("Unable to find account query template for key: %s", templateKey));
     }
-    LOGGER.debug("Building account lookup PromQL.");
+    log.debug("Building account lookup PromQL.");
     return buildQuery(template.get(), queryDescriptor);
   }
 
@@ -123,7 +122,7 @@ public class QueryBuilder {
       }
     }
 
-    LOGGER.debug("PromQL: {}", query);
+    log.debug("PromQL: {}", query);
     return query;
   }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
@@ -49,7 +49,7 @@ class QueryBuilderTest {
   void testBuildQuery() {
     String templateKey = "default";
     String template =
-        "Account: #{runtime[account]} Metric ID: #{metric.id} P1: #{metric.prometheus.queryParams[metadataMetric]}";
+        "Account: #{runtime[account]} Metric ID: #{metric.id} P1: #{metric.prometheus.queryParams[metadataMetric]} ${SYSTEM_PROPERTY:default}";
 
     String id = "Cores";
     String account = "12345";
@@ -69,7 +69,7 @@ class QueryBuilderTest {
 
     QueryBuilder builder = new QueryBuilder(props);
     assertEquals(
-        String.format("Account: %s Metric ID: %s P1: %s", account, id, param1),
+        String.format("Account: %s Metric ID: %s P1: %s default", account, id, param1),
         builder.build(queryDesc));
   }
 

--- a/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/service/prometheus/promql/QueryBuilderTest.java
@@ -49,7 +49,7 @@ class QueryBuilderTest {
   void testBuildQuery() {
     String templateKey = "default";
     String template =
-        "Account: #{runtime[account]} Metric ID: #{metric.id} P1: #{metric.prometheus.queryParams[metadataMetric]} ${SYSTEM_PROPERTY:default}";
+        "Account: #{runtime[account]} Metric ID: #{metric.id} P1: #{metric.prometheus.queryParams[metadataMetric]}";
 
     String id = "Cores";
     String account = "12345";
@@ -69,7 +69,7 @@ class QueryBuilderTest {
 
     QueryBuilder builder = new QueryBuilder(props);
     assertEquals(
-        String.format("Account: %s Metric ID: %s P1: %s default", account, id, param1),
+        String.format("Account: %s Metric ID: %s P1: %s", account, id, param1),
         builder.build(queryDesc));
   }
 


### PR DESCRIPTION
Jira issue: [SWATCH-1801](https://issues.redhat.com/browse/SWATCH-1801)

## Description
This is the simplest solution I can think of, to replace the SPeL expression parser which perfectly works for our use case and avoids the usage of reflection (so it's compatible with Quarkus native if in the future we want to use it). 

The drawback is that it lacks many features that regular expression parsers have like conditional expressions and many others. 

Another alternative to SPeL expressions and Quarkus Qute is to use [Mvel2](http://mvel.documentnode.com/) (which is supported by JBoss RedHat team). This framework works in Spring Boot and Quarkus, *but not in Quarkus native*, see [the Quarkus example](https://github.com/Sgitario/quarkus-examples/tree/main/mvel2) I created for this - use `mvn clean install` from the mvel2 directory and `mvn clean install -Dnative` to run the test using the native binaries and you can see the test will fail). 

Moreover, because of using Mvel2 or Qute (or any other expression parsers), we would need to update all the properties to accommodate the new conventions (for example, instead of using `#{metric.id}`, we need to use `@{metric.id}` in Mvel2. 

Therefore, using this very simple solution, it works in Quarkus native (because it does not use reflection), also it does not require changes and it's very well performant (because of the same, neither uses reflection nor requires adding an additional dependency).