### PR TITLE
SWATCH-1771 - Update promql templates to handle unexpected duplicate instance results

### DIFF
--- a/src/main/resources/application-metrics-rhel.yaml
+++ b/src/main/resources/application-metrics-rhel.yaml
@@ -9,11 +9,11 @@ rhsm-subscriptions:
       metric:
         queryTemplates:
           default: >-
-            #{metric.prometheus.queryParams[metric]}
+            max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           addonSamples: >-
-            #{metric.prometheus.queryParams[metric]}
+            max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
         maxAttempts: 50

--- a/src/main/resources/application-openshift-metering-worker.yaml
+++ b/src/main/resources/application-openshift-metering-worker.yaml
@@ -10,11 +10,11 @@ rhsm-subscriptions:
       metric:
         queryTemplates:
           default: >-
-            #{metric.prometheus.queryParams[metric]}
+            max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           addonSamples: >-
-            #{metric.prometheus.queryParams[metric]}
+            max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1771](https://issues.redhat.com/browse/SWATCH-1771)

## Description
We expect a single cluster per metric.  In case of bad data/misconfiguration by the reporter, it's possible to have multiple values.  When this happens, prometheus throws an exception when trying to join.

In the event that the metric corresponds to multiple clusters/instances (identified by unique instance keys, generally _id), we'll take the max value of those to ensure one-to-many matches and avoid attempting to do a many-to-many grouping.


## Verification
### Steps

Get the ORG_ID from the jira card to use for testing.

`./bin/metering-promql.py --org $ORG_ID --product rhacs`

Copy the output of "Cores PromQL" and paste it in grafana

https://telemeter-lts-dashboards.datahub.redhat.com/explore
Use the `historical` data source
Set the timeframe **2023-09-26 00:00:00** to **2023-09-27 23:59:59**

### Verification

On the main branch, you'll reproduce the issue as detailed in the card.

With this update, the query should execute successfully.  The query doesn't actually have any matching data, so "No data" being displayed it the expected outcome.