### PR TITLE
SWATCH-1765: Fix Contract capacity population for ROSA

### DIFF
--- a/src/main/resources/liquibase/202310041633-fix-placeholder-values-for-rosa.xml
+++ b/src/main/resources/liquibase/202310041633-fix-placeholder-values-for-rosa.xml
@@ -1,0 +1,23 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202310041633-1" author="ksynvrit">
+        <comment>Change four_vcpu_hour to Cores on subscription_measurements.</comment>
+        <update tableName="subscription_measurements">
+            <column name="metric_id" value="Cores"/>
+            <where>metric_id='four_vcpu_hour'</where>
+        </update>
+    </changeSet>
+
+    <changeSet id="202310041633-2" author="ksynvrit">
+        <comment>Change control_plane to Instance-hours on subscription_measurements.</comment>
+        <update tableName="subscription_measurements">
+            <column name="metric_id" value="Instance-hours"/>
+            <where>metric_id='control_plane'</where>
+        </update>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -129,6 +129,7 @@
     <!-- <include file="liquibase/202309011416-drop-id-event-record.xml"/> -->
     <include file="liquibase/202309081416-add-span-id-event-record.xml"/>
     <include file="liquibase/202309181256-add-recorddate-column-events.xml"/>
+    <include file="liquibase/202310041633-fix-placeholder-values-for-rosa.xml"/>
     <!-- Need to fix duplicate key issue -->
     <!-- <include file="liquibase/202309181629-fix-measurement-metric-id-formatting.xml"/> -->
 </databaseChangeLog>

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformer.java
@@ -20,16 +20,22 @@
  */
 package com.redhat.swatch.contract.model;
 
+import com.redhat.swatch.clients.swatch.internal.subscription.api.model.Metric;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi;
 import com.redhat.swatch.contract.exception.ContractsException;
 import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.repository.BillingProvider;
+import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
+import com.redhat.swatch.contract.repository.SubscriptionMeasurementEntity;
 import com.redhat.swatch.contract.repository.SubscriptionProductIdEntity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -54,6 +60,9 @@ public class MeasurementMetricIdTransformer {
                 .map(SubscriptionProductIdEntity::getProductId)
                 .orElseThrow();
         var metrics = internalSubscriptionsApi.getMetrics(tag);
+        // the metricId currently set here is actually the aws Dimension and get translated to the
+        // metric uom after calculation
+        checkForUnsupportedMetrics(metrics, subscription);
         subscription
             .getSubscriptionMeasurements()
             .forEach(
@@ -76,6 +85,50 @@ public class MeasurementMetricIdTransformer {
     } catch (ApiException e) {
       log.error("Error looking up dimension for metrics", e);
       throw new ContractsException(ErrorCode.UNHANDLED_EXCEPTION, e.getMessage());
+    }
+  }
+
+  /**
+   * Resolves all conflicting metrics from cloud provider-specific formats.
+   *
+   * <p>For example, 100 four_vcpu_hours (AWS dimension) will be the metricId for contract metrics
+   * While the transformed unit will be stored as a SWATCH UOM into 400 CORES in the subscriptions'
+   * metrics measurements.
+   *
+   * @param contract contract w/ measurements in the cloud-provider-specific dimensions
+   */
+  public void resolveConflictingMetrics(ContractEntity contract) {
+    // resolve contract measurements with the correct metrics from sync service
+    // this will keep subscriptions and contract metrics consistent with its dimension to SWATCH UOM
+    log.debug(
+        "Resolving conflicting metrics between subscription & contract  for {}",
+        contract.getOrgId());
+    try {
+      var metrics =
+          internalSubscriptionsApi.getMetrics(contract.getProductId()).stream()
+              .map(Metric::getAwsDimension)
+              .collect(Collectors.toSet());
+      contract.getMetrics().removeIf(metric -> !metrics.contains(metric.getMetricId()));
+
+    } catch (ApiException e) {
+      log.error("Error resolving dimensions for contract metrics", e);
+      throw new ContractsException(ErrorCode.UNHANDLED_EXCEPTION, e.getMessage());
+    }
+  }
+
+  private void checkForUnsupportedMetrics(List<Metric> metrics, SubscriptionEntity subscription) {
+    if (!subscription.getSubscriptionMeasurements().isEmpty()) {
+      // Will check for correct metrics before translating awsDimension to Metrics UOM
+      log.debug("Checking for unsupported metricIds");
+      var supportedSet = metrics.stream().map(Metric::getAwsDimension).collect(Collectors.toSet());
+      List<SubscriptionMeasurementEntity> supportedMeasurements = new ArrayList<>();
+      // compare set of metric.awsDimension to measurements.metricId (pre Transformation state)
+      for (SubscriptionMeasurementEntity sub : subscription.getSubscriptionMeasurements()) {
+        if (supportedSet.contains(sub.getMetricId())) {
+          supportedMeasurements.add(sub);
+        }
+      }
+      subscription.setSubscriptionMeasurements(supportedMeasurements);
     }
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -280,6 +280,9 @@ public class ContractService {
     var subscription = new SubscriptionEntity();
     mapper.mapContractEntityToSubscriptionEntity(subscription, contract);
     measurementMetricIdTransformer.translateContractMetricIdsToSubscriptionMetricIds(subscription);
+    if (subscription.getSubscriptionMeasurements().size() != contract.getMetrics().size()) {
+      measurementMetricIdTransformer.resolveConflictingMetrics(contract);
+    }
     if (lookupSubscriptionId) {
       subscription.setSubscriptionId(lookupSubscriptionId(contract.getSubscriptionNumber()));
     }

--- a/swatch-contracts/src/main/resources/db/202310091227_fix_contract_metrics_for_rosa.xml
+++ b/swatch-contracts/src/main/resources/db/202310091227_fix_contract_metrics_for_rosa.xml
@@ -1,0 +1,23 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+<changeSet id="202310091227-1" author="ksynvrit">
+    <comment>Change four_vcpu_hour to valid dimension for rosa.</comment>
+    <update tableName="contract_metrics">
+        <column name="metric_id" value="four_vcpu_0"/>
+        <where>metric_id='four_vcpu_hour'</where>
+    </update>
+</changeSet>
+
+<changeSet id="202310091227-2" author="ksynvrit">
+<comment>Change control_plane to valid dimension for rosa.</comment>
+<update tableName="contract_metrics">
+    <column name="metric_id" value="control_plane_0"/>
+    <where>metric_id='control_plane'</where>
+</update>
+</changeSet>
+
+</databaseChangeLog>

--- a/swatch-contracts/src/main/resources/db/changeLog.xml
+++ b/swatch-contracts/src/main/resources/db/changeLog.xml
@@ -8,5 +8,6 @@
 
   <include file="db/202302030707_create_contracts_table.xml"/>
   <include file="db/202304061624_add_vendorproductcode_to_contracts_table.xml"/>
+  <include file="db/202310091227_fix_contract_metrics_for_rosa.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1765](https://issues.redhat.com/browse/SWATCH-1765)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
If you observe in prod you will see that `subscription_measurements` for subscription: `13579593` there's old test data in the database has the  incorrect `MetricId` for rosa and not allowing QE to see the capacity after contracts are created.

Liquibase changes will update the affect `contracts_metrics` & `subscription_measurements` and the code changes should remove any unsupported metrics from the processing subscription. `19` records that will be affected by this change.

Gabi Query:
```
http -b https://gabi-subscription-watch-prod.apps.crcp01ue1.o9m8.p1.openshiftapps.com/query Authorization:"Bearer $(oc whoami -t)" query="select * from subscription_measurements where subscription_id = '13579593';" 
    
```

example:
```
{"result":["13579593","2023-09-25T08:25:22.797423Z","four_vcpu_hour","PHYSICAL","5"],["13579593","2023-09-25T08:25:22.797423Z","control_plane","PHYSICAL","1"]]}
```
## Testing Steps
1.Run both `bootApplication` & `Swatch-Contract` make sure one of the services are running on a different port
2. Setup up DB:
```
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('MW02393', 'OpenShift Dedicated', null, null, null, null, null, null, 'Premium', null, 'Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)', false, null);

```
3. Use UI : http://localhost:XXXX/api/swatch-contracts/internal/swagger-ui/#/default/createContract and paste in data:
```
{
  "subscription_number": "sn800",
  "sku": "MW02393",
  "start_date": "2023-09-05T00:00:00Z",
  "org_id": "RosaOrg",
  "billing_provider": "aws",
  "billing_account_id": "bp1",
  "product_id": "rosa",
  "vendor_product_code": "VPC",
  "metrics": [
    {
      "metric_id": "four_vcpu_0",
      "value": 100
    },
    {
      "metric_id": "control_plane_0",
      "value": 100
    },
    {
      "metric_id": "four_vpc_hours",
      "value": 100
    }
  ]
}
```
3. Observe that `Cores` is visible in `contract_metrics` & `subscription_measurements` as it was the only metric that was correctly formatted to the metrics tag given from `bootApplication`: http://localhost:XXXX/api-docs/internal-subscription-sync.html#/internalSubscriptions/getMetrics
4. Attempt another request with the correct format for `Instance-hours` and observe it is now visible in the db. 