### PR TITLE
SWATCH-1818: Enable KafkaResource resources in tests for Quarkus modules

### DIFF
--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointTest.java
@@ -33,12 +33,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
 import java.util.List;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@Tag("integration")
-class ContractsHttpEndpointIntegrationTest {
+class ContractsHttpEndpointTest {
 
   @InjectMock ContractService contractService;
 

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.testcontainers:kafka'
+    testImplementation 'io.smallrye.reactive:smallrye-reactive-messaging-in-memory'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation libraries["junit-jupiter"]
@@ -77,7 +77,7 @@ tasks.register('configureQuarkusBuild') {
 tasks.register("wiremock", JavaExec) {
     description = "Run mock REST services for this service"
     classpath = sourceSets.test.runtimeClasspath
-    mainClass = "com.redhat.swatch.aws.wiremock.WiremockRunner"
+    mainClass = "com.redhat.swatch.aws.test.wiremock.WiremockRunner"
 }
 
 quarkusDev.dependsOn(configureQuarkusBuild)

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/AwsUnprocessedRecordsException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/AwsUnprocessedRecordsException.java
@@ -22,9 +22,10 @@ package com.redhat.swatch.aws.exception;
 
 import lombok.Getter;
 
+@Getter
 public class AwsUnprocessedRecordsException extends AwsProducerException {
 
-  @Getter private final int count;
+  private final int count;
 
   public AwsUnprocessedRecordsException(int count) {
     super(ErrorCode.AWS_UNPROCESSED_RECORDS_ERROR, String.format("count=%d", count));

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/DefaultApiException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/DefaultApiException.java
@@ -23,7 +23,9 @@ package com.redhat.swatch.aws.exception;
 import com.redhat.swatch.aws.openapi.model.Errors;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
 import jakarta.ws.rs.core.Response;
+import lombok.Getter;
 
+@Getter
 public class DefaultApiException extends ApiException {
 
   private final transient Errors errors;
@@ -31,9 +33,5 @@ public class DefaultApiException extends ApiException {
   public DefaultApiException(Response response, Errors errors) {
     super(response);
     this.errors = errors;
-  }
-
-  public Errors getErrors() {
-    return this.errors;
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/ErrorCode.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/ErrorCode.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.aws.exception;
 
 import lombok.Getter;
 
+@Getter
 public enum ErrorCode {
   AWS_UNPROCESSED_RECORDS_ERROR(1000, "Some AWS UsageRecords were not processed"),
   AWS_DIMENSION_NOT_CONFIGURED(1001, "Aws Dimension not configured"),
@@ -33,8 +34,8 @@ public enum ErrorCode {
 
   private static final String CODE_PREFIX = "SWATCHAWS";
 
-  @Getter private final String code;
-  @Getter private final String description;
+  private final String code;
+  private final String description;
 
   ErrorCode(int intCode, String description) {
     this.code = CODE_PREFIX + intCode;

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/files/AwsCredentialsLookup.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/files/AwsCredentialsLookup.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.aws.files;
 
 import com.redhat.swatch.aws.exception.AwsMissingCredentialsException;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -41,13 +42,14 @@ import software.amazon.awssdk.profiles.ProfileFile;
 public class AwsCredentialsLookup {
 
   private final Map<String, ProfileCredentialsProvider> awsCredentialMap = new HashMap<>();
-  private final ProfileFile profileFile = ProfileFile.defaultProfileFile();
+
+  @Inject ProfileFile profileFile;
 
   public synchronized AwsCredentialsProvider getCredentialsProvider(String awsSellerAccount) {
     return awsCredentialMap.computeIfAbsent(awsSellerAccount, this::createCredentialsFromProfile);
   }
 
-  public ProfileCredentialsProvider createCredentialsFromProfile(String awsSellerAccount) {
+  private ProfileCredentialsProvider createCredentialsFromProfile(String awsSellerAccount) {
     // NOTE: it is useful to do this check here, because it allows us to catch missing credentials
     // in a predictable way.
     if (profileFile.profile(awsSellerAccount).isEmpty()) {

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/files/ProfileFileConfiguration.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/files/ProfileFileConfiguration.java
@@ -18,20 +18,18 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.aws.exception;
+package com.redhat.swatch.aws.files;
 
-import lombok.Getter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import software.amazon.awssdk.profiles.ProfileFile;
 
-@Getter
-public class AwsDimensionNotConfiguredException extends AwsProducerException {
-  private final String productId;
-  private final String uom;
-
-  public AwsDimensionNotConfiguredException(String productId, String uom) {
-    super(
-        ErrorCode.AWS_DIMENSION_NOT_CONFIGURED,
-        String.format("productId=%s and uom=%s", productId, uom));
-    this.productId = productId;
-    this.uom = uom;
+@Dependent
+public class ProfileFileConfiguration {
+  @ApplicationScoped
+  @Produces
+  public ProfileFile defaultProfileFile() {
+    return ProfileFile.defaultProfileFile();
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/resource/KafkaResource.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/resource/KafkaResource.java
@@ -36,7 +36,7 @@ public class KafkaResource implements KafkaApi {
   }
 
   @Override
-  public void kakfaSeekPosition(KafkaSeekPosition position) throws ProcessingException {
+  public void kafkaSeekPosition(KafkaSeekPosition position) throws ProcessingException {
     var seekHelperPosition =
         switch (position) {
           case BEGINNING -> KafkaSeekHelper.KafkaSeekPosition.BEGINNING;
@@ -46,7 +46,7 @@ public class KafkaResource implements KafkaApi {
   }
 
   @Override
-  public void kakfaSeekTimestamp(String timestamp) throws ProcessingException {
+  public void kafkaSeekTimestamp(String timestamp) throws ProcessingException {
     kafkaSeekHelper.seekToTimestamp(OffsetDateTime.parse(timestamp));
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/splunk/QuarkusHecErrorCallback.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/splunk/QuarkusHecErrorCallback.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 import org.jboss.logmanager.ExtHandler;
 
 // This is a copy because quarkus's stuff is package protected.  Delete once
-// https://github.com/quarkiverse/quarkus-logging-splunk/pull/111 is merged
+// https://github.com/quarkiverse/quarkus-logging-splunk/pull/211 is merged
 public class QuarkusHecErrorCallback implements ErrorCallback {
   Boolean consoleEnabled;
 

--- a/swatch-producer-aws/src/main/resources/openapi.yaml
+++ b/swatch-producer-aws/src/main/resources/openapi.yaml
@@ -41,7 +41,7 @@ paths:
           schema:
             $ref: '#/components/schemas/KafkaSeekPosition'
       responses:
-        '202':
+        '204':
           description: "Kafka queue seeked successfully for all partitions."
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -51,7 +51,7 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-      operationId: kakfaSeekPosition
+      operationId: kafkaSeekPosition
       description: >
         Seek the kafka consumer manually to the specified position (for
         debugging/support purposes)
@@ -66,7 +66,7 @@ paths:
           schema:
             type: string
       responses:
-        '202':
+        '204':
           description: "Kafka queue seeked successfully for all partitions."
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -76,7 +76,7 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-      operationId: kakfaSeekTimestamp
+      operationId: kafkaSeekTimestamp
       description: >
         Seek the kafka consumer manually to the specified timestamp (for
         debugging/support purposes).

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/BillableUsageResourceIT.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/BillableUsageResourceIT.java
@@ -20,22 +20,39 @@
  */
 package com.redhat.swatch.aws;
 
+import static io.restassured.RestAssured.given;
+
+import com.redhat.swatch.aws.test.resources.InMemoryMessageBrokerKafkaResource;
+import com.redhat.swatch.aws.test.resources.PostgresResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.Assert;
-import org.junit.jupiter.api.Disabled;
+import io.restassured.http.ContentType;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Disabled("This placeholder test shows how to setup an integration test w/ DB & Kafka")
 @QuarkusTest
 @QuarkusTestResource(value = PostgresResource.class, restrictToAnnotatedClass = true)
-@QuarkusTestResource(value = KafkaResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(
+    value = InMemoryMessageBrokerKafkaResource.class,
+    restrictToAnnotatedClass = true)
 @Tag("integration")
-class TestContainerTest {
+class BillableUsageResourceIT {
 
   @Test
-  void testContainersStarting() {
-    Assert.assertTrue(true);
+  void testSubmitBillableUsage() {
+    given()
+        .contentType(ContentType.JSON)
+        .body(
+            """
+            {
+              "sla": "Standard",
+              "usage": "Development/Test",
+              "billingProvider": "aws"
+            }
+            """)
+        .post("/api/swatch-producer-aws/internal/aws/billable_usage")
+        .then()
+        .statusCode(HttpStatus.SC_NO_CONTENT);
   }
 }

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/KafkaResourceIT.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/KafkaResourceIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws;
+
+import static io.restassured.RestAssured.post;
+
+import com.redhat.swatch.aws.openapi.model.KafkaSeekPosition;
+import com.redhat.swatch.aws.test.resources.InMemoryMessageBrokerKafkaResource;
+import com.redhat.swatch.aws.test.resources.PostgresResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import java.time.OffsetDateTime;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@QuarkusTest
+@QuarkusTestResource(value = PostgresResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(
+    value = InMemoryMessageBrokerKafkaResource.class,
+    restrictToAnnotatedClass = true)
+@Tag("integration")
+class KafkaResourceIT {
+
+  @ParameterizedTest
+  @EnumSource(KafkaSeekPosition.class)
+  void testKafkaSeekPosition(KafkaSeekPosition position) {
+    post(basePath() + "/kafka_seek_position?position=" + position)
+        .then()
+        .statusCode(HttpStatus.SC_NO_CONTENT);
+  }
+
+  @Test
+  void testKafkaSeekTimestamp() {
+    post(basePath() + "/kafka_seek_timestamp?timestamp=" + OffsetDateTime.now())
+        .then()
+        .statusCode(HttpStatus.SC_NO_CONTENT);
+  }
+
+  private String basePath() {
+    return "/api/swatch-producer-aws/internal";
+  }
+}

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/files/AwsCredentialsLookupTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/files/AwsCredentialsLookupTest.java
@@ -25,7 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.aws.exception.AwsMissingCredentialsException;
+import com.redhat.swatch.aws.test.resources.InMemoryMessageBrokerKafkaResource;
 import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -37,6 +39,9 @@ import software.amazon.awssdk.profiles.Profile;
 import software.amazon.awssdk.profiles.ProfileFile;
 
 @QuarkusTest
+@QuarkusTestResource(
+    value = InMemoryMessageBrokerKafkaResource.class,
+    restrictToAnnotatedClass = true)
 class AwsCredentialsLookupTest {
   private static final String AWS_SELLER_ACCOUNT = "123";
 

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/files/AwsCredentialsLookupTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/files/AwsCredentialsLookupTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws.files;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.aws.exception.AwsMissingCredentialsException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.profiles.Profile;
+import software.amazon.awssdk.profiles.ProfileFile;
+
+@QuarkusTest
+class AwsCredentialsLookupTest {
+  private static final String AWS_SELLER_ACCOUNT = "123";
+
+  @InjectMock ProfileFile mockProfileFile;
+  @Inject AwsCredentialsLookup lookup;
+
+  @Test
+  void testGetCredentialsProviderShouldThrowAwsMissingCredentialsException() {
+    givenUnknownAwsSellerAccount();
+    assertThrows(AwsMissingCredentialsException.class, this::whenGetCredentialsProvider);
+  }
+
+  @Test
+  void testGetCredentialsProviderShouldReturnProvider() {
+    givenKnownAwsSellerAccount();
+    AwsCredentialsProvider provider = whenGetCredentialsProvider();
+    assertTrue(provider instanceof ProfileCredentialsProvider);
+  }
+
+  private void givenUnknownAwsSellerAccount() {
+    when(mockProfileFile.profile(AWS_SELLER_ACCOUNT)).thenReturn(Optional.empty());
+  }
+
+  private void givenKnownAwsSellerAccount() {
+    when(mockProfileFile.profile(AWS_SELLER_ACCOUNT))
+        .thenReturn(Optional.of(Profile.builder().name("any").properties(Map.of()).build()));
+  }
+
+  private AwsCredentialsProvider whenGetCredentialsProvider() {
+    return lookup.getCredentialsProvider(AWS_SELLER_ACCOUNT);
+  }
+}

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/processors/BillableUsageProcessorTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/processors/BillableUsageProcessorTest.java
@@ -35,12 +35,14 @@ import com.redhat.swatch.aws.openapi.model.BillableUsage;
 import com.redhat.swatch.aws.openapi.model.BillableUsage.BillingProviderEnum;
 import com.redhat.swatch.aws.openapi.model.Error;
 import com.redhat.swatch.aws.openapi.model.Errors;
+import com.redhat.swatch.aws.test.resources.InMemoryMessageBrokerKafkaResource;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.model.AwsUsageContext;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -60,6 +62,9 @@ import software.amazon.awssdk.services.marketplacemetering.model.UsageRecordResu
 import software.amazon.awssdk.services.marketplacemetering.model.UsageRecordResultStatus;
 
 @QuarkusTest
+@QuarkusTestResource(
+    value = InMemoryMessageBrokerKafkaResource.class,
+    restrictToAnnotatedClass = true)
 class BillableUsageProcessorTest {
 
   private static final String INSTANCE_HOURS = "INSTANCE_HOURS";

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/test/resources/InMemoryMessageBrokerKafkaResource.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/test/resources/InMemoryMessageBrokerKafkaResource.java
@@ -18,29 +18,27 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.aws;
+package com.redhat.swatch.aws.test.resources;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import java.util.Collections;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import java.util.HashMap;
 import java.util.Map;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.utility.DockerImageName;
 
-public class KafkaResource implements QuarkusTestResourceLifecycleManager {
-
-  static KafkaContainer kafka =
-      new KafkaContainer(
-          DockerImageName.parse("quay.io/cloudservices/cp-kafka")
-              .asCompatibleSubstituteFor("confluentinc/cp-kafka"));
+public class InMemoryMessageBrokerKafkaResource implements QuarkusTestResourceLifecycleManager {
 
   @Override
   public Map<String, String> start() {
-    kafka.start();
-    return Collections.singletonMap("kafka.bootstrap.servers", kafka.getBootstrapServers());
+    Map<String, String> env = new HashMap<>();
+    Map<String, String> props1 = InMemoryConnector.switchIncomingChannelsToInMemory("tally-in");
+    Map<String, String> props2 = InMemoryConnector.switchOutgoingChannelsToInMemory("tally-out");
+    env.putAll(props1);
+    env.putAll(props2);
+    return env;
   }
 
   @Override
   public void stop() {
-    kafka.stop();
+    InMemoryConnector.clear();
   }
 }

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/test/resources/PostgresResource.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/test/resources/PostgresResource.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.aws;
+package com.redhat.swatch.aws.test.resources;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.util.Collections;

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/test/wiremock/WiremockRunner.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/test/wiremock/WiremockRunner.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.aws.wiremock;
+package com.redhat.swatch.aws.test.wiremock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 

--- a/swatch-producer-azure/build.gradle
+++ b/swatch-producer-azure/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.testcontainers:kafka'
+    testImplementation 'io.smallrye.reactive:smallrye-reactive-messaging-in-memory'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.quarkus:quarkus-test-security'
     testImplementation libraries["junit-jupiter"]


### PR DESCRIPTION
Jira issue: [SWATCH-1818](https://issues.redhat.com/browse/SWATCH-1818)

## Description
Use an in-memory message broker following the Quarkus guide: https://quarkus.io/guides/kafka#testing-without-a-broker in Quarkus tests that need Kafka.

Moreover, this pull request includes changes that increase the code coverage for the producer aws project.