### PR TITLE
ci: run build/test phase sequentially instead of in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ spec:
             steps {
                 // The build task includes check, test, and assemble.  Linting happens during the check
                 // task and uses the spotless gradle plugin.
-                sh "./gradlew --no-daemon build testCodeCoverageReport"
+                sh "./gradlew --no-daemon --no-parallel build testCodeCoverageReport"
             }
         }
 


### PR DESCRIPTION
## Description
The "continuous-integration/jenkins/pr-merge" used to fail with:
```
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```

This is a random but quite often failure.

Splitting the build and test stages seems to improve the above random issue.