### PR TITLE
Add floorplan for subscriptions

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -696,3 +696,23 @@ objects:
         and granularity='DAILY'
         and measurement_type!='TOTAL'
         AND snapshot_date > now() - interval '2 day'; 
+    - prefix: swatch/subscriptions
+      query: >-
+        select
+        subscription.sku,
+        subscription.subscription_id,
+        subscription.start_date,
+        subscription.end_date,
+        subscription.quantity,
+        subscription_product_ids.product_id,
+        coalesce(metric_id_normalized.normalized, subscription_measurements.metric_id) as metric_id,
+        subscription_measurements.measurement_type,
+        subscription_measurements.value
+        from subscription
+        left join subscription_product_ids on subscription.subscription_id = subscription_product_ids.subscription_id
+        left join subscription_measurements on subscription.subscription_id = subscription_measurements.subscription_id
+        left join (values
+          ('SOCKETS', 'Sockets'),
+          ('CORES', 'Cores'),
+          ('INSTANCE_HOURS', 'Instance-hours')
+        ) as metric_id_normalized(value, normalized) on subscription_measurements.metric_id=metric_id_normalized.value


### PR DESCRIPTION
Notably this normalizes the metric_id values so that downstream consumers of this data don't have to deal with `SOCKETS` vs. `Sockets`.

Testing
=======
You can try the query with gabi in any environment, please add `limit 10` (or similar) so as to not select too much data at once.