### PR TITLE
Update payg eus product config so metrics get returned

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_eus_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_eus_payg.yaml
@@ -31,6 +31,6 @@ metrics:
       queryKey: default
       queryParams:
         instanceKey: _id
-        product: rhel-for-x86-eus-payg-placeholder-role
+        product: Red Hat Enterprise Linux Server #Probably will be updated by SWATCH-1834, since this is usually populated by role
         metric: system_cpu_logical_count
         metadataMetric: system_cpu_logical_count


### PR DESCRIPTION
Update eus payg product config to match test data available in rhelemeter stage currently.  This should make the swatch-metrics-rhel-job actually start to get data to do something with.

Manual testing of the promql:
1. Start up a token refresher for rhelemeter stage.  Get the client id and secret from vault under the "rhel-token-refresher" secret

```
RHOBS_STAGE_CLIENT_ID=REDACTED
RHOBS_STAGE_CLIENT_SECRET=REDACTED
RHOBS_STAGE_ISSUER_URL=https://sso.redhat.com/auth/realms/redhat-external
RHOBS_STAGE_SCOPE="openid offline_access"
RHOBS_STAGE_URL=https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/rhel/api/v1

podman run --name=telemeter-stage --rm -ti -p 8082:8080 \
    quay.io/observatorium/token-refresher:$TOKEN_REFRESHER_VERSION \
    --scope=$(echo $RHOBS_STAGE_SCOPE) \
    --oidc.client-secret=$(echo $RHOBS_STAGE_CLIENT_SECRET) \
    --oidc.client-id=$(echo $RHOBS_STAGE_CLIENT_ID) \
    --oidc.issuer-url=$(echo $RHOBS_STAGE_ISSUER_URL) \
    --url=$(echo $RHOBS_STAGE_URL)
```

Use script to generate promql that will be used 
```
./bin/metering-promql.py --org 16787820 --product rhel-for-x86-eus-payg

rhel-for-x86-eus-payg
---------------------
  Accounts PromQL: group(min_over_time(system_cpu_logical_count{product='Red Hat Enterprise Linux Server', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)
  vCPUs PromQL: max(system_cpu_logical_count) by (_id) * on(_id) group_right min_over_time(system_cpu_logical_count{product="Red Hat Enterprise Linux Server", external_organization="16787820", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
```

Test queries using curl to observe data gets returned
```
curl "http://localhost:8082/query?query=group%28min_over_time%28system_cpu_logical_count%7Bproduct%3D%27Red%20Hat%20Enterprise%20Linux%20Server%27%2C%20external_organization%20%21%3D%20%27%27%2C%20billing_model%3D%27marketplace%27%7D%5B1h%5D%29%29%20by%20%28external_organization%29" | jq
```

```json
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "external_organization": "11789772"
        },
        "value": [
          1697131270.115,
          "1"
        ]
      },
      {
        "metric": {
          "external_organization": "16787820"
        },
        "value": [
          1697131270.115,
          "1"
        ]
      }
    ]
  }
}
```

```
curl "http://localhost:8082/query?query=max%28system_cpu_logical_count%29%20by%20%28_id%29%20%2A%20on%28_id%29%20group_right%20min_over_time%28system_cpu_logical_count%7Bproduct%3D%22Red%20Hat%20Enterprise%20Linux%20Server%22%2C%20external_organization%3D%2216787820%22%2C%20billing_model%3D%22marketplace%22%2C%20support%3D~%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29" | jq
```
```json
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "_id": "96764ecf-ea1c-4493-b48d-ca13b64e3e68",
          "billing_marketplace": "aws",
          "billing_marketplace_account": "customerAccount16787820",
          "billing_marketplace_instance_id": "instanceId123",
          "billing_model": "marketplace",
          "external_organization": "16787820",
          "product": "Red Hat Enterprise Linux Server",
          "receive": "true",
          "socket_count": "1",
          "support": "Premium",
          "tenant_id": "72e6f641-b2e2-47eb-bbc2-fee3c8fbda26",
          "usage": "Production"
        },
        "value": [
          1697131293.076,
          "1"
        ]
      },
      {
        "metric": {
          "_id": "d3f8d7be-5b7c-481a-b403-52e3d768dde1",
          "billing_marketplace": "aws",
          "billing_marketplace_account": "gcp16787820",
          "billing_marketplace_instance_id": "projects/mock-project-id/zones/mock-zone/instances/mock-instance-name",
          "billing_model": "marketplace",
          "external_organization": "16787820",
          "product": "Red Hat Enterprise Linux Server",
          "receive": "true",
          "socket_count": "1",
          "support": "Premium",
          "tenant_id": "72e6f641-b2e2-47eb-bbc2-fee3c8fbda26",
          "usage": "Production"
        },
        "value": [
          1697131293.076,
          "1"
        ]
      }
    ]
  }
}```