### PR TITLE
SWATCH-1853: Event consumer throws error when updating existing events

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
@@ -27,7 +27,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.validation.Valid;
 import java.time.OffsetDateTime;
@@ -75,7 +74,7 @@ public class EventRecord {
     this.timestamp = event.getTimestamp();
   }
 
-  @Column(name = "event_id")
+  @Column(name = "event_id", updatable = false)
   private UUID eventId;
 
   @Id
@@ -107,7 +106,7 @@ public class EventRecord {
   */
 
   @CreationTimestamp
-  @Column(name = "record_date")
+  @Column(name = "record_date", updatable = false)
   private OffsetDateTime recordDate;
 
   @Valid
@@ -126,13 +125,6 @@ public class EventRecord {
     }
 
     this.eventId = event.getEventId();
-  }
-
-  @PreUpdate
-  public void syncEventId() {
-    if (event != null && event.getEventId() != null && !event.getEventId().equals(this.eventId)) {
-      this.eventId = event.getEventId();
-    }
   }
 
   @Override


### PR DESCRIPTION
Jira issue: [SWATCH-1853](https://issues.redhat.com/browse/SWATCH-1853)

## Description
When sending the same event twice into the service ingress consumer, for example if we mock the prometheus service to return the following content:

```
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : [
        {
          "metric" : {
            "_id" : "cluster id",
            "support" : "sla",
            "usage" : "usage",
            "product" : "product",
            "billing_marketplace" : "billing_marketplace",
            "billing_marketplace_account" : "billing_marketplace_account",
            "ebs_account" : "account"
          },
          "values": [[ $(date +%s), "1" ]]
        }
      ]
    }
}
```

And next we run the metering *twice* via:

```
http POST :8000/api/rhsm-subscriptions/v1/internal/metering/rosa?orgId=16790890 \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder \
x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16790890"}}}' | base64 -w 0)
```

This will produce two events, one that will create the event and the next one that will update it.

However, the second update will not be happening because it will throw the following exception:

```
2023-10-18 09:55:22,769 [thread=swatch-instance-ingress-0-C-1] [ERROR] [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] - ERROR: null value in column "event_id" of relation "events" violates not-null constraint
  Detail: Failing row contains (null, null, 2023-10-18 08:57:02-03, {"sla": "Premium", "role": "ocp", "org_id": "1111", "timestamp":..., snapshot_rosa_cores, prometheus, id0, 1111, null, 94027245-ae93-4a50-953f-3ffaa690b09b, null).
2023-10-18 09:55:22,776 [thread=swatch-instance-ingress-0-C-1] [WARN ] [org.candlepin.subscriptions.event.EventController] - Failed to save events. Retrying individually 1 events.
```

## Testing

1.- podman-compose up
2.- ./gradlew :bootRun
3.- Once the migration is finished, stop all the application that started in step 2.

4.- Mock the prometheus server at localhost:

Create the stub directory:
`mkdir -p stub/__files`

Add a stub file to return some data: `stub/__files/swatch-1853.json`

```
cat > stub/__files/swatch-1853.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : [
        {
          "metric" : {
            "_id" : "cluster id",
            "support" : "sla",
            "usage" : "Development/Test",
            "product" : "product",
            "billing_marketplace" : "billing_marketplace",
            "billing_marketplace_account" : "billing_marketplace_account",
            "ebs_account" : "account"
          },
          "values": [[ $(date +%s), "1" ]]
        }
      ]
    }
}
EOF
```

Add a stub file to return no data: `stub/__files/empty.json`

```
cat > stub/__files/empty.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : []
    }
}
EOF
```

Run wiremock:
`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

Configure stubbing for prometheus:

- this is to return some data when asking for instance-hours:
`curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/api/v1/query_range", "method": "GET", "queryParameters": {"query": {"contains":"instance_hours"}}}, "response": { "status": 200, "bodyFileName": "swatch-1853.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

- this is to return no data otherwise:
`curl -X POST --data '{ "priority": 5, "request": { "urlPath": "/api/v1/query_range", "method": "GET" }, "response": { "status": 200, "bodyFileName": "empty.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

5.- Start the swatch metrics app: `EVENT_SOURCE=prometheus PROM_URL="http://localhost:8101/api/v1/" SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true RHSM_RBAC_USE_STUB=true SUBSCRIPTION_SYNC_ENABLED=true ENABLE_SYNCHRONOUS_OPERATIONS=true SPRING_PROFILES_ACTIVE=openshift-metering-worker,kafka-queue ./gradlew :bootRun`

6.- Trigger the metrics from prometheus:
```
http POST :8000/api/rhsm-subscriptions/v1/internal/metering/rosa?orgId=16790890 \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder \
x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16790890"}}}' | base64 -w 0)
```

7.- Confirm the events have been produced in the Kafka topic "platform.rhsm-subscriptions.service-instance-ingress".

You should see two events in http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.service-instance-ingress/:

```
Key 16790890
Value
event_source prometheus
event_type snapshot_rosa_instance-hours
account_number account
org_id 16790890
service_type rosa Instance
instance_id cluster id
timestamp 2023-08-31T05:17:15Z
expiration 2023-08-31T06:17:15Z
display_name cluster id
measurements [ [object Object] ]
billing_account_id billing_marketplace_account

Key 16790890
Value
event_source prometheus
event_type cleanup-snapshot_rosa_instance-hours
org_id 16790890
timestamp 2023-08-31T06:00:00Z
```

The last event is the cleanup event!

8.- Now, let's start the tally service (you can now stop the swatch metrics service that start in the step 5): `SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true RHSM_RBAC_USE_STUB=true ./gradlew :bootRun`

9.- Wait some time, so the service consumes all the events from the topic, and then query the `events` table:

Connect to the database:
`psql -h localhost -U rhsm-subscriptions rhsm-subscriptions`

And query for the events in the database:

`SELECT * FROM EVENTS;`

And you should see only one event. The event id "b934c72e-f179-4d75-b589-4f703fb49812" should have been deleted because it was a stale event.


10.- Update the mock

Close the wiremock instance that mocks the prometheus service (the one that started on the step 5).

Update the stub `stub/__files/swatch-1853.json` to update for example the "usage" field:

```
cat > stub/__files/swatch-1853.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : [
        {
          "metric" : {
            "_id" : "cluster id",
            "support" : "sla",
            "usage" : "Production",
            "product" : "product",
            "billing_marketplace" : "billing_marketplace",
            "billing_marketplace_account" : "billing_marketplace_account",
            "ebs_account" : "account"
          },
          "values": [[ $(date +%s), "1" ]]
        }
      ]
    }
}
EOF
```

Run wiremock:
`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

Configure stubbing for prometheus:

- this is to return some data when asking for instance-hours:
`curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/api/v1/query_range", "method": "GET", "queryParameters": {"query": {"contains":"instance_hours"}}}, "response": { "status": 200, "bodyFileName": "swatch-1853.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

- this is to return no data otherwise:
`curl -X POST --data '{ "priority": 5, "request": { "urlPath": "/api/v1/query_range", "method": "GET" }, "response": { "status": 200, "bodyFileName": "empty.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

11.- Repeat the steps 5 to 9 and now the event usage should be updated to "Production" and the "record_date" column should not be empty.

Before these changes, the event was not updated.