### PR TITLE
SWATCH-1858: Change hsql dependency from runtimeOnly to testImplementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,7 @@ dependencies {
     testImplementation libraries["awaitility"]
     testImplementation project(':swatch-core-test')
     testImplementation project(':swatch-common-testcontainers')
-
-    runtimeOnly "org.hsqldb:hsqldb"
+    testImplementation "org.hsqldb:hsqldb"
 
     javaagent  libraries["splunk-otel-agent"]
 

--- a/swatch-system-conduit/build.gradle
+++ b/swatch-system-conduit/build.gradle
@@ -97,8 +97,8 @@ dependencies {
     testImplementation "org.springframework.security:spring-security-test"
     testImplementation "org.springframework.kafka:spring-kafka-test"
     testImplementation project(':swatch-core-test')
+    testImplementation "org.hsqldb:hsqldb"
 
-    runtimeOnly "org.hsqldb:hsqldb"
     runtimeOnly libraries["resteasy-jackson2-provider"]
 
     javaagent  libraries["splunk-otel-agent"]


### PR DESCRIPTION
Jira issue: [SWATCH-1858](https://issues.redhat.com/browse/SWATCH-1858)

## Description
Having the hsql dependency as runtime only, it will hide issues when not providing the overridden database dependency since it will use an in-memory hsql dependency.

## Testing
No need new testing. All the e2e tests should work as expected. 