### PR TITLE
Use stage endpoints as EE defaults for subscription sync and conduit

### DIFF
--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -144,7 +144,7 @@ rhsm-subscriptions:
       maximum-pool-size: ${DATABASE_MAX_POOL_SIZE}
   product:
     useStub: ${PRODUCT_USE_STUB:false}
-    url: ${PRODUCT_URL:https://product.qa.api.redhat.com/svcrest/product/v3}
+    url: ${PRODUCT_URL:https://product.stage.api.redhat.com/svcrest/product/v3}
     keystore: file:${PRODUCT_KEYSTORE:}
     keystorePassword: ${PRODUCT_KEYSTORE_PASSWORD:redhat}
     maxConnections: ${PRODUCT_MAX_CONNECTIONS:100}

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -102,7 +102,7 @@ parameters:
     value: 'marketplace'
   - name: USER_HOST
     # required: true # FIXME Not sure where this is provided
-    value: 'user.qa.api.redhat.com'
+    value: 'user.stage.api.redhat.com'
   - name: USER_MAX_CONNECTIONS
     value: '100'
   - name: USER_MAX_ATTEMPTS

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -78,9 +78,9 @@ parameters:
   - name: DATABASE_MAX_POOL_SIZE
     value: '25'
   - name: PRODUCT_URL
-    value: https://product.qa.api.redhat.com/svcrest/product/v3
+    value: https://product.stage.api.redhat.com/svcrest/product/v3
   - name: SUBSCRIPTION_URL
-    value: https://subscription.qa.api.redhat.com/svcrest/subscription/v5
+    value: https://subscription.stage.api.redhat.com/svcrest/subscription/v5
   - name: SUBSCRIPTION_MAX_CONNECTIONS
     value: '100'
   - name: SUBSCRIPTION_BACKOFF_INITIAL_INTERVAL
@@ -94,7 +94,7 @@ parameters:
   - name: SUBSCRIPTION_PAGE_SIZE
     value: '500'
   - name: USER_HOST
-    value: 'user.qa.api.redhat.com'
+    value: 'user.stage.api.redhat.com'
   - name: USER_MAX_CONNECTIONS
     value: '100'
   - name: USER_MAX_ATTEMPTS

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -57,13 +57,13 @@ parameters:
   - name: OFFERING_SYNC_SCHEDULE
     value: 0 2 * * *
   - name: SUBSCRIPTION_URL
-    value: https://subscription.qa.api.redhat.com/svcrest/subscription/v5
+    value: https://subscription.stage.api.redhat.com/svcrest/subscription/v5
   - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN
     value: 2m
   - name: SUBSCRIPTION_IGNORE_STARTING_LATER_THAN
     value: 2m
   - name: PRODUCT_URL
-    value: https://product.qa.api.redhat.com/svcrest/product/v3
+    value: https://product.stage.api.redhat.com/svcrest/product/v3
   - name: SUBSCRIPTION_MAX_CONNECTIONS
     value: '100'
   - name: SUBSCRIPTION_MAX_RETRY_ATTEMPTS

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -40,7 +40,7 @@ parameters:
   - name: CPU_LIMIT
     value: 1500m
   - name: RHSM_URL
-    value: https://api.rhsm.qa.redhat.com/v1
+    value: https://api.rhsm.stage.redhat.com/v1
   - name: RHSM_MAX_ATTEMPTS
     value: '10'
   - name: RHSM_BACK_OFF_MAX_INTERVAL

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -69,7 +69,7 @@ parameters:
     value: 'marketplace'
   - name: USER_HOST
     # required: true # FIXME Not sure where this is provided
-    value: 'user.qa.api.redhat.com'
+    value: 'user.stage.api.redhat.com'
   - name: USER_MAX_CONNECTIONS
     value: '100'
   - name: USER_MAX_ATTEMPTS


### PR DESCRIPTION
Why?  To support IQE tests.

Related: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/84923

