### PR TITLE
SWATCH-1829: Bump kubedock to updated image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ kind: Pod
 spec:
   containers:
     - name: kubedock
-      image: quay.io/cloudservices/kubedock:123efe0
+      image: quay.io/cloudservices/kubedock:d431b39
       tty: true
       args:
        - server

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     }
     agent {
         kubernetes {
-            label 'swatch-17-kubedock' // this value + unique identifier becomes the pod name
+            label 'swatch-17-kubedock-2023-10-19' // this value + unique identifier becomes the pod name
             idleMinutes 5  // how long the pod will live after no jobs have run on it
             defaultContainer 'openjdk17'
             yaml """


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1829](https://issues.redhat.com/browse/SWATCH-1829)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Bump kubedock image to a version having deps that are not vulnerable to CVE-2023-39325/CVE-2023-44487.