### PR TITLE
SWATCH-1522: Configure RHEL for x86 HA - traditional subscriptions

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_ha.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_ha.yaml
@@ -1,0 +1,15 @@
+---
+platform: RHEL
+
+id: rhel-for-x86-ha
+
+variants:
+  - tag: rhel-for-x86-ha
+    engineeringIds:
+      - 83 # Red Hat Enterprise Linux High Availability for x86_64
+
+defaults:
+  variant: rhel-for-x86-ha
+
+metrics:
+  - id: Sockets

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
@@ -46,7 +46,7 @@ class SubscriptionDefinitionRegistryTest {
   void testLoadAllTheThings() {
 
     var actual = subscriptionDefinitionRegistry.getSubscriptions().size();
-    var expected = 17;
+    var expected = 18;
 
     assertEquals(expected, actual);
   }


### PR DESCRIPTION
Jira issue: [SWATCH-1522](https://issues.redhat.com/browse/SWATCH-1522)

## Description

As a developer, I need tallying to counting of traditional (yearly) subscriptions for RHEL High Availability.   I want to define the configuration for rhel-for-x86-ha and use that to do this work. This is focused on traditional subscriptions. There will be other cards for metered subscriptions. 

## Testing notes

I've added a test case that covers these changes. The test case and functionality must be reviewed.

Steps for manual testing (the automatic test case mimics the below steps):

1.- podman-compose up
2.- Build the whole project:

```
./gradlew clean build -x test
```

3.- Add host to Insight DB:

```
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) 
VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "83"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123', '{}');
```

The important part of the above query is `installed_products` which id contains the value "83".

4.- DEV_MODE=true SPRING_PROFILES_ACTIVE=worker ./gradlew :bootRun
5.- Run nightly Tally using command below:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder
```

6.- Verification in RHSM subscription database:

```
select count(*) from host_tally_buckets where product_id = 'rhel-for-x86-ha'
```

It should return 4 rows.

