### PR TITLE
SWATCH-1857 Modify the timestamp to remittance_pending_date when we send usage to AWS

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -198,7 +198,10 @@ public class BillableUsageController {
         currentlyMeasuredTotal,
         totalRemitted,
         usageCalc);
-
+    // There were issues with transmitting usage to AWS since the cost event timestamps were in the
+    // past. This modification allows us to send usage to AWS if we get it during the current hour
+    // of event tally.
+    usage.setSnapshotDate(usageCalc.getRemittanceDate());
     // Update the reported usage value to the newly calculated one.
     usage.setValue(usageCalc.getBillableValue());
     usage.setBillingFactor(usageCalc.getBillingFactor());


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1857](https://issues.redhat.com/browse/SWATCH-1857)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
There were issues with transmitting usage to AWS since the cost event timestamps were in the past. This modification allows us to send usage to AWS if we get it during the current hour of event tally.

Since we persist remitted date when we send usage, we used it as the date to send usage. There is no need to use record_date since it will be -2 hours, and now() will return around the same value as the remittance date.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

**Note: You have to change the record date to current hour and tally for that hour.** 

### Setup
<!-- Add any steps required to set up the test case -->
1. Have some cost events from the past:
```
INSERT INTO public.events (event_id, account_number, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('527e29b6-321c-4021-a1f4-fcff4326ae2d', null, '2023-10-18 19:00:00.000000 +00:00', '{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "13259775", "event_id": "527e29b6-321c-4021-a1f4-fcff4326ae2d", "timestamp": "2023-10-18T19:00:00Z", "event_type": "snapshot", "expiration": "2023-10-18T20:00:00Z", "instance_id": "i-0d8d5297e354051db", "product_ids": ["69", "70"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 1.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "746157280291"}', 'snapshot', 'cost-management', 'i-0d8d5297e354051db', '13259775', null, '2023-10-19 15:05:25.594093 +00:00');
INSERT INTO public.events (event_id, account_number, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('bb9aaeb7-8013-412f-9b03-abc93f378585', null, '2023-10-18 18:00:00.000000 +00:00', '{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "13259775", "event_id": "bb9aaeb7-8013-412f-9b03-abc93f378585", "timestamp": "2023-10-18T18:00:00Z", "event_type": "snapshot", "expiration": "2023-10-18T19:00:00Z", "instance_id": "i-0d8d5297e354051db", "product_ids": ["69", "70"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 1.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "746157280291"}', 'snapshot', 'cost-management', 'i-0d8d5297e354051db', '13259775', null, '2023-10-19 15:05:25.593136 +00:00');
INSERT INTO public.events (event_id, account_number, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('2a3d273e-7811-4be8-b7b0-8304ac04c119', null, '2023-10-18 18:00:00.000000 +00:00', '{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "13259775", "event_id": "2a3d273e-7811-4be8-b7b0-8304ac04c119", "timestamp": "2023-10-18T18:00:00Z", "event_type": "snapshot", "expiration": "2023-10-18T19:00:00Z", "instance_id": "i-0bfdf751c6b771e2f", "product_ids": ["69", "70"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 1.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "746157280291"}', 'snapshot', 'cost-management', 'i-0bfdf751c6b771e2f', '13259775', null, '2023-10-19 15:05:26.095938 +00:00');
```

2. Have a subscription and offering:

`INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, account_number, subscription_number, billing_provider, billing_account_id) VALUES ('RH02781HR', '13259775', '12592043', 1, '2023-10-17 04:00:00.000000 +00:00', '2023-11-17 04:59:59.999000 +00:00', '9c9ediyijsij3tnxrtwfdqb7w;b44i9vdwLqs;568056954830', '', '12592200', 'aws', '746157280291');
`

`INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('RH02781HR', 'RHEL Server', 'RHEL', null, 2, null, null, 'Red Hat Enterprise Linux Server', 'Premium', 'Production', 'Red Hat Enterprise Linux for Third Party Linux Migration with Extended Life Cycle Support (On-Demand, Hourly Production Support)', false, '');
`

### Steps
<!-- Enter each step of the test below -->
1.Start three apps:
**swatch-core:**
 `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8001 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun `

**swatch-contract:**
`SERVER_PORT=8882 ./gradlew  :swatch-contracts:quarkusDev`

**swatch-aws:**
` SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8001/api/rhsm-subscriptions/v1 ./gradlew swatch-producer-aws:quarkusDev`

2. Execute hourly tally:
`http POST ":8001/api/rhsm-subscriptions/v1/internal/tally/hourly?org=13259775&start=2023-10-19T15:00Z&end=2023-10-19T16:00Z" x-rh-swatch-psk:placeholder`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. AWS logs:
```
Picked up billable usage message class BillableUsage {
    orgId: 13259775
    id: 28e14a81-6d6e-4d5c-8454-7569c739ef53
    billingProvider: aws
    billingAccountId: 746157280291
    snapshotDate: 2023-10-19T19:20:41.451958853Z
    productId: rhel-for-x86-eus-payg
    sla: Premium
    usage: Production
    uom: VCPUS
    value: 0.0
    billingFactor: 1.0
    vendorProductCode: null
    usageRecordDate: null
} to process
2023-10-19 15:20:41,496 INFO  [com.red.swa.aws.pro.BillableUsageProcessor] (vert.x-worker-thread-1) Sending usage request to AWS: BatchMeterUsageRequest(UsageRecords=[UsageRecord(Timestamp=2023-10-19T19:20:41.451958853Z, CustomerIdentifier=b44i9vdwLqs, Dimension=Centos_Test, Quantity=0)], ProductCode=9c9ediyijsij3tnxrtwfdqb7w), organization=13259775, product_id=rhel-for-x86-eus-payg
2023-10-19 15:20:41,497 WARN  [com.red.swa.aws.pro.BillableUsageProcessor] (vert.x-worker-thread-1) SWATCHAWS1003: AWS credentials missing: sellerAccount=568056954830 for organization=13259775, awsCustomerId=b44i9vdwLqs

```
