### PR TITLE
SWATCH-1523: Configure RHEL for x86 Resilient Storage

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -56,6 +56,8 @@ import org.candlepin.subscriptions.utilization.api.model.GranularityType;
 import org.candlepin.subscriptions.utilization.api.model.TallyReportData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -70,8 +72,6 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
   static final String USER_ID = "123";
   static final String ORG_ID = "owner" + USER_ID;
   static final String PRODUCT_TAG = "rosa";
-  static final String ENG_ID_FOR_RHEL_FOR_X86_HA = "83";
-  static final String RHEL_FOR_X86_HA = "rhel-for-x86-ha";
   static final String PHYSICAL = "PHYSICAL";
 
   @Autowired TallySnapshotController controller;
@@ -110,14 +110,15 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
   }
 
   @WithMockRedHatPrincipal(value = USER_ID)
-  @Test
-  void testProduceSnapshotsForOrgFromHostsPartOfHbi() {
+  @ParameterizedTest
+  @CsvSource(value = {"83,rhel-for-x86-ha", "90,rhel-for-x86-rs"})
+  void testProduceSnapshotsForOrgFromHostsPartOfHbi(String engId, String product) {
     givenOrgAndAccountInConfig();
-    UUID inventoryId = givenInventoryHostWithProductIds(ENG_ID_FOR_RHEL_FOR_X86_HA);
+    UUID inventoryId = givenInventoryHostWithProductIds(engId);
 
     whenProduceSnapshotsForOrg();
 
-    assertAllHostTallyBucketsHaveExpectedProduct(inventoryId, RHEL_FOR_X86_HA);
+    assertAllHostTallyBucketsHaveExpectedProduct(inventoryId, product);
   }
 
   private void assertAllHostTallyBucketsHaveExpectedProduct(

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_rs.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_rs.yaml
@@ -1,0 +1,15 @@
+---
+platform: RHEL
+
+id: rhel-for-x86-rs
+
+variants:
+  - tag: rhel-for-x86-rs
+    engineeringIds:
+      - 90 # Red Hat Enterprise Linux Resilient Storage for x86_64
+
+defaults:
+  variant: rhel-for-x86-rs
+
+metrics:
+  - id: Sockets

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
@@ -46,7 +46,7 @@ class SubscriptionDefinitionRegistryTest {
   void testLoadAllTheThings() {
 
     var actual = subscriptionDefinitionRegistry.getSubscriptions().size();
-    var expected = 18;
+    var expected = 19;
 
     assertEquals(expected, actual);
   }


### PR DESCRIPTION
Jira issue: [SWATCH-1523](https://issues.redhat.com/browse/SWATCH-1523)

## Description
As a developer, I need tallying to counting of traditional (yearly) subscriptions for RHEL Resilient Storage.  

## Testing

I've added a test case that covers these changes. The test case and functionality must be reviewed. 

Steps for manual testing (the automatic test case mimics the below steps):

1.- podman-compose up
2.- Build the whole project:

```
./gradlew clean build -x test
```

3.- Add host to Insight DB:

```
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) 
VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "90"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123', '{}');
```

The important part of the above query is `installed_products` which id contains the value "90".

4.- DEV_MODE=true SPRING_PROFILES_ACTIVE=worker ./gradlew :bootRun
5.- Run nightly Tally using command below:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder
```

6.- Verification in RHSM subscription database:

```
select count(*) from host_tally_buckets where product_id = 'rhel-for-x86-rs'
```

It should return 4 rows.

