### PR TITLE
SWATCH-1127: Update method security interceptor to use @EnableMethodSecurity

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/SecurityConfiguration.java
@@ -27,13 +27,13 @@ import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 /** Holder class for security configurations */
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableMethodSecurity
 @ComponentScan(
     basePackages = "org.candlepin.subscriptions.security",
     // Prevent TestConfiguration annotated classes from being picked up by ComponentScan


### PR DESCRIPTION
Jira issue: [SWATCH-1127](https://issues.redhat.com/browse/SWATCH-1127)

## Description
Update method security interceptor to use @EnableMethodSecurity instead of @EnableGlobalMethodSecurity 

## Testing
Ensuring no breaking tests is enough to verify these changes.