### PR TITLE
Fix SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT for aws producer

### DIFF
--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -42,7 +42,7 @@ parameters:
   - name: SPLUNK_HEC_INCLUDE_EX
     value: 'true'
   - name: SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT
-    value: http://rhsm-capacity-ingress:8000/api/rhsm-subscriptions/v1
+    value: http://swatch-subscription-sync-service:8000/api/rhsm-subscriptions/v1
   - name: AWS_MARKETPLACE_ENDPOINT_URL
     value: 'http://localhost:8101/aws-marketplace/'
   - name: AWS_MANUAL_SUBMISSION_ENABLED


### PR DESCRIPTION

## Description
Everytime EE get deployed, by default it has wrong endpoint for subscription service in aws worker. We have to manually change it to work fine.

## Testing
Verify swatch-producer-aws-service pointing to correct subscription service endpoint. 

