### PR TITLE
SWATCH-1099: deleteDataAssociatedWithOrg should delete contracts

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyDataController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyDataController.java
@@ -36,6 +36,7 @@ import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.security.OptInController;
 import org.candlepin.subscriptions.tally.AccountResetService;
+import org.candlepin.subscriptions.tally.billing.ContractsController;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
 import org.candlepin.subscriptions.util.DateRange;
 import org.candlepin.subscriptions.utilization.api.model.OptInConfig;
@@ -49,21 +50,26 @@ public class InternalTallyDataController {
   private final CaptureSnapshotsTaskManager tasks;
   private final ObjectMapper objectMapper;
   private final OptInController controller;
+  private final ContractsController contractsController;
 
   public InternalTallyDataController(
       AccountResetService accountResetService,
       EventController eventController,
       CaptureSnapshotsTaskManager tasks,
       ObjectMapper objectMapper,
-      OptInController controller) {
+      OptInController controller,
+      ContractsController contractsController) {
     this.accountResetService = accountResetService;
     this.eventController = eventController;
     this.tasks = tasks;
     this.objectMapper = objectMapper;
     this.controller = controller;
+    this.contractsController = contractsController;
   }
 
   public void deleteDataAssociatedWithOrg(String orgId) {
+    // we first delete the contracts and if it works, we continue with the rest of the data.
+    contractsController.deleteContractsWithOrg(orgId);
     accountResetService.deleteDataForOrg(orgId);
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -52,6 +52,11 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class InternalTallyResource implements InternalApi {
 
+  public static final String FEATURE_NOT_ENABLED_MESSSAGE =
+      "This feature is not currently enabled.";
+  private static final String SUCCESS_STATUS = "Success";
+  private static final String REJECTED_STATUS = "Rejected";
+
   private final ApplicationClock clock;
   private final ApplicationProperties applicationProperties;
   private final MarketplaceResendTallyController resendTallyController;
@@ -61,11 +66,6 @@ public class InternalTallyResource implements InternalApi {
   private final RemittanceRetentionController remittanceRetentionController;
   private final InternalTallyDataController internalTallyDataController;
   private final SecurityProperties properties;
-
-  public static final String FEATURE_NOT_ENABLED_MESSSAGE =
-      "This feature is not currently enabled.";
-  private static final String SUCCESS_STATUS = "Success";
-  private static final String REJECTED_STATUS = "Rejected";
 
   @SuppressWarnings("java:S107")
   public InternalTallyResource(
@@ -155,7 +155,7 @@ public class InternalTallyResource implements InternalApi {
       try {
         internalTallyDataController.deleteDataAssociatedWithOrg(orgId);
       } catch (Exception e) {
-        log.error("Unable to delete data for organization {} due to {}", orgId, e);
+        log.error("Unable to delete data for organization {}", orgId, e);
         response.setDetail(String.format("Unable to delete data for organization %s", orgId));
         return response;
       }

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyDataControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyDataControllerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import static org.mockito.Mockito.verify;
+
+import org.candlepin.subscriptions.tally.AccountResetService;
+import org.candlepin.subscriptions.tally.billing.ContractsController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"worker", "test"})
+class InternalTallyDataControllerTest {
+  @MockBean ContractsController contractsController;
+  @MockBean AccountResetService accountResetService;
+  @Autowired InternalTallyDataController controller;
+
+  @Test
+  void testDeleteDataAssociatedWithOrg() {
+    String orgId = "org1";
+    controller.deleteDataAssociatedWithOrg(orgId);
+    verify(contractsController).deleteContractsWithOrg(orgId);
+    verify(accountResetService).deleteDataForOrg(orgId);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
@@ -52,11 +53,11 @@ class InternalTallyResourceTest {
   @Mock private TallyRetentionController tallyRetentionController;
   @Mock private RemittanceRetentionController remittanceRetentionController;
   @Mock private InternalTallyDataController internalTallyDataController;
+  @Mock private SecurityProperties properties;
 
   private InternalTallyResource resource;
   private ApplicationProperties appProps;
   private ApplicationClock clock;
-  SecurityProperties properties;
 
   @BeforeEach
   void setupTest() {
@@ -146,9 +147,15 @@ class InternalTallyResourceTest {
 
   @Test
   void testPurgeRemittances() {
-    OffsetDateTime start = clock.startOfCurrentHour();
-    OffsetDateTime end = start.plusHours(1L);
     resource.purgeRemittances();
     verify(remittanceRetentionController).purgeRemittancesAsync();
+  }
+
+  @Test
+  void testDeleteDataAssociatedWithOrg() {
+    String orgId = "org1";
+    when(properties.isDevMode()).thenReturn(true);
+    resource.deleteDataAssociatedWithOrg(orgId);
+    verify(internalTallyDataController).deleteDataAssociatedWithOrg(orgId);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/ContractsControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/ContractsControllerTest.java
@@ -368,6 +368,12 @@ class ContractsControllerTest {
     assertEquals(String.format("No contract info found for usage! %s", usage), e.getMessage());
   }
 
+  @Test
+  void testDeleteContractsWithOrg() throws ApiException {
+    controller.deleteContractsWithOrg("org1");
+    verify(contractsApi).deleteContractsByOrg("org1");
+  }
+
   private BillableUsage defaultUsage() {
     return new BillableUsage()
         .withOrgId("org123")

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
@@ -32,6 +32,10 @@ public class ContractRepository implements PanacheSpecificationSupport<ContractE
     return find(ContractEntity.class, specification, null);
   }
 
+  public List<ContractEntity> getContractsByOrgId(String orgId) {
+    return find("orgId", orgId).list();
+  }
+
   public ContractEntity findContract(UUID uuid) {
     log.info("Find contract by uuid {}", uuid);
     return find("uuid", uuid).firstResult();

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -112,6 +112,12 @@ public class ContractsTestingResource implements DefaultApi {
   }
 
   @Override
+  @RolesAllowed({"test", "support", "service"})
+  public StatusResponse deleteContractsByOrg(String orgId) throws ProcessingException {
+    return service.deleteContractsByOrgId(orgId);
+  }
+
+  @Override
   @RolesAllowed({"test"})
   public StatusResponse createPartnerEntitlementContract(PartnerEntitlementContract contract)
       throws ProcessingException {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -53,14 +53,14 @@ public class ContractsTestingResource implements DefaultApi {
   @Override
   @Transactional
   @RolesAllowed({"test"})
-  public Contract createContract(Contract contract) throws ApiException, ProcessingException {
+  public Contract createContract(Contract contract) throws ProcessingException {
     log.info("Creating contract");
     return service.createContract(contract);
   }
 
   @Override
   @RolesAllowed({"test"})
-  public void deleteContractByUUID(String uuid) throws ApiException, ProcessingException {
+  public void deleteContractByUUID(String uuid) throws ProcessingException {
     log.info("Deleting contract {}", uuid);
     service.deleteContract(uuid);
   }
@@ -85,7 +85,7 @@ public class ContractsTestingResource implements DefaultApi {
       String billingProvider,
       String billingAccountId,
       OffsetDateTime timestamp)
-      throws ApiException, ProcessingException {
+      throws ProcessingException {
     return service.getContracts(
         orgId, productId, billingProvider, billingAccountId, vendorProductCode, timestamp);
   }
@@ -93,7 +93,7 @@ public class ContractsTestingResource implements DefaultApi {
   @Override
   @Transactional
   @RolesAllowed({"test", "support"})
-  public StatusResponse syncAllContracts() throws ApiException, ProcessingException {
+  public StatusResponse syncAllContracts() throws ProcessingException {
     log.info("Syncing All Contracts");
     var contracts = service.getAllContracts();
     if (contracts.isEmpty()) {
@@ -107,14 +107,14 @@ public class ContractsTestingResource implements DefaultApi {
 
   @Override
   @RolesAllowed({"test", "support"})
-  public StatusResponse syncContractsByOrg(String orgId) throws ApiException, ProcessingException {
+  public StatusResponse syncContractsByOrg(String orgId) throws ProcessingException {
     return service.syncContractByOrgId(orgId);
   }
 
   @Override
   @RolesAllowed({"test"})
   public StatusResponse createPartnerEntitlementContract(PartnerEntitlementContract contract)
-      throws ApiException, ProcessingException {
+      throws ProcessingException {
     return service.createPartnerContract(contract);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -62,6 +62,9 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 @ApplicationScoped
 public class ContractService {
 
+  private static final String SUCCESS_MESSAGE = "SUCCESS";
+  private static final String FAILURE_MESSAGE = "FAILED";
+
   private final ContractRepository contractRepository;
   private final SubscriptionRepository subscriptionRepository;
   private final ContractMapper mapper;
@@ -88,7 +91,7 @@ public class ContractService {
    * payload. This method will always set the end date to 'null', which indicates an active
    * contract.
    *
-   * @param contract
+   * @param contract the contract dto to create.
    * @return Contract dto
    */
   @Transactional
@@ -143,12 +146,13 @@ public class ContractService {
    * Build Specifications based on provided parameters if not null and use to query the database
    * based on specifications.
    *
-   * @param orgId
-   * @param productId
-   * @param billingProvider
-   * @param billingAccountId
-   * @param vendorProductCode
-   * @return List<Contract> dtos
+   * @param orgId the org ID.
+   * @param productId the product ID.
+   * @param billingProvider the billing provider.
+   * @param billingAccountId the billing account ID.
+   * @param vendorProductCode the vendor product code.
+   *
+   * @return List<Contract> the list of contracts.
    */
   public List<Contract> getContracts(
       String orgId,
@@ -185,7 +189,7 @@ public class ContractService {
    * Delete a contract for a given uuid. This is soft delete. It sets the end date of a contract to
    * the current timestamp.
    *
-   * @param uuid
+   * @param uuid the contract id.
    */
   @Transactional
   public void deleteContract(String uuid) {
@@ -306,8 +310,6 @@ public class ContractService {
   @Transactional
   public StatusResponse syncContractByOrgId(String contractOrgSync) {
     StatusResponse statusResponse = new StatusResponse();
-    final String failureMessage = "FAILED";
-    final String successMsg = "SUCCESS";
 
     try {
       var currentContracts = listCurrentlyActiveContractsByOrgId(contractOrgSync);
@@ -315,7 +317,7 @@ public class ContractService {
       if (currentContracts.isEmpty()) {
         log.debug("No active contract for {}", contractOrgSync);
         return statusResponse
-            .status(failureMessage)
+            .status(FAILURE_MESSAGE)
             .message(contractOrgSync + " not found in table");
       }
 
@@ -332,12 +334,12 @@ public class ContractService {
               transformEntitlementToContractEntity(result.getContent(), contract);
           if (Objects.nonNull(entitlementEntity)) {
             log.info("Syncing new Contract for {}", contractOrgSync);
-            statusResponse.setStatus(successMsg);
+            statusResponse.setStatus(SUCCESS_MESSAGE);
             var now = OffsetDateTime.now();
             persistSubscription(createSubscriptionForContract(entitlementEntity, true), now);
             persistContract(entitlementEntity, now);
           } else {
-            statusResponse.setStatus(failureMessage);
+            statusResponse.setStatus(FAILURE_MESSAGE);
             statusResponse.setMessage("Entitlement Cannot be found for " + contractOrgSync);
             return statusResponse;
           }
@@ -346,12 +348,12 @@ public class ContractService {
       statusResponse.setMessage("Contracts Synced for " + contractOrgSync);
     } catch (NumberFormatException e) {
       log.error(e.getMessage());
-      statusResponse.setStatus(failureMessage);
+      statusResponse.setStatus(FAILURE_MESSAGE);
       statusResponse.setMessage("An Error occurred while reconciling contract");
       return statusResponse;
     } catch (ApiException e) {
       log.error(e.getMessage());
-      statusResponse.setStatus(failureMessage);
+      statusResponse.setStatus(FAILURE_MESSAGE);
       statusResponse.setMessage("An Error occurred while calling Partner Api");
       return statusResponse;
     }
@@ -414,19 +416,6 @@ public class ContractService {
 
   private boolean isDuplicateContract(ContractEntity newEntity, ContractEntity existing) {
     return Objects.equals(newEntity, existing);
-  }
-
-  /**
-   * Updating of the unique constraint properties (productId, subscriptionNumber, and startDate are
-   * not allowed.
-   *
-   * @param o
-   * @param dto
-   * @return boolean
-   */
-  boolean isUpdateAllowed(ContractEntity o, Contract dto) {
-
-    return Objects.equals(dto.getVendorProductCode(), o.getVendorProductCode());
   }
 
   private ContractEntity transformEntitlementToContractEntity( // NOSONAR
@@ -519,7 +508,7 @@ public class ContractService {
 
   private void populateProductIdBySku(ContractEntity entity) {
     var sku = entity.getSku();
-    log.trace("Call swatch api to get producttags by sku {}", sku);
+    log.trace("Call swatch api to get product tags by sku {}", sku);
 
     if (Objects.nonNull(sku)) {
       try {

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -265,11 +265,40 @@ paths:
                     status: 'Success'
                     message: "Contracts Synced for given org_id"
           description: success
-
       security:
         - support: []
         - test: []
       operationId: syncContractsByOrg
+
+  /api/swatch-contracts/internal/rpc/reset/contracts/{org_id}:
+    description: "Clear all contracts for a given org ID. "
+    delete:
+      parameters:
+        - name: org_id
+          description: ""
+          schema:
+            type: string
+          in: path
+          required: true
+      summary: "Clear all contracts for given org_id."
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+              examples:
+                status response:
+                  value:
+                    status: 'Success'
+                    message: "Contracts Cleared for given org_id"
+          description: success
+      security:
+        - support: [ ]
+        - test: [ ]
+        - service: [ ]
+      operationId: deleteContractsByOrg
+
   /internal/rpc/syncAllContracts:
     description: "Trigger a sync for all contracts"
     post:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/ContractsHttpEndpointTest.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.contract;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.openapi.model.Contract;
@@ -33,6 +34,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
 import java.util.List;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -55,7 +57,7 @@ class ContractsHttpEndpointTest {
         .when()
         .get("/api/swatch-contracts/internal/contracts")
         .then()
-        .statusCode(200)
+        .statusCode(HttpStatus.SC_OK)
         .body("size()", is(1))
         .body("[0].org_id", is("org123"));
   }
@@ -81,7 +83,7 @@ class ContractsHttpEndpointTest {
         .when()
         .post("/api/swatch-contracts/internal/contracts")
         .then()
-        .statusCode(200);
+        .statusCode(HttpStatus.SC_OK);
   }
 
   @Test
@@ -94,7 +96,7 @@ class ContractsHttpEndpointTest {
         .when()
         .delete("/api/swatch-contracts/internal/contracts/123")
         .then()
-        .statusCode(204);
+        .statusCode(HttpStatus.SC_NO_CONTENT);
   }
 
   @Test
@@ -132,6 +134,19 @@ class ContractsHttpEndpointTest {
         .when()
         .post("/api/swatch-contracts/internal/rpc/partner/contracts")
         .then()
-        .statusCode(200);
+        .statusCode(HttpStatus.SC_OK);
+  }
+
+  @Test
+  @TestSecurity(
+      user = "placeholder",
+      roles = {"test"})
+  void deleteContractsByOrgId() {
+    given()
+        .when()
+        .delete("/api/swatch-contracts/internal/rpc/reset/contracts/org123")
+        .then()
+        .statusCode(HttpStatus.SC_NO_CONTENT);
+    verify(contractService).deleteContractsByOrgId("org123");
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -20,23 +20,18 @@
  */
 package com.redhat.swatch.contract.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.redhat.swatch.clients.subscription.api.model.Subscription;
 import com.redhat.swatch.clients.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
 import com.redhat.swatch.contract.BaseUnitTest;
 import com.redhat.swatch.contract.model.MeasurementMetricIdTransformer;
-import com.redhat.swatch.contract.openapi.model.*;
+import com.redhat.swatch.contract.openapi.model.Contract;
+import com.redhat.swatch.contract.openapi.model.Metric;
+import com.redhat.swatch.contract.openapi.model.OfferingProductTags;
+import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
+import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContractCloudIdentifiers;
+import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.repository.ContractEntity;
-import com.redhat.swatch.contract.repository.ContractMetricEntity;
 import com.redhat.swatch.contract.repository.ContractRepository;
 import com.redhat.swatch.contract.repository.OfferingEntity;
 import com.redhat.swatch.contract.repository.OfferingRepository;
@@ -46,23 +41,39 @@ import com.redhat.swatch.contract.resource.WireMockResource;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
 import jakarta.inject.Inject;
-import java.time.OffsetDateTime;
-import java.util.*;
+import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 @QuarkusTestResource(value = WireMockResource.class, restrictToAnnotatedClass = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ContractServiceTest extends BaseUnitTest {
+
+  private static final String ORG_ID = "org123";
+  private static final String PRODUCT_ID = "BASILISK123";
+  private static final String SUBSCRIPTION_NUMBER = "subs123";
+
   @Inject ContractService contractService;
-  @InjectMock ContractRepository contractRepository;
+  @InjectSpy ContractRepository contractRepository;
   @InjectMock OfferingRepository offeringRepository;
   @InjectMock SubscriptionRepository subscriptionRepository;
 
@@ -70,12 +81,8 @@ class ContractServiceTest extends BaseUnitTest {
 
   @InjectMock @RestClient SearchApi subscriptionApi;
   @InjectMock MeasurementMetricIdTransformer measurementMetricIdTransformer;
-  ContractEntity actualContract1;
 
-  Contract contractDto;
-
-  @Captor ArgumentCaptor<ContractEntity> contractArgumentCaptor;
-
+  @Transactional
   @BeforeEach
   public void setup() {
     when(offeringRepository.findById(anyString()))
@@ -86,47 +93,159 @@ class ContractServiceTest extends BaseUnitTest {
               offering.setSku((String) args[0]);
               return offering;
             });
+
+    contractRepository.deleteAll();
+    mockSubscriptionServiceSubscription();
+    mockOfferingProductTagsToReturn(List.of("MH123"));
   }
 
-  @BeforeAll
-  public void setupTestData() {
-    actualContract1 = new ContractEntity();
+  @Test
+  void testSaveContracts() {
+    Contract request = givenContractRequest();
+    Contract response = contractService.createContract(request);
+
+    ContractEntity entity = contractRepository.findById(UUID.fromString(response.getUuid()));
+    assertEquals(request.getSku(), entity.getSku());
+    assertEquals(response.getUuid(), entity.getUuid().toString());
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(measurementMetricIdTransformer).translateContractMetricIdsToSubscriptionMetricIds(any());
+  }
+
+  @Test
+  void testGetContracts() {
+    givenExistingContract();
+    List<Contract> contractList =
+        contractService.getContracts(ORG_ID, PRODUCT_ID, null, null, null, null);
+    assertEquals(1, contractList.size());
+    assertEquals(2, contractList.get(0).getMetrics().size());
+  }
+
+  @Test
+  void createPartnerContract_WhenNonNullEntityAndContractNotFoundInDB() {
+    var contract = givenPartnerEntitlementContractRequest();
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+    assertEquals("New contract created", statusResponse.getMessage());
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(measurementMetricIdTransformer).translateContractMetricIdsToSubscriptionMetricIds(any());
+  }
+
+  @Test
+  void createPartnerContract_WhenNullEntityThrowError() {
+    mockOfferingProductTagsToReturn(null);
+    var contract = givenPartnerEntitlementContractRequest();
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+    assertEquals("Empty value in non-null fields", statusResponse.getMessage());
+  }
+
+  @Test
+  void whenInvalidPartnerContract_DoNotPersist() {
+    var contract = givenPartnerEntitlementContractWithoutProductCode();
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+    assertEquals("Empty value found in UMB message", statusResponse.getMessage());
+  }
+
+  @Test
+  void createPartnerContract_NotDuplicateContractThenPersist() {
+    givenExistingContract();
+
+    PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
+
+    StatusResponse statusResponse = contractService.createPartnerContract(request);
+    assertEquals(
+            "Previous contract archived and new contract created", statusResponse.getMessage());
+  }
+
+  @Test
+  void createPartnerContract_DuplicateContractThenDoNotPersist() {
+    PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
+    contractService.createPartnerContract(request);
+
+    StatusResponse statusResponse = contractService.createPartnerContract(request);
+    assertEquals("Duplicate record found", statusResponse.getMessage());
+  }
+
+  @Test
+  void syncContractWithExistingAndNewContracts() {
+    givenExistingContract();
+    StatusResponse statusResponse = contractService.syncContractByOrgId(ORG_ID);
+    assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
+    // 2 instances of subscription are created, one for the original contract, and one for the
+    // update
+    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
+    verify(measurementMetricIdTransformer, times(2))
+            .translateContractMetricIdsToSubscriptionMetricIds(any());
+  }
+
+  @Test
+  void syncContractWithEmptyContractsList() {
+    StatusResponse statusResponse = contractService.syncContractByOrgId(ORG_ID);
+    assertEquals(ORG_ID + " not found in table", statusResponse.getMessage());
+  }
+
+  @Test
+  void testDeleteContractDeletesSubscription() {
+    ContractEntity contract = givenExistingContract();
+    SubscriptionEntity subscription = givenExistingSubscription();
+    contractService.deleteContract(contract.getUuid().toString());
+    verify(subscriptionRepository).delete(subscription);
+    verify(contractRepository).delete(argThat(c -> c.getUuid().equals(contract.getUuid())));
+  }
+
+  @Test
+  void testDeleteContractNoopWhenMissing() {
+    contractService.deleteContract(UUID.randomUUID().toString());
+    verify(subscriptionRepository, times(0)).delete(any());
+    verify(contractRepository, times(0)).delete(any());
+  }
+
+  @Test
+  void createPartnerContract_DuplicateContractThenDoNotPersist() throws ApiException {
+    ContractEntity incomingContract = new ContractEntity();
     var uuid = UUID.randomUUID();
-    actualContract1.setUuid(uuid);
-    actualContract1.setBillingAccountId("billAcct123");
-    actualContract1.setStartDate(OffsetDateTime.now());
-    actualContract1.setEndDate(OffsetDateTime.now());
-    actualContract1.setBillingProvider("test123");
-    actualContract1.setVendorProductCode("product123");
-    actualContract1.setSku("BAS123");
-    actualContract1.setProductId("BASILISK123");
-    actualContract1.setOrgId("org123");
-    actualContract1.setLastUpdated(OffsetDateTime.now());
-    actualContract1.setSubscriptionNumber("test");
+    OffsetDateTime offsetDateTime = OffsetDateTime.now();
 
-    ContractMetricEntity contractMetric1 = new ContractMetricEntity();
-    contractMetric1.setContractUuid(uuid);
-    contractMetric1.setMetricId("cpu-hours");
-    contractMetric1.setValue(2);
+  private static PartnerEntitlementContract givenPartnerEntitlementContractWithoutProductCode() {
+    var contract = givenPartnerEntitlementContractRequest();
+    contract.getCloudIdentifiers().setProductCode(null);
+    return contract;
+  }
 
-    ContractMetricEntity contractMetric2 = new ContractMetricEntity();
-    contractMetric2.setContractUuid(uuid);
-    contractMetric2.setMetricId("instance-hours");
-    contractMetric2.setValue(4);
+  private static PartnerEntitlementContract givenPartnerEntitlementContractRequest() {
+    var contract = new PartnerEntitlementContract();
+    contract.setRedHatSubscriptionNumber(SUBSCRIPTION_NUMBER);
 
-    actualContract1.setMetrics(Set.of(contractMetric1, contractMetric2));
+    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
+            new PartnerEntitlementContractCloudIdentifiers();
+    cloudIdentifiers.setAwsCustomerId("HSwCpt6sqkC");
+    cloudIdentifiers.setAwsCustomerAccountId("568056954830");
+    cloudIdentifiers.setProductCode("product123");
+    contract.setCloudIdentifiers(cloudIdentifiers);
+    return contract;
+  }
 
-    contractDto = new Contract();
-    contractDto.setUuid(uuid.toString());
-    contractDto.setBillingAccountId("billAcct123");
-    contractDto.setStartDate(OffsetDateTime.now());
-    contractDto.setEndDate(OffsetDateTime.now());
-    contractDto.setBillingProvider("test123");
-    contractDto.setSku("BAS123");
-    contractDto.setProductId("BASILISK123");
-    contractDto.setVendorProductCode("product123");
-    contractDto.setOrgId("org123");
-    contractDto.setSubscriptionNumber("test");
+  private SubscriptionEntity givenExistingSubscription() {
+    SubscriptionEntity subscription = new SubscriptionEntity();
+    when(subscriptionRepository.find(eq(SubscriptionEntity.class), any())).thenReturn(List.of(subscription));
+    return subscription;
+  }
+
+  private ContractEntity givenExistingContract() {
+    Contract created = contractService.createContract(givenContractRequest());
+    return contractRepository.findById(UUID.fromString(created.getUuid()));
+  }
+
+  private Contract givenContractRequest() {
+    Contract contractRequest = new Contract();
+    contractRequest.setUuid(UUID.randomUUID().toString());
+    contractRequest.setBillingAccountId("billAcct123");
+    contractRequest.setStartDate(OffsetDateTime.now());
+    contractRequest.setEndDate(OffsetDateTime.now());
+    contractRequest.setBillingProvider("test123");
+    contractRequest.setSku("BAS123");
+    contractRequest.setProductId(PRODUCT_ID);
+    contractRequest.setVendorProductCode("product123");
+    contractRequest.setOrgId(ORG_ID);
+    contractRequest.setSubscriptionNumber(SUBSCRIPTION_NUMBER);
 
     Metric metric1 = new Metric();
     metric1.setMetricId("instance-hours");
@@ -136,325 +255,24 @@ class ContractServiceTest extends BaseUnitTest {
     metric2.setMetricId("cpu-hours");
     metric2.setValue(4);
 
-    contractDto.setMetrics(List.of(metric1, metric2));
+    contractRequest.setMetrics(List.of(metric1, metric2));
+    return contractRequest;
   }
 
-  @Test
-  void testSaveContracts() {
-    doNothing().when(contractRepository).persist(any(ContractEntity.class));
-    Contract contractResponse = contractService.createContract(contractDto);
-    verify(contractRepository, times(1)).persist(contractArgumentCaptor.capture());
-    ContractEntity contract = contractArgumentCaptor.getValue();
-    assertEquals(contractDto.getSku(), contract.getSku());
-    assertEquals(contractResponse.getUuid(), contract.getUuid().toString());
-  }
-
-  @Test
-  void testGetContracts() {
-    when(contractRepository.getContracts(any())).thenReturn((List.of(actualContract1)));
-    var spec =
-        ContractEntity.orgIdEquals("org123").and(ContractEntity.productIdEquals("BASILISK123"));
-    List<Contract> contractList =
-        contractService.getContracts("org123", "BASILISK123", null, null, null, null);
-    verify(contractRepository).getContracts(any());
-    assertEquals(1, contractList.size());
-    assertEquals(2, contractList.get(0).getMetrics().size());
-  }
-
-  @Test
-  void createPartnerContract_WhenNonNullEntityAndContractNotFoundInDB() throws ApiException {
-    var contract = new PartnerEntitlementContract();
-    contract.setRedHatSubscriptionNumber("12400374");
-
-    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
-        new PartnerEntitlementContractCloudIdentifiers();
-    cloudIdentifiers.setAwsCustomerId("HSwCpt6sqkC");
-    cloudIdentifiers.setAwsCustomerAccountId("568056954830");
-    cloudIdentifiers.setProductCode("product123");
-    contract.setCloudIdentifiers(cloudIdentifiers);
-
-    OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(List.of("MH123"));
-    when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-    mockSubscriptionServiceSubscription();
-    StatusResponse statusResponse = contractService.createPartnerContract(contract);
-    assertEquals("New contract created", statusResponse.getMessage());
-  }
-
-  @Test
-  void createPartnerContract_WhenNullEntityThrowError() {
-    var contract = new PartnerEntitlementContract();
-    contract.setRedHatSubscriptionNumber("12400374");
-
-    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
-        new PartnerEntitlementContractCloudIdentifiers();
-    cloudIdentifiers.setAwsCustomerId("HSwCpt6sqkC");
-    cloudIdentifiers.setAwsCustomerAccountId("568056954830");
-    cloudIdentifiers.setProductCode("product123");
-    contract.setCloudIdentifiers(cloudIdentifiers);
-
-    OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(null);
-    when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-    StatusResponse statusResponse = contractService.createPartnerContract(contract);
-    assertEquals("Empty value in non-null fields", statusResponse.getMessage());
-  }
-
-  @Test
-  void whenInvalidPartnerContract_DoNotPersist() {
-    var contract = new PartnerEntitlementContract();
-    contract.setRedHatSubscriptionNumber("12400374");
-
-    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
-        new PartnerEntitlementContractCloudIdentifiers();
-    cloudIdentifiers.setAwsCustomerId("HSwCpt6sqkC");
-    cloudIdentifiers.setAwsCustomerAccountId("568056954830");
-    contract.setCloudIdentifiers(cloudIdentifiers);
-
-    OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(null);
-    when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-    StatusResponse statusResponse = contractService.createPartnerContract(contract);
-    assertEquals("Empty value found in UMB message", statusResponse.getMessage());
-  }
-
-  @Test
-  void createPartnerContract_NotDuplicateContractThenPersist() throws ApiException {
-    ContractEntity incomingContract = new ContractEntity();
-    var uuid = UUID.randomUUID();
-    OffsetDateTime offsetDateTime = OffsetDateTime.now();
-
-    var contract = new PartnerEntitlementContract();
-    contract.setRedHatSubscriptionNumber("12400374");
-
-    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
-        new PartnerEntitlementContractCloudIdentifiers();
-    cloudIdentifiers.setAwsCustomerId("HSwCpt6sqkC");
-    cloudIdentifiers.setAwsCustomerAccountId("568056954830");
-    cloudIdentifiers.setProductCode("product123");
-    contract.setCloudIdentifiers(cloudIdentifiers);
-
-    ContractEntity existingContract = new ContractEntity();
-    existingContract.setUuid(uuid);
-    existingContract.setBillingAccountId("568056954830");
-    existingContract.setStartDate(offsetDateTime);
-    existingContract.setEndDate(null);
-    existingContract.setBillingProvider("aws");
-    existingContract.setSku("RH000000");
-    existingContract.setProductId("BASILISK123");
-    existingContract.setVendorProductCode("product123");
-    existingContract.setOrgId("org123");
-    existingContract.setLastUpdated(offsetDateTime);
-    existingContract.setSubscriptionNumber("12400374");
-
-    ContractMetricEntity contractMetric4 = new ContractMetricEntity();
-    contractMetric4.setContractUuid(uuid);
-    contractMetric4.setMetricId("test_dim_1");
-    contractMetric4.setValue(5);
-
-    existingContract.setMetrics(Set.of(contractMetric4));
-
-    OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(List.of("MH123"));
-    when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-
-    when(contractRepository.getContracts(any())).thenReturn(List.of(existingContract));
-
-    mockSubscriptionServiceSubscription();
-
-    StatusResponse statusResponse = contractService.createPartnerContract(contract);
-    assertEquals(
-        "Previous contract archived and new contract created", statusResponse.getMessage());
-  }
-
-  private void mockSubscriptionServiceSubscription() throws ApiException {
+  private void mockSubscriptionServiceSubscription() {
     Subscription subscription = new Subscription();
     subscription.setId(42);
-    when(subscriptionApi.getSubscriptionBySubscriptionNumber(any()))
-        .thenReturn(List.of(subscription));
+    try {
+      when(subscriptionApi.getSubscriptionBySubscriptionNumber(any()))
+              .thenReturn(List.of(subscription));
+    } catch (ApiException e) {
+      fail(e);
+    }
   }
 
-  @Test
-  void createPartnerContract_DuplicateContractThenDoNotPersist() throws ApiException {
-    ContractEntity incomingContract = new ContractEntity();
-    var uuid = UUID.randomUUID();
-    OffsetDateTime offsetDateTime = OffsetDateTime.now();
-
-    var contract = new PartnerEntitlementContract();
-    contract.setRedHatSubscriptionNumber("12400374");
-
-    PartnerEntitlementContractCloudIdentifiers cloudIdentifiers =
-        new PartnerEntitlementContractCloudIdentifiers();
-    cloudIdentifiers.setAwsCustomerId("HSwCpt6sqkC");
-    cloudIdentifiers.setAwsCustomerAccountId("568056954830");
-    cloudIdentifiers.setProductCode("product123");
-    contract.setCloudIdentifiers(cloudIdentifiers);
-
-    ContractEntity existingContract = new ContractEntity();
-    existingContract.setUuid(uuid);
-    existingContract.setBillingAccountId("568056954830");
-    existingContract.setStartDate(offsetDateTime);
-    existingContract.setEndDate(null);
-    existingContract.setBillingProvider("aws");
-    existingContract.setSku("RH000000");
-    existingContract.setProductId("BASILISK123");
-    existingContract.setVendorProductCode("product123");
-    existingContract.setOrgId("org123");
-    existingContract.setLastUpdated(offsetDateTime);
-    existingContract.setSubscriptionNumber("12400374");
-
-    ContractMetricEntity contractMetric4 = new ContractMetricEntity();
-    contractMetric4.setContractUuid(uuid);
-    contractMetric4.setMetricId("foobar");
-    contractMetric4.setValue(1000000);
-
-    ContractMetricEntity contractMetric5 = new ContractMetricEntity();
-    contractMetric5.setContractUuid(uuid);
-    contractMetric5.setMetricId("cpu-hours");
-    contractMetric5.setValue(1000000);
-
-    existingContract.setMetrics(Set.of(contractMetric4, contractMetric5));
-
+  private void mockOfferingProductTagsToReturn(List<String> data) {
     OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(List.of("BASILISK123"));
+    productTags.data(data);
     when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-    mockSubscriptionServiceSubscription();
-    when(contractRepository.getContracts(any())).thenReturn(List.of(existingContract));
-
-    StatusResponse statusResponse = contractService.createPartnerContract(contract);
-    assertEquals("Duplicate record found", statusResponse.getMessage());
-  }
-
-  @Test
-  void syncContractWIthExistingAndNewContracts() throws ApiException {
-    var updateContract = new ContractEntity();
-    updateContract.setUuid(UUID.randomUUID());
-    updateContract.setOrgId("org123");
-    updateContract.setSubscriptionNumber("123456");
-    updateContract.setBillingProvider("redhat_fake");
-    updateContract.setBillingAccountId("896801664647");
-    updateContract.setStartDate(OffsetDateTime.now().minusDays(2));
-    updateContract.setEndDate(OffsetDateTime.now());
-    updateContract.setProductId("BASILISK123");
-    updateContract.setSku("MW01484");
-    when(contractRepository.getContracts(any()))
-        .thenReturn(List.of(actualContract1, updateContract));
-    when(contractRepository.findContract(any())).thenReturn(updateContract);
-
-    // mock sync call for updating contracts
-    OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(List.of("BASILISK123"));
-    when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-    mockSubscriptionServiceSubscription();
-
-    StatusResponse statusResponse = contractService.syncContractByOrgId(updateContract.getOrgId());
-    assertEquals("Contracts Synced for " + updateContract.getOrgId(), statusResponse.getMessage());
-  }
-
-  @Test
-  void syncContractWIthEmptyContractsList() {
-    var updateContract = new ContractEntity();
-    updateContract.setUuid(UUID.randomUUID());
-    updateContract.setOrgId("org123");
-    updateContract.setSubscriptionNumber("123456");
-    updateContract.setBillingProvider("redhat_fake");
-    updateContract.setBillingAccountId("896801664647");
-    updateContract.setStartDate(OffsetDateTime.now().minusDays(2));
-    updateContract.setEndDate(OffsetDateTime.now());
-    updateContract.setProductId("BASILISK123");
-    updateContract.setVendorProductCode("1234567890abcdefghijklmno");
-    updateContract.setSku("MW01484");
-    when(contractRepository.getContracts(any())).thenReturn(Collections.emptyList());
-    when(contractRepository.findContract(any())).thenReturn(updateContract);
-
-    // mock sync call for updating contracts
-    OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(List.of("BASILISK123"));
-    when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-
-    StatusResponse statusResponse = contractService.syncContractByOrgId(updateContract.getOrgId());
-    assertEquals(updateContract.getOrgId() + " not found in table", statusResponse.getMessage());
-  }
-
-  @Test
-  void testCreateContractCreatesSubscription() {
-    contractService.createContract(contractDto);
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
-    verify(measurementMetricIdTransformer).translateContractMetricIdsToSubscriptionMetricIds(any());
-  }
-
-  @Test
-  void testCreatePartnerContractCreatesSubscription() throws ApiException {
-    var contract = new PartnerEntitlementContract();
-    contract.setRedHatSubscriptionNumber("subnum");
-    contract.setCurrentDimensions(
-        List.of(new Dimension().dimensionName("name").dimensionValue("value")));
-    contract.setCloudIdentifiers(
-        new PartnerEntitlementContractCloudIdentifiers()
-            .awsCustomerAccountId("foo")
-            .awsCustomerId("bar")
-            .productCode("foobar"));
-    mockSubscriptionServiceSubscription();
-    OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(List.of("MH123"));
-    when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-
-    contractService.createPartnerContract(contract);
-
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
-    verify(measurementMetricIdTransformer).translateContractMetricIdsToSubscriptionMetricIds(any());
-  }
-
-  @Test
-  void testDeleteContractDeletesSubscription() {
-    UUID uuid = UUID.randomUUID();
-    ContractEntity contract = new ContractEntity();
-    when(contractRepository.findContract(uuid)).thenReturn(contract);
-    SubscriptionEntity subscription = new SubscriptionEntity();
-    when(subscriptionRepository.find(eq(SubscriptionEntity.class), any()))
-        .thenReturn(List.of(subscription));
-    contractService.deleteContract(uuid.toString());
-    verify(subscriptionRepository).delete(subscription);
-    verify(contractRepository).delete(contract);
-  }
-
-  @Test
-  void testDeleteContractNoopWhenMissing() {
-    UUID uuid = UUID.randomUUID();
-    when(contractRepository.findContract(uuid)).thenReturn(null);
-    when(subscriptionRepository.find(eq(SubscriptionEntity.class), any())).thenReturn(List.of());
-    contractService.deleteContract(uuid.toString());
-    verify(subscriptionRepository, times(0)).delete(any());
-    verify(contractRepository, times(0)).delete(any());
-  }
-
-  @Test
-  void testSyncContractByOrgIdCreatesSubscriptions() throws ApiException {
-    var updateContract = new ContractEntity();
-    updateContract.setUuid(UUID.randomUUID());
-    updateContract.setOrgId("org123");
-    updateContract.setSubscriptionNumber("123456");
-    updateContract.setBillingProvider("redhat_fake");
-    updateContract.setBillingAccountId("896801664647");
-    updateContract.setStartDate(OffsetDateTime.now().minusDays(2));
-    updateContract.setEndDate(OffsetDateTime.now());
-    updateContract.setProductId("BASILISK123");
-    updateContract.setSku("MW01484");
-    when(contractRepository.getContracts(any()))
-        .thenReturn(List.of(actualContract1, updateContract));
-    when(contractRepository.findContract(any())).thenReturn(updateContract);
-
-    // mock sync call for updating contracts
-    OfferingProductTags productTags = new OfferingProductTags();
-    productTags.data(List.of("BASILISK123"));
-    when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-    mockSubscriptionServiceSubscription();
-
-    contractService.syncContractByOrgId("org123");
-    // 2 instances of subscription are created, one for the original contract, and one for the
-    // update
-    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
-    verify(measurementMetricIdTransformer, times(2))
-        .translateContractMetricIdsToSubscriptionMetricIds(any());
   }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-1099](https://issues.redhat.com/browse/SWATCH-1099)

## Description
Add a DELETE endpoint to swatch-contracts that's available to the "service" role.

For QE, the new endpoint is: "DELETE: /api/swatch-contracts/internal/rpc/reset/contracts/{org_id}"

## Testing
Added tests to cover the new endpoint. 