### PR TITLE
SWATCH-1882: floorist-swatch tally failing "account_number" not exist

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -649,7 +649,6 @@ objects:
     - prefix: swatch/tally
       query: >-
         select
-        account_number,
         org_id,
         snapshot_date,
         product_id,


### PR DESCRIPTION
Jira issue: [SWATCH-1882](https://issues.redhat.com/browse/SWATCH-1882)

## Description
The column "account_config" was removed by https://github.com/RedHatInsights/rhsm-subscriptions/pull/2599 (merged yesterday). This pull request is to update the floorist query accordingly. 

## Testing
You can try the query with gabi in any environment, please add limit 10 (or similar) so as to not select too much data at once.