### PR TITLE
SWATCH-1879: column "account_number" in "subscription" does not exist

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -66,7 +66,6 @@ public interface ContractMapper {
   ContractEntity partnerContractToContractEntity(PartnerEntitlementContract contract);
 
   @Mapping(target = "subscriptionId", ignore = true)
-  @Mapping(target = "accountNumber", ignore = true)
   @Mapping(target = "billingProviderId", ignore = true)
   @Mapping(target = "quantity", constant = "1L")
   @Mapping(target = "offering", source = ".")

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionEntity.java
@@ -88,9 +88,6 @@ public class SubscriptionEntity implements Serializable {
   @Column(name = "billing_account_id")
   private String billingAccountId;
 
-  @Column(name = "account_number")
-  private String accountNumber;
-
   @Column(name = "billing_provider")
   private BillingProvider billingProvider;
 
@@ -136,7 +133,6 @@ public class SubscriptionEntity implements Serializable {
         && Objects.equals(endDate, sub.getEndDate())
         && Objects.equals(billingProviderId, sub.getBillingProviderId())
         && Objects.equals(billingAccountId, sub.getBillingAccountId())
-        && Objects.equals(accountNumber, sub.getAccountNumber())
         && Objects.equals(billingProvider, sub.getBillingProvider())
         && Objects.equals(ourProductIds, otherProductIds);
   }
@@ -154,7 +150,6 @@ public class SubscriptionEntity implements Serializable {
         endDate,
         billingProviderId,
         billingAccountId,
-        accountNumber,
         billingProvider,
         ourProductIds);
   }


### PR DESCRIPTION
Jira issue: [SWATCH-1879](https://issues.redhat.com/browse/SWATCH-1879)

## Description
The column "account_config" was removed by https://github.com/RedHatInsights/rhsm-subscriptions/pull/2599 (merged yesterday). This pull request is to update the floorist query accordingly. 

## Testing

1.- Deploy this pull request into one ephemeral namespace.
2.- Portforward the swatch contracts service using the port 8000, so localhost:8000 will talk to the swatch contracts service.
3.- Create a contract using:

```
POST http://localhost:8000/api/swatch-contracts/internal/contracts with valid payload {"subscription_number": "7620583a-e644-4fb6-8496-f9c609d9da76", "sku": "MW02393", "start_date": "2023-10-25T08:14:52Z", "org_id": 16787820, "billing_provider": "aws", "billing_account_id": "1234", "product_id": "rosa", "vendor_product_code": "6bfc68f2-ec2f-450a-b0f1-b8d383009e13", "metrics": [ {"metric_id": "control_plane_0", "value": 1}
, {"metric_id": "four_vcpu_0", "value": 1}]}
```