### PR TITLE
Get account_number from account_config table (stop-gap)

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -649,7 +649,8 @@ objects:
     - prefix: swatch/tally
       query: >-
         select
-        org_id,
+        c.account_number as account_number,
+        s.org_id as org_id,
         snapshot_date,
         product_id,
         measurement_type,
@@ -658,6 +659,7 @@ objects:
         value
         from tally_snapshots s
         join tally_measurements tm on s.id = tm.snapshot_id
+        left join account_config c on c.org_id=s.org_id
         where sla = '_ANY'
         and usage = '_ANY'
         and billing_provider = '_ANY'
@@ -668,6 +670,8 @@ objects:
     - prefix: swatch/subscriptions
       query: >-
         select
+        c.account_number,
+        subscription.org_id,
         subscription.sku,
         subscription.subscription_id,
         subscription.start_date,
@@ -685,3 +689,4 @@ objects:
           ('CORES', 'Cores'),
           ('INSTANCE_HOURS', 'Instance-hours')
         ) as metric_id_normalized(value, normalized) on subscription_measurements.metric_id=metric_id_normalized.value
+        left join account_config c on c.org_id=subscription.org_id


### PR DESCRIPTION
Until internal stakeholders can switch to org_id. Note this uses data we collected in account_config table when available.

Depends on the recreation of the account_config table in stage (we plan to comment out the changeset that removes it from prod, so that prod will have a populated table).

Depends on: #2710.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Queries tested via gabi, need to adjust the tally snapshot date range to 10 days to get an org_id with a mapped account_number.