### PR TITLE
Update swatch-664 replace account_config table

### DIFF
--- a/src/main/resources/liquibase/202310131200-remove-account-config.xml
+++ b/src/main/resources/liquibase/202310131200-remove-account-config.xml
@@ -6,32 +6,6 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-
-  <changeSet id="202310131000-01" author="vbusch">
-    <comment>Drop account_config table.  org_config is used instead.</comment>
-    <dropTable tableName="account_config"/>
-    <rollback>
-      <createTable tableName="account_config">
-        <column name="account_number" type="VARCHAR(255)">
-                <constraints nullable="true" unique="true" uniqueConstraintName="account_config_account_number_unq"/>
-        </column>
-        <column name="opt_in_type" type="VARCHAR(255)">
-          <constraints nullable="false" />
-        </column>
-        <column name="created" type="TIMESTAMP WITH TIME ZONE">
-          <constraints nullable="false" />
-        </column>
-        <column name="updated" type="TIMESTAMP WITH TIME ZONE">
-          <constraints nullable="false" />
-        </column>
-        <column name="org_id" type="varchar(32)">
-          <constraints primaryKey="true" primaryKeyName="account_config_pkey" />
-        </column>
-      </createTable>
-
-    </rollback>
-  </changeSet>
-
   <changeSet id="202310031000-02" author="vbusch">
     <comment>Drop account_number column from subscription table</comment>
     <dropColumn tableName="subscription" columnName="account_number"/>

--- a/src/main/resources/liquibase/202310251600-replace-account-config-table.xml
+++ b/src/main/resources/liquibase/202310251600-replace-account-config-table.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+
+  <changeSet id="202310251600-01" author="vbusch">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="account_config"/>
+      </not>
+    </preConditions>
+    <comment>Replace empty account_config table.</comment>
+    <createTable tableName="account_config">
+      <column name="account_number" type="VARCHAR(255)">
+        <constraints nullable="true" unique="true" uniqueConstraintName="account_config_account_number_unq"/>
+      </column>
+      <column name="opt_in_type" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="created" type="TIMESTAMP WITH TIME ZONE">
+        <constraints nullable="false" />
+      </column>
+      <column name="updated" type="TIMESTAMP WITH TIME ZONE">
+        <constraints nullable="false" />
+      </column>
+      <column name="org_id" type="varchar(32)">
+        <constraints primaryKey="true" primaryKeyName="account_config_pkey" />
+      </column>
+    </createTable>
+
+    <rollback>
+      <dropTable tableName="account_config"/>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -133,5 +133,6 @@
     <!-- Need to fix duplicate key issue -->
     <!-- <include file="liquibase/202309181629-fix-measurement-metric-id-formatting.xml"/> -->
     <include file="/liquibase/202310131200-remove-account-config.xml"/>
+    <include file="/liquibase/202310251600-replace-account-config-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Related to Jira issue: [SWATCH-667](https://issues.redhat.com/browse/SWATCH-667)
Related to Jira issue: [SWATCH-664](https://issues.redhat.com/browse/SWATCH-664)

## Description
Replacing the account_config table on staging.  It still exists on prod.

## Testing
Run liquibase and verify the account_config table is re-created.  
Also test that if it already exists, it doesn't throw an error.