### PR TITLE
SWATCH-1861: Add engid 389 to SAP detection

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -111,7 +111,7 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
 
   @WithMockRedHatPrincipal(value = USER_ID)
   @ParameterizedTest
-  @CsvSource(value = {"83,rhel-for-x86-ha", "90,rhel-for-x86-rs"})
+  @CsvSource(value = {"83,rhel-for-x86-ha", "90,rhel-for-x86-rs", "389,rhel-for-sap-x86"})
   void testProduceSnapshotsForOrgFromHostsPartOfHbi(String engId, String product) {
     givenOrgAndAccountInConfig();
     UUID inventoryId = givenInventoryHostWithProductIds(engId);

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_SAP_x86.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_SAP_x86.yaml
@@ -7,6 +7,7 @@ variants:
   - tag: rhel-for-sap-x86
     engineeringIds:
       - 388 # RHEL for SAP Update Services for SAP Solutions
+      - 389 # Red Hat Enterprise Linux for SAP Solutions for x86_64 - Update Services for SAP Solutions
       - 241 # Red Hat Enterprise Linux 8 for x86_64 - SAP Solutions
       - 146 # Red Hat Enterprise Linux for SAP
 


### PR DESCRIPTION
Jira issue: [SWATCH-1861](https://issues.redhat.com/browse/SWATCH-1861)

## Description
Add the engId 389 as part of the RHEL SAP configuration-

## Testing
I've added a test case that covers these changes. The test case and functionality must be reviewed.

Steps for manual testing (the automatic test case mimics the below steps):

1.- podman-compose up
2.- Build the whole project:

```
./gradlew clean build -x test
```

3.- Add host to Insight DB:

```
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) 
VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "389"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123', '{}');
```

The important part of the above query is `installed_products` which id contains the value "389".

4.- DEV_MODE=true SPRING_PROFILES_ACTIVE=worker ./gradlew :bootRun
5.- Run nightly Tally using command below:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder
```

6.- Verification in RHSM subscription database:

```
select count(*) from host_tally_buckets where product_id = 'rhel-for-sap-x86'
```

It should return 4 rows.

