### PR TITLE
[DRAFT] Adds moto service and connect it to swatch-producer-aws for ephemeral envs

### DIFF
--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -44,9 +44,11 @@ parameters:
   - name: SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT
     value: http://swatch-subscription-sync-service:8000/api/rhsm-subscriptions/v1
   - name: AWS_MARKETPLACE_ENDPOINT_URL
-    value: 'http://localhost:8101/aws-marketplace/'
+    value: 'http://moto:5000/'
   - name: AWS_MANUAL_SUBMISSION_ENABLED
-    value: 'false'
+    value: 'true'
+  - name: AWS_MARKETPLACE_ENDPOINT_OVERRIDE
+    value: 'true'
   - name: TALLY_IN_FAIL_ON_DESER_FAILURE
     value: 'true'
   - name: LOGGING_LEVEL_ROOT
@@ -207,3 +209,39 @@ objects:
     name: swatch-psks
   data:
     self: cGxhY2Vob2xkZXI=
+
+- apiVersion: v1
+  kind: Deployment
+  metadata:
+    name: moto
+  spec:
+    selector:
+      matchLabels:
+        app: moto
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: moto
+      spec:
+        containers:
+          - name: container
+            image: 'motoserver/moto:latest'
+            ports:
+              - containerPort: 5000
+                protocol: TCP
+            env:
+              - name: MOTO_PORT
+                value: '5000'
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: moto
+  spec:
+    selector:
+      app: moto
+    ports:
+      - protocol: TCP
+        port: 5000
+        targetPort: 5000


### PR DESCRIPTION


<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1848](https://issues.redhat.com/browse/SWATCH-1848)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Adds moto server, this should help test usage send from aws producer. 
Moto: - https://github.com/getmoto/moto/ is a mocking library for aws cloud

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Setup: 
Build a ephemeral environment with the clowdapp.yaml for swatch-producer-aws 

Adding AwsSellerId Secrets for swatch-producer-aws
- Update the aws-marketplace-credentials secret
- Update key from credentials to config.ini
- In value section add below
- [profile sellerAccount/customerAccountId]
- aws_access_key_id = randomstuff
- aws_secret_access_key = randomstuff 

Testing:
- Insert/Add Subscription
- Create Usage and run hourly tally

