### PR TITLE
Bump kubedock version to 0.14

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ kind: Pod
 spec:
   containers:
     - name: kubedock
-      image: quay.io/cloudservices/kubedock:d431b39
+      image: quay.io/cloudservices/kubedock:a40cd15
       tty: true
       args:
        - server


### PR DESCRIPTION
## Description
Kubedock release: https://github.com/joyrex2001/kubedock/releases/tag/0.14.0

Related to https://github.com/RedHatInsights/kubedock/pull/4