### PR TITLE
SWATCH-1720: Update SWATCH Contract To Handle Azure Contracts

### DIFF
--- a/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
+++ b/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
@@ -66,6 +66,8 @@ components:
           type: string
         vendorProductCode:
           type: string
+        resourceId :
+          type: string
         page:
           $ref: '#/components/schemas/PageRequest'
     PageRequest:
@@ -92,6 +94,7 @@ components:
           type: string
           enum:
             - aws_marketplace
+            - azure_marketplace
         partnerIdentities:
           $ref: '#/components/schemas/PartnerIdentityV1'
         rhEntitlements:
@@ -119,9 +122,17 @@ components:
           type: string
         sellerAccountId:
           type: string
+        azureSubscriptionId:
+          type: string
+        azureTenantId:
+          type: string
+        azureCustomerId:
+          type: string
     PurchaseV1:
       properties:
         vendorProductCode:
+          type: string
+        resourceId:
           type: string
         contracts:
           type: array
@@ -135,6 +146,8 @@ components:
         endDate:
           type: string
           format: date-time
+        planId:
+          type: string
         dimensions:
           type: array
           items:

--- a/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
+++ b/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
@@ -66,7 +66,7 @@ components:
           type: string
         vendorProductCode:
           type: string
-        resourceId :
+        azureResourceId :
           type: string
         page:
           $ref: '#/components/schemas/PageRequest'
@@ -132,7 +132,7 @@ components:
       properties:
         vendorProductCode:
           type: string
-        resourceId:
+        azureResourceId:
           type: string
         contracts:
           type: array

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -67,10 +67,12 @@ public interface ContractMapper {
   @BeanMapping(ignoreByDefault = true)
   ContractEntity partnerContractToContractEntity(PartnerEntitlementContract contract);
 
+  // this method uses the partner field in PartnerEntitlementContractCloudIdentifiers
+  //  to determine how product code is mapped for a specific provider
   default String extractVendorProductCode(PartnerEntitlementContractCloudIdentifiers code) {
     if (code.getProductCode() != null) {
       return code.getProductCode();
-    } else if (code.getOfferId() != null) {
+    } else if (code.getPartner().equals("azure_marketplace")) {
       return code.getOfferId();
     }
     return null;
@@ -114,6 +116,8 @@ public interface ContractMapper {
   void mapRhEntitlementsToContractEntity(
       @MappingTarget ContractEntity contractEntity, PartnerEntitlementV1 entitlement);
 
+  // this method is to properly map value from entitlement partnerIdentities
+  // as these fields are populated differently based on the marketplace
   default String extractBillingAccountId(PartnerIdentityV1 accountId) {
 
     if (accountId.getCustomerAwsAccountId() != null) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -63,12 +63,16 @@ public interface ContractMapper {
   ContractMetricEntity metricDtoToMetricEntity(Metric metric);
 
   @Mapping(target = "subscriptionNumber", source = "contract.redHatSubscriptionNumber")
-  @Mapping(target = "vendorProductCode", source = "cloudIdentifiers")
+  @Mapping(
+      target = "vendorProductCode",
+      source = "cloudIdentifiers",
+      qualifiedByName = "vendorProductCode")
   @BeanMapping(ignoreByDefault = true)
   ContractEntity partnerContractToContractEntity(PartnerEntitlementContract contract);
 
   // this method uses the partner field in PartnerEntitlementContractCloudIdentifiers
   //  to determine how product code is mapped for a specific provider
+  @Named("vendorProductCode")
   default String extractVendorProductCode(PartnerEntitlementContractCloudIdentifiers code) {
     if (code.getProductCode() != null) {
       return code.getProductCode();
@@ -76,6 +80,16 @@ public interface ContractMapper {
       return code.getOfferId();
     }
     return null;
+  }
+
+  @Named("billingProviderId")
+  default String extractBillingProviderId(PartnerEntitlementContractCloudIdentifiers code) {
+    String providerId = null;
+    if ("azure_marketplace".equals(code.getPartner())) {
+      providerId =
+          String.format("%s;%s;%s", code.getAzureResourceId(), code.getPlanId(), code.getOfferId());
+    }
+    return providerId;
   }
 
   @Mapping(target = "subscriptionId", ignore = true)

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractSourcePartnerEnum.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractSourcePartnerEnum.java
@@ -28,7 +28,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ContractSourcePartnerEnum {
-  AWS("aws_marketplace", "aws");
+  AWS("aws_marketplace", "aws"),
+  AZURE("azure_marketplace", "azure");
 
   private final String code;
   private final String value;

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -493,7 +493,7 @@ public class ContractService {
     String productCode;
     var marketplace = determineMarketplaceForContract(contract);
 
-    if (Objects.equals(marketplace, "aws")) {
+    if (Objects.equals(marketplace, ContractSourcePartnerEnum.AWS.getValue())) {
       customerAccountId = contract.getCloudIdentifiers().getAwsCustomerAccountId();
       productCode = contract.getCloudIdentifiers().getProductCode();
       if (Objects.nonNull(contract.getCloudIdentifiers())
@@ -515,7 +515,7 @@ public class ContractService {
         mapUpstreamContractToContractEntity(entity, result);
       }
     }
-    if (Objects.equals(marketplace, "azure")) {
+    if (Objects.equals(marketplace, ContractSourcePartnerEnum.AZURE.getValue())) {
       // azureResourceId is a unique identifier per SaaS purchase,
       // so it should be sufficient by itself
       customerAccountId = contract.getCloudIdentifiers().getAzureResourceId();
@@ -529,7 +529,7 @@ public class ContractService {
             customerAccountId);
         var result =
             partnerApi.getPartnerEntitlements(
-                new QueryPartnerEntitlementV1().resourceId(customerAccountId).page(page));
+                new QueryPartnerEntitlementV1().azureResourceId(customerAccountId).page(page));
         mapUpstreamContractToContractEntity(entity, result);
       }
     }

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -532,6 +532,14 @@ components:
               type: string
             productCode:
               type: string
+            azureResourceId:
+              type: string
+            azureTenantId:
+              type: string
+            offerId:
+              type: string
+            planId:
+              type: string
     Dimension:
       properties:
         dimensionName:

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -526,6 +526,8 @@ components:
         cloudIdentifiers:
           type: object
           properties:
+            partner:
+              type: string
             awsCustomerId:
               type: string
             awsCustomerAccountId:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
@@ -183,7 +183,7 @@ public class WireMockResource
                                      ],
                                      "purchase": {
                                          "vendorProductCode": "rh-rhel-sub-preview",
-                                         "resourceId": "a69ff71c-aa8b-43d9-dea8-822fab4bbb86",
+                                         "azureResourceId": "a69ff71c-aa8b-43d9-dea8-822fab4bbb86",
                                          "contracts": [
                                              {
                                                  "startDate": "2023-06-09T13:59:43.035365Z",

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
@@ -168,40 +168,42 @@ public class WireMockResource
                                       }
                                     },
                                     {
-                                      "rhAccountId": "org223",
-                                      "sourcePartner": "aws_marketplace",
-                                      "partnerIdentities": {
-                                        "awsCustomerId": "568056954830",
-                                        "customerAwsAccountId": "568056954830",
-                                        "sellerAccountId": "568056954830"
-                                      },
-                                      "rhEntitlements": [
-                                        {
-                                          "sku": "RH000000",
-                                          "subscriptionNumber": "121256"
-                                        }
-                                      ],
-                                      "purchase": {
-                                        "vendorProductCode": "1234567890abcdefghijklmno",
-                                        "contracts": [
-                                          {
-                                            "startDate": "2022-09-23T20:07:51.010445Z",
-                                            "dimensions": [
-                                              {
-                                                "name": "foobar",
-                                                "value": "1000000"
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      },
-                                      "status": "STATUS",
-                                      "entitlementDates": {
-                                        "startDate": "2023-03-17T12:29:48.569Z",
-                                        "endDate": "2023-03-17T12:29:48.569Z"
-                                      }
-                                    }
-                                  ],
+                                     "rhAccountId": "7186626",
+                                     "sourcePartner": "azure_marketplace",
+                                     "partnerIdentities": {
+                                         "azureSubscriptionId": "fa650050-dedd-4958-b901-d8e5118c0a5f",
+                                         "azureTenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408",
+                                         "azureCustomerId": "eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31"
+                                     },
+                                     "rhEntitlements": [
+                                         {
+                                             "sku": "BASILISK",
+                                             "subscriptionNumber": "13294886"
+                                         }
+                                     ],
+                                     "purchase": {
+                                         "vendorProductCode": "rh-rhel-sub-preview",
+                                         "resourceId": "a69ff71c-aa8b-43d9-dea8-822fab4bbb86",
+                                         "contracts": [
+                                             {
+                                                 "startDate": "2023-06-09T13:59:43.035365Z",
+                                                 "planId": "rh-rhel-sub-1yr",
+                                                 "dimensions": [
+                                                     {
+                                                         "name": "vCPU",
+                                                         "value": 4
+                                                     }
+                                                 ]
+                                             }
+                                         ]
+                                     },
+                                     "status": "UNSUBSCRIBED",
+                                     "entitlementDates": {
+                                         "startDate": "2023-06-09T13:59:43.035365Z",
+                                         "endDate": "2023-06-09T19:37:46.651363Z"
+                                     }
+                                 }
+                                ],
                                   "page": {
                                     "size": 0,
                                     "totalElements": 0,

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -194,7 +194,7 @@ class ContractServiceTest extends BaseUnitTest {
 
   @Test
   void testCreatePartnerContractCreatesAzureSubscription()
-      throws ApiException, com.redhat.swatch.clients.rh.partner.gateway.api.resources.ApiException {
+      throws com.redhat.swatch.clients.rh.partner.gateway.api.resources.ApiException {
     var contract = new PartnerEntitlementContract();
     PartnerApi partnerApi = mock(PartnerApi.class);
     contract.setRedHatSubscriptionNumber("subnum");
@@ -202,6 +202,7 @@ class ContractServiceTest extends BaseUnitTest {
         List.of(new Dimension().dimensionName("vCPU").dimensionValue("4")));
     contract.setCloudIdentifiers(
         new PartnerEntitlementContractCloudIdentifiers()
+            .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
             .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .offerId("azureProductCode")
@@ -221,7 +222,7 @@ class ContractServiceTest extends BaseUnitTest {
             .purchase(
                 new PurchaseV1()
                     .vendorProductCode("azureProductCode")
-                    .resourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
+                    .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
                     .contracts(
                         List.of(
                             new SaasContractV1()


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1720](https://issues.redhat.com/browse/SWATCH-1720)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This is to allow SWATCH contract to handle azure contracts from entitlement gateway. For azure subscriptions the subscriptions `azureResourceId` should be sufficient for getting a unique entitlement as it's a unique identifier per SaaS purchase : [slack thread](https://redhat-internal.slack.com/archives/C05M0H1JH7X/p1698352078477369) , as of the time of this change the gateway does not yet[ support search](https://issues.redhat.com/browse/ITPART-1130) by `resourceId`

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

 Add Environment Variables for SWATCH Contracts:
 ```
QUARKUS_PROFILE=dev;SWATCH_SELF_PSK=placeholder;ENTITLEMENT_GATEWAY_URL=http://localhost:8101/mock/partnerApi;SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101/mock/internalSubs
``` 
1. Create file path for testing:
```
mkdir -p stub/__files
```
2. Create the needed JSONs:
Azure.json
```
cat > stub/__files/azure.json <<EOF
{
    "content": [
        {
            "rhAccountId": "7186626",
            "sourcePartner": "azure_marketplace",
            "partnerIdentities": {
                "azureSubscriptionId": "fa650050-dedd-4958-b901-d8e5118c0a5f",
                "azureTenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408",
                "azureCustomerId": "eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31"
            },
            "rhEntitlements": [
                {
                    "sku": "BASILISK",
                    "redHatSubscriptionNumber": "13294886"
                }
            ],
            "purchase": {
                "vendorProductCode": "rh-rhel-sub-preview",
                "azureResourceId": "a69ff71c-aa8b-43d9-dea8-822fab4bbb86",
                "contracts": [
                    {
                        "startDate": "2023-06-09T13:59:43.035365Z",
                        "planId": "rh-rhel-sub-1yr",
                        "dimensions": [
                            {
                                "name": "vCPU",
                                "value": 4
                            }
                        ]
                    }
                ]
            },
            "status": "UNSUBSCRIBED",
            "entitlementDates": {
                "startDate": "2023-06-09T13:59:43.035365Z",
                "endDate": "2023-06-09T19:37:46.651363Z"
            }
        }
    ],
    "page": {
        "size": 0,
        "totalElements": 0,
        "totalPages": 0,
        "number": 0
    }
}
EOF
```
Tag.json:
```
cat > stub/__files/tag.json <<EOF
{"data":["BASILISK"]}
EOF
```
subscription.json:
```
cat > stub/__files/subscription.json <<EOF
[
    {
        "id": 13294886,
        "renewedId": null,
        "masterEndSystemName": "SUBSCRIPTION",
        "createdEndSystemName": "SUBSCRIPTION",
        "createdByUserName": null,
        "createdDate": 1672556530000,
        "lastUpdateEndSystemName": "SUBSCRIPTION",
        "lastUpdateUserName": null,
        "lastUpdateDate": 1672556530000,
        "externalCreatedDate": null,
        "externalLastUpdateDate": null,
        "installBaseStartDate": 1672549200000,
        "installBaseEndDate": 1704085199000,
        "inactiveDate": null,
        "oracleAccountNumber": "5456371",
        "oracleMSANumber": null,
        "oracleIBInstanceNumber": null,
        "webCustomerId": 7237138,
        "registrationNumber": null,
        "installationNumber": null,
        "subscriptionNumber": "13294886",
        "quantity": 10,
        "subscriptionProducts": null,
        "customer": {
        "id": 7237138,
        "name": "ANDORRA TELECOM, S.A.U.",
        "password": null,
        "creditApplicationCompleted": false,
        "customerType": "organization",
        "oracleCustomerNumber": 5456371,
        "namedAccount": false,
        "createdDate": 1397548100000,
        "updatedDate": 1612591188913
        },
        "effectiveStartDate": 1672549200000,
        "effectiveEndDate": 1703998800000,
        "externalReferences": null
    }
]
EOF
```
3. Create the Wire Mock container:
```
podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose
```
4. Use curl commands to map both json to the mock endpoints:
```
curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/mock/partnerApi/v1/partnerSubscriptions", "method": "POST" }, "response": { "status": 200, "bodyFileName": "azure.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new
```
```
curl -X POST --data '{ "priority": 2, "request": { "urlPath": "/mock/internalSubs/internal/offerings/BASILISK/product_tags", "method": "GET"}, "response": { "status": 200, "bodyFileName": "tag.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new
```
```
curl -X POST --data '{ "priority": 1, "request": { "method": "GET", "urlPattern": "/search/criteria;subscription_number=13294886/options;products=ALL;showExternalReferences=true/" }, "response": { "status": 200, "bodyFileName": "subscription.json", "headers": { "Content-Type": "application/json" } } }' http://localhost:8101/__admin/mappings/new
```
5. Run Swatch-contracts:
```
SUBSCRIPTION_URL=http://localhost:8101 ENTITLEMENT_GATEWAY_URL=http://localhost:8101/mock/partnerApi SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101/mock/internalSubs ./gradlew :swatch-contracts:quarkusDev
``` 
6. Swagger-UI: http://localhost:8000/api/swatch-contracts/internal/swagger-ui/#/default/createPartnerEntitlementContract
7. Paste in the azure Subscription below:

```
{
  "action" : "contract-updated",
  "redHatSubscriptionNumber" : "13294886",
  "currentDimensions" : [ {
    "dimensionName" : "vCPU",
    "dimensionValue" : "4",
    "expirationDate" : "2023-04-30T13:14:17.442176Z"
  } ],
  "cloudIdentifiers" : {
    "partner": "azure_marketplace",
    "azureResourceId" : "a69ff71c-aa8b-43d9-dea8-822fab4bbb86",
    "azureTenantId" : "6a545474-5c90-11ee-96b2-8c8caa9b43f1",
    "offerId" : "azureProductCode",
    "planId": "rh-rhel-sub-1yr"
  }
}
```
 Should observe that the UI returns a response of `Contract Created` and verify in your database that the a new row is created in contracts, contract_metrics, and subscription_measurements with the azure information recorded.
