### PR TITLE
SWATCH-1875 ELS EUS Payg product configs shouldn't require roles

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
@@ -12,8 +12,6 @@ variants:
       - 204
     productNames:
       - RHEL Server
-    roles:
-      - rhel-for-x86-els-payg-placeholder-role
 
 defaults:
   variant: rhel-for-x86-els-payg


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1875](https://issues.redhat.com/browse/SWATCH-1875)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
During hourly tally, we first check by role for payg systems, and subsequently by eng id. Role is no longer unique, hence we are eliminating it from the ELS product configuration.
Nightly tally we don't consider payg systems so we are good.   

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
There are no test steps since the role was a placeholder.
