### PR TITLE
Add git to the build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.16
 
 USER root
+# Add git, so that the build can determine the git hash
+# Disable all repos except for ubi repos, as ubi repos don't require auth;
+# this makes the container buildable without needing RHEL repos.
+RUN microdnf \
+  --disablerepo=* \
+  --enablerepo=ubi-9-appstream-rpms \
+  --enablerepo=ubi-9-baseos-rpms \
+  install -y \
+  git
 WORKDIR /stage
 
 COPY gradlew .

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -78,6 +78,15 @@
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.16
 
 USER root
+# Add git, so that the build can determine the git hash
+# Disable all repos except for ubi repos, as ubi repos don't require auth;
+# this makes the container buildable without needing RHEL repos.
+RUN microdnf \
+  --disablerepo=* \
+  --enablerepo=ubi-9-appstream-rpms \
+  --enablerepo=ubi-9-baseos-rpms \
+  install -y \
+  git
 WORKDIR /stage
 
 COPY gradlew .

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -78,6 +78,15 @@
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.16
 
 USER root
+# Add git, so that the build can determine the git hash
+# Disable all repos except for ubi repos, as ubi repos don't require auth;
+# this makes the container buildable without needing RHEL repos.
+RUN microdnf \
+  --disablerepo=* \
+  --enablerepo=ubi-9-appstream-rpms \
+  --enablerepo=ubi-9-baseos-rpms \
+  install -y \
+  git
 WORKDIR /stage
 
 COPY gradlew .

--- a/swatch-producer-azure/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-azure/src/main/docker/Dockerfile.jvm
@@ -78,6 +78,15 @@
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.16
 
 USER root
+# Add git, so that the build can determine the git hash
+# Disable all repos except for ubi repos, as ubi repos don't require auth;
+# this makes the container buildable without needing RHEL repos.
+RUN microdnf \
+  --disablerepo=* \
+  --enablerepo=ubi-9-appstream-rpms \
+  --enablerepo=ubi-9-baseos-rpms \
+  install -y \
+  git
 WORKDIR /stage
 
 COPY gradlew .

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -1,6 +1,15 @@
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.16
 
 USER root
+# Add git, so that the build can determine the git hash
+# Disable all repos except for ubi repos, as ubi repos don't require auth;
+# this makes the container buildable without needing RHEL repos.
+RUN microdnf \
+  --disablerepo=* \
+  --enablerepo=ubi-9-appstream-rpms \
+  --enablerepo=ubi-9-baseos-rpms \
+  install -y \
+  git
 WORKDIR /stage
 
 COPY gradlew .


### PR DESCRIPTION
This is necessary to allow the nebula release plugin to populate the git hash as part of the generated version.

Testing
-------

Look at log output in the fetched container image, e.g.

```shell
export hash=$(git rev-parse --short=7 HEAD)
podman run --rm -ti quay.io/cloudservices/rhsm-subscriptions:$hash
```

Notice a line like:

```
2023-10-30 14:27:52,054 [thread=main] [INFO ] [org.candlepin.subscriptions.BootApplication] - Starting BootApplication v1.1.0-snapshot.202310301421.uncommitted+swatch.664.update.a365244 using Java 17.0.9 with PID 1 (/deployments/rhsm-subscriptions-1.1.0-snapshot.202310301421.uncommitted+swatch.664.update.a365244.jar started by default in /deployments)
```