### PR TITLE
SWATCH-1800: Write a from-scratch equivalent of the task message JSON

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -24,7 +24,9 @@ export IQE_PARALLEL_ENABLED="false"
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 # Borrow the venv that bonfire sets up to do validation of our topic references
-python bin/validate-topics.py
+
+# Disable the validation of topics for now until SWATCH-1904 is resolved.
+# python bin/validate-topics.py
 
 IMAGES=""
 

--- a/swatch-metrics/build.gradle
+++ b/swatch-metrics/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'swatch.quarkus-conventions'
     id 'org.openapi.generator'
+    id 'jsonschema2pojo'
 }
 
 dependencies {
@@ -27,6 +28,8 @@ dependencies {
     compileOnly libraries["lombok"]
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'io.smallrye.reactive:smallrye-reactive-messaging-in-memory'
+    testImplementation libraries["awaitility"]
 }
 
 compileJava.dependsOn tasks.openApiGenerate
@@ -36,8 +39,8 @@ openApiGenerate {
     inputSpec = "${projectDir}/src/main/resources/META-INF/openapi.yaml"
     outputDir = "${buildDir}/generated"
     apiPackage = "com.redhat.swatch.metrics.admin.api"
-    modelPackage = "com.redhat.swatch.metrics.admin.api.model"
-    invokerPackage = "com.redhat.swatch.metrics.admin"
+    modelPackage = "com.redhat.swatch.metrics.model"
+    invokerPackage = "com.redhat.swatch.metrics"
     groupId = "com.redhat.swatch.metrics"
     configOptions = [sourceFolder     : "src/gen/java",
                      interfaceOnly    : "true",
@@ -48,8 +51,22 @@ openApiGenerate {
                      microprofileRestClientVersion: "3.0",
                      useJakartaEE: "true",
     ]
-    additionalProperties = [disableMultipart: "true", // see https://github.com/OpenAPITools/openapi-generator/pull/4713#issuecomment-633906581
-    ]
+    additionalProperties = [disableMultipart: "true"] // see https://github.com/OpenAPITools/openapi-generator/pull/4713#issuecomment-633906581
+}
+
+jsonSchema2Pojo {
+    source = files("${projectDir}/schemas")
+    targetPackage = "com.redhat.swatch.metrics.model"
+    targetDirectory = file("${buildDir}/generated/src/gen/java")
+    includeAdditionalProperties = false
+    includeJsr303Annotations = true
+    initializeCollections = false
+    dateTimeType = 'java.time.OffsetDateTime'
+    sourceType = 'yamlschema'
+    generateBuilders = true
+    includeGetters = true
+    includeSetters = true
+    useJakartaValidation = true
 }
 
 sourceSets.main.java.srcDirs += ["${buildDir}/generated/src/gen/java"]

--- a/swatch-metrics/deploy/clowdapp_quarkus.yaml
+++ b/swatch-metrics/deploy/clowdapp_quarkus.yaml
@@ -231,6 +231,8 @@ objects:
                 value: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP}
               - name: EVENT_SOURCE
                 value: 'prometheus'
+              - name: METERING_TASK_TOPIC
+                value: 'platform.rhsm-subscriptions.metering-tasks'
               - name: PROM_URL
                 value: ${PROM_URL}
               - name: OPENSHIFT_BILLING_MODEL_FILTER
@@ -401,6 +403,8 @@ objects:
                 value: ${METRICS_RHEL_KAFKA_SEEK_OVERRIDE_TIMESTAMP}
               - name: EVENT_SOURCE
                 value: 'rhelemeter'
+              - name: METERING_TASK_TOPIC
+                value: 'platform.rhsm-subscriptions.metering-rhel-tasks'
               - name: PROM_URL
                 value: ${PROM_URL}
               - name: OPENSHIFT_BILLING_MODEL_FILTER

--- a/swatch-metrics/schemas/metrics_task_descriptor.yaml
+++ b/swatch-metrics/schemas/metrics_task_descriptor.yaml
@@ -1,0 +1,23 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: MetricsTaskDescriptor
+required:
+  - org_id
+  - product_id
+  - metric
+  - start
+  - end
+properties:
+  org_id:
+    description: Preferred identifier for the relevant account (if present).
+    type: string
+  product_tag:
+    type: string
+  metric:
+    description: Preferred unit of measure for the subject (for products with multiple possible UOM).
+    type: string
+  start:
+    type: string
+    format: date-time
+  end:
+    type: string
+    format: date-time

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MeteringService.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MeteringService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.metrics.service;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.OffsetDateTime;
+
+@ApplicationScoped
+public class MeteringService {
+  public void collectMetrics(
+      String tag, MetricId metric, String orgId, OffsetDateTime start, OffsetDateTime end) {
+    // To be done in https://issues.redhat.com/browse/SWATCH-1805
+  }
+}

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MetricsConsumer.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MetricsConsumer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.metrics.service;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.metrics.model.MetricsTaskDescriptor;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@Slf4j
+@ApplicationScoped
+public class MetricsConsumer {
+
+  private static final String ORG_ID = "orgId";
+  private static final String METRIC = "metric";
+  private static final String PRODUCT_TAG = "productTag";
+  private static final String START = "start";
+  private static final String END = "end";
+
+  @Inject MeteringService service;
+
+  @Incoming("tasks-in")
+  public void process(MetricsTaskDescriptor task) {
+    log.info(
+        "Running {} {} metrics update task for orgId: {}",
+        task.getProductTag(),
+        task.getMetric(),
+        task.getOrgId());
+    try {
+      validate(task);
+      service.collectMetrics(
+          task.getProductTag(),
+          MetricId.fromString(task.getMetric()),
+          task.getOrgId(),
+          task.getStart(),
+          task.getEnd());
+      log.info("{} {} metrics task complete.", task.getProductTag(), task.getMetric());
+    } catch (Exception e) {
+      log.error("Problem running task: {}", this.getClass().getSimpleName(), e);
+    }
+  }
+
+  private void validate(MetricsTaskDescriptor task) {
+    validate(task.getOrgId(), ORG_ID);
+    validate(task.getProductTag(), PRODUCT_TAG);
+    validate(task.getMetric(), METRIC);
+    validate(task.getStart(), START);
+    validate(task.getEnd(), END);
+  }
+
+  private void validate(String str, String name) {
+    if (str == null || str.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format("Could not build task. '%s' was empty.", name));
+    }
+  }
+
+  private void validate(OffsetDateTime date, String name) {
+    if (date == null) {
+      throw new IllegalArgumentException(
+          String.format("Could not build task. '%s' was empty.", name));
+    }
+  }
+}

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MetricsProducer.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MetricsProducer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.metrics.service;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.metrics.model.MetricsTaskDescriptor;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+@Slf4j
+@ApplicationScoped
+public class MetricsProducer {
+
+  @ConfigProperty(name = "rhsm-subscriptions.prometheus-latency-duration")
+  Duration prometheusLatencyDuration;
+
+  @Inject
+  @Channel("tasks-out")
+  Emitter<MetricsTaskDescriptor> emitter;
+
+  public void queueMetricUpdateForOrgId(
+      String orgId, String productTag, MetricId metric, OffsetDateTime start, OffsetDateTime end) {
+    log.info(
+        "Queuing {} {} metric update for orgId={} for range [{}, {})",
+        productTag,
+        metric,
+        orgId,
+        start,
+        end);
+    enqueue(createMetricsTask(orgId, productTag, metric, start, end));
+  }
+
+  private MetricsTaskDescriptor createMetricsTask(
+      String orgId, String productTag, MetricId metric, OffsetDateTime start, OffsetDateTime end) {
+    MetricsTaskDescriptor task = new MetricsTaskDescriptor();
+    task.setOrgId(orgId);
+    task.setProductTag(productTag);
+    task.setMetric(metric.getValue());
+    task.setStart(start);
+    task.setEnd(end);
+    return task;
+  }
+
+  private void enqueue(MetricsTaskDescriptor task) {
+    log.info("Queuing task: {}", task);
+    OutgoingKafkaRecordMetadata<?> metadata =
+        OutgoingKafkaRecordMetadata.builder().withKey(task.getOrgId()).build();
+    emitter.send(Message.of(task).addMetadata(metadata));
+  }
+}

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/task/MetricsTaskDescriptorDeserializer.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/task/MetricsTaskDescriptorDeserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.metrics.service.task;
+
+import com.redhat.swatch.metrics.model.MetricsTaskDescriptor;
+import io.quarkus.kafka.client.serialization.JsonbDeserializer;
+
+/** Provides quarkus a hint that we want to use JSON-B to serialize MetricsTaskDescriptor objects */
+public class MetricsTaskDescriptorDeserializer extends JsonbDeserializer<MetricsTaskDescriptor> {
+  public MetricsTaskDescriptorDeserializer() {
+    super(MetricsTaskDescriptor.class);
+  }
+}

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/task/MetricsTaskDescriptorSerializer.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/task/MetricsTaskDescriptorSerializer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.metrics.service.task;
+
+import com.redhat.swatch.metrics.model.MetricsTaskDescriptor;
+import io.quarkus.kafka.client.serialization.JsonbSerializer;
+
+/** Provides quarkus a hint that we want to use JSON-B to serialize MetricsTaskDescriptor objects */
+public class MetricsTaskDescriptorSerializer extends JsonbSerializer<MetricsTaskDescriptor> {}

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -9,7 +9,8 @@ SPLUNK_HEC_BATCH_SIZE: 1000
 SPLUNK_HEC_BATCH_INTERVAL: 10S
 SPLUNK_HEC_RETRY_COUNT: 3
 SPLUNK_HEC_INCLUDE_EX: false
-TALLY_IN_FAIL_ON_DESER_FAILURE: true
+METRICS_IN_FAIL_ON_DESER_FAILURE: true
+METERING_TASK_TOPIC: platform.rhsm-subscriptions.metering-tasks
 
 # dev-specific defaults; these can still be overridden by env var
 "%dev":
@@ -89,8 +90,59 @@ quarkus:
   kafka:
     devservices:
       enabled: false
+  reactive-messaging:
+    kafka:
+      serializer-generation:
+        enabled: false
+
+# Clowder quarkus config takes care of setting these, no need to try to do clowder.kafka.brokers[0]
+# Common kafka settings
+kafka:
+  bootstrap:
+    servers: localhost:9092
+# Kafka security configuration.  These properties must be present so that
+# clowder-quarkus-config-source will populate them from the Clowder provided configuration JSON.
+# If the properties are simply absent from this file, then clowder-quarkus-config-source will not
+# set values for the property even if a value is present in the Clowder JSON.
+#
+# Additionally, Kafka has a bug, https://issues.apache.org/jira/browse/KAFKA-4090, where if a
+# client attempts to connect to a TLS enabled port using PLAINTEXT, an OutOfMemoryException gets
+# thrown instead of something more relevant to the actual issue.
+  sasl:
+    jaas:
+      config:
+    mechanism: PLAIN
+  security:
+    protocol: PLAINTEXT
+
+# Consumer settings
+mp:
+  messaging:
+    incoming:
+      tasks-in:
+        connector: smallrye-kafka
+        # Note that clowder config will not resolve the topic from the clowder config file because
+        # it does not properly resolve `${...}` properties.
+        # This should be fixed by https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/181
+        topic: ${METERING_TASK_TOPIC}
+        fail-on-deserialization-failure: ${METRICS_IN_FAIL_ON_DESER_FAILURE}
+        auto:
+          offset:
+            reset: earliest
+        value:
+          deserializer: com.redhat.swatch.metrics.service.task.MetricsTaskDescriptorDeserializer
+    outgoing:
+      tasks-out:
+        connector: smallrye-kafka
+        # Note that clowder config will not resolve the topic from the clowder config file because
+        # it does not properly resolve `${...}` properties.
+        # This should be fixed by https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/181
+        topic: ${METERING_TASK_TOPIC}
+        value:
+          serializer: com.redhat.swatch.metrics.service.task.MetricsTaskDescriptorSerializer
 
 rhsm-subscriptions:
+  prometheus-latency-duration: ${PROMETHEUS_LATENCY_DURATION:0h}
   metering:
     prometheus:
       metric:

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/MetricsConsumerTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/MetricsConsumerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.metrics.service;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.metrics.model.MetricsTaskDescriptor;
+import com.redhat.swatch.metrics.test.resources.InMemoryMessageBrokerKafkaResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(
+    value = InMemoryMessageBrokerKafkaResource.class,
+    restrictToAnnotatedClass = true)
+class MetricsConsumerTest {
+  private static final String ORG_ID = "org1";
+  private static final String PRODUCT_TAG = "productTag";
+  private static final MetricId METRIC = MetricId.fromString("Sockets");
+
+  @Inject @Any InMemoryConnector connector;
+
+  @InjectSpy MeteringService service;
+
+  @Test
+  void testMessagesAreConsumed() {
+    InMemorySource<MetricsTaskDescriptor> results = connector.source("tasks-in");
+
+    OffsetDateTime start = OffsetDateTime.now();
+    OffsetDateTime end = start.plusDays(1);
+    MetricsTaskDescriptor task = new MetricsTaskDescriptor();
+    task.setOrgId(ORG_ID);
+    task.setProductTag(PRODUCT_TAG);
+    task.setMetric(METRIC.getValue());
+    task.setStart(start);
+    task.setEnd(end);
+
+    results.send(task);
+
+    await().untilAsserted(() -> verify(service).collectMetrics(any(), any(), any(), any(), any()));
+  }
+}

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/test/resources/InMemoryMessageBrokerKafkaResource.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/test/resources/InMemoryMessageBrokerKafkaResource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.metrics.test.resources;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InMemoryMessageBrokerKafkaResource implements QuarkusTestResourceLifecycleManager {
+
+  @Override
+  public Map<String, String> start() {
+    Map<String, String> env = new HashMap<>();
+    env.putAll(InMemoryConnector.switchIncomingChannelsToInMemory("tasks-in"));
+    env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory("tasks-out"));
+    return env;
+  }
+
+  @Override
+  public void stop() {
+    InMemoryConnector.clear();
+  }
+}


### PR DESCRIPTION
Jira issue: [SWATCH-1800](https://issues.redhat.com/browse/SWATCH-1800)

## Description
We need to be able to queue up tasks (eg sync metrics hourly) for our task framework, but we don't want to have to add swatch-core as a dependency.

## Testing
I've added unit tests that cover the consumer and producer tasks using an in-memory kafka instance. 
