### PR TITLE
SWATCH-1764: update rosa product name

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
@@ -8,7 +8,7 @@ variants:
     roles:
       - moa-hostedcontrolplane
     productNames:
-      - OpenShift Dedicated
+      - OpenShift Online
 
 defaults:
   variant: rosa


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1764](https://issues.redhat.com/browse/SWATCH-1764)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

This issue was caused by OCP and ROSA offerings sharing the same product_name. In order to fix, rosa has been updated with a unique product_name.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert following data, including an offering with the new product_name:
```
INSERT INTO public.offering VALUES ('MW02393', 'OpenShift Online', 'OpenShift Enterprise', NULL, NULL, NULL, NULL, NULL, 'Premium', '', 'Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)', false, NULL, 'rosa');
INSERT INTO public.offering VALUES ('MW01484', 'OpenShift Dedicated', 'OpenShift Enterprise', NULL, NULL, NULL, NULL, NULL, 'Premium', '', 'Red Hat OpenShift Dedicated on Customer Cloud Subscription (Hourly)', false, NULL, 'OpenShift-dedicated-metrics');

INSERT INTO public.subscription VALUES ('MW02393', '13259775', '9063404', 50, '2021-04-14 04:00:00+00', '2024-04-13 03:59:59+00', 'test-subscription-1', '9063559', 'red hat', '')
INSERT INTO public.subscription VALUES ('MW01484', '13259775', '123', 50, '2021-04-14 04:00:00+00', '2024-04-13 03:59:59+00', 'test-subscription-1', '9063559', 'red hat', '')
```
1. Start app with; `DEV_MODE=true SPRING_PROFILES_ACTIVE=capacity-ingress,api ./gradlew :bootRun`
2. Opt in org:
```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJ0eXBlIjogIlVzZXIiLAogICAgICAgICJ1c2VyIiA6IHsKICAgICAgICAgICAgImlzX29yZ19hZG1pbiI6IHRydWUKICAgICAgICB9LAogICAgICAgICJpbnRlcm5hbCIgOiB7CiAgICAgICAgICAgICJvcmdfaWQiOiAiMTMyNTk3NzUiCiAgICAgICAgfQogICAgfQp9'
```

### Verification
<!-- Enter each step of the test below -->
1. Curl against subscription api for ROSA and verify that 1 subscription shown for sku MW02393:
```
curl -X 'GET' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/rosa' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: ewogICAgImlkZW50aXR5IjogewogICAgICAgICJ0eXBlIjogIlVzZXIiLAogICAgICAgICJ1c2VyIiA6IHsKICAgICAgICAgICAgImlzX29yZ19hZG1pbiI6IHRydWUKICAgICAgICB9LAogICAgICAgICJpbnRlcm5hbCIgOiB7CiAgICAgICAgICAgICJvcmdfaWQiOiAiMTMyNTk3NzUiCiAgICAgICAgfQogICAgfQp9'
```
