### PR TITLE
SWATCH-1880: Move purge Events from swatch-metrics to swatch-tally

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -23,21 +23,16 @@ package org.candlepin.subscriptions.metering.api.admin;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
-import io.micrometer.core.annotation.Timed;
-import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.metering.ResourceUtil;
 import org.candlepin.subscriptions.metering.admin.api.InternalApi;
-import org.candlepin.subscriptions.metering.retention.EventRecordsRetentionProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
@@ -53,42 +48,22 @@ public class InternalMeteringResource implements InternalApi {
   private final ApplicationProperties applicationProperties;
   private final PrometheusMetricsTaskManager tasks;
   private final PrometheusMeteringController controller;
-  private final EventRecordsRetentionProperties eventRecordsRetentionProperties;
-  private final EventRecordRepository eventRecordRepository;
   private final MetricProperties metricProperties;
   private final RetryTemplate retryTemplate;
 
   public InternalMeteringResource(
       ResourceUtil util,
       ApplicationProperties applicationProperties,
-      EventRecordsRetentionProperties eventRecordsRetentionProperties,
       PrometheusMetricsTaskManager tasks,
       PrometheusMeteringController controller,
-      EventRecordRepository eventRecordRepository,
       MetricProperties metricProperties,
       @Qualifier("meteringJobRetryTemplate") RetryTemplate retryTemplate) {
     this.util = util;
     this.applicationProperties = applicationProperties;
-    this.eventRecordsRetentionProperties = eventRecordsRetentionProperties;
     this.tasks = tasks;
     this.controller = controller;
-    this.eventRecordRepository = eventRecordRepository;
     this.metricProperties = metricProperties;
     this.retryTemplate = retryTemplate;
-  }
-
-  @Override
-  @Transactional
-  @Timed("rhsm-subscriptions.events.purge")
-  public void purgeEventRecords() {
-    var eventRetentionDuration = eventRecordsRetentionProperties.getEventRetentionDuration();
-
-    OffsetDateTime cutoffDate =
-        OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS).minus(eventRetentionDuration);
-
-    log.info("Purging event records older than {}", cutoffDate);
-    eventRecordRepository.deleteInBulkEventRecordsByTimestampBefore(cutoffDate);
-    log.info("Event record purge completed successfully");
   }
 
   @Override

--- a/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/profile/OpenShiftWorkerProfile.java
@@ -69,10 +69,7 @@ import org.springframework.retry.support.RetryTemplateBuilder;
   MeteringTasksConfiguration.class
 })
 @ComponentScan(
-    basePackages = {
-      "org.candlepin.subscriptions.metering.api",
-      "org.candlepin.subscriptions.metering.retention"
-    },
+    basePackages = "org.candlepin.subscriptions.metering.api",
     // Prevent TestConfiguration annotated classes from being picked up by ComponentScan
     excludeFilters = {
       @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),

--- a/src/main/java/org/candlepin/subscriptions/tally/events/EventRecordsRetentionProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/events/EventRecordsRetentionProperties.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.metering.retention;
+package org.candlepin.subscriptions.tally.events;
 
 import java.time.Duration;
 import lombok.Getter;

--- a/src/main/java/org/candlepin/subscriptions/tally/events/PurgeEventRecordsJob.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/events/PurgeEventRecordsJob.java
@@ -18,9 +18,9 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.metering.retention;
+package org.candlepin.subscriptions.tally.events;
 
-import org.candlepin.subscriptions.metering.api.admin.InternalMeteringResource;
+import org.candlepin.subscriptions.tally.admin.InternalTallyResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -31,10 +31,10 @@ public class PurgeEventRecordsJob implements Runnable {
 
   private static final Logger log = LoggerFactory.getLogger(PurgeEventRecordsJob.class);
 
-  private final InternalMeteringResource meteringResource;
+  private final InternalTallyResource resource;
 
-  public PurgeEventRecordsJob(InternalMeteringResource meteringResource) {
-    this.meteringResource = meteringResource;
+  public PurgeEventRecordsJob(InternalTallyResource resource) {
+    this.resource = resource;
   }
 
   @Override
@@ -42,7 +42,7 @@ public class PurgeEventRecordsJob implements Runnable {
   public void run() {
     log.info("Starting PurgeEventRecordsJob job.");
 
-    meteringResource.purgeEventRecords();
+    resource.purgeEventRecords();
 
     log.info("PurgeEventRecordsJob complete.");
   }

--- a/src/main/spec/internal-metering-api-spec.yaml
+++ b/src/main/spec/internal-metering-api-spec.yaml
@@ -24,17 +24,6 @@ servers:
         default: rhsm-subscriptions
 
 paths:
-  /internal/metering/events:
-    description: 'Purge event records'
-    delete:
-      operationId: purgeEventRecords
-      responses:
-        '200':
-          description: "Purge was successful."
-        '403':
-          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
-        '500':
-          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
   /internal/metering/sync:
     description: 'Perform product metering for all accounts.'
     put:

--- a/src/main/spec/internal-tally-api-spec.yaml
+++ b/src/main/spec/internal-tally-api-spec.yaml
@@ -233,6 +233,18 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [ internalTally ]
+  /internal/rpc/tally/events/purge:
+    description: 'Purge event records'
+    delete:
+      operationId: purgeEventRecords
+      responses:
+        '200':
+          description: "Purge was successful."
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags: [internalTally]
   /internal/rpc/tally/events/{event_id}:
     description: Delete an event. Supported only in dev-mode.
     delete:

--- a/src/test/java/org/candlepin/subscriptions/deployment/MetricsRhelDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/MetricsRhelDeploymentTest.java
@@ -29,8 +29,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles({"openshift-metering-worker", "test"})
-class MetricsWorkerDeploymentTest {
+@ActiveProfiles({"metrics-rhel", "test"})
+class MetricsRhelDeploymentTest {
   @Autowired MeteringConfiguration configuration;
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/deployment/OpenshiftMeteringWorkerDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/OpenshiftMeteringWorkerDeploymentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.subscriptions.metering.MeteringConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"openshift-metering-worker", "test"})
+class OpenshiftMeteringWorkerDeploymentTest {
+  @Autowired MeteringConfiguration configuration;
+
+  @Test
+  void testDeployment() {
+    assertNotNull(configuration);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResourceTest.java
@@ -31,9 +31,7 @@ import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.ApplicationProperties;
-import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.metering.ResourceUtil;
-import org.candlepin.subscriptions.metering.retention.EventRecordsRetentionProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
@@ -53,8 +51,6 @@ class InternalMeteringResourceTest {
 
   @Mock private PrometheusMetricsTaskManager tasks;
   @Mock private PrometheusMeteringController controller;
-  @Mock private EventRecordsRetentionProperties eventRecordsRetentionProperties;
-  @Mock private EventRecordRepository eventRecordRepository;
 
   private ApplicationProperties appProps;
   private ResourceUtil util;
@@ -75,15 +71,7 @@ class InternalMeteringResourceTest {
     retryTemplate = new RetryTemplate();
 
     resource =
-        new InternalMeteringResource(
-            util,
-            appProps,
-            eventRecordsRetentionProperties,
-            tasks,
-            controller,
-            eventRecordRepository,
-            metricProps,
-            retryTemplate);
+        new InternalMeteringResource(util, appProps, tasks, controller, metricProps, retryTemplate);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -30,11 +30,13 @@ import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.retention.RemittanceRetentionController;
 import org.candlepin.subscriptions.retention.TallyRetentionController;
 import org.candlepin.subscriptions.security.SecurityProperties;
 import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
 import org.candlepin.subscriptions.tally.TallySnapshotController;
+import org.candlepin.subscriptions.tally.events.EventRecordsRetentionProperties;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
 import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.candlepin.subscriptions.util.DateRange;
@@ -54,6 +56,8 @@ class InternalTallyResourceTest {
   @Mock private RemittanceRetentionController remittanceRetentionController;
   @Mock private InternalTallyDataController internalTallyDataController;
   @Mock private SecurityProperties properties;
+  @Mock private EventRecordRepository eventRecordRepository;
+  @Mock private EventRecordsRetentionProperties eventRecordsRetentionProperties;
 
   private InternalTallyResource resource;
   private ApplicationProperties appProps;
@@ -73,7 +77,9 @@ class InternalTallyResourceTest {
             tallyRetentionController,
             remittanceRetentionController,
             internalTallyDataController,
-            properties);
+            properties,
+            eventRecordRepository,
+            eventRecordsRetentionProperties);
   }
 
   @Test

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -117,10 +117,6 @@ parameters:
     value: '30 * * * *'
   - name: RHEL_METERING_SCHEDULE
     value: '30 * * * *'
-  - name: PURGE_EVENTS_SCHEDULE
-    value: '30 4 * * *'
-  - name: EVENT_RECORD_RETENTION
-    value: '90d'
   - name: OPENSHIFT_METERING_RANGE
     value: '60'
   - name: HOURLY_TALLY_OFFSET
@@ -317,8 +313,6 @@ objects:
                 value: 'prometheus'
               - name: PROM_URL
                 value: ${PROM_URL}
-              - name: EVENT_RECORD_RETENTION
-                value: ${EVENT_RECORD_RETENTION}
               - name: OPENSHIFT_BILLING_MODEL_FILTER
                 value: ${OPENSHIFT_BILLING_MODEL_FILTER}
               - name: USER_HOST
@@ -420,31 +414,6 @@ objects:
               limits:
                 cpu: ${CURL_CRON_CPU_LIMIT}
                 memory: ${CURL_CRON_MEMORY_LIMIT}
-        - name: purge-events
-          schedule: ${PURGE_EVENTS_SCHEDULE}
-          activeDeadlineSeconds: 1800
-          successfulJobsHistoryLimit: 2
-          restartPolicy: Never
-          podSpec:
-            image: ${CURL_CRON_IMAGE}:${CURL_CRON_IMAGE_TAG}
-            command:
-              - /usr/bin/bash
-              - -c
-              - >
-                /usr/bin/curl --fail -i -H "Origin: https://swatch-metrics-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X DELETE "http://swatch-metrics-service:8000/api/rhsm-subscriptions/v1/internal/metering/events"
-            env:
-              - name: SWATCH_SELF_PSK
-                valueFrom:
-                  secretKeyRef:
-                    name: swatch-psks
-                    key: self
-          resources:
-            requests:
-              cpu: ${CURL_CRON_CPU_REQUEST}
-              memory: ${CURL_CRON_MEMORY_REQUEST}
-            limits:
-              cpu: ${CURL_CRON_CPU_LIMIT}
-              memory: ${CURL_CRON_MEMORY_LIMIT}
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:

--- a/swatch-metrics/deploy/clowdapp_quarkus.yaml
+++ b/swatch-metrics/deploy/clowdapp_quarkus.yaml
@@ -110,10 +110,6 @@ parameters:
     value: '30 * * * *'
   - name: RHEL_METERING_SCHEDULE
     value: '30 * * * *'
-  - name: PURGE_EVENTS_SCHEDULE
-    value: '30 4 * * *'
-  - name: EVENT_RECORD_RETENTION
-    value: '90d'
   - name: HOURLY_TALLY_OFFSET
     value: '60'
   - name: METRICS_RHEL_METERING_RANGE
@@ -237,8 +233,6 @@ objects:
                 value: 'prometheus'
               - name: PROM_URL
                 value: ${PROM_URL}
-              - name: EVENT_RECORD_RETENTION
-                value: ${EVENT_RECORD_RETENTION}
               - name: OPENSHIFT_BILLING_MODEL_FILTER
                 value: ${OPENSHIFT_BILLING_MODEL_FILTER}
               - name: USER_HOST

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -98,6 +98,10 @@ parameters:
     value: 0 6 * * *
   - name: CAPTURE_HOURLY_SNAPSHOT_SCHEDULE
     value: '@hourly'
+  - name: PURGE_EVENTS_SCHEDULE
+    value: '30 4 * * *'
+  - name: EVENT_RECORD_RETENTION
+    value: '90d'
   # TODO after enable individual functionality (see ENT-4487)
   - name: DEV_MODE
     value: 'false'
@@ -414,6 +418,8 @@ objects:
               value: ${OTEL_SERVICE_NAME}
             - name: OTEL_JAVAAGENT_ENABLED
               value: ${OTEL_JAVAAGENT_ENABLED}
+            - name: EVENT_RECORD_RETENTION
+              value: ${EVENT_RECORD_RETENTION}
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -551,6 +557,32 @@ objects:
             - -c
             - >
               /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/remittance/purge"
+          env:
+            - name: SWATCH_SELF_PSK
+              valueFrom:
+                secretKeyRef:
+                  name: swatch-psks
+                  key: self
+        resources:
+          requests:
+            cpu: ${CURL_CRON_CPU_REQUEST}
+            memory: ${CURL_CRON_MEMORY_REQUEST}
+          limits:
+            cpu: ${CURL_CRON_CPU_LIMIT}
+            memory: ${CURL_CRON_MEMORY_LIMIT}
+
+      - name: purge-events
+        schedule: ${PURGE_EVENTS_SCHEDULE}
+        activeDeadlineSeconds: 1800
+        successfulJobsHistoryLimit: 2
+        restartPolicy: Never
+        podSpec:
+          image: ${CURL_CRON_IMAGE}:${CURL_CRON_IMAGE_TAG}
+          command:
+            - /usr/bin/bash
+            - -c
+            - >
+              /usr/bin/curl --fail -i -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X DELETE "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/events/purge"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:


### PR DESCRIPTION
Jira issue: [SWATCH-1880](https://issues.redhat.com/browse/SWATCH-1880)

## Description
Move the purge Events cronjob from swatch-metrics to swatch-tally

## Testing
You can deploy the application and overwrite the PURGE_EVENTS_SCHEDULE environment property with `PURGE_EVENTS_SCHEDULE=*/5 * * * *` (every 5 min).
Another option is to directly alter the CronJob resource that is generated when installing the Clowd app. The CronJob to modify is named "swatch-tally-purge-events". 

Then, in the logs of the job created, you should see:

```
Dload Upload Total Spent Left Speed
0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0
HTTP/1.1 204
Set-Cookie: JSESSIONID=29BD65D44DA4AC8268E64FD218E7B81E; Path=/; HttpOnly
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Date: Tue, 10 Oct 2023 06:46:51 GMT
```

And in the logs of the swatch tally service:
```
2023-10-10 06:46:50,639 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.security.LogPrincipalFilter] self- Internal API: /api/rhsm-subscriptions/v1/internal/rpc/tally/events/purge requested by user: self
2023-10-10 06:46:50,819 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.admin.InternalTallyResource] self- Purging event records older than 2023-07-12T00:00Z
2023-10-10 06:46:50,983 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.admin.InternalTallyResource] self- Event record purge completed successfully
```

So, the call was made and we confirmed that the service processed it. 


