### PR TITLE
Mark deprecated Host APIs

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -608,6 +608,7 @@ paths:
           maximum: 100
         description: "The numbers of items to return"
     get:
+      deprecated: true
       summary: "Fetch hosts matching report criteria."
       operationId: getHosts
       parameters:
@@ -727,6 +728,7 @@ paths:
           maximum: 100
         description: "The numbers of items to return"
     get:
+      deprecated: true
       summary: "Fetch guests for this hypervisor."
       operationId: getHypervisorGuests
       responses:


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-873](https://issues.redhat.com/browse/SWATCH-873)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This doesn't close SWATCH-873 but just formally marks these APIs as deprecated so they'll show up with red squiggles in the IDE and with warnings and what not.