### PR TITLE
SWATCH-1864: quarkus-based services: consume configuration for TLS for inter-service communication from clowder config

### DIFF
--- a/deploy/dev-clowdenv.yaml
+++ b/deploy/dev-clowdenv.yaml
@@ -26,6 +26,10 @@ objects:
         port: 8000
         privatePort: 8080
         mode: operator
+        # enable envoy sidecar to handle https connections
+        tls:
+          enabled: true
+          port: 8800
 
       # provides a prometheus metrics port on 9000
       metrics:

--- a/deploy_ephemeral_env.sh
+++ b/deploy_ephemeral_env.sh
@@ -22,7 +22,7 @@ export NAMESPACE=$(bonfire namespace reserve --pool ${NAMESPACE_POOL})
 SMOKE_NAMESPACE=$NAMESPACE  # track which namespace was used here for 'teardown' in common_deploy_logic
 
 # NOTE(khowell) this line added to force enable sidecars
-oc patch env env-$NAMESPACE -p '{"spec":{"providers":{"sidecars":{"tokenRefresher":{"enabled":true}}}}}' --type=merge
+oc patch env env-$NAMESPACE -p '{"spec":{"providers":{"sidecars":{"tokenRefresher":{"enabled":true}}, "web":{"tls":{"enabled": true, "port": 8800, "privatePort": 10800}}}}}' --type=merge
 
 bonfire deploy \
     ${APP_NAME} \

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -68,6 +68,7 @@ objects:
         sharedDbAppName: swatch-tally
       dependencies:
         - swatch-tally
+        - swatch-subscription-sync
 
       # Creates a database if local mode, or uses RDS in production
       # database:

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 SERVER_PORT=${clowder.endpoints.swatch-contracts.port:8000}
-SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://swatch-subscription-sync-service:8000/api/rhsm-subscriptions/v1
+SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=${clowder.endpoints.swatch-subscription-sync-service.url}
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
 DATABASE_HOST: ${clowder.database.hostname:localhost}
@@ -30,7 +30,7 @@ SPLUNK_HEC_INCLUDE_EX=false
 %dev.SPLUNKMETA_host=${USER}@${HOSTNAME}
 %dev.SPLUNKMETA_namespace=local
 %dev.SPLUNK_HEC_INCLUDE_EX=true
-%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8001/api/rhsm-subscriptions/v1
+%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
@@ -109,7 +109,10 @@ quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.Search
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".scope=jakarta.enterprise.context.ApplicationScoped
 
 # configuration properties for subscriptions-sync
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions/v1
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter
 
 # rbac service configuration

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -41,8 +41,6 @@ parameters:
     value: '3'
   - name: SPLUNK_HEC_INCLUDE_EX
     value: 'true'
-  - name: SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT
-    value: http://swatch-subscription-sync-service:8000/api/rhsm-subscriptions/v1
   - name: MOTO_REPLICAS
     value: '0'
   - name: AWS_MARKETPLACE_ENDPOINT_URL
@@ -85,6 +83,8 @@ objects:
       prometheus: quarkus
   spec:
     envName: ${ENV_NAME}
+    dependencies:
+      - swatch-subscription-sync
 
     kafkaTopics:
       - replicas: ${{KAFKA_BILLABLE_USAGE_REPLICAS}}
@@ -167,8 +167,6 @@ objects:
               value: ${SPLUNK_HEC_RETRY_COUNT}
             - name: SPLUNK_HEC_INCLUDE_EX
               value: ${SPLUNK_HEC_INCLUDE_EX}
-            - name: SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT
-              value: ${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}
             - name: AWS_MANUAL_SUBMISSION_ENABLED
               value: ${AWS_MANUAL_SUBMISSION_ENABLED}
             - name: AWS_MARKETPLACE_ENDPOINT_OVERRIDE

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 SERVER_PORT=${clowder.endpoints.swatch-producer-aws.port:8000}
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
-SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://${clowder.endpoints.capacity-ingress.hostname}:${clowder.endpoints.capacity-ingress.port}
+SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=${clowder.endpoints.swatch-subscription-sync-service.url}
 AWS_REGION=us-east-1
 AWS_MANUAL_SUBMISSION_ENABLED=false
 AWS_SEND_RETRIES=0
@@ -21,7 +21,7 @@ TALLY_IN_FAIL_ON_DESER_FAILURE=true
 # dev-specific defaults; these can still be overridden by env var
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
 %dev.AWS_CREDENTIALS_JSON=[{"accessKeyId":"accessKey","secretAccessKey":"placeholder","sellerAccount":"awsSellerAccountId"}]
-%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101/api/rhsm-subscriptions/v1
+%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101
 %dev.AWS_MARKETPLACE_ENDPOINT_URL=http://localhost:8101/aws-marketplace/
 %dev.AWS_MARKETPLACE_ENDPOINT_OVERRIDE=true
 %dev.AWS_MANUAL_SUBMISSION_ENABLED=true
@@ -88,7 +88,10 @@ mp.messaging.incoming.tally-in.auto.offset.reset = earliest
 mp.messaging.outgoing.tally-out.connector=smallrye-kafka
 mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.billable-usage
 
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions/v1
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter, com.redhat.swatch.aws.resource.DefaultApiExceptionMapper
 com.redhat.swatch.processors.BillableUsageProcessor/lookupAwsUsageContext/Retry/maxRetries=${AWS_USAGE_CONTEXT_LOOKUP_RETRIES}
 com.redhat.swatch.processors.BillableUsageProcessor/send/Retry/maxRetries=${AWS_SEND_RETRIES}

--- a/swatch-producer-azure/deploy/clowdapp.yaml
+++ b/swatch-producer-azure/deploy/clowdapp.yaml
@@ -53,6 +53,8 @@ objects:
       prometheus: quarkus
   spec:
     envName: ${ENV_NAME}
+    dependencies:
+      - swatch-subscription-sync
 
     kafkaTopics:
       - replicas: ${{KAFKA_BILLABLE_USAGE_REPLICAS}}

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 SERVER_PORT=${clowder.endpoints.swatch-producer-azure.port:8000}
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
-SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://swatch-subscription-sync-service:8000/api/rhsm-subscriptions/v1
+SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=${clowder.endpoints.swatch-subscription-sync-service.url}
 ENABLE_SPLUNK_HEC=true
 SPLUNK_HEC_URL=https://splunk-hec.redhat.com:8088/
 SPLUNK_SOURCE=${quarkus.application.name}
@@ -27,7 +27,7 @@ ENABLE_AZURE_DRY_RUN=true
 
 # dev-specific defaults; these can still be overridden by env var
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
-%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101/api/rhsm-subscriptions/v1
+%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101
 %dev.SWATCH_SELF_PSK=placeholder
 %dev.ENABLE_SPLUNK_HEC=false
 %dev.SPLUNK_HEC_URL=https://splunk-hec.prod.utility-us-east-2.redhat.com:8088/
@@ -87,7 +87,10 @@ mp.messaging.incoming.tally-in.auto.offset.reset = earliest
 mp.messaging.outgoing.tally-out.connector=smallrye-kafka
 mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.billable-usage
 
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions/v1
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}


### PR DESCRIPTION
Jira issue: [SWATCH-1864](https://issues.redhat.com/browse/SWATCH-1864)

## Description
The clowder config source already deals with the configuration of the URL, truststore path and the rest of properties for SSL. All we need is to use `${clowder.endpoints.<dependency name>-service.url}` instead of `http://${clowder.endpoints.capacity-ingress.hostname}:${clowder.endpoints.capacity-ingress.port}`. 
And also to properly declare the dependencies.

Note that this strongly depends on the ClowdEnvironment object to be updated with:

```
{
  "spec": {
    "providers": {
      "web": {
        "tls": {
          "enabled": true,
          "port": 8800
        }
      }
    }
  }
}
```

With `tls.enabled=true`, the envoy sidecar will be created for all the clowd apps. 
However, if the `tls` flag is not enabled, everything will keep working as usual but using HTTP. The clowder config source will see if the `tls` flag is enabled or not, and configure the rest client accordingly. 

## Testing
Ephemeral namespace already has the "tls.enabled=true" flag, so running the QE test suite to confirm everything works as before should be enough.

For manual deployment:

1. `bonfire namespace reserve --pool default` -> output should be the oc project name
2. `oc project <project name>`
3. `oc patch env env-<project name> -p '{"spec":{"providers":{"sidecars":{"tokenRefresher":{"enabled":true}}, "web":{"tls":{"enabled": true, "port": 8800}}}}}' --type=merge`
4. `bonfire deploy rhsm --source=appsre --namespace <project name> ...`