### PR TITLE
SWATCH-893: remove deprecated hosts API endpoint

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -706,65 +706,6 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - hosts
-  /hosts/{hypervisor_uuid}/guests:
-    description: 'Operations for hypervisor-guest mappings.'
-    parameters:
-      - name: hypervisor_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-        description: "The subscription-manager ID for the hypervisor we wish to query"
-      - name: offset
-        in: query
-        schema:
-          type: integer
-        description: "The number of items to skip before starting to collect the result set"
-      - name: limit
-        in: query
-        schema:
-          type: integer
-          minimum: 1
-          maximum: 100
-        description: "The numbers of items to return"
-    get:
-      deprecated: true
-      summary: "Fetch guests for this hypervisor."
-      operationId: getHypervisorGuests
-      responses:
-        '200':
-          description: 'The request for a capacity report was successful.'
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: "#/components/schemas/HypervisorGuestReport"
-              example:
-                data:
-                  - inventory_id: d6214a0b-b344-4778-831c-d53dcacb2da3
-                    display_name: guest01.example.com
-                    subscription_manager_id: adafd9d5-5b00-42fa-a6c9-75801d45cc6d
-                    last_seen: 2020-01-01T00:00:00Z
-                  - inventory_id: 9358e312-1c9f-42f4-8910-dcef6e970852
-                    display_name: guest02.example.com
-                    subscription_manager_id: b101a72f-1859-4489-acb8-d6d31c2578c4
-                    last_seen: 2020-01-01T00:00:00Z
-                links:
-                  first: '/api/rhsm-subscriptions/v1/hosts/a283ffb6-e0f3-4dbe-9732-ccfdb297ba07/guests?offset=0&limit=5'
-                  last: '/api/rhsm-subscriptions/v1/hosts/a283ffb6-e0f3-4dbe-9732-ccfdb297ba07/guests?offset=5&limit=5'
-                  previous: null
-                  next: '/api/rhsm-subscriptions/v1/hosts/a283ffb6-e0f3-4dbe-9732-ccfdb297ba07/guests?offset=5&limit=5'
-                meta:
-                  count: 10
-        '400':
-          $ref: "../spec/error-responses.yaml#/$defs/BadRequest"
-        '403':
-          $ref: "../spec/error-responses.yaml#/$defs/Forbidden"
-        '404':
-          $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
-        '500':
-          $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
-      tags:
-        - hosts
   /instances/{id}/guests:
     description: 'Operations for instance-id mappings.'
     parameters:
@@ -1579,16 +1520,6 @@ components:
           required:
             - count
             - product
-    HypervisorGuestReport:
-      properties:
-        data:
-          type: array
-          items:
-            $ref: "#/components/schemas/Host"
-        links:
-          $ref: "#/components/schemas/PageLinks"
-        meta:
-          $ref: "#/components/schemas/MetaCount"
     InstanceGuestReport:
       properties:
         data:

--- a/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/HostsResource.java
@@ -39,7 +39,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
-import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.HostApiProjection;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -50,8 +49,6 @@ import org.candlepin.subscriptions.security.auth.ReportingAccessRequired;
 import org.candlepin.subscriptions.utilization.api.model.HostReport;
 import org.candlepin.subscriptions.utilization.api.model.HostReportMeta;
 import org.candlepin.subscriptions.utilization.api.model.HostReportSort;
-import org.candlepin.subscriptions.utilization.api.model.HypervisorGuestReport;
-import org.candlepin.subscriptions.utilization.api.model.MetaCount;
 import org.candlepin.subscriptions.utilization.api.model.PageLinks;
 import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.model.SortDirection;
@@ -256,25 +253,5 @@ public class HostsResource implements HostsApi {
     if (!isDateRangePossible || !isBothDatesFromSameMonth) {
       throw new IllegalArgumentException("Invalid date range.");
     }
-  }
-
-  @Override
-  @ReportingAccessRequired
-  public HypervisorGuestReport getHypervisorGuests(
-      String hypervisorUuid, Integer offset, Integer limit) {
-    String orgId = ResourceUtils.getOrgId();
-    Pageable page = ResourceUtils.getPageable(offset, limit);
-    Page<Host> guests = repository.getHostsByHypervisor(orgId, hypervisorUuid, page);
-    PageLinks links;
-    if (offset != null || limit != null) {
-      links = pageLinkCreator.getPaginationLinks(uriInfo, guests);
-    } else {
-      links = null;
-    }
-
-    return new HypervisorGuestReport()
-        .links(links)
-        .meta(new MetaCount().count((int) guests.getTotalElements()))
-        .data(guests.getContent().stream().map(Host::asApiHost).collect(Collectors.toList()));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostRepositoryTest.java
@@ -438,36 +438,6 @@ class HostRepositoryTest {
 
   @Transactional
   @Test
-  void testReturnsGuestsOfHypervisor() {
-    String account = "hostGuestTest";
-    String uuid = UUID.randomUUID().toString();
-
-    Host hypervisor = createHost("hypervisor", account);
-    hypervisor.setSubscriptionManagerId(uuid);
-    addBucketToHost(hypervisor, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION);
-
-    Host guest = createHost("guest", account);
-    guest.setGuest(true);
-    guest.setHypervisorUuid(uuid);
-    addBucketToHost(guest, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION);
-
-    Host unmappedGuest = createHost("unmappedGuest", account);
-    unmappedGuest.setGuest(true);
-    addBucketToHost(unmappedGuest, "RHEL", ServiceLevel.PREMIUM, Usage.PRODUCTION);
-
-    List<Host> toSave = Arrays.asList(hypervisor, guest, unmappedGuest);
-    toSave.forEach(x -> x.setDisplayName(DEFAULT_DISPLAY_NAME));
-    persistHosts(toSave.toArray(new Host[] {}));
-
-    Page<Host> guests = repo.getHostsByHypervisor("ORG_" + account, uuid, PageRequest.of(0, 10));
-    assertEquals(1, guests.getTotalElements());
-    assertEquals(uuid, guests.getContent().get(0).getHypervisorUuid());
-    assertEquals("guest", guests.getContent().get(0).getInventoryId());
-    assertEquals("INSIGHTS_guest", guests.getContent().get(0).getInsightsId());
-  }
-
-  @Transactional
-  @Test
   void testReturnsGuestsOfHypervisorByInstanceId() {
     String account = "hostGuestTest";
     String uuid = UUID.randomUUID().toString();

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -525,13 +525,6 @@ public interface HostRepository
   }
 
   @Query(
-      "select distinct h from Host h where "
-          + "h.orgId = :orgId and "
-          + "h.hypervisorUuid = :hypervisor_id")
-  Page<Host> getHostsByHypervisor(
-      @Param("orgId") String orgId, @Param("hypervisor_id") String hypervisorId, Pageable pageable);
-
-  @Query(
       "select distinct h1 from Host h1 where "
           + "h1.orgId = :orgId and "
           + "h1.hypervisorUuid in (select h2.subscriptionManagerId from Host h2 where "


### PR DESCRIPTION
Jira issue: [SWATCH-893](https://issues.redhat.com/browse/SWATCH-893)

## Description
remove deprecated hosts API endpoint __ /hosts/{hypervisor_uuid}/guests

## Testing
test for regressions, remove any references to this API