### PR TITLE
SWATCH-1925: Fix access to swagger-ui in stage/prod

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -52,19 +52,17 @@ public class ResteasyConfiguration implements WebMvcConfigurer {
     registry.addViewController("/api-docs").setViewName("redirect:/api-docs/index.html");
     registry.addViewController("/api-docs/").setViewName("redirect:/api-docs/index.html");
     registry
-        .addViewController("/api/swatch-subscription-sync/internal/swagger-ui")
-        .setViewName("redirect:/api-docs/internal-subscription-sync.html");
-    registry
         .addViewController("/api/swatch-tally/internal/swagger-ui")
-        .setViewName("redirect:/api-docs/internal-tally.html");
+        .setViewName("redirect:/api/swatch-tally/internal/swagger-ui/index.html");
     registry
         .addViewController("/api/swatch-metrics/internal/swagger-ui")
-        .setViewName("redirect:/api-docs/internal-metering.html");
+        .setViewName("redirect:/api/swatch-metrics/internal/swagger-ui/index.html");
     registry
         .addViewController("/api/swatch-billing/internal/swagger-ui")
-        .setViewName("redirect:/api-docs/internal-billing.html");
+        .setViewName("redirect:/api/swatch-billing/internal/swagger-ui/index.html");
     registry
         .addViewController("/api/swatch-producer-red-hat-marketplace/internal/swagger-ui")
-        .setViewName("redirect:/api-docs/internal-producer-red-hat-marketplace.html");
+        .setViewName(
+            "redirect:/api/swatch-producer-red-hat-marketplace/internal/swagger-ui/index.html");
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -52,6 +52,9 @@ public class ResteasyConfiguration implements WebMvcConfigurer {
     registry.addViewController("/api-docs").setViewName("redirect:/api-docs/index.html");
     registry.addViewController("/api-docs/").setViewName("redirect:/api-docs/index.html");
     registry
+        .addViewController("/api/swatch-subscription-sync/internal/swagger-ui")
+        .setViewName("redirect:/api/swatch-subscription-sync/internal/swagger-ui/index.html");
+    registry
         .addViewController("/api/swatch-tally/internal/swagger-ui")
         .setViewName("redirect:/api/swatch-tally/internal/swagger-ui/index.html");
     registry

--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -87,7 +87,8 @@ public class ApiSecurityConfiguration {
         "/api-docs/**",
         "/webjars/**",
         "/**/*spec.yaml",
-        "/**/swagger-ui"
+        "/**/swagger-ui",
+        "/**/swagger-ui/index.html",
       };
 
   // NOTE: intentionally not annotated w/ @Bean; @Bean causes an extra use as an application filter

--- a/src/main/resources/static/api/swatch-billing/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-billing/internal/swagger-ui/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>rhsm internal billing service API Docs</title>
-    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui/swagger-ui.css" >
+    <title>swatch-billing internal API Docs</title>
+    <link rel="stylesheet" type="text/css" href="../../../../webjars/swagger-ui/swagger-ui.css" >
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
-    <script src="../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-billing-openapi.yaml",
+        url: "/api/rhsm-subscriptions/v1/openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/resources/static/api/swatch-metrics/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-metrics/internal/swagger-ui/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>rhsm internal subscription sync service API Docs</title>
-    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui/swagger-ui.css" >
+    <title>swatch-metrics internal API Docs</title>
+    <link rel="stylesheet" type="text/css" href="../../../../webjars/swagger-ui/swagger-ui.css" >
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
-    <script src="../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-subscription-sync-openapi.yaml",
+        url: "/api/rhsm-subscriptions/v1/internal-metering-openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/resources/static/api/swatch-producer-red-hat-marketplace/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-producer-red-hat-marketplace/internal/swagger-ui/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>rhsm internal tally service API Docs</title>
-    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui/swagger-ui.css" >
+    <title>swatch-producer-red-hat-marketplace internal API Docs</title>
+    <link rel="stylesheet" type="text/css" href="../../../../webjars/swagger-ui/swagger-ui.css" >
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
-    <script src="../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-tally-openapi.yaml",
+        url: "/api/rhsm-subscriptions/v1/internal-swatch-producer-red-hat-marketplace-openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/resources/static/api/swatch-subscription-sync/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-subscription-sync/internal/swagger-ui/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>rhsm internal metering service API Docs</title>
-    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui/swagger-ui.css" >
+    <title>swatch-subscription-sync internal API Docs</title>
+    <link rel="stylesheet" type="text/css" href="../../../../webjars/swagger-ui/swagger-ui.css" >
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
-    <script src="../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-metering-openapi.yaml",
+        url: "/api/rhsm-subscriptions/v1/internal-subscription-sync-openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/resources/static/api/swatch-tally/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-tally/internal/swagger-ui/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>rhsm internal system conduit service API Docs</title>
-    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui/swagger-ui.css" >
+    <title>swatch-tally internal API Docs</title>
+    <link rel="stylesheet" type="text/css" href="../../../../webjars/swagger-ui/swagger-ui.css" >
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
-    <script src="../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-organizations-sync-openapi.json",
+        url: "/api/rhsm-subscriptions/v1/internal-tally-openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/resteasy/ResteasyConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/resteasy/ResteasyConfiguration.java
@@ -55,6 +55,6 @@ public class ResteasyConfiguration implements WebMvcConfigurer {
   public void addViewControllers(ViewControllerRegistry registry) {
     registry
         .addViewController("api/swatch-system-conduit/internal/swagger-ui")
-        .setViewName("redirect:/api-docs/internal.html");
+        .setViewName("redirect:/api/swatch-system-conduit/internal/swagger-ui/index.html");
   }
 }

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/security/ApiSecurityConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/security/ApiSecurityConfiguration.java
@@ -96,7 +96,7 @@ public class ApiSecurityConfiguration {
         "/**/version",
         "/api-docs/**",
         "/webjars/**",
-        "/api/swatch-system-conduit/internal/swagger-ui"
+        "/api/swatch-system-conduit/internal/swagger-ui/index.html"
       };
 
   // NOTE: intentionally *not* annotated with @Bean; @Bean causes an extra use as an application

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/security/ApiSecurityConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/security/ApiSecurityConfiguration.java
@@ -96,7 +96,9 @@ public class ApiSecurityConfiguration {
         "/**/version",
         "/api-docs/**",
         "/webjars/**",
-        "/api/swatch-system-conduit/internal/swagger-ui/index.html"
+        "/**/*spec.yaml",
+        "/**/swagger-ui",
+        "/**/swagger-ui/index.html"
       };
 
   // NOTE: intentionally *not* annotated with @Bean; @Bean causes an extra use as an application

--- a/swatch-system-conduit/src/main/resources/static/api/swatch-system-conduit/internal/swagger-ui/index.html
+++ b/swatch-system-conduit/src/main/resources/static/api/swatch-system-conduit/internal/swagger-ui/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>rhsm internal producer red hat marketplace service API Docs</title>
-    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui/swagger-ui.css" >
+    <title>rhsm internal system conduit service API Docs</title>
+    <link rel="stylesheet" type="text/css" href="../../../../webjars/swagger-ui/swagger-ui.css" >
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
-    <script src="../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-bundle.js"> </script>
+    <script src="../../../../webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-swatch-producer-red-hat-marketplace-openapi.yaml",
+        url: "/api/rhsm-subscriptions/v1/internal-organizations-sync-openapi.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1925](https://issues.redhat.com/browse/SWATCH-1925)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
 Currently our internal swagger-ui endpoints for spring-boot services in stage and prod are not accessible. I believe this is due to turnpike rules and not having routes available for /api-docs. This change makes it so the swagger ui files are hosted in a directory structure that matches the expected URL so that no redirect to a new path needs to occur.
 
## Testing
Verification
1.Verify each of below URLs brings you to the swagger-ui when running with below command:
DEV_MODE=true ./gradlew :bootRun
http://localhost:8000/api/swatch-tally/internal/swagger-ui
http://localhost:8000/api/swatch-metrics/internal/swagger-ui
http://localhost:8000/api/swatch-subscription-sync/internal/swagger-ui
http://localhost:8000/api/swatch-billing/internal/swagger-ui
http://localhost:8000/api/swatch-producer-red-hat-marketplace/internal/swagger-ui

1.Verify each of below URLs brings you to the swagger-ui when running with below command:
DEV_MODE=true RHSM_USE_STUB=true ./gradlew swatch-system-conduit:bootRun
http://localhost:8000/api/swatch-system-conduit/internal/swagger-ui