### PR TITLE
SWATCH-1936: Remove account_number from floorist queries

### DIFF
--- a/src/main/resources/liquibase/202311161207-drop-account-config-table.xml
+++ b/src/main/resources/liquibase/202311161207-drop-account-config-table.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+
+  <changeSet id="202311161207-00" author="lburnett" dbms="postgresql">
+    <comment>Drop account_config table</comment>
+    <dropTable tableName="account_config"/>
+
+    <rollback>
+      <comment>Replace empty account_config table.</comment>
+      <createTable tableName="account_config">
+        <column name="account_number" type="VARCHAR(255)">
+          <constraints nullable="true" unique="true"
+            uniqueConstraintName="account_config_account_number_unq"/>
+        </column>
+        <column name="opt_in_type" type="VARCHAR(255)">
+          <constraints nullable="false"/>
+        </column>
+        <column name="created" type="TIMESTAMP WITH TIME ZONE">
+          <constraints nullable="false"/>
+        </column>
+        <column name="updated" type="TIMESTAMP WITH TIME ZONE">
+          <constraints nullable="false"/>
+        </column>
+        <column name="org_id" type="varchar(32)">
+          <constraints primaryKey="true" primaryKeyName="account_config_pkey"/>
+        </column>
+      </createTable>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -134,5 +134,6 @@
     <!-- <include file="liquibase/202309181629-fix-measurement-metric-id-formatting.xml"/> -->
     <include file="/liquibase/202310131200-remove-account-config.xml"/>
     <include file="/liquibase/202310251600-replace-account-config-table.xml"/>
+    <include file="/liquibase/202311161207-drop-account-config-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -681,8 +681,7 @@ objects:
     - prefix: swatch/tally
       query: >-
         select
-        c.account_number as account_number,
-        s.org_id as org_id,
+        org_id,
         snapshot_date,
         product_id,
         measurement_type,
@@ -691,7 +690,6 @@ objects:
         value
         from tally_snapshots s
         join tally_measurements tm on s.id = tm.snapshot_id
-        left join account_config c on c.org_id=s.org_id
         where sla = '_ANY'
         and usage = '_ANY'
         and billing_provider = '_ANY'
@@ -702,7 +700,6 @@ objects:
     - prefix: swatch/subscriptions
       query: >-
         select
-        c.account_number,
         subscription.org_id,
         subscription.sku,
         subscription.subscription_id,
@@ -721,4 +718,3 @@ objects:
           ('CORES', 'Cores'),
           ('INSTANCE_HOURS', 'Instance-hours')
         ) as metric_id_normalized(value, normalized) on subscription_measurements.metric_id=metric_id_normalized.value
-        left join account_config c on c.org_id=subscription.org_id


### PR DESCRIPTION
<!-- Replace XXXX with the issue number -->
Jira issue: [SWATCH-1936](https://issues.redhat.com/browse/SWATCH-1936)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

TeleSense requested that we stop reporting the "account_number" column.  By removing that, it allows us to finally drop the account_config table that we stopped using as part of [the clean up account number usage epic](https://issues.redhat.com/browse/SWATCH-657) . 

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

You can use gabi to verify the sql queries.  Changes should be reflected in S3 reports the next day.