### PR TITLE
SWATCH-379: Sync new vCPUs field to HBI when present

### DIFF
--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -67,6 +67,8 @@ public class StubRhsmApi extends RhsmApi {
     consumer1.getFacts().put("Mac-addresses", "00:00:00:00:00:00, ff:ff:ff:ff:ff:ff");
     consumer1.getFacts().put("cpu.cpu_socket(s)", "2");
     consumer1.getFacts().put("cpu.core(s)_per_socket", "2");
+    consumer1.getFacts().put("cpu.cpu(s)", "3");
+    consumer1.getFacts().put("cpu.thread(s)_per_core", "5");
 
     consumer1.getFacts().put("memory.memtotal", "32757812");
     consumer1.getFacts().put("uname.machine", "x86_64");

--- a/swatch-system-conduit/schemas/inventory/hbi-system-profile.yaml
+++ b/swatch-system-conduit/schemas/inventory/hbi-system-profile.yaml
@@ -23,6 +23,10 @@ properties:
     type: float
   number_of_sockets:
     type: integer
+  number_of_cpus:
+    type: integer
+  threads_per_core:
+    type: integer
   owner_id:
     type: string
   is_marketplace:

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -101,6 +101,8 @@ public class InventoryController {
   public static final String NET_INTERFACE_LO_IPV6_ADDRESS = "net.interface.lo.ipv6_address";
   public static final String CPU_SOCKETS = "cpu.cpu_socket(s)";
   public static final String CPU_CORES_PER_SOCKET = "cpu.core(s)_per_socket";
+  public static final String NUMBER_OF_CPUS = "cpu.cpu(s)";
+  public static final String THREADS_PER_CORE = "cpu.thread(s)_per_core";
   public static final String MEMORY_MEMTOTAL = "memory.memtotal";
   public static final String UNAME_MACHINE = "uname.machine";
   public static final String VIRT_IS_GUEST = "virt.is_guest";
@@ -293,6 +295,14 @@ public class InventoryController {
     }
     if (StringUtils.hasLength(coresPerSocket)) {
       facts.setCoresPerSocket(Integer.parseInt(coresPerSocket));
+    }
+    String numberOfCpus = rhsmFacts.get(NUMBER_OF_CPUS);
+    if (StringUtils.hasLength(numberOfCpus)) {
+      facts.setNumberOfCpus(Integer.parseInt(numberOfCpus));
+    }
+    String threadsPerCore = rhsmFacts.get(THREADS_PER_CORE);
+    if (StringUtils.hasLength(threadsPerCore)) {
+      facts.setThreadsPerCore(Integer.parseInt(threadsPerCore));
     }
 
     setMemoryFacts(rhsmFacts, facts);

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/ConduitFacts.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/ConduitFacts.java
@@ -76,6 +76,18 @@ public class ConduitFacts extends ConsumerInventory {
 
   @Positive
   @Override
+  public Integer getNumberOfCpus() {
+    return super.getNumberOfCpus();
+  }
+
+  @Positive
+  @Override
+  public Integer getThreadsPerCore() {
+    return super.getThreadsPerCore();
+  }
+
+  @Positive
+  @Override
   public Long getMemory() {
     return super.getMemory();
   }

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -141,6 +141,8 @@ public abstract class InventoryService {
     }
     systemProfile.setSystemMemoryBytes(facts.getSystemMemoryBytes());
     systemProfile.setNumberOfSockets(facts.getCpuSockets());
+    systemProfile.setNumberOfCpus(facts.getNumberOfCpus());
+    systemProfile.setThreadsPerCore(facts.getThreadsPerCore());
     systemProfile.setOwnerId(facts.getSubscriptionManagerId());
     systemProfile.setNetworkInterfaces(facts.getNetworkInterfaces());
     systemProfile.setIsMarketplace(facts.getIsMarketplace());

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -240,6 +240,10 @@ components:
           type: integer
         cores_per_socket:
           type: integer
+        number_of_cpus:
+          type: integer
+        threads_per_core:
+          type: integer
         last_checkin:
           type: string
           format: date-time

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -946,4 +946,34 @@ class InventoryControllerTest {
     verify(inventoryService).scheduleHostUpdate(cfacts);
     verify(inventoryService, times(1)).flushHostUpdates();
   }
+
+  @Test
+  void testNumberOfCpusIsMappedToConduitFacts() {
+    int expectedNumberOfCpus = 5;
+    Consumer consumer = new Consumer();
+    consumer.getFacts().put("cpu.cpu(s)", "" + expectedNumberOfCpus);
+
+    // verify when cpu.cpu(s) is set
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(expectedNumberOfCpus, conduitFacts.getNumberOfCpus());
+
+    // verify when cpu.cpu(s) is unset
+    conduitFacts = controller.getFactsFromConsumer(new Consumer());
+    assertNull(conduitFacts.getNumberOfCpus());
+  }
+
+  @Test
+  void testThreadsPerCoreIsMappedToConduitFacts() {
+    int expectedThreadsPerCore = 3;
+    Consumer consumer = new Consumer();
+    consumer.getFacts().put("cpu.thread(s)_per_core", "" + expectedThreadsPerCore);
+
+    // verify when cpu.thread(s)_per_core is set
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(expectedThreadsPerCore, conduitFacts.getThreadsPerCore());
+
+    // verify when cpu.thread(s)_per_core is unset
+    conduitFacts = controller.getFactsFromConsumer(new Consumer());
+    assertNull(conduitFacts.getThreadsPerCore());
+  }
 }

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -57,6 +57,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles({"rhsm-conduit", "test", "kafka-queue"})
 class KafkaEnabledInventoryServiceTest {
+
+  private static final int NUMBER_OF_CPUS = 5;
+  private static final int THREADS_PER_CORE = 3;
+
   @Autowired
   @Qualifier("kafkaRetryTemplate")
   private RetryTemplate retryTemplate;
@@ -90,6 +94,8 @@ class KafkaEnabledInventoryServiceTest {
     expectedFacts.setCpuSockets(45);
     expectedFacts.setOsName("Red Hat Enterprise Linux Workstation");
     expectedFacts.setOsVersion("6.3");
+    expectedFacts.setNumberOfCpus(NUMBER_OF_CPUS);
+    expectedFacts.setThreadsPerCore(THREADS_PER_CORE);
 
     InventoryServiceProperties props = new InventoryServiceProperties();
     props.setKafkaHostIngressTopic("placeholder");
@@ -121,6 +127,8 @@ class KafkaEnabledInventoryServiceTest {
         "RHEL", message.getData().getSystemProfile().getOperatingSystem().getName().value());
     assertEquals(6, message.getData().getSystemProfile().getOperatingSystem().getMajor());
     assertEquals(3, message.getData().getSystemProfile().getOperatingSystem().getMinor());
+    assertEquals(NUMBER_OF_CPUS, message.getData().getSystemProfile().getNumberOfCpus());
+    assertEquals(THREADS_PER_CORE, message.getData().getSystemProfile().getThreadsPerCore());
   }
 
   @Test


### PR DESCRIPTION
Jira issue: [SWATCH-379](https://issues.redhat.com/browse/SWATCH-379)

## Description
Populate the value in the system profile:

<candlepin fact> -> <system profile field>
cpu.cpu(s) -> number_of_cpus: [link to API](https://github.com/RedHatInsights/insights-host-inventory/blob/470f2264ed7be2f5b028f880a7aae2790ca9e660/swagger/system_profile.spec.yaml#L222)
cpu.thread(s)_per_core -> threads_per_core: [link to API](https://github.com/RedHatInsights/insights-host-inventory/blob/470f2264ed7be2f5b028f880a7aae2790ca9e660/swagger/system_profile.spec.yaml#L237)

## Testing
Added test to cover this change and ensure that the values are persisted. 
I don't think we need QE here (after SWATCH-401 is done, they can verify the end-to-end change).


0.- Start Kafka

`podman-compose up`

1.- Run conduit app with stubs
`RHSM_USE_STUB=true DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun`

2.- Sync organization:
`http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg   x-rh-swatch-psk:placeholder   org_id=org123`

3. Check the message that has been sent to Kafka in http://localhost:3030/#/cluster/default/topic/n/platform.inventory.host-ingress/ .

The stub is configured to add number of cpus to 3 and threads per core to 5. This is what you should see:

```
Key
Value
operation add_host
data
org_id org123
subscription_manager_id e7ec2d55-2a17-42dc-8e70-a23126f208fa
bios_uuid 723a1ecb-d3ce-4900-b095-d3c5911bfb1a
ip_addresses [ 192.167.11.2, 192.168.1.1, 192.168.122.1, 10.0.0.1 ]
fqdn host1.test.com
facts [ [object Object] ]
system_profile
operating_system { major: 6, minor: 3, name: RHEL }
os_release 6.3
releasever 8.0
arch x86_64
cores_per_socket 2
infrastructure_type virtual
system_memory_bytes 33543999488
number_of_sockets 2
number_of_cpus 3
threads_per_core 5
owner_id e7ec2d55-2a17-42dc-8e70-a23126f208fa
is_marketplace true
network_interfaces [ [object Object] ]
stale_timestamp 2023-11-29T15:08:11.524269078Z
reporter rhsm-conduit
platform_metadata { request_id: 645cc340-f15f-4b6d-8401-296b4fc26ebc }
```