### PR TITLE
SWATCH-921: Debug traces when billages are skipped due marketplace

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -105,6 +105,9 @@ public class RhMarketplacePayloadMapper {
     if (!isValid(billableUsage)) {
       log.warn("Skipping invalid billable usage {}", billableUsage);
       return null;
+    } else if (!isUsageRHMarketplaceEligible(billableUsage)) {
+      log.debug("Skipping billable usage due to another target marketplace {}", billableUsage);
+      return null;
     }
 
     OffsetDateTime snapshotDate = billableUsage.getSnapshotDate();
@@ -193,9 +196,7 @@ public class RhMarketplacePayloadMapper {
         && billableUsage.getBillingProvider() != null
         && billableUsage.getBillingAccountId() != null
         && billableUsage.getSnapshotDate() != null
-        && billableUsage.getId() != null
-        && isUsageRHMarketplaceEligible(billableUsage);
-  }
+        && billableUsage.getId() != null;
 
   public Stream<UsageRequest> createUsageRequests(TallySummary tallySummary) {
     return billableUsageMapper.fromTallySummary(tallySummary).map(this::createUsageRequest);

--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -31,18 +31,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.BillableUsage.Sla;
 import org.candlepin.subscriptions.json.BillableUsage.Usage;
-import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.rhmarketplace.api.model.UsageEvent;
 import org.candlepin.subscriptions.rhmarketplace.api.model.UsageMeasurement;
 import org.candlepin.subscriptions.rhmarketplace.api.model.UsageRequest;
-import org.candlepin.subscriptions.tally.billing.BillableUsageMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.retry.support.RetryTemplate;
@@ -50,14 +46,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 /** Maps BillableUsage to payload contents to be sent to RHM apis */
+@Slf4j
 @Service
 public class RhMarketplacePayloadMapper {
-  private static final Logger log = LoggerFactory.getLogger(RhMarketplacePayloadMapper.class);
-
-  public static final String OPENSHIFT_DEDICATED_4_CPU_HOUR =
-      "redhat.com:openshift_dedicated:4cpu_hour";
-
-  private final BillableUsageMapper billableUsageMapper;
   private final InternalSubscriptionsApi subscriptionsClient;
   private final RetryTemplate usageContextRetryTemplate;
 
@@ -66,9 +57,6 @@ public class RhMarketplacePayloadMapper {
       InternalSubscriptionsApi subscriptionsClient,
       @Qualifier("rhmUsageContextLookupRetryTemplate") RetryTemplate usageContextRetryTemplate) {
     this.subscriptionsClient = subscriptionsClient;
-    // NOTE(khowell) this dependency is temporary, and instantiating here was easier than
-    // refactoring profiles.
-    this.billableUsageMapper = new BillableUsageMapper();
     this.usageContextRetryTemplate = usageContextRetryTemplate;
   }
 
@@ -197,8 +185,5 @@ public class RhMarketplacePayloadMapper {
         && billableUsage.getBillingAccountId() != null
         && billableUsage.getSnapshotDate() != null
         && billableUsage.getId() != null;
-
-  public Stream<UsageRequest> createUsageRequests(TallySummary tallySummary) {
-    return billableUsageMapper.fromTallySummary(tallySummary).map(this::createUsageRequest);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
@@ -35,6 +35,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
+import lombok.Getter;
 import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.BillableUsage.BillingProvider;
 import org.candlepin.subscriptions.json.BillableUsage.Sla;
@@ -218,7 +219,7 @@ class RhMarketplacePayloadMapperTest {
                 .withBillingProvider(BillingProvider.GCP),
             false);
 
-    Arguments notEligableDefaultBillableUsage = Arguments.of(new BillableUsage(), false);
+    Arguments notEligibleDefaultBillableUsage = Arguments.of(new BillableUsage(), false);
 
     return Stream.of(
         eligibleRedHatBillingProvider,
@@ -227,7 +228,7 @@ class RhMarketplacePayloadMapperTest {
         notEligibleAzureBillingProvider,
         notEligibleOracleBillingProvider,
         notEligibleGcpBillingProvider,
-        notEligableDefaultBillableUsage);
+        notEligibleDefaultBillableUsage);
   }
 
   @Test
@@ -268,7 +269,8 @@ class RhMarketplacePayloadMapperTest {
    * A retry test support class that will increment a counter whenever an error occurs and the retry
    * logic is run.
    */
-  private class RetryTestSupport implements RetryListener {
+  @Getter
+  private static class RetryTestSupport implements RetryListener {
 
     private int retryCount = 0;
 
@@ -276,10 +278,6 @@ class RhMarketplacePayloadMapperTest {
     public <T, E extends Throwable> void onError(
         RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
       retryCount++;
-    }
-
-    public int getRetryCount() {
-      return retryCount;
     }
   }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-921](https://issues.redhat.com/browse/SWATCH-921)

## Description
Subscription Watch logs warnings when a marketplace payload mapper picks up a message that is destined for another marketplace. This creates a lot of warning-level log spam.

Note that I removed some methods and fields that were not used in this class (this was done in a separate commit to ease the review). 

## Testing
QE is unneeded. 