### PR TITLE
SWATCH-57: Add TallyReportTotalMonthly with date optional

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1200,7 +1200,7 @@ components:
             count:
               type: integer
             total_monthly:
-              $ref: "#/components/schemas/TallyReportDataPoint"
+              $ref: "#/components/schemas/TallyReportTotalMonthly"
             product:
               type: string
             metric_id:
@@ -1230,6 +1230,21 @@ components:
           description: "The date for this datapoint."
           type: string
           format: date-time
+        value:
+          type: integer
+          format: int32
+        has_data:
+          type: boolean
+    TallyReportTotalMonthly:
+      description: "Tally report monthly summary."
+      required:
+        - value
+      properties:
+        date:
+          description: "Date of the tally report."
+          type: string
+          format: date-time
+          nullable: true
         value:
           type: integer
           format: int32

--- a/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/TallyResource.java
@@ -204,8 +204,8 @@ public class TallyResource implements TallyApi {
         latestSnapshotDate = snapshot.getSnapshotDate();
       }
       var totalMonthlyValue = (int) Math.ceil(totalMonthlyValueRaw);
-      TallyReportDataPoint totalMonthly =
-          new TallyReportDataPoint()
+      TallyReportTotalMonthly totalMonthly =
+          new TallyReportTotalMonthly()
               .hasData(!snapshots.isEmpty())
               .value(totalMonthlyValue)
               .date(latestSnapshotDate);

--- a/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/TallyResourceTest.java
@@ -1018,8 +1018,8 @@ class TallyResourceTest {
             null,
             false,
             null);
-    TallyReportDataPoint expectedTotalMonthly =
-        new TallyReportDataPoint().date(null).value(0).hasData(false);
+    TallyReportTotalMonthly expectedTotalMonthly =
+        new TallyReportTotalMonthly().date(null).value(0).hasData(false);
     assertEquals(expectedTotalMonthly, response.getMeta().getTotalMonthly());
   }
 
@@ -1052,8 +1052,8 @@ class TallyResourceTest {
             null,
             false,
             null);
-    TallyReportDataPoint expectedTotalMonthly =
-        new TallyReportDataPoint()
+    TallyReportTotalMonthly expectedTotalMonthly =
+        new TallyReportTotalMonthly()
             .date(OffsetDateTime.parse("2021-11-03T00:00Z"))
             .value(7)
             .hasData(true);
@@ -1091,8 +1091,8 @@ class TallyResourceTest {
             null,
             false,
             null);
-    TallyReportDataPoint expectedTotalMonthly =
-        new TallyReportDataPoint()
+    TallyReportTotalMonthly expectedTotalMonthly =
+        new TallyReportTotalMonthly()
             .date(OffsetDateTime.parse("2021-11-03T00:00Z"))
             .value(7)
             .hasData(true);
@@ -1115,8 +1115,8 @@ class TallyResourceTest {
                 })
             .collect(Collectors.toList());
 
-    TallyReportDataPoint expectedTotalMonthly =
-        new TallyReportDataPoint()
+    TallyReportTotalMonthly expectedTotalMonthly =
+        new TallyReportTotalMonthly()
             .date(OffsetDateTime.parse("2023-03-08T12:35Z"))
             .value(22)
             .hasData(true);
@@ -1174,8 +1174,8 @@ class TallyResourceTest {
                 })
             .collect(Collectors.toList());
 
-    TallyReportDataPoint expectedTotalMonthly =
-        new TallyReportDataPoint()
+    TallyReportTotalMonthly expectedTotalMonthly =
+        new TallyReportTotalMonthly()
             .date(OffsetDateTime.parse("2023-03-02T12:35Z"))
             .value(3)
             .hasData(true);
@@ -1302,8 +1302,8 @@ class TallyResourceTest {
             snap4Date, 100,
             snap5Date, 150));
 
-    TallyReportDataPoint expectedTotalMonthly =
-        new TallyReportDataPoint().date(snap5Date).value(500).hasData(true);
+    TallyReportTotalMonthly expectedTotalMonthly =
+        new TallyReportTotalMonthly().date(snap5Date).value(500).hasData(true);
 
     TallyReportData report =
         resource.getTallyReportData(


### PR DESCRIPTION
Jira issue: [SWATCH-57](https://issues.redhat.com/browse/SWATCH-57)

## Description
Add a new type `TallyReportTotalMonthly` with the date optional.

## Testing
These changes are only meant for QE. 