### PR TITLE
SWATCH-1948: Catch ProcessingException and ApiException exceptions

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformer.java
@@ -32,6 +32,7 @@ import com.redhat.swatch.contract.repository.SubscriptionMeasurementEntity;
 import com.redhat.swatch.contract.repository.SubscriptionProductIdEntity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.ProcessingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -82,7 +83,7 @@ public class MeasurementMetricIdTransformer {
                               measurement.setMetricId(metric.getUom());
                             }));
       }
-    } catch (ApiException e) {
+    } catch (ProcessingException | ApiException e) {
       log.error("Error looking up dimension for metrics", e);
       throw new ContractsException(ErrorCode.UNHANDLED_EXCEPTION, e.getMessage());
     }
@@ -110,7 +111,7 @@ public class MeasurementMetricIdTransformer {
               .collect(Collectors.toSet());
       contract.getMetrics().removeIf(metric -> !metrics.contains(metric.getMetricId()));
 
-    } catch (ApiException e) {
+    } catch (ProcessingException | ApiException e) {
       log.error("Error resolving dimensions for contract metrics", e);
       throw new ContractsException(ErrorCode.UNHANDLED_EXCEPTION, e.getMessage());
     }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -45,6 +45,7 @@ import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ProcessingException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -220,7 +221,7 @@ public class ContractService {
       log.error(e.getMessage());
       statusResponse.setMessage("An Error occurred while reconciling contract");
       return statusResponse;
-    } catch (ApiException e) {
+    } catch (ProcessingException | ApiException e) {
       log.error(e.getMessage());
       statusResponse.setMessage("An Error occurred while calling Partner Api");
       return statusResponse;
@@ -338,7 +339,7 @@ public class ContractService {
       statusResponse.setStatus(FAILURE_MESSAGE);
       statusResponse.setMessage("An Error occurred while reconciling contract");
       return statusResponse;
-    } catch (ApiException e) {
+    } catch (ProcessingException | ApiException e) {
       log.error(e.getMessage());
       statusResponse.setStatus(FAILURE_MESSAGE);
       statusResponse.setMessage("An Error occurred while calling Partner Api");

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/prometheus/PrometheusService.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/prometheus/PrometheusService.java
@@ -34,6 +34,7 @@ import com.redhat.swatch.metrics.exception.ExternalServiceException;
 import com.redhat.swatch.metrics.service.prometheus.model.QuerySummaryResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.ProcessingException;
 import java.io.File;
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -79,7 +80,7 @@ public class PrometheusService {
           queryRangeApi.queryRange(
               query, start.toEpochSecond(), end.toEpochSecond(), Integer.toString(step), timeout);
       return parseQueryResult(data, resultDataItemConsumer);
-    } catch (ApiException ex) {
+    } catch (ProcessingException | ApiException ex) {
       throw new ExternalServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR, formatErrorMessage(ex), ex);
     }
@@ -96,13 +97,13 @@ public class PrometheusService {
       log.debug("Running prometheus query: Time: {}, Query: {}", time.toEpochSecond(), query);
       File data = queryApi.query(query, time, timeout);
       return parseQueryResult(data, itemConsumer);
-    } catch (ApiException ex) {
+    } catch (ProcessingException | ApiException ex) {
       throw new ExternalServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR, formatErrorMessage(ex), ex);
     }
   }
 
-  private String formatErrorMessage(ApiException ex) {
+  private String formatErrorMessage(Exception ex) {
     return String.format("Prometheus API Error! MESSAGE: %s", ex.getMessage());
   }
 

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/processors/BillableUsageProcessor.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/processors/BillableUsageProcessor.java
@@ -41,6 +41,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ProcessingException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -171,7 +172,7 @@ public class BillableUsageProcessor {
         }
       }
       throw new AwsUsageContextLookupException(e);
-    } catch (ApiException e) {
+    } catch (ProcessingException | ApiException e) {
       throw new AwsUsageContextLookupException(e);
     }
   }


### PR DESCRIPTION
Jira issue: SWATCH-1948

## Description
Catching the two exceptions is only meant to be caught for Quarkus rest clients because it will throw ProcessingException instead of ApiException. 

The problem is that the generated sources by the Quarkus REST-Client Reactive extension can only deal with runtime exceptions because it uses reactive flows, however the generated ApiException class by the OpenApi plugin is not a RuntimeException, but Exception.

Extended context in the JIRA ticket. 

## Testing
No QE is needed here. 