### PR TITLE
SWATCH-1390: Modify the internal api paths in the swatch codebase

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -5,13 +5,8 @@ info:
   version: 1.0.0
 
 servers:
-  - url: /{PATH_PREFIX}/{APP_NAME}/v1
-    variables:
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
-  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}/v1
+  - url: /api
+  - url: https://{HOSTNAME}/api
     variables:
       HOSTNAME:
         enum:
@@ -20,13 +15,9 @@ servers:
           - stage.cloud.redhat.com
           - cloud.redhat.com
         default: ci.cloud.redhat.com
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
 
 paths:
-  /version:
+  /rhsm-subscriptions/v1/version:
     description: "Provides version and build information about the deployed application."
     get:
       summary: "Request version and build information about the deployed application."
@@ -42,11 +33,13 @@ paths:
                 $ref: "#/components/schemas/VersionInfo"
         '500':
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
-  /opt-in:
+  /rhsm-subscriptions/v1/opt-in:
     description: "Endpoint for opting into subscription watch."
     get:
       summary: "Get the opt-in configuration for the current account."
       operationId: getOptInConfig
+      tags:
+        - optIn
       responses:
         '200':
           description: "The request for the account's opt-in configuration was successful."
@@ -76,6 +69,8 @@ paths:
       summary: "Create/Update an account's opt-in configuration. Org ID are defined by the
                 identity header."
       operationId: putOptInConfig
+      tags:
+        - optIn
       responses:
         '200':
           description: "The request for the account's opt-in configuration was successful."
@@ -105,6 +100,8 @@ paths:
       summary: "Delete an opt-in config for the associated org. The org ID are
                 pulled from the identity header."
       operationId: deleteOptInConfig
+      tags:
+        - optIn
       responses:
         '204':
           description: "Successfully deleted the opt-in configuration for the accociated org"
@@ -116,7 +113,7 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
-  /tally/products/{product_id}/{metric_id}:
+  /rhsm-subscriptions/v1/tally/products/{product_id}/{metric_id}:
     description: "Operations on a data set of a given tally report."
     parameters:
       - name: product_id
@@ -234,7 +231,7 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - tally
-  /tally/products/{product_id}:
+  /rhsm-subscriptions/v1/tally/products/{product_id}:
     description: "Operations for a tally report of a specific account and product."
     parameters:
       - name: product_id
@@ -364,7 +361,7 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - tally
-  /capacity/products/{product_id}/{metric_id}:
+  /rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}:
     description: 'Operations for capacity report for a given account and product'
     parameters:
       - name: product_id
@@ -475,7 +472,7 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - capacity
-  /capacity/products/{product_id}:
+  /rhsm-subscriptions/v1/capacity/products/{product_id}:
     description: 'Operations for capacity report for a given account and product'
     parameters:
       - name: product_id
@@ -586,7 +583,7 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - capacity
-  /hosts/products/{product_id}:
+  /rhsm-subscriptions/v1/hosts/products/{product_id}:
     description: 'Operations for hosts for a given account and product'
     parameters:
       - name: product_id
@@ -706,7 +703,7 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - hosts
-  /instances/{id}/guests:
+  /rhsm-subscriptions/v1/instances/{id}/guests:
     description: 'Operations for instance-id mappings.'
     parameters:
       - name: id
@@ -764,7 +761,7 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - instances
-  /instances/products/{product_id}:
+  /rhsm-subscriptions/v1/instances/products/{product_id}:
     parameters:
       - name: product_id
         description: The ID for the product we wish to query
@@ -861,7 +858,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InstanceResponse'
-  /subscriptions/products/{product_id}:
+  /rhsm-subscriptions/v1/subscriptions/products/{product_id}:
     description: "Operations for total capacity by SKU for all of the org's active subscriptions for given Swatch product ID."
     parameters:
       - name: product_id
@@ -1015,9 +1012,9 @@ paths:
           $ref: "../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - subscriptions
-  /openapi.json:
+  /rhsm-subscriptions/v1/openapi.json:
     $ref: "../spec/openapi-paths.yaml#/openapi-json"
-  /openapi.yaml:
+  /rhsm-subscriptions/v1/openapi.yaml:
     $ref: "../spec/openapi-paths.yaml#/openapi-yaml"
 
 components:

--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,7 @@ tasks.register("buildApiTally", GenerateTask) {
         interfaceOnly: "true",
         generatePom: "false",
         dateLibrary: "java8",
+        useTags: "true",
         useJakartaEe: "true",
     ]
 }
@@ -176,6 +177,7 @@ tasks.register("buildApiSubSync", GenerateTask) {
             interfaceOnly: "true",
             generatePom: "false",
             dateLibrary: "java8",
+            useTags: "true",
             useJakartaEe: "true",
     ]
 }
@@ -189,6 +191,7 @@ tasks.register("buildApiBilling", GenerateTask) {
             interfaceOnly: "true",
             generatePom: "false",
             dateLibrary: "java8",
+            useTags: "true",
             useJakartaEe: "true",
     ]
 }
@@ -202,6 +205,7 @@ tasks.register("buildApiMetering", GenerateTask) {
             interfaceOnly: "true",
             generatePom: "false",
             dateLibrary: "java8",
+            useTags: "true",
             useJakartaEe: "true",
     ]
 }
@@ -215,6 +219,7 @@ tasks.register("buildApiProducerRHM", GenerateTask) {
             interfaceOnly: "true",
             generatePom: "false",
             dateLibrary: "java8",
+            useTags: "true",
             useJakartaEe: "true",
     ]
 }
@@ -390,6 +395,7 @@ project(":api") {
             interfaceOnly: "true",
             generatePom: "false",
             dateLibrary: "java8",
+            useTags: "true",
             useJakartaEe: "true",
         ]
         importMappings = [

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -37,7 +37,7 @@ import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.security.SecurityProperties;
 import org.candlepin.subscriptions.subscription.SubscriptionPruneController;
 import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
-import org.candlepin.subscriptions.utilization.admin.api.InternalApi;
+import org.candlepin.subscriptions.utilization.admin.api.InternalSubscriptionsApi;
 import org.candlepin.subscriptions.utilization.admin.api.model.AwsUsageContext;
 import org.candlepin.subscriptions.utilization.admin.api.model.DefaultResponse;
 import org.candlepin.subscriptions.utilization.admin.api.model.Metric;
@@ -54,7 +54,7 @@ import org.springframework.stereotype.Component;
 /** Subscriptions Table API implementation. */
 @Slf4j
 @Component
-public class InternalSubscriptionResource implements InternalApi {
+public class InternalSubscriptionResource implements InternalSubscriptionsApi {
 
   private static final String SUCCESS_STATUS = "Success";
 

--- a/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
+++ b/src/main/java/org/candlepin/subscriptions/metering/api/admin/InternalMeteringResource.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.metering.ResourceUtil;
-import org.candlepin.subscriptions.metering.admin.api.InternalApi;
+import org.candlepin.subscriptions.metering.admin.api.InternalProductMeteringApi;
 import org.candlepin.subscriptions.metering.service.prometheus.MetricProperties;
 import org.candlepin.subscriptions.metering.service.prometheus.PrometheusMeteringController;
 import org.candlepin.subscriptions.metering.service.prometheus.task.PrometheusMetricsTaskManager;
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class InternalMeteringResource implements InternalApi {
+public class InternalMeteringResource implements InternalProductMeteringApi {
   private final ResourceUtil util;
   private final ApplicationProperties applicationProperties;
   private final PrometheusMetricsTaskManager tasks;

--- a/src/main/java/org/candlepin/subscriptions/resource/api/InternalBillingOpenApiResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/InternalBillingOpenApiResource.java
@@ -20,21 +20,25 @@
  */
 package org.candlepin.subscriptions.resource.api;
 
-import org.candlepin.subscriptions.metering.admin.api.InternalMeteringOpenapiYamlApi;
+import org.candlepin.subscriptions.billing.admin.api.RootApi;
 import org.springframework.stereotype.Component;
 
-/** Serves the OpenAPI json for the internal metering sync API */
 @Component
-public class InternalMeteringApiYamlResource implements InternalMeteringOpenapiYamlApi {
+public class InternalBillingOpenApiResource implements RootApi {
 
-  private ApiSpecController controller;
+  private final ApiSpecController controller;
 
-  public InternalMeteringApiYamlResource(ApiSpecController controller) {
+  public InternalBillingOpenApiResource(ApiSpecController controller) {
     this.controller = controller;
   }
 
   @Override
+  public String getOpenApiJson() {
+    return controller.getInternalBillingApiJson();
+  }
+
+  @Override
   public String getOpenApiYaml() {
-    return controller.getInternalMeteringApiYaml();
+    return controller.getInternalBillingApiYaml();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/InternalMeteringOpenApiResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/InternalMeteringOpenApiResource.java
@@ -20,17 +20,26 @@
  */
 package org.candlepin.subscriptions.resource.api;
 
-import org.candlepin.subscriptions.tally.admin.api.InternalTallyOpenapiJsonApi;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.candlepin.subscriptions.metering.admin.api.RootApi;
 import org.springframework.stereotype.Component;
 
-/** Serves the OpenAPI json for the internal tally API */
+/** Serves the OpenAPI json for the internal metering sync API */
 @Component
-public class InternalTallyApiJsonResource implements InternalTallyOpenapiJsonApi {
-  @Autowired ApiSpecController controller;
+public class InternalMeteringOpenApiResource implements RootApi {
+
+  private final ApiSpecController controller;
+
+  public InternalMeteringOpenApiResource(ApiSpecController controller) {
+    this.controller = controller;
+  }
 
   @Override
   public String getOpenApiJson() {
-    return controller.getInternalTallyApiJson();
+    return controller.getInternalMeteringApiJson();
+  }
+
+  @Override
+  public String getOpenApiYaml() {
+    return controller.getInternalMeteringApiYaml();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/InternalProducerRedHatMarketplaceOpenApiResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/InternalProducerRedHatMarketplaceOpenApiResource.java
@@ -20,21 +20,25 @@
  */
 package org.candlepin.subscriptions.resource.api;
 
-import org.candlepin.subscriptions.metering.admin.api.InternalMeteringOpenapiJsonApi;
+import org.candlepin.subscriptions.rhmarketplace.admin.api.RootApi;
 import org.springframework.stereotype.Component;
 
-/** Serves the OpenAPI json for the internal metering sync API */
 @Component
-public class InternalMeteringApiJsonResource implements InternalMeteringOpenapiJsonApi {
+public class InternalProducerRedHatMarketplaceOpenApiResource implements RootApi {
 
-  private ApiSpecController controller;
+  private final ApiSpecController controller;
 
-  public InternalMeteringApiJsonResource(ApiSpecController controller) {
+  public InternalProducerRedHatMarketplaceOpenApiResource(ApiSpecController controller) {
     this.controller = controller;
   }
 
   @Override
   public String getOpenApiJson() {
-    return controller.getInternalMeteringApiJson();
+    return controller.getInternalProducerRHMApiJson();
+  }
+
+  @Override
+  public String getOpenApiYaml() {
+    return controller.getInternalProducerRHMApiYaml();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/InternalSubscriptionSyncOpenApiResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/InternalSubscriptionSyncOpenApiResource.java
@@ -20,21 +20,26 @@
  */
 package org.candlepin.subscriptions.resource.api;
 
-import org.candlepin.subscriptions.rhmarketplace.admin.api.InternalSwatchProducerRedHatMarketplaceOpenapiYamlApi;
+import org.candlepin.subscriptions.utilization.admin.api.RootApi;
 import org.springframework.stereotype.Component;
 
+/** Serves the OpenAPI json for the internal subscription sync API */
 @Component
-public class InternalProducerRedHatMarketplaceApiYamlResource
-    implements InternalSwatchProducerRedHatMarketplaceOpenapiYamlApi {
+public class InternalSubscriptionSyncOpenApiResource implements RootApi {
 
-  private ApiSpecController controller;
+  private final ApiSpecController controller;
 
-  public InternalProducerRedHatMarketplaceApiYamlResource(ApiSpecController controller) {
+  public InternalSubscriptionSyncOpenApiResource(ApiSpecController controller) {
     this.controller = controller;
   }
 
   @Override
+  public String getOpenApiJson() {
+    return controller.getInternalSubSyncApiJson();
+  }
+
+  @Override
   public String getOpenApiYaml() {
-    return controller.getInternalProducerRHMApiYaml();
+    return controller.getInternalSubSyncApiYaml();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/InternalTallyOpenApiResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/InternalTallyOpenApiResource.java
@@ -20,21 +20,25 @@
  */
 package org.candlepin.subscriptions.resource.api;
 
-import org.candlepin.subscriptions.rhmarketplace.admin.api.InternalSwatchProducerRedHatMarketplaceOpenapiJsonApi;
+import org.candlepin.subscriptions.tally.admin.api.RootApi;
 import org.springframework.stereotype.Component;
 
+/** Serves the OpenAPI json for the internal tally API */
 @Component
-public class InternalProducerRedHatMarketplaceApiJsonResource
-    implements InternalSwatchProducerRedHatMarketplaceOpenapiJsonApi {
+public class InternalTallyOpenApiResource implements RootApi {
+  private final ApiSpecController controller;
 
-  private ApiSpecController controller;
-
-  public InternalProducerRedHatMarketplaceApiJsonResource(ApiSpecController controller) {
+  public InternalTallyOpenApiResource(ApiSpecController controller) {
     this.controller = controller;
   }
 
   @Override
   public String getOpenApiJson() {
-    return controller.getInternalProducerRHMApiJson();
+    return controller.getInternalTallyApiJson();
+  }
+
+  @Override
+  public String getOpenApiYaml() {
+    return controller.getInternalTallyApiYaml();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/OpenApiResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/OpenApiResource.java
@@ -20,18 +20,25 @@
  */
 package org.candlepin.subscriptions.resource.api;
 
-import org.candlepin.subscriptions.utilization.admin.api.InternalSubscriptionSyncOpenapiJsonApi;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.candlepin.subscriptions.utilization.api.resources.RootApi;
 import org.springframework.stereotype.Component;
 
-/** Serves the OpenAPI json for the internal subscription sync API */
+/** Serves the OpenAPI spec as /openapi.yaml. */
 @Component
-public class InternalSubscriptionSyncApiJsonResource
-    implements InternalSubscriptionSyncOpenapiJsonApi {
-  @Autowired ApiSpecController controller;
+public class OpenApiResource implements RootApi {
+  private final ApiSpecController controller;
+
+  public OpenApiResource(ApiSpecController controller) {
+    this.controller = controller;
+  }
+
+  @Override
+  public String getOpenApiYaml() {
+    return controller.getOpenApiYaml();
+  }
 
   @Override
   public String getOpenApiJson() {
-    return controller.getInternalSubSyncApiJson();
+    return controller.getOpenApiJson();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/swagger/BaseSwaggerResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/swagger/BaseSwaggerResource.java
@@ -18,22 +18,24 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.resource.api;
+package org.candlepin.subscriptions.resource.api.swagger;
 
-import org.candlepin.subscriptions.billing.admin.api.InternalBillingOpenapiJsonApi;
-import org.springframework.stereotype.Component;
+import jakarta.ws.rs.GET;
+import java.io.File;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ResourceLoader;
 
-@Component
-public class InternalBillingApiJsonResource implements InternalBillingOpenapiJsonApi {
+public abstract class BaseSwaggerResource {
 
-  private ApiSpecController controller;
+  private static final String INDEX_FILE = "classpath:static/api/%s/internal/swagger-ui/index.html";
 
-  public InternalBillingApiJsonResource(ApiSpecController controller) {
-    this.controller = controller;
-  }
+  @Autowired ResourceLoader resourceLoader;
 
-  @Override
-  public String getOpenApiJson() {
-    return controller.getInternalBillingApiJson();
+  abstract String getServiceName();
+
+  @GET
+  public File index() throws IOException {
+    return resourceLoader.getResource(String.format(INDEX_FILE, getServiceName())).getFile();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/swagger/BillingSwaggerResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/swagger/BillingSwaggerResource.java
@@ -18,15 +18,17 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.resteasy;
+package org.candlepin.subscriptions.resource.api.swagger;
 
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.Path;
 import org.springframework.stereotype.Component;
 
-/** Bootstrapper for RESTEasy. */
 @Component
-@ApplicationPath("/api")
-public class JaxrsApplication extends Application {
-  /* Intentionally left empty */
+@Path(value = "/swatch-billing/internal/swagger-ui")
+public class BillingSwaggerResource extends BaseSwaggerResource {
+
+  @Override
+  String getServiceName() {
+    return "swatch-billing";
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/swagger/MetricsSwaggerResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/swagger/MetricsSwaggerResource.java
@@ -18,22 +18,17 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.resource.api;
+package org.candlepin.subscriptions.resource.api.swagger;
 
-import org.candlepin.subscriptions.billing.admin.api.InternalBillingOpenapiYamlApi;
+import jakarta.ws.rs.Path;
 import org.springframework.stereotype.Component;
 
 @Component
-public class InternalBillingApiYamlResource implements InternalBillingOpenapiYamlApi {
-
-  private ApiSpecController controller;
-
-  public InternalBillingApiYamlResource(ApiSpecController controller) {
-    this.controller = controller;
-  }
+@Path(value = "/swatch-metrics/internal/swagger-ui")
+public class MetricsSwaggerResource extends BaseSwaggerResource {
 
   @Override
-  public String getOpenApiYaml() {
-    return controller.getInternalBillingApiYaml();
+  String getServiceName() {
+    return "swatch-metrics";
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/swagger/ProducerRedHatMarketplaceSwaggerResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/swagger/ProducerRedHatMarketplaceSwaggerResource.java
@@ -18,19 +18,17 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.resource.api;
+package org.candlepin.subscriptions.resource.api.swagger;
 
-import org.candlepin.subscriptions.utilization.api.resources.OpenapiYamlApi;
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.ws.rs.Path;
 import org.springframework.stereotype.Component;
 
-/** Serves the OpenAPI spec as /openapi.yaml. */
 @Component
-public class OpenApiYamlResource implements OpenapiYamlApi {
-  @Autowired ApiSpecController controller;
+@Path(value = "/swatch-producer-red-hat-marketplace/internal/swagger-ui")
+public class ProducerRedHatMarketplaceSwaggerResource extends BaseSwaggerResource {
 
   @Override
-  public String getOpenApiYaml() {
-    return controller.getOpenApiYaml();
+  String getServiceName() {
+    return "swatch-producer-red-hat-marketplace";
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/swagger/SubscriptionSyncSwaggerResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/swagger/SubscriptionSyncSwaggerResource.java
@@ -18,20 +18,17 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.resource.api;
+package org.candlepin.subscriptions.resource.api.swagger;
 
-import org.candlepin.subscriptions.utilization.admin.api.InternalSubscriptionSyncOpenapiYamlApi;
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.ws.rs.Path;
 import org.springframework.stereotype.Component;
 
-/** Serves the OpenAPI yaml for the internal subscription sync API */
 @Component
-public class InternalSubscriptionSyncApiYamlResource
-    implements InternalSubscriptionSyncOpenapiYamlApi {
-  @Autowired ApiSpecController controller;
+@Path(value = "/swatch-subscription-sync/internal/swagger-ui")
+public class SubscriptionSyncSwaggerResource extends BaseSwaggerResource {
 
   @Override
-  public String getOpenApiYaml() {
-    return controller.getInternalSubSyncApiYaml();
+  String getServiceName() {
+    return "swatch-subscription-sync";
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/swagger/TallySwaggerResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/swagger/TallySwaggerResource.java
@@ -18,19 +18,17 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.resource.api;
+package org.candlepin.subscriptions.resource.api.swagger;
 
-import org.candlepin.subscriptions.utilization.api.resources.OpenapiJsonApi;
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.ws.rs.Path;
 import org.springframework.stereotype.Component;
 
-/** Serves the OpenAPI spec as /openapi.json. */
 @Component
-public class OpenApiJsonResource implements OpenapiJsonApi {
-  @Autowired ApiSpecController controller;
+@Path(value = "/swatch-tally/internal/swagger-ui")
+public class TallySwaggerResource extends BaseSwaggerResource {
 
   @Override
-  public String getOpenApiJson() {
-    return controller.getOpenApiJson();
+  String getServiceName() {
+    return "swatch-tally";
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resteasy/ResteasyConfiguration.java
@@ -25,8 +25,6 @@ import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
  * Configuration of Resteasy.
@@ -46,26 +44,4 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
           type = FilterType.CUSTOM,
           classes = AutoConfigurationExcludeFilter.class)
     })
-public class ResteasyConfiguration implements WebMvcConfigurer {
-  @Override
-  public void addViewControllers(ViewControllerRegistry registry) {
-    registry.addViewController("/api-docs").setViewName("redirect:/api-docs/index.html");
-    registry.addViewController("/api-docs/").setViewName("redirect:/api-docs/index.html");
-    registry
-        .addViewController("/api/swatch-subscription-sync/internal/swagger-ui")
-        .setViewName("redirect:/api/swatch-subscription-sync/internal/swagger-ui/index.html");
-    registry
-        .addViewController("/api/swatch-tally/internal/swagger-ui")
-        .setViewName("redirect:/api/swatch-tally/internal/swagger-ui/index.html");
-    registry
-        .addViewController("/api/swatch-metrics/internal/swagger-ui")
-        .setViewName("redirect:/api/swatch-metrics/internal/swagger-ui/index.html");
-    registry
-        .addViewController("/api/swatch-billing/internal/swagger-ui")
-        .setViewName("redirect:/api/swatch-billing/internal/swagger-ui/index.html");
-    registry
-        .addViewController("/api/swatch-producer-red-hat-marketplace/internal/swagger-ui")
-        .setViewName(
-            "redirect:/api/swatch-producer-red-hat-marketplace/internal/swagger-ui/index.html");
-  }
-}
+public class ResteasyConfiguration {}

--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/InternalRhMarkeplaceResource.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/api/admin/InternalRhMarkeplaceResource.java
@@ -23,13 +23,13 @@ package org.candlepin.subscriptions.rhmarketplace.api.admin;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.rhmarketplace.ApiException;
 import org.candlepin.subscriptions.rhmarketplace.RhMarketplaceService;
-import org.candlepin.subscriptions.rhmarketplace.admin.api.InternalApi;
+import org.candlepin.subscriptions.rhmarketplace.admin.api.DefaultApi;
 import org.candlepin.subscriptions.rhmarketplace.admin.api.model.StatusResponse;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class InternalRhMarkeplaceResource implements InternalApi {
+public class InternalRhMarkeplaceResource implements DefaultApi {
   private final RhMarketplaceService rhMarketplaceService;
 
   private final StatusResponseMapper statusResponseMapper;

--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -81,6 +81,7 @@ public class ApiSecurityConfiguration {
 
   private static final String[] URLS_PERMITTED_WITHOUT_AUTH =
       new String[] {
+        "/**/*openapi",
         "/**/*openapi.yaml",
         "/**/*openapi.json",
         "/**/version",

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -36,7 +36,7 @@ import org.candlepin.subscriptions.retention.TallyRetentionController;
 import org.candlepin.subscriptions.security.SecurityProperties;
 import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
 import org.candlepin.subscriptions.tally.TallySnapshotController;
-import org.candlepin.subscriptions.tally.admin.api.InternalApi;
+import org.candlepin.subscriptions.tally.admin.api.InternalTallyApi;
 import org.candlepin.subscriptions.tally.admin.api.model.DefaultResponse;
 import org.candlepin.subscriptions.tally.admin.api.model.EventsResponse;
 import org.candlepin.subscriptions.tally.admin.api.model.OptInResponse;
@@ -55,7 +55,7 @@ import org.springframework.util.StringUtils;
 /** This resource is for exposing administrator REST endpoints for Tally. */
 @Component
 @Slf4j
-public class InternalTallyResource implements InternalApi {
+public class InternalTallyResource implements InternalTallyApi {
 
   public static final String FEATURE_NOT_ENABLED_MESSSAGE =
       "This feature is not currently enabled.";

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
@@ -24,14 +24,14 @@ import jakarta.ws.rs.BadRequestException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
-import org.candlepin.subscriptions.billing.admin.api.InternalApi;
+import org.candlepin.subscriptions.billing.admin.api.InternalBillingApi;
 import org.candlepin.subscriptions.billing.admin.api.model.MonthlyRemittance;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
 import org.springframework.stereotype.Component;
 
 /** This resource is for exposing administrator REST endpoints for Remittance. */
 @Component
-public class InternalBillingResource implements InternalApi {
+public class InternalBillingResource implements InternalBillingApi {
 
   private final InternalBillingController billingController;
 

--- a/src/main/resources/static/api/swatch-billing/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-billing/internal/swagger-ui/index.html
@@ -14,7 +14,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/openapi.yaml",
+        url: "/api/swatch-billing/internal/openapi.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/resources/static/api/swatch-metrics/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-metrics/internal/swagger-ui/index.html
@@ -14,7 +14,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-metering-openapi.yaml",
+        url: "/api/swatch-metrics/internal/openapi.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/resources/static/api/swatch-producer-red-hat-marketplace/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-producer-red-hat-marketplace/internal/swagger-ui/index.html
@@ -14,7 +14,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-swatch-producer-red-hat-marketplace-openapi.yaml",
+        url: "/api/swatch-producer-red-hat-marketplace/internal/openapi",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/resources/static/api/swatch-subscription-sync/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-subscription-sync/internal/swagger-ui/index.html
@@ -14,7 +14,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-subscription-sync-openapi.yaml",
+        url: "/api/swatch-subscription-sync/v1/internal/openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/resources/static/api/swatch-tally/internal/swagger-ui/index.html
+++ b/src/main/resources/static/api/swatch-tally/internal/swagger-ui/index.html
@@ -14,7 +14,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-tally-openapi.yaml",
+        url: "/api/swatch-tally/internal/openapi.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/spec/internal-billing-api-spec.yaml
+++ b/src/main/spec/internal-billing-api-spec.yaml
@@ -4,13 +4,8 @@ info:
   version: 1.0.0
 
 servers:
-  - url: /{PATH_PREFIX}/{APP_NAME}/v1
-    variables:
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
-  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}/v1
+  - url: /api
+  - url: https://{HOSTNAME}/api
     variables:
       HOSTNAME:
         enum:
@@ -19,13 +14,9 @@ servers:
           - stage.cloud.redhat.com
           - cloud.redhat.com
         default: ci.cloud.redhat.com
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
 
 paths:
-  /internal/remittance/accountRemittances:
+  /swatch-tally/internal/remittance/accountRemittances:
     description: 'Operations to get specific account remittances'
     parameters:
       - name: productId
@@ -83,9 +74,9 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalBilling
-  /internal-billing-openapi.json:
+  /swatch-billing/internal/openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
-  /internal-billing-openapi.yaml:
+  /swatch-billing/internal/openapi:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
 
 components:

--- a/src/main/spec/internal-metering-api-spec.yaml
+++ b/src/main/spec/internal-metering-api-spec.yaml
@@ -3,13 +3,8 @@ info:
   title: "rhsm-subscriptions internal metering API"
   version: 1.0.0
 servers:
-  - url: /{PATH_PREFIX}/{APP_NAME}/v1
-    variables:
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
-  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}/v1
+  - url: /api
+  - url: https://{HOSTNAME}/api
     variables:
       HOSTNAME:
         enum:
@@ -18,13 +13,9 @@ servers:
           - stage.cloud.redhat.com
           - cloud.redhat.com
         default: ci.cloud.redhat.com
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
 
 paths:
-  /internal/metering/sync:
+  /swatch-metrics/internal/metering/sync:
     description: 'Perform product metering for all accounts.'
     put:
       operationId: syncMetricsForAllAccounts
@@ -37,7 +28,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalProductMetering
-  /internal/metering/{productTag}:
+  /swatch-metrics/internal/metering/{productTag}:
     description: 'Operations related to product metering.'
     post:
       operationId: meterProductForOrgIdAndRange
@@ -84,9 +75,9 @@ For example, given an end date of 2021-01-06T00:00:00Z and a rangeInMinutes of 6
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalProductMetering
-  /internal-metering-openapi.json:
+  /swatch-metrics/internal/openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
-  /internal-metering-openapi.yaml:
+  /swatch-metrics/internal/openapi:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
 
 components:

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -5,13 +5,8 @@ info:
   version: 1.0.0
 
 servers:
-  - url: /{PATH_PREFIX}/{APP_NAME}/v1
-    variables:
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
-  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}/v1
+  - url: /api
+  - url: https://{HOSTNAME}/api
     variables:
       HOSTNAME:
         enum:
@@ -20,13 +15,9 @@ servers:
           - stage.cloud.redhat.com
           - cloud.redhat.com
         default: ci.cloud.redhat.com
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
 
 paths:
-  /internal/subscriptions:
+  /swatch-subscription-sync/internal/subscriptions:
     description: Save subscriptions manually. Supported only in dev-mode.
     post:
       operationId: saveSubscriptions
@@ -57,7 +48,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/rpc/subscriptions/sync:
+  /swatch-subscription-sync/internal/rpc/subscriptions/sync:
     description: Enqueue all sync-enabled orgs to sync their subscriptions with upstream
     put:
       summary: Enqueue all sync-enabled orgs to sync their subscriptions with upstream
@@ -86,7 +77,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/subscriptions/sync/org/{org_id}:
+  /swatch-subscription-sync/internal/subscriptions/sync/org/{org_id}:
     description: "Force sync of subscriptions for given org_id."
     parameters:
       - name: org_id
@@ -116,7 +107,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/subscriptions/prune:
+  /swatch-subscription-sync/internal/subscriptions/prune:
     description: Remove subscription and capacity records that are in the denylist.
     delete:
       summary: Remove subscription and capacity records that are in the denylist.
@@ -138,8 +129,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
-
-  /internal/subscriptions/rhmUsageContext:
+  /swatch-subscription-sync/internal/subscriptions/rhmUsageContext:
     description: "Get the Red Hat Marketplace usage context."
     parameters:
       - name: orgId
@@ -187,7 +177,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
-  /internal/subscriptions/awsUsageContext:
+  /swatch-subscription-sync/internal/subscriptions/awsUsageContext:
     description: "Get AWS usage context."
     parameters:
       - name: orgId
@@ -239,7 +229,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
-  /internal/offerings/{sku}/product_tags:
+  /swatch-subscription-sync/internal/offerings/{sku}/product_tags:
     description: "Mapping sku to product tags."
     parameters:
       - name: sku
@@ -271,7 +261,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
-  /internal/tags/{tag}/metrics:
+  /swatch-subscription-sync/internal/tags/{tag}/metrics:
     description: "Mapping sku to product tags."
     parameters:
       - name: tag
@@ -309,7 +299,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
-  /internal/rpc/offerings/sync/{sku}:
+  /swatch-subscription-sync/internal/rpc/offerings/sync/{sku}:
     description: Sync an offering from the upstream source.
     parameters:
       - name: sku
@@ -337,7 +327,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
-  /internal/rpc/offerings/sync:
+  /swatch-subscription-sync/internal/rpc/offerings/sync:
     description: Syncs all offerings not listed in deny list from the upstream source.
     put:
       summary: Syncs all offerings not listed in deny list from the upstream source.
@@ -359,7 +349,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/rpc/offerings/reconcile/{sku}:
+  /swatch-subscription-sync/internal/rpc/offerings/reconcile/{sku}:
     description: Reconcile capacity for an offering from the upstream source.
     parameters:
       - name: sku
@@ -387,7 +377,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
-  /internal/subscriptions/terminate/{subscription_id}:
+  /swatch-subscription-sync/internal/subscriptions/terminate/{subscription_id}:
     description: "Terminate a subscription with a given end date."
     parameters:
       - name: subscription_id
@@ -424,9 +414,9 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
-  /internal-subscription-sync-openapi.json:
+  /swatch-subscription-sync/internal/openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
-  /internal-subscription-sync-openapi.yaml:
+  /swatch-subscription-sync/internal/openapi:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
 
 components:

--- a/src/main/spec/internal-swatch-producer-red-hat-marketplace-api-spec.yaml
+++ b/src/main/spec/internal-swatch-producer-red-hat-marketplace-api-spec.yaml
@@ -4,13 +4,8 @@ info:
   version: 1.0.0
 
 servers:
-  - url: /{PATH_PREFIX}/{APP_NAME}/v1
-    variables:
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
-  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}/v1
+  - url: /api
+  - url: https://{HOSTNAME}/api
     variables:
       HOSTNAME:
         enum:
@@ -19,13 +14,9 @@ servers:
           - stage.cloud.redhat.com
           - cloud.redhat.com
         default: ci.cloud.redhat.com
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
 
 paths:
-  /internal/rhm/status/{batch_id}:
+  /swatch-producer-red-hat-marketplace/internal/rhm/status/{batch_id}:
     parameters:
       - name: batch_id
         in: path
@@ -42,9 +33,9 @@ paths:
             application/json:
               schema:
                 $ref: "../../../clients/rh-marketplace-client/rh-marketplace-api-spec.yaml#/components/schemas/StatusResponse"
-  /internal-swatch-producer-red-hat-marketplace-openapi.json:
+  /swatch-producer-red-hat-marketplace/internal/openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
-  /internal-swatch-producer-red-hat-marketplace-openapi.yaml:
+  /swatch-producer-red-hat-marketplace/internal/openapi:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
 components:
   securitySchemes:

--- a/src/main/spec/internal-tally-api-spec.yaml
+++ b/src/main/spec/internal-tally-api-spec.yaml
@@ -3,13 +3,8 @@ info:
   title: "rhsm-subscriptions internal tally API"
   version: 1.0.0
 servers:
-  - url: /{PATH_PREFIX}/{APP_NAME}/v1
-    variables:
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
-  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}/v1
+  - url: /api
+  - url: https://{HOSTNAME}/api
     variables:
       HOSTNAME:
         enum:
@@ -18,13 +13,9 @@ servers:
           - stage.cloud.redhat.com
           - cloud.redhat.com
         default: ci.cloud.redhat.com
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
 
 paths:
-  /internal/tally/resend:
+  /swatch-tally/internal/tally/resend:
     description: 'Operations to resend specific tally snapshots to marketplaces'
     post:
       operationId: resendTally
@@ -46,7 +37,7 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalTally
-  /internal/rpc/tally/remittance/purge:
+  /swatch-tally/internal/rpc/tally/remittance/purge:
     description: 'Operations to purge existing tally snapshots matching the configured retention policy.'
     post:
       operationId: purgeRemittances
@@ -63,7 +54,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [internalTally]
-  /internal/tally/hourly:
+  /swatch-tally/internal/tally/hourly:
     description: 'Operations pertaining to the hourly tally.'
     post:
       operationId: performHourlyTallyForOrg
@@ -105,11 +96,8 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal-tally-openapi.json:
-    $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
-  /internal-tally-openapi.yaml:
-    $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
-  /internal/rpc/tally/purge:
+      tags: [internalTally]
+  /swatch-tally/internal/rpc/tally/purge:
     description: 'Operations to purge existing tally snapshots matching the configured retention policy.'
     post:
       operationId: purgeTallySnapshots
@@ -126,7 +114,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [internalTally]
-  /internal/rpc/tally/{org_id}:
+  /swatch-tally/internal/rpc/tally/{org_id}:
     description: Clear tallies, hosts, and events for a given org ID. Enabled via ENABLE_ACCOUNT_RESET environment variable.
     delete:
       operationId: deleteDataAssociatedWithOrg
@@ -150,7 +138,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [internalTally]
-  /internal/rpc/tally/events/{org_id}:
+  /swatch-tally/internal/rpc/tally/events/{org_id}:
     description: Fetch events by Org
     get:
       operationId: fetchEventsForOrgIdInTimeRange
@@ -188,7 +176,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [ internalTally ]
-  /internal/rpc/tally/events:
+  /swatch-tally/internal/rpc/tally/events:
     description: Save a list of events. Supported only in dev-mode.
     post:
       operationId: saveEvents
@@ -233,7 +221,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [ internalTally ]
-  /internal/rpc/tally/events/purge:
+  /swatch-tally/internal/rpc/tally/events/purge:
     description: 'Purge event records'
     delete:
       operationId: purgeEventRecords
@@ -245,7 +233,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [internalTally]
-  /internal/rpc/tally/events/{event_id}:
+  /swatch-tally/internal/rpc/tally/events/{event_id}:
     description: Delete an event. Supported only in dev-mode.
     delete:
       operationId: deleteEvent
@@ -269,7 +257,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [internalTally]
-  /internal/rpc/tally/snapshots/{org_id}:
+  /swatch-tally/internal/rpc/tally/snapshots/{org_id}:
     description: Trigger and update tally snapshot for an org.
     put:
       operationId: tallyOrg
@@ -295,7 +283,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [ internalTally ]
-  /internal/rpc/tally/all-org-snapshots:
+  /swatch-tally/internal/rpc/tally/all-org-snapshots:
     description: Trigger and update tally for all configured org.
     put:
       operationId: tallyConfiguredOrgs
@@ -315,7 +303,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [internalTally]
-  /internal/rpc/tally/snapshots:
+  /swatch-tally/internal/rpc/tally/snapshots:
     description: Trigger hourly tally for all configured orgs for the specified range. The 'start' and "
        'end' parameters MUST be specified as a pair to complete a range. If they are left empty, 
        a date range is used based on NOW with the configured offsets applied (identical to if
@@ -351,7 +339,7 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [ internalTally ]
-  /internal/rpc/tally/opt-in:
+  /swatch-tally/internal/rpc/tally/opt-in:
     description: Create or update an opt in configuration. This operation is idempotent.
     put:
       operationId: createOrUpdateOptInConfig
@@ -378,6 +366,10 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [ internalTally ]
+  /swatch-tally/internal/openapi.json:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
+  /swatch-tally/internal/openapi:
+    $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
 components:
   requestBodies:
     UuidListBody:

--- a/src/test/java/org/candlepin/subscriptions/resource/api/SwaggerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/SwaggerTest.java
@@ -18,45 +18,41 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.deployment;
+package org.candlepin.subscriptions.resource.api;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.candlepin.subscriptions.SystemConduitApplication;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(
-    useMainMethod = SpringBootTest.UseMainMethod.ALWAYS,
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({"test"})
-class SystemConduitDeploymentTest {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SwaggerTest {
 
   private static final String LOCALHOST = "http://localhost:";
 
-  @Autowired SystemConduitApplication configuration;
   @LocalServerPort int port;
 
   private final TestRestTemplate restTemplate =
       new TestRestTemplate(TestRestTemplate.HttpClientOption.ENABLE_REDIRECTS);
 
-  @Test
-  void testDeployment() {
-    assertNotNull(configuration);
-  }
-
-  @Test
-  void testSwaggerPage() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "swatch-subscription-sync",
+        "swatch-tally",
+        "swatch-metrics",
+        "swatch-billing",
+        "swatch-producer-red-hat-marketplace"
+      })
+  void testSwaggerPage(String app) {
     ResponseEntity<String> response =
         restTemplate.getForEntity(
-            LOCALHOST + port + "/api/swatch-system-conduit/internal/swagger-ui", String.class);
-    assertTrue(response.getStatusCode().is2xxSuccessful());
+            LOCALHOST + port + "/api/" + app + "/internal/swagger-ui", String.class);
     assertNotNull(response.getBody());
     assertTrue(response.getBody().contains("API Docs"));
   }

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -269,7 +269,6 @@ paths:
         - support: []
         - test: []
       operationId: syncContractsByOrg
-
   /api/swatch-contracts/internal/rpc/reset/contracts/{org_id}:
     description: "Clear all contracts for a given org ID. "
     delete:
@@ -298,8 +297,7 @@ paths:
         - test: [ ]
         - service: [ ]
       operationId: deleteContractsByOrg
-
-  /internal/rpc/syncAllContracts:
+  /api/swatch-contracts/internal/rpc/syncAllContracts:
     description: "Trigger a sync for all contracts"
     post:
       summary: "Sync all contracts."
@@ -319,7 +317,7 @@ paths:
       security:
         - support: []
         - test: []
-  /internal/offerings/{sku}/product_tags:
+  /api/swatch-contracts/internal/offerings/{sku}/product_tags:
       description: "Mapping sku to product tags."
       parameters:
         - name: sku
@@ -349,7 +347,7 @@ paths:
           - test: [ ]
           - support: [ ]
           - service: [ ]
-  '/api/swatch-contracts/internal/rpc/partner/contracts':
+  /api/swatch-contracts/internal/rpc/partner/contracts:
     post:
       operationId: createPartnerEntitlementContract
       requestBody:

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -109,7 +109,7 @@ quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.Search
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".scope=jakarta.enterprise.context.ApplicationScoped
 
 # configuration properties for subscriptions-sync
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions/v1
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/swatch-subscription-sync/v1
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ConsumerApiSpecEqualityTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ConsumerApiSpecEqualityTest.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,7 +39,6 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.PathItem;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.yaml.snakeyaml.Yaml;
 
 /**
  * Test to verify equality between customer API spec and the service's own copy of the definition.
@@ -65,15 +63,6 @@ class ConsumerApiSpecEqualityTest {
     }
   }
 
-  private static Map<String, Object> loadSpec(String path) {
-    var yaml = new Yaml();
-    try {
-      return yaml.load(Files.newInputStream(Paths.get(path)));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   private static Stream<String> getCustomerApiPaths() {
     return serviceSpec.getPaths().getPathItems().keySet().stream()
         .filter(path -> path.startsWith("/api/rhsm-subscriptions/v1"));
@@ -82,7 +71,7 @@ class ConsumerApiSpecEqualityTest {
   @ParameterizedTest
   @MethodSource(value = "getCustomerApiPaths")
   void testCustomerApiDefinitionsEquivalentToMonolithSpec(String servicePath) throws IOException {
-    var monolithPath = servicePath.replace("api/rhsm-subscriptions/v1/", "");
+    var monolithPath = servicePath.replace("api/rhsm-subscriptions/v1/", "rhsm-subscriptions/v1/");
     var monolithPathItem = monolithSpec.getPaths().getPathItem(monolithPath);
     var servicePathItem = serviceSpec.getPaths().getPathItem(servicePath);
     for (var pathItem : Set.of(monolithPathItem, servicePathItem)) {

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -37,8 +37,6 @@ DEV_MODE: false
 DEVTEST_SUBSCRIPTION_EDITING_ENABLED: true
 DEVTEST_EVENT_EDITING_ENABLED: false
 ENABLE_ACCOUNT_RESET: false
-PATH_PREFIX: api
-APP_NAME: rhsm-subscriptions
 
 DATABASE_HOST: ${clowder.database.hostname:localhost}
 DATABASE_PORT: ${clowder.database.port:5432}

--- a/swatch-metrics/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-metrics/src/main/resources/META-INF/openapi.yaml
@@ -5,7 +5,7 @@ info:
   version: 1.0.0
 
 paths:
-  /api/swatch-metrics/v1/internal/metering/sync:
+  /api/swatch-metrics/internal/metering/sync:
     description: 'Perform product metering for all accounts.'
     put:
       operationId: syncMetricsForAllAccounts
@@ -16,7 +16,7 @@ paths:
           $ref: "../../../../../spec/error-responses.yaml#/$defs/Forbidden"
         '500':
           $ref: "../../../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /api/swatch-metrics/v1/internal/metering/{productTag}:
+  /api/swatch-metrics/internal/metering/{productTag}:
     description: 'Operations related to product metering.'
     post:
       operationId: meterProductForOrgIdAndRange

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/admin/api/MetricsTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/admin/api/MetricsTest.java
@@ -188,12 +188,10 @@ class MetricsTest {
       request = request.header("x-rh-swatch-synchronous-request", xRhSwatchSynchronousRequest);
     }
 
-    return request.post("/api/swatch-metrics/v1/internal/metering/" + productTag).then();
+    return request.post("/api/swatch-metrics/internal/metering/" + productTag).then();
   }
 
   private void syncMetricsForAllAccounts() {
-    put("/api/swatch-metrics/v1/internal/metering/sync")
-        .then()
-        .statusCode(HttpStatus.SC_NO_CONTENT);
+    put("/api/swatch-metrics/internal/metering/sync").then().statusCode(HttpStatus.SC_NO_CONTENT);
   }
 }

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -88,7 +88,7 @@ mp.messaging.incoming.tally-in.auto.offset.reset = earliest
 mp.messaging.outgoing.tally-out.connector=smallrye-kafka
 mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.billable-usage
 
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions/v1
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/swatch-subscription-sync/v1
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -87,7 +87,7 @@ mp.messaging.incoming.tally-in.auto.offset.reset = earliest
 mp.messaging.outgoing.tally-out.connector=smallrye-kafka
 mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.billable-usage
 
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions/v1
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/swatch-subscription-sync/v1
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -483,7 +483,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-subscription-sync-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-subscription-sync-service:8000/api/rhsm-subscriptions/v1/internal/rpc/subscriptions/sync"
+              /usr/bin/curl --fail -H "Origin: https://swatch-subscription-sync-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-subscription-sync-service:8000/api/swatch-subscription-sync/v1/internal/rpc/subscriptions/sync"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:
@@ -512,7 +512,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-subscription-sync-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-subscription-sync-service:8000/api/rhsm-subscriptions/v1/internal/rpc/offerings/sync"
+              /usr/bin/curl --fail -H "Origin: https://swatch-subscription-sync-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-subscription-sync-service:8000/api/swatch-subscription-sync/v1/internal/rpc/offerings/sync"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -347,7 +347,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-system-conduit-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-system-conduit-service:8000/api/rhsm-subscriptions/v1/internal/rpc/syncAllOrgs"
+              /usr/bin/curl --fail -H "Origin: https://swatch-system-conduit-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-system-conduit-service:8000/api/swatch-system-conduit/v1/internal/rpc/syncAllOrgs"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/resource/api/SwaggerResource.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/resource/api/SwaggerResource.java
@@ -18,19 +18,25 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.resource.api;
+package org.candlepin.subscriptions.conduit.resource.api;
 
-import org.candlepin.subscriptions.tally.admin.api.InternalTallyOpenapiYamlApi;
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import java.io.File;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
-/** Serves the OpenAPI yaml for the internal tally API */
 @Component
-public class InternalTallyApiYamlResource implements InternalTallyOpenapiYamlApi {
-  @Autowired ApiSpecController controller;
+@Path(value = "/swatch-system-conduit/internal/swagger-ui")
+public class SwaggerResource {
 
-  @Override
-  public String getOpenApiYaml() {
-    return controller.getInternalTallyApiYaml();
+  @Value("classpath:static/api/swatch-system-conduit/internal/swagger-ui/index.html")
+  Resource indexFile;
+
+  @GET
+  public File index() throws IOException {
+    return indexFile.getFile();
   }
 }

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/resteasy/JaxrsApplication.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/resteasy/JaxrsApplication.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 
 /** Bootstrapper for RESTEasy. */
 @Component
-@ApplicationPath("/api/rhsm-subscriptions/v1")
+@ApplicationPath("/api")
 public class JaxrsApplication extends Application {
   /* Intentionally left empty */
 }

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/resteasy/ResteasyConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/resteasy/ResteasyConfiguration.java
@@ -27,8 +27,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
-import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
  * Configuration of Resteasy.
@@ -49,12 +47,4 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
           type = FilterType.CUSTOM,
           classes = AutoConfigurationExcludeFilter.class)
     })
-public class ResteasyConfiguration implements WebMvcConfigurer {
-
-  @Override
-  public void addViewControllers(ViewControllerRegistry registry) {
-    registry
-        .addViewController("api/swatch-system-conduit/internal/swagger-ui")
-        .setViewName("redirect:/api/swatch-system-conduit/internal/swagger-ui/index.html");
-  }
-}
+public class ResteasyConfiguration {}

--- a/swatch-system-conduit/src/main/resources/static/api/swatch-system-conduit/internal/swagger-ui/index.html
+++ b/swatch-system-conduit/src/main/resources/static/api/swatch-system-conduit/internal/swagger-ui/index.html
@@ -14,7 +14,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api/rhsm-subscriptions/v1/internal-organizations-sync-openapi.json",
+        url: "/api/swatch-system-conduit/internal/openapi.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -4,13 +4,8 @@ info:
   description: "REST interface for the internal-organization-sync service. Please note any deprecated APIs. Our current deprecation policy is to keep deprecated APIs around for at least 6 months."
   version: 1.0.0
 servers:
-  - url: /{PATH_PREFIX}/{APP_NAME}/v1
-    variables:
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
-  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}/v1
+  - url: /api
+  - url: https://{HOSTNAME}/api
     variables:
       HOSTNAME:
         enum:
@@ -19,12 +14,8 @@ servers:
           - stage.cloud.redhat.com
           - cloud.redhat.com
         default: ci.cloud.redhat.com
-      PATH_PREFIX:
-        default: api
-      APP_NAME:
-        default: rhsm-subscriptions
 paths:
-  /internal/rpc/syncOrg:
+  /swatch-system-conduit/internal/rpc/syncOrg:
     description: "Trigger a sync for a given Org ID"
     post:
       summary: "Sync organization for given org_id."
@@ -48,7 +39,7 @@ paths:
           $ref: "../../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/rpc/syncAllOrgs:
+  /swatch-system-conduit/internal/rpc/syncAllOrgs:
     description: "Trigger a sync for all Organizations"
     post:
       summary: "Sync all organizations."
@@ -66,7 +57,7 @@ paths:
           $ref: "../../../../spec/error-responses.yaml#/$defs/Forbidden"
         '500':
           $ref: "../../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/organizations-sync-list:
+  /swatch-system-conduit/internal/organizations-sync-list:
     description: "Initiate altering database sync list by either adding or removing a given list of Org IDs"
     parameters:
       - name: org_ids
@@ -115,7 +106,7 @@ paths:
           $ref: "../../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/organizations-sync-list/{org_id}:
+  /swatch-system-conduit/internal/organizations-sync-list/{org_id}:
     description: "Initiate a search to check if given Org ID is in sync list"
     parameters:
       - name: org_id
@@ -143,7 +134,7 @@ paths:
           $ref: "../../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/organizations/{org_id}/inventory:
+  /swatch-system-conduit/internal/organizations/{org_id}/inventory:
     description: "Initiate viewing conduit representation of an org's systems from RHSM"
     parameters:
       - name: org_id
@@ -184,9 +175,9 @@ paths:
           $ref: "../../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
         '500':
           $ref: "../../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal-organizations-sync-openapi.json:
+  /swatch-system-conduit/internal/openapi.json:
     $ref: "../../../../spec/openapi-paths.yaml#/openapi-json"
-  /internal-organizations-sync-openapi.yaml:
+  /swatch-system-conduit/internal/openapi:
     $ref: "../../../../spec/openapi-paths.yaml#/openapi-yaml"
 components:
   requestBodies:

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/resteasy/HttpServerMetricsTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/resteasy/HttpServerMetricsTest.java
@@ -120,7 +120,7 @@ class HttpServerMetricsTest {
             + "method=\"GET\","
             + "outcome=\"SUCCESS\","
             + "status=\"204\","
-            + "uri=\"/api/rhsm-subscriptions/v1/internal/organizations/{org_id}/inventory\",} 1.0");
+            + "uri=\"/api/swatch-system-conduit/internal/organizations/{org_id}/inventory\",} 1.0");
   }
 
   private void assertMetricIsFoundWithError() {
@@ -130,7 +130,7 @@ class HttpServerMetricsTest {
             + "method=\"GET\","
             + "outcome=\"CLIENT_ERROR\","
             + "status=\"401\","
-            + "uri=\"/api/rhsm-subscriptions/v1/internal/organizations/org123/inventory\",} 1.0");
+            + "uri=\"/api/swatch-system-conduit/internal/organizations/org123/inventory\",} 1.0");
   }
 
   private HttpEntity<Void> request() {
@@ -152,7 +152,7 @@ class HttpServerMetricsTest {
   }
 
   private String apiBasePath() {
-    return LOCALHOST + port + "/api/rhsm-subscriptions/v1";
+    return LOCALHOST + port + "/api/swatch-system-conduit";
   }
 
   private String managementBasePath() {

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -470,7 +470,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/all-org-snapshots"
+              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-tally-service:8000/api/swatch-tally/v1/internal/rpc/tally/all-org-snapshots"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:
@@ -499,7 +499,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots"
+              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-tally-service:8000/api/swatch-tally/v1/internal/rpc/tally/snapshots"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:
@@ -528,7 +528,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge"
+              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/swatch-tally/v1/internal/rpc/tally/purge"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:
@@ -554,7 +554,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/remittance/purge"
+              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/swatch-tally/v1/internal/rpc/tally/remittance/purge"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:
@@ -580,7 +580,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -i -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X DELETE "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/events/purge"
+              /usr/bin/curl --fail -i -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X DELETE "http://swatch-tally-service:8000/api/swatch-tally/v1/internal/rpc/tally/events/purge"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:


### PR DESCRIPTION
Jira issue: [SWATCH-1390](https://issues.redhat.com/browse/SWATCH-1390)

## Description
For each of:

- swatch-metrics
- swatch-producer-red-hat-marketplace
- swatch-subscription-sync
- swatch-system-conduit
- swatch-tally
- swatch-contracts

Modify the internal API spec so that the paths consistently start with /api/$clowdapp (e.g. /api/swatch-metrics); you can use swatch-contracts and swatch-producer-aws as examples.

Technical details:
- After these changes, the API paths are fully customizable from the openapi resources. Before, it was hardcoded to "/api/rhsm-subscriptions/v1".
- I configured the openapi plugin to use tags, so the generated interface names are always the same regardless the operation path.

## Changes

### API

| Service | Old  | New | Comments |
|---|---|---|----|
| swatch-metrics | /api/swatch-metrics/v1/internal | /api/swatch-metrics/internal | |
| swatch-producer-red-hat-marketplace | /api/rhsm-subscriptions/v1/internal | /api/swatch-producer-red-hat-marketplace/internal | |
| swatch-subscription-sync | /api/rhsm-subscriptions/v1/internal | /api/swatch-subscription-sync/internal | |
| swatch-system-conduit | /api/rhsm-subscriptions/v1/internal | /api/swatch-system-conduit/internal | |
| swatch-tally | /api/rhsm-subscriptions/v1/internal | /api/swatch-tally/internal | |
| swatch-contracts | /internal | /api/swatch-contracts/internal | |

### OpenAPI

| Old  | New | Comments |
|---|---|----|
| /api/rhsm-subscriptions/v1/internal-billing-openapi.yaml | /api/swatch-tally/internal/openapi | |
| /api/rhsm-subscriptions/v1/internal-billing-openapi.json | /api/swatch-tally/internal/openapi.json | |
| /api/rhsm-subscriptions/v1/internal-tally-openapi.yaml | /api/swatch-tally/internal/openapi | |
| /api/rhsm-subscriptions/v1/internal-tally-openapi.json | /api/swatch-tally/internal/openapi.json | |
| /api/rhsm-subscriptions/v1/internal-billing-openapi.yaml | /api/swatch-subscription-sync/internal/openapi | |
| /api/rhsm-subscriptions/v1/internal-subscription-sync-openapi.json | /api/swatch-subscription-sync/internal/openapi.json | |
| /api/rhsm-subscriptions/v1/internal-swatch-producer-red-hat-marketplace-openapi.yaml | /api/swatch-producer-red-hat-marketplace/internal/openapi | |
| /api/rhsm-subscriptions/v1/internal-swatch-producer-red-hat-marketplace-openapi.json | /api/swatch-producer-red-hat-marketplace/internal/openapi.json | |

Quarkus and Spring Boot services should serve the openapi resource using the same API now. 

## Testing
QE needs to update the endpoints according to the above changes. Note that any other changes not part of the above table should be considered a regression issue and would need fixing as part of this pull request.