### PR TITLE
SWATCH-1965: Tweak entitlement With subscriptionNumber to match Partner Gateway specs

### DIFF
--- a/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
+++ b/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
@@ -149,7 +149,7 @@ components:
       properties:
         sku:
           type: string
-        redHatSubscriptionNumber:
+        subscriptionNumber:
           type: string
     ApiErrorV1:
       properties:

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -458,7 +458,7 @@ public class ContractService {
         if (Objects.nonNull(rhEntitlements)
             && !rhEntitlements.isEmpty()
             && Objects.nonNull(rhEntitlements.get(0))) {
-          var subscription = rhEntitlements.get(0).getRedHatSubscriptionNumber();
+          var subscription = rhEntitlements.get(0).getSubscriptionNumber();
           var sku = rhEntitlements.get(0).getSku();
           prevEntity.setSku(sku);
           prevEntity.setSubscriptionNumber(subscription);

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
@@ -56,7 +56,7 @@ class RhPartnerClientIntegrationTest {
     assertNotNull(rhEntitlements);
     assertNotNull(rhEntitlements.get(0));
     assertEquals("RH000000", rhEntitlements.get(0).getSku());
-    assertEquals("123456", rhEntitlements.get(0).getRedHatSubscriptionNumber());
+    assertEquals("123456", rhEntitlements.get(0).getSubscriptionNumber());
     var purchase = entitlement.getPurchase();
     assertNotNull(purchase);
     assertEquals("1234567890abcdefghijklmno", purchase.getVendorProductCode());

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
@@ -126,7 +126,7 @@ public class WireMockResource
                                       "rhEntitlements": [
                                         {
                                           "sku": "RH000000",
-                                          "redHatSubscriptionNumber": "123456"
+                                          "subscriptionNumber": "123456"
                                         }
                                       ],
                                       "purchase": {
@@ -178,7 +178,7 @@ public class WireMockResource
                                       "rhEntitlements": [
                                         {
                                           "sku": "RH000000",
-                                          "redHatSubscriptionNumber": "121256"
+                                          "subscriptionNumber": "121256"
                                         }
                                       ],
                                       "purchase": {


### PR DESCRIPTION
Rename affected field redhatSubscriptionNumber to match the expected response property


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-1965

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Fix for error as we were expecting `redHatSubscritpionNumber` and it is cause null error when syncing because Partner Gateway is sending a value as `subscriptionNumber` and we are changing the spec to reflect that until https://issues.redhat.com/browse/ITPART-1161 and than this change will be reverted.

## Testing
Run this on `main` branch
Insert contract to sync against:
```
INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id, vendor_product_code) VALUES ('94857b05-8e13-4407-90aa-52c2ae676deb', '123456789', '2023-11-02 15:44:22.846502 +00:00', '2023-11-02 15:44:22.846502 +00:00', null, 'org123', 'RH000000', 'aws', '568056954830', 'BASILISK', 'vendorProductCode');

INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('94857b05-8e13-4407-90aa-52c2ae676deb', 'foobar', 1000000);
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('94857b05-8e13-4407-90aa-52c2ae676deb', 'cpu-hours', 1000000);

```
Add mismatched field to wire mock:
1. Create folder for canned response with for the mismatched json: `mkdir -p stub/__files`
2. Add mismatched structure that is currently in the response for gateway and mock subscription:
Add mock tags : `cat > stub/__files/tag.json <<EOF
{"data":["BASILISK"]}
EOF`
```
cat > stub/__files/awsMismatch.json <<EOF
{
    "content": [
        {
            "rhAccountId": "org123",
            "sourcePartner": "aws_marketplace",
            "partnerIdentities": {
                "awsCustomerId": "HSwCpt6sqkC",
                "customerAwsAccountId": "568056954830",
                "sellerAccountId": "568056954830"
            },
            "rhEntitlements": [
                {
                    "sku": "RH000000",
                    "subscriptionNumber": "123456"
                }
            ],
            "purchase": {
                "vendorProductCode": "1234567890abcdefghijklmno",
                "contracts": [
                    {
                        "startDate": "2022-09-23T20:07:51.010445Z",
                        "endDate": "2023-04-20T00:09:14.192515Z",
                        "dimensions": [
                            {
                                "name": "foobar",
                                "value": "1000000"
                            },
                            {
                                "name": "cpu-hours",
                                "value": "1000000"
                            }
                        ]
                    },
                    {
                        "startDate": "2023-04-20T00:09:14.192515Z",
                        "dimensions": [
                            {
                                "name": "foobar",
                                "value": "1000000"
                            },
                            {
                                "name": "cpu-hours",
                                "value": "1000000"
                            }
                        ]
                    }
                ]
            },
            "status": "STATUS",
            "entitlementDates": {
                "startDate": "2023-03-17T12:29:48.569Z",
                "endDate": "2023-03-17T12:29:48.569Z"
            }
        }
    ],
    "page": {
        "size": 0,
        "totalElements": 0,
        "totalPages": 0,
        "number": 0
    }
}
EOF
``` 
mockSub:
```
cat > stub/__files/subscription.json <<EOF
[
    {
        "id": 123456,
        "renewedId": null,
        "masterEndSystemName": "SUBSCRIPTION",
        "createdEndSystemName": "SUBSCRIPTION",
        "createdByUserName": null,
        "createdDate": 1672556530000,
        "lastUpdateEndSystemName": "SUBSCRIPTION",
        "lastUpdateUserName": null,
        "lastUpdateDate": 1672556530000,
        "externalCreatedDate": null,
        "externalLastUpdateDate": null,
        "installBaseStartDate": 1672549200000,
        "installBaseEndDate": 1704085199000,
        "inactiveDate": null,
        "oracleAccountNumber": "5456371",
        "oracleMSANumber": null,
        "oracleIBInstanceNumber": null,
        "webCustomerId": 7237138,
        "registrationNumber": null,
        "installationNumber": null,
        "subscriptionNumber": "13294886",
        "quantity": 10,
        "subscriptionProducts": null,
        "customer": {
        "id": 7237138,
        "name": "ANDORRA TELECOM, S.A.U.",
        "password": null,
        "creditApplicationCompleted": false,
        "customerType": "organization",
        "oracleCustomerNumber": 5456371,
        "namedAccount": false,
        "createdDate": 1397548100000,
        "updatedDate": 1612591188913
        },
        "effectiveStartDate": 1672549200000,
        "effectiveEndDate": 1703998800000,
        "externalReferences": null
    }
]
EOF
```
3. Run wire mock pod `podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose` and map the jsons to the endpoints:
Partner response
```
curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/mock/partnerApi/v1/partnerSubscriptions", "method": "POST" }, "response": { "status": 200, "bodyFileName": "awsMismatch.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new
```
subscription response
```
curl -X POST --data '{ "priority": 1, "request": { "method": "GET", "urlPattern": "/search/criteria;subscription_number=123456/options;products=ALL;showExternalReferences=true/" }, "response": { "status": 200, "bodyFileName": "subscription.json", "headers": { "Content-Type": "application/json" } } }' http://localhost:8101/__admin/mappings/new
```
tag response:
```
curl -X POST --data '{ "priority": 2, "request": { "urlPath": "/mock/internalSubs/api/rhsm-subscriptions/v1/internal/offrings/RH000000/product_tags", "method": "GET"}, "response": { "status": 200, "bodyFileName": "tag.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new
```
5.Run contracts & hit the org sync and you should see that it fails as it received a null value because of the mismatched fields:
```
SUBSCRIPTION_URL=http://localhost:8101 ENTITLEMENT_GATEWAY_URL=http://localhost:8101/mock/partnerApi SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101/mock/internalSubs ./gradlew :swatch-contracts:quarkusDev
```

```
curl -X 'POST' \
  'http://localhost:8000/api/swatch-contracts/internal/rpc/sync/contracts/org123' \
  -H 'accept: application/json' \
  -H 'x-rh-swatch-psk: placeholder' \
  -d ''
```
6. Now switch to this branch and rebuild swatch contracts and see that the failure no longer occurs