### PR TITLE
Sample openshift definition for deploying wiremock to ephemeral environment

### DIFF
--- a/stub/README.md
+++ b/stub/README.md
@@ -1,0 +1,80 @@
+
+Deploy wiremock and service to existing namespace
+
+```
+oc process -f wiremock.yaml | oc apply -f - 
+```
+
+Make the pod accessible to interact with the wiremock admin api
+```
+oc port-forward service/wiremock 8101
+```
+
+Use HTTP to create stubs.  Easiest way seems to use "jsonBody" instead of "bodyFileName" like our PR instructions usually have.
+
+The below block is all you need in a .http file if you're using IntelliJ's HTTP client.  If you're using something else, need to be very careful with syntax and escape things appropriately.
+```http
+POST http://localhost:8101/__admin/mappings/new
+
+{
+    "priority": 1,
+    "request": {
+        "urlPath": "/mock/partnerApi/v1/partnerSubscriptions",
+        "method": "POST"
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "content": [
+                {
+                    "rhAccountId": "9999999",
+                    "sourcePartner": "azure_marketplace",
+                    "partnerIdentities": {
+                        "azureSubscriptionId": "fa650050-dedd-4958-b901-d8e5118c0a5f",
+                        "azureTenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408",
+                        "azureCustomerId": "eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31"
+                    },
+                    "rhEntitlements": [
+                        {
+                            "sku": "BASILISK",
+                            "redHatSubscriptionNumber": "1111111"
+                        }
+                    ],
+                    "purchase": {
+                        "vendorProductCode": "rh-rhel-sub-preview",
+                        "azureResourceId": "a69ff71c-aa8b-43d9-dea8-822fab4bbb86",
+                        "contracts": [
+                            {
+                                "startDate": "2023-06-09T13:59:43.035365Z",
+                                "planId": "rh-rhel-sub-1yr",
+                                "dimensions": [
+                                    {
+                                        "name": "vCPU",
+                                        "value": 4
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "status": "UNSUBSCRIBED",
+                    "entitlementDates": {
+                        "startDate": "2023-06-09T13:59:43.035365Z",
+                        "endDate": "2023-06-09T19:37:46.651363Z"
+                    }
+                }
+            ],
+            "page": {
+                "size": 0,
+                "totalElements": 0,
+                "totalPages": 0,
+                "number": 0
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}
+
+###
+```

--- a/stub/wiremock.yaml
+++ b/stub/wiremock.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: wiremock
+parameters: []
+objects:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: wiremock
+      labels:
+        app: wiremock
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: wiremock
+      template:
+        metadata:
+          labels:
+            app: wiremock
+        spec:
+          containers:
+            - name: wiremock
+              image: wiremock/wiremock:2.32.0
+              env: []
+
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: wiremock
+    spec:
+      selector:
+        app: wiremock
+      ports:
+        - protocol: TCP
+          port: 8101
+          targetPort: 8080

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -10,6 +10,7 @@ DATABASE_PASSWORD: ${clowder.database.password:rhsm-subscriptions}
 
 SWATCH_TEST_APIS_ENABLED=true
 %ephemeral.SWATCH_TEST_APIS_ENABLED=true
+%wiremock.SWATCH_TEST_APIS_ENABLED=true
 %stage.SWATCH_TEST_APIS_ENABLED=true
 %prod.SWATCH_TEST_APIS_ENABLED=false
 
@@ -43,6 +44,7 @@ SPLUNK_HEC_INCLUDE_EX=false
 %stage.ENTITLEMENT_GATEWAY_URL=https://ibm-entitlement-gateway.stage.api.redhat.com
 %prod.ENTITLEMENT_GATEWAY_URL=https://ibm-entitlement-gateway.api.redhat.com
 %ephemeral.ENTITLEMENT_GATEWAY_URL=${%stage.ENTITLEMENT_GATEWAY_URL}
+%wiremock.ENTITLEMENT_GATEWAY_URL=http://wiremock:8101/mock/partnerApi
 
 # per-environment Red Hat IT Subscription Service Endpoints
 %dev.SUBSCRIPTION_URL=https://subscription.dev.api.redhat.com/svcrest/subscription/v5
@@ -50,6 +52,8 @@ SPLUNK_HEC_INCLUDE_EX=false
 %stage.SUBSCRIPTION_URL=https://subscription.stage.api.redhat.com/svcrest/subscription/v5
 %prod.SUBSCRIPTION_URL=https://subscription.api.redhat.com/svcrest/subscription/v5
 %ephemeral.SUBSCRIPTION_URL=${%stage.SUBSCRIPTION_URL}
+%wiremock.SUBSCRIPTION_URL=http://wiremock:8101/mock/subs
+%wiremock.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://wiremock:8101/mock/internalSubs
 
 # dev-specific config items that don't need to be overridden via env var
 # do not use JSON logs in dev mode
@@ -170,6 +174,7 @@ FILTER_ORGS=
 # otel config
 quarkus.otel.sdk.disabled=true
 %ephemeral.quarkus.otel.sdk.disabled=true
+%wiremock.quarkus.otel.sdk.disabled=true
 %stage.quarkus.otel.sdk.disabled=false
 %prod.quarkus.otel.sdk.disabled=false
 


### PR DESCRIPTION
Supports testing of #2717 in Ephemeral Environments

The gist here is to optionally shove a wiremock deployment & service into an ephemeral environment, and then you can configure port-forward the pod to create stubs, and then configure other pods to point to wiremock.

This PR gives the yaml for wiremock to be deployed, and creation of a "wiremock" quarkus profile that will set ENTITLEMENT_GATEWAY_URL, SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT, and SUBSCRIPTION_URL to point to a deployed wiremock service.

Example workflow:

Deploy swatch with bonfire.  The template ref for this example is this PR's commit (needed for that mentioned ClowdApp change).  Then follow instructions in the README.md file to deploy wiremock and create a stub.

```
TEMPLATE_REF=f14b85cd8b00d3fc95e48dd3a4f2320cf4ef8398 IMAGE_TAG=pr-2717-latest && bonfire deploy rhsm \
 --source=appsre \
 --ref-env insights-production \
 --optional-deps-method none \
 --frontends false \
 --timeout 1800 \
 --no-remove-resources rhsm \
 --no-remove-resources swatch-api \
 --no-remove-resources swatch-contracts \
 --no-remove-resources swatch-producer-aws \
 --no-remove-resources swatch-producer-red-hat-marketplace \
 --no-remove-resources swatch-metrics \
 --no-remove-resources swatch-subscription-sync \
 --no-remove-resources swatch-system-conduit \
 --no-remove-resources swatch-tally \
 --no-remove-resources swatch-producer-azure \
 -i quay.io/cloudservices/rhsm-subscriptions=$IMAGE_TAG \
 -i quay.io/cloudservices/swatch-contracts=$IMAGE_TAG \
 -i quay.io/cloudservices/swatch-metrics=$IMAGE_TAG \
 -i quay.io/cloudservices/swatch-producer-aws=$IMAGE_TAG \
 -i quay.io/cloudservices/swatch-producer-azure=$IMAGE_TAG \
 -i quay.io/cloudservices/swatch-system-conduit=$IMAGE_TAG \
 --set-template-ref rhsm=$TEMPLATE_REF \
 --set-template-ref swatch-api=$TEMPLATE_REF \
 --set-template-ref swatch-contracts=$TEMPLATE_REF \
 --set-template-ref swatch-producer-aws=$TEMPLATE_REF \
 --set-template-ref swatch-producer-red-hat-marketplace=$TEMPLATE_REF \
 --set-template-ref swatch-metrics=$TEMPLATE_REF \
 --set-template-ref swatch-subscription-sync=$TEMPLATE_REF \
 --set-template-ref swatch-system-conduit=$TEMPLATE_REF \
 --set-template-ref swatch-tally=$TEMPLATE_REF \
 --set-template-ref swatch-producer-azure=$TEMPLATE_REF \
 -p swatch-contracts/QUARKUS_PROFILE=wiremock
```

