### PR TITLE
SWATCH-1928 Payg Event ingestion should write product tag in Events table

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -24,7 +24,6 @@ import com.google.common.collect.MoreCollectors;
 import com.google.common.collect.Sets;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
-import com.redhat.swatch.configuration.registry.Variant;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -32,7 +31,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -435,14 +433,14 @@ public class MetricUsageCollector {
             .orElse(BillingProvider.RED_HAT);
     String effectiveBillingAcctId =
         Optional.ofNullable(event.getBillingAccountId()).orElse(Optional.empty()).orElse("");
-    Set<String> productIds = getProductIds(event);
+    Set<String> productTags = event.getProductTag();
     Set<ServiceLevel> slas = Set.of(effectiveSla, ServiceLevel._ANY);
     Set<Usage> usages = Set.of(effectiveUsage, Usage._ANY);
     Set<BillingProvider> billingProviders = Set.of(effectiveProvider, BillingProvider._ANY);
     Set<String> billingAccountIds = getBillingAccountIds(effectiveBillingAcctId);
 
     Set<List<Object>> bucketTuples =
-        Sets.cartesianProduct(productIds, slas, usages, billingProviders, billingAccountIds);
+        Sets.cartesianProduct(productTags, slas, usages, billingProviders, billingAccountIds);
     bucketTuples.forEach(
         tuple -> {
           String productId = (String) tuple.get(0);
@@ -462,30 +460,6 @@ public class MetricUsageCollector {
                   false));
           host.addBucket(bucket);
         });
-  }
-
-  private Set<String> getProductIds(Event event) {
-    Set<String> productIds = new HashSet<>();
-    // Filter tags that are paygEligible for hourly tally
-
-    if (Objects.nonNull(event.getRole())) {
-      String role = event.getRole().toString();
-      SubscriptionDefinition.lookupSubscriptionByRole(role)
-          .filter(SubscriptionDefinition::isPaygEligible)
-          .flatMap(s -> s.findVariantForRole(role).map(Variant::getTag))
-          .ifPresent(productIds::add);
-    }
-
-    var engIds = Optional.ofNullable(event.getProductIds()).orElse(Collections.emptyList());
-    for (String engId : engIds) {
-      productIds.addAll(
-          SubscriptionDefinition.lookupSubscriptionByEngId(engId).stream()
-              .filter(SubscriptionDefinition::isPaygEligible)
-              .flatMap(s -> s.findVariantForEngId(engId).map(Variant::getTag).stream())
-              .toList());
-    }
-
-    return productIds;
   }
 
   private Set<String> getBillingAccountIds(String billingAcctId) {

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -85,7 +85,7 @@ class MetricUsageCollectorTest {
 
   static final String RHEL_WORKSTATION_SWATCH_PRODUCT_ID = "RHEL Workstation";
   static final String RHEL_COMPUTE_NODE_SWATCH_PRODUCT_ID = "RHEL Compute Node";
-  static final String OSD_PRODUCT_ID = "OpenShift-dedicated-metrics";
+  static final String OSD_PRODUCT_TAG = "OpenShift-dedicated-metrics";
 
   static final String OSD_METRIC_ID = "redhat.com:openshift_dedicated:4cpu_hour";
 
@@ -124,6 +124,7 @@ class MetricUsageCollectorTest {
         createEvent()
             .withEventId(UUID.randomUUID())
             .withRole(Event.Role.OSD)
+            .withProductTag(Set.of(OSD_PRODUCT_TAG))
             .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
             .withServiceType(SERVICE_TYPE)
             .withMeasurements(Collections.singletonList(measurement))
@@ -137,7 +138,7 @@ class MetricUsageCollectorTest {
     assertNotNull(accountUsageCalculation);
     UsageCalculation.Key usageCalculationKey =
         new UsageCalculation.Key(
-            OSD_PRODUCT_ID,
+            OSD_PRODUCT_TAG,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             BillingProvider.RED_HAT,
@@ -203,7 +204,8 @@ class MetricUsageCollectorTest {
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
-            .withProductIds(List.of(RHEL_FOR_X86, RHEL_ELS_PAYG_ENG_ID))
+            .withProductIds(List.of(RHEL_ENG_ID, RHEL_ELS_PAYG_ENG_ID))
+            .withProductTag(Set.of(RHEL_FOR_X86_ELS_PAYG))
             .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
             .withServiceType("RHEL System")
             .withMeasurements(Collections.singletonList(measurement))
@@ -258,6 +260,7 @@ class MetricUsageCollectorTest {
         createEvent()
             .withEventId(UUID.randomUUID())
             .withRole(Event.Role.OSD)
+            .withProductTag(Set.of(OSD_PRODUCT_TAG))
             .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
             .withServiceType(SERVICE_TYPE)
             .withMeasurements(Collections.singletonList(measurement))
@@ -272,7 +275,7 @@ class MetricUsageCollectorTest {
     assertNotNull(accountUsageCalculation);
     UsageCalculation.Key usageCalculationKey =
         new UsageCalculation.Key(
-            OSD_PRODUCT_ID,
+            OSD_PRODUCT_TAG,
             ServiceLevel._ANY,
             Usage.PRODUCTION,
             BillingProvider.RED_HAT,
@@ -294,6 +297,7 @@ class MetricUsageCollectorTest {
         createEvent()
             .withEventId(UUID.randomUUID())
             .withRole(Event.Role.OSD)
+            .withProductTag(Set.of(OSD_PRODUCT_TAG))
             .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
             .withServiceType(SERVICE_TYPE)
             .withMeasurements(Collections.singletonList(measurement))
@@ -308,7 +312,7 @@ class MetricUsageCollectorTest {
     assertNotNull(accountUsageCalculation);
     UsageCalculation.Key usageCalculationKey =
         new UsageCalculation.Key(
-            OSD_PRODUCT_ID,
+            OSD_PRODUCT_TAG,
             ServiceLevel.PREMIUM,
             Usage._ANY,
             BillingProvider.RED_HAT,
@@ -348,7 +352,7 @@ class MetricUsageCollectorTest {
 
     UsageCalculation.Key serverKey =
         new UsageCalculation.Key(
-            OSD_PRODUCT_ID, ServiceLevel.PREMIUM, Usage._ANY, BillingProvider.RED_HAT, "_ANY");
+            OSD_PRODUCT_TAG, ServiceLevel.PREMIUM, Usage._ANY, BillingProvider.RED_HAT, "_ANY");
     assertTrue(accountUsageCalculation.containsCalculation(serverKey));
     assertEquals(
         Double.valueOf(42.0),
@@ -379,7 +383,8 @@ class MetricUsageCollectorTest {
             .withMeasurements(Collections.singletonList(measurement))
             .withUsage(Event.Usage.PRODUCTION)
             .withBillingProvider(Event.BillingProvider.RED_HAT)
-            .withProductIds(List.of(RHEL_ENG_ID, RHEL_ELS_PAYG_ENG_ID));
+            .withProductIds(List.of(RHEL_ENG_ID, RHEL_ELS_PAYG_ENG_ID))
+            .withProductTag(Set.of(RHEL_FOR_X86_ELS_PAYG));
 
     AccountServiceInventory accountServiceInventory = createTestAccountServiceInventory();
     when(eventController.fetchEventsInTimeRangeByServiceType(any(), any(), any(), any(), any()))
@@ -433,6 +438,7 @@ class MetricUsageCollectorTest {
         createEvent()
             .withEventId(UUID.randomUUID())
             .withRole(Event.Role.OSD)
+            .withProductTag(Set.of(OSD_PRODUCT_TAG))
             .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
             .withServiceType(SERVICE_TYPE)
             .withMeasurements(Collections.singletonList(measurement))
@@ -447,7 +453,7 @@ class MetricUsageCollectorTest {
     assertNotNull(accountUsageCalculation);
     UsageCalculation.Key usageCalculationKey =
         new UsageCalculation.Key(
-            OSD_PRODUCT_ID,
+            OSD_PRODUCT_TAG,
             ServiceLevel.PREMIUM,
             Usage.PRODUCTION,
             BillingProvider.RED_HAT,
@@ -776,6 +782,10 @@ class MetricUsageCollectorTest {
 
   private static Event createEvent(String instanceId) {
     return (Event)
-        new Event().withEventId(UUID.randomUUID()).withOrgId("test-org").withInstanceId(instanceId);
+        new Event()
+            .withEventId(UUID.randomUUID())
+            .withOrgId("test-org")
+            .withInstanceId(instanceId)
+            .withProductTag(Set.of(OSD_PRODUCT_TAG));
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -35,6 +35,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.candlepin.clock.ApplicationClock;
@@ -166,6 +167,7 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
     event.setTimestamp(start.plusDays(dayAt));
     event.setSla(Event.Sla.PREMIUM);
     event.setRole(Event.Role.MOA_HOSTEDCONTROLPLANE);
+    event.setProductTag(Set.of(PRODUCT_TAG));
     event.setOrgId(ORG_ID);
     event.setEventType(getEventType(METRIC, PRODUCT_TAG));
     event.setInstanceId(PROMETHEUS);

--- a/swatch-model-events/build.gradle
+++ b/swatch-model-events/build.gradle
@@ -8,6 +8,7 @@ description = 'Event model definition used by Swatch Tally'
 dependencies {
     implementation libraries["jackson-annotations"] // for json generated models
     implementation libraries["jakarta-validation-api"] // for validation API in generated models
+    implementation "com.fasterxml.jackson.core:jackson-databind"
 
     testImplementation libraries["junit-jupiter"]
 }

--- a/swatch-model-events/schemas/event.yaml
+++ b/swatch-model-events/schemas/event.yaml
@@ -152,3 +152,10 @@ properties:
     type: string
     existingJavaType: java.util.Optional<String>
     required: false
+  product_tag:
+    description: Product tag
+    type: array
+    items:
+      type: string
+    required: false
+    uniqueItems: true


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-1928

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Finding the product_tag during event ingestion is the goal of this card. Therefore, we get away from determining the product tag at the time of running the tally or any other event-related process. As a result, I removed the code that determined the product tag during the tally process at a later stage. This card just takes care of payg products since there is no way to determine payg or non-payg through an event. There will be a future card https://issues.redhat.com/browse/SWATCH-1993 to handle that use case.


_Note: Since QE may be mocking the event beforehand and it hasn't gone through the event ingestion process, the product_tag will be missing, so they will need to modify their tests.
https://gitlab.cee.redhat.com/smqe/smqe-tools/-/blob/master/smqe_tools/__init__.py?ref_type=heads#L1628_

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert records into few tables:
**org_config**:
```
INSERT INTO public.org_config (org_id, opt_in_type, created, updated) VALUES ('13259775', 'API', '2021-05-27 12:37:35.139117 +00:00', '2022-07-01 06:37:30.573681 +00:00');
```

**account_services**:
```
INSERT INTO public.account_services (account_number, service_type, org_id) VALUES ('13259775', 'HBI_HOST', '13259775');
INSERT INTO public.account_services (account_number, service_type, org_id) VALUES ('13259775', 'RHEL System', '13259775');
INSERT INTO public.account_services (account_number, service_type, org_id) VALUES ('13259775', 'rosa Instance', '13259775');
```


**subscription**:
```
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH02781HR', '13259775', '13791458', 1, '2023-11-07 05:00:00.000000 +00:00', '2023-12-07 04:59:59.999000 +00:00', 'agrmmh1irkv7b0wh39cx7vugf;iDtyyzUCLVG;403771435366', '13791615', 'aws', '505066801768');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH02781HR', '13259775', '13791458', 1, '2023-11-13 05:00:00.000000 +00:00', '2023-12-13 04:59:59.000000 +00:00', 'agrmmh1irkv7b0wh39cx7vugf;iDtyyzUCLVG;403771435366', '13791615', 'aws', '505066801768');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH02781HR', '13259775', '13791458', 1, '2023-11-14 05:00:00.000000 +00:00', '2023-12-14 04:59:59.000000 +00:00', 'agrmmh1irkv7b0wh39cx7vugf;iDtyyzUCLVG;403771435366', '13791615', 'aws', '505066801768');
```


**offering**:
```
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku) VALUES ('RH02781HR', 'RHEL Server', 'RHEL', null, 2, null, null, '', 'Premium', 'Production', 'Red Hat Enterprise Linux for Third Party Linux Migration with Extended Life Cycle Support (On-Demand, Hourly Production Support)', false, '');
```

2. Using Big data tool produce Kakfa event to service-instance-ingress.
Note: For QE they can generate data using Prometheus mock data. https://github.com/RedHatInsights/rhsm-subscriptions/blob/main/bin/prometheus-mock-data.sh


### Step 1
<!-- Enter each step of the test below -->
1. Kafka event using Big data tool in service-instance-ingress:
```
{"sla": "Standard", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "23259772k", "event_id": "9eae212b-7943-4d45-84b3-956e1077d5b4", "timestamp": "2023-12-04T02:00:00Z", "event_type": "snapshot", "expiration": "2023-12-30T16:00:00Z", "instance_id": "ki-9954975551", "product_ids": ["69", "204"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 2.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "9999999999999"}
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. You should see the event gets created in event table with an additional `product_tag` field in event json blob. The value here is `"product_tag": ["rhel-for-x86-els-payg"]`
```
(event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date)
('9eae212b-7943-4d45-84b3-956e1077d5b4', '2023-12-04 02:00:00.000000 +00:00', '{"sla": "Standard", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "23259772k", "event_id": "9eae212b-7943-4d45-84b3-956e1077d5b4", "timestamp": "2023-12-04T02:00:00Z", "event_type": "snapshot", "expiration": "2023-12-30T16:00:00Z", "instance_id": "ki-9954975551", "product_ids": ["69", "204"], "product_tag": ["rhel-for-x86-els-payg"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 2.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "9999999999999"}', 'snapshot', 'cost-management', 'ki-9954975551', '23259772k', null, '2023-12-04 04:45:58.166015 +00:00')
```

### Log verification
```
2023-12-04 04:45:57,862 [thread=swatch-instance-ingress-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.ServiceInstanceMessageConsumer] - Events received w/ event list size=1. Consuming events.
2023-12-04 04:45:57,922 [thread=swatch-instance-ingress-0-C-1] [INFO ] [org.candlepin.subscriptions.event.EventController] - Event processing in batch: {"sla": "Standard", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "23259772k", "event_id": "9eae212b-7943-4d45-84b3-956e1077d5b4", "timestamp": "2023-12-04T02:00:00Z", "event_type": "snapshot", "expiration": "2023-12-30T16:00:00Z", "instance_id": "ki-9954975551", "product_ids": ["69", "204"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 2.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "9999999999999"}
```

No error message.

### Step 2 Run hourly tally. Select range according to the record_date in the generated event 
<!-- Enter each step of the test below -->
1.  ` http POST ":8001/api/rhsm-subscriptions/v1/internal/tally/hourly?org=23259772k&start=2023-12-04T04:00Z&end=2023-12-04T05:00Z" x-rh-swatch-psk:placeholder`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Tables:

**host_tally_bucket**
```
99d9feea-2dd7-4416-9ea8-b80a2328026a,_ANY,rhel-for-x86-els-payg,Standard,false,0,0,,_ANY,_ANY,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,_ANY,rhel-for-x86-els-payg,Standard,false,0,0,,_ANY,9999999999999,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,_ANY,rhel-for-x86-els-payg,Standard,false,0,0,,aws,_ANY,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,_ANY,rhel-for-x86-els-payg,Standard,false,0,0,,aws,9999999999999,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,Production,rhel-for-x86-els-payg,Standard,false,0,0,,_ANY,_ANY,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,Production,rhel-for-x86-els-payg,Standard,false,0,0,,_ANY,9999999999999,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,Production,rhel-for-x86-els-payg,Standard,false,0,0,,aws,_ANY,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,Production,rhel-for-x86-els-payg,Standard,false,0,0,,aws,9999999999999,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,_ANY,rhel-for-x86-els-payg,_ANY,false,0,0,,_ANY,_ANY,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,_ANY,rhel-for-x86-els-payg,_ANY,false,0,0,,_ANY,9999999999999,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,_ANY,rhel-for-x86-els-payg,_ANY,false,0,0,,aws,_ANY,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,_ANY,rhel-for-x86-els-payg,_ANY,false,0,0,,aws,9999999999999,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,Production,rhel-for-x86-els-payg,_ANY,false,0,0,,_ANY,_ANY,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,Production,rhel-for-x86-els-payg,_ANY,false,0,0,,_ANY,9999999999999,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,Production,rhel-for-x86-els-payg,_ANY,false,0,0,,aws,_ANY,0
99d9feea-2dd7-4416-9ea8-b80a2328026a,Production,rhel-for-x86-els-payg,_ANY,false,0,0,,aws,9999999999999,0
```

**tally_snapshots:**
```
0a40cf86-fb05-48bf-bf84-672f0929355b,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,_ANY,Production,aws,9999999999999
742d9d4f-0311-43a7-89f2-682e1ac46b80,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,Standard,Production,_ANY,_ANY
860814c4-f803-4ec0-96d2-c8003f744c3e,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,_ANY,Production,_ANY,_ANY
b016c50f-5cf0-41ec-8cd7-8cdbb41c0380,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,Standard,_ANY,aws,_ANY
e4fd6b08-0bf3-4ad8-8525-83e6f59cd265,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,Standard,_ANY,_ANY,9999999999999
0540ca3c-378d-40d7-9207-de411953f5a0,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,Standard,_ANY,aws,9999999999999
abf4ca71-1020-4ffd-9eb1-6632a827e474,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,_ANY,Production,aws,_ANY
e64acec1-4e7f-446b-a2d9-7c51dc78b389,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,Standard,_ANY,_ANY,_ANY
75e520e4-53f0-4f14-8f5e-b0b9f6d260dd,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,_ANY,_ANY,aws,9999999999999
90fa917b-a31b-4ff7-854a-f149238b2501,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,_ANY,Production,_ANY,9999999999999
4537b976-552f-45aa-8bf1-9a52422d6e25,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,_ANY,_ANY,_ANY,_ANY
70c4c37a-b5a2-4fcf-849b-71ea1888d79e,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,Standard,Production,aws,9999999999999
04453367-dbab-4b8c-90a9-263a3959a5e1,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,Standard,Production,_ANY,9999999999999
a098fdbe-e156-40c1-a9af-7393796fb418,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,Standard,Production,aws,_ANY
547e5bd7-0f5a-43cc-8af5-4c7e4e479890,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,_ANY,_ANY,_ANY,9999999999999
b77efa2e-41ee-4d5c-9a24-fa8cf16d5b04,rhel-for-x86-els-payg,HOURLY,23259772k,2023-12-04 02:00:00.000000 +00:00,,_ANY,_ANY,aws,_ANY
6072f0bb-67fe-43d6-9b61-9e001824c86c,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,_ANY,Production,aws,_ANY
41a3342f-66d8-4145-a1ef-a71f4014554e,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,Standard,_ANY,aws,9999999999999
98a818f5-6e45-42c1-8935-63fec4713ec9,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,Standard,Production,aws,_ANY
25177d59-cd42-432f-908e-471a647d3257,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,_ANY,_ANY,_ANY,_ANY
d428af5f-720e-483a-aa78-36cded721914,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,_ANY,_ANY,aws,9999999999999
4b268057-c3de-43ca-a74f-23582a610fb3,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,Standard,_ANY,_ANY,_ANY
64afc469-05d0-449c-a506-853ad13f2263,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,_ANY,Production,_ANY,9999999999999
316e4ba3-6810-4e6f-9f7f-6e57951dcd48,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,Standard,_ANY,aws,_ANY
21d384cc-7e5c-4211-af7b-92b32bec2db3,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,_ANY,_ANY,aws,_ANY
a828f0e5-c4ff-4bee-bd2e-aede7c3e4228,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,Standard,Production,_ANY,_ANY
39180b70-a594-4620-a5c8-1ab77dc94688,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,_ANY,Production,_ANY,_ANY
8f34cbd5-3408-4386-ba6e-b3c095143bd2,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,_ANY,Production,aws,9999999999999
c96db624-1a8d-42b8-9579-f0ec670eee71,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,Standard,Production,aws,9999999999999
9064eec1-fc6a-4d47-83cd-8e2df64ec3ee,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,Standard,Production,_ANY,9999999999999
cadbb888-0355-4820-83b2-3294b308d53d,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,_ANY,_ANY,_ANY,9999999999999
939da281-b651-4b1f-8589-6e722fd72c88,rhel-for-x86-els-payg,DAILY,23259772k,2023-12-04 00:00:00.000000 +00:00,,Standard,_ANY,_ANY,9999999999999

```

**billable_usage_remittance:**
```
(account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date) 
(null, '23259772k', 'rhel-for-x86-els-payg', 'vCPUs', '2023-12', 'Standard', 'Production', 'aws', '9999999999999', 2, '2023-12-04 05:07:28.741143 +00:00')
```

2. Tally logs:
```
2023-12-04 05:07:28,594 [thread=rhsm-subscriptions-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.SnapshotSummaryProducer] - Produced 32 TallySummary messages
2023-12-04 05:07:28,594 [thread=rhsm-subscriptions-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.TallySnapshotController] - Finished producing hourly snapshots for orgId 23259772k
2023-12-04 05:07:28,702 [thread=swatch-producer-billing-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.billing.BillableUsageController] - Processing monthly billable usage for orgId=23259772k productId=rhel-for-x86-els-payg uom=VCPUS provider=aws, billingAccountId=9999999999999 snapshotDate=2023-12-04T02:00Z
```


3. AWS logs:
```
> IDL2023-12-04 00:07:29,863 INFO  [io.sma.rea.mes.kafka] (vert.x-eventloop-thread-0) SRMSG18256: Initialize record store for topic-partition 'platform.rhsm-subscriptions.billable-usage-0' at position -1.=======-> 97% EXECUTING [26m 28s]
> IDL2023-12-04 00:07:29,963 DEBUG [com.red.swa.aws.pro.BillableUsageProcessor] (vert.x-worker-thread-1) Picked up billable usage message class BillableUsage {
    orgId: 23259772kEXECUTING [26m 28s]
    id: 70c4c37a-b5a2-4fcf-849b-71ea1888d79e
    billingProvider: aws
    billingAccountId: 9999999999999
    snapshotDate: 2023-12-04T05:07:28.741142982Z
    productId: rhel-for-x86-els-payg
    sla: Standard
    usage: Production
    uom: VCPUS
    value: 2.0
    billingFactor: 1.0
    vendorProductCode: null
    hardwareMeasurementType: AWS
} to process

```

### APIs to test for events:
 ```
http GET ":8001/api/rhsm-subscriptions/v1/internal/rpc/tally/events/23259772k?begin=2023-12-04T02:00Z&end=2023-12-04T03:00Z" x-rh-swatch-psk:placeholder
```

```
{
    "detail": "[{\"event_id\":\"9eae212b-7943-4d45-84b3-956e1077d5b4\",\"service_type\":\"RHEL System\",\"timestamp\":\"2023-12-04T02:00:00Z\",\"expiration\":\"2023-12-30T16:00:00Z\",\"measurements\":[{\"value\":2.0,\"uom\":\"vCPUs\"}],\"cloud_provider\":\"AWS\",\"hardware_type\":\"Cloud\",\"product_ids\":[\"69\",\"204\"],\"role\":\"Red Hat Enterprise Linux Server\",\"sla\":\"Standard\",\"usage\":\"Production\",\"billing_provider\":\"aws\",\"billing_account_id\":\"9999999999999\",\"product_tag\":[\"rhel-for-x86-els-payg\"],\"event_source\":\"cost-management\",\"event_type\":\"snapshot\",\"org_id\":\"23259772k\",\"instance_id\":\"ki-9954975551\"}]"
}

```
