### PR TITLE
SWATCH-1985: Fix kafka configuration issues

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonPathPropertySource.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonPathPropertySource.java
@@ -494,6 +494,12 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
   @SuppressWarnings("unchecked")
   private Object getKafkaBrokerConfig(String name, KafkaBrokerConfigMapper configFunction) {
     Object value = getJsonPathValue(KAFKA_BROKERS);
+    // NOTE: because we configure kafka in shared configuration, kafka config is included in
+    // services that don't use kafka. Clowder doesn't populate kafka config for those services, so
+    // we won't have a value to contribute.
+    if (value == null) {
+      return null;
+    }
     if (value instanceof Collection<?> list) {
       if (list.isEmpty()) {
         return null;

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -118,7 +118,9 @@ kafka:
 # thrown instead of something more relevant to the actual issue.
   sasl:
     jaas:
-      config:
+      # NOTE: empty string intentional, omitting the value is interpreted as null, and clowder
+      # config source will not populate the config when null
+      config: ''
     mechanism: PLAIN
   security:
     protocol: PLAINTEXT


### PR DESCRIPTION
Jira issue: [SWATCH-1985](https://issues.redhat.com/browse/SWATCH-1985)

Description
===========

There were a couple of recently introduced issues with kafka configuration:

1. swatch-metrics uses yaml config, and we set `kafka.sasl.jaas.config` to `null`, which clowder config source treats as missing, so it doesn't populate this property. (The fix is to set to empty string (`''`)
2. Recent updates to kafka config parsing in spring boot expect the clowder config to always contain kafka config (which doesn't happen if there are no topics specified in the ClowdApp). The fix is to simply not contribute kafka config if missing from clowder config.

Testing
=======

Setup
-----
Start kafka and postgres via podman-compose.

Verification
------------

Create an empty clowder config and then start the service:

```shell
echo '{}' > /tmp/empty.json
ACG_CONFIG=/tmp/empty.json ./gradlew :bootRun
```

Before this change, this will err with:

> java.lang.IllegalStateException: Unknown type found in clowder configuration for Kafka Broker property: clowder.kafka.brokers.sasl.securityProtocol

Afterward, the service should start up without errors.

Next create a clowder config having some minimal config and start swatch-metrics:

```shell
cat <<EOF > /tmp/cdappconfig.json
{
  "metricsPath": "/metrics",
  "metricsPort": 9000,
  "privatePort": 10000,
  "publicPort": 8000,
  "webPort": 8000,
  "kafka": {
    "brokers": [
      {
        "authtype": "sasl",
        "cacert": "-----BEGIN CERTIFICATE-----\nMIIFBTCCAu2gAwIBAgIUI8W01ruDKw/0ZF2IS9hDww8KeXowDQYJKoZIhvcNAQEL\nBQAwEjEQMA4GA1UEAwwHVGVzdCBDQTAeFw0yMjA3MTQxODAwNTVaFw0zMjA3MTEx\nODAwNTVaMBIxEDAOBgNVBAMMB1Rlc3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4IC\nDwAwggIKAoICAQCbu+Yiyqv+r+wu2DV+xCptmHz9Vtg5eT+5gTyYhf2Ycfq7xbFD\nBnY1a7LQ5naWxsJQNSFicBoroHZWjt4lOO1ov8Zb6aIE/ZqLbpbYdli1UpGswCAT\na9vkLrh9p/WeSHQftyL8HQDBuK61jqzw2xShR6USIAmUEENp8mP0sFYNJIsHofHP\nERlx5cZj78vBpJgMUlcHzifv+z6VJfQ63k2Eth/zcl94zD6fa+uHlOyzx8OCB7EC\nwa5GVJzKYc8x5bxJi3TvESCntPb+mFve+h2Md00sQwVRWW3BR4iJMm7aS6A2s6Q+\nH0qd9Wq9FhpLykmHc6tQnuwR40DusmXTMcPnzJrWcwV4V8DN0bPH2z94QV4aZ/iO\nNkN2DCOr/Ze8BMZnLYtbJxHU9xzMZj54l9ngdT8H0EmMZYdmQH39MUgI1J9u7C/v\nfqLMLOc9daPy0dbJgFud/s1ZTgAzX2VITv+yXMKDFTaKHEutA2j4U1Vucfp1EnfY\npDTsbJ2oYVhoXK869mu7OfByjQKTxQFGl45iXl50s7dsLGUy5r/W6+iL3zZGDkU/\nZH6X/Ujay3VmoekVEyBAf6WAKM36Sp/va/GhlIEQI/EwQdg/XCoRTbDhLbbkVcPA\nRdNL0Yxh6kyvFZOZCcyXBZNR4ykltIdMkFAAIgpY2DEnkrepSGytm/2gtQIDAQAB\no1MwUTAdBgNVHQ4EFgQUQUgWjSm2SiPfirhYZSlUzVHuJf8wHwYDVR0jBBgwFoAU\nQUgWjSm2SiPfirhYZSlUzVHuJf8wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0B\nAQsFAAOCAgEAO1WgnbRrf5uSh8Op1Xp8LC6C/4rQJP1d1zOL1QtaJ/Nh5Z0GCD9x\nY6iRqYZPl6Udj9/Y4H/TVuz2c6oNy0ZfmiENzOo21iVR+BjAbxq1ROLY3ZrSNwnR\n3nPISqQ+9bVmGjsX3T+K+Mu5na6N5y+9LvtIKhDOPXPW5LvjF39bX3J9qtsw15zw\nuUzu4/qeLWxTdDPuZPOk7L2ydMdYp/E+QCzBQ4hW2pj4hyvPR/DQ7t3mYH0PWf3M\nu6eQAePnfVxa0Lqm8XIc3Sl7b2leHvEDAwUDeQ2zT/CUtrnLHregEj89NjM21Efk\nzLprcKbY1+t+6OGcrkimEb++6YKAllKcgGyat5wKDyrSGGwvvZaDKp1IjjxEpVIR\n1rnw6O91kbyvMBdYuPCu55OwxJN/UOfjuQMHhwoouLNV90yYm5uwaWTV360+YgfA\nT25JEmalZRLfNeepuNq1pc34YAEGhHASduw+Q4uXUzeJxiveTR8Owar3DIlmXSye\nQoMAB9QqQbU3jh+pFCiUctUA/MT3dSEOEWSeGgBtykvKZvdxQ8/iPvdAkfd5vU7q\nnuFft1VQZOeVuIpH3kpv9+iROnX4W+iNO+omT5NcazTthJT3UohDDXvQCILJkl+e\nUfNfHwZGN4T/GekEp85CL2VcvM+Gx0gy3pf0IhlyzALCODwyoaZMno4=\n-----END CERTIFICATE-----",
        "hostname": "localhost",
        "port": 9096,
        "sasl": {
          "password": "redacted",
          "saslMechanism": "SCRAM-SHA-512",
          "securityProtocol": "SASL_SSL",
          "username": "redacted"
        },
        "securityProtocol": "SASL_SSL"
      }
    ],
    "topics": [
      {
        "name": "platform.rhsm-subscriptions.metering-tasks",
        "requestedName": "platform.rhsm-subscriptions.metering-tasks"
      },
      {
        "name": "platform.rhsm-subscriptions.service-instance-ingress",
        "requestedName": "platform.rhsm-subscriptions.service-instance-ingress"
      }
    ]
  }
}
EOF
ACG_CONFIG=/tmp/cdappconfig.json ./gradlew :swatch-metrics:quarkusDev
```

Without this fix, there will be an error like:

> Could not find a 'KafkaClient' entry in the JAAS configuration. System property 'java.security.auth.login.config' is not set

With this fix, the service will start up without errors.
