### PR TITLE
Add script to generate new changeset xml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,12 @@ Liquibase Hub or Liquibase Pro.
 
 DB migrations should be written to roll back cleanly (exceptions should be discussed with the team).
 
+To generate a new changeset, you can use a helper script in `bin/`:
+
+```shell
+bin/liquibase-new-changeset.sh change set description
+```
+
 -------------
 # swatch-product-configuration
 

--- a/bin/liquibase-new-changeset.sh
+++ b/bin/liquibase-new-changeset.sh
@@ -8,7 +8,7 @@ cat > src/main/resources/liquibase/$filename <<EOF
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="$date-01" author="$(whoami)">
     <!-- TODO -->
     <rollback>

--- a/bin/liquibase-new-changeset.sh
+++ b/bin/liquibase-new-changeset.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+desc=$(echo "$@" | sed 's/ /-/g' | tr A-Z a-z)
+date=$(date +%Y%m%d%H%M)
+filename=$(date +%Y%m%d%H%M)-$desc.xml
+cat > src/main/resources/liquibase/$filename <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="$date-01" author="$(whoami)">
+    <!-- TODO -->
+    <rollback>
+      <!-- TODO -->
+    </rollback>
+  </changeSet>
+</databaseChangeLog>
+EOF
+
+sed -i "/databaseChangeLog>/i\\    <include file=\"/liquibase/$filename\"/>" src/main/resources/liquibase/changelog.xml
+
+echo Generated src/main/resources/liquibase/$filename

--- a/bin/liquibase-new-changeset.sh
+++ b/bin/liquibase-new-changeset.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Usage: liquibase-new-changeset.sh <text to append to the generated changeset>
+# For example: running `liquibase-new-changeset.sh remove-account` would create a change set `202312050855-remove-account.xml` where `202312050855` is auto-populated from the current date.
 desc=$(echo "$@" | sed 's/ /-/g' | tr A-Z a-z)
 date=$(date +%Y%m%d%H%M)
 filename=$(date +%Y%m%d%H%M)-$desc.xml


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

For a recent task I found myself wanting to prototype db changes quickly.

Invoked as `bin/liquibase-new-changeset.sh change set description`.

It takes any args passed, and lower cases them, and replaces spaces with `-`, and then adds the new changeset to our changelog.xml file.