### PR TITLE
SWATCH-1924: Support querying prometheus/rhelemeter when "product" label has engIds

### DIFF
--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -34,11 +34,14 @@ import com.redhat.swatch.metrics.service.prometheus.model.QuerySummaryResult;
 import com.redhat.swatch.metrics.service.promql.QueryBuilder;
 import com.redhat.swatch.metrics.service.promql.QueryDescriptor;
 import com.redhat.swatch.metrics.util.MeteringEventFactory;
+import io.smallrye.common.constraint.NotNull;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.BadRequestException;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -198,11 +201,19 @@ public class PrometheusMeteringController {
     String product = labels.get("product");
     String resourceName = labels.get("resource_name");
 
+    // TODO update this note
     // NOTE: Role comes from the product label despite its name. The values set
     // here are NOT engineering or swatch product IDs. They map to the roles in
     // the swatch-product-configuration library. For openshift, the values will
     // be 'ocp' or 'osd'.
     String role = product == null ? resourceName : product;
+
+    List<String> productIds = extractProductIdsFromProductLabel(product);
+    if (!productIds.isEmpty()) {
+      // Force lookup of productTag later to use productIds instead of role
+      role = null;
+    }
+
     String billingProvider = labels.get("billing_marketplace");
     String billingAccountId = labels.get("billing_marketplace_account");
 
@@ -234,7 +245,8 @@ public class PrometheusMeteringController {
               MetricId.fromString(tagMetric.getId()),
               value,
               productTag,
-              meteringBatchId);
+              meteringBatchId,
+              productIds);
       // Send if and only if it has not been sent yet.
       // Related to https://github.com/RedHatInsights/rhsm-subscriptions/pull/374.
       if (eventsSent.add(EventKey.fromEvent(event))) {
@@ -275,7 +287,8 @@ public class PrometheusMeteringController {
       MetricId metric,
       BigDecimal value,
       String productTag,
-      UUID meteringBatchId) {
+      UUID meteringBatchId,
+      List<String> productIds) {
     Event event = new Event();
     MeteringEventFactory.updateMetricEvent(
         event,
@@ -293,7 +306,8 @@ public class PrometheusMeteringController {
         metric,
         value.doubleValue(),
         productTag,
-        meteringBatchId);
+        meteringBatchId,
+        productIds);
     return event;
   }
 
@@ -330,5 +344,40 @@ public class PrometheusMeteringController {
               productTag, metric.getId()));
     }
     return instanceKey;
+  }
+
+  @NotNull
+  protected List<String> extractProductIdsFromProductLabel(String product) {
+    List<String> productIds = new ArrayList<>();
+
+    /*
+      The regular expression pattern matches a sequence of numbers separated by commas with optional spaces in between.
+
+      Explanation:
+      ^          : Asserts the start of the line.
+      \d+        : Matches one or more digits (0-9).
+      (          : Starts a group that contains the following sequence:
+        ,        : Matches a comma.
+        \s*      : Matches zero or more whitespace characters.
+        \d+      : Matches one or more digits (0-9).
+      )*+        : The whole group can repeat zero or more times (including the comma followed by digits),
+                   and the possessive quantifier (*+) prevents excessive backtracking.
+
+      Example:
+      - 123,456,789: Matches a sequence of numbers separated by commas and optional spaces: 123, 456, 789.
+      - 1,23,4:     Matches a sequence of numbers separated by commas and optional spaces: 1, 23, 4.
+      - 100:        Matches a single number: 100.
+
+      Note: This pattern may lead to catastrophic backtracking for extremely large inputs due to its repetitive nature.
+    */
+
+    String pattern = "^\\d+(,\\s*\\d+)*+";
+
+    boolean isEngIdList = product != null && product.matches(pattern);
+
+    if (isEngIdList) {
+      productIds = Arrays.asList(product.split(","));
+    }
+    return productIds;
   }
 }

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -34,7 +34,6 @@ import com.redhat.swatch.metrics.service.prometheus.model.QuerySummaryResult;
 import com.redhat.swatch.metrics.service.promql.QueryBuilder;
 import com.redhat.swatch.metrics.service.promql.QueryDescriptor;
 import com.redhat.swatch.metrics.util.MeteringEventFactory;
-import io.smallrye.common.constraint.NotNull;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.BadRequestException;
@@ -202,11 +201,12 @@ public class PrometheusMeteringController {
     String product = labels.get("product");
     String resourceName = labels.get("resource_name");
 
-    // TODO update this note
-    // NOTE: Role comes from the product label despite its name. The values set
-    // here are NOT engineering or swatch product IDs. They map to the roles in
-    // the swatch-product-configuration library. For openshift, the values will
-    // be 'ocp' or 'osd'.
+    // NOTE: With data sourced from openshift telemeter instance, role comes from the product label
+    // despite its name. The values set here are NOT engineering or swatch product IDs. They map to
+    // the roles in the swatch-product-configuration library. For openshift, the values will be
+    // 'ocp' or 'osd'. For rhel data sourced from rhelemeter, role isn't applicable and the  product
+    // label contains engineering ids used to map to a product tag in swatch-product-configuration
+    // library.
     String role = product == null ? resourceName : product;
 
     List<String> productIds = extractProductIdsFromProductLabel(product);
@@ -349,7 +349,6 @@ public class PrometheusMeteringController {
     return instanceKey;
   }
 
-  @NotNull
   protected List<String> extractProductIdsFromProductLabel(String product) {
     List<String> productIds = new ArrayList<>();
 

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/util/MeteringEventFactory.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/util/MeteringEventFactory.java
@@ -74,7 +74,8 @@ public final class MeteringEventFactory {
       MetricId measuredMetric,
       Double measuredValue,
       String productTag,
-      UUID meteringBatchId) {
+      UUID meteringBatchId,
+      List<String> productIds) {
     Event event = new Event();
     updateMetricEvent(
         event,
@@ -92,7 +93,8 @@ public final class MeteringEventFactory {
         measuredMetric,
         measuredValue,
         productTag,
-        meteringBatchId);
+        meteringBatchId,
+        productIds);
     return event;
   }
 
@@ -142,7 +144,8 @@ public final class MeteringEventFactory {
       MetricId measuredMetric,
       Double measuredValue,
       String productTag,
-      UUID meteringBatchId) {
+      UUID meteringBatchId,
+      List<String> productIds) {
     toUpdate
         .withServiceType(serviceType)
         .withTimestamp(measuredTime)
@@ -159,8 +162,9 @@ public final class MeteringEventFactory {
         .withEventType(MeteringEventFactory.getEventType(measuredMetric.getValue(), productTag))
         .withOrgId(orgId)
         .withInstanceId(instanceId)
+        .withMeteringBatchId(meteringBatchId)
         .withProductTag(Set.of(productTag))
-        .withMeteringBatchId(meteringBatchId);
+        .withProductIds(productIds);
   }
 
   public static String getEventType(String metricId, String productTag) {

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/util/MeteringEventFactory.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/util/MeteringEventFactory.java
@@ -24,6 +24,7 @@ import com.redhat.swatch.configuration.registry.MetricId;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.candlepin.subscriptions.json.CleanUpEvent;
@@ -158,6 +159,7 @@ public final class MeteringEventFactory {
         .withEventType(MeteringEventFactory.getEventType(measuredMetric.getValue(), productTag))
         .withOrgId(orgId)
         .withInstanceId(instanceId)
+        .withProductTag(Set.of(productTag))
         .withMeteringBatchId(meteringBatchId);
   }
 

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -175,6 +175,9 @@ rhsm-subscriptions:
           addonSamples: >-
             group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon", resource_name='#{metric.prometheus.queryParams[resourceName]}', external_organization != '', billing_model='marketplace'}[1h]))
             by (external_organization)
+          rhelemeter: >-
+            group(min_over_time({product=~'#{metric.prometheus.queryParams[productLabelRegex]}', external_organization != '', billing_model='marketplace'}[1h]))
+            by (external_organization)
         queryTemplates:
           default: >-
             max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
@@ -184,6 +187,10 @@ rhsm-subscriptions:
             max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+          rhelemeter: >-
+            max(#{metric.prometheus.queryParams[metric]}) by (_id)
+            * on(_id) group_right
+            min_over_time({product=~"#{metric.prometheus.queryParams[productLabelRegex]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
         backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/util/MeteringEventFactoryTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/util/MeteringEventFactoryTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.candlepin.subscriptions.json.Event;
@@ -73,7 +74,8 @@ class MeteringEventFactoryTest {
             uom,
             measuredValue,
             productTag,
-            meteringBatchId);
+            meteringBatchId,
+            List.of());
 
     assertEquals(orgId, event.getOrgId());
     assertEquals(measuredTime, event.getTimestamp());
@@ -111,7 +113,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertNull(event.getSla());
   }
 
@@ -133,7 +136,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertEquals(Sla.__EMPTY__, event.getSla());
   }
 
@@ -155,7 +159,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertNull(event.getSla());
   }
 
@@ -177,7 +182,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertNull(event.getUsage());
   }
 
@@ -199,7 +205,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertNull(event.getUsage());
   }
 
@@ -221,7 +228,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertNull(event.getRole());
   }
 
@@ -243,7 +251,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertNull(event.getRole());
   }
 
@@ -265,7 +274,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertEquals(BillingProvider.AWS, event.getBillingProvider());
     assertTrue(event.getBillingAccountId().isPresent());
     assertEquals("aws_account_123", event.getBillingAccountId().get());
@@ -289,7 +299,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
     assertTrue(event.getBillingAccountId().isEmpty());
   }
@@ -312,7 +323,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
   }
 
@@ -334,7 +346,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertNull(event.getBillingProvider());
   }
 
@@ -356,7 +369,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertEquals("snapshot_openshift-dedicated-metrics_cores", event.getEventType());
   }
 
@@ -386,7 +400,8 @@ class MeteringEventFactoryTest {
             MetricIdUtils.getCores(),
             12.5,
             productTag,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            List.of());
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
   }
 }

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
@@ -29,6 +29,6 @@ metrics:
     prometheus:
       queryKey: rhelemeter
       queryParams:
-        productLabelRegex: .*(^|,)(204)($|,).*
-        metric: max by(_id) (sum_over_time(system_cpu_logical_count[1h:10m])) / scalar(count_over_time(vector(1)[1h:10m]))
+        productLabelRegex: .*(^|,)(204)($|,).* # this regex is used to fetch metrics for the product label that contains the product/engineering ID 204. the number here needs to map to a tag defined in the variant section of this file
+        metric: max by(_id) (sum_over_time(system_cpu_logical_count[1h:10m])) / scalar(count_over_time(vector(1)[1h:10m])) #To be replaced with recording rule in SWATCH-2075
         instanceKey: _id

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
@@ -12,8 +12,6 @@ variants:
       - 204
     productNames:
       - RHEL Server
-    roles:
-      - rhel-for-x86-els-payg-placeholder-role
 
 defaults:
   variant: rhel-for-x86-els-payg
@@ -29,9 +27,8 @@ metrics:
     awsDimension: vCPU_hours
     azureDimension: vcpu_hours
     prometheus:
-      queryKey: default
+      queryKey: rhelemeter
       queryParams:
+        productLabelRegex: .*(^|,)(204)($|,).*
+        metric: max by(_id) (sum_over_time(system_cpu_logical_count[1h:10m])) / scalar(count_over_time(vector(1)[1h:10m]))
         instanceKey: _id
-        product: Red Hat Enterprise Linux Server #Probably will be updated by SWATCH-1834, since this is usually populated by role
-        metric: system_cpu_logical_count
-        metadataMetric: system_cpu_logical_count


### PR DESCRIPTION
Jira issue: SWATCH-1924

**Context**
Getting creative with how we can detect these RHEL payg products with rhelemeter, since the role available on the hosts isn't unique enough to differentiate between different variants.

This change enables hosts to report a list of comma-separated engineering Ids in its "product" label. We'll detect comma-separated engineering Ids and set the swatch event.productIds field accordingly.

During hourly tally, we already match events to swatch subscription definitions by using event.role or event.productIds anyway.

# summary

## promql query changes
Introduced a new promql query template.  There's a couple of differences than the default template
* removes "metadataMetric" parameter
* adds "productLabelRegex" parameter.
* removes instanceKey parameter (note that instanceKey still needs to be defined on the product config files because it's being used programmatically elsewhere)

The rhel-for-x86-els-payg product configuration yaml has the regex defined as any comma-separated list that includes "204".

## Event message updates
Leverage changes made in #2844 and populate `productTag` field when emitting a metric Event on the service instance topic.  This is a little redundant, because the ingestion of metric Events (takes place in swatch-tally) looks up the productTag based on productIds & role and will re-set the value.  There's room for improvement here to potentially stop looking up productTag if an Event has a productTag set in the payload already. 

Populate `productIds` field when emitting a metric Event on the service instance topic.  The value comes from the prometheus response in the "product" payload.  As previously mentioned, during Event ingestion there's a productTag lookup.  Since there isn't a role that corresponds to rhel-for-x86-els-payg, that productTag can only be resolved by having productIds present.

## misc

While working on these changes, I encountered an issue with the timeframes that recording rules are evaluated.  There are non-trivial updates required for this, as detailed in SWATCH-2075.  As a workaround, I've set the `metric` field in the product config file to use the expression that backs the recording rule.  This workaround is to enable testing, and isn't a long-term solution.  We ultimately don't want to be attempting to maintain usage queries that are defined/crafted/owned by other product teams.


# expected behavior
* a POST request to `/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg` successfully retrieves data from rhelemeter
* swatch-metrics (or swatch-metrics-rhel if you're in EE) emits Event messages for the metrics returned from rhelemeter
* swatch-tally successfully consumes those message, resulting in entries in the rhsm-subscriptions.events database table
* a PUT request to `/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots` should result in snapshots

# test steps

these are written for local, but similar approach should work in ephemeral by port forwarding pods.  token refresher will already be attached to the swatch-metrics-rhel pod.

### 1. start up a token-refresher for stage rhelemeter

Secrets can be found in vault under _secrets/insights-stage/rhsm-stage/rhel-token-refresher_

```
podman run --name=token-refresher-$1 --rm -ti -p 8082:8080 \
  quay.io/observatorium/token-refresher:master-2023-09-20-f5e3403 \
  --scope="$SCOPE" \
  --oidc.client-secret="$CLIENT_SECRET" \
  --oidc.client-id="$CLIENT_ID" \
  --oidc.issuer-url="$ISSUER_URL" \
  --url="https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/rhel"
  ```

### 2. start up swatch-metrics-rhel
```bash
EVENT_SOURCE=rhelemeter PROM_URL="http://localhost:8082/api/v1/" ./gradlew :swatch-metrics:quarkusDev
```
### 3. kick off metering for test org
```bash
curl -X POST --location "http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=16787820" \
    -d 'accept: */*
x-rh-swatch-synchronous-request: false'
```

if you're running this at DEBUG log level, you should see some log statements containing details about the range query being done against prometheus - promql, step, and start/end ranges.

### 4. inspect `platform.rhsm-subscriptions.service-instance-ingress` topic to verify presence of metric data with appropriate fields set

### 5. start up swatch-tally and verify it consumes the messages
`SERVER_PORT=8001 DEV_MODE=true ./gradlew :bootRun`

you should see messages getting consumed after it starts up.

after the events are consumed, check the `data` column in the `events` table that the information from the Event message persisted properly (had issues at one point with productTag getting blown away before persisting)

### 6. kick off hourly tally
will have to adjust based on timestamps you're doing this

```
curl -X 'PUT' \
'http://localhost:8001/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots?begin=2024-01-08T19%3A00%3A00Z&end=2024-01-08T23%3A00%3A00Z' \
-H 'accept: application/json' \
-H 'x-rh-swatch-psk: placeholder'
```