### PR TITLE
Add example payload to openapi spec for POST /internal/subscription

### DIFF
--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -42,6 +42,33 @@ paths:
           application/json:
             schema:
               type: string
+            examples:
+              subscription:
+                "value": [
+                  {
+                    "id": "000149",
+                    "subscriptionNumber": "8838431",
+                    "subscriptionProducts": [
+                      {
+                        "sku": "MCT4121HR"
+                      }
+                    ],
+                    "webCustomerId": "14541308",
+                    "quantity": 1,
+                    "oracleAccountNumber": "",
+                    "effectiveStartDate": 1697847432103,
+                    "effectiveEndDate": 1730247432103,
+                    "externalReferences": {
+                      "awsMarketplace": {
+                        "subscriptionID": "100",
+                        "customerID": 102,
+                        "productCode": "testProductCode",
+                        "sellerAccount": "1234567",
+                        "customerAccountID": 102
+                      }
+                    }
+                  }
+                ]
       responses:
         '200':
           description: Save a list of subscriptions
@@ -49,6 +76,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SubscriptionResponse"
+              examples:
+                success:
+                  value: {
+                    "detail": "Success"
+                  }
+
         '400':
           $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
         '403':


### PR DESCRIPTION
swagger ui just showed "string" as the example, since it's not defined by a schema.  we programatically map the string to another openapi generated "Subscription" object.  We should change that eventually, but in the meantime I added an example payload.  I pulled the example out of a PR comment - https://github.com/RedHatInsights/rhsm-subscriptions/pull/2641#pullrequestreview-1705980261 

Also marking `reconcileCapacity` queryParam as required so swagger-ui makes you set it, otherwise you'll get a NPE in the logs


Verification
- on main branch, see that http://localhost:8000/api/swatch-subscription-sync/internal/swagger-ui/index.html#/internalSubscriptions/saveSubscriptions just had "string"
- on this branch, see that there's an example payload that should actually POST successfully once you set the the `x-rh-swatch-psk` header to `placeholder`