### PR TITLE
SWATCH-2006, SWATCH-2008: openapi definition for getAzureMarketplaceContext

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -39,6 +39,7 @@ import org.candlepin.subscriptions.subscription.SubscriptionPruneController;
 import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
 import org.candlepin.subscriptions.utilization.admin.api.InternalApi;
 import org.candlepin.subscriptions.utilization.admin.api.model.AwsUsageContext;
+import org.candlepin.subscriptions.utilization.admin.api.model.AzureUsageContext;
 import org.candlepin.subscriptions.utilization.admin.api.model.DefaultResponse;
 import org.candlepin.subscriptions.utilization.admin.api.model.Metric;
 import org.candlepin.subscriptions.utilization.admin.api.model.OfferingProductTags;
@@ -194,6 +195,25 @@ public class InternalSubscriptionResource implements InternalApi {
         .getSubscription(orgId, productId, sla, usage, awsAccountId, date)
         .map(this::buildAwsUsageContext)
         .orElseThrow();
+  }
+
+  @Override
+  public AzureUsageContext getAzureMarketplaceContext(
+      @jakarta.validation.constraints.NotNull String orgId,
+      @jakarta.validation.constraints.NotNull OffsetDateTime date,
+      @jakarta.validation.constraints.NotNull String productId,
+      String sla,
+      String usage,
+      String azureAccountId) {
+
+    var context = new AzureUsageContext();
+
+    context.setAzureResourceId("hardcodedAzureResourceId");
+    context.setAzureTenantId("hardcodedAzureTenantId");
+    context.setOfferId("hardcodedOfferId");
+    context.setPlanId("hardcodedPlanId");
+
+    return context;
   }
 
   @Override

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -272,6 +272,69 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalSubscriptions
+
+  /internal/subscriptions/azureUsageContext:
+    get:
+      operationId: getAzureMarketplaceContext
+      summary: Lookup necessary info to submit a usage record to Azure
+      tags:
+        - internalSubscriptions
+      parameters:
+        - name: orgId
+          description: 'Look at subscriptions for this orgId'
+          example: org123
+          schema:
+            type: string
+          in: query
+          required: true
+        - name: date
+          description: 'Look at subscriptions starting on this date'
+          example: 2023-10-31T00:00:00Z
+          schema:
+            format: date-time
+            type: string
+          in: query
+          required: true
+        - name: productId
+          description: 'This value should correspond to a product variant tag as defined in swatch product configuration'
+          example: rhel-for-x86-els-payg
+          schema:
+            type: string
+          in: query
+          required: true
+        - name: sla
+          description: 'Look at subscriptions matching this SLA'
+          example: Premium
+          schema:
+            type: string
+          in: query
+        - name: usage
+          description: 'Look at subscriptions matching this usage'
+          example: Production
+          schema:
+            type: string
+          in: query
+        - name: billingAccountId
+          description: 'Look at subscriptions matching this billing_account_id'
+          schema:
+            type: string
+          in: query
+          required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AzureUsageContext'
+          description: Found Azure usage context matching the criteria.
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '403':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
   /internal/offerings/{sku}/product_tags:
     description: "Mapping sku to product tags."
     parameters:
@@ -483,6 +546,25 @@ components:
         subscriptionStartDate:
           type: string
           format: date-time
+    AzureUsageContext:
+      description: Encapsulates all data needed to map tally snapshot usage to Azure UsageRecords.
+      properties:
+        azureResourceId:
+          description: IT Partner gateway will pass it under "cloudIdentifiers".  UMB messages under purchase.resourceId
+          type: string
+          example: 10d3a42f-cad5-4b55-8cd7-1569edf07a4d
+        azureTenantId:
+          description: IT Partner gateway will pass it under "cloudIdentifiers".  UMB messages under partnerIdentities.azureTenantId
+          type: string
+          example: 18087458-3905-4dea-80a4-758d69b7d2c5
+        offerId:
+          description: IT Partner gateway will pass it under "cloudIdentifiers".  UMB messages under purchase.vendorProductCode
+          type: string
+          example: azureProductCode
+        planId:
+          description: IT Partner gateway will pass it under "cloudIdentifiers".  UMB messages under contracts.planId
+          type: string
+          example: rh-rhel-sub-1yr
     OfferingProductTags:
       properties:
         data:


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2008

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Getting the openapi changes for the SWATCH-2006 story to enable testability.  Added corresponding stub method to the resource class.  It will return hardcoded values until SWATCH-2006 is implemented

**_Verification_**


`DEV_MODE=true RHSM_USE_STUB=true ./gradlew :bootRun` (or if deploying to EE, port forward the swatch-subscrpition-sync pod)

Navigate to: http://localhost:8000/api/swatch-subscription-sync/internal/swagger-ui/index.html#/internalSubscriptions/getAzureMarketplaceContext


Check api responds with current hardcoded values
```
http :8000/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext \
  accept:application/json \
  x-rh-swatch-psk:placeholder \
  "orgId==org123" \
  "date==2023-10-31T00:00:00Z" \
  "productId==rhel-for-x86-els-payg" \
  "sla==Premium" \
  "usage==Production"
```
```json
{
    "azureResourceId": "hardcodedAzureResourceId",
    "azureTenantId": "hardcodedAzureTenantId",
    "offerId": "hardcodedOfferId",
    "planId": "hardcodedPlanId"
}
```


