### PR TITLE
SWATCH-470: Internal subscriptions sync org rest api should return json

### DIFF
--- a/buildSrc/src/main/groovy/swatch.quarkus-rest-client-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.quarkus-rest-client-conventions.gradle
@@ -45,6 +45,7 @@ openApiGenerate {
 dependencies {
     implementation enforcedPlatform(libraries["quarkus-bom"])
     api 'io.quarkus:quarkus-rest-client-reactive-jackson'
+    api libraries["jackson-databind-nullable"]
     testImplementation 'io.rest-assured:rest-assured'
 }
 

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -40,15 +40,14 @@ import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
 import org.candlepin.subscriptions.utilization.admin.api.InternalApi;
 import org.candlepin.subscriptions.utilization.admin.api.model.AwsUsageContext;
 import org.candlepin.subscriptions.utilization.admin.api.model.AzureUsageContext;
-import org.candlepin.subscriptions.utilization.admin.api.model.DefaultResponse;
 import org.candlepin.subscriptions.utilization.admin.api.model.Metric;
 import org.candlepin.subscriptions.utilization.admin.api.model.OfferingProductTags;
 import org.candlepin.subscriptions.utilization.admin.api.model.OfferingResponse;
 import org.candlepin.subscriptions.utilization.admin.api.model.RhmUsageContext;
+import org.candlepin.subscriptions.utilization.admin.api.model.RpcResponse;
 import org.candlepin.subscriptions.utilization.admin.api.model.SubscriptionResponse;
 import org.candlepin.subscriptions.utilization.admin.api.model.TerminationRequest;
 import org.candlepin.subscriptions.utilization.admin.api.model.TerminationRequestData;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -57,6 +56,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class InternalSubscriptionResource implements InternalApi {
 
+  public static final String FEATURE_NOT_ENABLED_MESSAGE = "This feature is not currently enabled.";
   private static final String SUCCESS_STATUS = "Success";
 
   private final SubscriptionSyncController subscriptionSyncController;
@@ -70,9 +70,6 @@ public class InternalSubscriptionResource implements InternalApi {
   private final MetricMapper metricMapper;
 
   private final ApplicationProperties applicationProperties;
-
-  public static final String FEATURE_NOT_ENABLED_MESSSAGE =
-      "This feature is not currently enabled.";
 
   @Autowired
   public InternalSubscriptionResource(
@@ -118,7 +115,7 @@ public class InternalSubscriptionResource implements InternalApi {
       Boolean reconcileCapacity, String subscriptionsJson) {
     var response = new SubscriptionResponse();
     if (!properties.isDevMode() && !properties.isManualSubscriptionEditingEnabled()) {
-      response.setDetail(FEATURE_NOT_ENABLED_MESSSAGE);
+      response.setDetail(FEATURE_NOT_ENABLED_MESSAGE);
       return response;
     }
     try {
@@ -135,17 +132,19 @@ public class InternalSubscriptionResource implements InternalApi {
 
   /** Enqueue all sync-enabled orgs to sync their subscriptions with upstream. */
   @Override
-  public DefaultResponse syncAllSubscriptions(Boolean forceSync) {
+  public RpcResponse syncAllSubscriptions(Boolean forceSync) {
+    var response = new RpcResponse();
     if (Boolean.FALSE.equals(forceSync) && !applicationProperties.isSubscriptionSyncEnabled()) {
       log.info(
           "Will not sync subscriptions for all opted-in orgs even though job was scheduled because subscriptionSyncEnabled=false.");
-      return getDefaultResponse(FEATURE_NOT_ENABLED_MESSSAGE);
+      response.setResult(FEATURE_NOT_ENABLED_MESSAGE);
+      return response;
     }
 
     Object principal = ResourceUtils.getPrincipal();
     log.info("Sync for all sync enabled orgs triggered by {}", principal);
     subscriptionSyncController.syncAllSubscriptionsForAllOrgs();
-    return getDefaultResponse(SUCCESS_STATUS);
+    return response;
   }
 
   @Override
@@ -156,11 +155,11 @@ public class InternalSubscriptionResource implements InternalApi {
 
   /** Remove subscription and capacity records that are in the denylist */
   @Override
-  public DefaultResponse pruneUnlistedSubscriptions() {
+  public RpcResponse pruneUnlistedSubscriptions() {
     Object principal = ResourceUtils.getPrincipal();
     log.info("Prune of unlisted subscriptions triggered by {}", principal);
     subscriptionPruneController.pruneAllUnlistedSubscriptions();
-    return getDefaultResponse(SUCCESS_STATUS);
+    return new RpcResponse();
   }
 
   @Override
@@ -315,12 +314,5 @@ public class InternalSubscriptionResource implements InternalApi {
       throw new NotFoundException(
           "Subscription " + subscriptionId + " either does not exist or is already terminated");
     }
-  }
-
-  @NotNull
-  private DefaultResponse getDefaultResponse(String status) {
-    var response = new DefaultResponse();
-    response.setStatus(status);
-    return response;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -148,9 +148,9 @@ public class InternalSubscriptionResource implements InternalApi {
   }
 
   @Override
-  public String forceSyncSubscriptionsForOrg(String orgId) {
+  public RpcResponse forceSyncSubscriptionsForOrg(String orgId) {
     subscriptionSyncController.forceSyncSubscriptionsForOrgAsync(orgId);
-    return "Sync started.";
+    return new RpcResponse();
   }
 
   /** Remove subscription and capacity records that are in the denylist */

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -134,13 +134,12 @@ paths:
       tags:
         - internalSubscriptions
       responses:
-        '202':
-          description: "The request for syncing organization's subscription is processing."
+        '200':
+          description: The request for syncing a single organization's subscription is processing.
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: Sync started.
+                $ref: "#/components/schemas/RpcResponse"
         '400':
           $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
         '403':

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -110,7 +110,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DefaultResponse"
+                $ref: "#/components/schemas/RpcResponse"
         '400':
           $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
@@ -162,7 +162,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DefaultResponse"
+                $ref: "#/components/schemas/RpcResponse"
         '400':
           $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
         '403':
@@ -587,10 +587,10 @@ components:
           properties:
             termination_message:
               type: string
-    DefaultResponse:
+    RpcResponse:
       properties:
-        status:
-          type: string
+        result:
+          description: Result of the operation. Empty when succeeded.
     SubscriptionResponse:
       properties:
         detail:

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -52,6 +52,7 @@ import org.candlepin.subscriptions.subscription.SubscriptionPruneController;
 import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
 import org.candlepin.subscriptions.utilization.admin.api.model.AwsUsageContext;
 import org.candlepin.subscriptions.utilization.admin.api.model.RhmUsageContext;
+import org.candlepin.subscriptions.utilization.admin.api.model.RpcResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -101,7 +102,7 @@ class InternalSubscriptionResourceTest {
 
   @Test
   void forceSyncForOrgShouldReturnSuccess() {
-    assertEquals("Sync started.", resource.forceSyncSubscriptionsForOrg("123"));
+    assertEquals(new RpcResponse(), resource.forceSyncSubscriptionsForOrg("123"));
   }
 
   @Test


### PR DESCRIPTION
Jira issue: [SWATCH-470](https://issues.redhat.com/browse/SWATCH-470)

## Description
- Rename DefaultResponse to RpcResponse
- Remove status field
- Add result field w/ type "any" (don't specify the type param in spec).
- Document for "result" field, may be null (if unneeded). 

## Testing
Regression testing only. If there are tests that expect the old format ("Sync started. "), then these tests are to be updated to expect the JSON format (to check if the result was 200 OK).