### PR TITLE
SWATCH-2009: Fix round issue when dealing with double numbers

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/UsageCalculationTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import static com.redhat.swatch.configuration.util.MetricIdUtils.getCores;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertHardwareMeasurementTotals;
 import static org.candlepin.subscriptions.tally.collector.Assertions.assertNullExcept;
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,6 +51,22 @@ class UsageCalculationTest {
 
     assertHardwareMeasurementTotals(calculation, HardwareMeasurementType.TOTAL, 15, 20, 10);
     assertNullExcept(calculation, HardwareMeasurementType.TOTAL);
+  }
+
+  /**
+   * Added this test case due to a bug we've seen with doubles being rounded. More information in <a
+   * href="https://issues.redhat.com/browse/SWATCH-2009">SWATCH-2009</a>.
+   */
+  @Test
+  void testAddToTotalShouldRoundDoubleValues() {
+    UsageCalculation calculation = new UsageCalculation(createUsageKey("Product"));
+    calculation.addToTotal(getCores(), 2.9);
+    calculation.addToTotal(getCores(), 3.0);
+    calculation.addToTotal(getCores(), 2.3);
+    calculation.addToTotal(getCores(), 1.4);
+    calculation.addToTotal(getCores(), 0.2);
+    assertEquals(
+        9.8, calculation.getTotals(HardwareMeasurementType.TOTAL).getMeasurement(getCores()));
   }
 
   @Test


### PR DESCRIPTION
Jira issue: [SWATCH-2009](https://issues.redhat.com/browse/SWATCH-2009)

## Description
When processing multiple events, we were seeing weird values in the "tally_measurements" table like "9.799999999999999". This issue was caused by manipulating double numbers (see this link for further information: https://floating-point-gui.de/).

To fix the issue, we should use the BigDecimal class to accumulate the values in the UsageCalculation. 

## Testing
Only regression testing is needed. JUnit tests have been added. 