### PR TITLE
SWATCH-2036: Update Contracts service configuration to configure the RBAC service

### DIFF
--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -69,6 +69,7 @@ objects:
       dependencies:
         - swatch-tally
         - swatch-subscription-sync
+        - rbac
 
       # Creates a database if local mode, or uses RDS in production
       # database:

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -122,8 +122,13 @@ quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.
 # rbac service configuration
 RBAC_ENABLED=true
 %dev.RBAC_ENABLED=false
-RBAC_ENDPOINT=${clowder.endpoints.rbac-service:http://localhost:8080}
+RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
+%dev.RBAC_ENDPOINT=http://localhost:8080
+%test.RBAC_ENDPOINT=http://localhost:8080
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT}/api/rbac/v1
+quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store=${clowder.endpoints.rbac-service.trust-store-path}
+quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-password=${clowder.endpoints.rbac-service.trust-store-password}
+quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-type=${clowder.endpoints.rbac-service.trust-store-type}
 
 # avoid duplicate/wrong enum names and other problems by preventing generated interfaces from being
 # added back into the API spec

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -148,6 +148,7 @@ objects:
     dependencies:
       - swatch-tally
       - swatch-subscription-sync
+      - rbac
 
     kafkaTopics:
       - replicas: ${{KAFKA_TALLY_REPLICAS}}

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -186,6 +186,7 @@ objects:
         sharedDbAppName: swatch-tally
       dependencies:
         - swatch-tally
+        - rbac
 
       # Creates a database if local mode, or uses RDS in production
       # database:


### PR DESCRIPTION
Jira issue: [SWATCH-2036](https://issues.redhat.com/browse/SWATCH-2036)

## Description
Add the `rbac` dependency in the services that use it:
1. swatch-contracts
2. swatch-subscription-sync
3. swatch-producer-red-hat-marketplace

For the services 2. and 3., the rbac URL was already properly configured.
For the service 1 (swatch-contracts), it was being configured like:

```
${clowder.endpoints.rbac-service:http://localhost:8080}
```

And there were two issues here:
- The clowder config does not support default values, 
- The new format needs to end with `.url`

The final configuration should be:

```
RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
%dev.RBAC_ENDPOINT=http://localhost:8080
%test.RBAC_ENDPOINT=http://localhost:8080
quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT:http://localhost:8080}/api/rbac/v1
```

## Testing

1.- Deploy the changes into the ephemeral environment
2.- Check the swatch contacts logs and confirm that the trace `Endpoint 'rbac-service' is using the old format. Please move to the new one: [Endpoint].[url|trust-store-path|trust-store-password|trust-store-type]` is gone