### PR TITLE
SWATCH-2035: Use same version for Quarkus BOM and Quarkus Gradle plugin

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,6 +12,7 @@ buildscript {
 }
 
 ext {
+    quarkusVersion='3.6.3'
     libraries = [:]
     plugins = []
 }
@@ -22,7 +23,7 @@ ext.plugins = [
         "com.adarshr:gradle-test-logger-plugin:4.0.0",
         "com.diffplug.spotless:spotless-plugin-gradle:6.23.3",
         "com.netflix.nebula:nebula-release-plugin:18.0.8",
-        "io.quarkus:gradle-application-plugin:3.6.3",
+        "io.quarkus:gradle-application-plugin:${quarkusVersion}",
         // swagger-parser manually upgraded for compatibility with snakeyaml 2.0
         // see https://github.com/OpenAPITools/openapi-generator/issues/15876
         "io.swagger.parser.v3:swagger-parser:2.1.19",
@@ -35,7 +36,7 @@ ext.plugins = [
 ]
 
 // BOMs
-libraries["quarkus-bom"] = "io.quarkus.platform:quarkus-bom:3.6.3"
+libraries["quarkus-bom"] = "io.quarkus.platform:quarkus-bom:${quarkusVersion}"
 libraries["spring-boot-dependencies"] = "org.springframework.boot:spring-boot-dependencies:3.1.6"
 
 // Individual libraries


### PR DESCRIPTION
Jira issue: [SWATCH-2035](https://issues.redhat.com/browse/SWATCH-2035)

## Description
This is the recommended approach after reading https://github.com/dependabot/dependabot-core/issues/2046.

## Testing
Regression testing only.