### PR TITLE
Add instructions to deploy OTEL exporter, RabbitMQ and Splunk locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@
 config/*
 !config/codestyle
 !config/kafka
+!config/otel
+!config/rabbitmq
 
 #VS Code
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ config/*
 !config/kafka
 !config/otel
 !config/rabbitmq
+!config/splunk
 
 #VS Code
 .project

--- a/README.md
+++ b/README.md
@@ -122,6 +122,38 @@ consumers:
 These changes are permanent, committed the next time the kafka consumer is detected
 as idle.
 
+### RabbitMQ
+
+Some services like swatch-contracts need an AMQ service to handle the UMB messages. 
+For these services, we can start RabbitMQ as an AMQ service locally via:
+
+```
+podman-compose -f config/rabbitmq/docker-compose.yml up -d
+```
+
+RabbitMQ will be listening on the port 5672.
+
+*NOTE*: Our services might be configured to listen on a different hostname and port. For example, 
+for the SWATCH contracts service, we need to provide the UMB_HOSTNAME and UMB_PORT to point out to RabbitMQ: 
+`java -DUMB_HOSTNAME=localhost -DUMB_PORT=5672 -jar swatch-contracts/build/quarkus-app/quarkus-run.jar`
+
+### Opentelemetry (OTEL) Exporter
+
+Some services export the logging traces to an externalize service via an exporter. 
+Exporters act like a broker to configure what to do with these traces. 
+For local development, we can start an OTEL exporter that simply log the traces into the container logs. 
+We can start it via:
+
+```
+podman-compose -f config/otel/docker-compose.yml up -d
+```
+
+The OTEL exporter will be listening for gRPC connections on port 4317.
+
+*NOTE*: Our services might be configured to listen on a different hostname and port. For example,
+for the SWATCH contracts service, we need to provide the OTEL_ENDPOINT property to point out to the 
+local otel exporter: `java -DOTEL_ENDPOINT=http://localhost:4317 -jar swatch-contracts/build/quarkus-app/quarkus-run.jar`
+
 ### Build and Run rhsm-subscriptions
 
 ```

--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ The OTEL exporter will be listening for gRPC connections on port 4317.
 for the SWATCH contracts service, we need to provide the OTEL_ENDPOINT property to point out to the 
 local otel exporter: `java -DOTEL_ENDPOINT=http://localhost:4317 -jar swatch-contracts/build/quarkus-app/quarkus-run.jar`
 
+### Splunk
+
+Some services integrate the log traces into Splunk. For these services, we can start Splunk via:
+
+```
+podman-compose -f config/splunk/docker-compose.yml up -d
+```
+
+Splunk will be listening on port 8088. 
+
+*NOTE*: We need to configure our services to work with this Splunk instance. For example,
+for the SWATCH contracts service, we need: 
+`java -DENABLE_SPLUNK_HEC=false -DSPLUNK_HEC_URL=https://localhost:8088 -DSPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 -DSWATCH_SELF_PSK=placeholder -DSPLUNK_DISABLE_CERTIFICATE_VALIDATION=true -jar swatch-contracts/build/quarkus-app/quarkus-run.jar`
+
 ### Build and Run rhsm-subscriptions
 
 ```

--- a/config/otel/collector-config.yaml
+++ b/config/otel/collector-config.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  logging:
+    loglevel: DEBUG
+
+extensions:
+  health_check:
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors:
+      exporters: [logging]

--- a/config/otel/docker-compose.yml
+++ b/config/otel/docker-compose.yml
@@ -1,0 +1,10 @@
+---
+version: '3.1'
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"   # OTLP gRPC receiver

--- a/config/rabbitmq/docker-compose.yml
+++ b/config/rabbitmq/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.1'
 services:
   rabbitmq:
-    image: rabbitmq
+    image: docker.io/library/rabbitmq
     ports:
       - "5672:5672"
     volumes:

--- a/config/rabbitmq/docker-compose.yml
+++ b/config/rabbitmq/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+version: '3.1'
+services:
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - "5672:5672"
+    volumes:
+      - ./rabbit_enabled_plugins:/etc/rabbitmq/enabled_plugins

--- a/config/rabbitmq/docker-compose.yml
+++ b/config/rabbitmq/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     ports:
       - "5672:5672"
     volumes:
-      - ./rabbit_enabled_plugins:/etc/rabbitmq/enabled_plugins
+      - ./rabbit_enabled_plugins:/etc/rabbitmq/enabled_plugins:z

--- a/config/rabbitmq/rabbit_enabled_plugins
+++ b/config/rabbitmq/rabbit_enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_amqp1_0, rabbitmq_management, rabbitmq_web_dispatch, rabbitmq_management_agent, rabbitmq_stomp].

--- a/config/splunk/docker-compose.yml
+++ b/config/splunk/docker-compose.yml
@@ -11,3 +11,6 @@ services:
       - SPLUNK_START_ARGS=--accept-license
       - SPLUNK_PASSWORD=admin123
       - SPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75
+      # workaround rootless selinux issues, see https://github.com/splunk/splunk-ansible/issues/607
+      security_opt:
+        - label=disable

--- a/config/splunk/docker-compose.yml
+++ b/config/splunk/docker-compose.yml
@@ -1,0 +1,13 @@
+---
+version: '3.1'
+services:
+  splunk:
+    image: splunk/splunk
+    ports:
+      - '8088:8088'
+      - '8089' # SPLUNK API
+      - '8000' # SPLUNK CONSOLE
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_PASSWORD=admin123
+      - SPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75

--- a/config/splunk/docker-compose.yml
+++ b/config/splunk/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.1'
 services:
   splunk:
-    image: splunk/splunk
+    image: docker.io/splunk/splunk
     ports:
       - '8088:8088'
       - '8089' # SPLUNK API

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -183,7 +183,8 @@ quarkus.otel.sdk.disabled=true
 %stage.quarkus.otel.sdk.disabled=false
 %prod.quarkus.otel.sdk.disabled=false
 
-quarkus.otel.exporter.otlp.endpoint=http://splunk-otel-collector:4317
+OTEL_ENDPOINT=http://splunk-otel-collector:4317
+quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT}
 
 # expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
 quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -87,6 +87,7 @@ quarkus.http.test-port=0
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
+quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}
 quarkus.log.handler.splunk.metadata-source=${SPLUNK_SOURCE:swatch-contracts}
 quarkus.log.handler.splunk.metadata-source-type=${SPLUNK_SOURCE_TYPE:quarkus_service}


### PR DESCRIPTION
Related to Jira issue: [SWATCH-2038](https://issues.redhat.com/browse/SWATCH-2038)

## Description
These changes allow us to test the remote logging export locally.
For example, for swatch-contracts, we would need to:
1.- Start kafka, db, ... via:

```
podman-compose up -d
```
2.- Start otel exporter:

```
podman-compose -f config/otel/docker-compose.yml up -d
```

3.- Start rabbitmq:

```
podman-compose -f config/rabbitmq/docker-compose.yml up -d
```

4.- Build swatch contracts:

```
./gradlew clean swatch-contracts:assemble -x test
```

5.- Start the swatch contracts service:

```
java -DSWATCH_SELF_PSK=placeholder -DENABLE_SPLUNK_HEC=false -DSWATCH_TEST_APIS_ENABLED=true -DRBAC_ENABLED=false -DUMB_HOSTNAME=localhost -DUMB_PORT=5672 -DOTEL_ENDPOINT=http://localhost:4317 -DRBAC_ENDPOINT=localhost:8080 -jar swatch-contracts/build/quarkus-app/quarkus-run.jar 
```

## Testing
No QE is needed here. 