### PR TITLE
SWATCH-2043: Print exceptions in swatch contract resources

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
@@ -22,16 +22,24 @@ package com.redhat.swatch.contract.resource;
 
 import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.openapi.model.Error;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Provider
 public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
 
+  @Context UriInfo info;
+
   @Override
   public Response toResponse(Exception exception) {
+    log.error(
+        "Request '{}' failed with error '{}'", info.getPath(), exception.getMessage(), exception);
     var status = Status.INTERNAL_SERVER_ERROR;
     return Response.status(status)
         .entity(


### PR DESCRIPTION
Jira issue: [SWATCH-2043](https://issues.redhat.com/browse/SWATCH-2043)

## Description
The root cause of this problem is that the DefaultExceptionMapper is capturing the exception to construct the client response, but won't log the exception. 

## Testing
- Throw an exception in any of the resources, for example, a null pointer exception when creating entitlement contracts:

```
@Override
  @RolesAllowed({"test"})
  public StatusResponse createPartnerEntitlementContract(PartnerEntitlementContract contract)
      throws ProcessingException {
    String s = null;
    s.toString(); // BOOM!
    return service.createPartnerContract(contract);
  }
```

- Start the swatch contracts service:

```
SWATCH_SELF_PSK=placeholder UMB_ENABLED=false RBAC_ENABLED=false ./gradlew :swatch-contracts:quarkusDev
```

- Try to create an entitlement contract:

```
curl -v -X POST   'http://localhost:8000/api/swatch-contracts/internal/rpc/partner/contracts'   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'   -H 'Content-Type: application/json'   -d '{
  "action": "contract-new",
  "redHatSubscriptionNumber": "123456",
  "currentDimensions":[
    {"dimensionName":"control_plane_0","dimensionValue":"730","expirationDate":"2024-11-29T23:59:59.999Z"},
    {"dimensionName":"four_vcpu_0","dimensionValue":"1460","expirationDate":"2024-11-29T23:59:59.999Z"}
  ],
  "cloudIdentifiers": {
    "awsCustomerId": "EK57ooq39qs",
    "awsCustomerAccountId": "568056954830",
    "productCode": "6n58d3s3qpvk22dgew2gal7w3"
  }
}'
```

The CURL command will return:

```
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> POST /api/swatch-contracts/internal/rpc/partner/contracts HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.0.1
> accept: application/json
> x-rh-swatch-psk: placeholder
> Content-Type: application/json
> Content-Length: 467
> 
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json;charset=UTF-8
< content-length: 121
< 
* Connection #0 to host localhost left intact
{"status":"500","code":"CONTRACTS5000","title":"Cannot invoke \"String.toString()\" because \"s\" is null","detail":null}
```

After these changes, we should now see the stacktrace in the application logs. 