### PR TITLE
SWATCH-2061: Get subscriptionNumber from partner api for azure contracts

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -38,9 +38,12 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.candlepin.clock.ApplicationClock;
+import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.db.HostTallyBucketRepository;
+import org.candlepin.subscriptions.db.model.AccountServiceInventory;
 import org.candlepin.subscriptions.db.model.EventRecord;
+import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.inventory.db.InventoryRepository;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
@@ -82,6 +85,7 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
   @Autowired EventRecordRepository eventRecordRepository;
   @Autowired OptInResource optInResource;
   @Autowired HostTallyBucketRepository hostTallyBucketRepository;
+  @Autowired AccountServiceInventoryRepository accountServiceInventoryRepository;
 
   @MockBean(answer = Answers.CALLS_REAL_METHODS)
   InventoryRepository inventoryRepository;
@@ -100,7 +104,8 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
   void testProduceHourlySnapshotsForOrgFromEvents() {
     givenOrgAndAccountInConfig();
     givenFiveDaysOfRangeForReport();
-
+    // prevent retally
+    givenExistingHostInformation();
     givenEventAtDay(1, 78.4390);
     givenEventAtDay(3, 89.716);
 
@@ -158,6 +163,18 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
 
   private void givenOrgAndAccountInConfig() {
     optInResource.putOptInConfig();
+  }
+
+  private void givenExistingHostInformation() {
+    var host = new Host();
+    host.setOrgId(ORG_ID);
+    host.setInstanceId("1c474d4e-c277-472c-94ab-8229a40417eb");
+    host.setDisplayName("name");
+    host.setInstanceType("rosa Instance");
+    host.setLastSeen(clock.startOfCurrentMonth().minusMonths(1));
+    AccountServiceInventory service = new AccountServiceInventory(ORG_ID, "rosa Instance");
+    service.getServiceInstances().put(host.getInstanceId(), host);
+    accountServiceInventoryRepository.save(service);
   }
 
   private void givenEventAtDay(int dayAt, double value) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -156,13 +156,11 @@ public interface ContractMapper {
 
   @Named("rhSubscriptionNumber")
   default String getRhSubscriptionNumber(List<RhEntitlementV1> rhEntitlements) {
-    if (Objects.nonNull(rhEntitlements)
-        && !rhEntitlements.isEmpty()
-        && Objects.nonNull(rhEntitlements.get(0))) {
-      return rhEntitlements.get(0).getSubscriptionNumber();
-    } else {
-      return null;
-    }
+    return Objects.nonNull(rhEntitlements)
+            && !rhEntitlements.isEmpty()
+            && Objects.nonNull(rhEntitlements.get(0))
+        ? rhEntitlements.get(0).getSubscriptionNumber()
+        : null;
   }
 
   Set<ContractMetricEntity> dimensionV1ToContractMetricEntity(Set<DimensionV1> dimension);

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -85,7 +85,7 @@ public interface ContractMapper {
   @Named("billingProviderId")
   default String extractBillingProviderId(PartnerEntitlementContractCloudIdentifiers code) {
     String providerId = null;
-    if ("azure_marketplace".equals(code.getPartner())) {
+    if (Objects.equals("azure_marketplace", code.getPartner())) {
       providerId =
           String.format(
               "%s;%s;%s", code.getAzureResourceId(), code.getPlanId(), code.getAzureOfferId());
@@ -149,6 +149,17 @@ public interface ContractMapper {
         && !rhEntitlements.isEmpty()
         && Objects.nonNull(rhEntitlements.get(0))) {
       return rhEntitlements.get(0).getSku();
+    } else {
+      return null;
+    }
+  }
+
+  @Named("rhSubscriptionNumber")
+  default String getRhSubscriptionNumber(List<RhEntitlementV1> rhEntitlements) {
+    if (Objects.nonNull(rhEntitlements)
+        && !rhEntitlements.isEmpty()
+        && Objects.nonNull(rhEntitlements.get(0))) {
+      return rhEntitlements.get(0).getSubscriptionNumber();
     } else {
       return null;
     }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -384,8 +384,7 @@ public class ContractService {
   }
 
   private boolean validAzureEntitlementContract(PartnerEntitlementContract contract) {
-    return Objects.nonNull(contract.getRedHatSubscriptionNumber())
-        && Objects.nonNull(contract.getCloudIdentifiers())
+    return Objects.nonNull(contract.getCloudIdentifiers())
         && Objects.nonNull(contract.getCloudIdentifiers().getAzureResourceId())
         && Objects.nonNull(contract.getCloudIdentifiers().getAzureOfferId());
   }
@@ -575,6 +574,10 @@ public class ContractService {
               .flatMap(contract -> contract.getDimensions().stream())
               .collect(Collectors.toSet());
       entity.setMetrics(mapper.dimensionV1ToContractMetricEntity(dimensionV1s));
+      if (Objects.isNull(entity.getSubscriptionNumber())) {
+        entity.setSubscriptionNumber(
+            mapper.getRhSubscriptionNumber(entitlement.getRhEntitlements()));
+      }
       populateProductIdBySku(entity);
     }
   }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -243,6 +243,14 @@ class ContractServiceTest extends BaseUnitTest {
   }
 
   @Test
+  void testCreateAzureContractMissingRHSubscriptionId() throws Exception {
+    var contract = givenAzurePartnerEntitlementContract();
+    mockPartnerApi();
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+    assertEquals("New contract created", statusResponse.getMessage());
+  }
+
+  @Test
   void testCreatePartnerContractCreatesCorrectBillingProviderId() throws Exception {
     var contract = new PartnerEntitlementContract();
     contract.setRedHatSubscriptionNumber("subnum");
@@ -309,6 +317,20 @@ class ContractServiceTest extends BaseUnitTest {
     cloudIdentifiers.setAwsCustomerAccountId("568056954830");
     cloudIdentifiers.setProductCode("product123");
     contract.setCloudIdentifiers(cloudIdentifiers);
+    return contract;
+  }
+
+  private static PartnerEntitlementContract givenAzurePartnerEntitlementContract() {
+    var contract = new PartnerEntitlementContract();
+    contract.setCurrentDimensions(
+        List.of(new Dimension().dimensionName("vCPU").dimensionValue("4")));
+    contract.setCloudIdentifiers(
+        new PartnerEntitlementContractCloudIdentifiers()
+            .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
+            .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
+            .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
+            .azureOfferId("azureProductCode")
+            .planId("rh-rhel-sub-1yr"));
     return contract;
   }
 
@@ -383,7 +405,8 @@ class ContractServiceTest extends BaseUnitTest {
                     .azureSubscriptionId("fa650050-dedd-4958-b901-d8e5118c0a5f")
                     .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
                     .azureCustomerId("eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31"))
-            .rhEntitlements(List.of(new RhEntitlementV1().sku("MCT4249")))
+            .rhEntitlements(
+                List.of(new RhEntitlementV1().sku("MCT4249").subscriptionNumber("testSubId")))
             .purchase(
                 new PurchaseV1()
                     .vendorProductCode("azureProductCode")


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2061

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

"contract-updated" UMB messages will not contain the subscription number on azure contracts so we need to grab it from partner api.

## Testing
[swatch-2061-test-steps.txt](https://github.com/RedHatInsights/rhsm-subscriptions/files/13812083/swatch-2061-test-steps.txt)
