### PR TITLE
Fix broken metering-promql.py script

### DIFF
--- a/bin/metering-promql.py
+++ b/bin/metering-promql.py
@@ -23,12 +23,6 @@ parser.add_argument("--metric", help="Limit to a specific metric")
 parser.add_argument("--org", help="Limit metric queries to a specific org")
 args = parser.parse_args()
 
-with open("src/main/resources/application.yaml") as config_file:
-    config = yaml.safe_load(config_file)
-    account_query_templates = config["rhsm-subscriptions"]["metering"]["prometheus"][
-        "metric"
-    ]["accountQueryTemplates"]
-
 with open(
     "swatch-metrics/src/main/resources/application.yaml"
 ) as config_file:
@@ -36,6 +30,9 @@ with open(
     query_templates = config["rhsm-subscriptions"]["metering"]["prometheus"]["metric"][
         "queryTemplates"
     ]
+    account_query_templates = config["rhsm-subscriptions"]["metering"]["prometheus"][
+        "metric"
+    ]["accountQueryTemplates"]
 
 
 def promql(template, query_params):


### PR DESCRIPTION
This script broke after all the query template app properties got consolidated when swatch-metrics got carved out of the monolith

### Verification
Before the change

```
 ./bin/metering-promql.py --product rhel-for-x86-els-payg --org 16787820
```
```
Traceback (most recent call last):
  File "/home/lburnett/code/rhsm-subscriptions/./bin/metering-promql.py", line 28, in <module>
    account_query_templates = config["rhsm-subscriptions"]["metering"]["prometheus"][
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'metering'
```

After the change
```
./bin/metering-promql.py --product rhel-for-x86-els-payg --org 16787820
```
```
rhel-for-x86-els-payg
---------------------
  Accounts PromQL: group(min_over_time(system_cpu_logical_count{product='Red Hat Enterprise Linux Server', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)
  vCPUs PromQL: max(system_cpu_logical_count) by (_id) * on(_id) group_right min_over_time(system_cpu_logical_count{product="Red Hat Enterprise Linux Server", external_organization="16787820", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
```