### PR TITLE
SWATCH-2074: save dimension from umb message

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -69,6 +69,7 @@ public interface ContractMapper {
       target = "vendorProductCode",
       source = "cloudIdentifiers",
       qualifiedByName = "vendorProductCode")
+  @Mapping(target = "metrics", source = "currentDimensions")
   @BeanMapping(ignoreByDefault = true)
   ContractEntity partnerContractToContractEntity(PartnerEntitlementContract contract);
 
@@ -117,19 +118,9 @@ public interface ContractMapper {
     return BillingProvider.fromString(value);
   }
 
-  default Set<ContractMetricEntity> dimensionToContractMetricEntity(List<Dimension> dimensions) {
-    if (Objects.isNull(dimensions)) {
-      return new HashSet<>();
-    }
-    return dimensions.stream()
-        .map(
-            dimension ->
-                ContractMetricEntity.builder()
-                    .metricId(dimension.getDimensionName())
-                    .value(Double.valueOf(dimension.getDimensionValue()))
-                    .build())
-        .collect(Collectors.toSet());
-  }
+  @Mapping(target = "metricId", source = "dimension.dimensionName")
+  @Mapping(target = "value", source = "dimension.dimensionValue")
+  ContractMetricEntity umbDimentionToEntityDimension(Dimension dimension);
 
   @Mapping(target = "orgId", source = "entitlement.rhAccountId")
   @Mapping(target = "billingAccountId", source = "entitlement.partnerIdentities")

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -35,9 +35,11 @@ import com.redhat.swatch.contract.repository.ContractMetricEntity;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.repository.SubscriptionMeasurementEntity;
 import com.redhat.swatch.contract.repository.SubscriptionProductIdEntity;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Builder;
 import org.mapstruct.CollectionMappingStrategy;
@@ -115,11 +117,19 @@ public interface ContractMapper {
     return BillingProvider.fromString(value);
   }
 
-  @Mapping(target = "metricId", source = "dimension.dimensionName")
-  @Mapping(target = "value", source = "dimension.dimensionValue")
-  @Mapping(target = "contract", ignore = true)
-  @Mapping(target = "contractUuid", ignore = true)
-  ContractMetricEntity dimensionToContractMetricEntity(Dimension dimension);
+  default Set<ContractMetricEntity> dimensionToContractMetricEntity(List<Dimension> dimensions) {
+    if (Objects.isNull(dimensions)) {
+      return new HashSet<>();
+    }
+    return dimensions.stream()
+        .map(
+            dimension ->
+                ContractMetricEntity.builder()
+                    .metricId(dimension.getDimensionName())
+                    .value(Double.valueOf(dimension.getDimensionValue()))
+                    .build())
+        .collect(Collectors.toSet());
+  }
 
   @Mapping(target = "orgId", source = "entitlement.rhAccountId")
   @Mapping(target = "billingAccountId", source = "entitlement.partnerIdentities")

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -35,11 +35,9 @@ import com.redhat.swatch.contract.repository.ContractMetricEntity;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.repository.SubscriptionMeasurementEntity;
 import com.redhat.swatch.contract.repository.SubscriptionProductIdEntity;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Builder;
 import org.mapstruct.CollectionMappingStrategy;
@@ -120,7 +118,7 @@ public interface ContractMapper {
 
   @Mapping(target = "metricId", source = "dimension.dimensionName")
   @Mapping(target = "value", source = "dimension.dimensionValue")
-  ContractMetricEntity umbDimentionToEntityDimension(Dimension dimension);
+  ContractMetricEntity umbDimensionToEntityDimension(Dimension dimension);
 
   @Mapping(target = "orgId", source = "entitlement.rhAccountId")
   @Mapping(target = "billingAccountId", source = "entitlement.partnerIdentities")

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
@@ -103,6 +103,10 @@ public class ContractEntity extends PanacheEntityBase {
       mappedBy = "contract")
   private Set<ContractMetricEntity> metrics = new HashSet<>();
 
+  public void addMetrics(Set<ContractMetricEntity> metrics) {
+    metrics.forEach(this::addMetric);
+  }
+
   public void addMetric(ContractMetricEntity metric) {
     metrics.add(metric);
     metric.setContract(this);

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -243,7 +243,7 @@ public class ContractService {
             "Duplicate contract found that matches the record for uuid {}",
             existingContract.getUuid());
         statusResponse.setMessage("Duplicate record found");
-        statusResponse.setStatus(SUCCESS_MESSAGE);
+        statusResponse.setStatus(FAILURE_MESSAGE);
       } else {
         // Record found in contract table but, the contract has changed
         var now = OffsetDateTime.now();
@@ -262,6 +262,7 @@ public class ContractService {
       persistSubscription(createSubscriptionForContract(entity, billingProviderId, true), now);
       persistContract(entity, now);
       statusResponse.setMessage("New contract created");
+      statusResponse.setStatus(SUCCESS_MESSAGE);
     }
 
     return statusResponse;

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -212,7 +212,6 @@ public class ContractService {
     try {
       // Fill up information from upstream and swatch
       entity = mapper.partnerContractToContractEntity(contract);
-      entity.setMetrics(mapper.dimensionToContractMetricEntity(contract.getCurrentDimensions()));
       collectMissingUpStreamContractDetails(entity, contract);
       billingProviderId = mapper.extractBillingProviderId(contract.getCloudIdentifiers());
       if (!isValidEntity(entity)) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -212,6 +212,7 @@ public class ContractService {
     try {
       // Fill up information from upstream and swatch
       entity = mapper.partnerContractToContractEntity(contract);
+      entity.setMetrics(mapper.dimensionToContractMetricEntity(contract.getCurrentDimensions()));
       collectMissingUpStreamContractDetails(entity, contract);
       billingProviderId = mapper.extractBillingProviderId(contract.getCloudIdentifiers());
       if (!isValidEntity(entity)) {
@@ -573,12 +574,14 @@ public class ContractService {
               .filter(contract -> Objects.isNull(contract.getEndDate()))
               .flatMap(contract -> contract.getDimensions().stream())
               .collect(Collectors.toSet());
-      entity.setMetrics(mapper.dimensionV1ToContractMetricEntity(dimensionV1s));
+      entity.addMetrics(mapper.dimensionV1ToContractMetricEntity(dimensionV1s));
       if (Objects.isNull(entity.getSubscriptionNumber())) {
         entity.setSubscriptionNumber(
             mapper.getRhSubscriptionNumber(entitlement.getRhEntitlements()));
       }
       populateProductIdBySku(entity);
+    } else {
+      log.error("No results found from partner entitlement for contract {}", entity.toString());
     }
   }
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2074

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Contracts is failing to save UMB messages because dimensions are coming from the message itself rather than the partner API. This change allows us to get dimension from both the message and partnerApi.
