### PR TITLE
Don't halt DB pod start-up on error

### DIFF
--- a/init_dbs.sh
+++ b/init_dbs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-_psql () { psql --set ON_ERROR_STOP=1 "$@" ; }
+_psql () { psql --set ON_ERROR_STOP=0 "$@" ; }
 
 _psql --set=adminpass="$POSTGRESQL_ADMIN_PASSWORD" \
 <<<"ALTER USER \"postgres\" WITH ENCRYPTED PASSWORD :'adminpass';"


### PR DESCRIPTION
Any restart to the DB pod will result in an error since we try to create
the necessary user every time.  Rather than add the more complex logic
to detect whether the user exists or not, I'm just going to set the DB
start-up to keep going even if it encounters an error.
