### PR TITLE
 SWATCH-1968: Add Export service as a dependency in Tally & Subscription-sync

### DIFF
--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -187,6 +187,7 @@ objects:
       dependencies:
         - swatch-tally
         - rbac
+        - export-service
 
       # Creates a database if local mode, or uses RDS in production
       # database:

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -227,6 +227,7 @@ objects:
       - host-inventory
       - swatch-contracts
       - rbac
+      - export-service
     # IQE plugin your ClowdApp is associated with
     testing:
       iqePlugin: rhsm-subscriptions


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-1968

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Allow ability to spin up and interact with Export Service

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Switch to this branch before deployment 

Deploy bonfire :
```
bonfire deploy rhsm --source=appsre --ref-env insights-production --set-template-ref rhsm=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-image-tag quay.io/cloudservices/swatch-system-conduit=pr-2899-b45680a --timeout 900 --optional-deps-method none --frontends false --no-remove-resources rhsm --no-remove-resources swatch-api --no-remove-resources swatch-contracts --no-remove-resources swatch-producer-aws --no-remove-resources swatch-producer-red-hat-marketplace --no-remove-resources swatch-metrics --no-remove-resources swatch-subscription-sync --no-remove-resources swatch-system-conduit --no-remove-resources swatch-tally --no-remove-resources swatch-producer-azure --timeout 1800 -i quay.io/cloudservices/rhsm-subscriptions=pr-2899-b45680a -i quay.io/cloudservices/swatch-contracts=pr-2899-b45680a -i quay.io/cloudservices/swatch-metrics=pr-2899-b45680a -i quay.io/cloudservices/swatch-producer-aws=pr-2899-b45680a -i quay.io/cloudservices/swatch-producer-azure=pr-2899-b45680a -i quay.io/cloudservices/swatch-system-conduit=pr-2899-b45680a --set-template-ref rhsm=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-api=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-contracts=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-producer-aws=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-producer-red-hat-marketplace=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-metrics=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-subscription-sync=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-system-conduit=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-tally=b45680a1da9ec1335251614ce0d5029564ef2ba3 --set-template-ref swatch-producer-azure=b45680a1da9ec1335251614ce0d5029564ef2ba3
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Check local url generated from your ephemeral: example ->  https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com/k8s/ns/rhsm-stage/cloud.redhat.com~v1alpha1~ClowdApp 
2. You should see export service instance up and running