### PR TITLE
SWATCH-2066: Add timer for metrics collection

### DIFF
--- a/swatch-metrics/build.gradle
+++ b/swatch-metrics/build.gradle
@@ -7,6 +7,7 @@ plugins {
 dependencies {
     implementation 'io.quarkus:quarkus-config-yaml'
     implementation 'io.quarkus:quarkus-logging-json'
+    implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-opentelemetry'
     implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
     implementation 'io.quarkus:quarkus-rest-client-reactive-jackson'

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
@@ -316,7 +316,7 @@ class PrometheusMeteringControllerTest {
             .addValuesItem(List.of(BigDecimal.valueOf(1616787308L), BigDecimal.valueOf(4.0)));
     QueryResultData queryResultData =
         new QueryResultData().addResultItem(standardResultItem).addResultItem(premiumResultItem);
-    QueryResult data = new QueryResult().data(queryResultData);
+    QueryResult data = new QueryResult().data(queryResultData).status(StatusType.SUCCESS);
 
     prometheusServer.stubQueryRange(data);
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2066

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Add a timer to track metrics collection timing.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Start a prometheus container
   ```
   podman run -ti --rm -p 9090:9090 quay.io/prometheus/prometheus
   ```
1. Write a Clowder configuration file to `/tmp/test-clowder.json`
   ```json
   {
   "kafka": {
    "brokers": [
      {
        "hostname": "localhost",
        "port": 9092
      }
    ],
    "topics": []
   },
   "metricsPath": "/metrics",
   "metricsPort": 9000,
   "privatePort": 10000,
   "publicPort": 8000,
   "webPort": 8000
   }
   ```
1. Start swatch-metrics using the clowder and prometheus settings
   ```
   export RHSMSUBSCRIPTIONS_METERING_PROMETHEUS_CLIENT_URL=http://localhost:9090/api/v1
   ACG_CONFIG=/tmp/test-clowder.json ../gradlew quarkusDev
   ```

### Steps
1. Trigger a run
   ```
   http -v POST :8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg orgId==16787820 endDate==2024-01-09T20:00Z
   ```

### Verification
1. Examine the metrics for the timer
   ```
   http :8000/q/metrics | grep metrics_collection
   ```

## TODO
I don't believe these metrics are going to get scraped until we configure them to be hosted off `:9000/metrics` which is the Clowder expected way of doing things.  I'm going to work on that as a follow-up task later as part of the purpose of this PR is to push an update to restart some pods.