### PR TITLE
SWATCH-2069: Fix IncorrectResultSizeDataAccessException when saving subs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/ActiveMQServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/ActiveMQServiceConfiguration.java
@@ -51,6 +51,14 @@ public class ActiveMQServiceConfiguration {
       ActiveMQProperties activeMQProperties) throws Exception {
     ActiveMQSslConnectionFactory factory = new ActiveMQSslConnectionFactory();
     factory.setExceptionListener(e -> log.error("Exception thrown in ActiveMQ connection", e));
+    if (StringUtils.hasText(activeMQProperties.getUser())) {
+      factory.setUserName(activeMQProperties.getUser());
+    }
+
+    if (StringUtils.hasText(activeMQProperties.getPassword())) {
+      factory.setPassword(activeMQProperties.getPassword());
+    }
+
     if (StringUtils.hasText(activeMQProperties.getBrokerUrl())) {
       factory.setBrokerURL(activeMQProperties.getBrokerUrl());
       if (!umbProperties.providesTruststore() || !umbProperties.usesClientAuth()) {

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -351,6 +351,46 @@ class SubscriptionRepositoryTest {
     assertThat(resultList, Matchers.containsInAnyOrder(s1, s2));
   }
 
+  @Transactional
+  @Test
+  void testFindBySubscriptionNumberWhenDuplicates() {
+    String subId = "sub";
+    String subscriptionNumber = subId + "1";
+
+    // We want to create the same subscription twice, but the second will have a more recent start
+    // date.
+    var mostRecent = givenTwoDuplicateSubscriptions(subId);
+
+    // When trying to find a single subscription number, it fails because there are multiples
+    var actual = subscriptionRepo.findBySubscriptionNumber(subscriptionNumber);
+    assertTrue(actual.isPresent());
+    assertEquals(mostRecent.getStartDate(), actual.get().getStartDate());
+  }
+
+  @Transactional
+  @Test
+  void testFindActiveSubscriptionWhenDuplicates() {
+    String subId = "sub";
+    // We want to create the same subscription twice, but the second will have a more recent start
+    // date.
+    var mostRecent = givenTwoDuplicateSubscriptions(subId);
+
+    // When trying to find a single subscription number, it fails because there are multiples
+    var actual = subscriptionRepo.findActiveSubscription(subId);
+    assertTrue(actual.isPresent());
+    assertEquals(mostRecent.getStartDate(), actual.get().getStartDate());
+  }
+
+  private Subscription givenTwoDuplicateSubscriptions(String subId) {
+    String orgId = "org123";
+    String billingAccountId = "seller123";
+    OffsetDateTime startDate = NOW.truncatedTo(ChronoUnit.SECONDS);
+    var s1 = createSubscription(orgId, subId, billingAccountId, startDate, null);
+    var s2 = createSubscription(orgId, subId, billingAccountId, startDate.plusDays(2), null);
+    subscriptionRepo.saveAllAndFlush(List.of(s1, s2));
+    return s2;
+  }
+
   private Offering createOffering(
       String sku, String productName, int productId, ServiceLevel sla, Usage usage, String role) {
     return Offering.builder()

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -64,15 +64,15 @@ public interface SubscriptionRepository
         SELECT s FROM Subscription s
         WHERE (s.endDate IS NULL OR s.endDate > CURRENT_TIMESTAMP)
           AND s.subscriptionId = :subscriptionId
-        ORDER BY s.subscriptionId, s.startDate
+        ORDER BY s.startDate DESC
+        LIMIT 1
       """)
   @EntityGraph(value = "graph.SubscriptionSync")
   Optional<Subscription> findActiveSubscription(@Param("subscriptionId") String subscriptionId);
 
   @EntityGraph(value = "graph.SubscriptionSync")
-  // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(
-      "SELECT s FROM Subscription s WHERE s.subscriptionNumber = :subscriptionNumber ORDER BY s.subscriptionId, s.startDate")
+      "SELECT s FROM Subscription s WHERE s.subscriptionNumber = :subscriptionNumber ORDER BY s.startDate DESC LIMIT 1")
   Optional<Subscription> findBySubscriptionNumber(String subscriptionNumber);
 
   // Added an order by clause to avoid Hibernate issue HHH-17040


### PR DESCRIPTION
Jira issue: [SWATCH-2069](https://issues.redhat.com/browse/SWATCH-2069)

## Description
The methods "findBySubscriptionNumber" and "findActiveSubscription" expect to find unique results. When multiple entities are found, it returns the IncorrectResultSizeDataAccessException exception.

## Testing

1.- podman-compose up
2.- apply migrations

```
./gradlew :liquibaseUpdate
```

3.- add the required data:

which is the offering and the duplicate subscription with a different start date. 
```
INSERT INTO OFFERING(sku,product_name,product_family,sla,description,has_unlimited_usage) 
VALUES ('MW00332','OpenShift Data Science','OPENSHIFT ENTERPRISE','Premium','Red Hat OpenShift Data Science','false');

INSERT INTO subscription(sku,org_id,subscription_id,quantity,start_date,subscription_number)
VALUES('MW00332','16764251','12396617','25','2023-02-02T02:13:35.983189Z','12396774');

INSERT INTO subscription(sku,org_id,subscription_id,quantity,start_date,subscription_number)
VALUES('MW00332','16764251','12396617','25','2023-02-06T02:13:35.983189Z','12396774');
```

4.- (only for local testing) start ActiveMQ:

```
docker run --detach --name mycontainer -p 61616:61616 -p 8161:8161 --rm apache/activemq-artemis:latest-alpine
```

5.- start the service:

```
DEV_MODE=true SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true SPRING_PROFILES_ACTIVE="api,worker,kafka-queue,capacity-ingress" PRODUCT_USE_STUB=true UMB_ENABLED=true SPRING_ACTIVEMQ_BROKER_URL=tcp://localhost:61616 SPRING_ACTIVEMQ_USER=artemis SPRING_ACTIVEMQ_PASSWORD=artemis ./gradlew :bootRun
```

6.- Send the payload via artemis management site: http://localhost:8161/console/artemis/artemisSendMessage?nid=root-org.apache.activemq.artemis-0.0.0.0-addresses-Consumer.null.swatch-null-VirtualTopic_canonical_subscription.VirtualTopic.canonical.subscription-queues-anycast-Consumer.null.swatch-null-VirtualTopic_canonical_subscription.VirtualTopic.canonical.subscription

Payload:

```xml
<CanonicalMessage xmlns="http://esb.redhat.com/Canonical/6">
    <Header>
        <System>SUBSCRIPTION</System>
        <Operation>update</Operation>
        <Type>Subscription</Type>
        <InstanceId>6446c7c050d3b36402663da3</InstanceId>
        <Timestamp>2023-04-24T14:17:41.307</Timestamp>
    </Header>
    <Payload>
        <Sync>
            <Subscription>
                <CreatedBy>OSUBPRODTEST3EAC72C765804E2B8D34484E7FF8D1C8</CreatedBy>
                <CreatedDate>2023-04-24T14:11:16.809</CreatedDate>
                <LastUpdatedBy>RHMIDDLEWARE</LastUpdatedBy>
                <LastUpdatedDate>2023-04-24T14:15:18.000</LastUpdatedDate>
                <Identifiers>
                    <MasterSystem>SUBSCRIPTION</MasterSystem>
                    <Identifier entity-name="Install Base"
                        qualifier="number" system="EBS">39832705</Identifier>
                    <Identifier entity-name="Registration" qualifier="number">e401bce70edd43bd</Identifier>
                    <Identifier entity-name="Subscription"
                        qualifier="number" system="SUBSCRIPTION">12396774</Identifier>
                    <Reference entity-name="Installation" qualifier="number">c967ef3956ff3def</Reference>
                    <Reference entity-name="Customer" qualifier="number" system="EBS">customer123</Reference>
                    <Reference entity-name="Account" qualifier="number" system="EBS">account123</Reference>
                    <Reference entity-name="Customer" qualifier="id" system="WEB">16764251</Reference>
                    <Reference entity-name="Account" qualifier="id" system="WEB">16764251</Reference>
                </Identifiers>
                <Status>
                    <State>Active</State>
                    <StartDate>2023-04-24T00:00:00.000</StartDate>
                </Status>
                <Quantity>1</Quantity>
                <effectiveStartDate>2023-04-24T00:00:00.000</effectiveStartDate>
                <effectiveEndDate>2026-04-23T00:00:00.000</effectiveEndDate>
                <Product serviceable="false">
                    <CreatedBy>OSUBPRODTEST3EAC72C765804E2B8D34484E7FF8D1C8</CreatedBy>
                    <CreatedDate>2023-04-24T14:11:16.809</CreatedDate>
                    <Identifiers>
                        <MasterSystem>EBS</MasterSystem>
                        <Identifier entity-name="Product"
                            qualifier="number" system="SUBSCRIPTION">37188549</Identifier>
                    </Identifiers>
                    <Sku>BASILISK</Sku>
                    <InventoryOperatingUnit>
                        <Number>118</Number>
                    </InventoryOperatingUnit>
                    <Product serviceable="true">
                        <CreatedBy>OSUBPRODTEST3EAC72C765804E2B8D34484E7FF8D1C8</CreatedBy>
                        <CreatedDate>2023-04-24T14:11:16.809</CreatedDate>
                        <LastUpdatedBy>SYSADMIN</LastUpdatedBy>
                        <LastUpdatedDate>2023-04-24T14:17:02.000</LastUpdatedDate>
                        <Identifiers>
                            <MasterSystem>EBS</MasterSystem>
                            <AuthoringOperatingUnit>
                                <Number>103</Number>
                            </AuthoringOperatingUnit>
                            <Identifier entity-name="Product"
                                qualifier="number" system="SUBSCRIPTION">37188550</Identifier>
                            <Reference entity-name="Contract"
                                qualifier="number" system="EBS">16612423</Reference>
                            <Reference entity-name="Contract"
                                qualifier="id" system="EBS">25565753</Reference>
                        </Identifiers>
                        <Status>
                            <State>Active</State>
                            <StartDate>2023-04-24T00:00:00.000</StartDate>
                            <EndDate>2026-04-23T00:00:00.000</EndDate>
                        </Status>
                        <Status>
                            <State>Signed</State>
                            <StartDate>2023-04-24T00:00:00.000</StartDate>
                        </Status>
                        <Status primary="true">
                            <State>Terminated</State>
                            <StartDate>2023-04-24T14:17:02.000</StartDate>
                        </Status>
                        <Sku>SVC2681</Sku>
                        <InventoryOperatingUnit>
                            <Number>118</Number>
                        </InventoryOperatingUnit>
                        <ContractDescription>Reg Number activation from Hock</ContractDescription>
                        <ContractHeaderStatus>Terminated</ContractHeaderStatus>
                    </Product>
                </Product>
            </Subscription>
        </Sync>
    </Payload>
</CanonicalMessage>
```

7.- Verification:

You should see the following trace in the service logs:

```Received UMB message... ```

And no exceptions.

Before these changes, we were seeing the IncorrectResultSizeDataAccessException exceptions.