### PR TITLE
SWATCH-2066: Expose prometheus data on :9000/metrics for swatch-metrics

### DIFF
--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -142,7 +142,7 @@ objects:
     metadata:
       name: swatch-metrics
       labels:
-        prometheus: rhsm
+        prometheus: quarkus
     spec: # The name of the ClowdEnvironment providing the services
       envName: ${ENV_NAME}
 
@@ -340,7 +340,7 @@ objects:
     metadata:
       name: swatch-metrics-rhel
       labels:
-        prometheus: rhsm
+        prometheus: quarkus
     spec:
       envName: ${ENV_NAME}
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2066

## Description
This is necessary so that app-interface can actually find our Prometheus metrics!

## Testing
### Setup
1. Write a Clowder configuration file to `/tmp/test-clowder.json`
   ```json
   {
   "kafka": {
    "brokers": [
      {
        "hostname": "localhost",
        "port": 9092
      }
    ],
    "topics": []
   },
   "metricsPath": "/metrics",
   "metricsPort": 9000,
   "privatePort": 10000,
   "publicPort": 8000,
   "webPort": 8000
   }
   ```
1. Start swatch-metrics using the clowder and prometheus settings
   ```
   export RHSMSUBSCRIPTIONS_METERING_PROMETHEUS_CLIENT_URL=http://localhost:9090/api/v1
   ACG_CONFIG=/tmp/test-clowder.json QUARKUS_MANAGEMENT_ENABLED=true ../gradlew quarkusDev
   ```

### Verification
1. Pull the metrics
   ```
   http :9000/metrics
   ```
