### PR TITLE
DRAFT: SWATCH-2109 Use recording rule and eliminate double billing scenario

### DIFF
--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -188,9 +188,22 @@ rhsm-subscriptions:
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           rhelemeter: >-
-            max(#{metric.prometheus.queryParams[metric]}) by (_id)
-            * on(_id) group_right
-            min_over_time({product=~"#{metric.prometheus.queryParams[productLabelRegex]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            min(
+                last_over_time(#{metric.prometheus.queryParams[metric]}[1h:5m]) 
+                - 
+                delta(#{metric.prometheus.queryParams[metric]}[1h:5m])
+            ) by (_id) 
+            * on(_id) 
+            group_right 
+            topk(
+                1, 
+                #{metric.prometheus.queryParams[metadataMetric]}{
+                    product=~"#{metric.prometheus.queryParams[productLabelRegex]}", 
+                    external_organization="#{runtime[orgId]}",
+                    billing_model="marketplace",
+                    support=~"Premium|Standard|Self-Support|None"
+                }
+            ) by (_id)
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
         backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
@@ -30,5 +30,6 @@ metrics:
       queryKey: rhelemeter
       queryParams:
         productLabelRegex: .*(^|,)(204)($|,).* # this regex is used to fetch metrics for the product label that contains the product/engineering ID 204. the number here needs to map to a tag defined in the variant section of this file
-        metric: max by(_id) (sum_over_time(system_cpu_logical_count[1h:10m])) / scalar(count_over_time(vector(1)[1h:10m])) #To be replaced with recording rule in SWATCH-2075
+        metric: host:usage:workload:cpu_hours1h
+        metadataMetric: system_cpu_logical_count
         instanceKey: _id


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2109


Run a token refresher for stage rhelemeter

```
TOKEN_REFRESHER_VERSION=master-2023-09-20-f5e3403
SCOPE="openid offline_access"
CLIENT_SECRET=
CLIENT_ID=
ISSUER_URL=https://sso.redhat.com/auth/realms/redhat-external
URL=https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/rhel
```

```
podman run --name=token-refresher --rm -ti -p 8082:8080 \
  quay.io/observatorium/token-refresher:$TOKEN_REFRESHER_VERSION \
  --scope="$SCOPE" \
  --oidc.client-secret="$CLIENT_SECRET" \
  --oidc.client-id="$CLIENT_ID" \
  --oidc.issuer-url="$ISSUER_URL" \
  --url="$URL"
```


Start swatch-metrics configured for rhelemeter
```
EVENT_SOURCE=rhelemeter PROM_URL="http://localhost:8082/api/v1" ./gradlew :swatch-metrics:quarkusDev
```

Kick off gathering metrics for now
```
curl -X POST --location "http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=16787820" -H 'x-rh-swatch-synchronous-request: false' -H 'x-rh-swatch-psk: placeholder'
```
Sent 2 events in the logs


Kick off gathering metrics with optional API params
```
curl -X 'POST' \
  'http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=16787820&endDate=2024-01-10T20%3A00%3A00Z&rangeInMinutes=120' \
  -H 'accept: */*' \
  -H 'x-rh-swatch-synchronous-request: false' \
  -H 'x-rh-swatch-psk: placeholder' \
  -d ''
```
Sent 4 events in the logs
