### PR TITLE
Update tally retention policy for quarterly snapshots

### DIFF
--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -29,8 +29,8 @@ rhsm-subscriptions:
     weekly: ${TALLY_RETENTION_WEEKLY:12}
     # A year's worth
     monthly: ${TALLY_RETENTION_MONTHLY:12}
-    # Four year's worth
-    quarterly: ${TALLY_RETENTION_QUARTERLY:16}
+    # Five years' worth
+    quarterly: ${TALLY_RETENTION_QUARTERLY:20}
     yearly: ${TALLY_RETENTION_YEARLY:5}
   remittance-retention-policy:
     # 70 days worth


### PR DESCRIPTION
Supports user request to see last 5 years of Quarterly tallies from the UI.

Relates to Jira issue: SWATCH-1594, but doesn't close the RFE.

