### PR TITLE
SWATCH-2088: Allow Spring Kafka configuration to operate using the system truststore

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -36,6 +36,7 @@ import jakarta.validation.Validator;
 import org.candlepin.subscriptions.actuator.CertInfoContributor;
 import org.candlepin.subscriptions.capacity.CapacityIngressConfiguration;
 import org.candlepin.subscriptions.capacity.CapacityReconciliationWorkerConfiguration;
+import org.candlepin.subscriptions.clowder.KafkaSslBeanPostProcessor;
 import org.candlepin.subscriptions.clowder.RdsSslBeanPostProcessor;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.json.BaseEvent;
@@ -174,6 +175,20 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   @Bean
   public TimedAspect timedAspect(MeterRegistry registry) {
     return new TimedAspect(registry);
+  }
+
+  /**
+   * A bean post-processor responsible for setting up Kafka truststores correctly. It's declared
+   * here so that this bean will always be created. In other words, the creation of this bean isn't
+   * dependent on the web of Import annotations that we have declared across our Configuration
+   * classes. ApplicationConfiguration is the one Configuration class we can always count on to
+   * load.
+   *
+   * @return a KafkaJaasBeanPostProcessor object
+   */
+  @Bean
+  public KafkaSslBeanPostProcessor kafkaJaasBeanPostProcessor() {
+    return new KafkaSslBeanPostProcessor();
   }
 
   @Bean

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/KafkaSslBeanPostProcessor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/KafkaSslBeanPostProcessor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.clowder;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.function.Consumer;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.core.Ordered;
+import org.springframework.core.io.Resource;
+
+/**
+ * A bean post-processor to correctly configure the truststore for Kafka. The Clowder JSON can
+ * optionally specify the CA certificate. If the CA certificate isn't defined, the system truststore
+ * should be used. This is indicated in {@link KafkaProperties.Ssl} by having the truststore set to
+ * null. Unfortunately, there is no easy way to specify a default value of null for a property.
+ * Currently, our configuration looks like
+ *
+ * <pre>
+ *  kafka:
+ *    ssl:
+ *      trust-store-certificates: ${clowder.kafka.brokers.cacert:}
+ *      trust-store-type: ${clowder.kafka.brokers.cacert.type:}
+ * </pre>
+ *
+ * The {@link ClowderJsonPathPropertySource} will return null for the evaluation of
+ * <tt>clowder.kafka.brokers.cacert</tt> (since that key is missing in the Clowder JSON), but Spring
+ * will then fall back to the default which is the empty string. If no default is provided, Spring
+ * instead uses the literal value of "${clowder.kafka.brokers.cacert}". So this class exists to set
+ * the KafkaProperties.Ssl truststore values back to null if any of them are set to the empty
+ * string.
+ */
+public class KafkaSslBeanPostProcessor implements BeanPostProcessor, Ordered {
+  private int order = Ordered.LOWEST_PRECEDENCE;
+
+  @Override
+  public int getOrder() {
+    return order;
+  }
+
+  public void setOrder(int order) {
+    this.order = order;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    if (bean instanceof KafkaProperties kafkaProperties) {
+      var sslProps = kafkaProperties.getSsl();
+
+      checkEmptySetNull(sslProps.getTrustStoreCertificates(), sslProps::setTrustStoreCertificates);
+      checkEmptySetNull(sslProps.getTrustStoreLocation(), sslProps::setTrustStoreLocation);
+      checkEmptySetNull(sslProps.getTrustStoreType(), sslProps::setTrustStoreType);
+      checkEmptySetNull(sslProps.getTrustStorePassword(), sslProps::setTrustStorePassword);
+    }
+    return bean;
+  }
+
+  private void checkEmptySetNull(String currentValue, Consumer<String> setter) {
+    if (currentValue != null && currentValue.isEmpty()) {
+      setter.accept(null);
+    }
+  }
+
+  private void checkEmptySetNull(Resource currentValue, Consumer<Resource> setter) {
+    try {
+      if (currentValue != null
+          && currentValue.getContentAsString(Charset.defaultCharset()).isEmpty()) {
+        setter.accept(null);
+      }
+    } catch (IOException e) {
+      setter.accept(null);
+    }
+  }
+}

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -111,6 +111,10 @@ spring:
       # -+BEGIN\\s*.*CERTIFICATE[^-]*-+\\s+(?:\\s*[^\\r\\n]*:[^\\r\\n]*[\\r\\n]+)*([a-zA-Z0-9/+=\\s]*)-+END\\s*.*CERTIFICATE[^-]*-+\\s+")
       # A notable point about this expression is that the "----BEGIN CERTIFICATE-----" piece must be
       # followed by a newline which makes it challenging to place the value in a properties or YAML file.
+
+      # Important: these values need to default to the empty string.  An empty string is what tells
+      # the KafkaSslBeanPostProcessor to reset the values back to null in the KafkaProperties.Ssl
+      # object (which will result in Kafka using the system truststore).  See SWATCH-2088.
       trust-store-certificates: ${clowder.kafka.brokers.cacert:}
       trust-store-type: ${clowder.kafka.brokers.cacert.type:}
     listener:

--- a/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/KafkaSslBeanPostProcessorTest.java
+++ b/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/KafkaSslBeanPostProcessorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.clowder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.core.io.InputStreamResource;
+
+class KafkaSslBeanPostProcessorTest {
+  @Test
+  void postProcessAfterInitialization() {
+    var kafkaProperties = new KafkaProperties();
+    var ssl = kafkaProperties.getSsl();
+    ssl.setTrustStoreCertificates("");
+    ssl.setTrustStoreType("");
+    ssl.setTrustStorePassword("");
+
+    var postProcessor = new KafkaSslBeanPostProcessor();
+    postProcessor.postProcessAfterInitialization(kafkaProperties, "kafkaProperties");
+
+    assertNull(ssl.getTrustStoreCertificates());
+    assertNull(ssl.getTrustStoreType());
+    assertNull(ssl.getTrustStorePassword());
+  }
+
+  @Test
+  void postProcessAfterInitializationForResource() {
+    var kafkaProperties = new KafkaProperties();
+    var ssl = kafkaProperties.getSsl();
+    ssl.setTrustStoreLocation(new InputStreamResource(new ByteArrayInputStream(new byte[0])));
+    ssl.setTrustStoreType("");
+    ssl.setTrustStorePassword("");
+
+    var postProcessor = new KafkaSslBeanPostProcessor();
+    postProcessor.postProcessAfterInitialization(kafkaProperties, "kafkaProperties");
+
+    assertNull(ssl.getTrustStoreLocation());
+    assertNull(ssl.getTrustStoreType());
+    assertNull(ssl.getTrustStorePassword());
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2088

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Under normal circumstances, if you wanted to use the system truststore, you simply wouldn't set the kafka.ssl.truststore-certificates property at all.  The KafkaProperties.Ssl instance would then have null for the truststoreCertificates field and Kafka would initialize using the default system truststore.

We, however, are using Clowder and we need to set the truststore-certificates property if a certificate is provided to us.  We use the ClowderJsonPathPropertySource class to do this and set the property to something like `${clowder.kafka.brokers.cacert}`. Unfortunately, if the ClowderJsonPathPropertySource can't resolve that JSON path, the property ends up getting set to the literal string "${clowder.kafka.brokers.cacert}" which of course is not a valid certificate, nor does it indicate to Kafka to use the system truststore which is what we would want to do if the Clowder JSON were silent about the CA certificate to use.

We could use the value `${clowder.kafka.brokers.cacert:}` which would resolve to the empty string since that is the default provided after the colon.  However, the Kafka DefaultSslEngineFactory doesn't handle this very well since getting an empty string is a pretty strange thing to get for the value of a certificate.

This patch creates a bean post-processor that will change the truststore properties back to null if any of them are set to the empty string and consequently Kafka will use the system truststore.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Add the Kafka server certificate to the system truststore
   ```
   sudo cp config/kafka/test-ca.crt  /etc/pki/ca-trust/source/anchors/ && sudo update-ca-trust
   ```
   **IMPORTANT**: You will need to remove this certificate and re-run `update-ca-trust` after you are finished testing.  If you don't, you'll a) have a certificate in your system truststore that doesn't belong there and b) you'll get a failing unit test in `HttpClientTest` since that test actually uses `test-ca.crt` as a example of a CA that is not expected to be in the system truststore.
2. Create a clowder configuration meant to use the system truststore
   ```shell
   cat <<EOF > /tmp/cdappconfig.json
   {
   "kafka": {
    "brokers": [
      {
        "hostname": "localhost",
        "port": 9094,
        "authtype": "sasl",
        "sasl": {
         "username": "client",
         "password": "dummy",
         "securityProtocol":"SASL_SSL",
         "saslMechanism":"PLAIN"
         }
      }
    ],
    "topics": []
   },
   "metricsPath": "/metrics",
   "metricsPort": 9000,
   "privatePort": 10000,
   "publicPort": 8000,
   "webPort": 8000
   }
   EOF
   ```

### Steps
<!-- Enter each step of the test below -->
1. Running on `origin/main`, start the application with the Clowder configuration
   ```
   ACG_CONFIG=/tmp/cdappconfig.json  ./gradlew :bootRun
   ```
1.  The application will fail to start and you'll see a stack trace with the bottom cause reading "Caused by: org.apache.kafka.common.KafkaException: org.apache.kafka.common.errors.InvalidConfigurationException: SSL trust store certs can be specified only for PEM, but trust store type is .".
1.  Check out this branch and rerun the command from step 1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.  The application starts successfully.
1.  **IMPORTANT**: remove the `test-ca.crt` from your system truststore:
   ```
   sudo rm /etc/pki/ca-trust/source/anchors/test-ca.crt && sudo update-ca-trust
   ```
