### PR TITLE
SWATCH-2069: Populate subscription product ids when sync subscriptions

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -181,7 +181,10 @@ public class SubscriptionSyncController {
     }
 
     subscriptionOptional.ifPresentOrElse(
-        subscription -> newOrUpdated.setOffering(subscription.getOffering()),
+        subscription -> {
+          newOrUpdated.setOffering(subscription.getOffering());
+          newOrUpdated.setSubscriptionProductIds(subscription.getSubscriptionProductIds());
+        },
         // Set the offering via a proxy object rather than performing a full lookup.  See
         // https://thorben-janssen.com/jpa-getreference/
         () -> newOrUpdated.setOffering(offeringRepository.getReferenceById(sku)));
@@ -308,6 +311,9 @@ public class SubscriptionSyncController {
               }
               if (subscription.getBillingProviderId() == null) {
                 subscription.setBillingProviderId(existingData.getBillingProviderId());
+              }
+              if (subscription.getSubscriptionProductIds() == null) {
+                subscription.setSubscriptionProductIds(existingData.getSubscriptionProductIds());
               }
             });
   }

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -203,7 +203,7 @@ class SubscriptionSyncControllerTest {
   @Test
   void shouldUpdateSubscriptionWhenUpdateProductIds() {
     var dto = createDto(123, "456", 4);
-    var offering = givenOfferingWithProductIds(290);
+    givenOfferingWithProductIds(290);
     subscriptionSyncController.syncSubscription(dto);
     verify(subscriptionRepository).save(any());
     verify(capacityReconciliationController).reconcileCapacityForSubscription(any());
@@ -211,10 +211,9 @@ class SubscriptionSyncControllerTest {
     // let's update only the product IDs
     givenOfferingWithProductIds(290, 69);
     reset(subscriptionRepository, capacityReconciliationController);
-    subscriptionSyncController.syncSubscription(
-        dto, Optional.of(createSubscriptionFrom(offering, dto)));
+    subscriptionSyncController.syncSubscription(dto);
     verify(subscriptionRepository).save(any());
-    verify(capacityReconciliationController, times(2)).reconcileCapacityForSubscription(any());
+    verify(capacityReconciliationController).reconcileCapacityForSubscription(any());
   }
 
   @Test


### PR DESCRIPTION
Revert changes of issue: SWATCH-2069

## Description
We need to revert the changes that was made for SWATCH-2069 because when having duplications, we might select a subscription with a different start date that might lead to this exception:

```
2024-01-15 12:04:00,970 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [INFO ] [org.candlepin.subscriptions.subscription.SubscriptionWorker] - Received UMB message for subscriptionNumber=12648168 webCustomerId=16767885
2024-01-15 12:04:00,972 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [WARN ] [org.hibernate.orm.query] - HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory
2024-01-15 12:04:01,889 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [WARN ] [org.candlepin.subscriptions.subscription.SubscriptionSyncController] - PAYG eligible subscription with subscriptionId:12648011 has no billing provider.
2024-01-15 12:04:01,889 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [INFO ] [org.candlepin.subscriptions.capacity.CapacityReconciliationController] - Update for subscription ID 12648011 removed 1 products.
2024-01-15 12:04:01,893 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [ERROR] [org.hibernate.orm.jdbc.batch] - HHH100501: Exception executing batch [java.sql.BatchUpdateException: Batch entry 0 insert into subscription_product_ids (start_date,subscription_id,product_id) values ('2023-01-18 00:00:00+00','12648011','OpenShift Container Platform') was aborted: ERROR: duplicate key value violates unique constraint "subscription_product_ids_pk"
  Detail: Key (product_id, subscription_id, start_date)=(OpenShift Container Platform, 12648011, 2023-01-18 00:00:00+00) already exists.  Call getNextException to see other errors in the batch.], SQL: insert into subscription_product_ids (start_date,subscription_id,product_id) values (?,?,?)
2024-01-15 12:04:01,894 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [WARN ] [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] - SQL Error: 0, SQLState: 23505
2024-01-15 12:04:01,894 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [ERROR] [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] - Batch entry 0 insert into subscription_product_ids (start_date,subscription_id,product_id) values ('2023-01-18 00:00:00+00','12648011','OpenShift Container Platform') was aborted: ERROR: duplicate key value violates unique constraint "subscription_product_ids_pk"
  Detail: Key (product_id, subscription_id, start_date)=(OpenShift Container Platform, 12648011, 2023-01-18 00:00:00+00) already exists.  Call getNextException to see other errors in the batch.
2024-01-15 12:04:01,894 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [ERROR] [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] - ERROR: duplicate key value violates unique constraint "subscription_product_ids_pk"
  Detail: Key (product_id, subscription_id, start_date)=(OpenShift Container Platform, 12648011, 2023-01-18 00:00:00+00) already exists.
2024-01-15 12:04:01,899 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-2] [WARN ] [org.springframework.jms.listener.DefaultMessageListenerContainer] - Execution of JMS message listener failed, and no ErrorHandler has been set.
org.springframework.jms.listener.adapter.ListenerExecutionFailedException: Listener method 'public void org.candlepin.subscriptions.subscription.SubscriptionWorker.receive(java.lang.String) throws com.fasterxml.jackson.core.JsonProcessingException' threw exception
	at org.springframework.jms.listener.adapter.MessagingMessageListenerAdapter.invokeHandler(MessagingMessageListenerAdapter.java:118)
	at org.springframework.jms.listener.adapter.MessagingMessageListenerAdapter.onMessage(MessagingMessageListenerAdapter.java:84)
	at org.springframework.jms.listener.AbstractMessageListenerContainer.doInvokeListener(AbstractMessageListenerContainer.java:783)
	at org.springframework.jms.listener.AbstractMessageListenerContainer.invokeListener(AbstractMessageListenerContainer.java:741)
	at org.springframework.jms.listener.AbstractMessageListenerContainer.doExecuteListener(AbstractMessageListenerContainer.java:719)
	at org.springframework.jms.listener.AbstractPollingMessageListenerContainer.doReceiveAndExecute(AbstractPollingMessageListenerContainer.java:333)
	at org.springframework.jms.listener.AbstractPollingMessageListenerContainer.receiveAndExecute(AbstractPollingMessageListenerContainer.java:270)
	at org.springframework.jms.listener.DefaultMessageListenerContainer$AsyncMessageListenerInvoker.invokeListener(DefaultMessageListenerContainer.java:1258)
	at org.springframework.jms.listener.DefaultMessageListenerContainer$AsyncMessageListenerInvoker.executeOngoingLoop(DefaultMessageListenerContainer.java:1248)
	at org.springframework.jms.listener.DefaultMessageListenerContainer$AsyncMessageListenerInvoker.run(DefaultMessageListenerContainer.java:1141)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.springframework.dao.DataIntegrityViolationException: could not execute batch [Batch entry 0 insert into subscription_product_ids (start_date,subscription_id,product_id) values ('2023-01-18 00:00:00+00','12648011','OpenShift Container Platform') was aborted: ERROR: duplicate key value violates unique constraint "subscription_product_ids_pk"
  Detail: Key (product_id, subscription_id, start_date)=(OpenShift Container Platform, 12648011, 2023-01-18 00:00:00+00) already exists.  Call getNextException to see other errors in the batch.] [insert into subscription_product_ids (start_date,subscription_id,product_id) values (?,?,?)]; SQL [insert into subscription_product_ids (start_date,subscription_id,product_id) values (?,?,?)]; constraint [subscription_product_ids_pk]
	at org.springframework.orm.jpa.vendor.HibernateJpaDialect.convertHibernateAccessException(HibernateJpaDialect.java:290)
	at org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:241)
	at org.springframework.orm.jpa.JpaTransactionManager.doCommit(JpaTransactionManager.java:565)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.processCommit(AbstractPlatformTransactionManager.java:794)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.commit(AbstractPlatformTransactionManager.java:757)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.commitTransactionAfterReturning(TransactionAspectSupport.java:669)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:419)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:765)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:765)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:717)
	at org.candlepin.subscriptions.subscription.SubscriptionSyncController$$SpringCGLIB$$0.saveUmbSubscription(<generated>)
	at org.candlepin.subscriptions.subscription.SubscriptionWorker.receive(SubscriptionWorker.java:90)
	at jdk.internal.reflect.GeneratedMethodAccessor137.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:169)
	at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.invoke(InvocableHandlerMethod.java:119)
	at org.springframework.jms.listener.adapter.MessagingMessageListenerAdapter.invokeHandler(MessagingMessageListenerAdapter.java:110)
	... 10 common frames omitted
Caused by: org.hibernate.exception.ConstraintViolationException: could not execute batch [Batch entry 0 insert into subscription_product_ids (start_date,subscription_id,product_id) values ('2023-01-18 00:00:00+00','12648011','OpenShift Container Platform') was aborted: ERROR: duplicate key value violates unique constraint "subscription_product_ids_pk"
  Detail: Key (product_id, subscription_id, start_date)=(OpenShift Container Platform, 12648011, 2023-01-18 00:00:00+00) already exists.  Call getNextException to see other errors in the batch.] [insert into subscription_product_ids (start_date,subscription_id,product_id) values (?,?,?)]
	at org.hibernate.exception.internal.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:97)
	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:58)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:108)
	at org.hibernate.engine.jdbc.batch.internal.BatchImpl.lambda$performExecution$2(BatchImpl.java:294)
	at org.hibernate.engine.jdbc.mutation.internal.PreparedStatementGroupSingleTable.forEachStatement(PreparedStatementGroupSingleTable.java:59)
	at org.hibernate.engine.jdbc.batch.internal.BatchImpl.performExecution(BatchImpl.java:264)
	at org.hibernate.engine.jdbc.batch.internal.BatchImpl.execute(BatchImpl.java:242)
	at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.executeBatch(JdbcCoordinatorImpl.java:188)
	at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:662)
	at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:499)
	at org.hibernate.event.internal.AbstractFlushingEventListener.performExecutions(AbstractFlushingEventListener.java:363)
	at org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:41)
	at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:127)
	at org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1423)
	at org.hibernate.internal.SessionImpl.managedFlush(SessionImpl.java:504)
	at org.hibernate.internal.SessionImpl.flushBeforeTransactionCompletion(SessionImpl.java:2339)
	at org.hibernate.internal.SessionImpl.beforeTransactionCompletion(SessionImpl.java:1996)
	at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.beforeTransactionCompletion(JdbcCoordinatorImpl.java:439)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.beforeCompletionCallback(JdbcResourceLocalTransactionCoordinatorImpl.java:169)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commit(JdbcResourceLocalTransactionCoordinatorImpl.java:267)
	at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:101)
	at org.springframework.orm.jpa.JpaTransactionManager.doCommit(JpaTransactionManager.java:561)
	... 29 common frames omitted
Caused by: java.sql.BatchUpdateException: Batch entry 0 insert into subscription_product_ids (start_date,subscription_id,product_id) values ('2023-01-18 00:00:00+00','12648011','OpenShift Container Platform') was aborted: ERROR: duplicate key value violates unique constraint "subscription_product_ids_pk"
  Detail: Key (product_id, subscription_id, start_date)=(OpenShift Container Platform, 12648011, 2023-01-18 00:00:00+00) already exists.  Call getNextException to see other errors in the batch.
	at org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:165)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2402)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:574)
	at org.postgresql.jdbc.PgStatement.internalExecuteBatch(PgStatement.java:896)
	at org.postgresql.jdbc.PgStatement.executeBatch(PgStatement.java:919)
	at org.postgresql.jdbc.PgPreparedStatement.executeBatch(PgPreparedStatement.java:1685)
	at com.zaxxer.hikari.pool.ProxyStatement.executeBatch(ProxyStatement.java:127)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeBatch(HikariProxyPreparedStatement.java)
	at org.hibernate.engine.jdbc.batch.internal.BatchImpl.lambda$performExecution$2(BatchImpl.java:279)
	... 47 common frames omitted
Caused by: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "subscription_product_ids_pk"
  Detail: Key (product_id, subscription_id, start_date)=(OpenShift Container Platform, 12648011, 2023-01-18 00:00:00+00) already exists.
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2713)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2401)
	... 54 common frames omitted 
```

## Testing

1.- podman-compose up
2.- apply migrations

```
./gradlew :liquibaseUpdate
```

3.- add the required data:

which is the offering and the duplicate subscription with a different start date. 
```
-- Add offering + product id
INSERT INTO OFFERING(sku,product_name,product_family,sla,description,has_unlimited_usage) 
VALUES ('MW00332','OpenShift Data Science','OPENSHIFT ENTERPRISE','Premium','Red Hat OpenShift Data Science','false');

INSERT INTO sku_oid (sku,oid) 
VALUES ('MW00332',290);

-- Add old active subscription with product id
INSERT INTO subscription(sku,org_id,subscription_id,quantity,start_date,subscription_number)
VALUES('MW00332','16764251','12396617','25','2023-02-02T02:13:35.983189Z','12396774');

INSERT INTO subscription_product_ids(product_id,subscription_id,start_date)
VALUES('OpenShift Container Platform','12396617','2023-02-02T02:13:35.983189Z');

-- Add recent active subscription with the same product id
INSERT INTO subscription(sku,org_id,subscription_id,quantity,start_date,subscription_number)
VALUES('MW00332','16764251','12396618','25','2023-02-06T02:13:35.983189Z','12396774');

INSERT INTO subscription_product_ids(product_id,subscription_id,start_date)
VALUES('OpenShift Container Platform','12396618','2023-02-06T02:13:35.983189Z');
```

4.- (only for local testing) start ActiveMQ:

```
docker run --detach --name mycontainer -p 61616:61616 -p 8161:8161 --rm apache/activemq-artemis:latest-alpine
```

5.- start the service:

```
DEV_MODE=true SUBSCRIPTION_USE_STUB=true USER_USE_STUB=true SPRING_PROFILES_ACTIVE="api,worker,kafka-queue,capacity-ingress" PRODUCT_USE_STUB=true UMB_ENABLED=true SPRING_ACTIVEMQ_BROKER_URL=tcp://localhost:61616 SPRING_ACTIVEMQ_USER=artemis SPRING_ACTIVEMQ_PASSWORD=artemis ./gradlew :bootRun
```

6.- Send the payload via artemis management site: http://localhost:8161/console/artemis/artemisSendMessage?nid=root-org.apache.activemq.artemis-0.0.0.0-addresses-Consumer.null.swatch-null-VirtualTopic_canonical_subscription.VirtualTopic.canonical.subscription-queues-anycast-Consumer.null.swatch-null-VirtualTopic_canonical_subscription.VirtualTopic.canonical.subscription

Payload:

```xml
<CanonicalMessage xmlns="http://esb.redhat.com/Canonical/6">
    <Header>
        <System>SUBSCRIPTION</System>
        <Operation>update</Operation>
        <Type>Subscription</Type>
        <InstanceId>6446c7c050d3b36402663da3</InstanceId>
        <Timestamp>2023-04-24T14:17:41.307</Timestamp>
    </Header>
    <Payload>
        <Sync>
            <Subscription>
                <CreatedBy>OSUBPRODTEST3EAC72C765804E2B8D34484E7FF8D1C8</CreatedBy>
                <CreatedDate>2023-04-24T14:11:16.809</CreatedDate>
                <LastUpdatedBy>RHMIDDLEWARE</LastUpdatedBy>
                <LastUpdatedDate>2023-04-24T14:15:18.000</LastUpdatedDate>
                <Identifiers>
                    <MasterSystem>SUBSCRIPTION</MasterSystem>
                    <Identifier entity-name="Install Base"
                        qualifier="number" system="EBS">39832705</Identifier>
                    <Identifier entity-name="Registration" qualifier="number">e401bce70edd43bd</Identifier>
                    <Identifier entity-name="Subscription"
                        qualifier="number" system="SUBSCRIPTION">12396774</Identifier>
                    <Reference entity-name="Installation" qualifier="number">c967ef3956ff3def</Reference>
                    <Reference entity-name="Customer" qualifier="number" system="EBS">customer123</Reference>
                    <Reference entity-name="Account" qualifier="number" system="EBS">account123</Reference>
                    <Reference entity-name="Customer" qualifier="id" system="WEB">16764251</Reference>
                    <Reference entity-name="Account" qualifier="id" system="WEB">16764251</Reference>
                </Identifiers>
                <Status>
                    <State>Active</State>
                    <StartDate>2023-04-24T00:00:00.000</StartDate>
                </Status>
                <Quantity>25</Quantity>
                <effectiveStartDate>2023-02-02T02:13:35.983189Z</effectiveStartDate>
                <Product serviceable="false">
                    <CreatedBy>OSUBPRODTEST3EAC72C765804E2B8D34484E7FF8D1C8</CreatedBy>
                    <CreatedDate>2023-04-24T14:11:16.809</CreatedDate>
                    <Identifiers>
                        <MasterSystem>EBS</MasterSystem>
                        <Identifier entity-name="Product"
                            qualifier="number" system="SUBSCRIPTION">37188549</Identifier>
                    </Identifiers>
                    <Sku>MW00332</Sku>
                    <InventoryOperatingUnit>
                        <Number>118</Number>
                    </InventoryOperatingUnit>
                    <Product serviceable="true">
                        <CreatedBy>OSUBPRODTEST3EAC72C765804E2B8D34484E7FF8D1C8</CreatedBy>
                        <CreatedDate>2023-04-24T14:11:16.809</CreatedDate>
                        <LastUpdatedBy>SYSADMIN</LastUpdatedBy>
                        <LastUpdatedDate>2023-04-24T14:17:02.000</LastUpdatedDate>
                        <Identifiers>
                            <MasterSystem>EBS</MasterSystem>
                            <AuthoringOperatingUnit>
                                <Number>103</Number>
                            </AuthoringOperatingUnit>
                            <Identifier entity-name="Product"
                                qualifier="number" system="SUBSCRIPTION">37188550</Identifier>
                            <Reference entity-name="Contract"
                                qualifier="number" system="EBS">16612423</Reference>
                            <Reference entity-name="Contract"
                                qualifier="id" system="EBS">25565753</Reference>
                        </Identifiers>
                        <Status>
                            <State>Active</State>
                            <StartDate>2023-04-24T00:00:00.000</StartDate>
                            <EndDate>2026-04-23T00:00:00.000</EndDate>
                        </Status>
                        <Status>
                            <State>Signed</State>
                            <StartDate>2023-04-24T00:00:00.000</StartDate>
                        </Status>
                        <Status primary="true">
                            <State>Terminated</State>
                            <StartDate>2023-04-24T14:17:02.000</StartDate>
                        </Status>
                        <Sku>SVC2681</Sku>
                        <InventoryOperatingUnit>
                            <Number>118</Number>
                        </InventoryOperatingUnit>
                        <ContractDescription>Reg Number activation from Hock</ContractDescription>
                        <ContractHeaderStatus>Terminated</ContractHeaderStatus>
                    </Product>
                </Product>
            </Subscription>
        </Sync>
    </Payload>
</CanonicalMessage>
```

7.- Verification:

You should see the following trace in the service logs:

```Received UMB message... ```

And no exceptions.

Before these changes, we were seeing the IncorrectResultSizeDataAccessException exceptions.