### PR TITLE
SWATCH-2103: Schema updates for enabling retry remittance

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
@@ -21,11 +21,13 @@
 package org.candlepin.subscriptions.tally.billing.admin;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import org.candlepin.subscriptions.billing.admin.api.InternalApi;
 import org.candlepin.subscriptions.billing.admin.api.model.MonthlyRemittance;
+import org.candlepin.subscriptions.billing.admin.api.model.RetriesResponse;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
 import org.springframework.stereotype.Component;
 
@@ -67,5 +69,15 @@ public class InternalBillingResource implements InternalApi {
             .ending(ending)
             .build();
     return billingController.process(filter);
+  }
+
+  /**
+   * @param asOf
+   * @return
+   */
+  @Override
+  public RetriesResponse processRetries(OffsetDateTime asOf) {
+
+    throw new InternalServerErrorException("not yet implemented");
   }
 }

--- a/src/main/resources/liquibase/202401151414-add-retry_after-column-to-billable_usage_remittance-table.xml
+++ b/src/main/resources/liquibase/202401151414-add-retry_after-column-to-billable_usage_remittance-table.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202401151414-01" author="lburnett">
+
+    <comment>Add billable_usage_remittance.retry_after column.</comment>
+    <addColumn tableName="billable_usage_remittance">
+      <column name="retry_after" type="TIMESTAMP WITH TIME ZONE"/>
+    </addColumn>
+    <rollback>
+      <dropColumn tableName="billable_usage_remittance" columnName="retry_after"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -135,5 +135,6 @@
     <include file="/liquibase/202310131200-remove-account-config.xml"/>
     <include file="/liquibase/202310251600-replace-account-config-table.xml"/>
     <include file="/liquibase/202311161207-drop-account-config-table.xml"/>
+    <include file="/liquibase/202401151414-add-retry_after-column-to-billable_usage_remittance-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/spec/internal-billing-api-spec.yaml
+++ b/src/main/spec/internal-billing-api-spec.yaml
@@ -83,13 +83,44 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalBilling
+  /internal/rpc/remittance/processRetries:
+    post:
+      operationId: processRetries
+      summary: Trigger retry of reprocessing billable usages
+      description: Reprocess billable usages with as_of parameter AFTER billable_usage_remittance.retry_after column.
+      parameters:
+        - examples:
+            this_century:
+              value: 2000-01-01T00:00Z
+          name: as_of
+          description: Defaults to current timestamp if left empty
+          schema:
+            format: date-time
+            type: string
+          in: query
+          required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetriesResponse'
+          description: Accepted request to retry billable usage remittance
+      tags: ['internalBilling']
   /internal-billing-openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
   /internal-billing-openapi.yaml:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
-
 components:
   schemas:
+    RetriesResponse:
+      description: ''
+      type: object
+      properties:
+        detail:
+          description: success status
+          type: string
+          example: "Success"
     AccountRemittances:
       type: array
       items:

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
@@ -26,6 +26,7 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.io.Serializable;
+import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -44,4 +45,7 @@ public class BillableUsageRemittanceEntity implements Serializable {
   @Basic
   @Column(name = "remitted_pending_value", nullable = false, precision = 0)
   private Double remittedPendingValue;
+
+  @Column(name = "retry_after")
+  private OffsetDateTime retryAfter;
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2103

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Creates stub API for retrying processing of billable usage.  Adds new nullable column to database table as well.  Business logic not yet implemented.

## Testing
Inspect the database to verify new column.

Here's an httpie request to test the new API.

```
http POST :8000/api/rhsm-subscriptions/v1/internal/rpc/remittance/processRetries as_of==2000-01-01T00:00Z x-rh-swatch-psk:placeholder
```
```
HTTP/1.1 500 
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Connection: close
Content-Length: 86
Content-Type: application/vnd.api+json
Date: Mon, 15 Jan 2024 19:06:12 GMT
Expires: 0
Pragma: no-cache
Set-Cookie: JSESSIONID=CD73A3E1CC504CD5A78718B084ABD742; Path=/; HttpOnly
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 0

{
    "errors": [
        {
            "code": "SUBSCRIPTIONS1001",
            "status": "500",
            "title": "not yet implemented"
        }
    ]
}

```