### PR TITLE
Use app syntax for --no-remove-resources

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -50,12 +50,15 @@ export IQE_IBUTSU_SOURCE="rhsm-ephemeral-${IMAGE_TAG}"
 EXTRA_DEPLOY_ARGS="--timeout 1800 ${IMAGES}"
 OPTIONAL_DEPS_METHOD=none
 
-#each gets appended with --component
-export COMPONENTS_W_RESOURCES="rhsm swatch-api swatch-contracts swatch-producer-aws swatch-producer-red-hat-marketplace swatch-metrics swatch-subscription-sync swatch-system-conduit swatch-tally swatch-producer-azure"
+# set CLI option for --no-remove-resources
+export COMPONENTS_W_RESOURCES="app:rhsm"
+
 # NOTE: this ensures that all of the other services end up deployed with the latest template
-for EXTRA_COMPONENT_NAME in $COMPONENTS_W_RESOURCES; do
+export EXTRA_COMPONENTS="rhsm swatch-api swatch-contracts swatch-producer-aws swatch-producer-red-hat-marketplace swatch-metrics swatch-subscription-sync swatch-system-conduit swatch-tally swatch-producer-azure"
+for EXTRA_COMPONENT_NAME in $EXTRA_COMPONENTS; do
   export EXTRA_DEPLOY_ARGS="${EXTRA_DEPLOY_ARGS} --set-template-ref ${EXTRA_COMPONENT_NAME}=${GIT_COMMIT}"
 done
+
 # Deploy to an ephemeral namespace for testing
 source deploy_ephemeral_env.sh
 


### PR DESCRIPTION
Switches `--no-remove-resources` to use the new app syntax supported in bonfire v5.4.0