### PR TITLE
SWATCH-2109 Eliminate double billing scenarios & modify the PromQL for rhel metering to handle system label changes

### DIFF
--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -188,9 +188,24 @@ rhsm-subscriptions:
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           rhelemeter: >-
-            max(#{metric.prometheus.queryParams[metric]}) by (_id)
-            * on(_id) group_right
-            min_over_time({product=~"#{metric.prometheus.queryParams[productLabelRegex]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
+            max by (#{metric.prometheus.queryParams[instanceKey]}) (sum_over_time(#{metric.prometheus.queryParams[metric]}[1h:10m]))
+            /
+            scalar(count_over_time(vector(1)[1h:10m]))
+
+            * on (#{metric.prometheus.queryParams[instanceKey]}) group_right
+            topk by (#{metric.prometheus.queryParams[instanceKey]}) (
+              1,
+                group without (swatch_placeholder_label) (
+                  min_over_time(
+                  #{metric.prometheus.queryParams[metric]}{
+                  product=~"#{metric.prometheus.queryParams[productLabelRegex]}",
+                  external_organization="#{runtime[orgId]}",
+                  billing_model="marketplace",
+                  support=~"Premium|Standard|Self-Support|None"
+                  }[1h]
+                )
+              )
+            )
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
         backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
@@ -30,5 +30,5 @@ metrics:
       queryKey: rhelemeter
       queryParams:
         productLabelRegex: .*(^|,)(204)($|,).* # this regex is used to fetch metrics for the product label that contains the product/engineering ID 204. the number here needs to map to a tag defined in the variant section of this file
-        metric: max by(_id) (sum_over_time(system_cpu_logical_count[1h:10m])) / scalar(count_over_time(vector(1)[1h:10m])) #To be replaced with recording rule in SWATCH-2075
+        metric: system_cpu_logical_count
         instanceKey: _id


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2109

## Summary

Human explanation of the new query can be found here: https://github.com/RedHatInsights/rhsm-subscriptions/blob/lburnett/swatch-2109-rhelemeter-promql/swatch-metrics/README.md#querytemplatesrhelemeter

We've opted to not use the recording rule for two reasons.  First, it was only further complicating an already complicated promql query.  Second, we get more accurate data by not using it.  When we requested a recording rule to be made, we expected that its evaluation would happen the same frequency as the openshift telemeter instance.  Since that's not going to be the case, using a recording rule doesn't benefit us much.

## Verification of behavior reported in the card

>The problem: we have two series: one for a first half of an hour with a label support=premium, and one for the the second half of an hour with a label support=self-service.
I would expect a value of 0.5 for the first series and 0.5 for the second one

There is a slight change of "expected behavior".  Because of the timing of metrics being reported to prometheus, and how the average value over the hour is calculated, it's possible that an instance has datapoints with different metadata labels that overlap.  For this particular scenario described in the card, there was an overlap where there was instance metadata indicating Premium SLA and another datapoint for Standard SLA.  The query that we landed on will take the first metadata label seen.

What this means functionally is if a metadata field is updated, it can take up to an hour for any change in support level or billing account for a system before it's reflected in prometheus.  This can also result in us underbilling for the period of time between when the metadata field was changed and top of the next hour.  To address underbilling, we'd have to get a recording rule to record `max(system_cpu_logical_count) by (_id)` and then have it run at least every 10m, and then replace system_cpu_logical_count in the numerator with it.

See https://docs.google.com/document/d/1b8Wk-4Joy3nD5Pd0sACgHFN10Vleb6CWKRHCps4ftJE/edit?usp=sharing for more details, example queries, and screenshots.


## Testing

To inspect/verify the generated query, you can use the metering-promql script and then change the 204 to 69 in the output.

`./bin/metering-promql.py --product rhel-for-x86-els-payg --org 11789772`

Expectations:
- Eliminate double billing scenarios
1.  Before this card, we would get multiple data points for an instance per hour when gathering metrics from rhelemeter.  We should now only gather one metric value per hour per instance to be used when hourly tallying.
2. If an instance has its metadata labels changed, we shouldn't double bill for that instance for that hour.

To test the exact example from the card you'll have to get creative.  The instance is only reporting product code 69.  You'll have to update the regex in `swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml` to be 69 instead of 204.  Then you'll want to use orgId 11789772 instead of 16787820.  And you'll need to play with the timestamps on the APIs for getting metrics and starting an hourly tally to make sure the metrics that were showing the problem are considered.


### Steps

Run a token refresher for stage rhelemeter

```
TOKEN_REFRESHER_VERSION=master-2023-09-20-f5e3403
SCOPE="openid offline_access"
CLIENT_SECRET=
CLIENT_ID=
ISSUER_URL=https://sso.redhat.com/auth/realms/redhat-external
URL=https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/rhel
```

```
podman run --name=token-refresher --rm -ti -p 8082:8080 \
  quay.io/observatorium/token-refresher:$TOKEN_REFRESHER_VERSION \
  --scope="$SCOPE" \
  --oidc.client-secret="$CLIENT_SECRET" \
  --oidc.client-id="$CLIENT_ID" \
  --oidc.issuer-url="$ISSUER_URL" \
  --url="$URL"
```


Start swatch-metrics configured for rhelemeter
```
EVENT_SOURCE=rhelemeter PROM_URL="http://localhost:8082/api/v1" ./gradlew :swatch-metrics:quarkusDev
```

Kick off gathering metrics for now
```
curl -X POST --location "http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=16787820" -H 'x-rh-swatch-synchronous-request: false' -H 'x-rh-swatch-psk: placeholder'
```

Kick off gathering metrics with optional API params
```
curl -X 'POST' \
  'http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=16787820&endDate=2024-01-10T20%3A00%3A00Z&rangeInMinutes=120' \
  -H 'accept: */*' \
  -H 'x-rh-swatch-synchronous-request: false' \
  -H 'x-rh-swatch-psk: placeholder' \
  -d ''
```

If there were metrics to be found, you should see log messages indicating they're being sent as events.  At this point you can inspect the `platform.rhsm-subscriptions.service-instance-ingress` topic to see the events.

If you want to continue on in the process, you can turn on swatch-tally (worker profile).  You should see the messages being consumed and they end up in the `rhsm-subscriptions.events` table.  Then you can initiate an hourly tally and look at those results to verify accurate usage values.  If you still have swatch-metrics running, you'll need to change server ports.  Also keep in mind that the start/end dates for the internal/tally/hourly are going to compare against the **event.record_date** database column and not the timestamp of the actual metric fetched from prometheus.  

```
SERVER_PORT=8002 DEV_MODE=true ./gradlew :bootRun
```

```
curl 'http://localhost:8002/api/rhsm-subscriptions/v1/internal/tally/hourly?org=16787820&start=2024-01-16T00%3A00Z&end=2024-01-17T00%3A00Z' \
  -X 'POST' \
  -H 'x-rh-swatch-psk: placeholder' \
  -H 'x-rh-swatch-synchronous-request: false'
  ```