### PR TITLE
SWATCH-2084: Fix mismatch between subscription and event billing account IDs for azure

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProviderTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProviderTest.java
@@ -36,10 +36,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Subscription;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.SubscriptionsException;
 import org.candlepin.subscriptions.subscription.SubscriptionSyncController;
+import org.candlepin.subscriptions.tally.UsageCalculation;
+import org.candlepin.subscriptions.tally.UsageCalculation.Key;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -147,6 +151,39 @@ class UsageContextSubscriptionProviderTest {
     Optional<Subscription> subscription =
         provider.getSubscription("org123", "rosa", "Premium", "Production", "123", lookupDate);
     assertTrue(subscription.isPresent());
+    assertEquals(sub2, subscription.get());
+  }
+
+  @Test
+  void testShouldReturnSubscriptionWithPartialMatchingBillingAccountId() {
+    var endDate = OffsetDateTime.of(2022, 1, 1, 6, 0, 0, 0, ZoneOffset.UTC);
+    Subscription sub1 = new Subscription();
+    sub1.setBillingAccountId("marketplaceTenantId1;marketplaceSubscriptionId1");
+    sub1.setEndDate(endDate);
+    Subscription sub2 = new Subscription();
+    sub2.setBillingAccountId("marketplaceTenantId1;marketplaceSubscriptionId2");
+    sub2.setEndDate(endDate.plusMinutes(45));
+    Subscription sub3 = new Subscription();
+    sub3.setBillingAccountId("marketplaceTenantId1");
+    sub3.setEndDate(endDate.plusMinutes(60));
+
+    Key usageKey =
+        new UsageCalculation.Key(
+            "rosa",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "marketplaceTenantId1");
+
+    var lookupDate = endDate.plusMinutes(30);
+
+    when(syncController.findSubscriptions(
+            Optional.of("org123"), usageKey, lookupDate.minusHours(1), lookupDate))
+        .thenReturn(List.of(sub1, sub2, sub3));
+
+    Optional<Subscription> subscription =
+        provider.getSubscription(
+            "org123", "rosa", "Premium", "Production", "marketplaceTenantId1", lookupDate);
     assertEquals(sub2, subscription.get());
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -133,11 +133,8 @@ public interface ContractMapper {
   // this method is to properly map value from entitlement partnerIdentities
   // as these fields are populated differently based on the marketplace
   default String extractBillingAccountId(PartnerIdentityV1 accountId) {
-
     if (accountId.getCustomerAwsAccountId() != null) {
       return accountId.getCustomerAwsAccountId();
-    } else if (accountId.getAzureTenantId() != null) {
-      return accountId.getAzureTenantId();
     }
     return null;
   }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -195,12 +195,13 @@ class ContractServiceTest extends BaseUnitTest {
     PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
     contractService.createPartnerContract(request);
 
-    request.getCloudIdentifiers().setAzureResourceId("dupeId");
+    request.getCloudIdentifiers().azureResourceId("dupeId");
+    request.getCloudIdentifiers().azureTenantId("dupeId");
     request.getCloudIdentifiers().setAzureOfferId("dupeId");
     request.getCloudIdentifiers().setPlanId("dupeId");
     request.getCloudIdentifiers().setPartner("azure_marketplace");
 
-    givenExistingSubscription("dupeId;dupeId;dupeId");
+    givenExistingSubscription("dupeId;dupeId;dupeId;dupeId");
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
     assertEquals("Duplicate record found", statusResponse.getMessage());
@@ -305,7 +306,7 @@ class ContractServiceTest extends BaseUnitTest {
     verify(subscriptionRepository).persist(subscriptionSaveCapture.capture());
     subscriptionSaveCapture.getValue();
     assertEquals(
-        "a69ff71c-aa8b-43d9-dea8-822fab4bbb86;rh-rhel-sub-1yr;azureProductCode",
+        "a69ff71c-aa8b-43d9-dea8-822fab4bbb86;64dc69e4-d083-49fc-9569-ebece1dd1408;rh-rhel-sub-1yr;azureProductCode",
         subscriptionSaveCapture.getValue().getBillingProviderId());
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -140,7 +140,7 @@ public interface SubscriptionRepository
     if (Objects.nonNull(dbReportCriteria.getBillingAccountId())
         && !dbReportCriteria.getBillingAccountId().equals("_ANY")) {
       searchCriteria =
-          searchCriteria.and(billingAccountIdEquals(dbReportCriteria.getBillingAccountId()));
+          searchCriteria.and(billingAccountIdLike(dbReportCriteria.getBillingAccountId()));
     }
     if (Objects.nonNull(dbReportCriteria.getMetricId())
         || Objects.nonNull(dbReportCriteria.getHypervisorReportCategory())) {
@@ -277,9 +277,11 @@ public interface SubscriptionRepository
         builder.equal(root.get(Subscription_.billingProvider), billingProvider);
   }
 
-  private static Specification<Subscription> billingAccountIdEquals(String billingAccountId) {
+  private static Specification<Subscription> billingAccountIdLike(String billingAccountId) {
     return (root, query, builder) ->
-        builder.equal(root.get(Subscription_.billingAccountId), billingAccountId);
+        // If multiple ID's exist, match on firstID or firstID;secondID (azureTenantId or
+        // azureTenantId;azureSubscriptionId)
+        builder.like(root.get(Subscription_.billingAccountId), billingAccountId + "%");
   }
 
   private static Specification<Subscription> metricsCriteria(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/ErrorCode.java
@@ -53,6 +53,14 @@ public enum ErrorCode {
   SUBSCRIPTION_RECENTLY_TERMINATED(
       1005, "Subscription recently terminated. No active subscriptions."),
 
+  /**
+   * Subscription could not be determined. Likely caused by a subscription missing the
+   * azureSubscriptionId from the billingAccountId.
+   */
+  SUBSCRIPTION_CANNOT_BE_DETERMINED(
+      1006,
+      "Multiple possible matches found. Likely a subscription is missing part of its billingAccountId. (check azureSubscriptionId)"),
+
   /** An unexpected exception was thrown by the inventory service client. */
   INVENTORY_SERVICE_ERROR(2000, "Inventory Service Error"),
 

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -230,7 +230,16 @@ public class PrometheusMeteringController {
     }
 
     String billingProvider = labels.get("billing_marketplace");
-    String billingAccountId = labels.get("billing_marketplace_account");
+    String billingAccountId;
+
+    // extract azure IDs
+    String azureTenantId = labels.get("azure_tenant_id");
+    String azureSubscriptionId = labels.get("azure_subscription_id");
+    if (StringUtils.isNotEmpty(azureTenantId) && StringUtils.isNotEmpty(azureSubscriptionId)) {
+      billingAccountId = String.format("%s;%s", azureTenantId, azureSubscriptionId);
+    } else {
+      billingAccountId = labels.get("billing_marketplace_account");
+    }
 
     // For the openshift metrics, we expect our results to be a 'matrix'
     // vector [(instant_time,value), ...] so we only look at the result's

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
@@ -389,6 +389,84 @@ class PrometheusMeteringControllerTest {
         results.received().stream().map(Message::getPayload).allMatch(expectedEvents::contains));
   }
 
+  @Test
+  @SuppressWarnings("indentation")
+  void testCollectAzureOpenShiftMetricsWillPersistCorrectBillingAccountId() {
+    BigDecimal time1 = BigDecimal.valueOf(123456.234);
+    BigDecimal val1 = BigDecimal.valueOf(100L);
+    BigDecimal time2 = BigDecimal.valueOf(222222.222);
+    BigDecimal val2 = BigDecimal.valueOf(120L);
+    var expectedAzureTenantId = "testTenantId";
+    var expectedAzureSubscriptionId = "testSubscriptionId";
+    var expectedAzureBillingAccountId = "testTenantId;testSubscriptionId";
+
+    QueryResult data =
+        buildAzureOpenShiftClusterQueryResult(
+            expectedOrgId,
+            expectedClusterId,
+            expectedSla,
+            expectedUsage,
+            expectedBillingProvider,
+            expectedAzureTenantId,
+            expectedAzureSubscriptionId,
+            List.of(List.of(time1, val1), List.of(time2, val2)));
+    prometheusServer.stubQueryRange(data);
+
+    OffsetDateTime start = clock.startOfCurrentHour();
+    OffsetDateTime end = start.plusDays(1);
+
+    List<BaseEvent> expectedEvents =
+        List.of(
+            MeteringEventFactory.createMetricEvent(
+                expectedOrgId,
+                expectedClusterId,
+                expectedSla,
+                expectedUsage,
+                expectedRole,
+                PROMETHEUS,
+                clock.dateFromUnix(time1).minusSeconds(metricProperties.step()),
+                clock.dateFromUnix(time1),
+                expectedServiceType,
+                expectedBillingProvider,
+                expectedAzureBillingAccountId,
+                expectedMetricId,
+                val1.doubleValue(),
+                expectedProductTag,
+                expectedSpanId,
+                List.of()),
+            MeteringEventFactory.createMetricEvent(
+                expectedOrgId,
+                expectedClusterId,
+                expectedSla,
+                expectedUsage,
+                expectedRole,
+                PROMETHEUS,
+                clock.dateFromUnix(time2).minusSeconds(metricProperties.step()),
+                clock.dateFromUnix(time2),
+                expectedServiceType,
+                expectedBillingProvider,
+                expectedAzureBillingAccountId,
+                expectedMetricId,
+                val2.doubleValue(),
+                expectedProductTag,
+                expectedSpanId,
+                List.of()),
+            MeteringEventFactory.createCleanUpEvent(
+                expectedOrgId,
+                getEventType(expectedMetricId.toString(), expectedProductTag),
+                PROMETHEUS,
+                start,
+                end,
+                expectedSpanId));
+
+    whenCollectMetrics(start, end);
+
+    assertEquals(expectedEvents.size(), results.received().size());
+    verifyQueryRange(start, end);
+    assertTrue(
+        results.received().stream().map(Message::getPayload).allMatch(expectedEvents::contains));
+  }
+
   private void whenCollectMetrics(OffsetDateTime start, OffsetDateTime end) {
     whenCollectMetrics(expectedOrgId, start, end);
   }
@@ -423,6 +501,34 @@ class PrometheusMeteringControllerTest {
             .putMetricItem("external_organization", orgId)
             .putMetricItem("billing_marketplace", billingProvider)
             .putMetricItem("billing_marketplace_account", billingAccountId);
+
+    // NOTE: A tuple is [unix_time,value]
+    timeValueTuples.forEach(dataResult::addValuesItem);
+
+    return new QueryResult()
+        .status(StatusType.SUCCESS)
+        .data(new QueryResultData().resultType(ResultType.MATRIX).addResultItem(dataResult));
+  }
+
+  private QueryResult buildAzureOpenShiftClusterQueryResult(
+      String orgId,
+      String clusterId,
+      String sla,
+      String usage,
+      String billingProvider,
+      String azureTenantId,
+      String azureSubscriptionId,
+      List<List<BigDecimal>> timeValueTuples) {
+    QueryResultDataResultInner dataResult =
+        new QueryResultDataResultInner()
+            .putMetricItem("_id", clusterId)
+            .putMetricItem("support", sla)
+            .putMetricItem("usage", usage)
+            .putMetricItem("external_organization", orgId)
+            .putMetricItem("billing_marketplace", billingProvider)
+            .putMetricItem("azure_tenant_id", azureTenantId)
+            .putMetricItem("azure_subscription_id", azureSubscriptionId);
+
 
     // NOTE: A tuple is [unix_time,value]
     timeValueTuples.forEach(dataResult::addValuesItem);

--- a/swatch-model-events/schemas/event.yaml
+++ b/swatch-model-events/schemas/event.yaml
@@ -152,6 +152,21 @@ properties:
     type: string
     existingJavaType: java.util.Optional<String>
     required: false
+  azure_tenant_id:
+    description: The azure tenant ID used for billing
+    type: string
+    existingJavaType: java.util.Optional<String>
+    required: false
+  azure_resource_id:
+    description: The azure resource ID used for billing
+    type: string
+    existingJavaType: java.util.Optional<String>
+    required: false
+  azure_subscription_id:
+    description: The azure subscription ID used for billing
+    type: string
+    existingJavaType: java.util.Optional<String>
+    required: false
   product_tag:
     description: Product tag
     type: array

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageConsumer.java
@@ -192,6 +192,14 @@ public class BillableUsageConsumer {
         if (isRecentlyTerminatedError) {
           throw new SubscriptionRecentlyTerminatedException(e);
         }
+        var isSubscriptionCannotBeDeterminedError =
+            optionalErrors.get().getErrors().stream()
+                .anyMatch(error -> ("SUBSCRIPTIONS1006").equals(error.getCode()));
+        // TODO: https://issues.redhat.com/browse/SWATCH-2099 put messages on dead-letter topic to
+        // be reprocessed
+        if (isSubscriptionCannotBeDeterminedError) {
+          log.warn("Subscription could not be determined due to ambiguois billingAccountId");
+        }
       }
       throw new AzureUsageContextLookupException(e);
     } catch (ProcessingException | ApiException e) {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2084

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

We were saving billing_account_id as the azureTenantResourceId but it was coming from cost mgmt as azureSubscriptionId. It turns out we need both ID's to identify which is the correct azure subscription so with this change we store both as the billing_account_id (partially when no subscriptionId is available).

getAzureMarketplaceContext will now attempt to find a subscription based on the full billing_account_id (azure_tenant_id;azure_subscription_id) or the partial id if the subscriptionId is not made available yet. (just azure_tenant_id)

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
### Setup
<!-- Add any steps required to set up the test case -->
1. Save test data:
```
INSERT INTO public.offering VALUES ('RH02781HR', 'RHEL Server', 'RHEL', NULL, NULL, NULL, NULL, 'Red Hat Enterprise Linux Server', 'Premium', 'Production', 'Red Hat Enterprise Linux for Third Party Linux Migration with Extended Life Cycle Support (On-Demand, Hourly Production Support)', false, NULL);


INSERT INTO public.subscription VALUES ('RH02781HR', 'org123', '12639739', 1, '2024-01-05 15:59:19.698865+00', NULL, 'resourceId1;vcpu-hours;rh-rhel-migration-test-preview', '12639896', 'azure', 'testTenantId');
INSERT INTO public.subscription VALUES ('RH02781HR', 'org123', '12639740', 1, '2024-01-05 15:59:19.698865+00', NULL, 'resourceId2;vcpu-hours;rh-rhel-migration-test-preview', '12639896', 'azure', 'testTenantId;testSubscriptionId');
INSERT INTO public.subscription VALUES ('RH02781HR', 'org123', '12639741', 1, '2024-01-05 15:59:19.698865+00', NULL, 'resourceId3;vcpu-hours;rh-rhel-migration-test-preview', '12639896', 'azure', 'testDupeTenantId');
INSERT INTO public.subscription VALUES ('RH02781HR', 'org123', '12639742', 1, '2024-01-05 15:59:19.698865+00', NULL, 'resourceId4;vcpu-hours;rh-rhel-migration-test-preview', '12639896', 'azure', 'testDupeTenantId');
```

### Steps
<!-- Enter each step of the test below -->
1.Start subscription api with:  `DEV_MODE=true SPRING_PROFILES_ACTIVE=worker,api,kafka-queue SERVER_PORT=8001 ./gradlew :bootRun`
1. In separate terminal start swatch-producer-azure with: `SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8001 ./gradlew :swatch-producer-azure:quarkusDev`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Test getAzureMarketplaceContext should return 200 with response body:
`curl -X 'GET'   "localhost:8001/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext?orgId=org123&date=2024-01-08T00%3A00%3A00Z&productId=rhel-for-x86-els-payg&sla=Premium&usage=Production&billingAccountId=testTenantId;testSubscriptionId"   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'`
1. Send messages onto kafka topic for platform.rhsm-subscriptions.billable-usage:
2. Happy Path matches exact billing_account_ID, should get resourceId 2:
`{"org_id":"org123","id":null,"billing_provider":"azure","billing_account_id":"testTenantId;testSubscriptionId","snapshot_date":"2024-01-09T14:54:03.871320108Z","product_id":"rhel-for-x86-els-payg","sla":"Premium","usage":null,"uom":"vCPUs","value":42.0}`
3. Happy Path matches partial billing_account_ID, should get resourceId1:
`{"org_id":"org123","id":null,"billing_provider":"azure","billing_account_id":"testTenantId;notYetFoundSubscriptionId","snapshot_date":"2024-01-09T14:54:03.871320108Z","product_id":"rhel-for-x86-els-payg","sla":"Premium","usage":null,"uom":"vCPUs","value":42.0}`
4. Sad Path can't match partial billing_account_ID, error:
`{"org_id":"org123","id":null,"billing_provider":"azure","billing_account_id":"testDupeTenantId;notYetFoundSubscriptionId","snapshot_date":"2024-01-09T14:54:03.871320108Z","product_id":"rhel-for-x86-els-payg","sla":"Premium","usage":null,"uom":"vCPUs","value":42.0}`
