### PR TITLE
SWATCH-2069: Skip UMB message when multiple subscriptions are found

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorker.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorker.java
@@ -84,9 +84,11 @@ public class SubscriptionWorker extends SeekableKafkaConsumer {
         xmlMapper.readValue(subscriptionMessageXml, CanonicalMessage.class);
     UmbSubscription subscription = subscriptionMessage.getPayload().getSync().getSubscription();
     log.info(
-        "Received UMB message for subscriptionNumber={} webCustomerId={}",
+        "Received UMB message for subscriptionNumber={} webCustomerId={} startDate={} endDate={}",
         subscription.getSubscriptionNumber(),
-        subscription.getWebCustomerId());
+        subscription.getWebCustomerId(),
+        subscription.getEffectiveStartDate(),
+        subscription.getEffectiveEndDate());
     subscriptionSyncController.saveUmbSubscription(subscription);
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.db;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.transaction.Transactional;
@@ -75,7 +76,8 @@ class SubscriptionRepositoryTest {
     offeringRepo.save(offering);
     subscriptionRepo.saveAndFlush(subscription);
 
-    Subscription retrieved = subscriptionRepo.findActiveSubscription("123").orElse(null);
+    Subscription retrieved =
+        subscriptionRepo.findActiveSubscription("123").stream().findFirst().orElse(null);
 
     // because of an issue with precision related to findActiveSubscription passing the entity
     // cache, we'll have to check fields
@@ -319,8 +321,8 @@ class SubscriptionRepositoryTest {
     offeringRepo.save(offering1);
     subscriptionRepo.saveAllAndFlush(List.of(s1, s2));
 
-    assertTrue(subscriptionRepo.findActiveSubscription(s1.getSubscriptionId()).isPresent());
-    assertTrue(subscriptionRepo.findActiveSubscription(s2.getSubscriptionId()).isPresent());
+    assertFalse(subscriptionRepo.findActiveSubscription(s1.getSubscriptionId()).isEmpty());
+    assertFalse(subscriptionRepo.findActiveSubscription(s2.getSubscriptionId()).isEmpty());
   }
 
   @Transactional

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -131,7 +131,7 @@ class SubscriptionSyncControllerTest {
   @Test
   void shouldCreateNewRecordOnQuantityChange() {
     Mockito.when(subscriptionRepository.findActiveSubscription(Mockito.anyString()))
-        .thenReturn(Optional.of(createSubscription()));
+        .thenReturn(List.of(createSubscription()));
     Mockito.when(offeringRepository.existsById(SKU)).thenReturn(true);
     Offering offering = Offering.builder().sku(SKU).build();
     when(offeringRepository.getReferenceById(SKU)).thenReturn(offering);
@@ -498,7 +498,7 @@ class SubscriptionSyncControllerTest {
     o.setProductName(PAYG_PRODUCT_NAME);
     o.setMetered(true);
     when(offeringRepository.findById(SKU)).thenReturn(Optional.of(o));
-    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(Optional.of(s));
+    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(List.of(s));
 
     var termination = OffsetDateTime.now();
     var result = subscriptionSyncController.terminateSubscription("456", termination);
@@ -512,7 +512,7 @@ class SubscriptionSyncControllerTest {
     Offering offering = Offering.builder().productName(PAYG_PRODUCT_NAME).metered(true).build();
     s.setOffering(offering);
     when(offeringRepository.findById(SKU)).thenReturn(Optional.of(offering));
-    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(Optional.of(s));
+    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(List.of(s));
 
     var termination = OffsetDateTime.now().minusDays(1);
     var result = subscriptionSyncController.terminateSubscription("456", termination);
@@ -527,7 +527,7 @@ class SubscriptionSyncControllerTest {
     Subscription s = createSubscription();
     s.getOffering().setProductName(PAYG_PRODUCT_NAME);
     s.getOffering().setMetered(true);
-    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(Optional.of(s));
+    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(List.of(s));
 
     var termination = OffsetDateTime.now().plusDays(1);
     var result = subscriptionSyncController.terminateSubscription("456", termination);
@@ -541,7 +541,7 @@ class SubscriptionSyncControllerTest {
   void terminateActiveNonPAYGSubscriptionTest() {
     Subscription s = createSubscription();
     s.getOffering().setProductName("Random Product");
-    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(Optional.of(s));
+    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(List.of(s));
 
     var termination = OffsetDateTime.now();
     var result = subscriptionSyncController.terminateSubscription("456", termination);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -30,7 +30,6 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.db.model.BillingProvider;
@@ -67,13 +66,13 @@ public interface SubscriptionRepository
         ORDER BY s.subscriptionId, s.startDate
       """)
   @EntityGraph(value = "graph.SubscriptionSync")
-  Optional<Subscription> findActiveSubscription(@Param("subscriptionId") String subscriptionId);
+  List<Subscription> findActiveSubscription(@Param("subscriptionId") String subscriptionId);
 
   @EntityGraph(value = "graph.SubscriptionSync")
   // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(
       "SELECT s FROM Subscription s WHERE s.subscriptionNumber = :subscriptionNumber ORDER BY s.subscriptionId, s.startDate")
-  Optional<Subscription> findBySubscriptionNumber(String subscriptionNumber);
+  List<Subscription> findBySubscriptionNumber(String subscriptionNumber);
 
   // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(


### PR DESCRIPTION
Jira issue: [SWATCH-2069](https://issues.redhat.com/browse/SWATCH-2069)

## Description
The first attempt to fix SWATCH-2069 was to get the first subscription when multiple entities were found: https://github.com/RedHatInsights/rhsm-subscriptions/pull/2938. However, this fix caused lots of errors about the subscription_product_ids_pk constraint were violated. Therefore, it was reverted by https://github.com/RedHatInsights/rhsm-subscriptions/pull/2967. 

I've detected that we are receiving many UMB message for the same subscription number. For example:

```
{"severity":"INFO","logger":"org.candlepin.subscriptions.subscription.SubscriptionWorker","thread":"org.springframework.jms.JmsListenerEndpointContainer#1-1","message":"2024-01-17T08:17:44.784+0000 [thread=org.springframework.jms.JmsListenerEndpointContainer#1-1] [level=INFO] [category=org.candlepin.subscriptions.subscription.SubscriptionWorker]  - Received UMB message for subscriptionNumber=12591669 webCustomerId=16784852\n","properties":{"trace_id":"98c222176cad63ac514f07b9f30a7f5b","trace_flags":"01","span_id":"2c485b5f56fad97e"}}
```

For the above subscription number, we got up to 26 messages on 17 Jan. 

This can be due to a duplicated message because when throwing a NonUniqueResultException exception, the message was not ack, or because it's a subscription with a different start date (I've updated the log message to identify this scenario). 

In any case, I suggest detecting when multiple subscriptions are found and ack the message by simply skipping this message (and logging a warning). This is the same behavior we do when querying for the subscription ID using the IT Search API. 

Moreover, I've deleted some unused methods to clear a bit the usages on findBySubscriptionNumber and findActiveSubscription methods. 

## Testing
This only can be tested on stage by checking this splunk query:

```
index=rh_rhsm namespace=rhsm-stage ("subscription_product_ids_pk" OR "NonUniqueResultException")| bucket _time span=day | stats count(eval(searchmatch("subscription_product_ids_pk"))) as subscription_product_ids_pk_count count(eval(searchmatch("NonUniqueResultException"))) as NonUniqueResultException_count by _time
```

We expect zero exceptions in both columns if the fix is correct.