### PR TITLE
SWATCH-2105: Constrain tally floorist exports to 1 day's range

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -699,7 +699,7 @@ objects:
         and billing_account_id = '_ANY'
         and granularity='DAILY'
         and measurement_type!='TOTAL'
-        AND snapshot_date > now() - interval '2 day'; 
+        AND snapshot_date at time zone 'utc' = date_trunc('day', now() at time zone 'utc' - interval '2 day');
     - prefix: swatch/subscriptions
       query: >-
         select


### PR DESCRIPTION
Jira issue: [SWATCH-2105](https://issues.redhat.com/browse/SWATCH-2105)

## Description
Currently, the where clause includes this expression
`snapshot_date > now() - interval '2 day';`
However, depending on timing, this sometimes gathers 1 days data, sometimes 2 days worth.

Instead, change the clause to
`snapshot_date > date_trunc('day', now() - interval '2 day')`
which will force the query to pull only data from tallies for 2 days ago.

## Testing
1.- `podman-compose up` to start up the PostgreSQL database instance.
2.- `./gradlew liquibaseUpdate` to perform all the migrations
3.- Insert the test data:

```sql
-- Create snapshot 000000000001 from today

INSERT INTO tally_snapshots(id, product_id, granularity, org_id, snapshot_date, sla, "usage", billing_provider, billing_account_id)
VALUES('00000000-0000-0000-0000-000000000001', 'rosa', 'DAILY', '01', now(), '_ANY', '_ANY', '_ANY', '_ANY');

-- Create snapshot 000000000002 from yesterday

INSERT INTO tally_snapshots(id, product_id, granularity, org_id, snapshot_date, sla, "usage", billing_provider, billing_account_id)
VALUES('00000000-0000-0000-0000-000000000002', 'rosa', 'DAILY', '02', now() - interval '1 day', '_ANY', '_ANY', '_ANY', '_ANY');

-- Create snapshot 000000000003 from two days ago

INSERT INTO tally_snapshots(id, product_id, granularity, org_id, snapshot_date, sla, "usage", billing_provider, billing_account_id)
VALUES('00000000-0000-0000-0000-000000000003', 'rosa', 'DAILY', '03', now() - interval '2 day', '_ANY', '_ANY', '_ANY', '_ANY');

-- Create snapshot 000000000004 from three days ago

INSERT INTO tally_snapshots(id, product_id, granularity, org_id, snapshot_date, sla, "usage", billing_provider, billing_account_id)
VALUES('00000000-0000-0000-0000-000000000004', 'rosa', 'DAILY', '04', now() - interval '3 day', '_ANY', '_ANY', '_ANY', '_ANY');

-- Create measurements for all the previous snapshots
INSERT INTO tally_measurements(snapshot_id, measurement_type, metric_id, value)
	select s.id, 'PHYSICAL', 'CORES', 1
	from tally_snapshots s
	left join tally_measurements m on m.snapshot_id = s.id 
	where id::text like '00000000-0000-0000-0000-00000000000%' and m.snapshot_id is null;
```

4.- Run the query that has changed. 

You should see only three entries:

```
01	2024-01-19 13:27:43.335 +0100	rosa	PHYSICAL	CORES	CORES	1.0	2024-01-17 00:00:00.000 +0100
02	2024-01-18 13:27:43.335 +0100	rosa	PHYSICAL	CORES	CORES	1.0	2024-01-17 00:00:00.000 +0100
03	2024-01-17 13:27:43.335 +0100	rosa	PHYSICAL	CORES	CORES	1.0	2024-01-17 00:00:00.000 +0100
```

The entry with orgId 04 should be out because is three days old. 

Before these changes, the entry with orgId 03 was also out. 