### PR TITLE
SWATCH-2099: Produce failed messages to dlt for swatch-azure-producer

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -190,9 +190,9 @@ public class InternalSubscriptionResource implements InternalApi {
 
   @Override
   public AwsUsageContext getAwsUsageContext(
+      @jakarta.validation.constraints.NotNull OffsetDateTime date,
+      @jakarta.validation.constraints.NotNull String productId,
       String orgId,
-      OffsetDateTime date,
-      String productId,
       String sla,
       String usage,
       String awsAccountId) {
@@ -205,9 +205,9 @@ public class InternalSubscriptionResource implements InternalApi {
 
   @Override
   public AzureUsageContext getAzureMarketplaceContext(
-      @jakarta.validation.constraints.NotNull String orgId,
       @jakarta.validation.constraints.NotNull OffsetDateTime date,
       @jakarta.validation.constraints.NotNull String productId,
+      String orgId,
       String sla,
       String usage,
       String azureAccountId) {

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -224,7 +224,6 @@ paths:
     parameters:
       - name: orgId
         in: query
-        required: true
         schema:
           type: string
         description: "Customer's Org Id"
@@ -251,6 +250,8 @@ paths:
         in: query
         schema:
           type: string
+          default: _ANY
+
     get:
       summary: "Lookup necessary info to submit a usage record to AWS"
       operationId: getAwsUsageContext
@@ -285,7 +286,6 @@ paths:
           schema:
             type: string
           in: query
-          required: true
         - name: date
           description: 'Look at subscriptions starting on this date'
           example: 2023-10-31T00:00:00Z
@@ -313,12 +313,12 @@ paths:
           schema:
             type: string
           in: query
-        - name: billingAccountId
+        - name: azureAccountId
           description: 'Look at subscriptions matching this billing_account_id'
           schema:
             type: string
+            default: _ANY
           in: query
-          required: false
       responses:
         '200':
           content:

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -357,9 +357,9 @@ class InternalSubscriptionResourceTest {
             SubscriptionsException.class,
             () -> {
               resource.getAzureMarketplaceContext(
-                  "org123",
                   lookupDate,
                   "rosa",
+                  "org123",
                   "Premium",
                   "Production",
                   "azureTenantId;azureSubscriptionId");
@@ -386,7 +386,7 @@ class InternalSubscriptionResourceTest {
     var lookupDate = OffsetDateTime.now().minusMinutes(30);
     var azureUsageContext =
         resource.getAzureMarketplaceContext(
-            "org123", lookupDate, "BASILISK", "Premium", "Production", "azureTenantId");
+            lookupDate, "BASILISK", "org123", "Premium", "Production", "azureTenantId");
     assertEquals("resourceId1", azureUsageContext.getAzureResourceId());
   }
 
@@ -406,9 +406,9 @@ class InternalSubscriptionResourceTest {
     var lookupDate = OffsetDateTime.now().minusMinutes(30);
     var azureUsageContext =
         resource.getAzureMarketplaceContext(
-            "org123",
             lookupDate,
             "BASILISK",
+            "org123",
             "Premium",
             "Production",
             "azureTenantId;azureSubscriptionId2");

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -124,7 +124,7 @@ class InternalSubscriptionResourceTest {
         NotFoundException.class,
         () ->
             resource.getAwsUsageContext(
-                null, defaultLookUpDate, "rosa", "Premium", "Production", "123"));
+                defaultLookUpDate, "rosa", null, "Premium", "Production", "123"));
     Counter counter = meterRegistry.counter("swatch_missing_aws_subscription");
     assertEquals(1.0, counter.count());
   }
@@ -148,7 +148,7 @@ class InternalSubscriptionResourceTest {
         NotFoundException.class,
         () ->
             resource.getAwsUsageContext(
-                "org123", defaultLookUpDate, "rosa", "Premium", "Production", "123"));
+                defaultLookUpDate, "rosa", "org123", "Premium", "Production", "123"));
     Counter counter = meterRegistry.counter("swatch_missing_aws_subscription");
     assertEquals(1.0, counter.count());
   }
@@ -176,7 +176,7 @@ class InternalSubscriptionResourceTest {
         .thenReturn(List.of(sub1, sub2));
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
-            "org123", defaultLookUpDate, "rosa", "Premium", "Production", "123");
+            defaultLookUpDate, "rosa", "org123", "Premium", "Production", "123");
     Counter counter = meterRegistry.counter("swatch_ambiguous_aws_subscription");
     assertEquals(1.0, counter.count());
     assertEquals("foo1", awsUsageContext.getProductCode());
@@ -198,7 +198,7 @@ class InternalSubscriptionResourceTest {
             SubscriptionsException.class,
             () -> {
               resource.getAwsUsageContext(
-                  "org123", lookupDate, "rosa", "Premium", "Production", "123");
+                  lookupDate, "rosa", "org123", "Premium", "Production", "123");
             });
 
     assertEquals(
@@ -219,7 +219,7 @@ class InternalSubscriptionResourceTest {
         .thenReturn(List.of(sub1, sub2));
     var lookupDate = endDate.plusMinutes(30);
     AwsUsageContext awsUsageContext =
-        resource.getAwsUsageContext("org123", lookupDate, "rosa", "Premium", "Production", "123");
+        resource.getAwsUsageContext(lookupDate, "rosa", "org123", "Premium", "Production", "123");
     assertEquals("bar1", awsUsageContext.getProductCode());
     assertEquals("bar2", awsUsageContext.getCustomerId());
     assertEquals("bar3", awsUsageContext.getAwsSellerAccountId());
@@ -234,7 +234,7 @@ class InternalSubscriptionResourceTest {
     when(syncController.findSubscriptions(any(), any(), any(), any())).thenReturn(List.of(sub));
     var azureUsageContext =
         resource.getAzureMarketplaceContext(
-            "org123", endDate, "BASILISK", "Premium", "Production", "123");
+            endDate, "BASILISK", "org123", "Premium", "Production", "123");
     assertEquals("resourceId", azureUsageContext.getAzureResourceId());
     assertEquals("planId", azureUsageContext.getPlanId());
     assertEquals("offerId", azureUsageContext.getOfferId());

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/processors/BillableUsageProcessor.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/processors/BillableUsageProcessor.java
@@ -155,12 +155,12 @@ public class BillableUsageProcessor {
       throws AwsUsageContextLookupException {
     try {
       return internalSubscriptionsApi.getAwsUsageContext(
-          billableUsage.getOrgId(),
           billableUsage.getSnapshotDate(),
           billableUsage.getProductId(),
+          Optional.ofNullable(billableUsage.getBillingAccountId()).orElse("_ANY"),
+          billableUsage.getOrgId(),
           Optional.ofNullable(billableUsage.getSla()).map(SlaEnum::value).orElse(null),
-          Optional.ofNullable(billableUsage.getUsage()).map(UsageEnum::value).orElse(null),
-          Optional.ofNullable(billableUsage.getBillingAccountId()).orElse("_ANY"));
+          Optional.ofNullable(billableUsage.getUsage()).map(UsageEnum::value).orElse(null));
     } catch (DefaultApiException e) {
       var optionalErrors = Optional.ofNullable(e.getErrors());
       if (optionalErrors.isPresent()) {

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/exception/ErrorCode.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/exception/ErrorCode.java
@@ -30,7 +30,10 @@ public enum ErrorCode {
   SUBSCRIPTION_RECENTLY_TERMINATED(1006, "Subscription recently terminated"),
   USAGE_TIMESTAMP_OUT_OF_RANGE(1007, "Usage timestamp will not be accepted by AWS"),
   AZURE_MARKETPLACE_API_REQUEST_FAILED(1008, "Azure Marketplace Api request failed."),
-  AZURE_USAGE_CONTEXT_LOOKUP_ERROR(1009, "Error looking up Azure Usage Context.");
+  AZURE_USAGE_CONTEXT_LOOKUP_ERROR(1009, "Error looking up Azure Usage Context."),
+  SUBSCRIPTION_CANNOT_BE_DETERMINED(
+      1010,
+      "Multiple possible matches found. Likely a subscription is missing part of its billingAccountId.");
 
   private static final String CODE_PREFIX = "AZURE";
 

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/exception/SubscriptionCanNotBeDeterminedException.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/exception/SubscriptionCanNotBeDeterminedException.java
@@ -18,26 +18,11 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.azure.test.resources;
+package com.redhat.swatch.azure.exception;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.smallrye.reactive.messaging.memory.InMemoryConnector;
-import java.util.HashMap;
-import java.util.Map;
+public class SubscriptionCanNotBeDeterminedException extends AzureProducerException {
 
-public class InMemoryMessageBrokerKafkaResource implements QuarkusTestResourceLifecycleManager {
-
-  @Override
-  public Map<String, String> start() {
-    Map<String, String> env = new HashMap<>();
-    env.putAll(InMemoryConnector.switchIncomingChannelsToInMemory("tally-in"));
-    env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory("tally-out"));
-    env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory("tally-dlt"));
-    return env;
-  }
-
-  @Override
-  public void stop() {
-    InMemoryConnector.clear();
+  public SubscriptionCanNotBeDeterminedException(Exception e) {
+    super(ErrorCode.SUBSCRIPTION_CANNOT_BE_DETERMINED, e);
   }
 }

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/resource/DefaultApiExceptionMapper.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/resource/DefaultApiExceptionMapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.resource;
+
+import com.redhat.swatch.azure.exception.DefaultApiException;
+import com.redhat.swatch.clients.swatch.internal.subscription.api.model.Errors;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+@Provider
+@Slf4j
+@Priority(-1)
+public class DefaultApiExceptionMapper implements ResponseExceptionMapper<DefaultApiException> {
+
+  @Override
+  public boolean handles(int status, MultivaluedMap<String, Object> headers) {
+    return status >= 400;
+  }
+
+  @Override
+  public DefaultApiException toThrowable(Response response) {
+    return new DefaultApiException(response, parseErrors(response));
+  }
+
+  private Errors parseErrors(Response response) {
+    try {
+      return response.readEntity(Errors.class);
+    } catch (Exception e) {
+      log.debug("Failed to create Errors from response.", e);
+      return null;
+    }
+  }
+}

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageConsumer.java
@@ -177,9 +177,9 @@ public class BillableUsageConsumer {
       throws AzureUsageContextLookupException {
     try {
       return internalSubscriptionsApi.getAzureMarketplaceContext(
-          billableUsage.getOrgId(),
           billableUsage.getSnapshotDate(),
           billableUsage.getProductId(),
+          billableUsage.getOrgId(),
           Optional.ofNullable(billableUsage.getSla()).map(SlaEnum::value).orElse(null),
           Optional.ofNullable(billableUsage.getUsage()).map(UsageEnum::value).orElse(null),
           Optional.ofNullable(billableUsage.getBillingAccountId()).orElse("_ANY"));

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageDeadLetterTopicProducer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageDeadLetterTopicProducer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.service;
+
+import com.redhat.swatch.azure.openapi.model.BillableUsage;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+@ApplicationScoped
+public class BillableUsageDeadLetterTopicProducer {
+
+  public static final String RETRY_AFTER_HEADER = "retryAfter";
+
+  @Channel("tally-dlt")
+  Emitter<BillableUsage> dlq;
+
+  public void send(BillableUsage billableUsage) {
+    dlq.send(
+        Message.of(billableUsage)
+            .addMetadata(
+                OutgoingKafkaRecordMetadata.<String>builder()
+                    .withKey(billableUsage.getOrgId())
+                    .withHeaders(
+                        new RecordHeaders()
+                            .add(RETRY_AFTER_HEADER, nextTick().toString().getBytes()))
+                    .build()));
+  }
+
+  private OffsetDateTime nextTick() {
+    return OffsetDateTime.now(Clock.systemUTC()).plusHours(1);
+  }
+}

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -14,6 +14,7 @@ TALLY_IN_FAIL_ON_DESER_FAILURE=true
 WIREMOCK_HOSTNAME=wiremock
 
 # azure config
+AZURE_MARKETPLACE_USAGE_WINDOW=72h
 AZURE_MANUAL_SUBMISSION_ENABLED=false
 %dev.AZURE_MANUAL_SUBMISSION_ENABLED=true
 %test.AZURE_MANUAL_SUBMISSION_ENABLED=${%dev.AZURE_MANUAL_SUBMISSION_ENABLED}
@@ -99,6 +100,10 @@ mp.messaging.incoming.tally-in.auto.offset.reset = earliest
 # Producer settings
 mp.messaging.outgoing.tally-out.connector=smallrye-kafka
 mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.billable-usage
+
+# Dead Letter Topic settings
+mp.messaging.outgoing.tally-dlt.connector=smallrye-kafka
+mp.messaging.outgoing.tally-dlt.topic=platform.rhsm-subscriptions.billable-usage.dlt
 
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions/v1
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -109,7 +109,7 @@ quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter,com.redhat.swatch.azure.resource.DefaultApiExceptionMapper
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
@@ -51,10 +51,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.time.Clock;
-import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -68,11 +65,7 @@ import org.junit.jupiter.api.Test;
 class BillableUsageConsumerTest {
 
   private static final String INSTANCE_HOURS = "INSTANCE_HOURS";
-  private static final String CORES = "CORES";
   private static final String STORAGE_GIB_MONTHS = "STORAGE_GIBIBYTE_MONTHS";
-
-  private static final Clock clock =
-      Clock.fixed(Instant.parse("2023-10-02T12:30:00Z"), ZoneId.of("UTC"));
 
   private static final BillableUsage BASILISK_INSTANCE_HOURS_RECORD =
       new BillableUsage()
@@ -224,7 +217,7 @@ class BillableUsageConsumerTest {
     Errors errors = new Errors();
     Error error = new Error();
     error.setCode("SUBSCRIPTIONS1005");
-    errors.setErrors(Arrays.asList(error));
+    errors.setErrors(List.of(error));
     var response = Response.serverError().entity(errors).build();
     var exception = new DefaultApiException(response, errors);
     when(internalSubscriptionsApi.getAzureMarketplaceContext(


### PR DESCRIPTION
Jira issue: [SWATCH-2099](https://issues.redhat.com/browse/SWATCH-2099)

## Description
- When swatch-azure-producer receives a billableUsage and the subscription can not be determined (subscriptionId unavailable), a message is produced to billable-usage.dlt with retry_after header set to now() + 1hr
- When the subscriptionId is unavailable and the usage is past 72 hours (configurable) old, log a warning
Log non retriable other errors at either warning or error

Note that then the subscription API does not find the subscription, it returns the HTTP Status Code 404. 

## Testing
1. `podman-compose up`
2. mock the subscription service:  

`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

```
cat > stub/__files/swatch-2099.json <<EOF
{
    "errors" : [  { "code": "SUBSCRIPTIONS1006" }  ]
}
EOF
```

```
curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext", "method": "GET"}, "response": { "status": 404, "bodyFileName": "swatch-2099.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new
```

3. start the swatch producer azure service: 

```
SERVER_PORT=8001 SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101 ./gradlew :swatch-producer-azure:quarkusDev
```

4. **scenario 1: when snapshot_date is older than 72 hours**: add a message into the billing usage topic:

```
curl 'http://localhost:8001/api/swatch-producer-azure/internal/azure/billable_usage' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '{
    "org_id":"123456789",
    "id":null,
    "billing_provider":"azure",
    "billing_account_id":"64dc69e4-d083-49fc-9569-ebece1dd1408",
    "snapshot_date":"2023-12-21T01:10:28Z",
    "product_id":"BASILISK",
    "sla":"Premium",
    "usage":"Production",
    "uom":"Storage-gibibyte-months",
    "value":42.0
  }'
```

You should see:

```
Skipping billable usage with id=null because the subscription was not found and the snapshot '2023-12-21T01:10:28Z' is past the azure time window of 'PT72H'
```

And no messages in the dead letter queue are expected.

5. **scenario 2: when snapshot_date is not older**: add a message into the billing usage topic:

```
curl 'http://localhost:8001/api/swatch-producer-azure/internal/azure/billable_usage' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '{
    "org_id":"123456789",
    "id":null,
    "billing_provider":"azure",
    "billing_account_id":"64dc69e4-d083-49fc-9569-ebece1dd1408",
    "snapshot_date":"2024-01-23T01:10:28Z",
    "product_id":"BASILISK",
    "sla":"Premium",
    "usage":"Production",
    "uom":"Storage-gibibyte-months",
    "value":42.0
  }'
```

In this case, the snapshot_date is less than 72h, so you should see:

```
Skipping billable usage with id=null orgId=123456789 because the subscription was not found. Will retry again after one hour.
```

And the dlq should contain this message: http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.billable-usage.dlt/data/topic.

To see the retryAfter header, you need either use the KafkaProducer service like explained here: https://medium.com/dna-technology/display-kafka-record-headers-90c106cb34b6

Or add the following properties in the swatch producer azure service:

```
mp.messaging.incoming.tally-dlt-in.fail-on-deserialization-failure=${TALLY_IN_FAIL_ON_DESER_FAILURE}
mp.messaging.incoming.tally-dlt-in.connector=smallrye-kafka
mp.messaging.incoming.tally-dlt-in.topic=platform.rhsm-subscriptions.billable-usage.dlt
# Go back to the first records, if it's our first access
mp.messaging.incoming.tally-dlt-in.auto.offset.reset = earliest
```

And then, the dead letter queue consumer:

```java
@Slf4j
@ApplicationScoped
@IfBuildProfile("dev")
public class BillableUsageDeadLetterQueueConsumer {

  @Incoming("tally-dlt-in")
  @Blocking
  public void process(ConsumerRecord<String, BillableUsage> message) {
    var retryAfter = OffsetDateTime.parse(new String(message.headers().lastHeader(RETRY_AFTER_HEADER).value()));
    log.info("Received dead letter queue message: " + message + ", retryAfter was " + retryAfter);
  }
}
```

Now, you should see a log trace like:

```
Received dead letter queue message: ConsumerRecord(topic = platform.rhsm-subscriptions.billable-usage.dlt, partition = 0, leaderEpoch = 0, offset = 3, CreateTime = 1706007001135, serialized key size = 9, serialized value size = 346, headers = RecordHeaders(headers = [RecordHeader(key = retryAfter, value = [50, 48, 50, 52, 45, 48, 49, 45, 50, 51, 84, 49, 49, 58, 53, 48, 58, 48, 49, 46, 49, 51, 50, 49, 56, 49, 51, 52, 51, 90])], isReadOnly = false), key = 123456789, value = class BillableUsage {
    orgId: 123456789
    id: nulloducer-azure:quarkusDev
    billingProvider: azure
    billingAccountId: 64dc69e4-d083-49fc-9569-ebece1dd1408
    snapshotDate: 2024-01-23T01:10:28Z
    productId: BASILISK
    sla: Premium
    usage: Production
    uom: Storage-gibibyte-months
    value: 42.0
    billingFactor: null
    vendorProductCode: null
    hardwareMeasurementType: null
}), retryAfter was 2024-01-23T11:50:01.132181343Z
```