### PR TITLE
Revert "SWATCH-2066: Expose prometheus data for swatch-metrics"

### DIFF
--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -142,7 +142,7 @@ objects:
     metadata:
       name: swatch-metrics
       labels:
-        prometheus: quarkus
+        prometheus: rhsm
     spec: # The name of the ClowdEnvironment providing the services
       envName: ${ENV_NAME}
 
@@ -340,7 +340,7 @@ objects:
     metadata:
       name: swatch-metrics-rhel
       labels:
-        prometheus: quarkus
+        prometheus: rhsm
     spec:
       envName: ${ENV_NAME}
 


### PR DESCRIPTION
This change caused this error during ClowdApp reconciliation

```
{"level":"error","ts":1705692365.384922,"msg":"Reconciler error","controller":"clowdapp","controllerGroup":"cloud.redhat.com","controllerKind":"ClowdApp","ClowdApp":{"name":"swatch-metrics-rhel","namespace":"rhsm-stage"},"namespace":"rhsm-stage","name":"swatch-metrics-rhel","reconcileID":"23c6d526-fddf-41d0-abe9-d41f631f087c","error":"error updating resource Deployment swatch-metrics-rhel-service: Deployment.apps \"swatch-metrics-rhel-service\" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{\"app\":\"swatch-me…
```

We want to place the labels on the podSpec instead, but Clowder isn't currently propagating that when those fields are set.