### PR TITLE
swatch-2084: update eventController to set the azure billingAccountId

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -47,6 +47,7 @@ import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.json.BaseEvent;
 import org.candlepin.subscriptions.json.CleanUpEvent;
 import org.candlepin.subscriptions.json.Event;
+import org.candlepin.subscriptions.json.Event.BillingProvider;
 import org.candlepin.subscriptions.security.OptInController;
 import org.candlepin.subscriptions.util.TransactionHandler;
 import org.springframework.kafka.listener.BatchListenerFailedException;
@@ -234,6 +235,9 @@ public class EventController {
         }
 
         if (baseEvent instanceof Event eventToSave) {
+          if (Objects.equals(eventToSave.getBillingProvider(), (BillingProvider.AZURE))) {
+            setAzureBillingAccountId(eventToSave);
+          }
           enrichServiceInstanceFromIncomingFeed(eventToSave);
           result.addEvent(eventToSave, eventIndex.getValue());
         } else if (baseEvent instanceof CleanUpEvent cleanUpEvent) {
@@ -254,6 +258,15 @@ public class EventController {
       }
     }
     return result;
+  }
+
+  private void setAzureBillingAccountId(Event event) {
+    if (event.getAzureTenantId().isPresent() && event.getAzureSubscriptionId().isPresent()) {
+      String billingAccountId =
+          String.format(
+              "%s;%s", event.getAzureTenantId().get(), event.getAzureSubscriptionId().get());
+      event.setBillingAccountId(Optional.of(billingAccountId));
+    }
   }
 
   private void enrichServiceInstanceFromIncomingFeed(Event event) {

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -235,7 +235,7 @@ public class EventController {
         }
 
         if (baseEvent instanceof Event eventToSave) {
-          if (Objects.equals(eventToSave.getBillingProvider(), (BillingProvider.AZURE))) {
+          if (BillingProvider.AZURE.equals(eventToSave.getBillingProvider())) {
             setAzureBillingAccountId(eventToSave);
           }
           enrichServiceInstanceFromIncomingFeed(eventToSave);

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -59,6 +59,7 @@ class EventControllerTest {
   String eventRecord3;
   String eventRecord4;
   String eventRecord5;
+  String azureEventRecord1;
   String cleanUpEvent;
 
   @BeforeEach
@@ -166,6 +167,30 @@ class EventControllerTest {
                      }
                    ],
                    "service_type": "OpenShift Cluster"
+                 }
+                """;
+    azureEventRecord1 =
+        """
+                {
+                   "sla": "Premium",
+                   "role": "Red Hat Enterprise Linux Server",
+                   "org_id": "7",
+                   "timestamp": "2023-05-02T00:00:00Z",
+                   "event_type": "snapshot",
+                   "expiration": "2023-05-02T01:00:00Z",
+                   "instance_id": "e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "display_name": "automation_osd_cluster_e3a62bd1-fd00-405c-9401-f2288808588d",
+                   "event_source": "cost-management",
+                   "measurements": [
+                     {
+                       "uom": "vCPUs",
+                       "value": 1.0
+                     }
+                   ],
+                   "service_type": "RHEL System",
+                   "billing_provider": "azure",
+                   "azure_tenant_id": "TestAzureTenantId",
+                   "azure_subscription_id": "TestAzureSubscriptionId"
                  }
                 """;
     cleanUpEvent =
@@ -296,6 +321,21 @@ class EventControllerTest {
     assertEquals(1, exception.getIndex());
     // Last event is never attempted to save since second event fails
     verify(eventRecordRepository, times(2)).save(any());
+  }
+
+  @Test
+  void testPersistServiceInstances_AzureBillingAccountIdSet() {
+    List<String> eventRecords = new ArrayList<>();
+    eventRecords.add(azureEventRecord1);
+    eventController.persistServiceInstances(eventRecords);
+    when(eventRecordRepository.saveAll(any())).thenReturn(new ArrayList<>());
+
+    verify(eventRecordRepository).saveAll(eventsSaved.capture());
+    List<EventRecord> events = eventsSaved.getAllValues().get(0).stream().toList();
+    assertEquals(1, events.size());
+    assertEquals(
+        "TestAzureTenantId;TestAzureSubscriptionId",
+        events.get(0).getEvent().getBillingAccountId().get());
   }
 
   private void verifyDeletionOfStaleEventsIsDone() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2084

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Need to set the billingAccountId for azure events by using the fields azure_tenant_id and azure_subscription_id from cost-mgmt.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Start app w/: `DEV_MODE=true ./gradlew :bootRun`

### Steps
<!-- Enter each step of the test below -->
1. Put message on topic platform.rhsm-subscriptions.service-instance-ingress:
`{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "org_123", "event_id": "3d363cc8-b2bc-4230-a943-638a4822da70", "timestamp": "2024-01-21T22:00:00Z", "event_type": "snapshot", "expiration": "2024-01-21T23:00:00Z", "instance_id": "test", "product_ids": ["69", "204"], "product_tag": ["rhel-for-x86-els-payg"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 1.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "Azure", "azure_tenant_id": "testTenantId", "billing_provider": "azure", "azure_subscription_id": "testSubscriptionId"}
`
### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Check event for billing_account_id = "testTenantId;testSubscriptionId":
`select * from events where org_id = 'org_123';`
