### PR TITLE
SWATCH-2127: Secure the endpoint /instances/products/{product_id}

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -131,6 +131,7 @@ public class InstancesResource implements InstancesApi {
   }
 
   @Override
+  @ReportingAccessRequired
   @Transactional(readOnly = true)
   public InstanceResponse getInstancesByProduct(
       ProductId productId,

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -65,11 +65,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles({"api", "test"})
-@WithMockRedHatPrincipal("123456")
 class InstancesResourceTest {
 
   private static final ProductId ROSA = ProductId.fromString("rosa");
@@ -87,6 +87,7 @@ class InstancesResourceTest {
     when(orgConfigRepository.existsByOrgId("owner123456")).thenReturn(true);
   }
 
+  @WithMockRedHatPrincipal("123456")
   @Test
   void testShouldPopulateInstanceResponse() {
     BillingProvider expectedBillingProvider = BillingProvider.AWS;
@@ -169,6 +170,7 @@ class InstancesResourceTest {
     assertEquals(expected, report);
   }
 
+  @WithMockRedHatPrincipal("123456")
   @Test
   void testShouldPopulateInstanceResponseWithHypervisorAndPhysical() {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
@@ -267,6 +269,7 @@ class InstancesResourceTest {
     assertEquals(expected, report);
   }
 
+  @WithMockRedHatPrincipal("123456")
   @Test
   void testShouldPopulateCategoryWithCloud() {
     BillingProvider expectedBillingProvider = BillingProvider.AWS;
@@ -362,6 +365,7 @@ class InstancesResourceTest {
         () -> resource.validateBeginningAndEndingDates(ROSA, dayInJanuary, dayInFebruary));
   }
 
+  @WithMockRedHatPrincipal("123456")
   @Test
   void testCallRepoWithNullMonthForNonPAYGProduct() {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
@@ -444,6 +448,7 @@ class InstancesResourceTest {
             any());
   }
 
+  @WithMockRedHatPrincipal("123456")
   @Test
   void testGetInstanceGuestsReturnInstanceData() {
     var host = new Host();
@@ -461,6 +466,7 @@ class InstancesResourceTest {
     assertEquals(1, response.getData().size());
   }
 
+  @WithMockRedHatPrincipal("123456")
   @Test
   void testMinCoresOneWhenUomIsCores() {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
@@ -526,6 +532,7 @@ class InstancesResourceTest {
             any());
   }
 
+  @WithMockRedHatPrincipal("123456")
   @Test
   void testMinSocketsOneWhenUomIsSockets() {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
@@ -591,6 +598,7 @@ class InstancesResourceTest {
             any());
   }
 
+  @WithMockRedHatPrincipal("123456")
   @Test
   void testGetInstancesByProductThrowsExceptionForUnknownMetricId() {
     assertThrows(
@@ -611,5 +619,34 @@ class InstancesResourceTest {
                 null,
                 SORT_BY_DISPLAY_NAME,
                 null));
+  }
+
+  @Test
+  void testGetInstancesByProductThrowsAuthenticationCredentialsNotFoundExceptionWhenNoSecurity() {
+    assertThrows(
+        AuthenticationCredentialsNotFoundException.class,
+        () ->
+            resource.getInstancesByProduct(
+                ROSA,
+                null,
+                null,
+                ServiceLevelType.PREMIUM,
+                UsageType.PRODUCTION,
+                "Sockets",
+                BillingProviderType.RED_HAT,
+                null,
+                null,
+                null,
+                null,
+                null,
+                SORT_BY_DISPLAY_NAME,
+                null));
+  }
+
+  @Test
+  void testGetInstanceGuestsThrowsAuthenticationCredentialsNotFoundExceptionWhenNoSecurity() {
+    assertThrows(
+        AuthenticationCredentialsNotFoundException.class,
+        () -> resource.getInstanceGuests("instance123", null, null));
   }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-2127](https://issues.redhat.com/browse/SWATCH-2127)

## Description
This endpoint was missing the `@ReportingAccessRequired`

## Testing
Added a test to cover this endpoint.
For manual testing:
* Create a Servive account with no permissions
* Try and access v1/instances/products/ API on stage