### PR TITLE
SWATCH-2083: Update contract ingestion to require less data

### DIFF
--- a/bin/liquibase-new-changeset.sh
+++ b/bin/liquibase-new-changeset.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 # Usage: liquibase-new-changeset.sh <text to append to the generated changeset>
 # For example: running `liquibase-new-changeset.sh remove-account` would create a change set `202312050855-remove-account.xml` where `202312050855` is auto-populated from the current date.
-desc=$(echo "$@" | sed 's/ /-/g' | tr A-Z a-z)
+if [ -d src/main/resources/liquibase ]; then
+  LIQUIBASE_DIR=src/main/resources/liquibase
+  CHANGELOG=changelog.xml
+  SEPARATOR=-
+else
+  LIQUIBASE_DIR=src/main/resources/db
+  CHANGELOG=changeLog.xml
+  SEPARATOR=_
+fi
+desc=$(echo "$@" | sed "s/ /$SEPARATOR/g" | tr A-Z a-z)
 date=$(date +%Y%m%d%H%M)
-filename=$(date +%Y%m%d%H%M)-$desc.xml
-cat > src/main/resources/liquibase/$filename <<EOF
+filename=$(date +%Y%m%d%H%M)$SEPARATOR$desc.xml
+cat > $LIQUIBASE_DIR/$filename <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
@@ -20,6 +29,6 @@ cat > src/main/resources/liquibase/$filename <<EOF
 </databaseChangeLog>
 EOF
 
-sed -i "/databaseChangeLog>/i\\    <include file=\"/liquibase/$filename\"/>" src/main/resources/liquibase/changelog.xml
+sed -i "/databaseChangeLog>/i\\    <include file=\"/$(basename $LIQUIBASE_DIR)/$filename\"/>" $LIQUIBASE_DIR/$CHANGELOG
 
-echo Generated src/main/resources/liquibase/$filename
+echo Generated $LIQUIBASE_DIR/$filename

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -179,24 +179,22 @@ public interface ContractMapper {
 
   /** Extract billingProviderId from Partner Gateway API response */
   default String extractBillingProviderId(PartnerEntitlementV1 entitlement) {
-    switch (entitlement.getSourcePartner()) {
-      case AWS_MARKETPLACE -> {
-        return String.format(
-            "%s;%s;%s",
-            entitlement.getPurchase().getVendorProductCode(),
-            entitlement.getPartnerIdentities().getAwsCustomerId(),
-            entitlement.getPartnerIdentities().getSellerAccountId());
-      }
-      case AZURE_MARKETPLACE -> {
-        var azurePlanId =
-            entitlement.getPurchase().getContracts().stream()
-                .map(SaasContractV1::getPlanId)
-                .findFirst()
-                .orElse("");
-        var azureOfferId = entitlement.getPurchase().getVendorProductCode();
-        return String.format(
-            "%s;%s;%s", entitlement.getPurchase().getAzureResourceId(), azurePlanId, azureOfferId);
-      }
+    var partner = entitlement.getSourcePartner();
+    if (partner == SourcePartnerEnum.AWS_MARKETPLACE) {
+      return String.format(
+          "%s;%s;%s",
+          entitlement.getPurchase().getVendorProductCode(),
+          entitlement.getPartnerIdentities().getAwsCustomerId(),
+          entitlement.getPartnerIdentities().getSellerAccountId());
+    } else if (partner == SourcePartnerEnum.AZURE_MARKETPLACE) {
+      var azurePlanId =
+          entitlement.getPurchase().getContracts().stream()
+              .map(SaasContractV1::getPlanId)
+              .findFirst()
+              .orElse("");
+      var azureOfferId = entitlement.getPurchase().getVendorProductCode();
+      return String.format(
+          "%s;%s;%s", entitlement.getPurchase().getAzureResourceId(), azurePlanId, azureOfferId);
     }
     return null;
   }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -91,7 +91,12 @@ public interface ContractMapper {
     return null;
   }
 
-  /** Extract billingProviderId from Partner Gateway UMB message */
+  /**
+   * Extract billingProviderId from Partner Gateway UMB message.
+   *
+   * <p>Note: currently the value here will be overwritten by the API response, but future work may
+   * make the Partner Gateway API call unnecessary.
+   */
   @Named("billingProviderId")
   default String extractBillingProviderId(PartnerEntitlementContractCloudIdentifiers code) {
     String providerId = null;

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
@@ -56,7 +56,7 @@ public class ContractEntity extends PanacheEntityBase {
   private UUID uuid;
 
   @Basic
-  @Column(name = "subscription_number", nullable = false)
+  @Column(name = "subscription_number")
   private String subscriptionNumber;
 
   @Basic
@@ -82,6 +82,10 @@ public class ContractEntity extends PanacheEntityBase {
   @Basic
   @Column(name = "billing_provider", nullable = false)
   private String billingProvider;
+
+  @Basic
+  @Column(name = "billing_provider_id")
+  private String billingProviderId;
 
   @Basic
   @Column(name = "billing_account_id", nullable = false)
@@ -146,6 +150,13 @@ public class ContractEntity extends PanacheEntityBase {
         vendorProductCode);
   }
 
+  public String getAzureResourceId() {
+    if (!billingProvider.startsWith("azure") || billingProviderId == null) {
+      return null;
+    }
+    return billingProviderId.split(";")[0];
+  }
+
   public static Specification<ContractEntity> orgIdEquals(String orgId) {
     return (root, query, builder) -> builder.equal(root.get(ContractEntity_.orgId), orgId);
   }
@@ -180,10 +191,6 @@ public class ContractEntity extends PanacheEntityBase {
         builder.equal(root.get(ContractEntity_.vendorProductCode), vendorProductCode);
   }
 
-  public static Specification<ContractEntity> isActive() {
-    return (root, query, builder) -> builder.isNull(root.get(ContractEntity_.endDate));
-  }
-
   public static Specification<ContractEntity> activeOn(OffsetDateTime timestamp) {
     return (root, query, builder) ->
         builder.and(
@@ -191,5 +198,29 @@ public class ContractEntity extends PanacheEntityBase {
             builder.or(
                 builder.isNull(root.get(ContractEntity_.endDate)),
                 builder.greaterThan(root.get(ContractEntity_.endDate), timestamp)));
+  }
+
+  public static Specification<ContractEntity> activeDuringTimeRange(ContractEntity contract) {
+    return (root, query, builder) -> {
+      if (contract.getEndDate() != null) {
+        return builder.and(
+            builder.greaterThanOrEqualTo(
+                root.get(ContractEntity_.startDate), contract.getStartDate()),
+            builder.lessThanOrEqualTo(root.get(ContractEntity_.startDate), contract.getEndDate()));
+      } else {
+        return builder.greaterThanOrEqualTo(
+            root.get(ContractEntity_.startDate), contract.getStartDate());
+      }
+    };
+  }
+
+  public static Specification<ContractEntity> azureResourceIdEquals(String azureResourceId) {
+    return (root, query, builder) ->
+        builder.like(root.get(ContractEntity_.billingProviderId), azureResourceId + "%");
+  }
+
+  public static Specification<ContractEntity> billingProviderIdEquals(String billingProviderId) {
+    return (root, query, builder) ->
+        builder.equal(root.get(ContractEntity_.billingProviderId), billingProviderId);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.contract.repository;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -30,6 +31,10 @@ import lombok.extern.slf4j.Slf4j;
 public class ContractRepository implements PanacheSpecificationSupport<ContractEntity, UUID> {
   public List<ContractEntity> getContracts(Specification<ContractEntity> specification) {
     return find(ContractEntity.class, specification, null);
+  }
+
+  public Stream<ContractEntity> findContracts(Specification<ContractEntity> specification) {
+    return stream(ContractEntity.class, specification);
   }
 
   public List<ContractEntity> getContractsByOrgId(String orgId) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -108,7 +108,7 @@ public class ContractsTestingResource implements DefaultApi {
   @Override
   @RolesAllowed({"test", "support"})
   public StatusResponse syncContractsByOrg(String orgId) throws ProcessingException {
-    return service.syncContractByOrgId(orgId);
+    return service.syncContractByOrgId(orgId, OffsetDateTime.now());
   }
 
   @Override

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -73,7 +73,7 @@ public class ContractService {
     METADATA_UPDATED,
     CONTRACT_SPLIT_DUE_TO_CAPACITY_UPDATE,
     NEW_CONTRACT_CREATED,
-  };
+  }
 
   private static final String SUCCESS_MESSAGE = "SUCCESS";
   private static final String FAILURE_MESSAGE = "FAILED";

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -451,6 +451,9 @@ components:
           description: ""
           type: string
           example: aws
+        billing_provider_id:
+          description: Encoded additional information needed for billing
+          type: string
         billing_account_id:
           description: AWS billing account ids are 12 digits
           type: string

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -75,7 +75,7 @@ quarkus.datasource.password=${DATABASE_PASSWORD}
 quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}
 
 %test.quarkus.datasource.db-kind=h2
-%test.quarkus.datasource.jdbc.url=jdbc:h2:mem:db
+%test.quarkus.datasource.jdbc.url=jdbc:h2:mem:db;NON_KEYWORDS=VALUE
 %test.quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 
 quarkus.liquibase.database-change-log-lock-table-name=DATABASECHANGELOGLOCK_SWATCH_CONTRACTS

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -75,6 +75,7 @@ quarkus.datasource.password=${DATABASE_PASSWORD}
 quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}
 
 %test.quarkus.datasource.db-kind=h2
+# NOTE: because some of the entities use columns named "value", it is necessary to configure h2 to *not* treat it as a keyword.
 %test.quarkus.datasource.jdbc.url=jdbc:h2:mem:db;NON_KEYWORDS=VALUE
 %test.quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 

--- a/swatch-contracts/src/main/resources/db/202401111039_make_subscription_number_nullable.xml
+++ b/swatch-contracts/src/main/resources/db/202401111039_make_subscription_number_nullable.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202401111039-01" author="khowell">
+    <dropNotNullConstraint tableName="contracts" columnName="subscription_number"/>
+    <!-- rollback automatically generated -->
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-contracts/src/main/resources/db/202401121651_add_billingproviderid_to_contracts.xml
+++ b/swatch-contracts/src/main/resources/db/202401121651_add_billingproviderid_to_contracts.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202401121651-01" author="khowell">
+    <addColumn tableName="contracts">
+      <column name="billing_provider_id" type="varchar"/>
+    </addColumn>
+    <createIndex tableName="contracts" indexName="contracts_billing_provider_idx">
+      <column name="billing_provider_id"/>
+    </createIndex>
+    <!-- rollback automatically generated -->
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-contracts/src/main/resources/db/202401171354_add_subscription_and_offering_h2_only.xml
+++ b/swatch-contracts/src/main/resources/db/202401171354_add_subscription_and_offering_h2_only.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202401171354-01" author="khowell" dbms="h2">
+    <comment>Create the subscription table for tests only (since it is still managed by the monolith)</comment>
+    <createTable tableName="subscription">
+      <column name="sku" type="varchar"/>
+      <column name="org_id" type="varchar"/>
+      <column name="subscription_id" type="varchar">
+        <constraints nullable="false"/>
+      </column>
+      <column name="quantity" type="bigint"/>
+      <column name="start_date" type="timestamp">
+        <constraints nullable="false"/>
+      </column>
+      <column name="end_date" type="timestamp"/>
+      <column name="billing_provider_id" type="varchar"/>
+      <column name="subscription_number" type="varchar"/>
+      <column name="billing_provider" type="varchar"/>
+      <column name="billing_account_id" type="varchar"/>
+    </createTable>
+    <createTable tableName="subscription_measurements">
+      <column name="value" type="float"/>
+      <column name="measurement_type" type="varchar"/>
+      <column name="metric_id" type="varchar"/>
+      <column name="start_date" type="timestamp"/>
+      <column name="subscription_id" type="varchar"/>
+    </createTable>
+    <createTable tableName="subscription_product_ids">
+      <column name="subscription_id" type="varchar"/>
+      <column name="product_id" type="varchar"/>
+      <column name="start_date" type="timestamp"/>
+    </createTable>
+    <!-- rollback automatically generated -->
+  </changeSet>
+  <changeSet id="202401171354-02" author="khowell" dbms="h2">
+    <comment>Create the offering table for tests only (since it is still managed by the monolith)</comment>
+    <createTable tableName="offering">
+      <column name="sku" type="varchar">
+        <constraints nullable="false"/>
+      </column>
+      <column name="product_name" type="varchar"/>
+      <column name="product_family" type="varchar"/>
+      <column name="cores" type="bigint"/>
+      <column name="sockets" type="bigint"/>
+      <column name="hypervisor_cores" type="bigint"/>
+      <column name="hypervisor_sockets" type="bigint"/>
+      <column name="role" type="varchar"/>
+      <column name="sla" type="varchar"/>
+      <column name="usage" type="varchar"/>
+      <column name="description" type="varchar"/>
+      <column name="has_unlimited_usage" type="boolean"/>
+      <column name="derived_sku" type="varchar"/>
+    </createTable>
+    <createTable tableName="sku_child_sku">
+      <column name="sku" type="varchar"/>
+      <column name="child_sku" type="varchar"/>
+    </createTable>
+    <createTable tableName="sku_oid">
+      <column name="sku" type="varchar"/>
+      <column name="oid" type="varchar"/>
+    </createTable>
+    <!-- rollback automatically generated -->
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-contracts/src/main/resources/db/changeLog.xml
+++ b/swatch-contracts/src/main/resources/db/changeLog.xml
@@ -9,5 +9,7 @@
   <include file="db/202302030707_create_contracts_table.xml"/>
   <include file="db/202304061624_add_vendorproductcode_to_contracts_table.xml"/>
   <include file="db/202310091227_fix_contract_metrics_for_rosa.xml"/>
-
+  <include file="db/202401111039_make_subscription_number_nullable.xml"/>
+  <include file="db/202401121651_add_billingproviderid_to_contracts.xml"/>
+  <include file="/db/202401171354_add_subscription_and_offering_h2_only.xml"/>
 </databaseChangeLog>

--- a/swatch-contracts/src/main/resources/db/changeLog.xml
+++ b/swatch-contracts/src/main/resources/db/changeLog.xml
@@ -11,5 +11,5 @@
   <include file="db/202310091227_fix_contract_metrics_for_rosa.xml"/>
   <include file="db/202401111039_make_subscription_number_nullable.xml"/>
   <include file="db/202401121651_add_billingproviderid_to_contracts.xml"/>
-  <include file="/db/202401171354_add_subscription_and_offering_h2_only.xml"/>
+  <include file="db/202401171354_add_subscription_and_offering_h2_only.xml"/>
 </databaseChangeLog>

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi;
+import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
+import com.redhat.swatch.contract.repository.ContractRepository;
+import com.redhat.swatch.contract.repository.OfferingEntity;
+import com.redhat.swatch.contract.repository.OfferingRepository;
+import com.redhat.swatch.contract.repository.SubscriptionRepository;
+import com.redhat.swatch.contract.resource.WireMockResource;
+import com.redhat.swatch.contract.service.ContractService;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(value = WireMockResource.class, restrictToAnnotatedClass = true)
+public class AzureContractLifecycleIntegrationTest {
+
+  @Inject @RestClient PartnerApi partnerApi;
+
+  @Inject ContractService contractService;
+
+  @Inject ObjectMapper objectMapper;
+
+  @Inject SubscriptionRepository subscriptionRepository;
+
+  @Inject ContractRepository contractRepository;
+
+  @Inject OfferingRepository offeringRepository;
+
+  static String AZURE_TENANT_ID = "256af912-d792-4dd4-811d-1152375f1f41";
+  static String AZURE_SUBSCRIPTION_ID = "d351b825-7e4b-4bfb-aad3-28441b34b5f1";
+  static String AZURE_RESOURCE_ID = "f226c862-dbc3-4f91-b8ed-1eba40dcdc59";
+  static String RH_SUBSCRIPTION_NUMBER = "42";
+  static String RH_ORG_ID = "org123";
+  static String AZURE_UMB_MESSAGE_CONTRACT_CREATED =
+      String.format(
+          """
+          {
+            "action":"contract-updated",
+            "currentDimensions":[{"dimensionName":"vcpu_hours","dimensionValue":"0"}],
+            "cloudIdentifiers":{
+              "type":"saas",
+              "azureResourceId":"%s",
+              "azureOfferId":"azureOfferId",
+              "planId":"vcpu-hours",
+              "azureTenantId":"%s",
+              "partner":"azure_marketplace"
+            }
+          }
+          """,
+          AZURE_RESOURCE_ID, AZURE_TENANT_ID);
+
+  static String AZURE_PARTNER_API_RESPONSE_CONTRACT_CREATED =
+      String.format(
+          """
+          {
+            "content": [
+              {
+                "entitlementDates": {
+                  "endDate": "2030-01-01T00:00:00.000000Z",
+                  "startDate": "2024-01-01T00:00:00.000000Z"
+                },
+                "partnerIdentities": {
+                  "azureTenantId": "%s"
+                },
+                "purchase": {
+                  "azureResourceId": "%s",
+                  "contracts": [
+                    {
+                      "endDate": "2030-01-01T00:00:00.000000Z",
+                      "planId": "vcpu-hours",
+                      "startDate": "2024-01-01T00:00:00.000000Z"
+                    }
+                  ],
+                  "vendorProductCode": "azureOfferId"
+                },
+                "sourcePartner": "azure_marketplace",
+                "status": "SUBSCRIBED"
+              }
+            ],
+            "page": {
+              "size": 0,
+              "totalElements": 0,
+              "totalPages": 0,
+              "number": 0
+            }
+          }
+          """,
+          AZURE_TENANT_ID, AZURE_RESOURCE_ID);
+
+  static String AZURE_UMB_MESSAGE_ORG_ASSOCIATED =
+      String.format(
+          """
+          {
+            "action":"redhat-subscription-created",
+            "currentDimensions":[{"dimensionName":"vcpu_hours","dimensionValue":"0"}],
+            "cloudIdentifiers":{
+              "type":"saas",
+              "azureResourceId":"%s",
+              "azureOfferId":"azureOfferId",
+              "planId":"vcpu-hours",
+              "azureTenantId":"%s",
+              "partner":"azure_marketplace"
+            },
+            "redHatSubscriptionNumber":"%s"
+          }
+          """,
+          AZURE_RESOURCE_ID, AZURE_TENANT_ID, RH_SUBSCRIPTION_NUMBER);
+
+  static String AZURE_PARTNER_API_RESPONSE_ORG_ASSOCIATED =
+      String.format(
+          """
+          {
+            "content": [
+              {
+                "entitlementDates": {
+                  "endDate": "2030-01-01T00:00:00.000000Z",
+                  "startDate": "2024-01-01T00:00:00.000000Z"
+                },
+                "partnerIdentities": {
+                  "azureTenantId": "%s"
+                },
+                "purchase": {
+                  "azureResourceId": "%s",
+                  "contracts": [
+                    {
+                      "endDate": "2030-01-01T00:00:00.000000Z",
+                      "planId": "vcpu-hours",
+                      "startDate": "2024-01-01T00:00:00.000000Z"
+                    }
+                  ],
+                  "vendorProductCode": "azureOfferId"
+                },
+                "rhAccountId": "%s",
+                "rhEntitlements": [
+                  {
+                    "sku": "BASILISK",
+                    "subscriptionNumber": "%s"
+                  }
+                ],
+                "sourcePartner": "azure_marketplace",
+                "status": "SUBSCRIBED"
+              }
+            ],
+            "page": {
+              "size": 0,
+              "totalElements": 0,
+              "totalPages": 0,
+              "number": 0
+            }
+          }
+          """,
+          AZURE_TENANT_ID, AZURE_RESOURCE_ID, RH_ORG_ID, RH_SUBSCRIPTION_NUMBER);
+
+  static String AZURE_UMB_MESSAGE_AZURE_SUBSCRIPTION_ID_ADDED =
+      String.format(
+          """
+          {
+            "action":"contract-updated",
+            "currentDimensions":[{"dimensionName":"vcpu_hours","dimensionValue":"0"}],
+            "cloudIdentifiers":{
+              "type":"saas",
+              "azureResourceId":"%s",
+              "azureSubscriptionId":"%s",
+              "azureOfferId":"azureOfferId",
+              "planId":"vcpu-hours",
+              "azureTenantId":"%s",
+              "partner":"azure_marketplace"
+            }
+          }
+          """,
+          AZURE_RESOURCE_ID, AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID);
+
+  static String AZURE_PARTNER_API_RESPONSE_AZURE_SUBSCRIPTION_ID_ADDED =
+      String.format(
+          """
+          {
+            "content": [
+              {
+                "entitlementDates": {
+                  "endDate": "2030-01-01T00:00:00.000000Z",
+                  "startDate": "2024-01-01T00:00:00.000000Z"
+                },
+                "partnerIdentities": {
+                  "azureSubscriptionId": "%s",
+                  "azureTenantId": "%s"
+                },
+                "purchase": {
+                  "azureResourceId": "%s",
+                  "contracts": [
+                    {
+                      "endDate": "2030-01-01T00:00:00.000000Z",
+                      "planId": "vcpu-hours",
+                      "startDate": "2024-01-01T00:00:00.000000Z"
+                    }
+                  ],
+                  "vendorProductCode": "azureOfferId"
+                },
+                "rhAccountId": "%s",
+                "rhEntitlements": [
+                  {
+                    "sku": "BASILISK",
+                    "subscriptionNumber": "%s"
+                  }
+                ],
+                "sourcePartner": "azure_marketplace",
+                "status": "SUBSCRIBED"
+              }
+            ],
+            "page": {
+              "size": 0,
+              "totalElements": 0,
+              "totalPages": 0,
+              "number": 0
+            }
+          }
+          """,
+          AZURE_SUBSCRIPTION_ID,
+          AZURE_TENANT_ID,
+          AZURE_RESOURCE_ID,
+          RH_ORG_ID,
+          RH_SUBSCRIPTION_NUMBER);
+
+  @BeforeEach
+  @Transactional
+  public void setup() {
+    OfferingEntity offering = new OfferingEntity();
+    offering.setSku("BASILISK");
+    offeringRepository.persist(offering);
+  }
+
+  @AfterEach
+  @Transactional
+  public void cleanup() {
+    subscriptionRepository.deleteAll();
+    contractRepository.deleteAll();
+    offeringRepository.deleteAll();
+  }
+
+  @Test
+  void azureContractLifecycleHandledAppropriately() throws JsonProcessingException {
+    stubPartnerSubscriptionApi(AZURE_PARTNER_API_RESPONSE_CONTRACT_CREATED);
+    var status =
+        contractService.createPartnerContract(
+            objectMapper.readValue(
+                AZURE_UMB_MESSAGE_CONTRACT_CREATED, PartnerEntitlementContract.class));
+    assertEquals("FAILED", status.getStatus());
+    assertEquals("Contract missing RH orgId", status.getMessage());
+    assertEquals(0, contractRepository.count());
+    assertEquals(0, subscriptionRepository.count());
+
+    stubPartnerSubscriptionApi(AZURE_PARTNER_API_RESPONSE_ORG_ASSOCIATED);
+    status =
+        contractService.createPartnerContract(
+            objectMapper.readValue(
+                AZURE_UMB_MESSAGE_ORG_ASSOCIATED, PartnerEntitlementContract.class));
+    assertEquals("SUCCESS", status.getStatus());
+    assertEquals(1, contractRepository.count());
+    assertEquals(1, subscriptionRepository.count());
+
+    stubPartnerSubscriptionApi(AZURE_PARTNER_API_RESPONSE_AZURE_SUBSCRIPTION_ID_ADDED);
+    status =
+        contractService.createPartnerContract(
+            objectMapper.readValue(
+                AZURE_UMB_MESSAGE_AZURE_SUBSCRIPTION_ID_ADDED, PartnerEntitlementContract.class));
+    assertEquals("SUCCESS", status.getStatus());
+    assertEquals(1, contractRepository.count());
+    assertEquals(1, subscriptionRepository.count());
+    var contract = contractRepository.findAll().stream().findFirst().orElseThrow();
+    var subscription = subscriptionRepository.findAll().stream().findFirst().orElseThrow();
+    assertEquals(
+        String.format("%s;%s", AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID),
+        contract.getBillingAccountId());
+    assertEquals(
+        String.format("%s;%s", AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID),
+        subscription.getBillingAccountId());
+    assertTrue(contract.getBillingProviderId().startsWith(AZURE_RESOURCE_ID));
+    assertTrue(subscription.getBillingProviderId().startsWith(AZURE_RESOURCE_ID));
+  }
+
+  private static void stubPartnerSubscriptionApi(String jsonBody) {
+    stubFor(
+        any(urlMatching("/mock/partnerApi/v1/partnerSubscriptions"))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "application/json").withBody(jsonBody)));
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import com.redhat.swatch.contract.repository.ContractRepository;
 import com.redhat.swatch.contract.repository.OfferingEntity;
@@ -41,16 +40,13 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @QuarkusTestResource(value = WireMockResource.class, restrictToAnnotatedClass = true)
-public class AzureContractLifecycleIntegrationTest {
-
-  @Inject @RestClient PartnerApi partnerApi;
+class AzureContractLifecycleIntegrationTest {
 
   @Inject ContractService contractService;
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -20,6 +20,9 @@
  */
 package com.redhat.swatch.contract.service;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -27,20 +30,21 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.DimensionV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1.SourcePartnerEnum;
+import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1EntitlementDates;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlements;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerIdentityV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PurchaseV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.RhEntitlementV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.SaasContractV1;
-import com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi;
 import com.redhat.swatch.clients.subscription.api.model.Subscription;
 import com.redhat.swatch.clients.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
@@ -87,6 +91,7 @@ class ContractServiceTest extends BaseUnitTest {
   private static final String SUBSCRIPTION_NUMBER = "subs123";
 
   @Inject ContractService contractService;
+  @Inject ObjectMapper objectMapper;
   @InjectSpy ContractRepository contractRepository;
   @InjectMock OfferingRepository offeringRepository;
   @InjectMock SubscriptionRepository subscriptionRepository;
@@ -180,17 +185,6 @@ class ContractServiceTest extends BaseUnitTest {
   }
 
   @Test
-  void testCreatePartnerContractNewBillingProviderIdPersist() {
-    PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
-    contractService.createPartnerContract(request);
-
-    givenExistingSubscription("new:new:new");
-    StatusResponse statusResponse = contractService.createPartnerContract(request);
-    assertEquals(
-        "Previous contract archived and new contract created", statusResponse.getMessage());
-  }
-
-  @Test
   void testCreatePartnerContractDuplicateBillingProviderIdNotPersist() {
     PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
     contractService.createPartnerContract(request);
@@ -209,7 +203,8 @@ class ContractServiceTest extends BaseUnitTest {
   @Test
   void syncContractWithExistingAndNewContracts() {
     givenExistingContract();
-    StatusResponse statusResponse = contractService.syncContractByOrgId(ORG_ID);
+    StatusResponse statusResponse =
+        contractService.syncContractByOrgId(ORG_ID, OffsetDateTime.parse("2024-01-01T00:00Z"));
     assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
     // 2 instances of subscription are created, one for the original contract, and one for the
     // update
@@ -220,7 +215,8 @@ class ContractServiceTest extends BaseUnitTest {
 
   @Test
   void syncContractWithEmptyContractsList() {
-    StatusResponse statusResponse = contractService.syncContractByOrgId(ORG_ID);
+    StatusResponse statusResponse =
+        contractService.syncContractByOrgId(ORG_ID, OffsetDateTime.parse("2024-01-01T00:00Z"));
     assertEquals(ORG_ID + " not found in table", statusResponse.getMessage());
   }
 
@@ -389,9 +385,10 @@ class ContractServiceTest extends BaseUnitTest {
     Contract contractRequest = new Contract();
     contractRequest.setUuid(UUID.randomUUID().toString());
     contractRequest.setBillingAccountId("billAcct123");
-    contractRequest.setStartDate(OffsetDateTime.now());
-    contractRequest.setEndDate(OffsetDateTime.now());
+    contractRequest.setStartDate(OffsetDateTime.parse("2023-03-17T12:29:48.569Z"));
+    contractRequest.setEndDate(OffsetDateTime.parse("2024-03-17T12:29:48.569Z"));
     contractRequest.setBillingProvider("test123");
+    contractRequest.setBillingProviderId("1234567890abcdefghijklmno;HSwCpt6sqkC;568056954830");
     contractRequest.setSku("BAS123");
     contractRequest.setProductId(PRODUCT_ID);
     contractRequest.setVendorProductCode("product123");
@@ -429,9 +426,12 @@ class ContractServiceTest extends BaseUnitTest {
 
   // TODO: this is not being used because of wiremocks, either need to remove or replace wiremock
   private void mockPartnerApi() throws Exception {
-    PartnerApi partnerApi = mock(PartnerApi.class);
     var entitlement =
         new PartnerEntitlementV1()
+            .entitlementDates(
+                new PartnerEntitlementV1EntitlementDates()
+                    .startDate(OffsetDateTime.parse("2023-03-17T12:29:48.569Z"))
+                    .endDate(OffsetDateTime.parse("2024-03-17T12:29:48.569Z")))
             .rhAccountId("7186626")
             .sourcePartner(SourcePartnerEnum.AZURE_MARKETPLACE)
             .partnerIdentities(
@@ -456,6 +456,11 @@ class ContractServiceTest extends BaseUnitTest {
     OfferingProductTags productTags = new OfferingProductTags();
     productTags.data(List.of("MCT4249"));
     when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
-    when(partnerApi.getPartnerEntitlements(any())).thenReturn(azureQuery);
+    stubFor(
+        WireMock.any(urlMatching("/mock/partnerApi/v1/partnerSubscriptions"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(objectMapper.writeValueAsString(azureQuery))));
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -160,7 +160,7 @@ class ContractServiceTest extends BaseUnitTest {
   void whenInvalidPartnerContract_DoNotPersist() {
     var contract = givenPartnerEntitlementContractWithoutProductCode();
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
-    assertEquals("Empty value found in UMB message", statusResponse.getMessage());
+    assertEquals("Bad message, see logs for details", statusResponse.getMessage());
   }
 
   @Test
@@ -181,7 +181,7 @@ class ContractServiceTest extends BaseUnitTest {
     contractService.createPartnerContract(request);
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
-    assertEquals("Duplicate record found", statusResponse.getMessage());
+    assertEquals("Redundant message ignored", statusResponse.getMessage());
   }
 
   @Test
@@ -197,7 +197,7 @@ class ContractServiceTest extends BaseUnitTest {
     givenExistingSubscription("dupeId;dupeId;dupeId");
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
-    assertEquals("Duplicate record found", statusResponse.getMessage());
+    assertEquals("Redundant message ignored", statusResponse.getMessage());
   }
 
   @Test
@@ -424,7 +424,6 @@ class ContractServiceTest extends BaseUnitTest {
     when(syncService.getOfferingProductTags(any())).thenReturn(productTags);
   }
 
-  // TODO: this is not being used because of wiremocks, either need to remove or replace wiremock
   private void mockPartnerApi() throws Exception {
     var entitlement =
         new PartnerEntitlementV1()


### PR DESCRIPTION
Jira issue: [SWATCH-2083](https://issues.redhat.com/browse/SWATCH-2083)

With this change, a contract can be ingested before the subscriptionNumber has been assigned.

I made changes to our handling of the end dates, so that the contract records no longer use `null` end date for the most current contracts, but use the passed end date.

I added `billingProviderId` to `ContractEntity`, and changed the upsert to use billingProviderId to lookup the existing record, instead of depending on subscriptionNumber.

I also updated the `bin/liquibase-new-changeset.sh` script to work for swatch-contracts.

I also updated WireMockResource to enable use of the static stubbing methods in any test class using WireMock.

Testing
-------

See AzureContractLifecycleIntegrationTest, which simulates the various states an Azure contract data goes through.