### PR TITLE
SWATCH-2135: Update promql to return metrics when support label is unset

### DIFF
--- a/swatch-metrics/README.md
+++ b/swatch-metrics/README.md
@@ -41,7 +41,7 @@ sum_over_time((max by (_id) (system_cpu_logical_count))[1h:10m]) / scalar(count_
       product=~".*(^|,)(69)($|,).*",
       external_organization="11789772",
       billing_model="marketplace",
-      support=~"Premium|Standard|Self-Support|None"
+      support=~"Premium|Standard|Self-Support|None|"
       }[1h]
     )
   )

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -224,7 +224,7 @@ rhsm-subscriptions:
                   product=~"#{metric.prometheus.queryParams[productLabelRegex]}",
                   external_organization="#{runtime[orgId]}",
                   billing_model="marketplace",
-                  support=~"Premium|Standard|Self-Support|None"
+                  support=~"Premium|Standard|Self-Support|None|"
                   }[1h]
                 )
               )


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2135

## Description
The use case is an instance reported a metric with a support label of "Premium", but later started reporting metrics without having the support label set.  Those later metrics weren't returned by the promql, resulting in swatch not counting any usage for that instance anymore.

Prometheus treats an unset label the same as an empty string.  Adding a `|` at the end of the support regex will make the query return results when there isn't a support label set.  When the support label is unset, it should that usage should default to "Premium", as defined in the rhel-for-x86-els-payg product config yaml.

## Testing
To inspect/verify the generated query, you can use the metering-promql script and then change the 204 to 69 in the output.

```
./bin/metering-promql.py --product rhel-for-x86-els-payg --org 11789772
```

Output:
```
rhel-for-x86-els-payg
---------------------
  Accounts PromQL: group(min_over_time({product=~'.*(^|,)(69)($|,).*', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)
  vCPUs PromQL: sum_over_time((max by (_id) (system_cpu_logical_count))[1h:10m]) / scalar(count_over_time(vector(1)[1h:10m]))
* on (_id) group_right topk by (_id) (
  1,
    group without (swatch_placeholder_label) (
      min_over_time(
      system_cpu_logical_count{
      product=~".*(^|,)(69)($|,).*",
      external_organization="11789772",
      billing_model="marketplace",
      support=~"Premium|Standard|Self-Support|None|"
      }[1h]
    )
  )
)
```



## Verification

The use case I'm verifying uses instance `_id="d5b96614-a114-4371-8523-c9ee7cf64cc2"`.

### Verify promql results

2024-01-23 16:00:00, with 4hr lookback window

Parameters:
**start**: 1706011200
**end**: 1706025600
**step**: 3600

Expectations:
* Metrics are returned even when the "support" label is missing.  There should be no overlapping data points, so we should not double count that instance

Easiest way to test this would be to start up a token refresher locally for stage rhobs (see PR #3036 for instructions on how to do this) and use the thanos graph UI.

Before the change, graph looked like this:
![image](https://github.com/RedHatInsights/rhsm-subscriptions/assets/19955562/ef60e4fa-40c4-4c61-8b5c-2e2124354e92)

After this change, graph should look like this:
![image](https://github.com/RedHatInsights/rhsm-subscriptions/assets/19955562/cbc0e1a6-3740-41d6-877f-1e890c2fcfaf)
(note: you can see there's no overlap more clearly if you change the graph type to not stack)


### Verify swatch-metrics application results

Refer to PR #3036 for detailed instructions for setup here.

Expectations:
* swatch should be finding ONE metric per hour, even after the support label is removed, for the instance with _id="d5b96614-a114-4371-8523-c9ee7cf64cc2".  The value for each hour should be 1.
