### PR TITLE
Fix the MetricsTaskDescriptor definition

### DIFF
--- a/swatch-metrics/schemas/metrics_task_descriptor.yaml
+++ b/swatch-metrics/schemas/metrics_task_descriptor.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-07/schema#
 title: MetricsTaskDescriptor
 required:
   - org_id
-  - product_id
+  - product_tag
   - metric
   - start
   - end


### PR DESCRIPTION
## Description
Rename the "product_id" name from the required list to the right name "product_tag" ("product_id" does not exist).

No need QE here. 