### PR TITLE
SWATCH-2158: Set the usage date to now after remittance is created

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -198,10 +198,7 @@ public class BillableUsageController {
         currentlyMeasuredTotal,
         totalRemitted,
         usageCalc);
-    // There were issues with transmitting usage to AWS since the cost event timestamps were in the
-    // past. This modification allows us to send usage to AWS if we get it during the current hour
-    // of event tally.
-    usage.setSnapshotDate(usageCalc.getRemittanceDate());
+
     // Update the reported usage value to the newly calculated one.
     usage.setValue(usageCalc.getBillableValue());
     usage.setBillingFactor(usageCalc.getBillingFactor());
@@ -211,6 +208,11 @@ public class BillableUsageController {
     } else {
       log.debug("Nothing to remit. Remittance record will not be created.");
     }
+
+    // There were issues with transmitting usage to AWS since the cost event timestamps were in the
+    // past. This modification allows us to send usage to AWS if we get it during the current hour
+    // of event tally.
+    usage.setSnapshotDate(usageCalc.getRemittanceDate());
 
     log.info(
         "Finished producing monthly billable for orgId={} productId={} uom={} provider={}, snapshotDate={}",

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -437,7 +437,8 @@ class BillableUsageControllerTest {
   static Stream<Arguments> remittanceParameters() {
     OffsetDateTime startOfUsage = CLOCK.startOfCurrentMonth().plusDays(4);
     return Stream.of(
-        // arguments(currentUsage, currentRemittance, expectedRemitted, expectedBilledValue)
+        // arguments(usageDate, currentUsage, currentRemittance, expectedRemitted,
+        // expectedBilledValue)
         // NOTE: currantUsage is the sum of all snapshots, NOT the value from BillableUsage.
         arguments(startOfUsage, 0.5, 0.0, 1.0, 1.0),
         arguments(startOfUsage.plusDays(5), 1.0, 1.0, 0.0, 0.0),
@@ -596,12 +597,12 @@ class BillableUsageControllerTest {
           usage.getProductId(), usage.getUom().toString(), billingFactor, false);
     }
 
-    controller.submitBillableUsage(usage);
-
     // Remittance should only be saved when it changes.
     // NOTE: Using argument captors make errors caught by mocks a little easier to debug.
     BillableUsageRemittanceEntity expectedRemittance =
         remittance(usage, CLOCK.now(), expectedRemitted);
+
+    controller.submitBillableUsage(usage);
 
     ArgumentCaptor<BillableUsageRemittanceEntity> remitted =
         ArgumentCaptor.forClass(BillableUsageRemittanceEntity.class);


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2158

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Before this change, the remittance accumulation_period was getting set to the current YYYY-MM, but should have been the month of the incoming usage snapshot.

When performing a re-tally, existing remittance was being determined based on the month of the snapshot, however, was getting recorded in the DB as the current month. This would result in new remittance getting created, and being billed for, every time a re-tally was run that was missing remittance in a past month.

## Testing
Insert an event into the DB.
```
INSERT INTO public.events VALUES ('3588f50a-9014-4d6a-b542-566717398ade', '2023-12-29 15:00:00-04', '{"sla": "Premium", "role": "osd", "org_id": "org123", "event_id": "3588f50a-9014-4d6a-b542-566717398ade", "timestamp": "2023-12-29T19:00:00+00:00", "event_type": "snapshot_redhat.com:openshift_dedicated:4cpu_hour", "expiration": "2023-12-29T20:00:00+00:00", "instance_id": "bcc0576f-9f59-403f-8c84-90135009b8a9", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2023-12-29T19:35:10.045193+00:00", "display_name": "bcc0576f-9f59-403f-8c84-90135009b8a9", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 4.1}], "service_type": "OpenShift Cluster", "account_number": "account_org123", "billing_provider": "red hat", "billing_account_id": "redhat1"}', 'snapshot_redhat.com:openshift_dedicated:4cpu_hour', 'prometheus', 'bcc0576f-9f59-403f-8c84-90135009b8a9', 'org123', DEFAULT, NULL, '2023-12-29 15:35:10.045193-04');
```

Deploy the main branch:
```
SPRING_PROFILES_ACTIVE=api,worker,kafka-queue DEV_MODE=true ./gradlew :bootRun
```

Run an hourly tally and check the resulting remittance records. Then repeat this process a few more times. Notice that after each re-tally, an extra remittance record gets added.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=org123&start=2023-12-13T00:00Z&end=2024-01-29T20:00Z" x-rh-swatch-psk:placeholder
```

```
psql -U rhsm-subscriptions rhsm-subscriptions -c "select * from billable_usage_remittance where org_id='org123'"
```

Apply the fix in this PR, reset the DB and repeat the steps above. After each retally there should only be a single remittance record. 

Verify that the accumulation_period was set from the event's timestamp (year and month match).