### PR TITLE
SWATCH-2060: Add org_id to MDC to be logged in Splunk

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/tasks/UpdateOrgSnapshotsTask.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/tasks/UpdateOrgSnapshotsTask.java
@@ -24,9 +24,9 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import org.candlepin.subscriptions.tally.TallySnapshotController;
 import org.candlepin.subscriptions.task.Task;
+import org.candlepin.subscriptions.util.LogUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.validation.annotation.Validated;
 
 /** Updates the usage snapshots for a given org. */
@@ -46,11 +46,9 @@ public class UpdateOrgSnapshotsTask implements Task {
   @Override
   public void execute() {
     String org = orgList.get(0);
-    if (org != null) {
-      MDC.put("org_id", org);
-    }
+    LogUtils.addOrgIdToMdc(org);
     log.info("Updating snapshots for org {}.", org);
     snapshotController.produceSnapshotsForOrg(org);
-    MDC.clear();
+    LogUtils.clearOrgIdFromMdc();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/util/LogUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/util/LogUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import org.slf4j.MDC;
+
+public final class LogUtils {
+
+  private static final String MDC_ORG_ID = "org_id";
+
+  private LogUtils() {}
+
+  /**
+   * Includes the "org_id" key in the MDC registry to be logged. When the "org_id" is logged, we can
+   * search for traces in Splunk using properties.org_id='<orgId>'.
+   *
+   * @param orgId the org id to log.
+   */
+  public static void addOrgIdToMdc(String orgId) {
+    if (orgId != null) {
+      MDC.put(MDC_ORG_ID, orgId);
+    }
+  }
+
+  /** Removes the "org_id" key from the MDC registry. */
+  public static void clearOrgIdFromMdc() {
+    MDC.remove(MDC_ORG_ID);
+  }
+}


### PR DESCRIPTION
Related to issue: SWATCH-2060

## Description
Let's add the org_id to splunk, so we can better filter messages. 