### PR TITLE
POC Draft: billable usage kstream poc

### DIFF
--- a/swatch-producer-azure/build.gradle
+++ b/swatch-producer-azure/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
     implementation 'io.quarkus:quarkus-oidc-client'
+    implementation 'io.quarkus:quarkus-kafka-streams'
     implementation project(':clients:swatch-internal-subscription-client')
     implementation project(':swatch-common-config-workaround')
     implementation project(':swatch-common-resteasy')

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregateProcessorSupplier.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregateProcessorSupplier.java
@@ -1,0 +1,70 @@
+package com.redhat.swatch.azure.kafka;
+
+import com.redhat.swatch.azure.openapi.model.BillableUsage;
+import com.redhat.swatch.azure.openapi.model.BillableUsage.BillingProviderEnum;
+import com.redhat.swatch.azure.openapi.model.BillableUsage.SlaEnum;
+import com.redhat.swatch.azure.openapi.model.BillableUsage.UsageEnum;
+import com.redhat.swatch.azure.service.BillableUsageConsumer;
+import java.util.Set;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class BillableUsageAggregateProcessorSupplier implements
+    ProcessorSupplier<Windowed<BillableUsageAggregationKey>, BillableUsageAggregation, String, String> {
+
+  private BillableUsageConsumer billableUsageConsumer;
+
+  public BillableUsageAggregateProcessorSupplier(BillableUsageConsumer billableUsageConsumer) {
+    this.billableUsageConsumer = billableUsageConsumer;
+  }
+
+  @Override
+  public Processor<Windowed<BillableUsageAggregationKey>, BillableUsageAggregation, String, String> get() {
+    return new BillableUsageAggregateProcessor(this.billableUsageConsumer);
+  }
+
+  @Override
+  public Set<StoreBuilder<?>> stores() {
+    return ProcessorSupplier.super.stores();
+  }
+
+   class BillableUsageAggregateProcessor implements
+      Processor<Windowed<BillableUsageAggregationKey>, BillableUsageAggregation, String, String> {
+
+    private BillableUsageConsumer billableUsageConsumer;
+
+    public BillableUsageAggregateProcessor(BillableUsageConsumer billableUsageConsumer) {
+      this.billableUsageConsumer = billableUsageConsumer;
+    }
+
+    @Override
+    public void init(ProcessorContext context) {
+      Processor.super.init(context);
+    }
+
+    @Override
+    public void process(Record record) {
+      BillableUsageAggregationKey key = ((Windowed<BillableUsageAggregationKey>) record.key()).key();
+      BillableUsageAggregation aggregate = (BillableUsageAggregation) record.value();
+      var billableUsage = new BillableUsage();
+      billableUsage.setUsage(UsageEnum.fromValue(key.getUsage()));
+      billableUsage.setBillingAccountId(key.getBillingAccountId());
+      billableUsage.setBillingProvider(BillingProviderEnum.fromValue(key.getBillingProvider()));
+      billableUsage.setOrgId(key.getOrgId());
+      billableUsage.setProductId(key.getProductId());
+      billableUsage.setUom(key.getMetricId());
+      billableUsage.setSla(SlaEnum.fromValue(key.getSla()));
+      billableUsage.setValue(aggregate.getTotalValue());
+      billableUsageConsumer.process(billableUsage);
+    }
+
+    @Override
+    public void close() {
+      Processor.super.close();
+    }
+  }
+}

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregation.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregation.java
@@ -1,0 +1,27 @@
+package com.redhat.swatch.azure.kafka;
+
+import com.redhat.swatch.azure.openapi.model.BillableUsage;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+
+@RegisterForReflection
+@Getter
+@Setter
+public class BillableUsageAggregation {
+
+  private BillableUsageAggregationKey key;
+
+  private BigDecimal totalValue = new BigDecimal(0);
+
+
+  public BillableUsageAggregation updateFrom(BillableUsage billableUsage) {
+    if(key == null) {
+      key =  new BillableUsageAggregationKey(billableUsage);;
+    }
+   totalValue = totalValue.add(billableUsage.getValue());
+    return this;
+  }
+
+}

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregation.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregation.java
@@ -3,12 +3,14 @@ package com.redhat.swatch.azure.kafka;
 import com.redhat.swatch.azure.openapi.model.BillableUsage;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.math.BigDecimal;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @RegisterForReflection
 @Getter
 @Setter
+@EqualsAndHashCode
 public class BillableUsageAggregation {
 
   private BillableUsageAggregationKey key;

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregationKey.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregationKey.java
@@ -1,0 +1,40 @@
+package com.redhat.swatch.azure.kafka;
+
+import com.redhat.swatch.azure.openapi.model.BillableUsage;
+import io.quarkus.arc.All;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BillableUsageAggregationKey {
+
+  private String orgId;
+
+  private String productId;
+
+  private String metricId;
+
+  private String accumulationPeriod;
+
+  private String sla;
+
+  private String usage;
+
+  private String billingProvider;
+
+  private String billingAccountId;
+
+  public BillableUsageAggregationKey(BillableUsage billableUsage) {
+    super();
+    this.orgId = billableUsage.getOrgId();
+    this.billingAccountId = billableUsage.getBillingAccountId();
+    this.billingProvider = billableUsage.getBillingProvider().value();
+    this.usage = billableUsage.getUsage().value();
+    this.productId = billableUsage.getProductId();
+    this.sla = billableUsage.getSla().value();
+    this.metricId = billableUsage.getUom();
+  }
+}

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregationKey.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregationKey.java
@@ -17,8 +17,6 @@ public class BillableUsageAggregationKey {
 
   private String metricId;
 
-  private String accumulationPeriod;
-
   private String sla;
 
   private String usage;

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregationKeySerde.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/BillableUsageAggregationKeySerde.java
@@ -1,0 +1,55 @@
+package com.redhat.swatch.azure.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonSerializer;
+import java.io.IOException;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class BillableUsageAggregationKeySerde implements Serde<BillableUsageAggregationKey> {
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    Serde.super.configure(configs, isKey);
+  }
+
+  @Override
+  public void close() {
+    Serde.super.close();
+  }
+
+  @Override
+  public Serializer<BillableUsageAggregationKey> serializer() {
+    return new Serializer<BillableUsageAggregationKey>() {
+      @Override
+      public byte[] serialize(String topic, BillableUsageAggregationKey data) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+          return mapper.writeValueAsBytes(data);
+        } catch (JsonProcessingException e) {
+          throw new IllegalArgumentException("Cannot serialize data");
+        }
+      }
+    };
+  }
+
+  @Override
+  public Deserializer<BillableUsageAggregationKey> deserializer() {
+    return new Deserializer<BillableUsageAggregationKey>() {
+
+      @Override
+      public BillableUsageAggregationKey deserialize(String topic, byte[] data) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+          return mapper.readValue(data, BillableUsageAggregationKey.class);
+        } catch (IOException e) {
+          throw new IllegalArgumentException("Cannot deserialize data");
+        }
+      }
+    };
+  }
+}

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/StreamTopologyProducer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/StreamTopologyProducer.java
@@ -1,0 +1,78 @@
+package com.redhat.swatch.azure.kafka;
+
+import com.redhat.swatch.azure.openapi.model.BillableUsage;
+import com.redhat.swatch.azure.service.BillableUsageConsumer;
+import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.HashMap;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.Suppressed.BufferConfig;
+import org.apache.kafka.streams.kstream.Suppressed.StrictBufferConfig;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.WindowedSerdes;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.WindowStore;
+
+@ApplicationScoped
+public class StreamTopologyProducer {
+
+  static final String BILLABLE_USAGE_STORE = "billable-usage-store";
+
+  private static final String BILLABLE_USAGE_TOPIC = "platform.rhsm-subscriptions.billable-usage";
+
+  @Inject
+  private BillableUsageConsumer billableUsageConsumer;
+
+  @Produces
+  public Topology buildTopology() {
+    StreamsBuilder builder = new StreamsBuilder();
+
+    ObjectMapperSerde<BillableUsage> billableUsageSerde = new ObjectMapperSerde<>(
+        BillableUsage.class);
+    //var windowedAggregationKeySerde = WindowedSerdes.timeWindowedSerdeFrom(BillableUsageAggregationKey.class, TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10)).size());
+   var aggregationKeySerde = new ObjectMapperSerde<>(BillableUsageAggregationKey.class);
+    ObjectMapperSerde<BillableUsageAggregation> aggregationSerde = new ObjectMapperSerde<>(BillableUsageAggregation.class);
+
+    KeyValueBytesStoreSupplier storeSupplier = Stores.persistentKeyValueStore(
+        BILLABLE_USAGE_STORE);
+
+
+    builder.stream(
+            BILLABLE_USAGE_TOPIC,
+            Consumed.with(Serdes.String(), billableUsageSerde)
+        )
+        .groupBy((k, v) -> new BillableUsageAggregationKey(v))
+        .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10)))
+        .aggregate(
+            BillableUsageAggregation::new,
+            (key, value, billableUsageAggregation) -> billableUsageAggregation.updateFrom(value),
+            Materialized.<BillableUsageAggregationKey, BillableUsageAggregation, WindowStore<Bytes, byte[]>>as(BILLABLE_USAGE_STORE)
+                .withKeySerde(aggregationKeySerde)
+                .withValueSerde(aggregationSerde)
+        )
+        //Need some analysis on BufferConfig size
+        .suppress(Suppressed.untilTimeLimit(Duration.ofSeconds(10), BufferConfig.unbounded()))
+        .toStream()
+        .process(new BillableUsageAggregateProcessorSupplier(billableUsageConsumer), storeSupplier.name());
+
+    return builder.build();
+  }
+
+}

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageConsumer.java
@@ -93,6 +93,10 @@ public class BillableUsageConsumer {
 //  @Blocking
   public void process(BillableUsage billableUsage) {
     log.info("Picked up billable usage message {} to process", billableUsage);
+    //TODO: remove this, gets rid of log noise for testing
+    if(0 == 0) {
+      return;
+    }
     if (billableUsage == null) {
       log.warn("Skipping null billable usage: deserialization failure?");
       return;

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageConsumer.java
@@ -44,6 +44,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.ProcessingException;
 import java.time.Clock;
 import java.time.Duration;
@@ -62,7 +63,7 @@ import org.slf4j.MDC;
 @ApplicationScoped
 public class BillableUsageConsumer {
 
-  private final AzureMarketplaceService azureMarketplaceService;
+  @Inject private final AzureMarketplaceService azureMarketplaceService;
   private final BillableUsageDeadLetterTopicProducer billableUsageDeadLetterTopicProducer;
 
   private final Counter acceptedCounter;
@@ -71,6 +72,7 @@ public class BillableUsageConsumer {
   private final Optional<Boolean> isDryRun;
   private final Duration azureUsageWindow;
 
+  @Inject
   public BillableUsageConsumer(
       MeterRegistry meterRegistry,
       @RestClient InternalSubscriptionsApi internalSubscriptionsApi,
@@ -87,10 +89,10 @@ public class BillableUsageConsumer {
     this.azureUsageWindow = azureUsageWindow;
   }
 
-  @Incoming("tally-in")
-  @Blocking
+//  @Incoming("tally-in")
+//  @Blocking
   public void process(BillableUsage billableUsage) {
-    log.debug("Picked up billable usage message {} to process", billableUsage);
+    log.info("Picked up billable usage message {} to process", billableUsage);
     if (billableUsage == null) {
       log.warn("Skipping null billable usage: deserialization failure?");
       return;

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -58,7 +58,6 @@ AZURE_OIDC_SAAS_MARKETPLACE_RESOURCE=20e940b3-4c77-4b0b-9a53-9e16a1b010a7
 
 # dev-specific config items that don't need to be overridden via env var
 # do not use JSON logs in dev mode
-%dev.quarkus.log.console.json=false
 quarkus.log.level=${LOGGING_LEVEL_ROOT}
 quarkus.log.category."com.redhat.swatch".level=${LOGGING_LEVEL_COM_REDHAT_SWATCH}
 
@@ -91,12 +90,27 @@ kafka.ssl.truststore.type = PEM
 
 quarkus.reactive-messaging.kafka.serializer-generation.enabled=false
 
+
+quarkus.kafka-streams.bootstrap-servers=localhost:9092
+quarkus.kafka-streams.application-server=${HOST}:${SERVER_PORT}
+quarkus.kafka-streams.topics=platform.rhsm-subscriptions.billable-usage
+quarkus.kafka-streams.default.key.serde=com.redhat.swatch.azure.kafka.BillableUsageAggregationKeySerde
+quarkus.kafka-streams.default.value.serde=org.apache.kafka.common.serialization.Serdes$StringSerde
+
+
+# pass-through options
+kafka-streams.cache.max.bytes.buffering=10240
+kafka-streams.commit.interval.ms=1000
+kafka-streams.metadata.max.age.ms=500
+kafka-streams.auto.offset.reset=earliest
+kafka-streams.metrics.recording.level=DEBUG
+
 # Consumer settings
-mp.messaging.incoming.tally-in.fail-on-deserialization-failure=${TALLY_IN_FAIL_ON_DESER_FAILURE}
-mp.messaging.incoming.tally-in.connector=smallrye-kafka
-mp.messaging.incoming.tally-in.topic=platform.rhsm-subscriptions.billable-usage
-# Go back to the first records, if it's our first access
-mp.messaging.incoming.tally-in.auto.offset.reset = earliest
+#mp.messaging.incoming.tally-in.fail-on-deserialization-failure=${TALLY_IN_FAIL_ON_DESER_FAILURE}
+#mp.messaging.incoming.tally-in.connector=smallrye-kafka
+#mp.messaging.incoming.tally-in.topic=platform.rhsm-subscriptions.billable-usage
+## Go back to the first records, if it's our first access
+#mp.messaging.incoming.tally-in.auto.offset.reset = earliest
 
 # Producer settings
 mp.messaging.outgoing.tally-out.connector=smallrye-kafka


### PR DESCRIPTION
Testing:
`./gradlew :swatch-producer-azure:quarkusDev`

Create **two** billable usages below : 
key: org123
`{"org_id":"org123","billing_provider":"azure","billing_account_id":"testing;testing","snapshot_date":"2024-01-24T17:00:19.007433Z","product_id":"rhel-for-x86-els-payg","sla":"Premium","usage":"Production","uom":"vCPUs","value":"1.0"}`

Wait 10 seconds:

Create another messages like below:
key: org123
`{"org_id":"org123","billing_provider":"azure","billing_account_id":"test;test","snapshot_date":"2024-01-24T17:00:19.007433Z","product_id":"rhel-for-x86-els-payg","sla":"Standard","usage":"Development/Test","uom":"vCPUs","value":"3.0"}`

The new message coming in should trigger the window to close for the previous usages and a log should display with a billable usage value of 2 for the "Production" usage.




