### PR TITLE
SWATCH-2100: Create consumer of billable usage dead letter messages

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -300,7 +300,7 @@ public class TallyWorkerConfiguration {
       KafkaProperties kafkaProperties,
       @Qualifier("billableUsageDeadLetterTopicProperties")
           TaskQueueProperties taskQueueProperties) {
-    var props = kafkaProperties.buildConsumerProperties();
+    var props = kafkaProperties.buildConsumerProperties(null);
     props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, taskQueueProperties.getMaxPollRecords());
     var factory =
         new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), jsonDeserializer);

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -33,6 +33,7 @@ import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.event.EventController;
 import org.candlepin.subscriptions.inventory.db.InventoryDataSourceConfiguration;
+import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.product.ProductConfiguration;
 import org.candlepin.subscriptions.tally.billing.BillingProducerConfiguration;
@@ -61,6 +62,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
@@ -277,6 +279,56 @@ public class TallyWorkerConfiguration {
       prefix = "rhsm-subscriptions.service-instance-ingress-dead-letter.outgoing")
   public TaskQueueProperties serviceInstanceDeadLetterTopicProperties() {
     return new TaskQueueProperties();
+  }
+
+  @Bean
+  @Qualifier("billableUsageDeadLetterTopicProperties")
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.billable-usage-dead-letter.incoming")
+  public TaskQueueProperties billableUsageDeadLetterTopicProperties() {
+    return new TaskQueueProperties();
+  }
+
+  @Bean
+  public JsonDeserializer<BillableUsage> billableUsageJsonDeserializer(ObjectMapper objectMapper) {
+    return new JsonDeserializer<>(BillableUsage.class, objectMapper, false);
+  }
+
+  @Bean
+  @Qualifier("billableUsageDeadLetterConsumerFactory")
+  ConsumerFactory<String, BillableUsage> billableUsageDeadLetterConsumerFactory(
+      JsonDeserializer<BillableUsage> jsonDeserializer,
+      KafkaProperties kafkaProperties,
+      @Qualifier("billableUsageDeadLetterTopicProperties")
+          TaskQueueProperties taskQueueProperties) {
+    var props = kafkaProperties.buildConsumerProperties();
+    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, taskQueueProperties.getMaxPollRecords());
+    var factory =
+        new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), jsonDeserializer);
+    factory.setValueDeserializer(jsonDeserializer);
+    return factory;
+  }
+
+  @Bean
+  ConcurrentKafkaListenerContainerFactory<String, BillableUsage>
+      kafkaBillableUsageDeadLetterListenerContainerFactory(
+          @Qualifier("billableUsageDeadLetterConsumerFactory")
+              ConsumerFactory<String, BillableUsage> consumerFactory,
+          KafkaProperties kafkaProperties,
+          KafkaConsumerRegistry registry) {
+
+    var factory = new ConcurrentKafkaListenerContainerFactory<String, BillableUsage>();
+    factory.setConsumerFactory(consumerFactory);
+    factory.setBatchListener(true);
+    // Concurrency should be set to the number of partitions for the target topic.
+    factory.setConcurrency(kafkaProperties.getListener().getConcurrency());
+    if (kafkaProperties.getListener().getIdleEventInterval() != null) {
+      factory
+          .getContainerProperties()
+          .setIdleEventInterval(kafkaProperties.getListener().getIdleEventInterval().toMillis());
+    }
+    // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
+    factory.getContainerProperties().setConsumerRebalanceListener(registry);
+    return factory;
   }
 
   @Bean(name = "purgeRemittancesJobExecutor")

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -254,4 +254,19 @@ public class BillableUsageController {
         ending,
         measurementKey);
   }
+
+  public void updateBillableUsageRemittanceWithRetryAfter(
+      BillableUsage billableUsage, OffsetDateTime retryAfter) {
+    var billableUsageRemittance =
+        billableUsageRemittanceRepository.findById(
+            BillableUsageRemittanceEntityPK.keyFrom(
+                billableUsage, billableUsage.getSnapshotDate()));
+    if (billableUsageRemittance.isPresent()) {
+      billableUsageRemittance.get().setRetryAfter(retryAfter);
+      billableUsageRemittanceRepository.save(billableUsageRemittance.get());
+    } else {
+      log.warn(
+          "Unable to find billable usage to update retry_after. BillableUsage: {}", billableUsage);
+    }
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageDeadLetterConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageDeadLetterConsumer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class BillableUsageDeadLetterConsumer extends SeekableKafkaConsumer {
+
+  public static final String RETRY_AFTER_HEADER = "retryAfter";
+
+  private BillableUsageController billableUsageController;
+
+  @Autowired
+  public BillableUsageDeadLetterConsumer(
+      @Qualifier("billableUsageDeadLetterTopicProperties")
+          TaskQueueProperties billableUsageDeadLetterConsumerProperties,
+      KafkaConsumerRegistry kafkaConsumerRegistry,
+      BillableUsageController billableUsageController) {
+    super(billableUsageDeadLetterConsumerProperties, kafkaConsumerRegistry);
+    this.billableUsageController = billableUsageController;
+  }
+
+  @KafkaListener(
+      id = "#{__listener.groupId}",
+      topics = "#{__listener.topic}",
+      containerFactory = "kafkaBillableUsageDeadLetterListenerContainerFactory")
+  @Transactional(noRollbackFor = RuntimeException.class)
+  public void receive(
+      @Header(KafkaHeaders.BATCH_CONVERTED_HEADERS) List<Map<String, Object>> batchConvertedHeaders,
+      @Payload BillableUsage usage) {
+    var retryAfterHeader =
+        batchConvertedHeaders.stream().map(header -> header.get(RETRY_AFTER_HEADER)).findFirst();
+    if (retryAfterHeader.isPresent()) {
+      var retryAfter = OffsetDateTime.parse(new String((byte[]) retryAfterHeader.get()));
+      billableUsageController.updateBillableUsageRemittanceWithRetryAfter(usage, retryAfter);
+    } else {
+      log.debug("Message received with no retryAfter: {}", usage.toString());
+    }
+  }
+}

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -1,6 +1,7 @@
 TASKS_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.tasks')].name:platform.rhsm-subscriptions.tasks}
 TALLY_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.tally')].name:platform.rhsm-subscriptions.tally}
 BILLABLE_USAGE_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.billable-usage')].name:platform.rhsm-subscriptions.billable-usage}
+BILLABLE_USAGE_DEAD_LETTER_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.billable-usage.dlt')].name:platform.rhsm-subscriptions.billable-usage.dlt}
 SERVICE_INSTANCE_INGRESS_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.service-instance-ingress')].name:platform.rhsm-subscriptions.service-instance-ingress}
 SERVICE_INSTANCE_INGRESS_DEAD_LETTER_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.service-instance-ingress.dlt')].name:platform.rhsm-subscriptions.service-instance-ingress.dlt}
 
@@ -74,6 +75,12 @@ rhsm-subscriptions:
       truststore-password: ${clowder.endpoints.swatch-contracts-service.trust-store-password}
       truststore-type: ${clowder.endpoints.swatch-contracts-service.trust-store-type}
       psk: ${SWATCH_SELF_PSK:placeholder}
+  billable-usage-dead-letter:
+    incoming:
+      topic: ${BILLABLE_USAGE_DEAD_LETTER_TOPIC}
+      kafka-group-id: swatch-producer-billing-dead-letter
+      seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
+      seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
   tasks:
     topic: ${TASKS_TOPIC}
     kafka-group-id: ${KAFKA_GROUP_ID:rhsm-subscriptions-task-processor}

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageDeadLetterConsumerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageDeadLetterConsumerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BillableUsageDeadLetterConsumerTest {
+
+  @Mock BillableUsageController controller;
+  BillableUsageDeadLetterConsumer consumer;
+
+  @BeforeEach
+  void init() {
+    TaskQueueProperties queueProperties = new TaskQueueProperties();
+    KafkaConsumerRegistry kafkaConsumerRegistry = new KafkaConsumerRegistry();
+    this.consumer =
+        new BillableUsageDeadLetterConsumer(queueProperties, kafkaConsumerRegistry, controller);
+  }
+
+  @Test
+  void testConsumeMessageWithRetryAttemptHeader() {
+    var headers = new ArrayList<Map<String, Object>>();
+    var headerMap = new HashMap<String, Object>();
+    headerMap.put(
+        BillableUsageDeadLetterConsumer.RETRY_AFTER_HEADER,
+        OffsetDateTime.now().toString().getBytes());
+    headers.add(headerMap);
+    consumer.receive(headers, new BillableUsage());
+    verify(controller).updateBillableUsageRemittanceWithRetryAfter(any(), any());
+  }
+
+  @Test
+  void testConsumeMessageWithNoRetryAttemptHeader() {
+    var headers = new ArrayList<Map<String, Object>>();
+    consumer.receive(headers, new BillableUsage());
+    verifyNoInteractions(controller);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageDeadLetterConsumerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageDeadLetterConsumerTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class BillableUsageDeadLetterConsumerTest {
+class BillableUsageDeadLetterConsumerTest {
 
   @Mock BillableUsageController controller;
   BillableUsageDeadLetterConsumer consumer;


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2100

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Consume billable-usage.dlt messages and add retryAfter to billable_usage_remittance when available.

## Testing
1. `podman-compose up`
2. mock the subscription service:  

`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

```
cat > stub/__files/swatch-2099.json <<EOF
{
    "errors" : [  { "code": "SUBSCRIPTIONS1006" }  ]
}
EOF
```

```
curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext", "method": "GET"}, "response": { "status": 404, "bodyFileName": "swatch-2099.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new
```
3. Insert remittance data to be updated:
`INSERT INTO public.billable_usage_remittance VALUES (NULL, '123456789', 'BASILISK', 'Storage-gibibyte-months', '2024-01', 'Premium', 'Production', 'azure', '64dc69e4-d083-49fc-9569-ebece1dd1408', 42, '2024-01-30 01:10:28+00', '2024-01-30 18:24:26.998863+00');`
4. start the swatch producer azure service: 

```
SERVER_PORT=8001 SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101 ./gradlew :swatch-producer-azure:quarkusDev
```

5.  add a message into the billing-usage.dlt topic:

```
curl 'http://localhost:8001/api/swatch-producer-azure/internal/azure/billable_usage' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '{
    "org_id":"123456789",
    "id":null,
    "billing_provider":"azure",
    "billing_account_id":"64dc69e4-d083-49fc-9569-ebece1dd1408",
    "snapshot_date":"2024-01-30T01:10:28Z",
    "product_id":"BASILISK",
    "sla":"Premium",
    "usage":"Production",
    "uom":"Storage-gibibyte-months",
    "value":42.0
  }'
```

6. Start tally service with:
`DEV_MODE=true ./gradlew :bootRun`

## Verification
1. Check billable_usage_remittance table should have retryAfter populated to an hour in the future.
`select * from billable_usage_remittance where org_id = '123456789';`
