### PR TITLE
SWATCH-2162: Send metrics using backpressure mecanisms into Kafka

### DIFF
--- a/swatch-common-kafka/src/main/java/com/redhat/swatch/kafka/EmitterService.java
+++ b/swatch-common-kafka/src/main/java/com/redhat/swatch/kafka/EmitterService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.kafka;
+
+import io.smallrye.common.annotation.Blocking;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * Emitter service that implements back-pressure capabilities to deal with sending messages via an
+ * emitter.
+ *
+ * @param <T> messages to be sent.
+ */
+@Slf4j
+@Blocking
+public class EmitterService<T> {
+
+  private static final long WAIT_MILLISECONDS = 50;
+
+  private final Emitter<T> emitter;
+
+  public EmitterService(Emitter<T> emitter) {
+    this.emitter = emitter;
+  }
+
+  /**
+   * The emitter will be sending messages asynchronously until the emitter capacity is reached. If
+   * the emitter capacity is exceeded, we wait until it's freed up.
+   *
+   * @param message message to be sent.
+   */
+  public void send(Message<T> message) {
+    while (!emitter.hasRequests()) {
+      sleep();
+    }
+
+    emitter.send(message);
+  }
+
+  private void sleep() {
+    try {
+      Thread.sleep(WAIT_MILLISECONDS);
+    } catch (InterruptedException ex) {
+      log.warn("Thread was interrupted to send messages to the Kafka topic. ", ex);
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -27,6 +27,7 @@ import com.redhat.swatch.clients.prometheus.api.model.StatusType;
 import com.redhat.swatch.configuration.registry.Metric;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.kafka.EmitterService;
 import com.redhat.swatch.metrics.configuration.MetricProperties;
 import com.redhat.swatch.metrics.exception.MeteringException;
 import com.redhat.swatch.metrics.service.prometheus.PrometheusService;
@@ -71,7 +72,7 @@ public class PrometheusMeteringController {
   private static final String PROMETHEUS_QUERY_PARAM_INSTANCE_KEY = "instanceKey";
 
   private final PrometheusService prometheusService;
-  private final Emitter<BaseEvent> emitter;
+  private final EmitterService<BaseEvent> emitter;
   private final ApplicationClock clock;
   private final MetricProperties metricProperties;
   private final SpanGenerator spanGenerator;
@@ -92,7 +93,7 @@ public class PrometheusMeteringController {
     this.spanGenerator = spanGenerator;
     this.prometheusQueryBuilder = prometheusQueryBuilder;
     this.registry = registry;
-    this.emitter = emitter;
+    this.emitter = new EmitterService<>(emitter);
   }
 
   public void collectMetrics(

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -156,6 +156,9 @@ mp:
         # it does not properly resolve `${...}` properties.
         # This should be fixed by https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/181
         topic: ${SERVICE_INSTANCE_INGRESS_TOPIC}
+        # Workaround for https://github.com/smallrye/smallrye-reactive-messaging/issues/2465
+        # where 128 is the current default value for the buffer size
+        max-inflight-messages: 128
         value:
           serializer: io.quarkus.kafka.client.serialization.ObjectMapperSerializer
 


### PR DESCRIPTION
Jira issue: [SWATCH-2162](https://issues.redhat.com/browse/SWATCH-2162)

## Description
This solution has been agreed with Clement (the maintainer of the Quarkus messaging extensions). He suggested to use the emitter.hasRequests method to be sure the broker can handle more messages. The hasRequests works like a capacity barrier: when we send up to 1024 messages (1024 is the default value) without getting an ack from the broker, we wait until sending more messages).

Update: there seems to be two upper limits, (1) the one configured by the `max-inflight-messages` which is the one used by the `hasRequests` method and default value is 1024; and (2) the buffer limit which is used by the overflow strategy and default value is 128. Therefore, for this solution to work, we need to set the `max-inflight-messages` limit to the same as the buffer limit. 

Other solutions that we spoke about:
- use `@Outgoing` annotation along with the `@Blocking` annotation: this would hit a very performance penalty
- use `@OnOverflow(unbounded buffer)`: there is a OOM risk here that we should avoid
- use  `mp.messaging.outgoing.your-kafka-channel.waitForWriteCompletion=false`: but we can't ensure the messages are sent
- use `mp.messaging.outgoing.your-kafka-channel.max-inflight-messages=0`: again, we can't guarantee that the messages are sent

## Testing

Since I could not reproduce the "SRMSG00034: Insufficient downstream requests to emit item" issue, I asked Shubham for running the performance test against this pull request.  

## Testing locally

1.- podman-compose up
2.- Mock the prometheus server at localhost:

Create the stub directory:
`mkdir -p stub/__files`

Add a stub file to return some data: `stub/__files/swatch-1805.json`

```
cat > stub/__files/swatch-1805.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : [
        {
          "metric" : {
            "_id" : "cluster id",
            "support" : "sla",
            "usage" : "usage",
            "product" : "product",
            "billing_marketplace" : "billing_marketplace",
            "billing_marketplace_account" : "billing_marketplace_account",
            "ebs_account" : "account"
          },
          "values": [[ $(date +%s), "1" ]]
        }
      ]
    }
}
EOF
```

Add a stub file to return no data: `stub/__files/empty.json`

```
cat > stub/__files/empty.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : []
    }
}
EOF
```

Run wiremock:
`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

Configure stubbing for prometheus:

- this is to return some data when asking for instance-hours:
`curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/api/v1/query_range", "method": "GET", "queryParameters": {"query": {"contains":"instance_hours"}}}, "response": { "status": 200, "bodyFileName": "swatch-1805.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

- this is to return no data otherwise:
`curl -X POST --data '{ "priority": 5, "request": { "urlPath": "/api/v1/query_range", "method": "GET" }, "response": { "status": 200, "bodyFileName": "empty.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

3.- Start the swatch metrics app: `PROM_URL=http://localhost:8101/api/v1 ENABLE_SYNCHRONOUS_OPERATIONS=true ./gradlew :swatch-metrics:quarkusDev`

4.- Trigger the metrics from prometheus:
```
http POST :8000/api/swatch-metrics/v1/internal/metering/rosa?orgId=16790890 \
x-rh-swatch-synchronous-request:true
```

5.- Confirm the events have been produced in the Kafka topic "platform.rhsm-subscriptions.service-instance-ingress".

You should see two events in http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.service-instance-ingress/

