### PR TITLE
SWATCH-2066: Increase Kafka message acknowledgment timeout

### DIFF
--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -135,6 +135,9 @@ mp:
         # it does not properly resolve `${...}` properties.
         # This should be fixed by https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/181
         topic: ${METERING_TASK_TOPIC}
+        throttled:
+          unprocessed-record-max-age:
+            ms: 120000
         fail-on-deserialization-failure: ${METRICS_IN_FAIL_ON_DESER_FAILURE}
         auto:
           offset:


### PR DESCRIPTION
Jira issue: SWATCH-2066

## Description
Increases the Kafka message timeout from 1 minute to 2 minutes.

## Testing


### Setup
<!-- Add any steps required to set up the test case -->
1.  On a terminal, start a Prometheus instance (note that I bind to my local port 9095 since Cockpit uses 9090):
    ```
    podman run --rm -p 9095:9090 quay.io/prometheus/prometheus
    ```

### Steps
1.  Run the `swatch-metrics` app pointing to your prometheus instance
    ```
    RHSM_SUBSCRIPTIONS_METERING_PROMETHEUS_CLIENT_URL=http://localhost:9095/api/v1 ../gradlew quarkusDev
    ```
1. Enqueue a task
   ```
   http POST localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg orgId==16787820 endDate==2024-01-09T20:00Z
   ```
1. The task should flow through without a problem.
1. Stop the application and apply the following patch:
   ```patch
   diff --git a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MetricsConsumer.java b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MetricsConsumer.java
   index b75a0c157..cc7ca27ab 100644
   --- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MetricsConsumer.java
   +++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/MetricsConsumer.java
   @@ -54,6 +54,7 @@ public class MetricsConsumer {
            task.getOrgId());
        try {
          validate(task);
   +      Thread.sleep(240_000);
          service.collectMetrics(
              task.getProductTag(),
              MetricId.fromString(task.getMetric()),

   ```

1. Start the application again using the same command as step 1.
2. Enqueue another task using the same command as step 2.
3. Wait for 2 minutes.  After the first minute, you'll see a stacktrace that warns `Thread Thread[vert.x-worker-thread-1,5,main] has been blocked for 61275 ms, time limit is 60000 ms: io.vertx.core.VertxException: Thread blocked `.  Ignore this and **keep waiting**.  I'm sure there is some way to set the thread blocked limit to be longer but we don't really need to for this experiment.

### Verification
1. After 2 minutes you will see messages reading
   ```
   2024-02-01 12:16:29,993 WARN  [io.sma.rea.mes.kafka] (vert.x-eventloop-thread-0) SRMSG18231: The record 7 from
   topic-partition 'platform.rhsm-subscriptions.metering-tasks-0' has waited for 124 seconds to be acknowledged. This
   waiting time is greater than the configured threshold (120000 ms). At the moment 1 messages from this partition are
   awaiting acknowledgement. The last committed offset for this partition was 6. This error is due to a potential issue in the
   application which does not acknowledged the records in a timely fashion. The connector cannot commit as a record
   processing has not completed.
   2024-02-01 12:16:29,994 WARN  [io.sma.rea.mes.kafka] (vert.x-eventloop-thread-0) SRMSG18228: A failure has been reported for Kafka topics '[platform.rhsm-subscriptions.metering-tasks]':
   io.smallrye.reactive.messaging.kafka.commit.KafkaThrottledLatestProcessedCommit$TooManyMessagesWithoutAckException:
    The record 7 from topic/partition 'platform.rhsm-subscriptions.metering-tasks-0' has waited for 124 seconds to be
    acknowledged. At the moment 1 messages from this partition are awaiting acknowledgement. The last committed
    offset for this partition was 6.
   ```
1. Thus demonstrating that the wait time is now 2 minutes (120 seconds).
