### PR TITLE
SWATCH-2089: Bump com.netflix.nebula:nebula-release-plugin from 18.0.8 to 19.0.4

### DIFF
--- a/.github/workflows/validate-floorplan-queries.yaml
+++ b/.github/workflows/validate-floorplan-queries.yaml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Setup GIT config
+        run: |
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
       - name: Install JDK
         uses: actions/setup-java@v3
         with:

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
 ext.plugins = [
         "com.adarshr:gradle-test-logger-plugin:4.0.0",
         "com.diffplug.spotless:spotless-plugin-gradle:6.25.0",
-        "com.netflix.nebula:nebula-release-plugin:18.0.8",
+        "com.netflix.nebula:nebula-release-plugin:19.0.4",
         "io.quarkus:gradle-application-plugin:${quarkusVersion}",
         // swagger-parser manually upgraded for compatibility with snakeyaml 2.0
         // see https://github.com/OpenAPITools/openapi-generator/issues/15876

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -28,6 +28,10 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 # Disable the validation of topics for now until SWATCH-1904 is resolved.
 # python bin/validate-topics.py
 
+# Initialize the GIT config which is required by the Gradle Nebula plugin to build the images
+git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+
 IMAGES=""
 
 export COMPONENT_NAME="rhsm"  # name of app-sre "resourceTemplate" in deploy.yaml for this component


### PR DESCRIPTION
Jira issue: [SWATCH-2089](https://issues.redhat.com/browse/SWATCH-2089)

## Description
Bumps [com.netflix.nebula:nebula-release-plugin](https://github.com/nebula-plugins/nebula-release-plugin) from 18.0.8 to 19.0.4. 

This is related to this change: https://github.com/nebula-plugins/nebula-release-plugin/pull/253
Therefore, we need to configure the user we use in our actions before running the build. 

I also tried to do this as part of a gradle task, but they are running the verification of the git user as part of the release initial task, so we can't configure it. 

### More details
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/nebula-plugins/nebula-release-plugin/releases">com.netflix.nebula:nebula-release-plugin's releases</a>.</em></p> <blockquote>
<h2>v19.0.4</h2>
<ul>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/4e96a060718c93a231a2f04612e47ddb9f5691f5">Improve error logging for tag push</a></li> </ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/nebula-plugins/nebula-release-plugin/compare/v19.0.3...v19.0.4">https://github.com/nebula-plugins/nebula-release-plugin/compare/v19.0.3...v19.0.4</a></p>
<h2>v19.0.3</h2>
<ul>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/714cd39440b91176b175a2271c64dea64dbfba4a">GitReadCommand: DescribeHeadWithTag handles tags known externally as warning</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/nebula-plugins/nebula-release-plugin/compare/v19.0.2...v19.0.3">https://github.com/nebula-plugins/nebula-release-plugin/compare/v19.0.2...v19.0.3</a></p>
<h2>v19.0.2</h2>
<ul>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/5e778b63a1aa0f3a65c8a6ca06d2a16eb6a3dea0"><code>GetGitConfigValue</code> should use <code>--includes</code> to respect <code>include.*</code> directives in config files when looking up values</a></li> </ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/nebula-plugins/nebula-release-plugin/compare/v19.0.1...v19.0.2">https://github.com/nebula-plugins/nebula-release-plugin/compare/v19.0.1...v19.0.2</a></p>
<h2>v19.0.1</h2>
<h2>What's Changed</h2>
<ul>
<li>IsGitRepo: remove usage of --is-inside-work-tree in order to support composite builds by <a href="https://github.com/rpalcolea"><code>@​rpalcolea</code></a> in <a href="https://redirect.github.com/nebula-plugins/nebula-release-plugin/pull/254">nebula-plugins/nebula-release-plugin#254</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/nebula-plugins/nebula-release-plugin/compare/v19.0.0...v19.0.1">https://github.com/nebula-plugins/nebula-release-plugin/compare/v19.0.0...v19.0.1</a></p>
<h2>v19.0.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Git config verification: avoid mutating local git config and throw exception instead by <a href="https://github.com/rpalcolea"><code>@​rpalcolea</code></a> in <a href="https://redirect.github.com/nebula-plugins/nebula-release-plugin/pull/253">nebula-plugins/nebula-release-plugin#253</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/nebula-plugins/nebula-release-plugin/compare/v18.0.8...v19.0.0">https://github.com/nebula-plugins/nebula-release-plugin/compare/v18.0.8...v19.0.0</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/4e96a060718c93a231a2f04612e47ddb9f5691f5"><code>4e96a06</code></a> Improve error logging for tag push</li>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/714cd39440b91176b175a2271c64dea64dbfba4a"><code>714cd39</code></a> GitReadCommand: DescribeHeadWithTag handles tags known externally as warning</li>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/5e778b63a1aa0f3a65c8a6ca06d2a16eb6a3dea0"><code>5e778b6</code></a> GetGitConfigValue should use --includes to respect include.* directives in co...</li> <li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/c5f89fe37b5b57bb55bb00d0b0fcb6eb94c698f8"><code>c5f89fe</code></a> Nebula-plugin-plugin 20.11.0</li>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/ef7ddb0f91b38a1dc2b4ee804fe914302df384aa"><code>ef7ddb0</code></a> IsGitRepo: remove usage of --is-inside-work-tree in order to support composit...</li>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/a8bc82128ca4b736864dc1b31a3daa634b53d7d0"><code>a8bc821</code></a> Gradle 8.6-rc-1</li>
<li><a href="https://github.com/nebula-plugins/nebula-release-plugin/commit/bd38491fbe38d796862608b3e842eb9412d46d18"><code>bd38491</code></a> Git config verification: avoid mutating local git config and throw exception ...</li>
<li>See full diff in <a href="https://github.com/nebula-plugins/nebula-release-plugin/compare/v18.0.8...v19.0.4">compare view</a></li> </ul>
</details>
<br />
