### PR TITLE
SWATCH-2104: Change metric for ROSA HCP

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
@@ -39,5 +39,5 @@ metrics:
       queryParams:
         instanceKey: _id
         product: moa-hostedcontrolplane
-        metric: cluster:usage:workload:capacity_physical_cpu_hours
+        metric: cluster:usage:workload:capacity_virtual_cpu_hours
         metadataMetric: ocm_subscription


### PR DESCRIPTION
Jira issue: [SWATCH-2104](https://issues.redhat.com/browse/SWATCH-2104)

## Description
During investigation for [BIZ-654](https://issues.redhat.com/browse/BIZ-654), I discovered that ROSA HCP clusters appear to be half-sized when counted via cluster:usage:workload:capacity_physical_cpu_hours. cluster:usage:workload:capacity_virtual_cpu_hours values look fine though.

## Testing
Note for QE to use cluster:usage:workload:capacity_virtual_cpu_hours. 