### PR TITLE
SWATCH-1998: conduit - report provider_type & provider_id to HBI

### DIFF
--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -69,6 +69,7 @@ public class StubRhsmApi extends RhsmApi {
     consumer1.getFacts().put("cpu.core(s)_per_socket", "2");
     consumer1.getFacts().put("cpu.cpu(s)", "3");
     consumer1.getFacts().put("cpu.thread(s)_per_core", "5");
+    consumer1.getFacts().put("aws_instance_id", "123456");
 
     consumer1.getFacts().put("memory.memtotal", "32757812");
     consumer1.getFacts().put("uname.machine", "x86_64");

--- a/swatch-system-conduit/schemas/inventory/hbi-host.yaml
+++ b/swatch-system-conduit/schemas/inventory/hbi-host.yaml
@@ -41,3 +41,8 @@ properties:
     format: date-time
   reporter:
     type: string
+  provider_id:
+    type: string
+  provider_type:
+    type: string
+    existingJavaType: org.candlepin.subscriptions.utilization.api.model.ConsumerInventory.ProviderTypeEnum

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 import org.candlepin.subscriptions.conduit.inventory.ConduitFacts;
 import org.candlepin.subscriptions.conduit.inventory.InventoryService;
 import org.candlepin.subscriptions.conduit.inventory.InventoryServiceProperties;
+import org.candlepin.subscriptions.conduit.inventory.ProviderFact;
 import org.candlepin.subscriptions.conduit.job.OrgSyncTaskManager;
 import org.candlepin.subscriptions.conduit.json.inventory.HbiNetworkInterface;
 import org.candlepin.subscriptions.conduit.rhsm.RhsmService;
@@ -115,7 +116,8 @@ public class InventoryController {
   public static final String OCM_BILLING_MODEL = "ocm.billing_model";
   public static final String UNKNOWN = "unknown";
   public static final String TRUE = "True";
-  public static final String NONE = "none";
+  public static final String INSTANCE_ID = "instance_id";
+
   public static final Set<String> IGNORED_CONSUMER_TYPES = Set.of("candlepin", "satellite", "sam");
   public static final long MAX_ALLOWED_SYSTEM_MEMORY_BYTES = 9007199254740991L;
 
@@ -202,6 +204,7 @@ public class InventoryController {
     extractNetworkFacts(rhsmFacts, facts);
     extractHardwareFacts(rhsmFacts, facts);
     extractVirtualizationFacts(consumer, rhsmFacts, facts);
+    extractProviderFacts(rhsmFacts, facts);
     facts.setCloudProvider(extractCloudProvider(rhsmFacts));
 
     List<String> productIds =
@@ -210,6 +213,17 @@ public class InventoryController {
 
     extractMarketPlaceFacts(rhsmFacts, facts);
     return facts;
+  }
+
+  private void extractProviderFacts(Map<String, String> rhsmFacts, ConduitFacts facts) {
+    for (ProviderFact provider : ProviderFact.values()) {
+      String instanceId = rhsmFacts.get(provider.getFactPropertyName(INSTANCE_ID));
+      if (instanceId != null && !instanceId.isEmpty()) {
+        facts.setProviderId(instanceId);
+        facts.setProviderType(provider.getType());
+        break;
+      }
+    }
   }
 
   private void extractMarketPlaceFacts(Map<String, String> rhsmFacts, ConduitFacts facts) {

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -118,6 +118,8 @@ public abstract class InventoryService {
     host.setIpAddresses(facts.getIpAddresses());
     host.setMacAddresses(facts.getMacAddresses());
     host.setInsightsId(facts.getInsightsId());
+    host.setProviderId(facts.getProviderId());
+    host.setProviderType(facts.getProviderType());
 
     host.setSystemProfile(createSystemProfile(facts));
 

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/ProviderFact.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/ProviderFact.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.conduit.inventory;
+
+import lombok.Getter;
+import org.candlepin.subscriptions.utilization.api.model.ConsumerInventory;
+
+@Getter
+public enum ProviderFact {
+  AWS(ConsumerInventory.ProviderTypeEnum.AWS),
+  AZURE(ConsumerInventory.ProviderTypeEnum.AZURE),
+  GPC(ConsumerInventory.ProviderTypeEnum.GCP);
+
+  private final ConsumerInventory.ProviderTypeEnum type;
+
+  ProviderFact(ConsumerInventory.ProviderTypeEnum type) {
+    this.type = type;
+  }
+
+  public String getFactPropertyName(String key) {
+    return String.format("%s_%s", type.value(), key);
+  }
+}

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -287,6 +287,11 @@ components:
           type: string
         is_marketplace:
           type: boolean
+        provider_id:
+          type: string
+        provider_type:
+          type: string
+          enum: [ aws, azure, gcp ]
     DefaultResponse:
       properties:
         status:

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.conduit;
 
+import static org.candlepin.subscriptions.conduit.InventoryController.INSTANCE_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -49,6 +50,7 @@ import java.util.stream.Collectors;
 import org.candlepin.subscriptions.conduit.inventory.ConduitFacts;
 import org.candlepin.subscriptions.conduit.inventory.InventoryService;
 import org.candlepin.subscriptions.conduit.inventory.InventoryServiceProperties;
+import org.candlepin.subscriptions.conduit.inventory.ProviderFact;
 import org.candlepin.subscriptions.conduit.job.DatabaseOrgList;
 import org.candlepin.subscriptions.conduit.job.OrgSyncTaskManager;
 import org.candlepin.subscriptions.conduit.json.inventory.HbiNetworkInterface;
@@ -62,6 +64,8 @@ import org.candlepin.subscriptions.conduit.rhsm.client.model.Pagination;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -975,5 +979,18 @@ class InventoryControllerTest {
     // verify when cpu.thread(s)_per_core is unset
     conduitFacts = controller.getFactsFromConsumer(new Consumer());
     assertNull(conduitFacts.getThreadsPerCore());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = ProviderFact.class)
+  void testProviderIdAndProviderTypeToConduitFacts(ProviderFact provider) {
+    String expectedInstanceId = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.getFacts().put(provider.getFactPropertyName(INSTANCE_ID), expectedInstanceId);
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+
+    assertEquals(provider.getType(), conduitFacts.getProviderType());
+    assertEquals(expectedInstanceId, conduitFacts.getProviderId());
   }
 }

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -31,10 +31,12 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.candlepin.subscriptions.conduit.inventory.ConduitFacts;
 import org.candlepin.subscriptions.conduit.inventory.InventoryServiceProperties;
 import org.candlepin.subscriptions.conduit.json.inventory.HbiFactSet;
+import org.candlepin.subscriptions.utilization.api.model.ConsumerInventory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,6 +98,8 @@ class KafkaEnabledInventoryServiceTest {
     expectedFacts.setOsVersion("6.3");
     expectedFacts.setNumberOfCpus(NUMBER_OF_CPUS);
     expectedFacts.setThreadsPerCore(THREADS_PER_CORE);
+    expectedFacts.setProviderType(ConsumerInventory.ProviderTypeEnum.AZURE);
+    expectedFacts.setProviderId(UUID.randomUUID().toString());
 
     InventoryServiceProperties props = new InventoryServiceProperties();
     props.setKafkaHostIngressTopic("placeholder");
@@ -129,6 +133,8 @@ class KafkaEnabledInventoryServiceTest {
     assertEquals(3, message.getData().getSystemProfile().getOperatingSystem().getMinor());
     assertEquals(NUMBER_OF_CPUS, message.getData().getSystemProfile().getNumberOfCpus());
     assertEquals(THREADS_PER_CORE, message.getData().getSystemProfile().getThreadsPerCore());
+    assertEquals(expectedFacts.getProviderId(), message.getData().getProviderId());
+    assertEquals(expectedFacts.getProviderType(), message.getData().getProviderType());
   }
 
   @Test


### PR DESCRIPTION
Jira issue: [SWATCH-1998](https://issues.redhat.com/browse/SWATCH-1998)

## Description
If this is an aws/azure/gcp instance
Canonical facts include: provider_id and provider_type
- provider_id is set to the aws_instance_id/azure_instance_id/gcp_instance_id
- provicer_type is set to aws/azure/gcp depending on whichever is appropriate. 

## Testing

0.- Start Kafka

`podman-compose up`

1.- Run conduit app with stubs
`RHSM_USE_STUB=true DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun`

2.- Sync organization:
`http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg   x-rh-swatch-psk:placeholder   org_id=org123`

3. Check the message that has been sent to Kafka in http://localhost:3030/#/cluster/default/topic/n/platform.inventory.host-ingress/ .

The stub is configured to add number of cpus to 3 and threads per core to 5. This is what you should see:

```
Key
Value
operation add_host
data
org_id org123
subscription_manager_id 76961e8f-a5bb-4138-8343-ecd718e1691f
bios_uuid 0e26d770-3b73-4809-9d69-dc0ab7c2764f
ip_addresses [ 192.167.11.2, 192.168.1.1, 192.168.122.1, 10.0.0.1 ]
fqdn host1.test.com
facts [ [object Object] ]
system_profile { operating_system: [object Object], os_release: 6.3, releasever: 8.0, arch: x86_64, cores_per_socket: 2, infrastructure_type: virtual, system_memory_bytes: 33543999488, number_of_sockets: 2, number_of_cpus: 3, threads_per_core: 5, owner_id: 76961e8f-a5bb-4138-8343-ecd718e1691f, is_marketplace: true, network_interfaces: [object Object] }
stale_timestamp 2024-02-04T14:53:28.520740565Z
reporter rhsm-conduit
provider_id 123456
provider_type aws
platform_metadata { request_id: 716e1899-80a7-41ef-a26d-d90d06aaa3b8 }
```

Notice the new provider_id and provider_type values.