### PR TITLE
Change compose setup to not require postgres password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./postgresql.conf:/opt/app-root/src/postgresql-cfg/postgresql.conf:z
       - ./pg_hba.conf:/pg_hba.conf:z
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
   kafka:
     image: quay.io/strimzi/kafka:latest-kafka-3.1.0
     command: sh /init_kafka.sh
@@ -33,10 +33,10 @@ services:
         # Note that as of this writing (20 Jul 2022), Kraft mode does not support SCRAM
       - KAFKA_SASL_MECHANISM=PLAIN
     ports:
-      - "9092:9092"
+      - "127.0.0.1:9092:9092"
       # Port 9093 is used by the Kraft configuration
-      - "9094:9094"
-      - "29092:29092"
+      - "127.0.0.1:9094:9094"
+      - "127.0.0.1:29092:29092"
     volumes:
       - ./config/kafka/init_kafka.sh:/init_kafka.sh:z
       - ./config/kafka/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf:z
@@ -53,7 +53,7 @@ services:
       - KAFKA_REST_PROXY_URL=http://kafka-rest:8082
       - PROXY=true
     ports:
-      - "3030:8000"
+      - "127.0.0.1:3030:8000"
     depends_on:
       - kafka-rest
   inventory:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - POSTGRESQL_ADMIN_PASSWORD=admin
     volumes:
       - ./init_dbs.sh:/usr/share/container-scripts/postgresql/start/set_passwords.sh:z
+      - ./postgresql.conf:/opt/app-root/src/postgresql-cfg/postgresql.conf:z
+      - ./pg_hba.conf:/pg_hba.conf:z
     ports:
       - "5432:5432"
   kafka:

--- a/pg_hba.conf
+++ b/pg_hba.conf
@@ -1,0 +1,2 @@
+local   all             all                                trust
+host    all             all        0.0.0.0/0               trust

--- a/postgresql.conf
+++ b/postgresql.conf
@@ -1,0 +1,1 @@
+hba_file = '/pg_hba.conf'


### PR DESCRIPTION
## Description
This makes it more convenient for development, as the password doesn't need to be specified.

Note: I also updated the port mappings to use only the localhost interface. Generally, firewalls prevent external access, but it felt like a good related improvement.

You'll need to re-provision the database container to get this to work, so backup and restore DB data if you wish.