### PR TITLE
SWATCH-2101: Retry processing billable_usage's with retry_after field populated

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -228,6 +228,8 @@ public class BillableUsageController {
     var newRemittance =
         BillableUsageRemittanceEntity.builder()
             .key(BillableUsageRemittanceEntityPK.keyFrom(usage, clock.now()))
+            .tallyId(usage.getId())
+            .hardwareMeasurementType(usage.getHardwareMeasurementType())
             .build();
     // Remitted value should be set to usages metric_value rather than billing_value
     newRemittance.setRemittedPendingValue(usageCalc.getRemittedValue());

--- a/src/main/resources/liquibase/202402051200-add-id-and-hardware-columns-to-billable_usage_remittance-table.xml
+++ b/src/main/resources/liquibase/202402051200-add-id-and-hardware-columns-to-billable_usage_remittance-table.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202401151414-01" author="lburnett">
+
+    <comment>Add billable_usage_remittance.tally_id and billable_usage_remittance.hardware_measurement_type columns.</comment>
+    <addColumn tableName="billable_usage_remittance">
+      <column name="tally_id" type="UUID"/>
+      <column name="hardware_measurement_type" type="VARCHAR(32)"/>
+    </addColumn>
+    <rollback>
+      <dropColumn tableName="billable_usage_remittance" columnName="tally_id"/>
+      <dropColumn tableName="billable_usage_remittance" columnName="hardware_measurement_type"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -137,5 +137,6 @@
     <include file="/liquibase/202311161207-drop-account-config-table.xml"/>
     <include file="/liquibase/202312200751-add-metered-column-for-offering-table.xml"/>
     <include file="/liquibase/202401151414-add-retry_after-column-to-billable_usage_remittance-table.xml"/>
+    <include file="/liquibase/202402051200-add-id-and-hardware-columns-to-billable_usage_remittance-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/spec/internal-billing-api-spec.yaml
+++ b/src/main/spec/internal-billing-api-spec.yaml
@@ -151,7 +151,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RetriesResponse'
+                $ref: "#/components/schemas/DefaultResponse"
           description: Accepted request to retry billable usage remittance
       tags: ['internalBilling']
   /internal-billing-openapi.json:
@@ -160,14 +160,6 @@ paths:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-yaml"
 components:
   schemas:
-    RetriesResponse:
-      description: ''
-      type: object
-      properties:
-        detail:
-          description: success status
-          type: string
-          example: "Success"
     AccountRemittances:
       type: array
       items:

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -552,7 +552,12 @@ class BillableUsageControllerTest {
   private BillableUsageRemittanceEntity remittance(
       BillableUsage usage, OffsetDateTime remittedDate, Double value) {
     BillableUsageRemittanceEntityPK remKey = keyFrom(usage, remittedDate);
-    return BillableUsageRemittanceEntity.builder().key(remKey).remittedPendingValue(value).build();
+    return BillableUsageRemittanceEntity.builder()
+        .key(remKey)
+        .remittedPendingValue(value)
+        .tallyId(usage.getId())
+        .hardwareMeasurementType(usage.getHardwareMeasurementType())
+        .build();
   }
 
   private void performRemittanceTesting(

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingControllerTest.java
@@ -20,7 +20,11 @@
  */
 package org.candlepin.subscriptions.tally.billing.admin;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -34,9 +38,13 @@ import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntityPK;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.json.BillableUsage;
 import org.candlepin.subscriptions.json.BillableUsage.BillingProvider;
+import org.candlepin.subscriptions.tally.billing.BillingProducer;
 import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,16 +57,18 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @Transactional
 @Import(TestClockConfiguration.class)
+@ExtendWith(MockitoExtension.class)
 class InternalBillingControllerTest {
 
   @Autowired BillableUsageRemittanceRepository remittanceRepo;
-  @Autowired private ApplicationClock clock;
+  @Autowired ApplicationClock clock;
+  @Mock BillingProducer billingProducer;
 
   InternalBillingController controller;
 
   @BeforeEach
   void setup() {
-    controller = new InternalBillingController(remittanceRepo);
+    controller = new InternalBillingController(remittanceRepo, billingProducer);
 
     BillableUsageRemittanceEntity remittance1 =
         remittance("111", "product1", BillingProvider.AWS, 24.0, clock.startOfCurrentMonth());
@@ -90,7 +100,7 @@ class InternalBillingControllerTest {
   @Test
   void ifAccountNotFoundDisplayEmptyAccountRemittance() {
     var response =
-        controller.process(
+        controller.getRemittances(
             BillableUsageRemittanceFilter.builder()
                 .orgId("not_found")
                 .productId("product1")
@@ -102,7 +112,7 @@ class InternalBillingControllerTest {
   @Test
   void testFilterByOrgId() {
     var response =
-        controller.process(
+        controller.getRemittances(
             BillableUsageRemittanceFilter.builder().productId("product1").orgId("111").build());
     assertFalse(response.isEmpty());
     assertEquals(24.0, response.get(0).getRemittedValue());
@@ -112,7 +122,7 @@ class InternalBillingControllerTest {
   @Test
   void testFilterByAccountAndProduct() {
     var response =
-        controller.process(
+        controller.getRemittances(
             BillableUsageRemittanceFilter.builder().orgId("org123").productId("product1").build());
     assertFalse(response.isEmpty());
     assertEquals(2, response.size());
@@ -122,7 +132,7 @@ class InternalBillingControllerTest {
   @Test
   void testFilterByAccountAndProductAndMetricId() {
     var response =
-        controller.process(
+        controller.getRemittances(
             BillableUsageRemittanceFilter.builder()
                 .orgId("org123")
                 .productId("product1")
@@ -138,7 +148,7 @@ class InternalBillingControllerTest {
   @Test
   void testFilterByOrgIdAndProductAndMetricId() {
     var response =
-        controller.process(
+        controller.getRemittances(
             BillableUsageRemittanceFilter.builder()
                 .orgId("org123")
                 .productId("product1")
@@ -156,7 +166,7 @@ class InternalBillingControllerTest {
   @Test
   void testAccountAndOrgIdShouldReturnEmpty() {
     var response =
-        controller.process(
+        controller.getRemittances(
             BillableUsageRemittanceFilter.builder()
                 .productId("product1")
                 .metricId("Instance-hours")
@@ -167,7 +177,7 @@ class InternalBillingControllerTest {
   @Test
   void testFilterByBillingProviderAndOrgId() {
     var response =
-        controller.process(
+        controller.getRemittances(
             BillableUsageRemittanceFilter.builder()
                 .orgId("org123")
                 .billingProvider(BillingProvider.RED_HAT.value())
@@ -183,7 +193,7 @@ class InternalBillingControllerTest {
   @Test
   void testFilterByBillingAccountIdAndOrgId() {
     var response =
-        controller.process(
+        controller.getRemittances(
             BillableUsageRemittanceFilter.builder()
                 .orgId("org345")
                 .billingAccountId("org345_product3_ba")
@@ -213,6 +223,29 @@ class InternalBillingControllerTest {
             Set.of("1234"));
     assertEquals(2, remittancePresent);
     assertEquals(0, remittanceNotPresent);
+  }
+
+  @Test
+  void testProcessRetries() {
+    String orgId = "testProcessRetriesOrg123";
+    givenRemittanceWithOldRetryAfter(orgId);
+
+    controller.processRetries(OffsetDateTime.now());
+
+    // verify remittance has been sent
+    verify(billingProducer).produce(argThat(b -> b.getOrgId().equals(orgId)));
+    // verify retry after is reset
+    assertTrue(
+        remittanceRepo.findAll().stream()
+            .filter(b -> b.getKey().getOrgId().equals(orgId))
+            .allMatch(b -> b.getRetryAfter() == null));
+  }
+
+  private void givenRemittanceWithOldRetryAfter(String orgId) {
+    var remittance =
+        remittance(orgId, "product", BillingProvider.AZURE, 4.0, clock.startOfCurrentMonth());
+    remittance.setRetryAfter(clock.now().minusMonths(30));
+    remittanceRepo.saveAndFlush(remittance);
   }
 
   private BillableUsageRemittanceEntity remittance(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
@@ -46,6 +46,8 @@ public interface BillableUsageRemittanceRepository
   @Query
   void deleteByKeyOrgId(String orgId);
 
+  List<BillableUsageRemittanceEntity> findByRetryAfterLessThan(OffsetDateTime asOf);
+
   default boolean existsBy(BillableUsageRemittanceFilter filter) {
     return this.exists(buildSearchSpecification(filter));
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
@@ -27,6 +27,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -48,4 +49,10 @@ public class BillableUsageRemittanceEntity implements Serializable {
 
   @Column(name = "retry_after")
   private OffsetDateTime retryAfter;
+
+  @Column(name = "tally_id")
+  private UUID tallyId;
+
+  @Column(name = "hardware_measurement_type")
+  private String hardwareMeasurementType;
 }

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -94,6 +94,8 @@ parameters:
     value: 0 3 * * *
   - name: PURGE_REMITTANCE_SCHEDULE
     value: 0 3 * * *
+  - name: RETRY_REMITTANCE_SCHEDULE
+    value: '@hourly'
   - name: CAPTURE_SNAPSHOT_SCHEDULE
     value: 0 6 * * *
   - name: CAPTURE_HOURLY_SNAPSHOT_SCHEDULE
@@ -586,6 +588,32 @@ objects:
             - -c
             - >
               /usr/bin/curl --fail -i -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X DELETE "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/events/purge"
+          env:
+            - name: SWATCH_SELF_PSK
+              valueFrom:
+                secretKeyRef:
+                  name: swatch-psks
+                  key: self
+        resources:
+          requests:
+            cpu: ${CURL_CRON_CPU_REQUEST}
+            memory: ${CURL_CRON_MEMORY_REQUEST}
+          limits:
+            cpu: ${CURL_CRON_CPU_LIMIT}
+            memory: ${CURL_CRON_MEMORY_LIMIT}
+
+      - name: retry-remittances
+        schedule: ${RETRY_REMITTANCE_SCHEDULE}
+        activeDeadlineSeconds: 1800
+        successfulJobsHistoryLimit: 2
+        restartPolicy: Never
+        podSpec:
+          image: ${CURL_CRON_IMAGE}:${CURL_CRON_IMAGE_TAG}
+          command:
+            - /usr/bin/bash
+            - -c
+            - >
+              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/remittance/processRetries"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:


### PR DESCRIPTION
Jira issue: [SWATCH-2101](https://issues.redhat.com/browse/SWATCH-2101)

## Description
- Query billable_usage_remittance for retry_after > as_of (and non_null) Produce kafka message onto
- platform.billable_usage again Clear retry_after column in the table
- cron job to call the api every 1 hr

## Testing
1. podman-compose up
2. start tally service: `./gradlew :bootRun`
3. insert billable usage remittance:

INSERT INTO billable_usage_remittance(org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remittance_pending_date, retry_after, remitted_pending_value)
VALUES ('org123', 'rosa', 'CORES', '2024-02', 'Premium', 'Production', 'azure', '123456', '2024-02-11T04:00:09.620406Z', '2023-12-11T04:00:09.620406Z', '4.0')

4. invoke new endpoint:

```
http POST :8000/api/rhsm-subscriptions/v1/internal/rpc/remittance/processRetries \
Origin:console.redhat.com \
x-rh-swatch-psk:placeholder \
x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16790890"}}}' | base64 -w 0)
```

You should see a new trace in the app logs:

```
2024-02-05 11:59:32,146 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.security.LogPrincipalFilter] self- Internal API: /api/rhsm-subscriptions/v1/internal/rpc/remittance/processRetries requested by user: self
2024-02-05 11:59:32,198 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.billing.admin.InternalBillingResource] self- Retry billable usage remittances as of 2024-02-05T11:59:32.198623258Z
```

Also, a new message in the following topic: http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.billable-usage/

```
Key
Value
org_id org123
billing_provider azure
billing_account_id 123456
snapshot_date 2024-02-11T04:00:09.620406Z
product_id rosa
sla Premium
usage Production
uom CORES
value 4
```

And finally, the retry_after column for the entry you saved in the step 3, should be NULL:

```
select retry_after from billable_usage_remittance where org_id='org123';
```