### PR TITLE
SWATCH-2021: Allow Export request to fetch subscriptions from SWATCH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ bonfire
 
 
 stub/__files/
+
+tmp

--- a/bin/PlaceholderSubscriptionData.md
+++ b/bin/PlaceholderSubscriptionData.md
@@ -1,0 +1,210 @@
+Database Population Script
+==========================
+
+This script is designed to populate the `rhsm-subscriptions` database with random data for offerings, subscriptions, and related entities. It supports a dry-run mode for SQL statement preview and provides an option to delete all existing data before insertion.
+
+
+`generate_subscription_data.py`
+```python
+#!/usr/bin/python3
+
+import argparse
+import itertools
+import random
+import string
+from contextlib import closing
+
+import psycopg2
+from psycopg2 import extras
+
+DB_CONFIG = {
+    'dbname': 'rhsm-subscriptions',
+    'user': 'rhsm-subscriptions',
+    'password': 'rhsm-subscriptions',
+    'host': 'localhost',
+    'port': '5432'
+}
+START_DATE = "2023-09-25 08:25:22.797423 +00:00"
+END_DATE = "2024-09-25 08:25:22.000000 +00:00"
+VARIABLE_VALUES = {
+    "sla": ["Premium", "Standard"],
+    "usage": ["Production", "Development"],
+    "product_id": ["openshift-dedicated-metrics", "rosa"],
+    "billing_provider": ["aws", "gcp"],
+    "measurement_type": ["PHYSICAL", "VIRTUAL"],
+    "metric_id": ["Instance-hours", "Cores"]
+}
+
+
+def generate_random_string(letters, length):
+    return ''.join(random.choices(letters, k=length))
+
+
+def generate_sku():
+    return 'MW' + generate_random_string(string.digits, 5)
+
+
+def generate_org_id():
+    return generate_random_string(string.digits, random.randint(5, 8))
+
+
+def generate_generic_id(letters, length):
+    return generate_random_string(letters, length)
+
+
+def format_value(value):
+    if isinstance(value, str):
+        return f"'{value.replace("'", "''")}'"  # Escape single quotes in SQL string
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return 'TRUE' if value else 'FALSE'
+    return str(value)
+
+
+def batch_insert(cursor, query, data, dry_run=False):
+    if dry_run:
+        for record in data:
+            formatted_values = tuple(format_value(value) for value in record)
+            print(f'{query % formatted_values};')
+    else:
+        extras.execute_batch(cursor, query, data)
+
+
+def main(dry_run, delete_all):
+    if delete_all:
+        with closing(psycopg2.connect(**DB_CONFIG)) as conn:
+            with conn.cursor() as cursor:
+                delete_all_records(cursor, dry_run)
+                conn.commit()
+    else:
+        permutations = list(itertools.product(*VARIABLE_VALUES.values()))
+
+        if not dry_run:
+            with closing(psycopg2.connect(**DB_CONFIG)) as conn:
+                with conn.cursor() as cursor:
+                    process_data(permutations, cursor, dry_run)
+                    conn.commit()
+        else:
+            process_data(permutations, None, dry_run)
+
+
+def process_data(permutations, cursor, dry_run=False):
+    offering_data = []
+    subscription_data = []
+    subscription_measurements_data = []
+    subscription_product_ids_data = []
+
+    for perm in permutations:
+        sku = generate_sku()
+        org_id = generate_org_id()
+        subscription_id = generate_generic_id(string.ascii_uppercase + string.digits, 8)
+        sla, usage, product_id, billing_provider, measurement_type, metric_id = perm
+        billing_provider_id = generate_generic_id(string.ascii_letters + string.digits, 32)
+        billing_account_id = generate_generic_id(string.digits, 12)
+
+        offering_data.append((sku, "OpenShift Dedicated", "OpenShift Enterprise", 0, 0, 0, 0, "osd", sla, usage,
+                              "Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)", False, None, None))
+        subscription_data.append((sku, org_id, subscription_id, 1, START_DATE, END_DATE, billing_provider_id,
+                                  subscription_id, billing_provider, billing_account_id))
+        subscription_measurements_data.append((subscription_id, START_DATE, metric_id, measurement_type, 5))
+        subscription_product_ids_data.append((product_id, subscription_id, START_DATE))
+
+    insert_query_offering = "INSERT INTO offering VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+    insert_query_subscription = "INSERT INTO subscription VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+    insert_query_measurements = "INSERT INTO subscription_measurements VALUES (%s, %s, %s, %s, %s)"
+    insert_query_product_ids = "INSERT INTO subscription_product_ids VALUES (%s, %s, %s)"
+
+    batch_insert(cursor, insert_query_offering, offering_data, dry_run)
+    batch_insert(cursor, insert_query_subscription, subscription_data, dry_run)
+    batch_insert(cursor, insert_query_measurements, subscription_measurements_data, dry_run)
+    batch_insert(cursor, insert_query_product_ids, subscription_product_ids_data, dry_run)
+
+    if not dry_run:
+        print("Finished inserting offering, subscription, subscription_measurement, and subscription_product_ids data.")
+
+
+def delete_all_records(cursor, dry_run=False):
+    delete_queries = [
+        "DELETE FROM subscription_product_ids;",
+        "DELETE FROM subscription_measurements;",
+        "DELETE FROM subscription;",
+        "DELETE FROM offering;"
+    ]
+
+    for query in delete_queries:
+        if dry_run:
+            print(query)
+        else:
+            cursor.execute(query)
+
+    if not dry_run:
+        print("All records have been deleted from the specified tables.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Run the script in dry run mode to print SQL statements without executing')
+    parser.add_argument('--force-delete-all', action='store_true',
+                        help='Delete all existing data before inserting new data')
+    args = parser.parse_args()
+
+    main(args.dry_run, args.force_delete_all)
+```
+
+
+Features
+--------
+
+-   Generates random data for offerings, subscriptions, subscription measurements, and subscription product IDs.
+-   Supports dry-run mode for previewing the SQL insert statements without executing them.
+-   Allows for the deletion of all existing records in the specified tables before inserting new data.
+
+Requirements
+------------
+
+-   Python 3.x
+-   psycopg2 library
+-   Access to a PostgreSQL database with the required schema
+
+Installation
+------------
+
+1.  Ensure Python 3.x is installed on your system.
+2.  Install `psycopg2` using pip:
+
+    `pip install psycopg2-binary`
+
+3.  Clone this repository or download the script directly to your working directory.
+
+Usage
+-----
+
+The script can be run from the command line with various options to control its behavior.
+
+### Basic Command
+
+`python generate_subscription_data.py`
+
+This command runs the script in its default mode, inserting generated data into the database.
+
+### Dry-Run Mode
+
+To preview the SQL insert statements without making any changes to the database, use the `--dry-run` option:
+
+`python generate_subscription_data.py --dry-run`
+
+### Delete All Existing Data
+
+To delete all existing data from the relevant tables before inserting new data, use the `--force-delete-all` option:
+
+`python generate_subscription_data.py --force-delete-all`
+
+Warning: This will permanently remove all existing records in the specified tables.
+
+### Combining Options
+
+You can combine options as needed. For example, to preview the SQL statements for inserting data after deleting all existing records, run:
+
+`python generate_subscription_data.py --dry-run --force-delete-all`

--- a/bin/build-images.sh
+++ b/bin/build-images.sh
@@ -55,6 +55,7 @@ fi
 # Exit script if a podman command fails
 trap build_failed ERR
 
+./gradlew clean
 for p in "${projects[@]}"; do
   case "$p" in
     "rhsm")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - ./pg_hba.conf:/pg_hba.conf:z
     ports:
       - "127.0.0.1:5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 10s
+      retries: 5
+      timeout: 5s
   kafka:
     image: quay.io/strimzi/kafka:latest-kafka-3.1.0
     command: sh /init_kafka.sh
@@ -65,3 +70,51 @@ services:
     depends_on:
       - kafka
       - db
+  export:
+    container_name: export-server
+    image: quay.io/cloudservices/export-service:276d09f
+    environment:
+      - PGSQL_PORT=5432
+      - PGSQL_HOSTNAME=db
+      - DEBUG=true
+      - OPEN_API_FILE_PATH=/var/tmp/openapi.json
+      - OPEN_API_PRIVATE_PATH=/var/tmp/private.json
+      - PSKS=testing-a-psk
+      - KAFKA_BROKERS=kafka:29092
+      - AWS_ACCESS_KEY=minio
+      - AWS_SECRET_ACCESS_KEY=minioadmin
+      - PUBLIC_PORT=8000
+      - METRICS_PORT=9090
+      - MINIO_PORT=9099
+      - PRIVATE_PORT=10010
+    ports:
+      - 8002:8000
+      - 10000:10010
+    command: /bin/bash -c "export-service migrate_db upgrade && export-service api_server"
+    depends_on:
+      - db
+      - kafka
+
+  s3:
+    image: minio/minio
+    ports:
+      - 9099:9099
+      - 9990:9990
+    volumes:
+      - ./tmp/minio:/data:Z
+    environment:
+      - MINIO_ROOT_USER=${AWS_ACCESS_KEY-minio}
+      - MINIO_ROOT_PASSWORD=${AWS_SECRET_ACCESS_KEY-minioadmin}
+    command: server --address 0.0.0.0:9099 --console-address 0.0.0.0:9990 /data
+
+  s3-createbucket:
+    image: minio/mc
+    depends_on:
+      - s3
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add myminio http://s3:9099 ${AWS_ACCESS_KEY-minio} ${AWS_SECRET_ACCESS_KEY-minioadmin} || exit 1;
+      /usr/bin/mc mb --ignore-existing myminio/exports-bucket;
+      /usr/bin/mc policy set public myminio/exports-bucket;
+      "

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -90,6 +90,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
   UtilConfiguration.class,
 })
 public class ApplicationConfiguration implements WebMvcConfigurer {
+
+  public static final String SUBSCRIPTION_EXPORT_QUALIFIER = "subscriptionExport";
+
   @Bean
   ApplicationProperties applicationProperties() {
     return new ApplicationProperties();
@@ -124,7 +127,7 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   }
 
   @Bean
-  @Qualifier("subscriptionExport")
+  @Qualifier(SUBSCRIPTION_EXPORT_QUALIFIER)
   @ConfigurationProperties(prefix = "rhsm-subscriptions.subscription-export.tasks")
   TaskQueueProperties subscriptionExportProperties() {
     return new TaskQueueProperties();

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -91,8 +91,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 })
 public class ApplicationConfiguration implements WebMvcConfigurer {
 
-  public static final String SUBSCRIPTION_EXPORT_QUALIFIER = "subscriptionExport";
-
   @Bean
   ApplicationProperties applicationProperties() {
     return new ApplicationProperties();
@@ -123,13 +121,6 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   @Qualifier("offeringSyncTasks")
   @ConfigurationProperties(prefix = "rhsm-subscriptions.product.tasks")
   TaskQueueProperties offeringSyncQueueProperties() {
-    return new TaskQueueProperties();
-  }
-
-  @Bean
-  @Qualifier(SUBSCRIPTION_EXPORT_QUALIFIER)
-  @ConfigurationProperties(prefix = "rhsm-subscriptions.subscription-export.tasks")
-  TaskQueueProperties subscriptionExportProperties() {
     return new TaskQueueProperties();
   }
 

--- a/src/main/java/org/candlepin/subscriptions/subscription/ExportSubscriptionListener.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/ExportSubscriptionListener.java
@@ -28,11 +28,23 @@ import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
 import com.redhat.swatch.clients.export.api.client.ApiException;
 import com.redhat.swatch.clients.export.api.model.DownloadExportErrorRequest;
 import com.redhat.swatch.clients.export.api.resources.ExportApi;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.core.Response.Status;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.HypervisorReportCategory;
+import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.DbReportCriteria;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Subscription;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.ExportServiceException;
+import org.candlepin.subscriptions.json.SubscriptionSummary;
+import org.candlepin.subscriptions.json.SubscriptionsExport;
 import org.candlepin.subscriptions.rbac.RbacApiException;
 import org.candlepin.subscriptions.rbac.RbacService;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
@@ -46,9 +58,11 @@ import org.springframework.stereotype.Service;
 /** Listener for Export messages from Kafka */
 @Service
 @Slf4j
+@Transactional
 @Profile("capacity-ingress")
 public class ExportSubscriptionListener extends SeekableKafkaConsumer {
   private final ConsoleCloudEventParser parser;
+  private final SubscriptionRepository subscriptionRepository;
 
   private static final String ADMIN_ROLE = ":*:*";
   private static final String REPORT_READER = ":reports:read";
@@ -58,6 +72,7 @@ public class ExportSubscriptionListener extends SeekableKafkaConsumer {
 
   protected ExportSubscriptionListener(
       @Qualifier("subscriptionExport") TaskQueueProperties taskQueueProperties,
+      SubscriptionRepository subscriptionRepository,
       KafkaConsumerRegistry kafkaConsumerRegistry,
       ConsoleCloudEventParser parser,
       ExportApi exportApi,
@@ -66,6 +81,7 @@ public class ExportSubscriptionListener extends SeekableKafkaConsumer {
     this.parser = parser;
     this.exportApi = exportApi;
     this.rbacService = rbacService;
+    this.subscriptionRepository = subscriptionRepository;
   }
 
   @KafkaListener(
@@ -112,27 +128,39 @@ public class ExportSubscriptionListener extends SeekableKafkaConsumer {
   private void uploadData(ConsoleCloudEvent cloudEvent, ResourceRequestClass exportData) {
     checkRbac(exportData.getApplication(), exportData.getXRhIdentity());
     // Here we need to determine format (csv or json)
+    var dataRequest = fetchData(cloudEvent.getOrgId(), exportData);
     if (Objects.equals(exportData.getFormat(), Format.CSV)) {
-      fetchData(cloudEvent);
-      uploadCsv(exportData);
+      uploadCsv(exportData, dataRequest);
     } else if (Objects.equals(exportData.getFormat(), Format.JSON)) {
-      fetchData(cloudEvent);
-      uploadJson(exportData);
+      uploadJson(exportData, dataRequest);
     } else {
       throw new ExportServiceException(Status.FORBIDDEN.getStatusCode(), "Format isn't supported");
     }
   }
 
-  private void uploadCsv(ResourceRequestClass data) {
-    log.debug("Uploading CSV for request {}", data.getExportRequestUUID());
+  private void uploadCsv(ResourceRequestClass exportData, SubscriptionsExport data) {
+    log.debug(
+        "Uploading CSV for request {} with orgId: {}",
+        exportData.getExportRequestUUID(),
+        data.getSubscriptions().get(0).getOrgId());
     throw new ExportServiceException(
         Status.NOT_IMPLEMENTED.getStatusCode(), "Export upload csv isn't implemented ");
   }
 
-  private void uploadJson(ResourceRequestClass data) {
-    log.debug("Uploading Json for request {}", data.getExportRequestUUID());
-    throw new ExportServiceException(
-        Status.NOT_IMPLEMENTED.getStatusCode(), "Export Upload json isn't implemented");
+  private void uploadJson(ResourceRequestClass exportData, SubscriptionsExport data) {
+    log.debug(
+        "Uploading Json for request {} for orgId: {}",
+        exportData.getExportRequestUUID(),
+        data.getSubscriptions().get(0).getOrgId());
+    try {
+      exportApi.downloadExportUpload(
+          exportData.getUUID(),
+          exportData.getApplication(),
+          exportData.getExportRequestUUID(),
+          data);
+    } catch (ApiException e) {
+      throw new ExportServiceException(Status.BAD_REQUEST.getStatusCode(), e.getMessage());
+    }
   }
 
   private void checkRbac(String appName, String identity) {
@@ -153,11 +181,81 @@ public class ExportSubscriptionListener extends SeekableKafkaConsumer {
     throw new ExportServiceException(Status.FORBIDDEN.getStatusCode(), "Insufficient permission");
   }
 
-  private void fetchData(ConsoleCloudEvent cloudEvent) {
+  private SubscriptionsExport fetchData(String orgId, ResourceRequestClass exportData) {
     // Check subscription table for data for the event
-    log.debug("Fetching subscriptionOrg for {}", cloudEvent.getOrgId());
-    throw new ExportServiceException(
-        Status.NOT_IMPLEMENTED.getStatusCode(),
-        "Fetching data from subscription table isn't implemented");
+    log.debug("Fetching subscriptions for {}", orgId);
+
+    var reportCriteria = extractExportFilter(exportData, orgId);
+
+    var searchSpec = SubscriptionRepository.buildSearchSpecification(reportCriteria);
+
+    var subscriptions = subscriptionRepository.streamAll(searchSpec);
+
+    // pass streams for json and csv upload method
+    if (Objects.nonNull(subscriptions)) {
+      return transformSubscriptionForExport(subscriptions);
+    } else {
+      throw new ExportServiceException(
+          Status.NOT_FOUND.getStatusCode(), "Unable to find subscriptions for orgId: " + orgId);
+    }
+  }
+
+  private DbReportCriteria extractExportFilter(ResourceRequestClass data, String orgId) {
+    var filters = data.getFilters().entrySet();
+    var report = DbReportCriteria.builder().orgId(orgId);
+    for (var entry : filters) {
+      switch (entry.getKey().toLowerCase()) {
+        case "productid" -> report.productId(entry.getValue().toString());
+        case "usage" -> report.usage(Usage.fromString(entry.getValue().toString()));
+        case "category" ->
+            report.hypervisorReportCategory(
+                HypervisorReportCategory.valueOf(entry.getValue().toString()));
+        case "sla" -> report.serviceLevel(ServiceLevel.fromString(entry.getValue().toString()));
+        case "uom" -> report.metricId(entry.getValue().toString());
+        case "billingprovider" ->
+            report.billingProvider(BillingProvider.fromString(entry.getValue().toString()));
+        case "billingaccountid" -> report.billingAccountId(entry.getValue().toString());
+        default -> log.warn("Filter {} isn't supported currently", entry.getKey());
+      }
+    }
+    return report.build();
+  }
+
+  private SubscriptionsExport transformSubscriptionForExport(Stream<Subscription> subscriptions) {
+
+    var subscriptionExport = new SubscriptionsExport();
+
+    var subscriptionsStream =
+        subscriptions
+            .map(
+                subscription -> {
+                  var subscriptionJson = new org.candlepin.subscriptions.json.Subscription();
+                  var summaries = new ArrayList<SubscriptionSummary>();
+                  subscriptionJson.setOrgId(subscription.getOrgId());
+                  subscriptionJson.setSku(subscription.getOffering().getSku());
+                  subscriptionJson.setUsage(subscription.getOffering().getUsage().getValue());
+                  subscriptionJson.setProductName(subscription.getOffering().getProductName());
+                  subscriptionJson.setServiceLevel(
+                      subscription.getOffering().getServiceLevel().getValue());
+
+                  for (var entry : subscription.getSubscriptionMeasurements().entrySet()) {
+                    var summary = new SubscriptionSummary();
+                    summary.setMeasurementType(entry.getKey().getMeasurementType());
+                    summary.setCapacity(entry.getValue());
+                    summary.setMetricId(entry.getKey().getMetricId());
+                    summary.setSubscriptionNumber(subscription.getSubscriptionNumber());
+                    summary.setQuantity(subscription.getQuantity());
+                    summary.setBeginning(subscription.getStartDate());
+                    summary.setEnding(subscription.getEndDate());
+                    summaries.add(summary);
+                  }
+                  subscriptionJson.setSubscriptionSummaries(summaries);
+                  return subscriptionJson;
+                })
+            .toList();
+
+    subscriptionExport.setSubscriptions(subscriptionsStream);
+
+    return subscriptionExport;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
@@ -44,8 +44,7 @@ import org.springframework.retry.support.RetryTemplateBuilder;
 @Import({
   ResteasyConfiguration.class,
   RhsmSubscriptionsDataSourceConfiguration.class,
-  CapacityReconciliationConfiguration.class,
-  ExportClientConfiguration.class
+  CapacityReconciliationConfiguration.class
 })
 @EnableJms
 @ComponentScan(

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/ExportClientConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/ExportClientConfiguration.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.subscription;
+package org.candlepin.subscriptions.subscription.export;
 
 import com.redhat.swatch.clients.export.api.client.ExportApiClientFactory;
 import org.candlepin.subscriptions.http.HttpClientProperties;

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription.export;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+@Configuration
+@Import({ExportClientConfiguration.class})
+public class ExportSubscriptionConfiguration {
+
+  public static final String SUBSCRIPTION_EXPORT_QUALIFIER = "subscriptionExport";
+
+  @Bean
+  @Qualifier(SUBSCRIPTION_EXPORT_QUALIFIER)
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.subscription-export")
+  TaskQueueProperties subscriptionExportProperties() {
+    return new TaskQueueProperties();
+  }
+
+  @Bean("exportConsumerFactory")
+  ConsumerFactory<String, String> exportConsumerFactory(KafkaProperties kafkaProperties) {
+    return new DefaultKafkaConsumerFactory<>(
+        kafkaProperties.buildConsumerProperties(null),
+        new StringDeserializer(),
+        new StringDeserializer());
+  }
+
+  @Bean
+  ConcurrentKafkaListenerContainerFactory<String, String> exportListenerContainerFactory(
+      @Qualifier("exportConsumerFactory") ConsumerFactory<String, String> consumerFactory,
+      KafkaProperties kafkaProperties,
+      KafkaConsumerRegistry registry) {
+
+    var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
+    factory.setConsumerFactory(consumerFactory);
+    // Concurrency should be set to the number of partitions for the target topic.
+    factory.setConcurrency(kafkaProperties.getListener().getConcurrency());
+    if (kafkaProperties.getListener().getIdleEventInterval() != null) {
+      factory
+          .getContainerProperties()
+          .setIdleEventInterval(kafkaProperties.getListener().getIdleEventInterval().toMillis());
+    }
+    // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
+    factory.getContainerProperties().setConsumerRebalanceListener(registry);
+    return factory;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionListener.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionListener.java
@@ -18,9 +18,9 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.subscription;
+package org.candlepin.subscriptions.subscription.export;
 
-import static org.candlepin.subscriptions.ApplicationConfiguration.SUBSCRIPTION_EXPORT_QUALIFIER;
+import static org.candlepin.subscriptions.subscription.export.ExportSubscriptionConfiguration.SUBSCRIPTION_EXPORT_QUALIFIER;
 
 import com.redhat.cloud.event.apps.exportservice.v1.Format;
 import com.redhat.cloud.event.apps.exportservice.v1.ResourceRequest;

--- a/src/main/resources/application-capacity-ingress.yaml
+++ b/src/main/resources/application-capacity-ingress.yaml
@@ -7,7 +7,7 @@ SUBSCRIPTION_EXPORT_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform
 
 rhsm-subscriptions:
   export-service:
-    url: ${clowder.privateEndpoints.export-service-service.url:http://localhost:10000}
+    url: ${clowder.privateEndpoints.export-service-service.url:http://localhost:8081}
     psk: ${SWATCH_EXPORT_PSK:placeholder}
   subscription-sync-enabled: ${SUBSCRIPTION_SYNC_ENABLED:true}
   product:

--- a/src/main/resources/application-capacity-ingress.yaml
+++ b/src/main/resources/application-capacity-ingress.yaml
@@ -6,9 +6,10 @@ SUBSCRIPTION_EXPORT_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform
 
 
 rhsm-subscriptions:
+  #These export-service settings get used for subscription exports
   export-service:
-    url: ${clowder.privateEndpoints.export-service-service.url:http://localhost:8081}
-    psk: ${SWATCH_EXPORT_PSK:placeholder}
+    url: ${clowder.privateEndpoints.export-service-service.url:http://localhost:10000}
+    psk: ${SWATCH_EXPORT_PSK:testing-a-psk}
   subscription-sync-enabled: ${SUBSCRIPTION_SYNC_ENABLED:true}
   product:
     tasks:

--- a/src/main/resources/application-capacity-ingress.yaml
+++ b/src/main/resources/application-capacity-ingress.yaml
@@ -6,6 +6,9 @@ SUBSCRIPTION_EXPORT_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform
 
 
 rhsm-subscriptions:
+  subscription-export:
+    topic: ${SUBSCRIPTION_EXPORT_TOPIC}
+    kafka-group-id: swatch-subscription-export
   #These export-service settings get used for subscription exports
   export-service:
     url: ${clowder.privateEndpoints.export-service-service.url:http://localhost:10000}
@@ -27,7 +30,3 @@ rhsm-subscriptions:
     tasks:
       topic: ${CAPACITY_RECONCILE_TOPIC}
       kafka-group-id: capacity-reconciliation-worker
-  subscription-export:
-    tasks:
-      topic: ${SUBSCRIPTION_EXPORT_TOPIC}
-      kafka-group-id: swatch-subscription-export

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,8 +54,9 @@ rhsm-subscriptions:
     back-off-multiplier: ${USER_BACK_OFF_MULTIPLIER:2}
     max-attempts: ${USER_MAX_ATTEMPTS:1}
   export-service:
-    url: ${clowder.endpoints.export-service.url:http://localhost:10010}
-    psk: ${SWATCH_EXPORT_PSK:placeholder}
+    #These export-service settings get used for instance exports
+    url: ${clowder.endpoints.export-service.url:http://localhost:10000}
+    psk: ${SWATCH_EXPORT_PSK:testing-a-psk}
 management:
   health:
     jms:

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/ExportSubscriptionListenerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/ExportSubscriptionListenerTest.java
@@ -20,63 +20,229 @@
  */
 package org.candlepin.subscriptions.task.queue.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.candlepin.subscriptions.ApplicationConfiguration.SUBSCRIPTION_EXPORT_QUALIFIER;
+import static org.candlepin.subscriptions.subscription.ExportSubscriptionListener.ADMIN_ROLE;
+import static org.candlepin.subscriptions.subscription.ExportSubscriptionListener.SWATCH_APP;
+import static org.mockito.Mockito.when;
 
-import com.redhat.swatch.clients.export.api.client.ApiException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.event.apps.exportservice.v1.Format;
+import com.redhat.cloud.event.apps.exportservice.v1.ResourceRequest;
+import com.redhat.cloud.event.apps.exportservice.v1.ResourceRequestClass;
+import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
+import com.redhat.cloud.event.parser.GenericConsoleCloudEvent;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.candlepin.clock.ApplicationClock;
+import org.candlepin.subscriptions.db.OfferingRepository;
+import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.model.Offering;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Subscription;
+import org.candlepin.subscriptions.db.model.SubscriptionMeasurementKey;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.json.SubscriptionSummary;
+import org.candlepin.subscriptions.json.SubscriptionsExport;
+import org.candlepin.subscriptions.rbac.RbacApiException;
 import org.candlepin.subscriptions.rbac.RbacService;
 import org.candlepin.subscriptions.subscription.ExportSubscriptionListener;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.test.ExtendWithEmbeddedKafka;
 import org.candlepin.subscriptions.test.ExtendWithExportServiceWireMock;
 import org.candlepin.subscriptions.test.ExtendWithSwatchDatabase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @ActiveProfiles(value = {"worker", "kafka-queue", "api", "test-inventory", "capacity-ingress"})
-class ExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
-    implements ExtendWithSwatchDatabase, ExtendWithEmbeddedKafka {
+class ExportSubscriptionListenerTest
+    implements ExtendWithEmbeddedKafka, ExtendWithSwatchDatabase, ExtendWithExportServiceWireMock {
+
+  private static final String ORG_ID = "13259775";
+
+  @Autowired
+  @Qualifier(SUBSCRIPTION_EXPORT_QUALIFIER)
+  TaskQueueProperties taskQueueProperties;
+
+  @Autowired ConsoleCloudEventParser parser;
+  @Autowired ObjectMapper objectMapper;
   @Autowired ExportSubscriptionListener listener;
+  @Autowired KafkaProperties kafkaProperties;
+  @Autowired OfferingRepository offeringRepository;
+  @Autowired SubscriptionRepository subscriptionRepository;
+  @Autowired ApplicationClock clock;
 
   @MockBean RbacService rbacService;
-  static final String EXPORTMSG =
-      """
-            {
-                "$schema": "https://console.redhat.com/api/schemas/events/v1/events.json",
-                "id": "2356aad8-de45-4ba0-80bd-4637763ad115",
-                "source": "urn:redhat:source:console:app:export-service",
-                "specversion": "1.0",
-                "type": "com.redhat.console.export-service.request",
-                "subject": "urn:redhat:subject:export-service:request:2e3d7746-2cf2-441e-84fe-cf28863d22ae",
-                "time": "2023-01-01T00:00:00Z",
-                "redhatorgid": "org123",
-                "redhatconsolebundle": "rhel",
-                "dataschema": "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json",
-                "data": {
-                    "resource_request": {
-                        "uuid": "b24c269d-33d6-410e-8808-c71c9635e84f",
-                        "export_request_uuid": "2e3d7746-2cf2-441e-84fe-cf28863d22ae",
-                        "application": "subscriptions",
-                        "format": "csv",
-                        "resource": "subscriptions",
-                        "x-rh-identity": "base64-encoded-identity",
-                        "filters": {
-                            "filter1": "value1",
-                            "filter2": "value2"
-                        }
-                    }
-                }
-            }
-            """;
 
-  @Test
-  void testExportMsgConsumption() {
-    assertDoesNotThrow(this::givenValidExportMsg);
+  KafkaTemplate<String, String> kafkaTemplate;
+  Offering offering;
+  List<Subscription> subscriptionsToBeExported = new ArrayList<>();
+  GenericConsoleCloudEvent<ResourceRequest> request;
+
+  @Transactional
+  @BeforeEach
+  public void setup() {
+    Map<String, Object> properties = kafkaProperties.buildProducerProperties(null);
+    properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+    var factory = new DefaultKafkaProducerFactory<String, String>(properties);
+    kafkaTemplate = new KafkaTemplate<>(factory);
+
+    offering = new Offering();
+    offering.setSku("MKU001");
+    offering.setUsage(Usage.PRODUCTION);
+    offeringRepository.save(offering);
   }
 
-  private void givenValidExportMsg() throws ApiException {
-    listener.receive(EXPORTMSG);
+  @Test
+  void testRequestWithoutPermissions() {
+    givenExportRequestWithoutPermissions();
+    whenReceiveExportRequest();
+    verifyRequestWasSentToExportServiceWithError(request);
+  }
+
+  @Test
+  void testRequestWithPermissions() {
+    givenExportRequestWithPermissions(Format.JSON);
+    whenReceiveExportRequest();
+    verifyRequestWasSentToExportService();
+  }
+
+  @Test
+  void testRequestShouldBeUploadedWithSubscriptionsAsJson() {
+    givenSubscriptionWithMeasurement();
+    givenExportRequestWithPermissions(Format.JSON);
+    whenReceiveExportRequest();
+    verifyRequestWasSentToExportService();
+  }
+
+  @Test
+  void testRequestShouldBeUploadedWithSubscriptionsAsCsv() {
+    givenSubscriptionWithMeasurement();
+    givenExportRequestWithPermissions(Format.CSV);
+    whenReceiveExportRequest();
+    // Since this is not implemented yet, we send an error:
+    verifyRequestWasSentToExportServiceWithError(request);
+  }
+
+  @Transactional
+  void givenSubscriptionWithMeasurement() {
+    Subscription subscription = new Subscription();
+    subscription.setSubscriptionId(UUID.randomUUID().toString());
+    subscription.setStartDate(clock.now());
+    subscription.setOffering(offering);
+    subscription.setOrgId(ORG_ID);
+    subscription.setSubscriptionMeasurements(
+        Map.of(
+            new SubscriptionMeasurementKey(MetricIdUtils.getCores().toString(), "PHYSICAL"), 5.0));
+    subscriptionRepository.save(subscription);
+    subscriptionsToBeExported.add(subscription);
+  }
+
+  private void givenExportRequestWithoutPermissions() {
+    givenExportRequest(Format.JSON);
+    givenRbacPermissions(List.of());
+  }
+
+  private void givenExportRequestWithPermissions(Format format) {
+    givenExportRequest(format);
+    givenRbacPermissions(List.of(SWATCH_APP + ADMIN_ROLE));
+  }
+
+  private void givenExportRequest(Format format) {
+    request = new GenericConsoleCloudEvent<>();
+    request.setId(UUID.randomUUID());
+    request.setSource("urn:redhat:source:console:app:export-service");
+    request.setSpecVersion("1.0");
+    request.setType("com.redhat.console.export-service.request");
+    request.setDataSchema(
+        "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json");
+    request.setTime(LocalDateTime.now());
+    request.setOrgId(ORG_ID);
+
+    var resourceRequest = new ResourceRequest();
+    resourceRequest.setResourceRequest(new ResourceRequestClass());
+    resourceRequest.getResourceRequest().setExportRequestUUID(UUID.randomUUID());
+    resourceRequest.getResourceRequest().setUUID(UUID.randomUUID());
+    resourceRequest.getResourceRequest().setApplication("subscriptions");
+    resourceRequest.getResourceRequest().setFormat(format);
+    resourceRequest.getResourceRequest().setResource("subscriptions");
+    resourceRequest.getResourceRequest().setXRhIdentity("MTMyNTk3NzU=");
+    resourceRequest.getResourceRequest().setFilters(new HashMap<>());
+
+    request.setData(resourceRequest);
+  }
+
+  private void givenRbacPermissions(List<String> SWATCH_APP) {
+    try {
+      when(rbacService.getPermissions(
+              request.getData().getResourceRequest().getApplication(),
+              request.getData().getResourceRequest().getXRhIdentity()))
+          .thenReturn(SWATCH_APP);
+    } catch (RbacApiException e) {
+      Assertions.fail("Failed to call the get permissions method", e);
+    }
+  }
+
+  private void whenReceiveExportRequest() {
+    kafkaTemplate.send(taskQueueProperties.getTopic(), parser.toJson(request));
+  }
+
+  private void verifyRequestWasSentToExportService() {
+    var expected = new SubscriptionsExport();
+    expected.setSubscriptions(new ArrayList<>());
+    for (Subscription subscription : subscriptionsToBeExported) {
+      var item = new org.candlepin.subscriptions.json.Subscription();
+      item.setOrgId(subscription.getOrgId());
+      item.setSubscriptionSummaries(new ArrayList<>());
+
+      // map offering
+      var offering = subscription.getOffering();
+      item.setSku(offering.getSku());
+      Optional.ofNullable(offering.getUsage()).map(Usage::getValue).ifPresent(item::setUsage);
+      Optional.ofNullable(offering.getServiceLevel())
+          .map(ServiceLevel::getValue)
+          .ifPresent(item::setServiceLevel);
+      item.setProductName(offering.getProductName());
+
+      // map measurements
+      for (var entry : subscription.getSubscriptionMeasurements().entrySet()) {
+        var summary = new SubscriptionSummary();
+        summary.setMeasurementType(entry.getKey().getMeasurementType());
+        summary.setCapacity(entry.getValue());
+        summary.setMetricId(entry.getKey().getMetricId());
+        summary.setSubscriptionNumber(subscription.getSubscriptionNumber());
+        summary.setQuantity(subscription.getQuantity());
+        item.getSubscriptionSummaries().add(summary);
+      }
+      expected.getSubscriptions().add(item);
+    }
+
+    try {
+      verifyRequestWasSentToExportServiceWithUploadData(
+          request, objectMapper.writeValueAsString(expected));
+    } catch (JsonProcessingException e) {
+      Assertions.fail("Failed to serialize the export data", e);
+    }
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/ExportSubscriptionListenerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/ExportSubscriptionListenerTest.java
@@ -41,7 +41,6 @@ class ExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
   @Autowired ExportSubscriptionListener listener;
 
   @MockBean RbacService rbacService;
-
   static final String EXPORTMSG =
       """
             {

--- a/src/test/java/org/candlepin/subscriptions/task/queue/kafka/ExportSubscriptionListenerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/task/queue/kafka/ExportSubscriptionListenerTest.java
@@ -20,9 +20,9 @@
  */
 package org.candlepin.subscriptions.task.queue.kafka;
 
-import static org.candlepin.subscriptions.ApplicationConfiguration.SUBSCRIPTION_EXPORT_QUALIFIER;
-import static org.candlepin.subscriptions.subscription.ExportSubscriptionListener.ADMIN_ROLE;
-import static org.candlepin.subscriptions.subscription.ExportSubscriptionListener.SWATCH_APP;
+import static org.candlepin.subscriptions.subscription.export.ExportSubscriptionConfiguration.SUBSCRIPTION_EXPORT_QUALIFIER;
+import static org.candlepin.subscriptions.subscription.export.ExportSubscriptionListener.ADMIN_ROLE;
+import static org.candlepin.subscriptions.subscription.export.ExportSubscriptionListener.SWATCH_APP;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -54,7 +54,7 @@ import org.candlepin.subscriptions.json.SubscriptionSummary;
 import org.candlepin.subscriptions.json.SubscriptionsExport;
 import org.candlepin.subscriptions.rbac.RbacApiException;
 import org.candlepin.subscriptions.rbac.RbacService;
-import org.candlepin.subscriptions.subscription.ExportSubscriptionListener;
+import org.candlepin.subscriptions.subscription.export.ExportSubscriptionListener;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.test.ExtendWithEmbeddedKafka;
 import org.candlepin.subscriptions.test.ExtendWithExportServiceWireMock;

--- a/swatch-core/schemas/subscription_summary.yaml
+++ b/swatch-core/schemas/subscription_summary.yaml
@@ -1,0 +1,22 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: SubscriptionSummary
+properties:
+  export_id:
+    type: string
+    format: uuid
+  subscription_number:
+    type: string
+  metric_id:
+    type: string
+  quantity:
+    type: long
+  capacity:
+    type: number
+  measurement_type:
+    type: string
+  beginning:
+    type: string
+    format: date-time
+  ending:
+    type: string
+    format: date-time

--- a/swatch-core/schemas/subscriptions_export.yaml
+++ b/swatch-core/schemas/subscriptions_export.yaml
@@ -1,0 +1,23 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: SubscriptionExport
+properties:
+  subscriptions:
+    type: array
+    items:
+      type: object
+      properties:
+        sku:
+          type: string
+        product_name:
+          type: string
+        service_level:
+          type: string
+        usage:
+          type: string
+        org_id:
+          type: string
+        subscription_summaries:
+          description: List of subscription data per organization
+          type: array
+          items:
+            $ref: subscription_summary.yaml

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/StreamSpecificationExecutor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/StreamSpecificationExecutor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.stream.Stream;
+import org.springframework.data.jpa.domain.Specification;
+
+public interface StreamSpecificationExecutor<T> {
+  Stream<T> streamAll(Class<T> tClass, Specification<T> spec);
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/StreamSpecificationExecutorImpl.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/StreamSpecificationExecutorImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.stream.Stream;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+/**
+ * This implementation is to support the interface to allow fetching data using Java Stream API,
+ * this is needed as JPA does not support streamAll() by default <a
+ * href="https://stackoverflow.com/questions/41261051/how-to-use-declare-stream-as-return-type-when-dealing-with-jpa-specification-and/54375652#54375652">...</a>
+ *
+ * @param <T>
+ */
+@Component
+public class StreamSpecificationExecutorImpl<T> implements StreamSpecificationExecutor<T> {
+  @PersistenceContext(unitName = "rhsmSubscriptionsEntityManagerFactory")
+  private EntityManager entityManager;
+
+  @Override
+  public Stream<T> streamAll(Class<T> tClass, Specification<T> spec) {
+    var criteriaBuilder = entityManager.getCriteriaBuilder();
+    var criteriaQuery = criteriaBuilder.createQuery(tClass);
+    var root = criteriaQuery.from(tClass);
+
+    criteriaQuery.where(spec.toPredicate(root, criteriaQuery, criteriaBuilder));
+    return entityManager.createQuery(criteriaQuery).getResultStream();
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -55,7 +55,8 @@ import org.springframework.util.ObjectUtils;
 /** Repository for Subscription Entities */
 public interface SubscriptionRepository
     extends JpaRepository<Subscription, Subscription.SubscriptionCompoundId>,
-        JpaSpecificationExecutor<Subscription> {
+        JpaSpecificationExecutor<Subscription>,
+        StreamSpecificationExecutor<Subscription> {
 
   // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(
@@ -165,6 +166,11 @@ public interface SubscriptionRepository
   @Override
   @EntityGraph(attributePaths = {"subscriptionMeasurements"})
   List<Subscription> findAll(Specification<Subscription> spec, Sort sort);
+
+  @EntityGraph(attributePaths = {"subscriptionMeasurements"})
+  default Stream<Subscription> streamAll(Specification<Subscription> spec) {
+    return streamAll(Subscription.class, spec);
+  }
 
   private static Specification<Subscription> hasUnlimitedUsage() {
     return (root, query, builder) -> {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2021

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This PR is to allow SWATCH to fetch data from an export request and upload to export service based on the filters, such as `productId` or `UOM` determined on the event. WIth the payload you can add unsupported filters and it will be logged as `unsupported filter` you can toggle for data in SWATCH using the filters in the export payload. here are the current filters that are supported (must pass filters in camel-case):

-  product_id
- sla
- usage
- uom <- metricId
- billing_provider
- billing_account_id
- category

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
--> 
Make sure the DB & Kafka pods are running podman-compose up
1.Use the Big data Tools of Intellij as producer to test the consumer topic platform.export.requests. Payload is below to test for local testing.

For local testing will use data for a happy path to seen to upload:
## Setup
Add Subscription data in your DB:
```sql
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered) VALUES ('MW02393', 'OpenShift Dedicated', 'OpenShift Enterprise', 0, 0, 0, 0, 'osd', 'Premium', 'Production', 'Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)', false, null, null);
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02393', '13259775', '13579593', 1, '2023-09-25 08:25:22.797423 +00:00', '2024-09-25 08:25:22.000000 +00:00', 'bcwuzc8ww10vvxfair55mliy8;4G5dKpAKahm', '13579750', 'aws', '505066801768');
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('13579593', '2023-09-25 08:25:22.797423 +00:00', 'Cores', 'PHYSICAL', 5);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('13579593', '2023-09-25 08:25:22.797423 +00:00', 'Instance-hours', 'PHYSICAL', 1);
```

```
{
    "$schema": "https://console.redhat.com/api/schemas/events/v1/events.json",
    "id": "2356aad8-de45-4ba0-80bd-4637763ad115",
    "source": "urn:redhat:source:console:app:export-service",
    "specversion": "1.0",
    "type": "com.redhat.console.export-service.request",
    "subject": "urn:redhat:subject:export-service:request:2e3d7746-2cf2-441e-84fe-cf28863d22ae",
    "time": "2023-01-01T00:00:00Z",
    "redhatorgid": "13259775",
    "redhatconsolebundle": "rhel",
    "dataschema": "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json",
    "data": {
        "resource_request": {
            "uuid": "b24c269d-33d6-410e-8808-c71c9635e84f",
            "export_request_uuid": "2e3d7746-2cf2-441e-84fe-cf28863d22ae",
            "application": "subscriptions",
            "format": "json",
            "resource": "subscriptions",
            "x-rh-identity": "MTMyNTk3NzU=",
            "filters": {
                "filter1": "RHEL",
                "usage": "Production"
            }
        }
    }
}
```
In local testing this should fail at trying to send to export service: you can `oc port-forward Service/export-service-service 8081:9000` to test upload on local, observe in logs of your EE of Export service that it uploads to the export-service and return 404

## (This is optional) this is to test similarly to QE
Ephemeral environment :
1. oc login: https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/
2. deploy bonfire
```
TEMPLATE_REF=pr hash
IMAGE_TAG=<pr tag>
QUAY_REPO=cloudservices

bonfire deploy rhsm \
 --timeout=1800 \
 --source=appsre \
 --ref-env insights-production \
 --set-template-ref rhsm=$TEMPLATE_REF \
 --set-image-tag quay.io/$QUAY_REPO/swatch-system-conduit=$IMAGE_TAG \
 --optional-deps-method none \
 --frontends false \
 --no-remove-resources rhsm \
 --no-remove-resources swatch-api \
 --no-remove-resources swatch-contracts \
 --no-remove-resources swatch-producer-aws \
 --no-remove-resources swatch-producer-red-hat-marketplace \
 --no-remove-resources swatch-metrics \
 --no-remove-resources swatch-subscription-sync \
 --no-remove-resources swatch-system-conduit \
 --no-remove-resources swatch-tally \
 --no-remove-resources swatch-producer-azure \
 -i quay.io/$QUAY_REPO/rhsm-subscriptions=$IMAGE_TAG \
 -i quay.io/$QUAY_REPO/swatch-contracts=$IMAGE_TAG \
 -i quay.io/$QUAY_REPO/swatch-metrics=$IMAGE_TAG \
 -i quay.io/$QUAY_REPO/swatch-producer-aws=$IMAGE_TAG \
 -i quay.io/$QUAY_REPO/swatch-producer-azure=$IMAGE_TAG \
 -i quay.io/$QUAY_REPO/swatch-system-conduit=$IMAGE_TAG \
 --set-template-ref rhsm=$TEMPLATE_REF \
 --set-template-ref swatch-api=$TEMPLATE_REF \
 --set-template-ref swatch-contracts=$TEMPLATE_REF \
 --set-template-ref swatch-producer-aws=$TEMPLATE_REF \
 --set-template-ref swatch-producer-red-hat-marketplace=$TEMPLATE_REF \
 --set-template-ref swatch-metrics=$TEMPLATE_REF \
 --set-template-ref swatch-subscription-sync=$TEMPLATE_REF \
 --set-template-ref swatch-system-conduit=$TEMPLATE_REF \
 --set-template-ref swatch-tally=$TEMPLATE_REF \
 --set-template-ref swatch-producer-azure=$TEMPLATE_REF
```
3. `oc project <namespace>`
4. Create iqe pod in namespace -> `bonfire deploy-iqe-cji rhsm --debug-pod -n <ephemeral-namespace>`
5. Access terminal in Iqe pod and enter `iqe shell` after that put in first `import json` and paste the command below
```
app.mq.producer.produce_msg(topic='platform.export.requests', value=json.loads('''{
    "$schema": "https://console.redhat.com/api/schemas/events/v1/events.json",
    "id": "2356aad8-de45-4ba0-80bd-4637763ad115",
    "source": "urn:redhat:source:console:app:export-service",
    "specversion": "1.0",
    "type": "com.redhat.console.export-service.request",
    "subject": "urn:redhat:subject:export-service:request:2e3d7746-2cf2-441e-84fe-cf28863d22ae",
    "time": "2023-01-01T00:00:00Z",
    "redhatorgid": "13259775",
    "redhatconsolebundle": "rhel",
    "dataschema": "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json",
    "data": {
        "resource_request": {
            "uuid": "b24c269d-33d6-410e-8808-c71c9635e84f",
            "export_request_uuid": "2e3d7746-2cf2-441e-84fe-cf28863d22ae",
            "application": "subscriptions",
            "format": "json",
            "resource": "subscriptions",
            "x-rh-identity": "MTMyNTk3NzU=",
            "filters": {
                "filter1": "RHEL",
                "usage": "Production"
            }
        }
    }
}''') , headers=[('content-type','application/cloudevents+json; charset=UTF-8')])
```
6. This might fail as I don't know what data exist in stage or EE, so [add some data](https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=ENT&title=Import+Data+from+the+Ephemeral+Environments+to+Localhost)  you can make the above `sql` into a sql file and `pg_dump` in the EE of the `Swatch-tally-db` or reference already existing subscription in stage. Change request data accordingly and `base64 encode` the orgId for `x-identity` to pass the RBAC check in cloud
 
### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Attempted to send request with filters (ProductId, Usage, Category, BillingProvider
BillingAccountId ) and observe the data being sent to export service
2. If unsupported filter is sent SWATCH will log the filter and query the databases for all subscription by the export request orgId.
3. That filters work by attempting to use a different filters values and observe different data being sent to export 