### PR TITLE
SWATCH-2031: Get the events.display_name from labels in prometheus ingestion

### DIFF
--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -211,6 +211,7 @@ public class PrometheusMeteringController {
     String clusterId = labels.get(getPrometheusInstanceKeyFromMetric(productTag, tagMetric));
     String sla = labels.get("support");
     String usage = labels.get("usage");
+    String displayName = Optional.ofNullable(labels.get("display_name")).orElse(clusterId);
 
     // These were added as an edge case with RHODS as it doesn't have product as a
     // label in prometheus
@@ -272,7 +273,8 @@ public class PrometheusMeteringController {
               value,
               productTag,
               meteringBatchId,
-              productIds);
+              productIds,
+              displayName);
       // Send if and only if it has not been sent yet.
       // Related to https://github.com/RedHatInsights/rhsm-subscriptions/pull/374.
       if (eventsSent.add(EventKey.fromEvent(event))) {
@@ -314,7 +316,8 @@ public class PrometheusMeteringController {
       BigDecimal value,
       String productTag,
       UUID meteringBatchId,
-      List<String> productIds) {
+      List<String> productIds,
+      String displayName) {
     Event event = new Event();
     MeteringEventFactory.updateMetricEvent(
         event,
@@ -333,7 +336,8 @@ public class PrometheusMeteringController {
         value.doubleValue(),
         productTag,
         meteringBatchId,
-        productIds);
+        productIds,
+        displayName);
     return event;
   }
 

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/util/MeteringEventFactory.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/util/MeteringEventFactory.java
@@ -54,8 +54,9 @@ public final class MeteringEventFactory {
    * @param role the role of the cluster.
    * @param measuredTime the time the measurement was taken.
    * @param expired the time the measurement had ended.
-   * @param measuredValue the value that was measured./
-   * @param productTag
+   * @param measuredValue the value that was measured.
+   * @param productTag the product tag.
+   * @param displayName the display name.
    * @return a populated Event instance.
    */
   @SuppressWarnings("java:S107")
@@ -75,7 +76,8 @@ public final class MeteringEventFactory {
       Double measuredValue,
       String productTag,
       UUID meteringBatchId,
-      List<String> productIds) {
+      List<String> productIds,
+      String displayName) {
     Event event = new Event();
     updateMetricEvent(
         event,
@@ -94,7 +96,8 @@ public final class MeteringEventFactory {
         measuredValue,
         productTag,
         meteringBatchId,
-        productIds);
+        productIds,
+        displayName);
     return event;
   }
 
@@ -145,12 +148,13 @@ public final class MeteringEventFactory {
       Double measuredValue,
       String productTag,
       UUID meteringBatchId,
-      List<String> productIds) {
+      List<String> productIds,
+      String displayName) {
     toUpdate
         .withServiceType(serviceType)
         .withTimestamp(measuredTime)
         .withExpiration(Optional.of(expired))
-        .withDisplayName(Optional.of(instanceId))
+        .withDisplayName(Optional.of(displayName))
         .withSla(getSla(serviceLevel, orgId, instanceId))
         .withUsage(getUsage(usage, orgId, instanceId))
         .withBillingProvider(getBillingProvider(billingProvider, orgId, instanceId))

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
@@ -80,6 +80,7 @@ class PrometheusMeteringControllerTest {
   private final String expectedServiceType = "OpenShift Cluster";
   private final String expectedBillingProvider = "red hat";
   private final String expectedBillingAccountId = "mktp-account";
+  private final String expectedDisplayName = "display name";
   private final MetricId expectedMetricId = MetricIdUtils.getCores();
   private final String expectedProductTag = "OpenShift-metrics";
   private final UUID expectedSpanId = UUID.randomUUID();
@@ -142,6 +143,7 @@ class PrometheusMeteringControllerTest {
             expectedUsage,
             expectedBillingProvider,
             expectedBillingAccountId,
+            expectedDisplayName,
             List.of(List.of(new BigDecimal("12312.345"), new BigDecimal(24))));
 
     prometheusServer.stubQueryRange(errorResponse, errorResponse, good);
@@ -165,6 +167,7 @@ class PrometheusMeteringControllerTest {
             expectedUsage,
             expectedBillingProvider,
             expectedBillingAccountId,
+            expectedDisplayName,
             List.of(List.of(new BigDecimal("12312.345"), new BigDecimal(24))));
     prometheusServer.stubQueryRange(data);
 
@@ -188,6 +191,7 @@ class PrometheusMeteringControllerTest {
             expectedUsage,
             expectedBillingProvider,
             expectedBillingAccountId,
+            expectedDisplayName,
             List.of(List.of(time1, val1), List.of(time2, val2)));
     prometheusServer.stubQueryRange(data);
 
@@ -212,7 +216,8 @@ class PrometheusMeteringControllerTest {
                 val1.doubleValue(),
                 expectedProductTag,
                 expectedSpanId,
-                List.of()),
+                List.of(),
+                expectedDisplayName),
             MeteringEventFactory.createMetricEvent(
                 expectedOrgId,
                 expectedClusterId,
@@ -229,7 +234,8 @@ class PrometheusMeteringControllerTest {
                 val2.doubleValue(),
                 expectedProductTag,
                 expectedSpanId,
-                List.of()),
+                List.of(),
+                expectedDisplayName),
             MeteringEventFactory.createCleanUpEvent(
                 expectedOrgId,
                 getEventType(expectedMetricId.toString(), expectedProductTag),
@@ -261,6 +267,7 @@ class PrometheusMeteringControllerTest {
             expectedUsage,
             expectedBillingProvider,
             expectedBillingAccountId,
+            expectedDisplayName,
             List.of(List.of(time1, val1), List.of(time2, val2)));
     prometheusServer.stubQueryRange(data);
 
@@ -284,7 +291,8 @@ class PrometheusMeteringControllerTest {
             val1.doubleValue(),
             expectedProductTag,
             expectedSpanId,
-            List.of());
+            List.of(),
+            expectedDisplayName);
 
     List<BaseEvent> expectedEvents =
         List.of(
@@ -305,7 +313,8 @@ class PrometheusMeteringControllerTest {
                 val2.doubleValue(),
                 expectedProductTag,
                 expectedSpanId,
-                List.of()),
+                List.of(),
+                expectedDisplayName),
             MeteringEventFactory.createCleanUpEvent(
                 expectedOrgId,
                 getEventType(expectedMetricId.toString(), expectedProductTag),
@@ -369,7 +378,8 @@ class PrometheusMeteringControllerTest {
             4.0,
             expectedProductTag,
             expectedSpanId,
-            List.of());
+            List.of(),
+            expectedClusterId);
 
     List<BaseEvent> expectedEvents =
         List.of(
@@ -433,7 +443,8 @@ class PrometheusMeteringControllerTest {
                 val1.doubleValue(),
                 expectedProductTag,
                 expectedSpanId,
-                List.of()),
+                List.of(),
+                expectedClusterId),
             MeteringEventFactory.createMetricEvent(
                 expectedOrgId,
                 expectedClusterId,
@@ -450,7 +461,8 @@ class PrometheusMeteringControllerTest {
                 val2.doubleValue(),
                 expectedProductTag,
                 expectedSpanId,
-                List.of()),
+                List.of(),
+                expectedClusterId),
             MeteringEventFactory.createCleanUpEvent(
                 expectedOrgId,
                 getEventType(expectedMetricId.toString(), expectedProductTag),
@@ -492,6 +504,7 @@ class PrometheusMeteringControllerTest {
       String usage,
       String billingProvider,
       String billingAccountId,
+      String displayName,
       List<List<BigDecimal>> timeValueTuples) {
     QueryResultDataResultInner dataResult =
         new QueryResultDataResultInner()
@@ -500,7 +513,8 @@ class PrometheusMeteringControllerTest {
             .putMetricItem("usage", usage)
             .putMetricItem("external_organization", orgId)
             .putMetricItem("billing_marketplace", billingProvider)
-            .putMetricItem("billing_marketplace_account", billingAccountId);
+            .putMetricItem("billing_marketplace_account", billingAccountId)
+            .putMetricItem("display_name", displayName);
 
     // NOTE: A tuple is [unix_time,value]
     timeValueTuples.forEach(dataResult::addValuesItem);

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/util/MeteringEventFactoryTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/util/MeteringEventFactoryTest.java
@@ -28,7 +28,6 @@ import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Event.BillingProvider;
@@ -40,6 +39,7 @@ import org.junit.jupiter.api.Test;
 class MeteringEventFactoryTest {
 
   private static final String EVENT_SOURCE = "any";
+  private static final String DISPLAY_NAME = "display name";
 
   private final String productTag = "OpenShift-dedicated-metrics";
 
@@ -75,13 +75,13 @@ class MeteringEventFactoryTest {
             measuredValue,
             productTag,
             meteringBatchId,
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
 
     assertEquals(orgId, event.getOrgId());
     assertEquals(measuredTime, event.getTimestamp());
     assertEquals(expiry, event.getExpiration().get());
     assertEquals(clusterId, event.getInstanceId());
-    assertEquals(Optional.of(clusterId), event.getDisplayName());
     assertEquals(Sla.PREMIUM, event.getSla());
     assertEquals(Usage.PRODUCTION, event.getUsage());
     assertEquals(EVENT_SOURCE, event.getEventSource());
@@ -93,6 +93,8 @@ class MeteringEventFactoryTest {
     Measurement measurement = event.getMeasurements().get(0);
     assertEquals(uom.toString(), measurement.getUom());
     assertEquals(measuredValue, measurement.getValue());
+    assertTrue(event.getDisplayName().isPresent());
+    assertEquals(DISPLAY_NAME, event.getDisplayName().get());
   }
 
   @Test
@@ -114,7 +116,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertNull(event.getSla());
   }
 
@@ -137,7 +140,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertEquals(Sla.__EMPTY__, event.getSla());
   }
 
@@ -160,7 +164,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertNull(event.getSla());
   }
 
@@ -183,7 +188,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertNull(event.getUsage());
   }
 
@@ -206,7 +212,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertNull(event.getUsage());
   }
 
@@ -229,7 +236,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertNull(event.getRole());
   }
 
@@ -252,7 +260,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertNull(event.getRole());
   }
 
@@ -275,7 +284,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertEquals(BillingProvider.AWS, event.getBillingProvider());
     assertTrue(event.getBillingAccountId().isPresent());
     assertEquals("aws_account_123", event.getBillingAccountId().get());
@@ -300,7 +310,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
     assertTrue(event.getBillingAccountId().isEmpty());
   }
@@ -324,7 +335,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
   }
 
@@ -347,7 +359,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertNull(event.getBillingProvider());
   }
 
@@ -370,7 +383,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertEquals("snapshot_openshift-dedicated-metrics_cores", event.getEventType());
   }
 
@@ -401,7 +415,8 @@ class MeteringEventFactoryTest {
             12.5,
             productTag,
             UUID.randomUUID(),
-            List.of());
+            List.of(),
+            DISPLAY_NAME);
     assertEquals(BillingProvider.RED_HAT, event.getBillingProvider());
   }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-2031](https://issues.redhat.com/browse/SWATCH-2031)

## Description
When data is sourced from prometheus the "display_name" label is used to populate an event's display_name, if present

## Testing
1.- podman-compose up
2.- start the tally service: ./gradlew :bootRun
3.- Mock the prometheus server at localhost:

Create the stub directory:
`mkdir -p stub/__files`

Add a stub file to return some data: `stub/__files/swatch-2031.json`

```
cat > stub/__files/swatch-2031.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : [
        {
          "metric" : {
            "_id" : "cluster id",
            "support" : "sla",
            "usage" : "usage",
            "product" : "product",
            "billing_marketplace" : "billing_marketplace",
            "billing_marketplace_account" : "billing_marketplace_account",
            "ebs_account" : "account",
            "display_name": "the user set display name"
          },
          "values": [[ $(date +%s), "1" ]]
        }
      ]
    }
}
EOF
```

Add a stub file to return no data: `stub/__files/empty.json`

```
cat > stub/__files/empty.json <<EOF
{
    "status" : "success",
    "data" : {
      "resultType" : "matrix",
      "result" : []
    }
}
EOF
```

Run wiremock:
`podman run -it --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose`

Configure stubbing for prometheus:

- this is to return some data when asking for instance-hours:
`curl -X POST --data '{ "priority": 1, "request": { "urlPath": "/api/v1/query_range", "method": "GET", "queryParameters": {"query": {"contains":"instance_hours"}}}, "response": { "status": 200, "bodyFileName": "swatch-2031.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

- this is to return no data otherwise:
`curl -X POST --data '{ "priority": 5, "request": { "urlPath": "/api/v1/query_range", "method": "GET" }, "response": { "status": 200, "bodyFileName": "empty.json", "headers":{"Content-Type":"application/json"} }}' http://localhost:8101/__admin/mappings/new`

4.- Start the swatch metrics app: `SERVER_PORT=8001 PROM_URL="http://localhost:8101/api/v1/" EVENT_SOURCE=prometheus ./gradlew :swatch-metrics:quarkusDev`

5.- Trigger the metrics from prometheus:
```
http POST :8001/api/swatch-metrics/v1/internal/metering/rosa?orgId=16790890 \
Origin:console.redhat.com \
x-rh-swatch-psk:placeholder \
x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16790890"}}}' | base64 -w 0)
```

6.- Wait some time, so the service consumes all the events from the topic, and then query the `events` table:

`SELECT * FROM EVENTS;`

And you should see only one event. And the "display_name" column should be "the user set display name". 
Before these changes, the "display_name" was "cluster id".