### PR TITLE
Fix parameter order for getAwsUsageContext

### DIFF
--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation libraries["junit-jupiter"]
+    testImplementation libraries["wiremock"]
     testImplementation project(':swatch-common-testcontainers')
 }
 

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/processors/BillableUsageProcessor.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/processors/BillableUsageProcessor.java
@@ -157,10 +157,10 @@ public class BillableUsageProcessor {
       return internalSubscriptionsApi.getAwsUsageContext(
           billableUsage.getSnapshotDate(),
           billableUsage.getProductId(),
-          Optional.ofNullable(billableUsage.getBillingAccountId()).orElse("_ANY"),
           billableUsage.getOrgId(),
           Optional.ofNullable(billableUsage.getSla()).map(SlaEnum::value).orElse(null),
-          Optional.ofNullable(billableUsage.getUsage()).map(UsageEnum::value).orElse(null));
+          Optional.ofNullable(billableUsage.getUsage()).map(UsageEnum::value).orElse(null),
+          Optional.ofNullable(billableUsage.getBillingAccountId()).orElse("_ANY"));
     } catch (DefaultApiException e) {
       var optionalErrors = Optional.ofNullable(e.getErrors());
       if (optionalErrors.isPresent()) {

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/processors/AwsUsageContextLookupApiTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/processors/AwsUsageContextLookupApiTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws.processors;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import com.redhat.swatch.aws.openapi.model.BillableUsage;
+import com.redhat.swatch.aws.openapi.model.BillableUsage.BillingProviderEnum;
+import com.redhat.swatch.aws.openapi.model.BillableUsage.SlaEnum;
+import com.redhat.swatch.aws.openapi.model.BillableUsage.UsageEnum;
+import com.redhat.swatch.aws.test.resources.WireMockResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(value = WireMockResource.class)
+class AwsUsageContextLookupApiTest {
+  @Inject BillableUsageProcessor processor;
+
+  @Test
+  void testParameterOrderGetAwsUsageContext() {
+    var now = OffsetDateTime.now();
+    try {
+      processor.lookupAwsUsageContext(
+          new BillableUsage()
+              .sla(SlaEnum.PREMIUM)
+              .usage(UsageEnum.PRODUCTION)
+              .orgId("orgId")
+              .productId("productId")
+              .billingAccountId("billingAccountId")
+              .billingProvider(BillingProviderEnum.AWS)
+              .snapshotDate(now));
+    } catch (Exception e) {
+      // intentionally ignoring the exception
+    }
+    verify(
+        getRequestedFor(urlMatching(".*/awsUsageContext.*"))
+            .withQueryParam("date", equalTo(now.toString()))
+            .withQueryParam("productId", equalTo("productId"))
+            .withQueryParam("sla", equalTo("Premium"))
+            .withQueryParam("usage", equalTo("Production"))
+            .withQueryParam("awsAccountId", equalTo("billingAccountId")));
+  }
+}

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/test/resources/WireMockResource.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/test/resources/WireMockResource.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws.test.resources;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import jakarta.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WireMockResource
+    implements QuarkusTestResourceConfigurableLifecycleManager<WireMockTest> {
+  private WireMockServer wireMockServer;
+
+  @Override
+  public Map<String, String> start() {
+    wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    wireMockServer.start();
+    // allow static stubbing methods for this thread
+    WireMock.configureFor(new WireMock(wireMockServer));
+    // setup static wiremock methods to affect this wiremock server
+    WireMock.configureFor("localhost", wireMockServer.port());
+    var config = new HashMap<String, String>();
+    config.put("SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT", wireMockServer.baseUrl());
+    return config;
+  }
+
+  @Override
+  public void stop() {
+    wireMockServer.stop();
+  }
+
+  @Override
+  public void inject(TestInjector testInjector) {
+    testInjector.injectIntoFields(
+        wireMockServer,
+        new TestInjector.AnnotatedAndMatchesType(Inject.class, WireMockServer.class));
+    // allow static stubbing methods for test threads
+    WireMock.configureFor(new WireMock(wireMockServer));
+  }
+}


### PR DESCRIPTION
We made some tweaks to the API definition at some point and that resulted in the generated method having a different parameter order.

Testing
-------
See `AwsUsageContextLookupApiTest`