### PR TITLE
SWATCH-2153 Metrics gathering for rhel telemetry had duplicate data

### DIFF
--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -194,7 +194,7 @@ rhsm-subscriptions:
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
             min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", support=~"Premium|Standard|Self-Support|None"}[1h])
           rhelemeter: >-
-            max by (#{metric.prometheus.queryParams[instanceKey]}) (sum_over_time(#{metric.prometheus.queryParams[metric]}[1h:10m]))
+            sum_over_time((max by (#{metric.prometheus.queryParams[instanceKey]}) (#{metric.prometheus.queryParams[metric]}))[1h:10m])
             /
             scalar(count_over_time(vector(1)[1h:10m]))
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2153 rhel-meter promql

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Human explanation of the new query can be found here: `swatch-metrics/README.md`

Previous decision:
We've opted to not use the recording rule for two reasons.  First, it was only further complicating an already complicated promql query.  Second, we get more accurate data by not using it.  When we requested a recording rule to be made, we expected that its evaluation would happen the same frequency as the openshift telemeter instance.  Since that's not going to be the case, using a recording rule doesn't benefit us much. 

**Note:** After talking with the RHOBS team, it will be advantageous to have a recording rule in the long run for performance-related reasons. So later on, we will collaborate with them. Using the query in PR we also don't need to change "range query"(Graph) to "instance query"(Table)


## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
To inspect/verify the generated query, you can use the metering-promql script and then change the 204 to 69 in the output.

`./bin/metering-promql.py --product rhel-for-x86-els-payg --org 11789772`

Output:
```
rhel-for-x86-els-payg
---------------------
  Accounts PromQL: group(min_over_time({product=~'.*(^|,)(69)($|,).*', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)
  vCPUs PromQL: max by (_id) (sum_over_time(system_cpu_logical_count[1h:10m])) / scalar(count_over_time(vector(1)[1h:10m]))
* on (_id) group_right topk by (_id) (
  1,
    group without (swatch_placeholder_label) (
      min_over_time(
      system_cpu_logical_count{
      product=~".*(^|,)(69)($|,).*",
      external_organization="11789772",
      billing_model="marketplace",
      support=~"Premium|Standard|Self-Support|None"
      }[1h]
    )
  )
)
```


Expectations:
- Eliminate double billing scenarios
1.  Before this card, we would get multiple data points for an instance per hour when gathering metrics from rhelemeter.  We should now only gather one metric value per hour per instance to be used when hourly tallying.

To test the exact example from the card you'll have to get creative.  The instance is only reporting product code 69.  You'll have to update the regex in `swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml` to be 69 instead of 204.  Then you'll want to use orgId 11789772 instead of 16787820.  And you'll need to play with the timestamps on the APIs for getting metrics and starting an hourly tally to make sure the metrics that were showing the problem are considered.

### Setup
<!-- Add any steps required to set up the test case -->
1. Run `rhelemeter-stage` command from `swatch-support-scripts` or alternatively do:

```
TOKEN_REFRESHER_VERSION=master-2023-09-20-f5e3403
SCOPE="openid offline_access"
CLIENT_SECRET=
CLIENT_ID=
ISSUER_URL=https://sso.redhat.com/auth/realms/redhat-external
URL=https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/rhel
```

```
podman run --name=token-refresher --rm -ti -p 8082:8080 \
  quay.io/observatorium/token-refresher:$TOKEN_REFRESHER_VERSION \
  --scope="$SCOPE" \
  --oidc.client-secret="$CLIENT_SECRET" \
  --oidc.client-id="$CLIENT_ID" \
  --oidc.issuer-url="$ISSUER_URL" \
  --url="$URL"
```

2. Start swatch-metrics configured for rhelemeter
```
EVENT_SOURCE=rhelemeter PROM_URL="http://localhost:8082/api/v1" ./gradlew :swatch-metrics:quarkusDev
```

3. If there were metrics to be found, you should see log messages indicating they're being sent as events. At this point you can inspect the `platform.rhsm-subscriptions.service-instance-ingress` topic using Bigdata tools to see the events.

### Steps and Verification
<!-- Enter each step of the test below -->
1. Kick off gathering metrics for now
```
curl -X POST --location "http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=11789772" -H 'x-rh-swatch-synchronous-request: false' -H 'x-rh-swatch-psk: placeholder'
``` 
**Log:**
`2024-02-07 12:44:52,630 INFO  [com.red.swa.met.ser.pro.PrometheusService] (vert.x-worker-thread-1) Fetching metrics from prometheus: 2024-02-07T17:00Z -> 2024-02-07T17:00Z [Step: 3600]`

**Running prometheus range query: Start: 1707325200 End: 1707325200 Step: 3600, Query:** 
```
sum_over_time((max by (_id) (system_cpu_logical_count))[1h:10m]) / scalar(count_over_time(vector(1)[1h:10m]))
* on (_id) group_right topk by (_id) (
  1,
    group without (swatch_placeholder_label) (
      min_over_time(
      system_cpu_logical_count{
      product=~".*(^|,)(69)($|,).*",
      external_organization="11789772",
      billing_model="marketplace",
      support=~"Premium|Standard|Self-Support|None"
      }[1h]
    )
  )
)
```

**Kafka platform.rhsm-subscriptions.service-instance-ingress:**
```
{
  "start": "2024-02-07T16:00:00Z",
  "end": "2024-02-07T17:00:00Z",
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "metering_batch_id": "10961cf1-741b-4234-a0cf-fce9a924dc42"
}

```

2.  Kick off gathering metrics with optional API params for 23 Jan timestamp for 60 mins
```
curl -X 'POST'   'http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=11789772&endDate=2024-01-23T14%3A00%3A00Z&rangeInMinutes=60'   -H 'accept: */*'   -H 'x-rh-swatch-synchronous-request: false'   -H 'x-rh-swatch-psk: placeholder'   -d ''
```

Log:
`2024-02-07 13:35:24,347 INFO  [com.red.swa.met.ser.pro.PrometheusService] (vert.x-worker-thread-1) Fetching metrics from prometheus: 2024-01-23T14:00Z -> 2024-01-23T14:00Z [Step: 3600]`

Running prometheus range query: Start: 1706018400 End: 1706018400 Step: 3600, Query: 
```
sum_over_time((max by (_id) (system_cpu_logical_count))[1h:10m]) / scalar(count_over_time(vector(1)[1h:10m]))
* on (_id) group_right topk by (_id) (
  1,
    group without (swatch_placeholder_label) (
      min_over_time(
      system_cpu_logical_count{
      product=~".*(^|,)(69)($|,).*",
      external_organization="11789772",
      billing_model="marketplace",
      support=~"Premium|Standard|Self-Support|None"
      }[1h]
    )
  )
)

```
Kafka:
```
{
  "service_type": "RHEL System",
  "timestamp": "2024-01-23T13:00:00Z",
  "expiration": "2024-01-23T14:00:00Z",
  "display_name": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "measurements": [
    {
      "value": 1.0,
      "uom": "vCPUs"
    }
  ],
  "product_ids": [
    "69"
  ],
  "sla": "Premium",
  "usage": "Production",
  "billing_provider": "aws",
  "billing_account_id": "988542195534",
  "product_tag": [
    "rhel-for-x86-els-payg"
  ],
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "instance_id": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "metering_batch_id": "77ee8d56-c385-414c-ad9f-8a1a77183731"
}

{
  "start": "2024-01-23T13:00:00Z",
  "end": "2024-01-23T14:00:00Z",
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "metering_batch_id": "77ee8d56-c385-414c-ad9f-8a1a77183731"
}
```

3.  Kick off gathering metrics with optional API params for 23 Jan timestamp for 240 mins
```
curl -X 'POST'   'http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=11789772&endDate=2024-01-23T16%3A00%3A00Z&rangeInMinutes=240'   -H 'accept: */*'   -H 'x-rh-swatch-synchronous-request: false'   -H 'x-rh-swatch-psk: placeholder'   -d ''
```

Log:
`2024-02-07 13:41:11,081 INFO  [com.red.swa.met.ser.pro.PrometheusService] (vert.x-worker-thread-1) Fetching metrics from prometheus: 2024-01-23T13:00Z -> 2024-01-23T16:00Z [Step: 3600]`

Running prometheus range query: Start: 1706014800 End: 1706025600 Step: 3600, Query: 
```
sum_over_time((max by (_id) (system_cpu_logical_count))[1h:10m]) / scalar(count_over_time(vector(1)[1h:10m]))
* on (_id) group_right topk by (_id) (
  1,
    group without (swatch_placeholder_label) (
      min_over_time(
      system_cpu_logical_count{
      product=~".*(^|,)(69)($|,).*",
      external_organization="11789772",
      billing_model="marketplace",
      support=~"Premium|Standard|Self-Support|None"
      }[1h]
    )
  )
)
```

Kafka:
```

{
  "service_type": "RHEL System",
  "timestamp": "2024-01-23T12:00:00Z",
  "expiration": "2024-01-23T13:00:00Z",
  "display_name": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "measurements": [
    {
      "value": 1.0,
      "uom": "vCPUs"
    }
  ],
  "product_ids": [
    "69"
  ],
  "sla": "Premium",
  "usage": "Production",
  "billing_provider": "aws",
  "billing_account_id": "988542195534",
  "product_tag": [
    "rhel-for-x86-els-payg"
  ],
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "instance_id": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "metering_batch_id": "6270fccc-f704-4510-b499-bceb2470658e"
}


{
  "service_type": "RHEL System",
  "timestamp": "2024-01-23T13:00:00Z",
  "expiration": "2024-01-23T14:00:00Z",
  "display_name": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "measurements": [
    {
      "value": 1.0,
      "uom": "vCPUs"
    }
  ],
  "product_ids": [
    "69"
  ],
  "sla": "Premium",
  "usage": "Production",
  "billing_provider": "aws",
  "billing_account_id": "988542195534",
  "product_tag": [
    "rhel-for-x86-els-payg"
  ],
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "instance_id": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "metering_batch_id": "6270fccc-f704-4510-b499-bceb2470658e"
}


{
  "start": "2024-01-23T12:00:00Z",
  "end": "2024-01-23T16:00:00Z",
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "metering_batch_id": "6270fccc-f704-4510-b499-bceb2470658e"
}
```

Screenshot of how the graph should like:
![Screenshot from 2024-02-07 14-00-50](https://github.com/RedHatInsights/rhsm-subscriptions/assets/11471167/ce5bbf76-403f-4634-a157-96a0ec9d0e55)


### ${{\color{Red}\Huge{\textsf{  Verification of duplicate behavior}}}}\$ :
## Steps

1. Execute:
```
curl -X 'POST'   'http://localhost:8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg?orgId=11789772&endDate=2024-01-23T16%3A00%3A00Z&rangeInMinutes=240'   -H 'accept: */*'   -H 'x-rh-swatch-synchronous-request: false'   -H 'x-rh-swatch-psk: placeholder'   -d ''
```

Log:
2024-02-07 13:54:27,615 INFO  [com.red.swa.met.ser.pro.PrometheusService] (vert.x-worker-thread-1) Fetching metrics from prometheus: 2024-01-23T13:00Z -> 2024-01-23T16:00Z [Step: 3600]

Running prometheus range query: Start: 1706014800 End: 1706025600 Step: 3600, Query: 
```
max by (_id) (sum_over_time(system_cpu_logical_count[1h:10m])) / scalar(count_over_time(vector(1)[1h:10m]))
* on (_id) group_right topk by (_id) (
  1,
    group without (swatch_placeholder_label) (
      min_over_time(
      system_cpu_logical_count{
      product=~".*(^|,)(69)($|,).*",
      external_organization="11789772",
      billing_model="marketplace",
      support=~"Premium|Standard|Self-Support|None"
      }[1h]
    )
  )
)
```

Kafka:
```
{
  "service_type": "RHEL System",
  "timestamp": "2024-01-23T12:00:00Z",
  "expiration": "2024-01-23T13:00:00Z",
  "display_name": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "measurements": [
    {
      "value": 3.0,
      "uom": "vCPUs"
    }
  ],
  "product_ids": [
    "69"
  ],
  "sla": "Premium",
  "usage": "Production",
  "billing_provider": "aws",
  "billing_account_id": "988542195534",
  "product_tag": [
    "rhel-for-x86-els-payg"
  ],
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "instance_id": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "metering_batch_id": "20fb65f1-8d5d-437b-9859-12a7ca124ede"
}


{
  "service_type": "RHEL System",
  "timestamp": "2024-01-23T13:00:00Z",
  "expiration": "2024-01-23T14:00:00Z",
  "display_name": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "measurements": [
    {
      "value": 1.8571428571428572,
      "uom": "vCPUs"
    }
  ],
  "product_ids": [
    "69"
  ],
  "sla": "Premium",
  "usage": "Production",
  "billing_provider": "aws",
  "billing_account_id": "988542195534",
  "product_tag": [
    "rhel-for-x86-els-payg"
  ],
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "instance_id": "d5b96614-a114-4371-8523-c9ee7cf64cc2",
  "metering_batch_id": "20fb65f1-8d5d-437b-9859-12a7ca124ede"
}


{
  "start": "2024-01-23T12:00:00Z",
  "end": "2024-01-23T16:00:00Z",
  "event_source": "rhelemeter",
  "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
  "org_id": "11789772",
  "metering_batch_id": "20fb65f1-8d5d-437b-9859-12a7ca124ede"
}

```

Screenshot with wrong graph for previous promql:
![Screenshot from 2024-02-07 13-58-59](https://github.com/RedHatInsights/rhsm-subscriptions/assets/11471167/d45f9df6-70ca-4cd7-98ba-c51915e75288)
