### PR TITLE
SWATCH-2066: Synchronize the timeout for metrics task messages with the `@Retry` configuration

### DIFF
--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/configuration/MetricProperties.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/configuration/MetricProperties.java
@@ -22,7 +22,6 @@ package com.redhat.swatch.metrics.configuration;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
-import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
@@ -81,15 +80,6 @@ public interface MetricProperties {
    */
   @WithDefault("3")
   int templateParameterDepth();
-
-  /** How many attempts before giving up on the MeteringJob. */
-  Integer jobMaxAttempts();
-
-  /** Retry backoff initial interval of the MeteringJob. */
-  Duration jobBackOffInitialInterval();
-
-  /** Retry backoff interval of the MeteringJob. */
-  Duration jobBackOffMaxInterval();
 
   /** The event source type. */
   String eventSource();

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -43,6 +43,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.BadRequestException;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -142,7 +143,7 @@ public class PrometheusMeteringController {
   }
 
   @SuppressWarnings("java:S107")
-  @Retry
+  @Retry(maxDuration = 120, durationUnit = ChronoUnit.SECONDS)
   public void collectMetricsForRange(
       String tag,
       String orgId,

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -218,6 +218,3 @@ rhsm-subscriptions:
         backOffMultiplier: ${OPENSHIFT_BACK_OFF_MULTIPLIER:1.5}
         eventSource: ${EVENT_SOURCE:prometheus}
         rangeInMinutes: ${OPENSHIFT_METERING_RANGE:60}
-        jobMaxAttempts: ${METERING_JOB_MAX_ATTEMPTS:3}
-        jobBackOffMaxInterval: ${METERING_JOB_BACK_OFF_MAX_INTERVAL:50000}
-        jobBackOffInitialInterval: ${METERING_JOB_BACK_OFF_INITIAL_INTERVAL:1000}

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -140,6 +140,9 @@ mp:
             # This value needs to be synced with the retry configuration which will retry up to
             # 3 times with a max duration of 120 seconds, so the correct value would be 3 x 120 =
             ms: 360000
+        # By default, when a message is nack, the application stops consuming messages.
+        # With the "ignore" strategy, we ignore the error (it's logged internally) and continue processing messages.
+        failure-strategy: ignore
         fail-on-deserialization-failure: ${METRICS_IN_FAIL_ON_DESER_FAILURE}
         auto:
           offset:

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -137,7 +137,9 @@ mp:
         topic: ${METERING_TASK_TOPIC}
         throttled:
           unprocessed-record-max-age:
-            ms: 120000
+            # This value needs to be synced with the retry configuration which will retry up to
+            # 3 times with a max duration of 120 seconds, so the correct value would be 3 x 120 =
+            ms: 360000
         fail-on-deserialization-failure: ${METRICS_IN_FAIL_ON_DESER_FAILURE}
         auto:
           offset:


### PR DESCRIPTION
Jira issue: [SWATCH-2066](https://issues.redhat.com/browse/SWATCH-2066)

## Description
- The property `throttled.unprocessed-record-max-age.ms` needs to be synced with the retry configuration which will retry up to 3 times with a max duration of 120 seconds, so the correct value would be 3 x 120 = 360 seconds for this property
- Change the failure strategy since, by default, when a message is nack, the application stops consuming messages. With the "ignore" strategy, we ignore the error (it's logged internally) and continue processing messages.
- Remove some unused properties in the metrics service

Relates to https://github.com/RedHatInsights/rhsm-subscriptions/pull/3019
