### PR TITLE
SWATCH-2192: Not using the path "/q" for swatch metrics ++ add gauge events counter

### DIFF
--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -131,11 +131,11 @@ parameters:
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
   - name: METRICS_HEALTH_LIVENESS_PATH
-    value: /q/health/live
+    value: /health/live
   - name: METRICS_HEALTH_READY_PATH
-    value: /q/health/ready
+    value: /health/ready
   - name: METRICS_HEALTH_PORT
-    value: '8000'
+    value: '9000'
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -54,6 +54,14 @@ SERVICE_INSTANCE_INGRESS_TOPIC: platform.rhsm-subscriptions.service-instance-ing
         disabled: false
 
 quarkus:
+  # Exposing the health checks and metrics on :9000.
+  # The port should be configurable using the clowder config source:
+  # https://github.com/RedHatInsights/clowder-quarkus-config-source/issues/217
+  management:
+    enabled: true
+    port: 9000
+    # Configure the Quarkus non application paths to listen on "/" instead of "/q"
+    root-path: /
   http:
     port: ${SERVER_PORT}
     test-port: 0
@@ -80,8 +88,12 @@ quarkus:
   swagger-ui:
     path: /api/${quarkus.application.name}/internal/swagger-ui
     always-include: true
+    management:
+      enabled: false
   smallrye-openapi:
     path: /api/${quarkus.application.name}/internal/openapi
+    management:
+      enabled: false
   otel:
     exporter:
       otlp:

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/admin/api/MetricsTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/admin/api/MetricsTest.java
@@ -58,8 +58,6 @@ class MetricsTest {
 
   @Test
   void testServiceIsUpAndRunning() {
-    // health resource is up and running
-    get("/q/health").then().statusCode(HttpStatus.SC_OK);
     // openapi resources are up and running
     get("/api/swatch-metrics/internal/openapi").then().statusCode(HttpStatus.SC_OK);
     get("/api/swatch-metrics/internal/swagger-ui").then().statusCode(HttpStatus.SC_OK);


### PR DESCRIPTION
Jira issue: [SWATCH-2192](https://issues.redhat.com/browse/SWATCH-2192)

## Description
Configure swatch-metrics to expose the metrics endpoint via the path "/metrics" instead of "/q/metrics" on port 9000 as in Spring services. Note that this implies that the health check endpoints changed as well. 

Moreover, we have added a new gauge metrics to count the number of events fetched from prometheus.

## Testing
This will be tested in stage. 