### PR TITLE
SWATCH-1929: Replace rhsm.VM_HOST_UUID by system profile.virtual_host_uuid

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -35,7 +35,6 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
             'facts': json.dumps({
                 'rhsm': {
                     'orgId': org_id or f'org_{account}',
-                    'VM_HOST_UUID': str(hypervisor_uuid) if hypervisor_uuid else None,
                     'IS_VIRTUAL': is_guest,
                 },
             }),
@@ -50,7 +49,8 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
                 'number_of_sockets': sockets,
                 'cloud_provider': cloud_provider,
                 'is_marketplace': is_marketplace,
-                'host_type': host_type
+                'host_type': host_type,
+                'virtual_host_uuid': str(hypervisor_uuid) if hypervisor_uuid else None,
             }),
             'stale_timestamp': '2030-01-01',
             'reporter': 'rhsm-conduit',

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -75,11 +75,11 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
       nativeQuery = true,
       value =
           "select "
-              + "distinct h.facts->'rhsm'->>'VM_HOST_UUID' as hyp_id, "
+              + "distinct h.system_profile_facts->>'virtual_host_uuid' as hyp_id, "
               + "h_.canonical_facts->>'subscription_manager_id' as hyp_subman_id "
               + "from hosts h "
-              + "left outer join hosts h_ on h.facts->'rhsm'->>'VM_HOST_UUID' = h_.canonical_facts->>'subscription_manager_id' "
-              + "where h.facts->'rhsm'->'VM_HOST_UUID' is not null "
+              + "left outer join hosts h_ on h.system_profile_facts->>'virtual_host_uuid' = h_.canonical_facts->>'subscription_manager_id' "
+              + "where h.system_profile_facts->>'virtual_host_uuid' is not null "
               + "and h.org_id IN (:orgIds)"
               + "union all "
               + "select "

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -98,7 +98,6 @@ import lombok.Setter;
         select
         h.id as inventory_id, h.org_id, h.modified_on, h.account, h.display_name,
         h.facts->'rhsm'->>'IS_VIRTUAL' as is_virtual,
-        h.facts->'rhsm'->>'VM_HOST_UUID' as hypervisor_uuid,
         h.facts->'satellite'->>'virtual_host_uuid' as satellite_hypervisor_uuid,
         h.facts->'satellite'->>'system_purpose_role' as satellite_role,
         h.facts->'satellite'->>'system_purpose_sla' as satellite_sla,
@@ -111,6 +110,7 @@ import lombok.Setter;
         h.facts->'rhsm'->>'SYSPURPOSE_UNITS' as syspurpose_units,
         h.facts->'rhsm'->>'BILLING_MODEL' as  billing_model,
         h.facts->'qpc'->>'IS_RHEL' as is_rhel,
+        h.system_profile_facts->>'virtual_host_uuid' as hypervisor_uuid,
         h.system_profile_facts->>'infrastructure_type' as system_profile_infrastructure_type,
         h.system_profile_facts->>'cores_per_socket' as system_profile_cores_per_socket,
         h.system_profile_facts->>'number_of_sockets' as system_profile_sockets,
@@ -127,11 +127,11 @@ import lombok.Setter;
         h.stale_timestamp,
         coalesce(
             h.facts->'satellite'->>'virtual_host_uuid',
-            h.facts->'rhsm'->>'VM_HOST_UUID',
+            h.system_profile_facts->>'virtual_host_uuid',
             h.canonical_facts->>'subscription_manager_id') as hardware_subman_id,
         coalesce(
             h.facts->'satellite'->>'virtual_host_uuid',
-            h.facts->'rhsm'->>'VM_HOST_UUID'
+            h.system_profile_facts->>'virtual_host_uuid'
         ) as any_hypervisor_uuid
         from hosts h
         cross join lateral (

--- a/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
+++ b/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
@@ -50,7 +50,6 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
   private static final String DISPLAY_NAME = "display name";
   private static final String REPORTER = "test";
   private static final String SUBSCRIPTION_MANAGER_ID = "subs id";
-  private static final String VM_HOST_UUID = "vm host uuid test";
   private static final String VIRTUAL_HOST_UUID = "virtual host uuid test";
   private static final String SYSTEM_PURPOSE_ROLE = "system purpose role test";
   private static final String SYSTEM_PURPOSE_SLA = "system purpose sla test";
@@ -96,7 +95,7 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
     assertEquals(ORG_ID, fact.getOrgId());
     assertNotNull(fact.getModifiedOn());
     assertTrue(fact.isVirtual());
-    assertEquals(VM_HOST_UUID, fact.getHypervisorUuid());
+    assertEquals(VIRTUAL_HOST_UUID, fact.getHypervisorUuid());
     assertEquals(VIRTUAL_HOST_UUID, fact.getSatelliteHypervisorUuid());
     assertEquals(SYSTEM_PURPOSE_ROLE, fact.getSatelliteRole());
     assertEquals(SYSTEM_PURPOSE_SLA, fact.getSatelliteSla());
@@ -140,7 +139,7 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
     List<Object[]> reportedHypervisors =
         repository.getReportedHypervisors(List.of(ORG_ID)).toList();
     assertEquals(2, reportedHypervisors.size());
-    assertEquals(VM_HOST_UUID, reportedHypervisors.get(0)[0]);
+    assertEquals(VIRTUAL_HOST_UUID, reportedHypervisors.get(0)[0]);
     assertEquals(VIRTUAL_HOST_UUID, reportedHypervisors.get(1)[0]);
   }
 
@@ -168,8 +167,6 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
             of(
                 "IS_VIRTUAL",
                 "true",
-                "VM_HOST_UUID",
-                VM_HOST_UUID,
                 "GUEST_ID",
                 GUEST_ID,
                 "SYNC_TIMESTAMP",
@@ -217,7 +214,9 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
             "is_marketplace",
             "true",
             "installed_products",
-            INSTALLED_PRODUCTS),
+            INSTALLED_PRODUCTS,
+            "virtual_host_uuid",
+            VIRTUAL_HOST_UUID),
         REPORTER,
         now(),
         now(),

--- a/swatch-system-conduit/schemas/inventory/hbi-system-profile.yaml
+++ b/swatch-system-conduit/schemas/inventory/hbi-system-profile.yaml
@@ -35,4 +35,6 @@ properties:
     type: array
     items:
       $ref: "hbi-network-interface.yaml"
+  virtual_host_uuid:
+    type: string
 

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -566,7 +566,7 @@ public class InventoryController {
 
     String vmHypervisorUuid = consumer.getHypervisorUuid();
     if (StringUtils.hasLength(vmHypervisorUuid)) {
-      facts.setVmHostUuid(vmHypervisorUuid);
+      facts.setVirtualHostUuid(vmHypervisorUuid);
     }
 
     String vmId = consumer.getGuestId();

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -149,6 +149,7 @@ public abstract class InventoryService {
     systemProfile.setNetworkInterfaces(facts.getNetworkInterfaces());
     systemProfile.setIsMarketplace(facts.getIsMarketplace());
     systemProfile.setReleasever(facts.getReleaseVer());
+    systemProfile.setVirtualHostUuid(facts.getVirtualHostUuid());
     return systemProfile;
   }
 
@@ -166,7 +167,6 @@ public abstract class InventoryService {
     addFact(rhsmFactMap, "ARCHITECTURE", conduitFacts.getArchitecture());
     addFact(rhsmFactMap, "IS_VIRTUAL", conduitFacts.getIsVirtual());
     addFact(rhsmFactMap, "VM_HOST", conduitFacts.getVmHost());
-    addFact(rhsmFactMap, "VM_HOST_UUID", conduitFacts.getVmHostUuid());
     addFact(rhsmFactMap, "GUEST_ID", conduitFacts.getGuestId());
     addFact(rhsmFactMap, "RH_PROD", conduitFacts.getRhProd());
     addFact(rhsmFactMap, "SYSPURPOSE_ROLE", conduitFacts.getSysPurposeRole());

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -261,7 +261,7 @@ components:
           type: boolean
         vm_host:
           type: string
-        vm_host_uuid:
+        virtual_host_uuid:
           type: string
         guest_id:
           type: string

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -230,7 +230,7 @@ class InventoryControllerTest {
     assertEquals(uuid, conduitFacts.getSubscriptionManagerId());
     assertEquals("test_org", conduitFacts.getOrgId());
     assertEquals("hypervisor1.test.com", conduitFacts.getVmHost());
-    assertEquals(hypervisorUuid, conduitFacts.getVmHostUuid());
+    assertEquals(hypervisorUuid, conduitFacts.getVirtualHostUuid());
     assertEquals("guest", conduitFacts.getGuestId());
     assertEquals("host1.test.com", conduitFacts.getFqdn());
     assertEquals(systemUuid, conduitFacts.getBiosUuid());


### PR DESCRIPTION
Jira issue: [SWATCH-1929](https://issues.redhat.com/browse/SWATCH-1929)

## Description
Add support for the recently added system profile fact virtual_host_uuid (https://github.com/RedHatInsights/inventory-schemas/pull/121) which replaces legacy facts rhsm.VM_HOST_UUID.

## Testing
1.- podman-compose up
2.- Create hosts for orgId=16790890 in Insights database

```
./bin/insert-mock-hosts --hbi --clear --org 16790890 --account account123 --num-guests 1 --hypervisor-id 123456
```
3.- DEV_MODE=true SUBSCRIPTION_SYNC_ENABLED=true ENABLE_SYNCHRONOUS_OPERATIONS=true ./gradlew :bootRun
4.- Perform tally snapshot:

```bash
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/16790890" \
Origin:console.redhat.com \
x-rh-swatch-synchronous-request:true \
x-rh-swatch-psk:placeholder \
x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"16790890"}}}' | base64 -w 0)
```

5.- Query the created hosts in the swatch database and confirm the virtual_host_uuid has been used:

`SELECT hypervisor_uuid FROM hosts;`

It should be 123456.
