### PR TITLE
SWATCH-2203: Get product tags by product name when no role or eng ids

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -458,6 +458,35 @@ class SubscriptionSyncControllerTest {
   }
 
   @Test
+  void
+      findProductTagsBySku_WhenSkuPresentWithNoRoleOrEngIDsThenItShouldUseProductNameWhenMeteredFlagIsTrue() {
+    Offering offering = new Offering();
+    offering.setProductName("OpenShift Online");
+    offering.setRole(null);
+    offering.setProductIds(null);
+    offering.setMetered(true);
+    when(offeringRepository.findOfferingBySku("sku")).thenReturn(offering);
+
+    OfferingProductTags productTags = subscriptionSyncController.findProductTags("sku");
+    assertEquals(1, productTags.getData().size());
+    assertEquals("rosa", productTags.getData().get(0));
+  }
+
+  @Test
+  void
+      findProductTagsBySku_WhenSkuPresentWithNoRoleOrEngIDsThenItShouldNotUseProductNameWhenMeteredFlagIsFalse() {
+    Offering offering = new Offering();
+    offering.setProductName("OpenShift Online");
+    offering.setRole(null);
+    offering.setProductIds(null);
+    offering.setMetered(false);
+    when(offeringRepository.findOfferingBySku("sku")).thenReturn(offering);
+
+    OfferingProductTags productTags = subscriptionSyncController.findProductTags("sku");
+    assertNull(productTags.getData());
+  }
+
+  @Test
   void findProductTagsBySku_WhenSkuNotPresent() {
     when(offeringRepository.findOfferingBySku("sku")).thenReturn(null);
     RuntimeException e =


### PR DESCRIPTION
Jira issue: [SWATCH-2203](https://issues.redhat.com/browse/SWATCH-2203)

## Description
In https://github.com/RedHatInsights/rhsm-subscriptions/pull/2905 we changed how to resolve the offering product tags. Before, we were using the product name to get the linked product tags. After these changes, we started using the offering role AND/OR the offering eng IDs. However, it seems that this change was not aligned with the upstream offering data where offerings were missing both role and eng IDs. 
Therefore, we need to keep using the product name when the offering is missing the role and the eng IDs to not break the contract ingestion. 

## Testing
1.- podman-compose up
2.- DEV_MODE=true SPRING_PROFILES_ACTIVE=worker ./gradlew :bootRun
3.- Create offering:

`INSERT INTO OFFERING(sku,product_name,product_family,sla,description,has_unlimited_usage, metered) VALUES ('MW02393','OpenShift Online','OpenShift Enterprise','Premium','Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)','false', 'true');`

4.- Check for offering tags:

```
curl -X GET -H 'Content-Type: application/json' -H 'Origin:console.redhat.com' -H 'x-rh-swatch-psk:placeholder' http://localhost:8000/api/rhsm-subscriptions/v1/internal/offerings/MW02393/product_tags
```

It should return:

```
{"data":["rosa"]}
```