### PR TITLE
Run an init script in the container builds to set git email

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Ensure the checkout has the HBI submodule initialized:
 git submodule update --init --recursive
 ```
 
+Make sure you have `user.email` and `user.name` set in the local `.git/config`.
+The Nebula release plugin has an annoying property where it introspects the Git
+config for the name and email address.  When doing container builds, there is no
+global Git config so if you haven't set the name and email locally, the
+container build will fail.  Use `git config --local` to set these values.
+
+```
+git config --local user.name "John Doe"
+git config --local user.email johndoe@example.com
+```
+
 ### Dependent services
 
 NOTE: in order to deploy insights-inventory (not always useful), you'll need to login to quay.io first.


### PR DESCRIPTION
This is a result of the update of
com.netflix.nebula:nebula-release-plugin from 18.0.8 to 19.0.4.  For
some reason the new plugin demands that the user.name and user.email be
set in the git configuration.
