### PR TITLE
SWATCH-2206: Add retries/debug logs to Partner Gateway processing

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/DebugClientLogger.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/DebugClientLogger.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.config;
+
+import io.quarkus.arc.Unremovable;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.reactive.client.api.ClientLogger;
+
+/** ClientLogger implementation that only logs requests for a matching URI */
+@Slf4j
+@Unremovable
+@ApplicationScoped
+public class DebugClientLogger implements ClientLogger {
+
+  @ConfigProperty(name = "rest-client-debug-logging.uri-filter")
+  Pattern uriFilterPattern;
+
+  private ThreadLocal<Boolean> shouldLog = new ThreadLocal<Boolean>();
+
+  @Override
+  public void setBodySize(int bodySize) {
+    // intentionally ignored
+  }
+
+  @Override
+  public void logResponse(HttpClientResponse response, boolean redirect) {
+    if (Objects.equals(shouldLog.get(), Boolean.TRUE)) {
+      response.bodyHandler(body -> log.debug("Response: \n{}", body.toString()));
+    }
+  }
+
+  @Override
+  public void logRequest(HttpClientRequest request, Buffer body, boolean omitBody) {
+    if (uriFilterPattern.matcher(request.getURI()).matches()) {
+      shouldLog.set(true);
+      log.debug(
+          "Request method={} URI={}: \n{}", request.getMethod(), request.getURI(), body.toString());
+    } else {
+      shouldLog.set(false);
+    }
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ContractNotAssociatedToOrgException.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ContractNotAssociatedToOrgException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.exception;
+
+public class ContractNotAssociatedToOrgException extends Exception {
+  /* intentionally empty */
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ContractValidationFailedException.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ContractValidationFailedException.java
@@ -29,6 +29,6 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class ContractValidationFailedException extends Exception {
-  private final ContractEntity entity;
-  private final Set<ConstraintViolation<ContractEntity>> violations;
+  private final transient ContractEntity entity;
+  private final transient Set<ConstraintViolation<ContractEntity>> violations;
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ContractValidationFailedException.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ContractValidationFailedException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.exception;
+
+import com.redhat.swatch.contract.repository.ContractEntity;
+import jakarta.validation.ConstraintViolation;
+import java.util.Set;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ContractValidationFailedException extends Exception {
+  private final ContractEntity entity;
+  private final Set<ConstraintViolation<ContractEntity>> violations;
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
@@ -29,6 +29,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.Objects;
@@ -41,6 +43,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+@NotNull
 @Entity
 @Table(name = "contracts")
 @AllArgsConstructor
@@ -71,14 +74,17 @@ public class ContractEntity extends PanacheEntityBase {
   @Column(name = "end_date")
   private OffsetDateTime endDate;
 
+  @NotNull
   @Basic
   @Column(name = "org_id", nullable = false)
   private String orgId;
 
+  @NotNull
   @Basic
   @Column(name = "sku", nullable = false)
   private String sku;
 
+  @NotNull
   @Basic
   @Column(name = "billing_provider", nullable = false)
   private String billingProvider;
@@ -87,10 +93,12 @@ public class ContractEntity extends PanacheEntityBase {
   @Column(name = "billing_provider_id")
   private String billingProviderId;
 
+  @NotNull
   @Basic
   @Column(name = "billing_account_id", nullable = false)
   private String billingAccountId;
 
+  @NotNull
   @Basic
   @Column(name = "product_id", nullable = false)
   private String productId;
@@ -99,6 +107,8 @@ public class ContractEntity extends PanacheEntityBase {
   @Column(name = "vendor_product_code", nullable = false)
   private String vendorProductCode;
 
+  @NotEmpty
+  @NotNull
   @Builder.Default
   @OneToMany(
       targetEntity = ContractMetricEntity.class,

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -67,7 +67,8 @@ quarkus.log.category."com.redhat.swatch".level=${LOGGING_LEVEL_COM_REDHAT_SWATCH
 quarkus.security.deny-unannotated-members=true
 # Disable role checking in dev mode. Use QUARKUS_SECURITY_AUTH_ENABLED_IN_DEV_MODE=true to override.
 quarkus.security.auth.enabled-in-dev-mode=false
-
+# Set retry delay to 0 to keep tests fast
+%test.Retry/delay=0
 
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=${DATABASE_USERNAME}
@@ -106,6 +107,14 @@ quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".scope=jakarta.enterprise.context.ApplicationScoped
+
+# rest-client debug logging
+# NOTE: all of uri-filter-regex, log category level, and logging.scope need to be set for a request/response to be logged.
+rest-client-debug-logging.uri-filter=.*partnerSubscriptions.*
+quarkus.log.category."com.redhat.swatch.contract.config.DebugClientLogger".level=DEBUG
+%test.quarkus.rest-client.logging.scope=request-response
+%dev.quarkus.rest-client.logging.scope=request-response
+%stage.quarkus.rest-client.logging.scope=request-response
 
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".url=${SUBSCRIPTION_URL:http://localhost:8102}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store=${KEYSTORE_RESOURCE:}


### PR DESCRIPTION
Jira issue: [SWATCH-2206](https://issues.redhat.com/browse/SWATCH-2206)

Description
===========

In order to handle transient issues with the data coming back from the partner gateway API, as well as provide debug logging to assist the partner gateway engineers in debugging issues.

Note that I added a custom debug logger `DebugClientLogger` that can be configured to log the request and response bodies. See comments in `application.properties` for details. (It's configured for partnerEntitlement requests for `dev`, `test`, and `stage` profiles only).

I changed the contract entity validation to use hibernate validator, to get better messages about which fields are missing. (Each failed field is now logged at a `WARN` level).

I tweaked the API enrichment so that if the contract fails validation afterward, the enrichment will be retried up to 10 times, with a 500ms delay between each retry (adding ~5 seconds total for this unexpected case). Given we expect the initial message (not having an orgId for the contract) to fail until the contract is linked, this type of failure is _not_ retried.

Testing
=======

Run the AzureContractLifecycleIntegrationTest to see changes in logging and retries:

```shell
./gradlew :swatch-contracts:test -i --tests=AzureContractLifecycleIntegrationTest
```

Observe:
* Retries are verified by wiremock `verify` calls.
* Request and response bodies are logged (look for `DebugClientLogger` logs in the output).