### PR TITLE
SWATCH-1044: Use a separate client certificate for the UMB in the ephemerals

### DIFF
--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -50,6 +50,8 @@ parameters:
     value: swatch-tally
   - name: QUARKUS_PROFILE
     value: prod
+  - name: UMB_KEYSTORE_PATH
+    value: /pinhead/keystore.jks
 
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
@@ -190,6 +192,13 @@ objects:
                     key: keystore_password
               - name: KEYSTORE_PATH
                 value: /pinhead/keystore.jks
+              - name: UMB_KEYSTORE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: tls
+                    key: keystore_password
+              - name: UMB_KEYSTORE_PATH
+                value: ${UMB_KEYSTORE_PATH}
               - name: TRUSTSTORE_PATH
                 value: /pinhead/truststore.jks
               - name: TRUSTSTORE_PASSWORD

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/UmbConfiguration.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/UmbConfiguration.java
@@ -33,10 +33,10 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Slf4j
 public class UmbConfiguration {
 
-  @ConfigProperty(name = "KEYSTORE_PATH")
+  @ConfigProperty(name = "UMB_KEYSTORE_PATH")
   Optional<String> keystorePath;
 
-  @ConfigProperty(name = "KEYSTORE_PASSWORD")
+  @ConfigProperty(name = "UMB_KEYSTORE_PASSWORD")
   Optional<String> keystorePassword;
 
   @ConfigProperty(name = "TRUSTSTORE_PATH")

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -150,21 +150,26 @@ mp.openapi.scan.exclude.packages=com.redhat.swatch.contract.openapi
 SWATCH_CONTRACT_PRODUCER_ENABLED = false
 
 UMB_ENABLED=false
+%ephemeral.UMB_ENABLED=true
 %stage.UMB_ENABLED=true
 %prod.UMB_ENABLED=true
 
 UMB_HOSTNAME=localhost
+%ephemeral.UMB_HOSTNAME=umb.stage.api.redhat.com
 %stage.UMB_HOSTNAME=umb.stage.api.redhat.com
 %prod.UMB_HOSTNAME=umb.api.redhat.com
 
 UMB_PORT=5672
+%ephemeral.UMB_PORT=5671
 %stage.UMB_PORT=5671
 %prod.UMB_PORT=5671
 
 CONTRACT_UMB_QUEUE=umb-contract
+%ephemeral.CONTRACT_UMB_QUEUE=VirtualTopic.services.partner-entitlement-gateway
 %stage.CONTRACT_UMB_QUEUE=VirtualTopic.services.partner-entitlement-gateway
 %prod.CONTRACT_UMB_QUEUE=VirtualTopic.services.partner-entitlement-gateway
 
+%ephemeral.UMB_SERVICE_ACCOUNT_NAME=nonprod-insightsrhsm-ephemeral
 %stage.UMB_SERVICE_ACCOUNT_NAME=nonprod-insightsrhsm
 %prod.UMB_SERVICE_ACCOUNT_NAME=insightsrhsm
 
@@ -180,6 +185,8 @@ mp.messaging.outgoing.contractstest.client-options-name=umb
 
 mp.messaging.incoming.contracts.connector=smallrye-in-memory
 mp.messaging.outgoing.contractstest.connector=smallrye-in-memory
+%ephemeral.mp.messaging.incoming.contracts.connector=smallrye-amqp
+%ephemeral.mp.messaging.outgoing.contractstest.connector=smallrye-in-memory
 %stage.mp.messaging.incoming.contracts.connector=smallrye-amqp
 %stage.mp.messaging.outgoing.contractstest.connector=smallrye-in-memory
 %prod.mp.messaging.incoming.contracts.connector=smallrye-amqp

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -92,6 +92,8 @@ parameters:
     value: 'false'
   - name: UMB_PROCESSING_ENABLED
     value: 'true'
+  - name: UMB_KEYSTORE_PATH
+    value: /pinhead/keystore.jks
   - name: ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC
     value: 'true'
   - name: ENABLE_SPLUNK_HEC
@@ -410,7 +412,7 @@ objects:
             - name: SPRING_ACTIVEMQ_BROKER_URL
               value: ${SPRING_ACTIVEMQ_BROKER_URL}
             - name: UMB_KEYSTORE
-              value: file:/pinhead/keystore.jks
+              value: file:${UMB_KEYSTORE_PATH}
             - name: UMB_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Jira issue: SWATCH-1044

The changes to the ephemeral environment base have already been merged, so doing a standard deployment of swatch-contracts to the ephemeral environment should be sufficient to use the new keystore and client certificate.