### PR TITLE
SWATCH-2144: Populate cloud provider instance IDs from HBI when possible

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -74,6 +74,7 @@ import lombok.Setter;
             @ColumnResult(name = "guest_id"),
             @ColumnResult(name = "subscription_manager_id"),
             @ColumnResult(name = "insights_id"),
+            @ColumnResult(name = "provider_id"),
             @ColumnResult(name = "cloud_provider"),
             @ColumnResult(name = "stale_timestamp", type = OffsetDateTime.class),
             @ColumnResult(name = "hardware_subman_id")
@@ -121,6 +122,7 @@ import lombok.Setter;
         h.system_profile_facts->>'is_marketplace' as is_marketplace,
         h.canonical_facts->>'subscription_manager_id' as subscription_manager_id,
         h.canonical_facts->>'insights_id' as insights_id,
+        h.canonical_facts->>'provider_id' as provider_id,
         rhsm_products.products,
         qpc_prods.qpc_products,
         system_profile.system_profile_product_ids,

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -55,6 +55,7 @@ public class InventoryHostFacts {
   private String guestId;
   private String subscriptionManagerId;
   private String insightsId;
+  private String providerId;
   private Set<String> qpcProducts;
   private Set<String> systemProfileProductIds;
   private String syspurposeRole;
@@ -106,6 +107,7 @@ public class InventoryHostFacts {
       String guestId,
       String subscriptionManagerId,
       String insightsId,
+      String providerId,
       String cloudProvider,
       OffsetDateTime staleTimestamp,
       String hardwareSubmanId) {
@@ -138,6 +140,7 @@ public class InventoryHostFacts {
     this.guestId = guestId;
     this.subscriptionManagerId = subscriptionManagerId;
     this.insightsId = insightsId;
+    this.providerId = providerId;
     this.billingModel = billingModel;
     this.cloudProvider = cloudProvider;
     this.staleTimestamp = staleTimestamp;

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -179,15 +179,21 @@ public class InventoryAccountUsageCollector {
 
   public static void populateHostFieldsFromHbi(
       Host host, InventoryHostFacts inventoryHostFacts, NormalizedFacts normalizedFacts) {
-    if (inventoryHostFacts.getInventoryId() != null) {
-      host.setInventoryId(inventoryHostFacts.getInventoryId().toString());
-      // We assume that the instance ID for any given HBI host record is the inventory ID; compare
-      // to an OpenShift Cluster from Prometheus data, where we use the cluster ID.
-      if (host.getInstanceId() == null) {
-        // Don't overwrite the instanceId if already set, since that would cause potential
-        // duplicates in the serviceInstances map in AccountServiceInventory.
+    // Don't overwrite the instanceId if already set, since that would cause potential
+    // duplicates in the serviceInstances map in AccountServiceInventory.
+    if (host.getInstanceId() == null) {
+      if (inventoryHostFacts.getProviderId() != null) {
+        // will use the provider ID from HBI if sets:
+        host.setInstanceId(inventoryHostFacts.getProviderId());
+      } else if (inventoryHostFacts.getInventoryId() != null) {
+        // We assume that the instance ID for any given HBI host record is the inventory ID; compare
+        // to an OpenShift Cluster from Prometheus data, where we use the cluster ID.
         host.setInstanceId(inventoryHostFacts.getInventoryId().toString());
       }
+    }
+
+    if (inventoryHostFacts.getInventoryId() != null) {
+      host.setInventoryId(inventoryHostFacts.getInventoryId().toString());
     }
 
     host.setInsightsId(inventoryHostFacts.getInsightsId());

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -179,21 +179,21 @@ public class InventoryAccountUsageCollector {
 
   public static void populateHostFieldsFromHbi(
       Host host, InventoryHostFacts inventoryHostFacts, NormalizedFacts normalizedFacts) {
-    // Don't overwrite the instanceId if already set, since that would cause potential
-    // duplicates in the serviceInstances map in AccountServiceInventory.
-    if (host.getInstanceId() == null) {
-      if (inventoryHostFacts.getProviderId() != null) {
-        // will use the provider ID from HBI if sets:
-        host.setInstanceId(inventoryHostFacts.getProviderId());
-      } else if (inventoryHostFacts.getInventoryId() != null) {
-        // We assume that the instance ID for any given HBI host record is the inventory ID; compare
-        // to an OpenShift Cluster from Prometheus data, where we use the cluster ID.
-        host.setInstanceId(inventoryHostFacts.getInventoryId().toString());
-      }
+
+    if (inventoryHostFacts.getProviderId() != null) {
+      // will use the provider ID from HBI
+      host.setInstanceId(inventoryHostFacts.getProviderId());
     }
 
     if (inventoryHostFacts.getInventoryId() != null) {
       host.setInventoryId(inventoryHostFacts.getInventoryId().toString());
+
+      // fallback logic to set the instance ID if and only if the instanceId is not set yet:
+      if (host.getInstanceId() == null) {
+        // We assume that the instance ID for any given HBI host record is the inventory ID; compare
+        // to an OpenShift Cluster from Prometheus data, where we use the cluster ID.
+        host.setInstanceId(inventoryHostFacts.getInventoryId().toString());
+      }
     }
 
     host.setInsightsId(inventoryHostFacts.getInsightsId());

--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.db.model;
 import static org.candlepin.subscriptions.tally.InventoryAccountUsageCollector.populateHostFieldsFromHbi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -219,14 +218,14 @@ class HostTest {
   }
 
   @Test
-  void testPopulateHostFieldsFromHbiShouldNotOverwriteInstanceId() {
+  void testPopulateHostFieldsFromHbiShouldOverwriteInstanceId() {
     Host host = new Host();
     host.setInstanceId(UUID.randomUUID().toString());
     InventoryHostFacts inventoryHostFacts = new InventoryHostFacts();
     inventoryHostFacts.setProviderId(UUID.randomUUID().toString());
 
     populateHostFieldsFromHbi(host, inventoryHostFacts, new NormalizedFacts());
-    assertNotEquals(inventoryHostFacts.getProviderId(), host.getInstanceId());
+    assertEquals(inventoryHostFacts.getProviderId(), host.getInstanceId());
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
@@ -21,7 +21,11 @@
 package org.candlepin.subscriptions.db.model;
 
 import static org.candlepin.subscriptions.tally.InventoryAccountUsageCollector.populateHostFieldsFromHbi;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import java.time.OffsetDateTime;
@@ -41,6 +45,7 @@ class HostTest {
 
     populateHostFieldsFromHbi(host, inventoryHostFacts, normalizedFacts);
 
+    assertNull(host.getInstanceId());
     assertNull(host.getInventoryId());
     assertNull(host.getInsightsId());
     assertNull(host.getOrgId());
@@ -201,6 +206,37 @@ class HostTest {
     HostTallyBucket actualBucket = host.getBuckets().stream().findFirst().orElseThrow();
     assertEquals(2, actualBucket.getCores());
     assertEquals(2, actualBucket.getSockets());
+  }
+
+  @Test
+  void testPopulateHostFieldsFromHbiShouldSetInstanceIdFromProviderId() {
+    Host host = new Host();
+    InventoryHostFacts inventoryHostFacts = new InventoryHostFacts();
+    inventoryHostFacts.setProviderId(UUID.randomUUID().toString());
+
+    populateHostFieldsFromHbi(host, inventoryHostFacts, new NormalizedFacts());
+    assertEquals(inventoryHostFacts.getProviderId(), host.getInstanceId());
+  }
+
+  @Test
+  void testPopulateHostFieldsFromHbiShouldNotOverwriteInstanceId() {
+    Host host = new Host();
+    host.setInstanceId(UUID.randomUUID().toString());
+    InventoryHostFacts inventoryHostFacts = new InventoryHostFacts();
+    inventoryHostFacts.setProviderId(UUID.randomUUID().toString());
+
+    populateHostFieldsFromHbi(host, inventoryHostFacts, new NormalizedFacts());
+    assertNotEquals(inventoryHostFacts.getProviderId(), host.getInstanceId());
+  }
+
+  @Test
+  void testPopulateHostFieldsFromHbiShouldUseInventoryIdWhenProviderIdIsNotSet() {
+    Host host = new Host();
+    InventoryHostFacts inventoryHostFacts = new InventoryHostFacts();
+    inventoryHostFacts.setInventoryId(UUID.randomUUID());
+
+    populateHostFieldsFromHbi(host, inventoryHostFacts, new NormalizedFacts());
+    assertEquals(inventoryHostFacts.getInventoryId().toString(), host.getInstanceId());
   }
 
   private InventoryHostFacts getInventoryHostFactsFull() {

--- a/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
+++ b/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
@@ -69,6 +69,7 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
   private static final String CLOUD_PROVIDER = "CLOUD_PROVIDER test";
   private static final String ARCH = "ARCH test";
   private static final String INSIGHTS_ID = "INSIGHTS_ID test";
+  private static final String PROVIDER_ID = "provider ID test";
   private static final Set<String> RH_PROD = Set.of("a1", "a2", "a3");
   private static final Set<String> RH_PRODUCTS_INSTALLED = Set.of("b1", "b2", "b3");
   private static final Set<Map<String, String>> INSTALLED_PRODUCTS =
@@ -116,6 +117,7 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
     assertEquals(ARCH, fact.getSystemProfileArch());
     assertTrue(fact.isMarketplace());
     assertEquals(INSIGHTS_ID, fact.getInsightsId());
+    assertEquals(PROVIDER_ID, fact.getProviderId());
     assertEquals(VIRTUAL_HOST_UUID, fact.getHardwareSubmanId());
     assertEquals(RH_PROD, fact.getProducts());
     assertEquals(RH_PRODUCTS_INSTALLED, fact.getQpcProducts());
@@ -195,7 +197,13 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
                 SYSTEM_PURPOSE_USAGE),
             "qpc",
             of("IS_RHEL", "true", "rh_products_installed", RH_PRODUCTS_INSTALLED)),
-        of("subscription_manager_id", SUBSCRIPTION_MANAGER_ID, "insights_id", INSIGHTS_ID),
+        of(
+            "subscription_manager_id",
+            SUBSCRIPTION_MANAGER_ID,
+            "insights_id",
+            INSIGHTS_ID,
+            "provider_id",
+            PROVIDER_ID),
         of(
             "infrastructure_type",
             INFRASTRUCTURE_TYPE,


### PR DESCRIPTION
Jira issue: [SWATCH-2144](https://issues.redhat.com/browse/SWATCH-2144)

## Description
Given systems in HBI from any known provider type, after tally, calling `/instances/products/RHEL for x86` should return the appropriate cloud-provider instance ID in the `data.*.instance_id` field.

Note that these changes introduce a breaking change where before the instance ID was the inventory ID and now it's the provider ID. 

## Testing
1.- podman-compose up
2.- Add host to Insight DB:

```
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) 
VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6", "provider_id": "d125f119"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "83"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123', '{}');
```

The important part of the above query is `provider_id` which id contains the value "d125f119".

3.- DEV_MODE=true ./gradlew :bootRun
4.- Run nightly Tally using command below:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" \
Origin:console.redhat.com \
x-rh-swatch-psk:placeholder
```

5.- Verification in RHSM subscription database:

```
echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w 0
-- eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19
```

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/opt-in?org_id=org123' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19'
```

```
http GET ":8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-ha" x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19
```

It should return:

```json
{
    "data": [
        {
            "category": "physical",
            "display_name": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55",
            "id": "66697626-af5c-46a1-8b4f-d39c8d97fa5a",
            "instance_id": "d125f119",
            "last_seen": "1993-03-26T00:00:00Z",
            "measurements": [
                2.0
            ],
            "number_of_guests": 0,
            "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6"
        }
    ],
    "meta": {
        "count": 1,
        "measurements": [
            "Sockets"
        ],
        "product": "rhel-for-x86-ha"
    }
}
```

Where `data.*.instance_id` must be `d125f119`.