### PR TITLE
Add debug traces for Prometheus requests/responses for swatch-metrics

### DIFF
--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/prometheus/PrometheusService.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/prometheus/PrometheusService.java
@@ -36,18 +36,18 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.ProcessingException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Wraps prometheus specific API calls to make them more application specific. */
+@Slf4j
 @ApplicationScoped
 public class PrometheusService {
-
-  private static final Logger log = LoggerFactory.getLogger(PrometheusService.class);
   private static final String JSON_PROPERTY_RESULT_TYPE = "resultType";
   private static final String JSON_PROPERTY_RESULT = "result";
   public static final String JSON_PROPERTY_STATUS = "status";
@@ -120,6 +120,14 @@ public class PrometheusService {
    */
   private QuerySummaryResult parseQueryResult(
       File data, Consumer<QueryResultDataResultInner> itemConsumer) {
+    if (log.isDebugEnabled()) {
+      try {
+        log.debug(
+            "Response from prometheus: {}", Files.readString(Path.of(data.getAbsolutePath())));
+      } catch (IOException ignored) {
+        // intentionally ignored
+      }
+    }
 
     var builder = QuerySummaryResult.builder();
     try (JsonParser parser = factory.createParser(data)) {

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -70,6 +70,11 @@ quarkus:
     category:
       "com.redhat.swatch":
         level: ${LOGGING_LEVEL_COM_REDHAT_SWATCH}
+      # Needed to troubleshoot issues with swatch metrics service became stuck:
+      "org.jboss.resteasy.reactive.client.logging.DefaultClientLogger":
+        level: DEBUG
+      "com.redhat.swatch.metrics.service.prometheus.PrometheusService":
+        level: DEBUG
     handler:
       splunk:
         enabled: ${ENABLE_SPLUNK_HEC:false}
@@ -108,6 +113,9 @@ quarkus:
       serializer-generation:
         enabled: false
   rest-client:
+    logging:
+      scope: request-response
+      body-limit: 5000
     "com.redhat.swatch.clients.prometheus.api.resources.QueryApi":
       url: ${rhsm-subscriptions.metering.prometheus.client.url}
       scope: jakarta.enterprise.context.ApplicationScoped


### PR DESCRIPTION
## Description
To find out what is causing the swatch metrics to became stuck, we need to add some debug traces with the requests and response from the Prometheus call. 

With these changes, we would see the requests:
```
2024-02-12 17:02:54,770 DEBUG [org.jbo.res.rea.cli.log.DefaultClientLogger] (vert.x-eventloop-thread-0) Request: GET http://localhost:38795/query_range?query=max%28cluster%3Ausage%3Aworkload%3Acapacity_physical_cpu_hours%29+by+%28_id%29+*+on%28_id%29+group_right+min_over_time%28ocm_subscription%7Bproduct%3D%22ocp%22%2C+external_organization%3D%22account%22%2C+billing_model%3D%22marketplace%22%2C+support%3D~%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&start=1707757200&end=1707840174&step=3600&timeout=10000 Headers[Accept=application/json User-Agent=Resteasy Reactive Client], Empty body
```

And the responses:
```
2024-02-12 17:02:54,771 DEBUG [com.red.swa.met.ser.pro.PrometheusService] (Test worker) Response from prometheus: {"status":"success","data":{"resultType":"matrix","result":[{"metric":{"external_organization":"my-test-org","billing_marketplace_account":"mktp-account","billing_marketplace":"red hat","usage":"Production","_id":"C1","support":"Premium"},"value":[],"values":[[12312.345,24]]}]},"errorType":null,"error":null}
```