### PR TITLE
SWATCH-2066: Gracefully fail when prometheus returns empty body

### DIFF
--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -160,9 +160,6 @@ mp:
             # This value needs to be synced with the retry configuration which will retry up to
             # 3 times with a max duration of 120 seconds, so the correct value would be 3 x 120 =
             ms: 360000
-        # By default, when a message is nack, the application stops consuming messages.
-        # With the "ignore" strategy, we ignore the error (it's logged internally) and continue processing messages.
-        failure-strategy: ignore
         fail-on-deserialization-failure: ${METRICS_IN_FAIL_ON_DESER_FAILURE}
         auto:
           offset:

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -70,11 +70,6 @@ quarkus:
     category:
       "com.redhat.swatch":
         level: ${LOGGING_LEVEL_COM_REDHAT_SWATCH}
-      # Needed to troubleshoot issues with swatch metrics service became stuck:
-      "org.jboss.resteasy.reactive.client.logging.DefaultClientLogger":
-        level: DEBUG
-      "com.redhat.swatch.metrics.service.prometheus.PrometheusService":
-        level: DEBUG
     handler:
       splunk:
         enabled: ${ENABLE_SPLUNK_HEC:false}
@@ -113,9 +108,6 @@ quarkus:
       serializer-generation:
         enabled: false
   rest-client:
-    logging:
-      scope: request-response
-      body-limit: 5000
     "com.redhat.swatch.clients.prometheus.api.resources.QueryApi":
       url: ${rhsm-subscriptions.metering.prometheus.client.url}
       scope: jakarta.enterprise.context.ApplicationScoped

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/resources/PrometheusQueryWiremock.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/resources/PrometheusQueryWiremock.java
@@ -106,6 +106,10 @@ public class PrometheusQueryWiremock {
             .willReturn(okJson(toJson(expectedResult))));
   }
 
+  public void stubQueryRangeWithEmptyBody() {
+    wireMockServer.stubFor(get(urlPathEqualTo(QUERY_RANGE_PATH)).willReturn(ok()));
+  }
+
   public void stubQueryRange(QueryResult expectedResult) {
     wireMockServer.stubFor(
         get(urlPathEqualTo(QUERY_RANGE_PATH)).willReturn(okJson(toJson(expectedResult))));

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.metrics.service;
 
 import static com.redhat.swatch.metrics.util.MeteringEventFactory.getEventType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +34,7 @@ import com.redhat.swatch.clients.prometheus.api.model.StatusType;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import com.redhat.swatch.metrics.configuration.MetricProperties;
+import com.redhat.swatch.metrics.exception.ExternalServiceException;
 import com.redhat.swatch.metrics.resources.InjectPrometheus;
 import com.redhat.swatch.metrics.resources.PrometheusQueryWiremock;
 import com.redhat.swatch.metrics.resources.PrometheusResource;
@@ -151,6 +153,14 @@ class PrometheusMeteringControllerTest {
 
     whenCollectMetrics("account", start, end);
     prometheusServer.verifyQueryRangeWasCalled(3);
+  }
+
+  @Test
+  void testCollectMetricsShouldRetryWhenPrometheusReturnsEmptyBody() {
+    OffsetDateTime start = OffsetDateTime.now();
+    OffsetDateTime end = start.plusDays(1);
+    prometheusServer.stubQueryRangeWithEmptyBody();
+    assertThrows(ExternalServiceException.class, () -> whenCollectMetrics(start, end));
   }
 
   @Test


### PR DESCRIPTION
Jira issue: [SWATCH-2066](https://issues.redhat.com/browse/SWATCH-2066)

## Description
Sometimes prometheus returns an empty string with HTTP OK status:

```
REQUEST:
2024-02-13 01:30:42,178 DEBUG [org.jbo.res.rea.cli.log.DefaultClientLogger] (vert.x-eventloop-thread-1) Request: GET http://localhost:8082/query_range?query=max%28cluster%3Ausage%3Aworkload%3Acapacity_physical_cpu_hours%29+by+%28_id%29+*+on%28_id%29+group_right+min_over_time%28ocm_subscription%7Bproduct%3D%22moa-hostedcontrolplane%22%2C+external_organization%3D%223949694%22%2C+billing_model%3D%22marketplace%22%2C+support%3D~%22Premium%7CStandard%7CSelf-Support%7CNone%22%7D%5B1h%5D%29&start=1707786000&end=1707786000&step=3600&timeout=10000 Headers[Accept=application/json User-Agent=Resteasy Reactive Client], Empty body

RESPONSE:
2024-02-13 01:30:42,178 DEBUG [com.red.swa.met.ser.pro.PrometheusService] (executor-thread-22) Response from prometheus: 
```

This makes our service to enter in an endless loop, so the service becames unresponsive. 

When Prometheus returns some data, everything goes correct:

```
RESPONSE:
2024-02-13 05:30:46,186 DEBUG [com.red.swa.met.ser.pro.PrometheusService] (executor-thread-20) Response from prometheus: {\"status\":\"success\",\"data\":{\"resultType\":\"matrix\",\"result\":[],\"explanation\":null}}
```

## Testing
Added test that reproduces the above issue.