### PR TITLE
SWATCH-2066: Gracefully fail when prometheus returns empty body

### DIFF
--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -157,7 +157,9 @@ mp:
         topic: ${METERING_TASK_TOPIC}
         throttled:
           unprocessed-record-max-age:
-            ms: 120000
+            # This value needs to be synced with the retry configuration which will retry up to
+            # 3 times with a max duration of 120 seconds, so the correct value would be 3 x 120 =
+            ms: 360000
         fail-on-deserialization-failure: ${METRICS_IN_FAIL_ON_DESER_FAILURE}
         auto:
           offset:

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -70,11 +70,6 @@ quarkus:
     category:
       "com.redhat.swatch":
         level: ${LOGGING_LEVEL_COM_REDHAT_SWATCH}
-      # Needed to troubleshoot issues with swatch metrics service became stuck:
-      "org.jboss.resteasy.reactive.client.logging.DefaultClientLogger":
-        level: DEBUG
-      "com.redhat.swatch.metrics.service.prometheus.PrometheusService":
-        level: DEBUG
     handler:
       splunk:
         enabled: ${ENABLE_SPLUNK_HEC:false}
@@ -113,9 +108,6 @@ quarkus:
       serializer-generation:
         enabled: false
   rest-client:
-    logging:
-      scope: request-response
-      body-limit: 5000
     "com.redhat.swatch.clients.prometheus.api.resources.QueryApi":
       url: ${rhsm-subscriptions.metering.prometheus.client.url}
       scope: jakarta.enterprise.context.ApplicationScoped

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/resources/PrometheusQueryWiremock.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/resources/PrometheusQueryWiremock.java
@@ -106,6 +106,10 @@ public class PrometheusQueryWiremock {
             .willReturn(okJson(toJson(expectedResult))));
   }
 
+  public void stubQueryRangeWithEmptyBody() {
+    wireMockServer.stubFor(get(urlPathEqualTo(QUERY_RANGE_PATH)).willReturn(ok()));
+  }
+
   public void stubQueryRange(QueryResult expectedResult) {
     wireMockServer.stubFor(
         get(urlPathEqualTo(QUERY_RANGE_PATH)).willReturn(okJson(toJson(expectedResult))));

--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.metrics.service;
 
 import static com.redhat.swatch.metrics.util.MeteringEventFactory.getEventType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +34,7 @@ import com.redhat.swatch.clients.prometheus.api.model.StatusType;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import com.redhat.swatch.metrics.configuration.MetricProperties;
+import com.redhat.swatch.metrics.exception.ExternalServiceException;
 import com.redhat.swatch.metrics.resources.InjectPrometheus;
 import com.redhat.swatch.metrics.resources.PrometheusQueryWiremock;
 import com.redhat.swatch.metrics.resources.PrometheusResource;
@@ -151,6 +153,14 @@ class PrometheusMeteringControllerTest {
 
     whenCollectMetrics("account", start, end);
     prometheusServer.verifyQueryRangeWasCalled(3);
+  }
+
+  @Test
+  void testCollectMetricsShouldRetryWhenPrometheusReturnsEmptyBody() {
+    OffsetDateTime start = OffsetDateTime.now();
+    OffsetDateTime end = start.plusDays(1);
+    prometheusServer.stubQueryRangeWithEmptyBody();
+    assertThrows(ExternalServiceException.class, () -> whenCollectMetrics(start, end));
   }
 
   @Test


### PR DESCRIPTION
Jira issue: SWATCH-2066
Cherry-pick for https://github.com/RedHatInsights/rhsm-subscriptions/pull/3063