### PR TITLE
Correct indentation error in Splunk podman-compose

### DIFF
--- a/config/splunk/docker-compose.yml
+++ b/config/splunk/docker-compose.yml
@@ -4,13 +4,13 @@ services:
   splunk:
     image: docker.io/splunk/splunk
     ports:
-      - '8088:8088'
-      - '8089' # SPLUNK API
-      - '8000' # SPLUNK CONSOLE
+      - '127.0.0.1:8088:8088'
+      - '127.0.0.1:8089:8089' # SPLUNK API
+      - '127.0.0.1:8000:8000' # SPLUNK CONSOLE
     environment:
       - SPLUNK_START_ARGS=--accept-license
       - SPLUNK_PASSWORD=admin123
       - SPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75
       # workaround rootless selinux issues, see https://github.com/splunk/splunk-ansible/issues/607
-      security_opt:
-        - label=disable
+    security_opt:
+      - label=disable


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: No issue

## Description
The Splunk podman compose wasn't working because of an indentation error.

## Testing

### Steps
<!-- Enter each step of the test below -->
1. Run the container:
    ```
    podman-compose -f config/splunk/docker-compose.yml up
    ```

### Verification
1.  Container runs successfully
