### PR TITLE
SWATCH-2201: Remove the property `account` from the hbi-host schema

### DIFF
--- a/swatch-system-conduit/schemas/inventory/hbi-host.yaml
+++ b/swatch-system-conduit/schemas/inventory/hbi-host.yaml
@@ -3,8 +3,6 @@ title: HbiHost
 properties:
   display_name:
     type: string
-  account:
-    type: string
   org_id:
     type: string
   insights_id:


### PR DESCRIPTION
Jira issue: [SWATCH-2201](https://issues.redhat.com/browse/SWATCH-2201)

## Description
This property is no longer used since we swichted over account to org_id.

## Testing
1.- podman-compose up
2.- RHSM_USE_STUB=true ./gradlew :swatch-system-conduit:bootRun
3.- add host to the inventory database:

```
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) 
VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "83"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123', '{}');
```

4.- sync the organization:
curl -X POST -H 'Content-Type:application/json' -H 'x-rh-swatch-psk:placeholder' -H 'Origin:console.redhat.com' -d '{"org_id": "org123"}' http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg

5.- now, the platform.inventory.host-ingress topic should contain the following message without the account field:

```
operation add_host
data
org_id org123
subscription_manager_id 4df5e108-8592-483d-a9c1-5a15fdcd512e
bios_uuid b74b52ed-1e2c-4994-8e16-4fb4afd96f90
ip_addresses [ 192.167.11.2, 192.168.1.1, 192.168.122.1, 10.0.0.1 ]
fqdn host1.test.com
facts [ [object Object] ]
system_profile { operating_system: [object Object], os_release: 6.3, releasever: 8.0, arch: x86_64, cores_per_socket: 2, infrastructure_type: virtual, system_memory_bytes: 33543999488, number_of_sockets: 2, number_of_cpus: 3, threads_per_core: 5, owner_id: 4df5e108-8592-483d-a9c1-5a15fdcd512e, is_marketplace: true, network_interfaces: [object Object] }
stale_timestamp 2024-02-21T15:40:10.325266652Z
reporter rhsm-conduit
provider_id 123456
provider_type aws
platform_metadata { request_id: 01265668-338d-49a9-83b2-ce3ce0bfc1b1 }
```