### PR TITLE
SWATCH-2190: Change Splunk certificate verification in dev to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ as idle.
 
 ### RabbitMQ
 
-Some services like swatch-contracts need an AMQ service to handle the UMB messages. 
+Some services like swatch-contracts need an AMQ service to handle the UMB messages.
 For these services, we can start RabbitMQ as an AMQ service locally via:
 
 ```
@@ -144,15 +144,15 @@ podman-compose -f config/rabbitmq/docker-compose.yml up -d
 
 RabbitMQ will be listening on the port 5672.
 
-*NOTE*: Our services might be configured to listen on a different hostname and port. For example, 
-for the SWATCH contracts service, we need to provide the UMB_HOSTNAME and UMB_PORT to point out to RabbitMQ: 
+*NOTE*: Our services might be configured to listen on a different hostname and port. For example,
+for the SWATCH contracts service, we need to provide the UMB_HOSTNAME and UMB_PORT to point out to RabbitMQ:
 `java -DUMB_HOSTNAME=localhost -DUMB_PORT=5672 -jar swatch-contracts/build/quarkus-app/quarkus-run.jar`
 
 ### Opentelemetry (OTEL) Exporter
 
-Some services export the logging traces to an externalize service via an exporter. 
-Exporters act like a broker to configure what to do with these traces. 
-For local development, we can start an OTEL exporter that simply log the traces into the container logs. 
+Some services export the logging traces to an externalize service via an exporter.
+Exporters act like a broker to configure what to do with these traces.
+For local development, we can start an OTEL exporter that simply log the traces into the container logs.
 We can start it via:
 
 ```
@@ -162,7 +162,7 @@ podman-compose -f config/otel/docker-compose.yml up -d
 The OTEL exporter will be listening for gRPC connections on port 4317.
 
 *NOTE*: Our services might be configured to listen on a different hostname and port. For example,
-for the SWATCH contracts service, we need to provide the OTEL_ENDPOINT property to point out to the 
+for the SWATCH contracts service, we need to provide the OTEL_ENDPOINT property to point out to the
 local otel exporter: `java -DOTEL_ENDPOINT=http://localhost:4317 -jar swatch-contracts/build/quarkus-app/quarkus-run.jar`
 
 ### Splunk
@@ -173,11 +173,30 @@ Some services integrate the log traces into Splunk. For these services, we can s
 podman-compose -f config/splunk/docker-compose.yml up -d
 ```
 
-Splunk will be listening on port 8088. 
+Splunk will be accepting events over port 8088.  The web interface is on port
+8000 and you can log in as `admin`/`admin123`.  There are several different
+environment variables you can pass to the container and the
+[documentation](https://splunk.github.io/docker-splunk/) is helpful.
 
 *NOTE*: We need to configure our services to work with this Splunk instance. For example,
-for the SWATCH contracts service, we need: 
-`java -DENABLE_SPLUNK_HEC=false -DSPLUNK_HEC_URL=https://localhost:8088 -DSPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 -DSWATCH_SELF_PSK=placeholder -DSPLUNK_DISABLE_CERTIFICATE_VALIDATION=true -jar swatch-contracts/build/quarkus-app/quarkus-run.jar`
+for the SWATCH Azure producer, we need:
+
+```
+SERVER_PORT=8001 \
+ENABLE_SPLUNK_HEC=true \
+SPLUNK_HEC_URL=https://localhost:8088 \
+SPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
+./gradlew :swatch-producer-azure:quarkusDev
+```
+
+Some of these environment variables are our own (e.g. `SPLUNK_HEC_URL`) and are
+piped into the `quarkus.log.handler.splunk` namespace which is what ultimately
+controls the Splunk HEC configuration.  By default SSL/TLS certificate
+validation is disable in the `dev` profile for the `swatch-producer-aws`,
+`swatch-producer-azure`, and `swatch-contracts` projects.  If you are seeing
+SSL/TLS error (generally something like `unable to find valid certification path
+to requested target`), then setting `QUARKUS_LOG_HANDLER_SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true`
+is the sure-fire way to disable SSL/TLS certificate validation.
 
 ### Build and Run rhsm-subscriptions
 

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -31,6 +31,8 @@ SPLUNK_HEC_INCLUDE_EX=false
 %dev.SPLUNKMETA_host=${USER}@${HOSTNAME}
 %dev.SPLUNKMETA_namespace=local
 %dev.SPLUNK_HEC_INCLUDE_EX=true
+%dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true
+
 %dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -31,6 +31,7 @@ TALLY_IN_FAIL_ON_DESER_FAILURE=true
 %dev.SPLUNKMETA_host=${USER}@${HOSTNAME}
 %dev.SPLUNKMETA_namespace=local
 %dev.SPLUNK_HEC_INCLUDE_EX=true
+%dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.AWS_CREDENTIALS_JSON=${%dev.AWS_CREDENTIALS_JSON}
@@ -98,6 +99,7 @@ com.redhat.swatch.processors.BillableUsageProcessor/send/Retry/maxRetries=${AWS_
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
+quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}
 quarkus.log.handler.splunk.metadata-source=${SPLUNK_SOURCE:swatch-producer-aws}
 quarkus.log.handler.splunk.metadata-source-type=${SPLUNK_SOURCE_TYPE:quarkus_service}

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -56,6 +56,7 @@ KSTREAM_BILLABLE_USAGE_AGGREGATION_GRACE_DURATION=600s
 %dev.SPLUNKMETA_host=${USER}@${HOSTNAME}
 %dev.SPLUNKMETA_namespace=local
 %dev.SPLUNK_HEC_INCLUDE_EX=true
+%dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 
@@ -136,6 +137,7 @@ quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
+quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}
 quarkus.log.handler.splunk.metadata-source=${SPLUNK_SOURCE:swatch-producer-aws}
 quarkus.log.handler.splunk.metadata-source-type=${SPLUNK_SOURCE_TYPE:quarkus_service}


### PR DESCRIPTION
When using Splunk in the dev profile, developers will be sending their events to a Splunk docker container that will not have a server certificate signed by a recognized certificate authority.  Instead the certificate will be self-signed.  Configuring the applications to disable certificate validation in the dev (and only in the dev) profile will be make life easier for developers while still maintaining security in non-development environments.

<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2190

## Description
Correct some of the documentation and configuration around running Splunk in a development capacity.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
1.  Start a Splunk docker container
    ```
    podman-compose -f config/splunk/docker-compose.yml up -d
    ```

### Steps
1.  Run `swatch-producer-azure` as follows:
    ```
    SERVER_PORT=8001 \
    ENABLE_SPLUNK_HEC=true \
    SPLUNK_HEC_URL=https://localhost:8088 \
    SPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
    ./gradlew :swatch-producer-azure:quarkusDev
    ```

### Verification
1.  Wait a bit (~30 seconds) since Splunk sends log messages in batches.  You should not see any TLS/SSL errors/exceptions.  The root exception to look out for is `Caused by: sun.security.provider.certpath.SunCertPathBuilderException`
1. Go to https://localhost:8000 and log in with `admin`/`admin123`.  Then search `namespace="local"` and you should see a bunch of log messages that got passed in.