### PR TITLE
SWATCH-2226 syncContractByOrgId should sync all contracts

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractMapper.java
@@ -159,7 +159,7 @@ public interface ContractMapper {
   @Mapping(target = "startDate", source = "entitlementDates.startDate")
   @Mapping(target = "endDate", source = "entitlementDates.endDate")
   @Mapping(target = "productId", ignore = true)
-  @Mapping(target = "vendorProductCode", ignore = true)
+  @Mapping(target = "vendorProductCode", source = "entitlement.purchase.vendorProductCode")
   void mapRhEntitlementsToContractEntity(
       @MappingTarget ContractEntity contractEntity, PartnerEntitlementV1 entitlement);
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
@@ -29,7 +29,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
@@ -107,7 +106,6 @@ public class ContractEntity extends PanacheEntityBase {
   @Column(name = "vendor_product_code", nullable = false)
   private String vendorProductCode;
 
-  @NotEmpty
   @NotNull
   @Builder.Default
   @OneToMany(

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
@@ -20,6 +20,7 @@
  */
 package com.redhat.swatch.contract.repository;
 
+import io.quarkus.panache.common.Parameters;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 import java.util.UUID;
@@ -39,6 +40,12 @@ public class ContractRepository implements PanacheSpecificationSupport<ContractE
 
   public List<ContractEntity> getContractsByOrgId(String orgId) {
     return find("orgId", orgId).list();
+  }
+
+  public long deleteContractsByOrgIdForEmptyValues(String orgId) {
+    return delete(
+        "orgId = :orgId and (billingProviderId is null or billingProviderId='' or endDate is null)",
+        Parameters.with("orgId", orgId));
   }
 
   public ContractEntity findContract(UUID uuid) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -100,15 +100,16 @@ public class ContractsTestingResource implements DefaultApi {
       return new StatusResponse().status("No active contract found for the orgIds");
     }
     for (ContractEntity org : contracts) {
-      syncContractsByOrg(org.getOrgId());
+      syncContractsByOrg(org.getOrgId(), true);
     }
     return new StatusResponse().status("All Contract are Synced");
   }
 
   @Override
   @RolesAllowed({"test", "support"})
-  public StatusResponse syncContractsByOrg(String orgId) throws ProcessingException {
-    return service.syncContractByOrgId(orgId, OffsetDateTime.now());
+  public StatusResponse syncContractsByOrg(String orgId, Boolean isPreCleanup)
+      throws ProcessingException {
+    return service.syncContractByOrgId(orgId, isPreCleanup);
   }
 
   @Override

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -252,6 +252,12 @@ paths:
             type: string
           in: path
           required: true
+        - name: is_pre_cleanup
+          description: "When present, then delete existing contracts based on criteria"
+          schema:
+            type: boolean
+            default: false
+          in: query
       summary: "Sync contracts for given org_id."
       responses:
         '200':

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -204,21 +204,19 @@ class ContractServiceTest extends BaseUnitTest {
   @Test
   void syncContractWithExistingAndNewContracts() {
     givenExistingContract();
-    StatusResponse statusResponse =
-        contractService.syncContractByOrgId(ORG_ID, OffsetDateTime.parse("2024-01-01T00:00Z"));
+    StatusResponse statusResponse = contractService.syncContractByOrgId(ORG_ID, false);
     assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
     // 2 instances of subscription are created, one for the original contract, and one for the
     // update
-    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
-    verify(measurementMetricIdTransformer, times(2))
+    verify(subscriptionRepository, times(4)).persist(any(SubscriptionEntity.class));
+    verify(measurementMetricIdTransformer, times(4))
         .translateContractMetricIdsToSubscriptionMetricIds(any());
   }
 
   @Test
   void syncContractWithEmptyContractsList() {
-    StatusResponse statusResponse =
-        contractService.syncContractByOrgId(ORG_ID, OffsetDateTime.parse("2024-01-01T00:00Z"));
-    assertEquals(ORG_ID + " not found in table", statusResponse.getMessage());
+    StatusResponse statusResponse = contractService.syncContractByOrgId(ORG_ID, false);
+    assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2226

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

**Note: Please only run `syncContractsByOrg` endpoint since we want to only run by org first and make sure the sync and its results are okay on prod.** 

### ${{\color{Red}\Huge{\textsf{ Don't run the syncAllContracts until QE validates this in prod.}}}}\$

- [ ] We have to cleanup old contracts because they had empty billing_provider_id hence when we sync the contract it thinks that it is a new contract. Hence we are deleting any active contracts or has empty billing provider for a given org.
- [ ] We are calling Partner gateway for a given org and updating contracts and subscription.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
It is best to directly to connect with prod and modify some of these data to test against prod. However I will be doing my best to put some wiremock based steps but, reviewer has to be innovative to test it with mocking.

### Setup test data with prod like current scenario
<!-- Add any steps required to set up the test case -->

**offering:**
`INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered) VALUES ('MW02393', 'OpenShift Online', 'OpenShift Enterprise', null, null, null, null, '', 'Premium', '', 'Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)', false, '', true);
`

**org_config:**
`INSERT INTO public.org_config (org_id, opt_in_type, created, updated) VALUES ('3949694', 'DB', '2020-04-14 20:31:41.660008 +00:00', '2023-05-22 08:30:04.560645 +00:00');`

**contracts:**
```
INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id, vendor_product_code, billing_provider_id) VALUES ('161eab92-78db-4d03-a59e-d2d87e75768a', '14060133', '2024-02-02 08:57:29.470864 +00:00', '2023-12-29 11:37:38.590479 +00:00', '2024-02-02 08:57:29.470864 +00:00', '3949694', 'MW02393', 'aws', '157884790730', 'rosa', 'bcwuzc8ww10vvxfair55m', '');
INSERT INTO public.contracts (uuid, subscription_number, last_updated, start_date, end_date, org_id, sku, billing_provider, billing_account_id, product_id, vendor_product_code, billing_provider_id) VALUES ('b9ed5af1-f381-4192-b473-35b63ad77b3e', '14060133', '2024-02-02 08:57:29.470864 +00:00', '2024-02-02 08:57:29.470864 +00:00', null, '3949694', 'MW02393', 'aws', '157884790730', 'rosa', 'bcwuzc8ww10vvxfair55m', '');

```

**contract_metrics:**
```
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('b9ed5af1-f381-4192-b473-35b63ad77b3e', 'premium_support', 1);
INSERT INTO public.contract_metrics (contract_uuid, metric_id, metric_value) VALUES ('b9ed5af1-f381-4192-b473-35b63ad77b3e', 'four_vcpu_hour', 18600);
```

**subscription:**
```
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00069', '3949694', '9504913', 1, '2019-09-13 04:00:00.000000 +00:00', '2026-12-31 05:00:00.000000 +00:00', '', '9505069', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00009F3', '3949694', '8686822', 12, '2021-01-01 05:00:00.000000 +00:00', '2023-12-31 05:00:00.000000 +00:00', '', '8686978', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00007F3', '3949694', '8686823', 45, '2021-01-01 05:00:00.000000 +00:00', '2023-12-31 05:00:00.000000 +00:00', '', '8686977', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00009F3', '3949694', '8686800', 4, '2021-01-01 05:00:00.000000 +00:00', '2023-12-31 05:00:00.000000 +00:00', '', '8686955', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW01369', '3949694', '14065661', 1, '2023-12-30 00:00:00.000000 +00:00', '2024-02-27 00:00:00.000000 +00:00', '', '14065818', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02393', '3949694', '14059976', 1, '2024-02-02 00:00:00.000000 +00:00', '2025-02-01 23:59:59.000000 +00:00', 'bcwuzc8ww10vvxfair55m;ZaTQYpfisUj;771835612317', '14060133', 'aws', '157884790730');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02393', '3949694', '14059976', 1, '2023-11-06 00:00:00.000000 +00:00', '2024-02-01 23:59:59.000000 +00:00', 'bcwuzc8ww10vvxfair55m;ZaTQYpfisUj;771835612317', '14060133', 'aws', '157884790730');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02393', '3949694', '14059976', 1, '2023-12-29 11:37:38.590479 +00:00', '2024-02-02 08:57:29.470864 +00:00', '', '14060133', 'aws', '157884790730');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MCT4022', '3949694', '13985196', 10, '2023-12-14 05:00:00.000000 +00:00', '2027-01-01 04:59:59.000000 +00:00', '', '13985353', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00009', '3949694', '13985194', 15, '2024-01-01 05:00:00.000000 +00:00', '2024-12-31 05:00:00.000000 +00:00', '', '13985351', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00009', '3949694', '13985193', 12, '2024-01-01 05:00:00.000000 +00:00', '2024-12-31 05:00:00.000000 +00:00', '', '13985350', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00007', '3949694', '13985192', 34, '2024-01-01 05:00:00.000000 +00:00', '2024-12-31 05:00:00.000000 +00:00', '', '13985349', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MCT3691F3', '3949694', '13985185', 2, '2024-01-01 05:00:00.000000 +00:00', '2026-12-31 05:00:00.000000 +00:00', '', '13985343', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00270', '3949694', '13985181', 10, '2024-01-01 05:00:00.000000 +00:00', '2024-12-31 05:00:00.000000 +00:00', '', '13985338', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02393', '3949694', '13787254', 1, '2023-11-06 05:00:00.000000 +00:00', '2024-11-06 04:59:59.000000 +00:00', 'bcwuzc8ww10vvxfair55m;G7VY9CZp6JV;771835612317', '13787411', 'aws', '918934589723');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02393', '3949694', '13787217', 1, '2023-11-06 05:00:00.000000 +00:00', '2024-11-06 04:59:59.000000 +00:00', 'bcwuzc8ww10vvxfair55m;9eZA9pRHXmm;771835612317', '13787374', 'aws', '638936737416');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW01369', '3949694', '13755903', 1, '2023-10-31 04:00:00.000000 +00:00', '2023-12-29 05:00:00.000000 +00:00', '', '13756060', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MCT3754F3', '3949694', '11601249', 216, '2022-09-13 04:00:00.000000 +00:00', '2025-09-12 04:00:00.000000 +00:00', '', '11601406', '', '');

```

subscription_product_ids:
```
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('rhel-for-x86-eus', '11601249', '2022-09-13 04:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for ARM', '11601249', '2022-09-13 04:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('OpenShift Container Platform', '11601249', '2022-09-13 04:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '8686823', '2021-01-01 05:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '8686800', '2021-01-01 05:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '8686822', '2021-01-01 05:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('rhel-for-x86-eus', '13755903', '2023-10-31 04:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('OpenShift Container Platform', '13755903', '2023-10-31 04:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for ARM', '13755903', '2023-10-31 04:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '13985192', '2024-01-01 05:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('rhel-for-x86-els-payg', '13985181', '2024-01-01 05:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '13985193', '2024-01-01 05:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '13985194', '2024-01-01 05:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for x86', '13985196', '2023-12-14 05:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('rhel-for-x86-eus', '14065661', '2023-12-30 00:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('OpenShift Container Platform', '14065661', '2023-12-30 00:00:00.000000 +00:00');
INSERT INTO public.subscription_product_ids (product_id, subscription_id, start_date) VALUES ('RHEL for ARM', '14065661', '2023-12-30 00:00:00.000000 +00:00');

```

**subscription_measurements:**
```
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('13985192', '2024-01-01 05:00:00.000000 +00:00', 'Sockets', 'HYPERVISOR', 68);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('13985181', '2024-01-01 05:00:00.000000 +00:00', 'Sockets', 'PHYSICAL', 20);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('13985193', '2024-01-01 05:00:00.000000 +00:00', 'Sockets', 'PHYSICAL', 24);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('13985194', '2024-01-01 05:00:00.000000 +00:00', 'Sockets', 'PHYSICAL', 30);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('11601249', '2022-09-13 04:00:00.000000 +00:00', 'Cores', 'PHYSICAL', 432);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('8686823', '2021-01-01 05:00:00.000000 +00:00', 'Sockets', 'HYPERVISOR', 90);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('8686800', '2021-01-01 05:00:00.000000 +00:00', 'Sockets', 'PHYSICAL', 8);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('8686822', '2021-01-01 05:00:00.000000 +00:00', 'Sockets', 'PHYSICAL', 24);
```

- Get swatch-core running:
`RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8001 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun`

- Get swatch-contracts running with pointing to prod:
```
Index: swatch-contracts/src/main/resources/application.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>ISO-8859-1
===================================================================
diff --git a/swatch-contracts/src/main/resources/application.properties b/swatch-contracts/src/main/resources/application.properties
--- a/swatch-contracts/src/main/resources/application.properties	(revision dde32b0e21b0b2ae3baadbd99ec18a742ebede24)
+++ b/swatch-contracts/src/main/resources/application.properties	(date 1708626650050)
@@ -180,7 +180,7 @@
 mp.messaging.outgoing.contractstest.connector=smallrye-in-memory
 %stage.mp.messaging.incoming.contracts.connector=smallrye-amqp
 %stage.mp.messaging.outgoing.contractstest.connector=smallrye-in-memory
-%prod.mp.messaging.incoming.contracts.connector=smallrye-amqp
+%prod.mp.messaging.incoming.contracts.connector=smallrye-in-memory
 %prod.mp.messaging.outgoing.contractstest.connector=smallrye-in-memory
 
 #This is to trace only my package and enable logging if the org exists
@@ -192,7 +192,7 @@
 %ephemeral.quarkus.otel.sdk.disabled=true
 %wiremock.quarkus.otel.sdk.disabled=true
 %stage.quarkus.otel.sdk.disabled=false
-%prod.quarkus.otel.sdk.disabled=false
+%prod.quarkus.otel.sdk.disabled=true
 
 OTEL_ENDPOINT=http://splunk-otel-collector:4317
 quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT}

```

`ENABLE_SPLUNK_HEC=false ENTITLEMENT_GATEWAY_URL=https://ibm-entitlement-gateway.api.redhat.com KEYSTORE_PASSWORD=<PWD> KEYSTORE_RESOURCE=file:/home/../rhsm-subscriptions/config/certs/bkpcerts_prod/keystore.jks QUARKUS_PROFILE=prod SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8001 SWATCH_SELF_PSK=placeholder UMB_ENABLED=false RBAC_ENABLED=false RBAC_ENDPOINT=http://localhost:8080 UMB_HOSTNAME=localhost  ./gradlew  :swatch-contracts:quarkusDev
`

### Steps and Verification
<!-- Enter each step of the test below -->

**Step 1 before running sync contract by orgid check for capacity:**
`http ':8001/api/rhsm-subscriptions/v1/subscriptions/products/rosa' uom==Cores x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"3949694"}}}' | base64 -w0)`

```
{
    "data": [
        {
            "billing_provider": "aws",
            "capacity": 0,
            "has_infinite_quantity": false,
            "hypervisor_capacity": 0,
            "next_event_date": "2024-11-06T04:59:59Z",
            "next_event_type": "Subscription End",
            "product_name": "Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)",
            "quantity": 3,
            "service_level": "Premium",
            "sku": "MW02393",
            "subscriptions": [
                {
                    "id": "13787217",
                    "number": "13787374"
                },
                {
                    "id": "13787254",
                    "number": "13787411"
                },
                {
                    "id": "14059976",
                    "number": "14060133"
                }
            ],
            "total_capacity": 0,
            "usage": ""
        }
    ],
    "meta": {
        "count": 1,
        "product": "rosa",
        "subscription_type": "On-demand",
        "uom": "cores"
    }
}
```
** ${{\color{Yellow}\Huge{\textsf{ Notice it doesn't have capacity for subscriptionnumber: 14060133}}}}\$ **

Step 1 Run the syncContractsByOrg with is_pre_cleanup flag true on this branch:
`curl -X 'POST'   'http://localhost:8000/api/swatch-contracts/internal/rpc/sync/contracts/3949694?is_pre_cleanup=true'   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'   -d ''`

 **Output Verification**:
`{"status":"SUCCESS","message":"Contracts Synced for 3949694"}`

**Logs:**
 Total contract deleted for org 3949694 during pre cleanup 2

** ${{\color{Yellow}\Huge{\textsf{ Notice table changes and capacity}}}}\$ **
- Contract table now has missed contracts
- Capacity now shows up

**contracts:**
```
uuid,subscription_number,last_updated,start_date,end_date,org_id,sku,billing_provider,billing_account_id,product_id,vendor_product_code,billing_provider_id
aa8a47bb-5c92-4d5a-aa41-e9de70d0c78f,14060133,2024-02-22 16:27:43.225667 +00:00,2024-02-02 08:59:32.714240 +00:00,2025-02-02 08:57:18.166000 +00:00,3949694,MW02393,aws,157884790730,rosa,bcwuzc8ww10vvxfair55m,bcwuzc8ww10vvxfair55m;ZaTQYpfisUj;771835612317
105b2389-a029-45e3-bc0a-dc1640d533fb,13787374,2024-02-22 16:27:43.373510 +00:00,2023-11-06 21:35:36.936064 +00:00,2024-11-06 21:33:27.224000 +00:00,3949694,MW02393,aws,638936737416,rosa,bcwuzc8ww10vvxfair55m,bcwuzc8ww10vvxfair55m;9eZA9pRHXmm;771835612317
216cef25-8658-4f34-90eb-dc5c25cf6bd7,13787411,2024-02-22 16:27:43.478937 +00:00,2023-11-06 21:51:32.946104 +00:00,2024-11-06 21:49:21.391000 +00:00,3949694,MW02393,aws,918934589723,rosa,bcwuzc8ww10vvxfair55m,bcwuzc8ww10vvxfair55m;G7VY9CZp6JV;771835612317
```

**contract_metrics:**
```
uuid,subscription_number,last_updated,start_date,end_date,org_id,sku,billing_provider,billing_account_id,product_id,vendor_product_code,billing_provider_id
aa8a47bb-5c92-4d5a-aa41-e9de70d0c78f,14060133,2024-02-22 16:27:43.225667 +00:00,2024-02-02 08:59:32.714240 +00:00,2025-02-02 08:57:18.166000 +00:00,3949694,MW02393,aws,157884790730,rosa,bcwuzc8ww10vvxfair55m,bcwuzc8ww10vvxfair55m;ZaTQYpfisUj;771835612317
105b2389-a029-45e3-bc0a-dc1640d533fb,13787374,2024-02-22 16:27:43.373510 +00:00,2023-11-06 21:35:36.936064 +00:00,2024-11-06 21:33:27.224000 +00:00,3949694,MW02393,aws,638936737416,rosa,bcwuzc8ww10vvxfair55m,bcwuzc8ww10vvxfair55m;9eZA9pRHXmm;771835612317
216cef25-8658-4f34-90eb-dc5c25cf6bd7,13787411,2024-02-22 16:27:43.478937 +00:00,2023-11-06 21:51:32.946104 +00:00,2024-11-06 21:49:21.391000 +00:00,3949694,MW02393,aws,918934589723,rosa,bcwuzc8ww10vvxfair55m,bcwuzc8ww10vvxfair55m;G7VY9CZp6JV;771835612317
```


**subscription:**
```
sku,org_id,subscription_id,quantity,start_date,end_date,billing_provider_id,subscription_number,billing_provider,billing_account_id
RH00069,3949694,9504913,1,2019-09-13 04:00:00.000000 +00:00,2026-12-31 05:00:00.000000 +00:00,"",9505069,"",""
RH00009F3,3949694,8686822,12,2021-01-01 05:00:00.000000 +00:00,2023-12-31 05:00:00.000000 +00:00,"",8686978,"",""
RH00007F3,3949694,8686823,45,2021-01-01 05:00:00.000000 +00:00,2023-12-31 05:00:00.000000 +00:00,"",8686977,"",""
RH00009F3,3949694,8686800,4,2021-01-01 05:00:00.000000 +00:00,2023-12-31 05:00:00.000000 +00:00,"",8686955,"",""
MW01369,3949694,14065661,1,2023-12-30 00:00:00.000000 +00:00,2024-02-27 00:00:00.000000 +00:00,"",14065818,"",""
MW02393,3949694,14059976,1,2024-02-02 08:59:32.714240 +00:00,2025-02-02 08:57:18.166000 +00:00,bcwuzc8ww10vvxfair55m;ZaTQYpfisUj;771835612317,14060133,aws,157884790730
MW02393,3949694,14059976,1,2024-02-02 00:00:00.000000 +00:00,2025-02-01 23:59:59.000000 +00:00,bcwuzc8ww10vvxfair55m;ZaTQYpfisUj;771835612317,14060133,aws,157884790730
MW02393,3949694,14059976,1,2023-11-06 00:00:00.000000 +00:00,2024-02-01 23:59:59.000000 +00:00,bcwuzc8ww10vvxfair55m;ZaTQYpfisUj;771835612317,14060133,aws,157884790730
MW02393,3949694,14059976,1,2023-12-29 11:37:38.590479 +00:00,2024-02-02 08:57:29.470864 +00:00,"",14060133,aws,157884790730
MCT4022,3949694,13985196,10,2023-12-14 05:00:00.000000 +00:00,2027-01-01 04:59:59.000000 +00:00,"",13985353,"",""
RH00009,3949694,13985194,15,2024-01-01 05:00:00.000000 +00:00,2024-12-31 05:00:00.000000 +00:00,"",13985351,"",""
RH00009,3949694,13985193,12,2024-01-01 05:00:00.000000 +00:00,2024-12-31 05:00:00.000000 +00:00,"",13985350,"",""
RH00007,3949694,13985192,34,2024-01-01 05:00:00.000000 +00:00,2024-12-31 05:00:00.000000 +00:00,"",13985349,"",""
MCT3691F3,3949694,13985185,2,2024-01-01 05:00:00.000000 +00:00,2026-12-31 05:00:00.000000 +00:00,"",13985343,"",""
RH00270,3949694,13985181,10,2024-01-01 05:00:00.000000 +00:00,2024-12-31 05:00:00.000000 +00:00,"",13985338,"",""
MW02393,3949694,13787254,1,2023-11-06 05:00:00.000000 +00:00,2024-11-06 04:59:59.000000 +00:00,bcwuzc8ww10vvxfair55m;G7VY9CZp6JV;771835612317,13787411,aws,918934589723
MW02393,3949694,13787254,1,2023-11-06 21:51:32.946104 +00:00,2024-11-06 21:49:21.391000 +00:00,bcwuzc8ww10vvxfair55m;G7VY9CZp6JV;771835612317,13787411,aws,918934589723
MW02393,3949694,13787217,1,2023-11-06 21:35:36.936064 +00:00,2024-11-06 21:33:27.224000 +00:00,bcwuzc8ww10vvxfair55m;9eZA9pRHXmm;771835612317,13787374,aws,638936737416
MW02393,3949694,13787217,1,2023-11-06 05:00:00.000000 +00:00,2024-11-06 04:59:59.000000 +00:00,bcwuzc8ww10vvxfair55m;9eZA9pRHXmm;771835612317,13787374,aws,638936737416
MW01369,3949694,13755903,1,2023-10-31 04:00:00.000000 +00:00,2023-12-29 05:00:00.000000 +00:00,"",13756060,"",""
MCT3754F3,3949694,11601249,216,2022-09-13 04:00:00.000000 +00:00,2025-09-12 04:00:00.000000 +00:00,"",11601406,"",""
```


**subscription_measurements:**
```
subscription_id,start_date,metric_id,measurement_type,value
13985192,2024-01-01 05:00:00.000000 +00:00,Sockets,HYPERVISOR,68
13985181,2024-01-01 05:00:00.000000 +00:00,Sockets,PHYSICAL,20
13985193,2024-01-01 05:00:00.000000 +00:00,Sockets,PHYSICAL,24
13985194,2024-01-01 05:00:00.000000 +00:00,Sockets,PHYSICAL,30
11601249,2022-09-13 04:00:00.000000 +00:00,Cores,PHYSICAL,432
8686823,2021-01-01 05:00:00.000000 +00:00,Sockets,HYPERVISOR,90
8686800,2021-01-01 05:00:00.000000 +00:00,Sockets,PHYSICAL,8
8686822,2021-01-01 05:00:00.000000 +00:00,Sockets,PHYSICAL,24
14059976,2024-02-02 08:59:32.714240 +00:00,Cores,PHYSICAL,74400
```

**subscription_product_ids:**
```
product_id,subscription_id,start_date
rhel-for-x86-eus,11601249,2022-09-13 04:00:00.000000 +00:00
RHEL for ARM,11601249,2022-09-13 04:00:00.000000 +00:00
OpenShift Container Platform,11601249,2022-09-13 04:00:00.000000 +00:00
RHEL for x86,8686823,2021-01-01 05:00:00.000000 +00:00
RHEL for x86,8686800,2021-01-01 05:00:00.000000 +00:00
RHEL for x86,8686822,2021-01-01 05:00:00.000000 +00:00
rhel-for-x86-eus,13755903,2023-10-31 04:00:00.000000 +00:00
OpenShift Container Platform,13755903,2023-10-31 04:00:00.000000 +00:00
RHEL for ARM,13755903,2023-10-31 04:00:00.000000 +00:00
RHEL for x86,13985192,2024-01-01 05:00:00.000000 +00:00
rhel-for-x86-els-payg,13985181,2024-01-01 05:00:00.000000 +00:00
RHEL for x86,13985193,2024-01-01 05:00:00.000000 +00:00
RHEL for x86,13985194,2024-01-01 05:00:00.000000 +00:00
RHEL for x86,13985196,2023-12-14 05:00:00.000000 +00:00
rhel-for-x86-eus,14065661,2023-12-30 00:00:00.000000 +00:00
OpenShift Container Platform,14065661,2023-12-30 00:00:00.000000 +00:00
RHEL for ARM,14065661,2023-12-30 00:00:00.000000 +00:00
rosa,14059976,2024-02-02 08:59:32.714240 +00:00
rosa,13787217,2023-11-06 21:35:36.936064 +00:00
rosa,13787254,2023-11-06 21:51:32.946104 +00:00
```

Capacity api:
`http ':8001/api/rhsm-subscriptions/v1/subscriptions/products/rosa' uom==Cores x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"3949694"}}}' | base64 -w0)`

```
{
    "data": [
        {
            "billing_provider": "aws",
            "capacity": 74400,
            "has_infinite_quantity": false,
            "hypervisor_capacity": 0,
            "next_event_date": "2025-02-02T08:57:18.166Z",
            "next_event_type": "Subscription End",
            "product_name": "Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)",
            "quantity": 1,
            "service_level": "Premium",
            "sku": "MW02393",
            "subscriptions": [
                {
                    "id": "14059976",
                    "number": "14060133"
                }
            ],
            "total_capacity": 74400,
            "uom": "cores",
            "usage": ""
        }
    ],
    "meta": {
        "count": 1,
        "product": "rosa",
        "subscription_type": "On-demand",
        "uom": "cores"
    }
}

```
I want QE to validate this with subscription sync and see if the capacity is still showing correctly. One thing I notice is capacity doesn't pull the subscription_id='13787254' and '13787217'. This is the same issue on main branch and is not related to this PR. This is because when a contract is created after subscription it has different start date.

The above is not a bug since it will show up when you do:
`http ':8001/api/rhsm-subscriptions/v1/subscriptions/products/rosa'  x-rh-identity:$(echo '{"identity":{"type":"User","internal":{"org_id":"3949694"}}}' | base64 -w0)`
