### PR TITLE
SWATCH-2063: Remove json-path dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,7 @@ RHSM_RBAC_USE_STUB=true ./gradlew bootRun
 * `RHSM_RBAC_USE_STUB`: stub out the rbac service
 * `RHSM_RBAC_APPLICATION_NAME`: name of the RBAC permission application name (`<APP_NAME>:*:*`),
   by default this property is set to 'subscriptions'.
-* `RHSM_RBAC_HOST`: RBAC service hostname
-* `RHSM_RBAC_PORT`: RBAC service port
+* `RHSM_RBAC_URL`: RBAC service url
 * `RHSM_RBAC_MAX_CONNECTIONS`: max concurrent connections to RBAC service
 * `SWATCH_*_PSK`: pre-shared keys for internal service-to-service authentication
   where the `*` represents the name of an authorized service
@@ -344,9 +343,8 @@ For example,
 }}
 ```
 
-Becomes `clowder.kafka.brokers[0].hostname`.  These properties are then passed into the Spring
-Environment and may be used elsewhere (the `ClowderJsonEnvironmentPostProcessor` runs *before*
-most other environment processing classes).
+These properties are then passed into the Spring Environment and may be used elsewhere (the 
+`ClowderJsonEnvironmentPostProcessor` runs *before* most other environment processing classes).
 
 The pattern we follow is to assign the Clowder style properties to an **intermediate** property
 that follows Spring Boot's environment variable
@@ -360,7 +358,7 @@ not resolve to anything.
 An example of an intermediate property would be
 
 ```
-KAFKA_BOOTSTRAP_HOST=${clowder.kafka.brokers[0].hostname:localhost}
+KAFKA_BOOTSTRAP_HOST=${clowder.kafka.brokers:localhost}
 ```
 
 This pattern has the useful property of allowing us to override any Clowder settings (in

--- a/src/main/resources/application-api.yaml
+++ b/src/main/resources/application-api.yaml
@@ -1,14 +1,13 @@
 # See https://goessner.net/articles/JsonPath/ for JSON Path syntax
 
-RHSM_RBAC_HOST: ${clowder.endpoints[?(@.app == 'rbac')].hostname:localhost}
-RHSM_RBAC_PORT: ${clowder.endpoints[?(@.app == 'rbac')].port:8819}
+RHSM_RBAC_URL: ${clowder.endpoints.rbac-service.url:http://localhost:8819}
 
 rhsm-subscriptions:
   pretty-print-json: ${PRETTY_PRINT_JSON:false}
   rbac-service:
     application-name: ${RHSM_RBAC_APPLICATION_NAME:subscriptions}
     use-stub: ${RHSM_RBAC_USE_STUB:false}
-    url: ${clowder.endpoints.rbac-service.url:http://localhost:8819}/api/rbac/v1
+    url: ${RHSM_RBAC_URL}/api/rbac/v1
     truststore: ${clowder.endpoints.rbac-service.trust-store-path}
     truststore-password: ${clowder.endpoints.rbac-service.trust-store-password}
     truststore-type: ${clowder.endpoints.rbac-service.trust-store-type}

--- a/src/main/resources/application-capacity-ingress.yaml
+++ b/src/main/resources/application-capacity-ingress.yaml
@@ -1,8 +1,8 @@
-OFFERING_SYNC_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.offering-sync')].name:platform.rhsm-subscriptions.offering-sync}
-SUBSCRIPTION_SYNC_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.subscription-sync')].name:platform.rhsm-subscriptions.subscription-sync}
-SUBSCRIPTION_PRUNE_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.subscription-prune')].name:platform.rhsm-subscriptions.subscription-prune}
-CAPACITY_RECONCILE_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.capacity-reconcile')].name:platform.rhsm-subscriptions.capacity-reconcile}
-SUBSCRIPTION_EXPORT_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.export.requests')].name:platform.export.requests}
+OFFERING_SYNC_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.offering-sync".name:platform.rhsm-subscriptions.offering-sync}
+SUBSCRIPTION_SYNC_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.subscription-sync".name:platform.rhsm-subscriptions.subscription-sync}
+SUBSCRIPTION_PRUNE_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.subscription-prune".name:platform.rhsm-subscriptions.subscription-prune}
+CAPACITY_RECONCILE_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.capacity-reconcile".name:platform.rhsm-subscriptions.capacity-reconcile}
+SUBSCRIPTION_EXPORT_TOPIC: ${clowder.kafka.topics."platform.export.requests".name:platform.export.requests}
 
 
 rhsm-subscriptions:

--- a/src/main/resources/application-rh-marketplace.yaml
+++ b/src/main/resources/application-rh-marketplace.yaml
@@ -1,5 +1,5 @@
-BILLABLE_USAGE_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.billable-usage')].name:platform.rhsm-subscriptions.billable-usage}
-TALLY_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.tally')].name:platform.rhsm-subscriptions.tally}
+BILLABLE_USAGE_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.billable-usage".name:platform.rhsm-subscriptions.billable-usage}
+TALLY_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.tally".name:platform.rhsm-subscriptions.tally}
 
 rhsm-subscriptions:
   rh-marketplace:

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -1,9 +1,9 @@
-TASKS_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.tasks')].name:platform.rhsm-subscriptions.tasks}
-TALLY_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.tally')].name:platform.rhsm-subscriptions.tally}
-BILLABLE_USAGE_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.billable-usage')].name:platform.rhsm-subscriptions.billable-usage}
-BILLABLE_USAGE_DEAD_LETTER_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.billable-usage.dlt')].name:platform.rhsm-subscriptions.billable-usage.dlt}
-SERVICE_INSTANCE_INGRESS_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.service-instance-ingress')].name:platform.rhsm-subscriptions.service-instance-ingress}
-SERVICE_INSTANCE_INGRESS_DEAD_LETTER_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.service-instance-ingress.dlt')].name:platform.rhsm-subscriptions.service-instance-ingress.dlt}
+TASKS_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.tasks".name:platform.rhsm-subscriptions.tasks}
+TALLY_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.tally".name:platform.rhsm-subscriptions.tally}
+BILLABLE_USAGE_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.billable-usage".name:platform.rhsm-subscriptions.billable-usage}
+BILLABLE_USAGE_DEAD_LETTER_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.billable-usage.dlt".name:platform.rhsm-subscriptions.billable-usage.dlt}
+SERVICE_INSTANCE_INGRESS_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.service-instance-ingress".name:platform.rhsm-subscriptions.service-instance-ingress}
+SERVICE_INSTANCE_INGRESS_DEAD_LETTER_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.service-instance-ingress.dlt".name:platform.rhsm-subscriptions.service-instance-ingress.dlt}
 
 rhsm-subscriptions:
   hourlyTallyDurationLimitDays: 90d

--- a/swatch-core/build.gradle
+++ b/swatch-core/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind" // for use of objectmapper in EventRecord
     implementation "org.springframework.kafka:spring-kafka"
     implementation "io.micrometer:micrometer-core"
-    implementation "com.jayway.jsonpath:json-path"
     implementation libraries["splunk-library-javalogging"]
     implementation libraries["janino"]
     implementation (libraries["resteasy-spring-boot-starter"]) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJson.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJson.java
@@ -20,30 +20,65 @@
  */
 package org.candlepin.subscriptions.clowder;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 /** Class to represent the clowder JSON for the ClowderJsonPathPropertySource */
 public class ClowderJson {
   public static final String EMPTY_JSON = "{}";
 
+  private final ObjectMapper objectMapper;
   private final JsonNode root;
 
   public ClowderJson() throws IOException {
-    InputStream s = new ByteArrayInputStream(EMPTY_JSON.getBytes(StandardCharsets.UTF_8));
-    ObjectMapper mapper = new ObjectMapper();
-    this.root = mapper.readTree(s);
+    this(new ByteArrayInputStream(EMPTY_JSON.getBytes(StandardCharsets.UTF_8)), new ObjectMapper());
   }
 
   public ClowderJson(InputStream s, ObjectMapper mapper) throws IOException {
+    this.objectMapper = mapper;
     this.root = mapper.readTree(s);
   }
 
-  public JsonNode getRoot() {
-    return root;
+  public String getNodeAsString(String property) {
+    return Optional.ofNullable(getNode(property)).map(JsonNode::asText).orElse(null);
+  }
+
+  public List<Map<String, Object>> getNodeAsListOfMaps(String property) {
+    JsonNode value = getNode(property);
+    if (value == null) {
+      return List.of();
+    }
+
+    List<Map<String, Object>> list = new ArrayList<>();
+    if (value.isArray()) {
+      for (var child : value) {
+        list.add(convertNodeToMap(child));
+      }
+    }
+    return list;
+  }
+
+  public JsonNode getNode(String property) {
+    JsonNode node = root;
+    for (String name : property.split(Pattern.quote("."))) {
+      if (node != null) {
+        node = node.get(name);
+      }
+    }
+    return node;
+  }
+
+  private Map<String, Object> convertNodeToMap(JsonNode o) {
+    return objectMapper.convertValue(o, new TypeReference<Map<String, Object>>() {});
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonPathPropertySource.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonPathPropertySource.java
@@ -20,26 +20,15 @@
  */
 package org.candlepin.subscriptions.clowder;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.PathNotFoundException;
-import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
@@ -65,8 +54,9 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
     implements OriginLookup<String> {
 
   public static final String PROPERTY_SOURCE_NAME = "Clowder JSON";
-  public static final String PREFIX = "clowder.";
+  public static final String CLOWDER = "clowder.";
   private static final String KAFKA_BROKERS = "kafka.brokers";
+  private static final String KAFKA_TOPICS = "kafka.topics";
   private static final String ENDPOINTS = "endpoints";
   private static final String PRIVATE_ENDPOINTS = "privateEndpoints";
   private static final Integer PORT_NOT_SET = 0;
@@ -91,6 +81,10 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
           ".cacert", ClowderJsonPathPropertySource::kafkaBrokerToCaCert,
           ".cacert.type", ClowderJsonPathPropertySource::kafkaBrokerToCaCertType);
 
+  /** Custom rules to configure the Kafka topics using clowder file. */
+  private static final Map<String, KafkaTopicConfigMapper> KAFKA_TOPICS_PROPERTIES =
+      Map.of(".name", ClowderJsonPathPropertySource::kafkaTopicToName);
+
   /** Custom rules to configure rest-clients using clowder file. */
   private static final Map<String, EndpointConfigMapper> ENDPOINTS_PROPERTIES =
       Map.of(
@@ -98,6 +92,17 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
           ".trust-store-path", ClowderJsonPathPropertySource::endpointToTrustStorePath,
           ".trust-store-password", ClowderJsonPathPropertySource::endpointToTrustStorePassword,
           ".trust-store-type", ClowderJsonPathPropertySource::endpointToTrustStoreType);
+
+  private final Map<String, Function<String, Object>> handledPropertyStrategies =
+      Map.of(
+          KAFKA_BROKERS,
+          this::getKafkaBrokerProperty,
+          KAFKA_TOPICS,
+          this::getKafkaTopicProperty,
+          ENDPOINTS,
+          this::getEndpointProperty,
+          PRIVATE_ENDPOINTS,
+          this::getEndpointProperty);
 
   private static final String SERVLET_ENVIRONMENT_CLASS =
       "org.springframework.web.context.support.StandardServletEnvironment";
@@ -108,20 +113,6 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
               StandardServletEnvironment.JNDI_PROPERTY_SOURCE_NAME,
               StandardServletEnvironment.SERVLET_CONTEXT_PROPERTY_SOURCE_NAME,
               StandardServletEnvironment.SERVLET_CONFIG_PROPERTY_SOURCE_NAME));
-
-  /* This initialization does tie our hands a bit. We can't inject an ObjectMapper of our
-   * choosing for example.  The JSONPath documentation states that Configuration changes during
-   * runtime are discouraged (although that comment is directed specifically to the change of the
-   * default Configuration).  I'm going to leave the Configuration as a static final for now but
-   * in the future, it may be necessary to create a Configuration in the constructor with the
-   * mappingProvider using an ObjectMapper we inject into the constructor.
-   */
-  public static final Configuration JSON_NODE_CONFIGURATION =
-      Configuration.builder()
-          .mappingProvider(new JacksonMappingProvider())
-          .jsonProvider(new JacksonJsonNodeJsonProvider())
-          .options(Option.ALWAYS_RETURN_LIST)
-          .build();
 
   private ClowderTrustStoreConfiguration trustStoreConfiguration;
 
@@ -135,30 +126,23 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
 
   @Override
   public Object getProperty(String name) {
-    if (!name.startsWith(PREFIX)) {
+    if (!name.startsWith(CLOWDER)) {
       return null;
     }
 
-    // handling for special properties like kafka brokers
-    if (name.contains(KAFKA_BROKERS)) {
-      String brokerConfig = name.substring(PREFIX.length() + KAFKA_BROKERS.length());
-      // special logic to provide a comma-separated list of kafka brokers
-      // value is expected to be a list of key-value collection with the broker configuration.
-      KafkaBrokerConfigMapper configFunction = KAFKA_BROKERS_PROPERTIES.get(brokerConfig);
-      if (configFunction != null) {
-        return getKafkaBrokerConfig(name, configFunction);
-      }
-    }
-    // handling for rest-clients for public or ports and determine the type
-    if (name.contains(ENDPOINTS) || name.contains(PRIVATE_ENDPOINTS)) {
-      for (Map.Entry<String, EndpointConfigMapper> entry : ENDPOINTS_PROPERTIES.entrySet()) {
-        if (name.endsWith(entry.getKey())) {
-          return determineEndpointConfig(name, entry.getValue());
-        }
+    for (var strategy : handledPropertyStrategies.entrySet()) {
+      if (name.contains(strategy.getKey())) {
+        return strategy.getValue().apply(name);
       }
     }
 
-    return getJsonPathValue(name.substring(PREFIX.length()));
+    // fallback strategy, resolve `database.name` as it is.
+    var value = source.getNode(name.replace(CLOWDER, ""));
+    if (value != null) {
+      return value.asText();
+    }
+
+    return null;
   }
 
   private Object determineEndpointConfig(String name, EndpointConfigMapper value) {
@@ -193,83 +177,6 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
     return ClowderTrustStoreConfiguration.CLOWDER_ENDPOINT_STORE_TYPE;
   }
 
-  protected Object getJsonPathValue(String path) {
-    JsonNode root = source.getRoot();
-
-    ArrayNode result;
-    try {
-      result = JsonPath.using(JSON_NODE_CONFIGURATION).parse(root).read(path);
-    } catch (PathNotFoundException e) {
-      /* Spring resolves properties in a recursive fashion.  For example, "${my.prop:defaultVal}"
-       * is first resolved as "my.prop:defaultVal" and if that doesn't resolve, Spring splits on the
-       * colon and then attempts to resolve "my.prop" and only then if "my.prop" isn't found does
-       * it return the default.  If the JSON Path isn't found, we need to return null so that
-       * Spring will continue the resolution process.
-       */
-      return null;
-    }
-
-    /* JSON Path expressions with a filter (like phoneNumbers[?(@.type=='home')]) are called
-     * indefinite since they can return zero or more results.  Indefinite results are always
-     * returned in a list while definite results (e.g. name) are scalars.  We turn on the
-     * Option.ALWAYS_RETURN_LIST option so that we get a consistent return type.
-     *
-     * If the list only has 1 element, it's either a definite result or an indefinite
-     * result with a size of 1, and we're going to want the sole element from the list, so we
-     * just unwrap it here.
-     */
-    if (result.size() == 1) {
-      return cast(result.get(0));
-    }
-
-    if (result.isEmpty()) {
-      return null;
-    }
-
-    return cast(result);
-  }
-
-  @SuppressWarnings("java:S3776")
-  protected Object cast(JsonNode node) {
-    if (node.isNull()) {
-      return null;
-    } else if (node.isBoolean()) {
-      return node.asBoolean();
-    } else if (node.isTextual()) {
-      return node.asText();
-    } else if (node.isFloatingPointNumber()) {
-      if (node.isBigDecimal()) {
-        return node.decimalValue();
-      } else {
-        return node.asDouble();
-      }
-    } else if (node.isIntegralNumber()) {
-      if (node.isBigInteger()) {
-        return node.bigIntegerValue();
-      } else if (node.canConvertToInt()) {
-        return node.asInt();
-      } else {
-        return node.asLong();
-      }
-    } else if (node.isArray()) {
-      List<Object> l = new ArrayList<>();
-      for (JsonNode listNode : node) {
-        l.add(cast(listNode));
-      }
-      return l;
-    } else if (node.isObject()) {
-      Map<Object, Object> m = new LinkedHashMap<>();
-
-      for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
-        String key = it.next();
-        Object value = cast(node.get(key));
-        m.put(key, value);
-      }
-      return m;
-    }
-    throw new IllegalStateException("Unknown JsonNode type: " + node);
-  }
-
   @Override
   public Origin getOrigin(String key) {
     return new PropertySourceOrigin(this, PROPERTY_SOURCE_NAME);
@@ -289,6 +196,40 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
     } else {
       sources.addFirst(this);
     }
+  }
+
+  private Object getKafkaBrokerProperty(String name) {
+    String brokerConfig = name.substring(CLOWDER.length() + KAFKA_BROKERS.length());
+    // special logic to provide a comma-separated list of kafka brokers
+    // value is expected to be a list of key-value collection with the broker configuration.
+    KafkaBrokerConfigMapper configFunction = KAFKA_BROKERS_PROPERTIES.get(brokerConfig);
+    if (configFunction != null) {
+      return getKafkaBrokerConfig(configFunction);
+    }
+
+    return null;
+  }
+
+  private Object getKafkaTopicProperty(String name) {
+    if (name.contains(KAFKA_TOPICS)) {
+      for (Map.Entry<String, KafkaTopicConfigMapper> entry : KAFKA_TOPICS_PROPERTIES.entrySet()) {
+        if (name.endsWith(entry.getKey())) {
+          return getKafkaTopicConfig(name, entry.getValue());
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private Object getEndpointProperty(String name) {
+    for (Map.Entry<String, EndpointConfigMapper> entry : ENDPOINTS_PROPERTIES.entrySet()) {
+      if (name.endsWith(entry.getKey())) {
+        return determineEndpointConfig(name, entry.getValue());
+      }
+    }
+
+    return null;
   }
 
   public static Object kafkaBrokerToBootstrapServer(List<Map<String, Object>> brokerConfig) {
@@ -363,8 +304,12 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
     return null;
   }
 
+  public static Object kafkaTopicToName(Map<String, Object> topicConfig) {
+    return topicConfig.get("name");
+  }
+
   private void initializeTrustStoreConfiguration() {
-    Object tlsCAPath = getJsonPathValue("tlsCAPath");
+    Object tlsCAPath = source.getNodeAsString("tlsCAPath");
     if (tlsCAPath instanceof String tlsCAPathAsString && !tlsCAPathAsString.isBlank()) {
       trustStoreConfiguration = new ClowderTrustStoreConfiguration(tlsCAPathAsString);
     } else {
@@ -501,74 +446,62 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
     return StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME;
   }
 
-  @SuppressWarnings("unchecked")
-  private Object getKafkaBrokerConfig(String name, KafkaBrokerConfigMapper configFunction) {
-    Object value = getJsonPathValue(KAFKA_BROKERS);
+  private Object getKafkaBrokerConfig(KafkaBrokerConfigMapper configFunction) {
+    var brokers = source.getNodeAsListOfMaps(KAFKA_BROKERS);
     // NOTE: because we configure kafka in shared configuration, kafka config is included in
     // services that don't use kafka. Clowder doesn't populate kafka config for those services, so
     // we won't have a value to contribute.
-    if (value == null) {
+    if (brokers.isEmpty()) {
       return null;
     }
-    if (value instanceof Collection<?> list) {
-      if (list.isEmpty()) {
-        return null;
-      }
-      List<Map<String, Object>> brokers = list.stream().map(o -> (Map<String, Object>) o).toList();
-      return configFunction.apply(brokers);
-    } else {
-      throw new IllegalStateException(
-          "Unknown type found in clowder configuration for Kafka Broker property: " + name);
-    }
+    return configFunction.apply(brokers);
   }
 
   private Object getEndpointConfig(String name, EndpointConfigMapper configFunction) {
-    Object value = getJsonPathValue(ENDPOINTS);
-    if (value instanceof Collection<?> list) {
-      if (list.isEmpty()) {
-        return null;
-      }
-
-      String endpoint = extractEndpointName(name);
-      Map<String, Object> found =
-          list.stream()
-              .map(o -> (Map<String, Object>) o)
-              .filter(c -> endpoint.equals(getEndpointName(c)))
-              .findFirst()
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "Could not find the endpoint configuration for property: " + name));
-      return configFunction.apply(this, found);
-    } else {
-      throw new IllegalStateException(
-          "Unknown type found in clowder configuration for endpoint property: " + name);
+    var endpoints = source.getNodeAsListOfMaps(ENDPOINTS);
+    if (endpoints.isEmpty()) {
+      return null;
     }
+    String endpoint = extractName(name, ENDPOINTS);
+    Map<String, Object> found =
+        endpoints.stream()
+            .filter(c -> endpoint.equals(getEndpointName(c)))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Could not find the endpoint configuration for property: " + name));
+    return configFunction.apply(this, found);
   }
 
   private Object getPrivateEndpointConfig(String name, EndpointConfigMapper configFunction) {
-    Object value = getJsonPathValue(PRIVATE_ENDPOINTS);
-    if (value instanceof Collection<?> list) {
-      if (list.isEmpty()) {
-        return null;
-      }
-
-      String endpoint = extractPrivateEndpointName(name);
-      Map<String, Object> found =
-          list.stream()
-              .map(o -> (Map<String, Object>) o)
-              .filter(c -> endpoint.equals(getEndpointName(c)))
-              .findFirst()
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "Could not find the private endpoint configuration for property: "
-                              + name));
-      return configFunction.apply(this, found);
-    } else {
-      throw new IllegalStateException(
-          "Unknown type found in clowder configuration for private endpoint property: " + name);
+    var endpoints = source.getNodeAsListOfMaps(PRIVATE_ENDPOINTS);
+    if (endpoints.isEmpty()) {
+      return null;
     }
+    String endpoint = extractName(name, PRIVATE_ENDPOINTS);
+    Map<String, Object> found =
+        endpoints.stream()
+            .filter(c -> endpoint.equals(getEndpointName(c)))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Could not find the private endpoint configuration for property: " + name));
+    return configFunction.apply(this, found);
+  }
+
+  private Object getKafkaTopicConfig(String name, KafkaTopicConfigMapper configFunction) {
+    var topics = source.getNodeAsListOfMaps(KAFKA_TOPICS);
+    if (topics.isEmpty()) {
+      return null;
+    }
+    String topic = extractName(name, KAFKA_TOPICS);
+    return topics.stream()
+        .filter(c -> topic.equals(c.get("requestedName")))
+        .findFirst()
+        .map(configFunction)
+        .orElse(null);
   }
 
   @SuppressWarnings("unchecked")
@@ -597,14 +530,13 @@ public class ClowderJsonPathPropertySource extends PropertySource<ClowderJson>
   @FunctionalInterface
   private interface KafkaBrokerConfigMapper extends Function<List<Map<String, Object>>, Object> {}
 
-  private String extractEndpointName(String name) {
-    String part = name.substring(PREFIX.length() + ENDPOINTS.length() + 1);
-    return part.substring(0, part.indexOf("."));
-  }
+  @FunctionalInterface
+  private interface KafkaTopicConfigMapper extends Function<Map<String, Object>, Object> {}
 
-  private String extractPrivateEndpointName(String name) {
-    String part = name.substring(PREFIX.length() + PRIVATE_ENDPOINTS.length() + 1);
-    return part.substring(0, part.indexOf("."));
+  private String extractName(String property, String prefix) {
+    String part = property.substring(CLOWDER.length() + prefix.length() + 1);
+    String name = part.substring(0, part.lastIndexOf("."));
+    return name.replaceAll(Pattern.quote("\""), "");
   }
 
   private static String getEndpointName(Map<String, Object> endpointConfig) {

--- a/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/ClowderJsonEnvironmentPostProcessorTest.java
+++ b/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/ClowderJsonEnvironmentPostProcessorTest.java
@@ -48,8 +48,6 @@ class ClowderJsonEnvironmentPostProcessorTest {
     addClowderJson();
 
     postProcessor.postProcessEnvironment(environment, null);
-    assertEquals(
-        "env-rhsm-kafka.rhsm.svc", environment.getProperty("clowder.kafka.brokers[0].hostname"));
     assertEquals("swatch-tally-db", environment.getProperty("clowder.database.name"));
   }
 

--- a/swatch-core/src/test/resources/test-clowder-config.json
+++ b/swatch-core/src/test/resources/test-clowder-config.json
@@ -17,12 +17,6 @@
             "port": 8000
         },
         {
-            "app": "rbac",
-            "hostname": "rbac-service.rhsm.svc",
-            "name": "service",
-            "port": 8000
-        },
-        {
             "app": "index",
             "hostname": "index.rhsm.svc",
             "name": "service",

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -115,8 +115,7 @@ quarkus:
       url: ${rhsm-subscriptions.metering.prometheus.client.url}
       scope: jakarta.enterprise.context.ApplicationScoped
 
-# Clowder quarkus config takes care of setting these, no need to try to do clowder.kafka.brokers[0]
-# Common kafka settings
+# Clowder quarkus config takes care of setting the common kafka settings
 kafka:
   bootstrap:
     servers: localhost:9092

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -57,9 +57,7 @@ quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
 
-#clowder quarkus config takes care of setting these, no need to try to do clowder.kafka.brokers[0]
-
-# Common kafka settings
+#clowder quarkus config takes care of setting the common kafka settings
 kafka.bootstrap.servers=localhost:9092
 
 # Kafka security configuration.  These properties must be present so that

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -78,9 +78,7 @@ quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
 
-#clowder quarkus config takes care of setting these, no need to try to do clowder.kafka.brokers[0]
-
-# Common kafka settings
+#clowder quarkus config takes care of setting the common kafka settings
 kafka.bootstrap.servers=localhost:9092
 
 # Kafka security configuration.  These properties must be present so that

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
-CONDUIT_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-conduit.tasks')].name:platform.rhsm-conduit.tasks}
-INVENTORY_HOST_INGRESS_TOPIC: ${clowder.kafka.topics[?(@.requestedName == 'platform.inventory.host-ingress')].name:platform.inventory.host-ingress}
+CONDUIT_TOPIC: ${clowder.kafka.topics."platform.rhsm-conduit.tasks".name:platform.rhsm-conduit.tasks}
+INVENTORY_HOST_INGRESS_TOPIC: ${clowder.kafka.topics."platform.inventory.host-ingress".name:platform.inventory.host-ingress}
 
 spring:
   config:


### PR DESCRIPTION
Jira issue: SWATCH-2063

## Description
- Uses directly the JsonNode from jackson.
- Replace `${clowder.endpoints[?(@.app == 'rbac')].hostname` to `${clowder.endpoints.rbac-service.url}`
- Replace `${clowder.kafka.topics[?(@.requestedName == 'platform.rhsm-subscriptions.offering-sync')].name}` to `${clowder.kafka.topics."platform.rhsm-subscriptions.offering-sync".name}`

## Testing
Regression testing only. 