### PR TITLE
SWATCH-2195: Do not wait for hourly tally operation to finish when synchronous_request is true

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -41,7 +41,9 @@ import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.queue.TaskConsumer;
 import org.candlepin.subscriptions.task.queue.TaskConsumerConfiguration;
-import org.candlepin.subscriptions.task.queue.TaskConsumerFactory;
+import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskProcessor;
+import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskQueueConsumerFactory;
+import org.candlepin.subscriptions.task.queue.kafka.KafkaTaskConsumerFactory;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
@@ -144,10 +146,19 @@ public class TallyWorkerConfiguration {
   }
 
   @Bean
-  @Qualifier("tallyTaskConsumer")
+  @Profile("kafka-queue")
   public TaskConsumer tallyTaskProcessor(
       @Qualifier("tallyTaskQueueProperties") TaskQueueProperties taskQueueProperties,
-      TaskConsumerFactory<? extends TaskConsumer> taskConsumerFactory,
+      KafkaTaskConsumerFactory taskConsumerFactory,
+      TallyTaskFactory taskFactory) {
+
+    return taskConsumerFactory.createTaskConsumer(taskFactory, taskQueueProperties);
+  }
+
+  @Bean
+  public ExecutorTaskProcessor syncTaskProcessorForTallyTaskProcessor(
+      @Qualifier("tallyTaskQueueProperties") TaskQueueProperties taskQueueProperties,
+      ExecutorTaskQueueConsumerFactory taskConsumerFactory,
       TallyTaskFactory taskFactory) {
 
     return taskConsumerFactory.createTaskConsumer(taskFactory, taskQueueProperties);

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -35,7 +35,6 @@ import org.candlepin.subscriptions.retention.RemittanceRetentionController;
 import org.candlepin.subscriptions.retention.TallyRetentionController;
 import org.candlepin.subscriptions.security.SecurityProperties;
 import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
-import org.candlepin.subscriptions.tally.TallySnapshotController;
 import org.candlepin.subscriptions.tally.admin.api.InternalApi;
 import org.candlepin.subscriptions.tally.admin.api.model.DefaultResponse;
 import org.candlepin.subscriptions.tally.admin.api.model.EventsResponse;
@@ -66,7 +65,6 @@ public class InternalTallyResource implements InternalApi {
   private final ApplicationClock clock;
   private final ApplicationProperties applicationProperties;
   private final MarketplaceResendTallyController resendTallyController;
-  private final TallySnapshotController tallySnapshotController;
   private final CaptureSnapshotsTaskManager snapshotsTaskManager;
   private final TallyRetentionController tallyRetentionController;
   private final RemittanceRetentionController remittanceRetentionController;
@@ -80,7 +78,6 @@ public class InternalTallyResource implements InternalApi {
       ApplicationClock clock,
       ApplicationProperties applicationProperties,
       MarketplaceResendTallyController resendTallyController,
-      TallySnapshotController tallySnapshotController,
       CaptureSnapshotsTaskManager snapshotsTaskManager,
       TallyRetentionController tallyRetentionController,
       RemittanceRetentionController remittanceRetentionController,
@@ -91,7 +88,6 @@ public class InternalTallyResource implements InternalApi {
     this.clock = clock;
     this.applicationProperties = applicationProperties;
     this.resendTallyController = resendTallyController;
-    this.tallySnapshotController = tallySnapshotController;
     this.snapshotsTaskManager = snapshotsTaskManager;
     this.tallyRetentionController = tallyRetentionController;
     this.remittanceRetentionController = remittanceRetentionController;
@@ -112,15 +108,12 @@ public class InternalTallyResource implements InternalApi {
               range.getStartString(), range.getEndString()));
     }
 
-    if (ResourceUtils.sanitizeBoolean(xRhSwatchSynchronousRequest, false)) {
-      if (!applicationProperties.isEnableSynchronousOperations()) {
-        throw new BadRequestException("Synchronous tally operations are not enabled.");
-      }
-      log.info("Synchronous hourly tally requested for orgId {}: {}", orgId, range);
-      tallySnapshotController.produceHourlySnapshotsForOrg(orgId, range);
-    } else {
-      snapshotsTaskManager.tallyOrgByHourly(orgId, range);
+    boolean sync = ResourceUtils.sanitizeBoolean(xRhSwatchSynchronousRequest, false);
+    if (sync && !applicationProperties.isEnableSynchronousOperations()) {
+      throw new BadRequestException("Synchronous tally operations are not enabled.");
     }
+
+    snapshotsTaskManager.tallyOrgByHourly(orgId, range, sync);
   }
 
   @Override

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -99,7 +99,10 @@ public class InternalTallyResource implements InternalApi {
 
   @Override
   public void performHourlyTallyForOrg(
-      String orgId, OffsetDateTime start, OffsetDateTime end, Boolean xRhSwatchSynchronousRequest) {
+      String orgId,
+      OffsetDateTime start,
+      OffsetDateTime end,
+      Boolean xRhSwatchUseThreadPoolExecutor) {
     DateRange range = new DateRange(start, end);
     if (!clock.isHourlyRange(start, end)) {
       throw new IllegalArgumentException(
@@ -108,12 +111,8 @@ public class InternalTallyResource implements InternalApi {
               range.getStartString(), range.getEndString()));
     }
 
-    boolean sync = ResourceUtils.sanitizeBoolean(xRhSwatchSynchronousRequest, false);
-    if (sync && !applicationProperties.isEnableSynchronousOperations()) {
-      throw new BadRequestException("Synchronous tally operations are not enabled.");
-    }
-
-    snapshotsTaskManager.tallyOrgByHourly(orgId, range, sync);
+    snapshotsTaskManager.tallyOrgByHourly(
+        orgId, range, ResourceUtils.sanitizeBoolean(xRhSwatchUseThreadPoolExecutor, false));
   }
 
   @Override

--- a/src/main/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManager.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/job/CaptureSnapshotsTaskManager.java
@@ -35,6 +35,7 @@ import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.TaskType;
 import org.candlepin.subscriptions.task.queue.TaskProducerConfiguration;
 import org.candlepin.subscriptions.task.queue.TaskQueue;
+import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskQueue;
 import org.candlepin.subscriptions.util.DateRange;
 import org.candlepin.subscriptions.util.LogUtils;
 import org.slf4j.Logger;
@@ -58,8 +59,8 @@ public class CaptureSnapshotsTaskManager {
   private final ApplicationProperties appProperties;
   private final TaskQueueProperties taskQueueProperties;
   private final TaskQueue queue;
+  private final ExecutorTaskQueue syncQueue;
   private final ApplicationClock applicationClock;
-
   private final OrgConfigRepository orgRepo;
 
   @Autowired
@@ -67,12 +68,14 @@ public class CaptureSnapshotsTaskManager {
       ApplicationProperties appProperties,
       @Qualifier("tallyTaskQueueProperties") TaskQueueProperties tallyTaskQueueProperties,
       TaskQueue queue,
+      ExecutorTaskQueue syncQueue,
       ApplicationClock applicationClock,
       OrgConfigRepository orgRepo) {
 
     this.appProperties = appProperties;
     this.taskQueueProperties = tallyTaskQueueProperties;
     this.queue = queue;
+    this.syncQueue = syncQueue;
     this.applicationClock = applicationClock;
     this.orgRepo = orgRepo;
   }
@@ -121,7 +124,7 @@ public class CaptureSnapshotsTaskManager {
     }
   }
 
-  public void tallyOrgByHourly(String orgId, DateRange tallyRange) {
+  public void tallyOrgByHourly(String orgId, DateRange tallyRange, boolean sync) {
     LogUtils.addOrgIdToMdc(orgId);
     if (!applicationClock.isHourlyRange(tallyRange.getStartDate(), tallyRange.getEndDate())) {
       log.error(
@@ -140,13 +143,20 @@ public class CaptureSnapshotsTaskManager {
         tallyRange.getStartString(),
         tallyRange.getEndString());
 
-    queue.enqueue(
+    var task =
         TaskDescriptor.builder(
                 TaskType.UPDATE_HOURLY_SNAPSHOTS, taskQueueProperties.getTopic(), orgId)
             .setSingleValuedArg("orgId", orgId)
             .setSingleValuedArg("startDateTime", tallyRange.getStartString())
             .setSingleValuedArg("endDateTime", tallyRange.getEndString())
-            .build());
+            .build();
+    if (sync) {
+      log.info("Synchronous hourly tally requested for orgId {}: {}", orgId, tallyRange);
+      syncQueue.enqueue(task);
+    } else {
+      queue.enqueue(task);
+    }
+
     LogUtils.clearOrgIdFromMdc();
   }
 
@@ -178,7 +188,7 @@ public class CaptureSnapshotsTaskManager {
 
       orgStream.forEach(
           orgId -> {
-            tallyOrgByHourly(orgId, new DateRange(startDateTime, endDateTime));
+            tallyOrgByHourly(orgId, new DateRange(startDateTime, endDateTime), false);
             count.addAndGet(1);
           });
 

--- a/src/main/spec/internal-tally-api-spec.yaml
+++ b/src/main/spec/internal-tally-api-spec.yaml
@@ -89,13 +89,13 @@ paths:
             type: string
             format: date-time
             description: "The end date for the tally (e.g. 22-05-03T10:00:00Z). Must be specified along with the start parameter."
-        - name: x-rh-swatch-synchronous-request
+        - name: x-rh-swatch-use-thread-pool-executor
           in: header
           required: false
           schema:
             type: boolean
             default: "false"
-            description: "When present, a synchronous request is made."
+            description: "When present, the request is processed asynchronously using the thread-pool executor instead of using the Kafka executor."
       responses:
         '200':
           description: "The hourly tally operation succeeded for the specified orgId."

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.tally.admin;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
@@ -35,7 +34,6 @@ import org.candlepin.subscriptions.retention.RemittanceRetentionController;
 import org.candlepin.subscriptions.retention.TallyRetentionController;
 import org.candlepin.subscriptions.security.SecurityProperties;
 import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
-import org.candlepin.subscriptions.tally.TallySnapshotController;
 import org.candlepin.subscriptions.tally.events.EventRecordsRetentionProperties;
 import org.candlepin.subscriptions.tally.job.CaptureSnapshotsTaskManager;
 import org.candlepin.subscriptions.test.TestClockConfiguration;
@@ -52,7 +50,6 @@ class InternalTallyResourceTest {
   private static final String ORG_ID = "org1";
 
   @Mock private MarketplaceResendTallyController resendTallyController;
-  @Mock private TallySnapshotController snapshotController;
   @Mock private CaptureSnapshotsTaskManager snapshotTaskManager;
   @Mock private TallyRetentionController tallyRetentionController;
   @Mock private RemittanceRetentionController remittanceRetentionController;
@@ -74,7 +71,6 @@ class InternalTallyResourceTest {
             clock,
             appProps,
             resendTallyController,
-            snapshotController,
             snapshotTaskManager,
             tallyRetentionController,
             remittanceRetentionController,
@@ -130,8 +126,7 @@ class InternalTallyResourceTest {
     OffsetDateTime start = clock.startOfCurrentHour();
     OffsetDateTime end = start.plusHours(1L);
     resource.performHourlyTallyForOrg(ORG_ID, start, end, true);
-    verify(snapshotController).produceHourlySnapshotsForOrg(ORG_ID, new DateRange(start, end));
-    verifyNoInteractions(snapshotTaskManager);
+    verify(snapshotTaskManager).tallyOrgByHourly("org1", new DateRange(start, end), true);
   }
 
   @Test
@@ -140,8 +135,7 @@ class InternalTallyResourceTest {
     OffsetDateTime start = clock.startOfCurrentHour();
     OffsetDateTime end = start.plusHours(1L);
     resource.performHourlyTallyForOrg("org1", start, end, false);
-    verify(snapshotTaskManager).tallyOrgByHourly("org1", new DateRange(start, end));
-    verifyNoInteractions(snapshotController);
+    verify(snapshotTaskManager).tallyOrgByHourly("org1", new DateRange(start, end), false);
   }
 
   @Test
@@ -149,8 +143,7 @@ class InternalTallyResourceTest {
     OffsetDateTime start = clock.startOfCurrentHour();
     OffsetDateTime end = start.plusHours(1L);
     resource.performHourlyTallyForOrg(ORG_ID, start, end, false);
-    verify(snapshotTaskManager).tallyOrgByHourly(ORG_ID, new DateRange(start, end));
-    verifyNoInteractions(snapshotController);
+    verify(snapshotTaskManager).tallyOrgByHourly(ORG_ID, new DateRange(start, end), false);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -104,20 +104,7 @@ class InternalTallyResourceTest {
         "Start/End times must be at the top of the hour: [2019-05-24T12:00:00Z -> 2019-05-24T12:05:00Z]",
         iae2.getMessage());
 
-    // Avoid additional exception by enabling synchronous operations.
-    appProps.setEnableSynchronousOperations(true);
     resource.performHourlyTallyForOrg(ORG_ID, start, clock.startOfHour(end.plusHours(1)), true);
-  }
-
-  @Test
-  void preventSynchronousHourlyTallyForOrgWhenSynchronousOperationsDisabled() {
-    OffsetDateTime start = clock.startOfCurrentHour();
-    OffsetDateTime end = start.plusHours(1L);
-    BadRequestException e =
-        assertThrows(
-            BadRequestException.class,
-            () -> resource.performHourlyTallyForOrg(ORG_ID, start, end, true));
-    assertEquals("Synchronous tally operations are not enabled.", e.getMessage());
   }
 
   @Test

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/TaskConsumerConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/TaskConsumerConfiguration.java
@@ -51,7 +51,6 @@ public class TaskConsumerConfiguration {
   }
 
   @Bean
-  @Profile("!kafka-queue")
   ExecutorTaskQueueConsumerFactory inMemoryTaskConsumerFactory(ExecutorTaskQueue queue) {
     return new ExecutorTaskQueueConsumerFactory(queue);
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/inmemory/ExecutorTaskQueueConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/inmemory/ExecutorTaskQueueConfiguration.java
@@ -25,15 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
-/**
- * Configuration that is common to both producers and consumers for in-memory task queues.
- *
- * <p>Only activated as a fallback (in case Kafka is disabled).
- */
+/** Configuration that is common to both producers and consumers for in-memory task queues. */
 @Configuration
-@Profile("!kafka-queue")
 public class ExecutorTaskQueueConfiguration {
   private static final Logger log = LoggerFactory.getLogger(ExecutorTaskQueueConfiguration.class);
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -69,6 +70,7 @@ public class KafkaTaskProducerConfiguration {
   }
 
   @Bean
+  @Primary
   public TaskQueue kafkaTaskQueue(KafkaTemplate<String, JsonTaskMessage> producer) {
     return new KafkaTaskQueue(producer);
   }


### PR DESCRIPTION
Jira issue: [SWATCH-2195](https://issues.redhat.com/browse/SWATCH-2195)

## Description
Currently when we are trying to run hourly tally operation on large orgs with synchronous_request: true, we are seeing 504 Server Error: Gateway Time-out for url. We just need a way to skip queues and not to wait for response till operation finish to avoid 504 gateway timeouts.

The idea is to reuse the executor task queue that was in place along with the kafka task queue.  Before these changes, only one task queue was started (when using the kafka-queue profile, it was reading tasks from the topic). After these changes, the in memory task queue will always be started and will be used when running the hourly tally operation when the header "x-rh-swatch-use-thread-pool-executor:true" is provided.

## Testing
1. podman-compose up
2. start the service by enabling synchronous requests:
```
DEV_MODE=true ./gradlew :bootRun
```
3. Run hourly tally with the header "x-rh-swatch-use-thread-pool-executor:true":
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=16805042&start=2023-12-15T06%3A00%3A00Z&end=2023-12-15T10%3A00%3A00Z" x-rh-swatch-psk:placeholder Origin:console.redhat.com x-rh-swatch-use-thread-pool-executor:true
```
The request should have been processed and the kafka queue should be empty: http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.tasks/

4. Run again the hourly tally with the header "x-rh-swatch-use-thread-pool-executor:false":
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=16805042&start=2023-12-15T06%3A00%3A00Z&end=2023-12-15T10%3A00%3A00Z" x-rh-swatch-psk:placeholder Origin:console.redhat.com x-rh-swatch-use-thread-pool-executor:false
```

Now, the request should go through Kafka and you should see a message in the topic: http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.tasks/