### PR TITLE
Print logs after bad requests in Quarkus services

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -128,6 +128,7 @@ quarkus.http.access-log.pattern=combined
 quarkus.log.category."io.quarkus.http.access-log".handlers=ACCESS_LOG
 # Don't send access log messages to the root handler
 quarkus.log.category."io.quarkus.http.access-log".use-parent-handlers=false
+quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG
 
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".url=${ENTITLEMENT_GATEWAY_URL:http://localhost:8101}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".key-store=${KEYSTORE_RESOURCE:}

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -68,6 +68,8 @@ quarkus:
     category:
       "com.redhat.swatch":
         level: ${LOGGING_LEVEL_COM_REDHAT_SWATCH}
+      "org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext":
+        level: DEBUG
     handler:
       splunk:
         enabled: ${ENABLE_SPLUNK_HEC:false}

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -48,6 +48,7 @@ TALLY_IN_FAIL_ON_DESER_FAILURE=true
 %dev.quarkus.log.console.json=false
 quarkus.log.level=${LOGGING_LEVEL_ROOT}
 quarkus.log.category."com.redhat.swatch".level=${LOGGING_LEVEL_COM_REDHAT_SWATCH}
+quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG
 
 quarkus.http.port=${SERVER_PORT}
 # make quarkus choose a dynamic port for testing to avoid port collisions w/ simultaneous tests

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -69,6 +69,7 @@ KSTREAM_BILLABLE_USAGE_AGGREGATION_GRACE_DURATION=600s
 # do not use JSON logs in dev mode
 quarkus.log.level=${LOGGING_LEVEL_ROOT}
 quarkus.log.category."com.redhat.swatch".level=${LOGGING_LEVEL_COM_REDHAT_SWATCH}
+quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG
 
 quarkus.http.port=${SERVER_PORT}
 # make quarkus choose a dynamic port for testing to avoid port collisions w/ simultaneous tests


### PR DESCRIPTION
By default, Quarkus does not print any traces when the service rejects a bad request. With this change, we'll print a trace when a request is rejected and the reason.

## Testing

1. podman-compose up
2. ./gradlew liquibaseUpdate
3. start the contract service:

```
./gradlew :swatch-contracts:quarkusDev
```

4. send an invalid request:

```
curl -v -X POST -H "Content-Type: application/json" -H "Origin: https://cloud.redhat.com" -H "x-rh-swatch-psk: placeholder" --data "{\"subscription_number\": \"895871\", \"sku\": \"MW02393\", \"start_date\": \"2024-03-05T12:27:51Z\", \"org_id\": 123456, \"billing_provider\": \"aws\", \"billing_account_id\": \"nikhil\", \"product_id\": \"rosa\", \"vendor_product_code\": \"03c87bf4-5f9e-49b1-b107-1283270e78af\", \"metrics\": false}" http://localhost:8000/api/swatch-contracts/internal/contracts
```

This is `\"metrics\": false` what makes the request invalid. 

And next, you should see what happened by reading the service logs:

```
2024-03-05 14:38:39,677 DEBUG [org.jbo.res.rea.ser.han.RequestDeserializeHandler] (executor-thread-1) {sampled=true, spanId=2f30221477b692fb, traceId=0da488aeb2cbce24e56d13a094fcff93, user=urn:console.redhat.com:service:swatch} Error occurred during deserialization of input: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.util.ArrayList<com.redhat.swatch.contract.openapi.model.Metric>` from Boolean value (token `JsonToken.VALUE_FALSE`)
 at [Source: (org.jboss.resteasy.reactive.server.vertx.VertxInputStream); line: 1, column: 264] (through reference chain: com.redhat.swatch.contract.openapi.model.Contract["metrics"])
        at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
        at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1752)
```