### PR TITLE
SWATCH-1896: exclude RHEL rhel ELS/HA/RS from OpenShift and Satellite

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -34,34 +34,47 @@ public class StubSearchApi extends SearchApi {
   public static final String END_DATE = "2031-01-01T01:02:33Z";
 
   @Override
-  public Subscription getSubscriptionById(String id) throws ApiException {
+  public Subscription getSubscriptionById(String id) {
     if ("789".equals(id)) {
       return createAwsBillingProviderData();
+    } else if ("790".equals(id)) {
+      return createDataForOrgId(790);
     }
-    return createData();
+    return createDefaultData();
   }
 
   @Override
-  public List<Subscription> getSubscriptionBySubscriptionNumber(String subscriptionNumber)
-      throws ApiException {
+  public List<Subscription> getSubscriptionBySubscriptionNumber(String subscriptionNumber) {
     return List.of(createAwsBillingProviderData());
   }
 
   @Override
   public List<Subscription> searchSubscriptionsByOrgId(
-      String orgId, Integer index, Integer pageSize) throws ApiException {
-    return List.of(createData(), createAwsBillingProviderData(), createRhelData());
+      String orgId, Integer index, Integer pageSize) {
+    return List.of(
+        createDefaultData(),
+        createAwsBillingProviderData(),
+        createRhelData(),
+        createDataForOrgId(790));
   }
 
-  private Subscription createData() {
+  private Subscription createDefaultData() {
+    return createData(123, "MW01485");
+  }
+
+  private Subscription createDataForOrgId(int orgId) {
+    return createData(orgId, "SKU00" + orgId);
+  }
+
+  private Subscription createData(int orgId, String sku) {
     return new Subscription()
-        .id(235251)
-        .subscriptionNumber("2253591")
-        .webCustomerId(123)
+        .id(orgId)
+        .subscriptionNumber("" + orgId)
+        .webCustomerId(orgId)
         .quantity(1)
         .effectiveStartDate(OffsetDateTime.parse(START_DATE).toEpochSecond() * 1000L)
         .effectiveEndDate(OffsetDateTime.parse(END_DATE).toEpochSecond() * 1000L)
-        .subscriptionProducts(List.of(new SubscriptionProduct().sku("MW01485")));
+        .subscriptionProducts(List.of(new SubscriptionProduct().sku(sku)));
   }
 
   private Subscription createRhelData() {

--- a/src/main/resources/product-stub-data/engprods-SKU00790.json
+++ b/src/main/resources/product-stub-data/engprods-SKU00790.json
@@ -1,0 +1,17 @@
+{
+  "entries": [
+    {
+      "sku": "SKU00790",
+      "engProducts": {
+        "engProducts": [
+          {
+            "oid": 290
+          },
+          {
+            "oid": 70
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/resources/product-stub-data/tree-SKU00790_attrs-true.json
+++ b/src/main/resources/product-stub-data/tree-SKU00790_attrs-true.json
@@ -1,0 +1,28 @@
+{
+  "products": [
+    {
+      "sku": "SKU00790",
+      "description": "Red Hat OpenShift Container Platform, Premium (1 vCPU, Monthly, On-Demand, Billing)",
+      "status": "ACTIVE",
+      "attributes": [
+        {
+          "code": "PRODUCT_FAMILY",
+          "value": "OpenShift Enterprise"
+        },
+        {
+          "code": "SOCKET_LIMIT",
+          "value": "Unlimited"
+        },
+        {
+          "code": "SERVICE_TYPE",
+          "value": "Standard"
+        },
+        {
+          "code": "PRODUCT_NAME",
+          "value": "Red Hat OpenShift Container Platform, Premium (1 vCPU, Monthly, On-Demand, Billing)"
+        }
+      ],
+      "roles": []
+    }
+  ]
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -522,6 +522,21 @@ class FactNormalizerTest {
     assertClassification(facts, true, true, false);
   }
 
+  @Test
+  void testShouldPruneProductsThatAreExcludedInConfiguration() {
+    // Where 290 is "OpenShift Container Platform", then we should remove:
+    // - 72 because is "RHEL for IBM z" and is in the includedSubscriptions configuration of
+    // OpenShift Container Platform.
+    // - 90 because is "rhel-for-x86-rs" and same as above
+    // 250 is "Satellite Server" that is not excluded, so it should not be pruned.
+    InventoryHostFacts host = createRhsmHost(List.of(290, 72, 90, 250), null, clock.now());
+    NormalizedFacts normalized = normalizer.normalize(host, hypervisorData());
+    assertThat(
+        "Products after normalization: " + normalized.getProducts(),
+        normalized.getProducts(),
+        Matchers.contains("OpenShift Container Platform", "Satellite Server"));
+  }
+
   static Stream<Arguments> syspurposeUnitsArgs() {
     return Stream.of(
         arguments("Sockets", 2, 0), arguments("Cores/vCPU", 0, 4), arguments("Foobar", 2, 4));

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -176,6 +176,12 @@ public class SubscriptionDefinition {
         .collect(Collectors.toUnmodifiableSet());
   }
 
+  public static Set<String> getAllProductTagsByProductId(String id) {
+    return SubscriptionDefinition.findById(id)
+        .map(s -> s.getVariants().stream().map(Variant::getTag).collect(Collectors.toSet()))
+        .orElse(Set.of());
+  }
+
   public static Set<String> getAllProductTagsWithPaygEligibleByRoleOrEngIds(
       String role, Collection<?> engIds, String productName) {
     Set<String> productTags = new HashSet<>();

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift_Container_Platform.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/OpenShift_Container_Platform.yaml
@@ -7,6 +7,9 @@ includedSubscriptions:
   - rhel-for-x86
   - rhel-for-ibm-z
   - rhel-for-ibm-power
+  - rhel-for-x86-eus
+  - rhel-for-x86-ha
+  - rhel-for-x86-rs
 
 variants:
   - tag: OpenShift Container Platform

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/Satellite_Capsule.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/Satellite_Capsule.yaml
@@ -5,6 +5,9 @@ id: satellite-capsule
 
 includedSubscriptions:
   - rhel-for-x86
+  - rhel-for-x86-eus
+  - rhel-for-x86-ha
+  - rhel-for-x86-rs
 
 variants:
   - tag: Satellite Capsule

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/Satellite_Server.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/Satellite_Server.yaml
@@ -5,6 +5,9 @@ id: satellite-server
 
 includedSubscriptions:
   - rhel-for-x86
+  - rhel-for-x86-eus
+  - rhel-for-x86-ha
+  - rhel-for-x86-rs
 
 variants:
   - tag: Satellite Server


### PR DESCRIPTION
JIRA ticket: [SWATCH-1896](https://issues.redhat.com/browse/SWATCH-1896)

With new RHEL add-ons configs, We need to update includedSubscriptions from OpenShift Container Platform  and Satellite products to include new rhel ELS/HA/RS add-ons.

## Testing notes

I've added a test case that covers these changes. The test case and functionality must be reviewed.

Steps for manual testing (the automatic test case mimics the below steps):

1.- podman-compose up
2.- start service using stubs:

```
PRODUCT_USE_STUB=true SUBSCRIPTION_USE_STUB=true DEV_MODE=true ./gradlew :bootRun
```

Note that as part of these changes, I've added a stub that includes an orgId 790 with two products: 290 (openshift-container-platform) and 70 (rhel-for-x86-eus).

3.- Synchronize the org ID:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/790" \
Origin:console.redhat.com \
x-rh-swatch-psk:placeholder
```

4.- Verification in RHSM subscription database:

```
select product_id from subscription_product_ids where subscription_id='790'
```

It should return:

```
OpenShift Container Platform
```

Before these changes, it was returning:

```
OpenShift Container Platform
rhel-for-x86-eus
```