### PR TITLE
SWATCH-2214 Switch from RateLimiter to BulkLimiter when calling RSHM API

### DIFF
--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -44,6 +44,14 @@ public class StubRhsmApi extends RhsmApi {
       String xRhsmApiAccountID, Integer limit, String offset, String lastCheckinAfter)
       throws ApiException {
 
+    if (xRhsmApiAccountID.equals("slowOrg123")) {
+      try {
+        Thread.sleep(5000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
     OrgInventory inventory = new OrgInventory();
 
     Consumer consumer1 = new Consumer();

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -98,11 +98,9 @@ parameters:
     value: '3'
   - name: HOST_LAST_SYNC_THRESHOLD
     value: '30h'
-  - name: RHSM_API_LIMIT_FOR_PERIOD
-    value: '150'
-  - name: RHSM_API_LIMIT_REFRESH_PERIOD
-    value: 100ms
-  - name: RHSM_API_LIMIT_TIMEOUT_DURATION
+  - name: RHSM_API_MAX_CONCURRENT_CALLS
+    value: '5'
+  - name: RHSM_API_MAX_WAIT_DURATION
     value: 30m
   - name: OTEL_SERVICE_NAME
     value: swatch-system-conduit
@@ -285,12 +283,10 @@ objects:
                 secretKeyRef:
                   name: swatch-psks
                   key: self
-            - name: RHSM_API_LIMIT_FOR_PERIOD
-              value: ${RHSM_API_LIMIT_FOR_PERIOD}
-            - name: RHSM_API_LIMIT_REFRESH_PERIOD
-              value: ${RHSM_API_LIMIT_REFRESH_PERIOD}
-            - name: RHSM_API_LIMIT_TIMEOUT_DURATION
-              value: ${RHSM_API_LIMIT_TIMEOUT_DURATION}
+            - name: RHSM_API_MAX_CONCURRENT_CALLS
+              value: ${RHSM_API_MAX_CONCURRENT_CALLS}
+            - name: RHSM_API_MAX_WAIT_DURATION
+              value: ${RHSM_API_MAX_WAIT_DURATION}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
             - name: OTEL_SERVICE_NAME

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -6,12 +6,11 @@ spring:
     import: classpath:swatch-core/application.yaml  # load the common configuration
   profiles:
     active: kafka-queue
-resilience4j.ratelimiter:
+resilience4j.bulkhead:
   instances:
     rhsmApi:
-      limitForPeriod: ${RHSM_API_LIMIT_FOR_PERIOD:15}
-      limitRefreshPeriod: ${RHSM_API_LIMIT_REFRESH_PERIOD:100ms}
-      timeoutDuration: ${RHSM_API_LIMIT_TIMEOUT_DURATION:30m}
+      maxConcurrentCalls: ${RHSM_API_MAX_CONCURRENT_CALLS:5}
+      maxWaitDuration: ${RHSM_API_MAX_WAIT_DURATION:30m}
 rhsm-conduit:
   rhsm:
     use-stub: ${RHSM_USE_STUB:false}

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/rhsm/RhsmServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/rhsm/RhsmServiceTest.java
@@ -24,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-import io.github.resilience4j.ratelimiter.RateLimiterConfig;
-import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import jakarta.validation.ConstraintViolationException;
 import java.util.Collections;
 import org.candlepin.subscriptions.conduit.inventory.InventoryServiceProperties;
@@ -73,8 +73,8 @@ class RhsmServiceTest {
     when(rhsmApi.getConsumersForOrg(
             anyString(), any(Integer.class), nullable(String.class), anyString()))
         .thenThrow(ApiException.class);
-    var rateLimiterConfig = RateLimiterConfig.custom().limitForPeriod(Integer.MAX_VALUE).build();
-    var rateLimiterRegistry = RateLimiterRegistry.of(rateLimiterConfig);
+    var bulkheadConfig = BulkheadConfig.custom().maxConcurrentCalls(Integer.MAX_VALUE).build();
+    var bulkheadRegistry = BulkheadRegistry.of(bulkheadConfig);
 
     // Make the tests run faster!
     retryTemplate.setBackOffPolicy(new NoBackOffPolicy());
@@ -84,7 +84,7 @@ class RhsmServiceTest {
             new RhsmApiProperties(),
             rhsmApi,
             retryTemplate,
-            rateLimiterRegistry);
+            bulkheadRegistry);
 
     assertThrows(
         ApiException.class,


### PR DESCRIPTION
Jira issue: [SWATCH-2214](https://issues.redhat.com/browse/SWATCH-2214)

After digging into the RateLimiter, I see a couple of disadvantages to limit / contain the RHSM API calls:
1. We did set the limit of calls to 150, but at the same time, this limit is reset every 100 milliseconds, so the limit is too permisive and likely it will ever be reached out.
2. We can't increase the limitRefreshPeriod property to a higher value because we would be too strict and the RateLimiter does not allow to decrement the counter to permit more calls. 

Therefore, I agree with the reporter of SWATCH-2214 that the bulkhead pattern matches better for the purpose of not exhaust the RHSM services. 

This PR replaces the env vars from https://github.com/RedHatInsights/rhsm-subscriptions/pull/2010 with:

* `RHSM_API_MAX_CONCURRENT_CALLS` - how many concurrent calls we will allow for the RHSM API service.
* `RHSM_API_MAX_WAIT_DURATION` - the max time a pending RHSM API interaction should wait before timing out.

These are set by default to values that enforce an effective limit of 150 requests/second:

* max concurrent calls: 5
* max wait duration: 30m

Timeout chosen as 30m, as this corresponds to our kafka max poll interval (if it takes longer than that the kafka message is going to be rejected anyways)

## Testing

1. podman-compose up
2. Run the application with some overrides to test the bulkhead limiting:

```shell
DEV_MODE=true \
  RHSM_USE_STUB=true \
  RHSM_MAX_ATTEMPTS=1 \
  RHSM_API_MAX_CONCURRENT_CALLS=1 \
  RHSM_API_MAX_WAIT_DURATION=10s \
  ./gradlew :swatch-system-conduit:bootRun
```

Check the metrics for the limiter:

```shell
http :9000/metrics | grep resilience4j | grep rhsmApi
```

Output:
```
resilience4j_bulkhead_available_concurrent_calls{name="rhsmApi",} 1.0
resilience4j_bulkhead_max_allowed_concurrent_calls{name="rhsmApi",} 1.0
```

Next, invoke conduit operations:

```shell
http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg \
  org_id=slowOrg123 \
  x-rh-swatch-psk:placeholder
```

and within 5 seconds, open a new terminal and check again the metrics, where you should see:

```
resilience4j_bulkhead_available_concurrent_calls{name="rhsmApi",} 0.0
resilience4j_bulkhead_max_allowed_concurrent_calls{name="rhsmApi",} 1.0
```

The resilience4j_bulkhead_available_concurrent_calls counter is 0.0 because there is an ongoing operation. If we consult again the metrics (when the above conduit operation is done), we should see that the counter is back to 1.0:

```
resilience4j_bulkhead_available_concurrent_calls{name="rhsmApi",} 1.0
resilience4j_bulkhead_max_allowed_concurrent_calls{name="rhsmApi",} 1.0
```