### PR TITLE
SWATCH-2214: Adjust timeout with the kafka consumer timeout and retry

### DIFF
--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -101,7 +101,7 @@ parameters:
   - name: RHSM_API_MAX_CONCURRENT_CALLS
     value: '5'
   - name: RHSM_API_MAX_WAIT_DURATION
-    value: 30m
+    value: 3m
   - name: OTEL_SERVICE_NAME
     value: swatch-system-conduit
   - name: OTEL_JAVAAGENT_ENABLED

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ resilience4j.bulkhead:
   instances:
     rhsmApi:
       maxConcurrentCalls: ${RHSM_API_MAX_CONCURRENT_CALLS:5}
-      maxWaitDuration: ${RHSM_API_MAX_WAIT_DURATION:30m}
+      maxWaitDuration: ${RHSM_API_MAX_WAIT_DURATION:3m}
 rhsm-conduit:
   rhsm:
     use-stub: ${RHSM_USE_STUB:false}


### PR DESCRIPTION
Jira issue: [SWATCH-2214](https://issues.redhat.com/browse/SWATCH-2214)

The Spring Retry is configured to perform up to 10 attempts the RHSM API. Plus, the Kafka consumer timeout is configured to 30 min. 

The problem is that in https://github.com/RedHatInsights/rhsm-subscriptions/pull/3126 we configured the RHSM API timeout to be 30 min. So, if one single call hangs up to 30 min, we won't retry and the Kafka consumer will have already rejected the message from the topic.

Therefore, we need to configure the max wait duration to 3 min, so we can meet the 10 number of attempts, and also the kafka timeout which is 30 min. With these changes, when the RHSM API is unresponsive, we will do the following attempts:

```
1. at 0
2. at 3min 1sec
2. at 6min 3sec
3. at 9min 7sec
4. at 12min 15sec
5. at 15min 31sec
7. at 18min 63sec
8. at 21min 64s
9. at 24min 64s
10. at 27min 64s
```
