### PR TITLE
SWATCH-2214: Synchronize orgs in conduit using tasks

### DIFF
--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -49,6 +49,8 @@ parameters:
     value: 1s
   - name: RHSM_BACK_OFF_MULTIPLIER
     value: '2'
+  - name: ENABLE_SYNCHRONOUS_OPERATIONS
+    value: 'false'
   - name: DATABASE_CONNECTION_TIMEOUT_MS
     value: '30000'
   # TODO This has been lowered from what it was in the previous environment (from 25 to 10)
@@ -267,6 +269,8 @@ objects:
               value: ${KAFKA_SEEK_OVERRIDE_END}
             - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
               value: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP}
+            - name: ENABLE_SYNCHRONOUS_OPERATIONS
+              value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
             - name: HOST_LAST_SYNC_THRESHOLD
               value: ${HOST_LAST_SYNC_THRESHOLD}
             - name: DATABASE_HOST

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitProperties.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** POJO to hold property values via Spring's "Type-Safe Configuration Properties" pattern. */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "rhsm-conduit")
+public class SystemConduitProperties {
+
+  /** If enabled, will allow synchronous operations when requested. */
+  private boolean enableSynchronousOperations = false;
+}

--- a/swatch-system-conduit/src/main/resources/application.yaml
+++ b/swatch-system-conduit/src/main/resources/application.yaml
@@ -12,6 +12,7 @@ resilience4j.bulkhead:
       maxConcurrentCalls: ${RHSM_API_MAX_CONCURRENT_CALLS:5}
       maxWaitDuration: ${RHSM_API_MAX_WAIT_DURATION:3m}
 rhsm-conduit:
+  enable-synchronous-operations: ${ENABLE_SYNCHRONOUS_OPERATIONS:false}
   rhsm:
     use-stub: ${RHSM_USE_STUB:false}
     url: ${RHSM_URL:http://localhost:9090}

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -28,6 +28,14 @@ paths:
     description: "Trigger a sync for a given Org ID"
     post:
       summary: "Sync organization for given org_id."
+      parameters:
+        - name: x-rh-swatch-synchronous-request
+          in: header
+          required: false
+          schema:
+            type: boolean
+            default: "false"
+            description: "When present, a synchronous request is made."
       requestBody:
         $ref: "#/components/requestBodies/OrgSyncRequestBody"
       operationId: syncOrg


### PR DESCRIPTION
Jira issue: [SWATCH-2214](https://issues.redhat.com/browse/SWATCH-2214)

## Description
We will allow to enable a synchronous operation to sync the organization by skipping the Kafka queue by running the swatch conduit with ENABLE_SYNCHRONOUS_OPERATIONS=true, plus adding our standard "x-rh-swatch-synchronous-request" header when calling "/internal/rpc/syncOrg" endpoint.

## Testing
Added unit tests to cover this change.