### PR TITLE
SWATCH-2186: NOT MERGE! Investigate exports uploads

### DIFF
--- a/clients-core/src/main/java/org/candlepin/subscriptions/http/HttpClient.java
+++ b/clients-core/src/main/java/org/candlepin/subscriptions/http/HttpClient.java
@@ -112,8 +112,8 @@ public class HttpClient {
     if (isDebugging) {
       clientConfig.register(org.jboss.logging.Logger.class);
     }
-    ClientBuilder clientBuilder = ClientBuilder.newBuilder().withConfig(clientConfig);
 
+    ClientBuilder clientBuilder = ClientBuilder.newBuilder().withConfig(clientConfig);
     return ((ResteasyClientBuilder) clientBuilder).httpEngine(engine).build();
   }
 

--- a/clients/export-client/export-api-spec.yaml
+++ b/clients/export-client/export-api-spec.yaml
@@ -41,7 +41,8 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              type: string
+              format: binary
           application/csv:
             schema:
               type: string

--- a/clients/export-client/src/main/java/com/redhat/swatch/clients/export/api/client/StubExportApi.java
+++ b/clients/export-client/src/main/java/com/redhat/swatch/clients/export/api/client/StubExportApi.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.clients.export.api.client;
 
 import com.redhat.swatch.clients.export.api.model.DownloadExportErrorRequest;
 import com.redhat.swatch.clients.export.api.resources.ExportApi;
+import java.io.File;
 import java.util.UUID;
 
 public class StubExportApi extends ExportApi {
@@ -35,7 +36,7 @@ public class StubExportApi extends ExportApi {
   }
 
   @Override
-  public void downloadExportUpload(UUID id, String application, UUID resource, Object body) {
+  public void downloadExportUpload(UUID id, String application, UUID resource, File body) {
     // do nothing on purpose.
   }
 }

--- a/clients/export-client/src/test/java/com/redhat/swatch/clients/export/api/client/ExportApiClientFactoryTest.java
+++ b/clients/export-client/src/test/java/com/redhat/swatch/clients/export/api/client/ExportApiClientFactoryTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.redhat.swatch.clients.export.api.model.DownloadExportErrorRequest;
 import com.redhat.swatch.clients.export.api.resources.ExportApi;
 import com.redhat.swatch.clients.export.resources.ExportServiceWiremock;
+import java.io.File;
+import java.io.IOException;
 import java.util.UUID;
 import org.candlepin.subscriptions.http.HttpClientProperties;
 import org.junit.jupiter.api.AfterEach;
@@ -95,9 +97,10 @@ class ExportApiClientFactoryTest {
 
   private void thenInvokeDownloadExportUploadShouldWork(ExportApi client) {
     try {
-      client.downloadExportUpload(EXPORT_ID, APPLICATION_NAME, RESOURCE_ID, "content");
+      client.downloadExportUpload(
+          EXPORT_ID, APPLICATION_NAME, RESOURCE_ID, File.createTempFile("test", ".json"));
       server.verifyDownloadExportUpload(EXPORT_ID, APPLICATION_NAME, RESOURCE_ID);
-    } catch (ApiException e) {
+    } catch (ApiException | IOException e) {
       fail(e);
     }
   }

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.capacity;
 
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
+import org.candlepin.subscriptions.subscription.ExportClientConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan;
@@ -39,7 +40,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @Configuration
 @Profile("capacity-ingress")
 @EnableAsync
-@Import({ResteasyConfiguration.class, RhsmSubscriptionsDataSourceConfiguration.class})
+@Import({ResteasyConfiguration.class, RhsmSubscriptionsDataSourceConfiguration.class, ExportClientConfiguration.class})
 @ComponentScan(
     basePackages = {"org.candlepin.subscriptions.capacity", "org.candlepin.subscriptions.product"},
     // Prevent TestConfiguration annotated classes from being picked up by ComponentScan

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
@@ -40,7 +40,11 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @Configuration
 @Profile("capacity-ingress")
 @EnableAsync
-@Import({ResteasyConfiguration.class, RhsmSubscriptionsDataSourceConfiguration.class, ExportClientConfiguration.class})
+@Import({
+  ResteasyConfiguration.class,
+  RhsmSubscriptionsDataSourceConfiguration.class,
+  ExportClientConfiguration.class
+})
 @ComponentScan(
     basePackages = {"org.candlepin.subscriptions.capacity", "org.candlepin.subscriptions.product"},
     // Prevent TestConfiguration annotated classes from being picked up by ComponentScan

--- a/src/main/resources/application-capacity-ingress.yaml
+++ b/src/main/resources/application-capacity-ingress.yaml
@@ -9,6 +9,7 @@ rhsm-subscriptions:
   export-service:
     url: ${clowder.privateEndpoints.export-service-service.url:http://localhost:10000}
     psk: ${SWATCH_EXPORT_PSK:placeholder}
+    file-threshold: 500MB
   subscription-sync-enabled: ${SUBSCRIPTION_SYNC_ENABLED:true}
   product:
     tasks:
@@ -30,3 +31,4 @@ rhsm-subscriptions:
     tasks:
       topic: ${SUBSCRIPTION_EXPORT_TOPIC}
       kafka-group-id: swatch-subscription-export
+DEV_RESTEASY_ENTITY_FILE_THRESHOLD: 500MB

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,6 +56,7 @@ rhsm-subscriptions:
   export-service:
     url: ${clowder.endpoints.export-service.url:http://localhost:10010}
     psk: ${SWATCH_EXPORT_PSK:placeholder}
+    file-threshold: 500MB
 management:
   health:
     jms:

--- a/src/test/java/org/candlepin/subscriptions/subscription/PerfExportSubscriptionListenerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/PerfExportSubscriptionListenerTest.java
@@ -44,7 +44,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles(value = {"worker", "test-inventory", "capacity-ingress"})
+@ActiveProfiles(value = {"test-inventory", "capacity-ingress"})
 class PerfExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
     implements ExtendWithSwatchDatabase {
 
@@ -53,7 +53,7 @@ class PerfExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
    * https://github.com/orgs/resteasy/discussions/4085.
    */
   static {
-    System.setProperty("dev.resteasy.entity.file.threshold", "600MB");
+    System.setProperty("dev.resteasy.entity.file.threshold", "-1");
   }
 
   private static final UUID EXPORT_ID = UUID.randomUUID();
@@ -100,7 +100,7 @@ class PerfExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
   @Transactional
   void verifyExportUploadWithSingleSubscription() {
     logExportRequestsBody(true);
-    Stream<Subscription> data = repository.streamAll(Pageable.ofSize(10));
+    Stream<Subscription> data = repository.streamAll(Pageable.ofSize(5));
     listener.uploadJson(data, request);
     verifyExportUpload(EXPORT_ID, APPLICATION_NAME, RESOURCE_ID);
   }

--- a/src/test/java/org/candlepin/subscriptions/subscription/PerfExportSubscriptionListenerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/PerfExportSubscriptionListenerTest.java
@@ -48,6 +48,14 @@ import org.springframework.test.context.ActiveProfiles;
 class PerfExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
     implements ExtendWithSwatchDatabase {
 
+  /**
+   * I've asked if there are other ways to configure this property in
+   * https://github.com/orgs/resteasy/discussions/4085.
+   */
+  static {
+    System.setProperty("dev.resteasy.entity.file.threshold", "600MB");
+  }
+
   private static final UUID EXPORT_ID = UUID.randomUUID();
   private static final String APPLICATION_NAME = "SWATCH";
   private static final UUID RESOURCE_ID = UUID.randomUUID();
@@ -77,7 +85,7 @@ class PerfExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
       offering.setSku(SKU);
       session.insert(offering);
 
-      for (int i = 0; i < 5; i++) {
+      for (int i = 0; i < 500_000; i++) {
         session.insert(createSubscription(offering));
       }
       tx.commit();
@@ -99,7 +107,7 @@ class PerfExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
 
   @Transactional
   @ParameterizedTest
-  @ValueSource(ints = {500_000})
+  @ValueSource(ints = {50_000, 100_000, 200_000, 300_000, 400_000, 500_000})
   void verifyExportUpload(int size) {
     logExportRequestsBody(false);
     Stream<Subscription> data = repository.streamAll(Pageable.ofSize(size));

--- a/src/test/java/org/candlepin/subscriptions/subscription/PerfExportSubscriptionListenerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/PerfExportSubscriptionListenerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription;
+
+import com.redhat.cloud.event.apps.exportservice.v1.ResourceRequestClass;
+import jakarta.transaction.Transactional;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.db.OfferingRepository;
+import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Offering;
+import org.candlepin.subscriptions.db.model.Subscription;
+import org.candlepin.subscriptions.test.ExtendWithExportServiceWireMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles(value = {"worker", "test", "capacity-ingress"})
+class PerfExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock {
+
+  private static final UUID EXPORT_ID = UUID.randomUUID();
+  private static final String APPLICATION_NAME = "SWATCH";
+  private static final UUID RESOURCE_ID = UUID.randomUUID();
+
+  @Autowired ExportSubscriptionListener listener;
+  @Autowired SubscriptionRepository repository;
+  @Autowired OfferingRepository offeringRepository;
+
+  private ResourceRequestClass request;
+
+  @BeforeEach
+  void setup() {
+    request = new ResourceRequestClass();
+    request.setUUID(EXPORT_ID);
+    request.setApplication(APPLICATION_NAME);
+    request.setExportRequestUUID(RESOURCE_ID);
+
+    stubExportUploadFor(EXPORT_ID, APPLICATION_NAME, RESOURCE_ID);
+
+    for (int i = 0; i < 50000; i++) {
+      repository.save(createSubscription());
+    }
+  }
+
+  /** This is interesting to view the body in the console. */
+  @Test
+  @Transactional
+  void verifyExportUploadWithSingleSubscription() {
+    logExportRequestsBody(true);
+    Stream<Subscription> data = repository.streamAll(Pageable.ofSize(1));
+    listener.uploadJson(data, request);
+    verifyExportUpload(EXPORT_ID, APPLICATION_NAME, RESOURCE_ID);
+  }
+
+  @Transactional
+  @ParameterizedTest
+  @ValueSource(ints = {1, 100, 1000, 10000, 50000})
+  void verifyExportUpload(int size) {
+    logExportRequestsBody(false);
+    Stream<Subscription> data = repository.streamAll(Pageable.ofSize(size));
+    listener.uploadJson(data, request);
+    verifyExportUpload(EXPORT_ID, APPLICATION_NAME, RESOURCE_ID);
+  }
+
+  private Subscription createSubscription() {
+    Subscription subscription = new Subscription();
+    subscription.setBillingProviderId(UUID.randomUUID().toString());
+    subscription.setSubscriptionId("1");
+    subscription.setOrgId("2");
+    subscription.setQuantity(4L);
+    subscription.setStartDate(OffsetDateTime.now());
+    subscription.setEndDate(OffsetDateTime.now());
+    subscription.setSubscriptionNumber(UUID.randomUUID().toString());
+    subscription.setBillingProvider(BillingProvider.RED_HAT);
+    subscription.setBillingAccountId(UUID.randomUUID().toString());
+    Offering offering = new Offering();
+    offering.setSku(UUID.randomUUID().toString());
+    subscription.setOffering(offering);
+
+    offeringRepository.save(offering);
+
+    return subscription;
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/test/ExtendWithExportServiceWireMock.java
+++ b/src/test/java/org/candlepin/subscriptions/test/ExtendWithExportServiceWireMock.java
@@ -48,7 +48,7 @@ public class ExtendWithExportServiceWireMock {
                 // This is mandatory to handle large files, otherwise Wiremock returns 500 Server
                 // Error
                 .jettyHeaderRequestSize(16384)
-                .jettyHeaderResponseSize(50000)
+                .jettyHeaderResponseSize(80000)
                 .stubRequestLoggingDisabled(true)
                 .maxLoggedResponseSize(1000));
     exportServer.resetAll();

--- a/src/test/java/org/candlepin/subscriptions/test/ExtendWithExportServiceWireMock.java
+++ b/src/test/java/org/candlepin/subscriptions/test/ExtendWithExportServiceWireMock.java
@@ -41,7 +41,16 @@ public class ExtendWithExportServiceWireMock {
   private static boolean logExportRequestsBody = true;
 
   static WireMockServer start() {
-    exportServer = new WireMockServer(wireMockConfig().dynamicPort());
+    exportServer =
+        new WireMockServer(
+            wireMockConfig()
+                .dynamicPort()
+                // This is mandatory to handle large files, otherwise Wiremock returns 500 Server
+                // Error
+                .jettyHeaderRequestSize(16384)
+                .jettyHeaderResponseSize(50000)
+                .stubRequestLoggingDisabled(true)
+                .maxLoggedResponseSize(1000));
     exportServer.resetAll();
     exportServer.addMockServiceRequestListener(
         (request, response) -> {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -86,6 +86,10 @@ public interface SubscriptionRepository
       "SELECT s FROM Subscription s WHERE s.orgId = :orgId ORDER BY s.subscriptionId, s.startDate")
   Stream<Subscription> findByOrgId(String orgId);
 
+  @QueryHints(value = {@QueryHint(name = HINT_FETCH_SIZE, value = "1024")})
+  @Query("SELECT s FROM Subscription s")
+  Stream<Subscription> streamAll(Pageable pageable);
+
   void deleteBySubscriptionId(String subscriptionId);
 
   void deleteByOrgId(String orgId);


### PR DESCRIPTION
Jira issue: [SWATCH-2186](https://issues.redhat.com/browse/SWATCH-2186)

## Description
I've opened up this pull request with the only purpose to investigate SWATCH-2186: Investigate Performance Optimization For Export Fetching. **NOT MERGE**

What I did here is first to insert up to 50000 subscriptions in database, and then manipulate the uploadJson method from ExportSubscriptionListener to provide Stream<Subscription> data. This data will be used to write the final object to be sent to the Export service (see example [here](https://github.com/RedHatInsights/export-service-go/blob/main/example_export_upload.json)).
With this data, we'll use Jackson API to construct a file on the fly (without keeping any objects on memory).

The results prove that we can handle a large number of subscription in a constant time:

| Number of Subscriptions  | Execution Time | Size of the request |
| ----------- | ----------- | ----------- |
| 1      | 21 sec       | 356 bytes |
| 100   | 16 sec        | 26492 bytes |
| 1000   | 16 sec        | 264092 bytes |
| 10000   | 16 sec        | 2.64 MB |
| 50000   | 14 sec        | 13.2 MB |

Find the following memory usage chart where we can see that the amount of memory remained almost constant when executing the upload for the different size of subscriptions:

![Captura de pantalla de 2024-03-12 14-28-15](https://github.com/RedHatInsights/rhsm-subscriptions/assets/6310047/aafbc7f4-ceab-4d6a-bbb1-17a32d653478)

Important technical details:
- We need to directly use the Stream<Subscription> in the upload methods where Subscription is the hibernate entity instead of using the pojo Subscription. 
- I've changed the openapi definition of the export service, so we can directly provide the file. I've confirmed that there is no different in terms of the HTTP request (we're still sending an application/json request as expected).
- I've added a test case named "verifyExportUploadWithSingleSubscription" to verify that request we're sending to the export service. The other test case named "verifyExportUpload" is hiding the body because it's too large to be printed in the terminal. 