### PR TITLE
SWATCH-2329 Replace the deprecated methods in KafkaProperties

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationWorkerConfiguration.java
@@ -43,7 +43,7 @@ public class CapacityReconciliationWorkerConfiguration {
   ConsumerFactory<String, ReconcileCapacityByOfferingTask> capacityReconciliationConsumerFactory(
       KafkaProperties kafkaProperties) {
     return new DefaultKafkaConsumerFactory<>(
-        kafkaProperties.buildConsumerProperties(),
+        kafkaProperties.buildConsumerProperties(null),
         new StringDeserializer(),
         new JsonDeserializer<>(ReconcileCapacityByOfferingTask.class));
   }

--- a/src/main/java/org/candlepin/subscriptions/product/OfferingWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/product/OfferingWorkerConfiguration.java
@@ -55,7 +55,7 @@ public class OfferingWorkerConfiguration {
   ConsumerFactory<String, OfferingSyncTask> offeringSyncConsumerFactory(
       KafkaProperties kafkaProperties) {
     return new DefaultKafkaConsumerFactory<>(
-        kafkaProperties.buildConsumerProperties(),
+        kafkaProperties.buildConsumerProperties(null),
         new StringDeserializer(),
         new JsonDeserializer<>(OfferingSyncTask.class));
   }

--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplaceWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplaceWorkerConfiguration.java
@@ -75,7 +75,7 @@ public class RhMarketplaceWorkerConfiguration {
   ConsumerFactory<String, TallySummary> tallySummaryConsumerFactory(
       KafkaProperties kafkaProperties) {
     return new DefaultKafkaConsumerFactory<>(
-        kafkaProperties.buildConsumerProperties(),
+        kafkaProperties.buildConsumerProperties(null),
         new StringDeserializer(),
         new JsonDeserializer<>(TallySummary.class));
   }
@@ -120,7 +120,7 @@ public class RhMarketplaceWorkerConfiguration {
   ConsumerFactory<String, BillableUsage> billableUsageConsumerFactory(
       KafkaProperties kafkaProperties) {
     return new DefaultKafkaConsumerFactory<>(
-        kafkaProperties.buildConsumerProperties(),
+        kafkaProperties.buildConsumerProperties(null),
         new StringDeserializer(),
         new JsonDeserializer<>(BillableUsage.class));
   }

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionWorkerConfiguration.java
@@ -49,7 +49,7 @@ public class SubscriptionWorkerConfiguration {
   ConsumerFactory<String, SyncSubscriptionsTask> syncSubscriptionsConsumerFactory(
       KafkaProperties kafkaProperties) {
     return new DefaultKafkaConsumerFactory<>(
-        kafkaProperties.buildConsumerProperties(),
+        kafkaProperties.buildConsumerProperties(null),
         new StringDeserializer(),
         new JsonDeserializer<>(SyncSubscriptionsTask.class));
   }
@@ -58,7 +58,7 @@ public class SubscriptionWorkerConfiguration {
   ConsumerFactory<String, PruneSubscriptionsTask> pruneSubscriptionsConsumerFactory(
       KafkaProperties kafkaProperties) {
     return new DefaultKafkaConsumerFactory<>(
-        kafkaProperties.buildConsumerProperties(),
+        kafkaProperties.buildConsumerProperties(null),
         new StringDeserializer(),
         new JsonDeserializer<>(PruneSubscriptionsTask.class));
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -245,7 +245,7 @@ public class TallyWorkerConfiguration {
   ConsumerFactory<String, String> serviceInstanceConsumerFactory(
       KafkaProperties kafkaProperties,
       @Qualifier("serviceInstanceTopicProperties") TaskQueueProperties taskQueueProperties) {
-    var props = kafkaProperties.buildConsumerProperties();
+    var props = kafkaProperties.buildConsumerProperties(null);
     props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, taskQueueProperties.getMaxPollRecords());
     return new DefaultKafkaConsumerFactory<>(
         props, new StringDeserializer(), new StringDeserializer());

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
@@ -86,7 +86,7 @@ public class BillingProducerConfiguration {
   ConsumerFactory<String, TallySummary> billingProducerTallySummaryConsumerFactory(
       KafkaProperties kafkaProperties) {
     return new DefaultKafkaConsumerFactory<>(
-        kafkaProperties.buildConsumerProperties(),
+        kafkaProperties.buildConsumerProperties(null),
         new StringDeserializer(),
         new JsonDeserializer<>(TallySummary.class));
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
@@ -53,7 +53,7 @@ public class KafkaConfigurator {
 
   public ConsumerFactory<String, JsonTaskMessage> defaultConsumerFactory(
       KafkaProperties kafkaProperties) {
-    Map<String, Object> consumerConfig = kafkaProperties.buildConsumerProperties();
+    Map<String, Object> consumerConfig = kafkaProperties.buildConsumerProperties(null);
 
     // Task messages should be manually committed once they have been processed.
     consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
@@ -63,7 +63,7 @@ public class KafkaTaskProducerConfiguration {
 
   @NotNull
   public static Map<String, Object> getProducerProperties(KafkaProperties kafkaProperties) {
-    Map<String, Object> properties = kafkaProperties.buildProducerProperties();
+    Map<String, Object> properties = kafkaProperties.buildProducerProperties(null);
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
     return properties;

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/InventoryServiceKafkaConfigurator.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/InventoryServiceKafkaConfigurator.java
@@ -40,7 +40,7 @@ public class InventoryServiceKafkaConfigurator {
 
   public DefaultKafkaProducerFactory<String, CreateUpdateHostMessage> defaultProducerFactory(
       KafkaProperties kafkaProperties, ObjectMapper mapper) {
-    Map<String, Object> producerConfig = kafkaProperties.buildProducerProperties();
+    Map<String, Object> producerConfig = kafkaProperties.buildProducerProperties(null);
     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 
     DefaultKafkaProducerFactory<String, CreateUpdateHostMessage> factory =


### PR DESCRIPTION
Jira issue: [SWATCH-2329](https://issues.redhat.com/browse/SWATCH-2329)

## Description
Replace `buildProducerProperties()` by `buildProducerProperties(null)` and `buildConsumerProperties()` by `buildConsumerProperties(null)`.

## Testing
Only regression testing. 