### PR TITLE
Add billing provider to filterable parameters for subscription resource

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -115,7 +115,7 @@ public class SubscriptionTableController {
             + "Usage={}, "
             + "between={} and {}, "
             + "Uom={}, "
-            + "MetricId={}"
+            + "MetricId={}, "
             + "Billing Provider={}",
         orgId,
         productId,

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -115,7 +115,8 @@ public class SubscriptionTableController {
             + "Usage={}, "
             + "between={} and {}, "
             + "Uom={}, "
-            + "MetricId={}",
+            + "MetricId={}"
+            + "Billing Provider={}",
         orgId,
         productId,
         hypervisorReportCategory,
@@ -124,7 +125,8 @@ public class SubscriptionTableController {
         reportStart,
         reportEnd,
         uom,
-        metricId);
+        metricId,
+        sanitizedBillingProvider);
     String effectiveMetricId = getEffectiveMetricId(metricId, uom);
 
     var reportCriteria =
@@ -137,6 +139,7 @@ public class SubscriptionTableController {
             .ending(reportEnd)
             .metricId(effectiveMetricId)
             .hypervisorReportCategory(hypervisorReportCategory)
+            .billingProvider(sanitizedBillingProvider)
             .build();
     var subscriptionSpec = SubscriptionRepository.buildSearchSpecification(reportCriteria);
     var subscriptions = subscriptionRepository.findAll(subscriptionSpec);


### PR DESCRIPTION
Jira issue: SWATCH-2244

## Description
Allow filtering based on billing provider in calls to `subscriptions/products/<product_id>`

## Testing

### Setup
1.  Sync offerings from stage.  You can create the offerings yourself, but it's easier to just pull the stage data.  You'll need to have the keystore and truststore for the stage subscription endpoint along with the password.  You'll also need the stage subscription endpoint.  I can provide all those or you can retrieve them from the `api` pod's environment (`SUBSCRIPTION_URL`) and Vault (`/insights/show/secrets/insights-stage/rhsm-stage/pinhead` and `/insights/show/secrets/insights-stage/rhsm-stage/tls` for the password).
    ```
    http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/offerings/sync x-rh-swatch-psk:placeholder
    ```
1.  Create (or find) an org with subscriptions that have a billing provider.  I pulled in stage data for the `subscriptions` table and then used to following to randomly select an org from the results of the second query (and making my request based on the tag given by the first query)
    ```sql
    SELECT *
    FROM sku_product_tag
    WHERE sku in  (
      SELECT DISTINCT sku
      FROM subscription
      WHERE billing_provider = 'aws'
      GROUP BY sku
    );

    select org_id from subscription where sku = 'MCT4121HR' and billing_provider = 'aws';
    ```

### Steps
<!-- Enter each step of the test below -->
1.  Make a call filtering on `billing_provider`.
    ```
    http :8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform \
    billing_provider==azure \
    beginning==2022-03-01T00:00:00.000Z \
    ending==2024-03-31T23:59:59.999Z \
    x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"ORG_HERE"}}}' | base64 -w 0)
    ```

1.  Make the same call but with no `billing_provider` filter
    ```
    http :8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform \
    beginning==2022-03-01T00:00:00.000Z \
    ending==2024-03-31T23:59:59.999Z \
    x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"ORG_HERE"}}}' | base64 -w 0)
    ```

### Verification
1.  You shouldn't see any AWS results in the first `http` call and you should see them in the second.
