### PR TITLE
SWATCH-2330: Reduce the number of queries to purge the tally snapshots

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -88,9 +88,9 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
   @Modifying
   @Query(
       value =
-          "delete from TallySnapshot where orgId=:orgId and granularity=:granularity and snapshotDate < :cutoffDate")
-  void deleteAllByOrgIdAndGranularityAndSnapshotDateBefore(
-      String orgId, Granularity granularity, OffsetDateTime cutoffDate);
+          "delete from TallySnapshot where orgId in (select distinct c.orgId from OrgConfig c) and granularity=:granularity and snapshotDate < :cutoffDate")
+  void deleteAllByGranularityAndSnapshotDateBefore(
+      Granularity granularity, OffsetDateTime cutoffDate);
 
   @Query(
       value =


### PR DESCRIPTION
Instead of doing 6 queries per organization, it will only do 6 queries in total for all organizations.

Jira issue: [SWATCH-2330](https://issues.redhat.com/browse/SWATCH-2330)

## Description
Before these changes, a timeout exception is thrown when the purge task takes more than one hour (see splunk query in the linked JIRA).

Checking the orgs in Prod, we have 53231 organizations, and for each organization, we run a query to delete the tally snapshots by variant (we have 6 variants - daily, hourly, etc). According to the explain analysis ran by Postgresql, the query to delete the tally snapshots is quite fast: around 100ms (more or less).

Therefore, doing some maths: 53231 (orgs) x 6 (variants) x 100ms (average time taken to execute the query) = 31938600 ms to complete the task which is 8.8 hours.

Of course, this is an estimation and it will always depend on the data, but it can be even worse since we're doing several delete queries (one for tally_snapshots and another one for tally_measurements).

This pull request changes the way we are doing the delete queries to instead of doing 2 queries by variant (6) and org (53231) which results into 638772 delete statements, now we do only 2 queries by variant (6) for all the orgs at once which results into 12 delete statements. 

Testing the changes locally using a limited amount of data from PROD, before these changes, the purge task was taking around 7-8 min to finish and after the changes, it takes 30 seconds. See testing steps for more information. 

## Testing
0. download the data and script from https://drive.google.com/file/d/1vlHzCmPIoy8jov9g-qXGhYKC0VHRBX2g/view?usp=sharing.

1. start the postgresql instance:

```
podman-compose up
```

2. initialize the schema:

```
./gradlew liquibaseUpdate
```

3. load the data:

```
./load_data.sh
```

This file contains:
- 53255 orgs
- 2000000 snapshots
- 4000000 measurements

4. start the service:

```
DEV_MODE=true ./gradlew :bootRun
```

5. run the purge:

```
curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: placeholder" -X POST "http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge"
```

6. wait until the tally snapshot purge task is finished.
When the task is done, you should see the following in the app logs:

```
2024-03-19 16:05:39,969 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.security.LogPrincipalFilter] self- Internal API: /api/rhsm-subscriptions/v1/internal/rpc/tally/purge requested by user: self
2024-03-19 16:05:40,081 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.admin.InternalTallyResource] self- Initiating tally snapshot purge.
2024-03-19 16:05:40,086 [thread=purge-tally-snapshots-1] [INFO ] [org.candlepin.subscriptions.retention.TallyRetentionController] - Starting tally snapshot purge.
2024-03-19 16:06:05,634 [thread=purge-tally-snapshots-1] [INFO ] [org.candlepin.subscriptions.retention.TallyRetentionController] - Tally snapshot purge completed successfully.
```

Note that it took 30 seconds to finish.

7. Verify that the data in the tally_snapshots and in the tally_measurements tables.

```
select count(*) from tally_snapshots; -- expected: 2308
select count(*) from tally_measurements; -- expected: 3995364
```

## Verification
Doing the same above steps in the main branch, the step 5 will take much longer

```
2024-03-19 15:47:46,050 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.security.LogPrincipalFilter] self- Internal API: /api/rhsm-subscriptions/v1/internal/rpc/tally/purge requested by user: self
2024-03-19 15:47:46,101 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.admin.InternalTallyResource] self- Initiating tally snapshot purge.
2024-03-19 15:47:46,110 [thread=purge-tally-snapshots-1] [INFO ] [org.candlepin.subscriptions.retention.TallyRetentionController] - Starting tally snapshot purge.
2024-03-19 15:53:53,023 [thread=purge-tally-snapshots-1] [INFO ] [org.candlepin.subscriptions.retention.TallyRetentionController] - Tally snapshot purge completed successfully.
```

And double check we got the same numbers:

```
select count(*) from tally_snapshots; -- expected: 2308
select count(*) from tally_measurements; -- expected: 3995364
```