### PR TITLE
SWATCH-2021: Move export related classes into the same package

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -124,13 +124,6 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   }
 
   @Bean
-  @Qualifier("subscriptionExport")
-  @ConfigurationProperties(prefix = "rhsm-subscriptions.subscription-export.tasks")
-  TaskQueueProperties subscriptionExportProperties() {
-    return new TaskQueueProperties();
-  }
-
-  @Bean
   AuthProperties authProperties() {
     return new AuthProperties();
   }

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.capacity;
 
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
+import org.candlepin.subscriptions.subscription.export.ExportSubscriptionConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan;
@@ -39,7 +40,11 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @Configuration
 @Profile("capacity-ingress")
 @EnableAsync
-@Import({ResteasyConfiguration.class, RhsmSubscriptionsDataSourceConfiguration.class})
+@Import({
+  ResteasyConfiguration.class,
+  RhsmSubscriptionsDataSourceConfiguration.class,
+  ExportSubscriptionConfiguration.class
+})
 @ComponentScan(
     basePackages = {"org.candlepin.subscriptions.capacity", "org.candlepin.subscriptions.product"},
     // Prevent TestConfiguration annotated classes from being picked up by ComponentScan

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
@@ -44,8 +44,7 @@ import org.springframework.retry.support.RetryTemplateBuilder;
 @Import({
   ResteasyConfiguration.class,
   RhsmSubscriptionsDataSourceConfiguration.class,
-  CapacityReconciliationConfiguration.class,
-  ExportClientConfiguration.class
+  CapacityReconciliationConfiguration.class
 })
 @EnableJms
 @ComponentScan(

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/ExportClientConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/ExportClientConfiguration.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.subscription;
+package org.candlepin.subscriptions.subscription.export;
 
 import com.redhat.swatch.clients.export.api.client.ExportApiClientFactory;
 import org.candlepin.subscriptions.http.HttpClientProperties;

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionConfiguration.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.subscription.export;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+@Import({ExportClientConfiguration.class})
+public class ExportSubscriptionConfiguration {
+
+  public static final String SUBSCRIPTION_EXPORT_QUALIFIER = "subscriptionExport";
+  public static final String EXPORT_CONSUMER_FACTORY_QUALIFIER = "exportConsumerFactory";
+
+  @Bean(name = SUBSCRIPTION_EXPORT_QUALIFIER)
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.subscription-export.tasks")
+  TaskQueueProperties subscriptionExportProperties() {
+    return new TaskQueueProperties();
+  }
+
+  @Bean(EXPORT_CONSUMER_FACTORY_QUALIFIER)
+  ConsumerFactory<String, String> exportConsumerFactory(KafkaProperties kafkaProperties) {
+    return new DefaultKafkaConsumerFactory<>(
+        kafkaProperties.buildConsumerProperties(null),
+        new StringDeserializer(),
+        new StringDeserializer());
+  }
+
+  @Bean
+  ConcurrentKafkaListenerContainerFactory<String, String> exportListenerContainerFactory(
+      @Qualifier(EXPORT_CONSUMER_FACTORY_QUALIFIER) ConsumerFactory<String, String> consumerFactory,
+      KafkaProperties kafkaProperties,
+      KafkaConsumerRegistry registry,
+      DefaultErrorHandler subscriptionExportKafkaErrorHandler) {
+
+    var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
+    factory.setConsumerFactory(consumerFactory);
+    // Concurrency should be set to the number of partitions for the target topic.
+    factory.setConcurrency(kafkaProperties.getListener().getConcurrency());
+    if (kafkaProperties.getListener().getIdleEventInterval() != null) {
+      factory
+          .getContainerProperties()
+          .setIdleEventInterval(kafkaProperties.getListener().getIdleEventInterval().toMillis());
+    }
+    // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
+    factory.getContainerProperties().setConsumerRebalanceListener(registry);
+
+    factory.setCommonErrorHandler(subscriptionExportKafkaErrorHandler);
+
+    return factory;
+  }
+
+  @Bean
+  DefaultErrorHandler subscriptionExportKafkaErrorHandler(
+      @Qualifier(SUBSCRIPTION_EXPORT_QUALIFIER) TaskQueueProperties subscriptionExportProperties) {
+    return new DefaultErrorHandler(
+        new FixedBackOff(
+            subscriptionExportProperties.getRetryBackOffMillis(),
+            subscriptionExportProperties.getRetryAttempts()));
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionListener.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionListener.java
@@ -18,7 +18,9 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.subscription;
+package org.candlepin.subscriptions.subscription.export;
+
+import static org.candlepin.subscriptions.subscription.export.ExportSubscriptionConfiguration.SUBSCRIPTION_EXPORT_QUALIFIER;
 
 import com.redhat.cloud.event.apps.exportservice.v1.Format;
 import com.redhat.cloud.event.apps.exportservice.v1.ResourceRequest;
@@ -57,7 +59,7 @@ public class ExportSubscriptionListener extends SeekableKafkaConsumer {
   private final RbacService rbacService;
 
   protected ExportSubscriptionListener(
-      @Qualifier("subscriptionExport") TaskQueueProperties taskQueueProperties,
+      @Qualifier(SUBSCRIPTION_EXPORT_QUALIFIER) TaskQueueProperties taskQueueProperties,
       KafkaConsumerRegistry kafkaConsumerRegistry,
       ConsoleCloudEventParser parser,
       ExportApi exportApi,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -53,9 +53,6 @@ rhsm-subscriptions:
     back-off-max-interval: ${USER_BACK_OFF_MAX_INTERVAL:1m}
     back-off-multiplier: ${USER_BACK_OFF_MULTIPLIER:2}
     max-attempts: ${USER_MAX_ATTEMPTS:1}
-  export-service:
-    url: ${clowder.endpoints.export-service.url:http://localhost:10010}
-    psk: ${SWATCH_EXPORT_PSK:placeholder}
 management:
   health:
     jms:

--- a/src/test/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionListenerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/export/ExportSubscriptionListenerTest.java
@@ -18,16 +18,14 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.task.queue.kafka;
+package org.candlepin.subscriptions.subscription.export;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.redhat.swatch.clients.export.api.client.ApiException;
 import org.candlepin.subscriptions.rbac.RbacService;
-import org.candlepin.subscriptions.subscription.ExportSubscriptionListener;
 import org.candlepin.subscriptions.test.ExtendWithEmbeddedKafka;
 import org.candlepin.subscriptions.test.ExtendWithExportServiceWireMock;
-import org.candlepin.subscriptions.test.ExtendWithSwatchDatabase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,9 +33,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles(value = {"worker", "kafka-queue", "api", "test-inventory", "capacity-ingress"})
-class ExportSubscriptionListenerTest extends ExtendWithExportServiceWireMock
-    implements ExtendWithSwatchDatabase, ExtendWithEmbeddedKafka {
+@ActiveProfiles(value = {"kafka-queue", "test", "capacity-ingress"})
+class ExportSubscriptionListenerTest
+    implements ExtendWithExportServiceWireMock, ExtendWithEmbeddedKafka {
+
   @Autowired ExportSubscriptionListener listener;
 
   @MockBean RbacService rbacService;

--- a/src/test/java/org/candlepin/subscriptions/test/ExtendWithEmbeddedKafka.java
+++ b/src/test/java/org/candlepin/subscriptions/test/ExtendWithEmbeddedKafka.java
@@ -27,12 +27,12 @@ import org.springframework.test.context.DynamicPropertySource;
 @EmbeddedKafka(
     partitions = 1,
     topics = {
-      "${rhsm-subscriptions.tasks.topic}",
-      "${rhsm-subscriptions.subscription.tasks.topic}",
-      "${rhsm-subscriptions.billing-producer.incoming.topic}",
-      "${rhsm-subscriptions.billing-producer.outgoing.topic}",
-      "${rhsm-subscriptions.service-instance-ingress.incoming.topic}",
-      "${rhsm-subscriptions.subscription-export.tasks.topic}"
+      "${rhsm-subscriptions.tasks.topic:platform.rhsm-subscriptions.tasks}",
+      "${rhsm-subscriptions.subscription.tasks.topic:platform.rhsm-subscriptions.subscription-sync}",
+      "${rhsm-subscriptions.billing-producer.incoming.topic:platform.rhsm-subscriptions.tally}",
+      "${rhsm-subscriptions.billing-producer.outgoing.topic:platform.rhsm-subscriptions.billable-usage}",
+      "${rhsm-subscriptions.service-instance-ingress.incoming.topic:platform.rhsm-subscriptions.service-instance-ingress}",
+      "${rhsm-subscriptions.subscription-export.tasks.topic:platform.export.requests}"
     })
 public interface ExtendWithEmbeddedKafka {
   @DynamicPropertySource


### PR DESCRIPTION
Jira issue: [SWATCH-2021](https://issues.redhat.com/browse/SWATCH-2021)

## Description
Part of SWATCH-2021, we need to move all the export related classes into the same package.

## Testing
Only regression testing.