### PR TITLE
SWATCH-2276: Expose the OrgConfigRepository.findSyncEnabledOrgs

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/tasks/EnabledOrgsMessageConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/tasks/EnabledOrgsMessageConsumer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.tasks;
+
+import static org.candlepin.subscriptions.tally.TallyWorkerConfiguration.ENABLED_ORGS_KAFKA_LISTENER_CONTAINER_FACTORY_BEAN;
+import static org.candlepin.subscriptions.tally.TallyWorkerConfiguration.ENABLED_ORGS_TOPIC_PROPERTIES_BEAN;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.OrgConfigRepository;
+import org.candlepin.subscriptions.json.EnabledOrgsRequest;
+import org.candlepin.subscriptions.json.EnabledOrgsResponse;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
+import org.candlepin.subscriptions.util.SeekableKafkaConsumer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class EnabledOrgsMessageConsumer extends SeekableKafkaConsumer {
+
+  private final Set<String> targetTopicsAllowed;
+  private final OrgConfigRepository repository;
+  private final KafkaTemplate<String, EnabledOrgsResponse> producer;
+
+  @Autowired
+  public EnabledOrgsMessageConsumer(
+      @Qualifier(ENABLED_ORGS_TOPIC_PROPERTIES_BEAN) TaskQueueProperties enabledOrgsTopicProperties,
+      KafkaConsumerRegistry kafkaConsumerRegistry,
+      @Value("${rhsm-subscriptions.enabled-orgs.target-topics-allowed}")
+          Set<String> targetTopicsAllowed,
+      OrgConfigRepository repository,
+      KafkaTemplate<String, EnabledOrgsResponse> producer) {
+    super(enabledOrgsTopicProperties, kafkaConsumerRegistry);
+    this.targetTopicsAllowed = targetTopicsAllowed;
+    this.repository = repository;
+    this.producer = producer;
+  }
+
+  @KafkaListener(
+      id = "#{__listener.groupId}",
+      topics = "#{__listener.topic}",
+      containerFactory = ENABLED_ORGS_KAFKA_LISTENER_CONTAINER_FACTORY_BEAN)
+  @Transactional(noRollbackFor = RuntimeException.class)
+  public void receive(@Payload EnabledOrgsRequest request) {
+    if (!targetTopicsAllowed.contains(request.getTargetTopic())) {
+      log.warn(
+          "Ignoring enabled organizations request for target topic '{}' because it's not allowed. List of allowed target topics are: '{}'",
+          request.getTargetTopic(),
+          targetTopicsAllowed);
+      return;
+    }
+
+    log.info("Sending all enabled organizations to topic '{}'", request.getTargetTopic());
+    AtomicInteger requests = new AtomicInteger(0);
+    try (var organizations = repository.findSyncEnabledOrgs()) {
+      organizations.forEach(
+          orgId -> {
+            producer.send(request.getTargetTopic(), new EnabledOrgsResponse().withOrgId(orgId));
+            requests.incrementAndGet();
+          });
+    }
+
+    log.info(
+        "Sent {} messages with the organization ID to topic '{}'",
+        requests.get(),
+        request.getTargetTopic());
+  }
+}

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -4,6 +4,7 @@ BILLABLE_USAGE_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.billab
 BILLABLE_USAGE_DEAD_LETTER_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.billable-usage.dlt".name:platform.rhsm-subscriptions.billable-usage.dlt}
 SERVICE_INSTANCE_INGRESS_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.service-instance-ingress".name:platform.rhsm-subscriptions.service-instance-ingress}
 SERVICE_INSTANCE_INGRESS_DEAD_LETTER_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.service-instance-ingress.dlt".name:platform.rhsm-subscriptions.service-instance-ingress.dlt}
+ENABLED_ORGS_TOPIC: ${clowder.kafka.topics."platform.rhsm-subscriptions.enabled-orgs-for-tasks".name:platform.rhsm-subscriptions.enabled-orgs-for-tasks}
 
 rhsm-subscriptions:
   hourlyTallyDurationLimitDays: 90d
@@ -94,6 +95,13 @@ rhsm-subscriptions:
     kafka-group-id: ${KAFKA_GROUP_ID:rhsm-subscriptions-task-processor}
     seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
     seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+  enabled-orgs:
+    target-topics-allowed: platform.rhsm-subscriptions.subscription-prune-task, platform.rhsm-subscriptions.subscription-sync-task
+    incoming:
+      topic: ${ENABLED_ORGS_TOPIC}
+      kafka-group-id: ${KAFKA_GROUP_ID:rhsm-subscriptions-enabled-orgs-processor}
+      seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
+      seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
   tally-max-hbi-account-size: ${TALLY_MAX_HBI_ACCOUNT_SIZE:2147483647}  # Integer.MAX_VALUE by default
   hbi-reconciliation-flush-interval: ${HBI_RECONCILIATION_FLUSH_INTERVAL:1024}
   use-cpu-system-facts-to-all-products: ${USE_CPU_SYSTEM_FACTS_TO_ALL_PRODUCTS:true}

--- a/src/test/java/org/candlepin/subscriptions/tally/tasks/EnabledOrgsMessageConsumerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/tasks/EnabledOrgsMessageConsumerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.tasks;
+
+import static org.candlepin.subscriptions.tally.TallyWorkerConfiguration.ENABLED_ORGS_TOPIC_PROPERTIES_BEAN;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.transaction.Transactional;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.candlepin.subscriptions.db.OrgConfigRepository;
+import org.candlepin.subscriptions.json.EnabledOrgsRequest;
+import org.candlepin.subscriptions.json.EnabledOrgsResponse;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.candlepin.subscriptions.test.ExtendWithEmbeddedKafka;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+@SpringBootTest
+@ActiveProfiles({"kafka-queue", "worker", "test"})
+class EnabledOrgsMessageConsumerTest implements ExtendWithEmbeddedKafka {
+
+  private static final String ORG_ID = "123456";
+
+  @Autowired
+  @Qualifier(ENABLED_ORGS_TOPIC_PROPERTIES_BEAN)
+  TaskQueueProperties enabledOrgsTopicProperties;
+
+  @Autowired KafkaProperties kafkaProperties;
+  @MockBean OrgConfigRepository repository;
+  @MockBean KafkaTemplate<String, EnabledOrgsResponse> producer;
+  @SpyBean EnabledOrgsMessageConsumer consumer;
+  KafkaTemplate<String, EnabledOrgsRequest> kafkaTemplate;
+  EnabledOrgsRequest request;
+
+  @Transactional
+  @BeforeEach
+  public void setup() {
+    Mockito.reset(consumer);
+    Map<String, Object> properties = kafkaProperties.buildProducerProperties(null);
+    properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+    var factory = new DefaultKafkaProducerFactory<String, EnabledOrgsRequest>(properties);
+    kafkaTemplate = new KafkaTemplate<>(factory);
+
+    // mock the repository
+    when(repository.findSyncEnabledOrgs()).thenReturn(Stream.of(ORG_ID));
+  }
+
+  @Test
+  void testRequestIsIgnoredWhenUsingNotAllowedTargetTopic() {
+    givenRequestWithTargetTopic("wrong");
+    whenSendRequest();
+    thenRepositoryWasNotUsed();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "platform.rhsm-subscriptions.subscription-prune-task",
+        "platform.rhsm-subscriptions.subscription-sync-task"
+      })
+  void testRequestWithAllowedTargetTopic(String targetTopic) {
+    givenRequestWithTargetTopic(targetTopic);
+    whenSendRequest();
+    thenRepositoryWasUsed();
+    thenResponseIsSentToTargetTopic(targetTopic);
+  }
+
+  private void givenRequestWithTargetTopic(String targetTopic) {
+    request = new EnabledOrgsRequest().withTargetTopic(targetTopic);
+  }
+
+  private void whenSendRequest() {
+    kafkaTemplate.send(enabledOrgsTopicProperties.getTopic(), request);
+    // wait until message is processed
+    Awaitility.await().untilAsserted(() -> verify(consumer).receive(request));
+  }
+
+  private void thenRepositoryWasNotUsed() {
+    Mockito.verifyNoInteractions(repository);
+  }
+
+  private void thenRepositoryWasUsed() {
+    verify(repository).findSyncEnabledOrgs();
+  }
+
+  private void thenResponseIsSentToTargetTopic(String targetTopic) {
+    verify(producer).send(targetTopic, new EnabledOrgsResponse().withOrgId(ORG_ID));
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/test/ExtendWithEmbeddedKafka.java
+++ b/src/test/java/org/candlepin/subscriptions/test/ExtendWithEmbeddedKafka.java
@@ -32,7 +32,11 @@ import org.springframework.test.context.DynamicPropertySource;
       "${rhsm-subscriptions.billing-producer.incoming.topic:platform.rhsm-subscriptions.tally}",
       "${rhsm-subscriptions.billing-producer.outgoing.topic:platform.rhsm-subscriptions.billable-usage}",
       "${rhsm-subscriptions.service-instance-ingress.incoming.topic:platform.rhsm-subscriptions.service-instance-ingress}",
-      "${rhsm-subscriptions.subscription-export.tasks.topic:platform.export.requests}"
+      "${rhsm-subscriptions.subscription-export.tasks.topic:platform.export.requests}",
+      "${rhsm-subscriptions.enabled-orgs.incoming.topic:platform.rhsm-subscriptions.enabled-orgs-for-tasks}",
+      // these following two topics are created outside of swatch-tally:
+      "platform.rhsm-subscriptions.subscription-prune-task",
+      "platform.rhsm-subscriptions.subscription-sync-task"
     })
 public interface ExtendWithEmbeddedKafka {
   @DynamicPropertySource

--- a/swatch-core/schemas/enabled_orgs_request.yaml
+++ b/swatch-core/schemas/enabled_orgs_request.yaml
@@ -1,0 +1,8 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: EnabledOrgsRequest
+required:
+  - target_topic
+properties:
+  target_topic:
+    description: The target topic where to send all the enabled orgs found.
+    type: string

--- a/swatch-core/schemas/enabled_orgs_response.yaml
+++ b/swatch-core/schemas/enabled_orgs_response.yaml
@@ -1,0 +1,7 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: EnabledOrgsResponse
+required:
+  - org_id
+properties:
+  org_id:
+    type: string

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -161,6 +161,10 @@ parameters:
     value: '3'
   - name: KAFKA_SUBSCRIPTIONS_TASKS_PARTITIONS
     value: '3'
+  - name: KAFKA_ENABLED_ORGS_REPLICAS
+    value: '3'
+  - name: KAFKA_ENABLED_ORGS_PARTITIONS
+    value: '3'
   - name: ENABLE_SYNCHRONOUS_OPERATIONS
     value: 'false'
   - name: TALLY_MAX_HBI_ACCOUNT_SIZE
@@ -259,6 +263,9 @@ objects:
       - replicas: ${{KAFKA_SERVICE_INSTANCE_DEAD_LETTER_REPLICAS}}
         partitions: ${{KAFKA_SERVICE_INSTANCE_DEAD_LETTER_PARTITIONS}}
         topicName: platform.rhsm-subscriptions.service-instance-ingress.dlt
+      - replicas: ${{KAFKA_ENABLED_ORGS_REPLICAS}}
+        partitions: ${{KAFKA_ENABLED_ORGS_PARTITIONS}}
+        topicName: platform.rhsm-subscriptions.enabled-orgs-for-tasks
 
     database:
       # Must specify both a name and a major postgres version


### PR DESCRIPTION
Jira issue: [SWATCH-2276](https://issues.redhat.com/browse/SWATCH-2276)

## Description
Expose the OrgConfigRepository.findSyncEnabledOrgs via Kafka topics.  Added request/response model in swatch-core that will also be used by the swatch-contracts service.

## Testing
1. start kafka and rest of the services
2. start the tally service:
```
DEV_MODE=true SPRING_PROFILES_ACTIVE=worker ./gradlew :bootRun
```
3. send request to the topic: `platform.rhsm-subscriptions.enabled-orgs-for-tasks`:
```
{"target_topic": "wrong"}
```
4. verify this message is ignored because the target topic is invalid

you should see the following trace in the tally service logs:

```
2024-03-22 10:30:32,560 [thread=rhsm-subscriptions-enabled-orgs-processor-0-C-1] [WARN ] [org.candlepin.subscriptions.tally.tasks.EnabledOrgsMessageConsumer] - Ignoring enabled organizations request for target topic 'wrong' because it's not allowed. List of allowed target topics are: '[platform.rhsm-subscriptions.subscription-prune-task, platform.rhsm-subscriptions.subscription-sync-task]'
```

5. create an enabled org in database:
```
INSERT INTO public.org_config(org_id, opt_in_type, created, updated)
VALUES('123456', 'DB', now(), now());
```

6. send a valid request to the same topic than step 3:
```
{"target_topic": "platform.rhsm-subscriptions.subscription-sync-task"}
```

7. now, you should see the following logs in the tally service:
```
2024-03-22 10:36:56,600 [thread=rhsm-subscriptions-enabled-orgs-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.tasks.EnabledOrgsMessageConsumer] - Sending all enabled organizations to topic 'platform.rhsm-subscriptions.subscription-sync-task'
2024-03-22 10:36:56,702 [thread=kafka-producer-network-thread | producer-1] [WARN ] [org.apache.kafka.clients.NetworkClient] - [Producer clientId=producer-1] Error while fetching metadata with correlation id 1 : {platform.rhsm-subscriptions.subscription-sync-task=UNKNOWN_TOPIC_OR_PARTITION}
2024-03-22 10:36:57,003 [thread=rhsm-subscriptions-enabled-orgs-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.tasks.EnabledOrgsMessageConsumer] - Sent 1 messages with the organization ID to topic 'platform.rhsm-subscriptions.subscription-sync-task'
```

Note that the second trace is expected because the topic has not been created yet. 

8. check the topic "platform.rhsm-subscriptions.subscription-sync-task" contains the expected org id:
http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.subscription-sync-task/

content:
```
Key
Value
org_id 123456
```