### PR TITLE
[HOTFIX] SWATCH-2345: Remove stale host buckets during hourly tally

### DIFF
--- a/src/main/resources/product-stub-data/engprods-MW02164HR.json
+++ b/src/main/resources/product-stub-data/engprods-MW02164HR.json
@@ -1,0 +1,10 @@
+{
+  "entries": [
+    {
+      "sku": "MW02164HR",
+      "engProducts": {
+        "engProducts": []
+      }
+    }
+  ]
+}

--- a/src/main/resources/product-stub-data/tree-MW02164HR_attrs-true.json
+++ b/src/main/resources/product-stub-data/tree-MW02164HR_attrs-true.json
@@ -1,0 +1,24 @@
+{
+  "products": [
+    {
+      "sku": "MW02164HR",
+      "description": "Red Hat Advanced Cluster Security Cloud Service, Premium (1 vCPU, Hourly, On-Demand, Billing)",
+      "status": "ACTIVE",
+      "attributes": [
+        {
+          "code": "SOCKET_LIMIT",
+          "value": "Unlimited"
+        },
+        {
+          "code": "SERVICE_TYPE",
+          "value": "Premium"
+        },
+        {
+          "code": "PRODUCT_NAME",
+          "value": "Advanced Cluster Security - Kubernetes"
+        }
+      ],
+      "roles": []
+    }
+  ]
+}


### PR DESCRIPTION
NOTE: Same as #3167 but for hotfix branch.

Jira issue: [SWATCH-2345](https://issues.redhat.com/browse/SWATCH-2345)

Description
===========

When swatch applies an event to a host record, one of the things it does is update the tally buckets associated to that host. However, the changes for hourly tally are only additive (compared to the nightly tally).

The effect is that a system counts towards buckets it should not, and a system's usage gets included in buckets it shouldn't.

For example, if the billing account id changes, it counts towards both the old billing account ID and the new one.

To address, I updated the logic to remove buckets that no longer apply.

I also added stub data for RHACS, since that was in the example that Nikhil provided for iqe steps.

Testing
=======

Setup
-----

Run the monolith on port 8000:

```shell
DEV_MODE=true PRODUCT_USE_STUB=true SUBSCRIPTION_USE_STUB=true ./gradlew :bootRun
```

Simultaneously, run the contract service on port 8001:

```shell
QUARKUS_MANAGEMENT_PORT=9001 SERVER_PORT=8001 ./gradlew swatch-contracts:quarkusDev
```

Launch `iqe shell` using `swatch-support-scripts` (internal repo).

Verification
------------

Clear data for the test account:

```python
app.rhsm_subscriptions.reset_account()
```

Create a mock subscription for billingAccount "nikhil":

```python
app.rhsm_subscriptions.create_mock_subscription(product_id='rhacs',  billing_account_id="nikhil", billing_provider="aws", start_day="2024-03-19")
```

Create a mock subscription for billingAccount "sanket":

```python
app.rhsm_subscriptions.create_mock_subscription(product_id='rhacs',  billing_account_id="sanket", billing_provider="aws", start_day="2024-03-19")
```

Create separate usage events simulating a change of billing account id from "nikhil" to "sanket":

```python
events = [
    {
        'event_source': 'prometheus',
        'event_type': 'snapshot_Instance-hours',
        'org_id': '123456789',
        'product_tag': ['rhacs'],
        'instance_id': 'nikhil-uuid',
        'timestamp': '2024-03-21T09:00:00Z',
        'expiration': '2024-03-21T10:00:00Z',
        'display_name': 'rhacs_cluster_nikhil-uuid',
        'measurements': [{'value': 1, 'uom': 'Cores'}],
        'sla': 'Premium',
        'service_type': 'Rhacs Cluster',
        'role': 'rhacs',
        'billing_provider': 'aws',
        'billing_account_id': 'nikhil'
    },
    {
        'event_source': 'prometheus',
        'event_type': 'snapshot_Instance-hours',
        'org_id': '123456789',
        'product_tag': ['rhacs'],
        'instance_id': 'nikhil-uuid',
        'timestamp': '2024-03-21T10:00:00Z',
        'expiration': '2024-03-21T11:00:00Z',
        'display_name': 'rhacs_cluster_nikhil-uuid',
        'measurements': [{'value': 3, 'uom': 'Cores'}],
        'sla': 'Premium',
        'service_type': 'Rhacs Cluster',
        'role': 'rhacs',
        'billing_provider': 'aws',
        'billing_account_id': 'sanket'
    }
]
from smqe_tools import _save_events; _save_events("123456789", events)
```

Perform hourly tally:

```python
app.rhsm_subscriptions.sync_tally_hourly(perform_metering=False, hours=4)
```

Check the results:

```python
app.rhsm_subscriptions.get_account_remittance("rhacs")
```

Without this change, you'll see 4 for nikhil and 3 for sanket.

With this change, the second event only counts towards sanket, giving 1 to nikhil and 3 to sanket.