### PR TITLE
SWATCH-2366: Unify resteasy dependencies into one single property

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,6 +14,7 @@ buildscript {
 ext {
     quarkusVersion='3.6.6'
     springVersion='3.2.4'
+    resteasyVersion='6.2.8.Final'
     libraries = [:]
     plugins = []
 }
@@ -63,13 +64,13 @@ libraries["netty-codec-http2"] = "io.netty:netty-codec-http2:4.1.108.Final"
 libraries["quarkus-logging-logback"] = "io.quarkiverse.logging.logback:quarkus-logging-logback:1.1.2"
 libraries["quarkus-logging-splunk"] = "io.quarkiverse.logging.splunk:quarkus-logging-splunk:3.1.3"
 libraries["resilience4j-spring-boot2"] = "io.github.resilience4j:resilience4j-spring-boot2:2.2.0"
-libraries["resteasy-jackson2-provider"] = "org.jboss.resteasy:resteasy-jackson2-provider:6.2.7.Final"
+libraries["resteasy-jackson2-provider"] = "org.jboss.resteasy:resteasy-jackson2-provider:${resteasyVersion}"
 libraries["jackson-annotations"] = "com.fasterxml.jackson.core:jackson-annotations:2.17.0"
 libraries["jakarta-validation-api"] = "jakarta.validation:jakarta.validation-api:3.0.2"
-libraries["resteasy-client"] = "org.jboss.resteasy:resteasy-client:6.2.7.Final"
-libraries["resteasy-multipart-provider"] = "org.jboss.resteasy:resteasy-multipart-provider:6.2.7.Final"
+libraries["resteasy-client"] = "org.jboss.resteasy:resteasy-client:${resteasyVersion}"
+libraries["resteasy-multipart-provider"] = "org.jboss.resteasy:resteasy-multipart-provider:${resteasyVersion}"
 libraries["resteasy-spring-boot-starter"] = "org.jboss.resteasy:resteasy-servlet-spring-boot-starter:6.1.1.Final"
-libraries["resteasy-validator-provider"] = "org.jboss.resteasy:resteasy-validator-provider:6.2.7.Final"
+libraries["resteasy-validator-provider"] = "org.jboss.resteasy:resteasy-validator-provider:${resteasyVersion}"
 libraries["splunk-library-javalogging"] = "com.splunk.logging:splunk-library-javalogging:1.11.8"
 libraries["swagger-annotations"] = "io.swagger:swagger-annotations:1.6.14"
 libraries["swagger-ui"] = "org.webjars:swagger-ui:5.12.0"


### PR DESCRIPTION
Jira issue: [SWATCH-2366](https://issues.redhat.com/browse/SWATCH-2366)

## Description
The following dependencies are declared in gradle individually:

org.jboss.resteasy:resteasy-multipart-provider
org.jboss.resteasy:resteasy-client
org.jboss.resteasy:resteasy-validator-provider
org.jboss.resteasy:resteasy-jackson2-provider
So, when a new version of resteasy is released, dependabot creates four pull requests for each one.

Unify the resteasy dependencies to use a single property `resteasyVersion` to declare the resteasy version.

## Testing
Only regression testing.