### PR TITLE
SWATCH-2326: include the inventory_id in the instances report

### DIFF
--- a/api/rhsm-subscriptions-api-spec.yaml
+++ b/api/rhsm-subscriptions-api-spec.yaml
@@ -1139,12 +1139,15 @@ components:
           $ref: '#/components/schemas/CloudProvider'
         subscription_manager_id:
           type: string
+        inventory_id:
+          type: string
       example:
         id: d6214a0b-b344-4778-831c-d53dcacb2da3
-        instance_id: 879180f3-76a4-46d5-8fff-7fb32067340b
+        instance_id: i-vvqwfvrcnrzoujhwa
         display_name: rhv.example.com
         billing_provider: red hat
         billing_account_id: e460fbca-a351-4c6a-a36a-18fdbfbc5a20
+        inventory_id: 879180f3-76a4-46d5-8fff-7fb32067340b
         measurements:
           - 42
           - null

--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -317,6 +317,7 @@ public class InstancesResource implements InstancesApi {
     instance.setLastAppliedEventRecordDate(tallyInstanceView.getLastAppliedEventRecordDate());
     instance.setNumberOfGuests(tallyInstanceView.getNumOfGuests());
     instance.setSubscriptionManagerId(tallyInstanceView.getSubscriptionManagerId());
+    instance.setInventoryId(tallyInstanceView.getInventoryId());
     return instance;
   }
 

--- a/src/main/resources/liquibase/202403260830-update-instance-view-to-include-inventory-id.xml
+++ b/src/main/resources/liquibase/202403260830-update-instance-view-to-include-inventory-id.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202403260830-1" author="jcarvaja">
+    <comment>
+      Update the tally_instance_view to include the Host's inventory_id.
+    </comment>
+    <dropView viewName="tally_instance_view"/>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_view">
+      select
+        distinct org_id,
+        h.id,
+        h.instance_id as instance_id,
+        h.display_name,
+        h.billing_provider as host_billing_provider,
+        h.billing_account_id as host_billing_account_id,
+        b.billing_provider as bucket_billing_provider,
+        b.billing_account_id as bucket_billing_account_id,
+        h.last_seen,
+        h.last_applied_event_record_date,
+        coalesce(h.num_of_guests, 0) AS num_of_guests,
+        b.product_id,
+        b.sla,
+        b.usage,
+        coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+        m.metric_id,
+        m.value,
+        b.sockets,
+        b.cores,
+        h.subscription_manager_id,
+        h.inventory_id
+      from hosts h
+        join host_tally_buckets b on h.id = b.host_id
+        left outer join instance_measurements m on h.id = m.host_id;
+    </createView>
+    <rollback>
+      <dropView viewName="tally_instance_view"/>
+      <createView
+              replaceIfExists="true"
+              viewName="tally_instance_view">
+        select
+        distinct org_id,
+        h.id,
+        h.instance_id as instance_id,
+        h.display_name,
+        h.billing_provider as host_billing_provider,
+        h.billing_account_id as host_billing_account_id,
+        b.billing_provider as bucket_billing_provider,
+        b.billing_account_id as bucket_billing_account_id,
+        h.last_seen,
+        h.last_applied_event_record_date,
+        coalesce(h.num_of_guests, 0) AS num_of_guests,
+        b.product_id,
+        b.sla,
+        b.usage,
+        coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+        m.metric_id,
+        m.value,
+        b.sockets,
+        b.cores,
+        h.subscription_manager_id
+        from hosts h
+        join host_tally_buckets b on h.id = b.host_id
+        left outer join instance_measurements m on h.id = m.host_id;
+      </createView>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -147,5 +147,6 @@
     <include file="/liquibase/202312010920-add-org-id-instance-id-index-to-hosts.xml" />
     <include file="/liquibase/202401080920-remove-uniqueness-constraint-on-events.xml" />
     <include file="/liquibase/202401161133-update-instance-view-to-include-last-applied-event-record-date.xml" />
+    <include file="/liquibase/202403260830-update-instance-view-to-include-inventory-id.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.OrgConfigRepository;
 import org.candlepin.subscriptions.db.TallyInstanceViewRepository;
@@ -98,6 +99,7 @@ class InstancesResourceTest {
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
     tallyInstanceView.setLastAppliedEventRecordDate(OffsetDateTime.now());
+    tallyInstanceView.setInventoryId(UUID.randomUUID().toString());
     tallyInstanceView.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
@@ -131,6 +133,7 @@ class InstancesResourceTest {
     var data = new InstanceData();
     data.setId("testHostId");
     data.setInstanceId(tallyInstanceView.getKey().getInstanceId());
+    data.setInventoryId(tallyInstanceView.getInventoryId());
     data.setDisplayName(tallyInstanceView.getDisplayName());
     data.setBillingProvider(expectedBillingProvider.asOpenApiEnum());
     data.setLastSeen(tallyInstanceView.getLastSeen());

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -82,6 +82,9 @@ public class TallyInstanceView implements Serializable {
   @Column(name = "subscription_manager_id")
   private String subscriptionManagerId;
 
+  @Column(name = "inventory_id")
+  private String inventoryId;
+
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(
       name = "instance_monthly_totals",


### PR DESCRIPTION
Jira issue: [SWATCH-2326](https://issues.redhat.com/browse/SWATCH-2326)

## Description
In SWATCH-2144, we changed the existing instance_id from inventory_id to the actual provider id. However, the UI was using this instance_id to build up the link to the inventory service. So, we need to provide the inventory_id, so the UI can continue building this url.

## Testing
MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/621