### PR TITLE
SWATCH-1957 Remove use of product name while emitting usage

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.subscription;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.MoreCollectors;
+import com.redhat.swatch.configuration.registry.Variant;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -627,9 +628,15 @@ public class SubscriptionSyncController {
     Assert.isTrue(Usage._ANY != usageKey.getUsage(), "Usage cannot be _ANY");
     Assert.isTrue(ServiceLevel._ANY != usageKey.getSla(), "Service Level cannot be _ANY");
 
+    String productTag = usageKey.getProductId();
+    if (!Variant.isValidProductTag(productTag)) {
+      log.warn("No product tag configured: {}", productTag);
+      return Collections.emptyList();
+    }
+
     DbReportCriteria.DbReportCriteriaBuilder reportCriteriaBuilder =
         DbReportCriteria.builder()
-            .productTag(usageKey.getProductId())
+            .productTag(productTag)
             .serviceLevel(usageKey.getSla())
             // NOTE(khowell) due to an oversight PAYG SKUs don't currently have a usage set -
             // at some point we should use usageKey.getUsage() instead of "_ANY"

--- a/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/SubscriptionRepositoryTest.java
@@ -71,7 +71,7 @@ class SubscriptionRepositoryTest {
     // reset NOW so that it is current and not fixed.
     NOW = OffsetDateTime.now();
     Subscription subscription = createSubscription("1", "123", "sellerAcctId");
-    Offering offering = createOffering("testSku", 1066, null, null, null);
+    Offering offering = createOffering("testSku", "rosa", 1066, null, null, null);
     subscription.setOffering(offering);
     offeringRepo.save(offering);
     subscriptionRepo.saveAndFlush(subscription);
@@ -97,18 +97,21 @@ class SubscriptionRepositoryTest {
   @Test
   void canMatchOfferings() {
     Subscription subscription = createSubscription("1", "123", "sellerAcctId");
-    Offering o1 = createOffering("testSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+    Offering o1 =
+        createOffering("testSku1", "rosa", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     subscription.setOffering(o1);
     offeringRepo.save(o1);
     subscriptionRepo.save(subscription);
 
-    Offering o2 = createOffering("testSku2", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
+    Offering o2 =
+        createOffering("testSku2", "rosa", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
     offeringRepo.saveAndFlush(o2);
 
-    Set<String> productNames = Set.of("Test SKU 1");
+    String productTag = "rosa";
     var resultList =
         subscriptionRepo.findByCriteria(
             DbReportCriteria.builder()
+                .productTag(productTag)
                 .serviceLevel(ServiceLevel.STANDARD)
                 .usage(Usage.PRODUCTION)
                 .billingProvider(BillingProvider._ANY)
@@ -126,22 +129,25 @@ class SubscriptionRepositoryTest {
   @Transactional
   @Test
   void doesNotMatchMismatchedSkusOfferings() {
-    Offering offering = createOffering("testSku", 1066, null, null, null);
+    Offering offering = createOffering("testSku", "rosa", 1066, null, null, null);
     offeringRepo.save(offering);
 
     Subscription subscription = createSubscription("1", "123", "sellerAcctId");
     subscription.setOffering(offering);
     subscriptionRepo.saveAndFlush(subscription);
 
-    Offering o1 = createOffering("otherSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+    Offering o1 =
+        createOffering("otherSku1", "rosa", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     offeringRepo.saveAndFlush(o1);
-    Offering o2 = createOffering("otherSku2", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
+    Offering o2 =
+        createOffering("otherSku2", "rosa", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
     offeringRepo.saveAndFlush(o2);
 
+    String productTag = "rosa";
     var result =
         subscriptionRepo.findByCriteria(
             DbReportCriteria.builder()
-                .productTag("testProductTag")
+                .productTag(productTag)
                 .serviceLevel(ServiceLevel.STANDARD)
                 .usage(Usage.PRODUCTION)
                 .billingProvider(BillingProvider._ANY)
@@ -156,22 +162,25 @@ class SubscriptionRepositoryTest {
   @Transactional
   @Test
   void doesNotMatchMismatchedBillingAccountId() {
-    Offering offering = createOffering("testSku", 1066, null, null, null);
+    Offering offering = createOffering("testSku", "rosa", 1066, null, null, null);
     offeringRepo.save(offering);
 
     Subscription subscription = createSubscription("1", "123", "sellerAcctId");
     subscription.setOffering(offering);
     subscriptionRepo.saveAndFlush(subscription);
 
-    Offering o1 = createOffering("testSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+    Offering o1 =
+        createOffering("testSku1", "rosa", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     offeringRepo.save(o1);
-    Offering o2 = createOffering("testSku2", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
+    Offering o2 =
+        createOffering("testSku2", "rosa", 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
     offeringRepo.saveAndFlush(o2);
 
+    String productTag = "rosa";
     var resultList =
         subscriptionRepo.findByCriteria(
             DbReportCriteria.builder()
-                .productTag("testProductTag")
+                .productTag(productTag)
                 .serviceLevel(ServiceLevel.STANDARD)
                 .usage(Usage.PRODUCTION)
                 .billingProvider(BillingProvider._ANY)
@@ -192,16 +201,18 @@ class SubscriptionRepositoryTest {
     Subscription subscription2 =
         createSubscription("1", "234", "sellerAcctId", NOW, NOW.plusDays(30));
     Offering offering =
-        createOffering("testSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+        createOffering("testSku1", "rosa", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     List<Subscription> subscriptions = List.of(subscription1, subscription2);
     subscriptions.forEach(x -> x.setOffering(offering));
     offeringRepo.save(offering);
     subscriptionRepo.saveAllAndFlush(subscriptions);
 
+    String productTag = "rosa";
+
     var resultList =
         subscriptionRepo.findByCriteria(
             DbReportCriteria.builder()
-                .productTag("testProductTag")
+                .productTag(productTag)
                 .serviceLevel(ServiceLevel.STANDARD)
                 .usage(Usage.PRODUCTION)
                 .billingProvider(BillingProvider._ANY)
@@ -223,7 +234,8 @@ class SubscriptionRepositoryTest {
   @Test
   void findsAllSubscriptionsForSla() {
     Offering mct3718 =
-        createOffering("MCT3718", 1066, ServiceLevel.SELF_SUPPORT, Usage.PRODUCTION, "ROLE");
+        createOffering(
+            "MCT3718", "rosa", 1066, ServiceLevel.SELF_SUPPORT, Usage.PRODUCTION, "ROLE");
     offeringRepo.save(mct3718);
 
     for (int i = 0; i < 5; i++) {
@@ -241,8 +253,8 @@ class SubscriptionRepositoryTest {
   @Transactional
   @Test
   void findsAllSubscriptionsForAGivenSku() {
-    Offering mct3718 = createOffering("MCT3718", 1066, null, null, null);
-    Offering rh00798 = createOffering("RH00798", 1512, null, null, null);
+    Offering mct3718 = createOffering("MCT3718", "rosa", 1066, null, null, null);
+    Offering rh00798 = createOffering("RH00798", "rosa", 1512, null, null, null);
     offeringRepo.saveAllAndFlush(List.of(mct3718, rh00798));
 
     for (int i = 0; i < 5; i++) {
@@ -272,13 +284,13 @@ class SubscriptionRepositoryTest {
   void findsUnlimitedSubscriptions() {
     var s1 = createSubscription("org123", "sub123", "seller123");
     var s2 = createSubscription("org123", "sub321", "seller123");
-    var offering1 = createOffering("testSkuUnlimited", 1066, null, null, null);
+    var offering1 = createOffering("testSkuUnlimited", "rosa", 1066, null, null, null);
     offering1.setHasUnlimitedUsage(true);
     List.of(s1, s2).forEach(x -> x.setOffering(offering1));
 
     var s3 = createSubscription("org123", "sub456", "seller123");
     var s4 = createSubscription("org123", "sub678", "seller123");
-    var offering2 = createOffering("testSkuLimited", 1066, null, null, null);
+    var offering2 = createOffering("testSkuLimited", "rosa", 1066, null, null, null);
     offering2.setHasUnlimitedUsage(false);
     List.of(s3, s4).forEach(x -> x.setOffering(offering2));
 
@@ -301,7 +313,7 @@ class SubscriptionRepositoryTest {
     var s2 = createSubscription("org123", "sub321", "seller123");
     s2.setEndDate(null);
 
-    var offering1 = createOffering("testSkuUnlimited", 1066, null, null, null);
+    var offering1 = createOffering("testSkuUnlimited", "rosa", 1066, null, null, null);
     List.of(s1, s2).forEach(x -> x.setOffering(offering1));
 
     offeringRepo.save(offering1);
@@ -319,7 +331,7 @@ class SubscriptionRepositoryTest {
     var s2 = createSubscription("org123", "sub321", "seller123");
     s2.setEndDate(null);
 
-    var offering1 = createOffering("testSkuUnlimited", 1066, null, null, null);
+    var offering1 = createOffering("testSkuUnlimited", "rosa", 1066, null, null, null);
     List.of(s1, s2).forEach(x -> x.setOffering(offering1));
 
     offeringRepo.save(offering1);
@@ -342,7 +354,8 @@ class SubscriptionRepositoryTest {
   @Transactional
   @Test
   void testMatchesOnFirstPartOfMultipartBillingAccountId() {
-    Offering o1 = createOffering("testSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+    Offering o1 =
+        createOffering("testSku1", "rosa", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     offeringRepo.save(o1);
 
     Subscription subscription1 =
@@ -353,10 +366,11 @@ class SubscriptionRepositoryTest {
     subscriptionRepo.saveAndFlush(subscription1);
     subscriptionRepo.saveAndFlush(subscription2);
 
+    String productTag = "rosa";
     var resultList =
         subscriptionRepo.findByCriteria(
             DbReportCriteria.builder()
-                .productTag("testProductTag")
+                .productTag(productTag)
                 .serviceLevel(ServiceLevel.STANDARD)
                 .usage(Usage.PRODUCTION)
                 .billingProvider(BillingProvider._ANY)
@@ -372,7 +386,8 @@ class SubscriptionRepositoryTest {
   @Transactional
   @Test
   void testMatchesOnBothPartsOfMultipartBillingAccountId() {
-    Offering o1 = createOffering("testSku1", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
+    Offering o1 =
+        createOffering("testSku1", "rosa", 1, ServiceLevel.STANDARD, Usage.PRODUCTION, "ocp");
     offeringRepo.save(o1);
 
     Subscription subscription1 =
@@ -383,10 +398,11 @@ class SubscriptionRepositoryTest {
     subscriptionRepo.saveAndFlush(subscription1);
     subscriptionRepo.saveAndFlush(subscription2);
 
+    String productTag = "rosa";
     var resultList =
         subscriptionRepo.findByCriteria(
             DbReportCriteria.builder()
-                .productTag("testProductTag")
+                .productTag(productTag)
                 .serviceLevel(ServiceLevel.STANDARD)
                 .usage(Usage.PRODUCTION)
                 .billingProvider(BillingProvider._ANY)
@@ -408,8 +424,8 @@ class SubscriptionRepositoryTest {
     Offering mct3718 =
         createOffering(
             "MCT3718",
-            1066,
             expectedProductTag,
+            1066,
             ServiceLevel.SELF_SUPPORT,
             Usage.PRODUCTION,
             "ROLE");
@@ -428,12 +444,7 @@ class SubscriptionRepositoryTest {
   }
 
   private Offering createOffering(
-      String sku, int productId, ServiceLevel sla, Usage usage, String role) {
-    return createOffering(sku, productId, "testProductTag", sla, usage, role);
-  }
-
-  private Offering createOffering(
-      String sku, int productId, String productTag, ServiceLevel sla, Usage usage, String role) {
+      String sku, String productTag, int productId, ServiceLevel sla, Usage usage, String role) {
     return Offering.builder()
         .sku(sku)
         .productIds(Set.of(productId))
@@ -441,6 +452,7 @@ class SubscriptionRepositoryTest {
         .serviceLevel(sla)
         .usage(usage)
         .role(role)
+        .productTags(Set.of(productTag))
         .build();
   }
 

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.*;
 
@@ -95,14 +93,6 @@ public class Variant {
                 subscriptionDefinition.getSupportedGranularity().contains(granularity));
   }
 
-  public static Optional<Variant> findByProductName(String productName) {
-    return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
-        .map(SubscriptionDefinition::getVariants)
-        .flatMap(List::stream)
-        .filter(v -> v.getProductNames().contains(productName))
-        .findFirst();
-  }
-
   public static Stream<Variant> filterVariantsByProductName(String productName) {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
         .map(SubscriptionDefinition::getVariants)
@@ -110,11 +100,8 @@ public class Variant {
         .filter(v -> v.getProductNames().contains(productName));
   }
 
-  public static Set<String> getProductNamesForTag(String productId) {
-    return findByTag(productId).stream()
-        .map(Variant::getProductNames)
-        .flatMap(List::stream)
-        .collect(Collectors.toSet());
+  public static boolean isValidProductTag(String productId) {
+    return findByTag(productId).isPresent();
   }
 
   public static List<Metric> getMetricsForTag(String tag) {

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
@@ -66,6 +66,14 @@ class VariantTest {
   }
 
   @Test
+  void testValidProductTag() {
+    assertTrue(Variant.isValidProductTag("RHEL for x86"));
+    assertFalse(Variant.isValidProductTag("rhel-for-x86"));
+    assertTrue(Variant.isValidProductTag("OpenShift Container Platform"));
+    assertFalse(Variant.isValidProductTag("openshift-container-platform"));
+  }
+
+  @Test
   void testGranularityCompatibilityNotSupported() {
     assertFalse(
         Variant.isGranularityCompatible("RHEL for x86", SubscriptionDefinitionGranularity.HOURLY));


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-1957

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
We were using product name earlier that was causing issue when we were creating aws usage context. This code removes the use of product name and uses product tag instead.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
1. Create offering
2. Add rosa subscription
3. Create rosa event
4. Sync hourly tally
5. Check for usage

### Setup
<!-- Add any steps required to set up the test case -->
1. 
`INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered) VALUES ('MW02393', 'OpenShift Online', 'OpenShift Enterprise', null, null, null, null, null, 'Premium', '', 'Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)', false, null, true);`

`INSERT INTO public.sku_product_tag (sku, product_tag) VALUES ('MW02393', 'rosa');`


`INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02393', '17791312', '178730', 1, '2024-03-19 04:14:09.365000 +00:00', '2024-04-08 04:14:09.365000 +00:00', 'testProductCode;612345;1234567', '0834547', 'aws', '612345');`



### Steps and Verification
<!-- Enter each step of the test below -->
1. `curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext?productId=rosa&date=2024-03-29T00%3A00Z&orgId=17791312&accountNumber=11768912&sla=Premium&usage=ProductionawsAccountId=9458475893'   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'`

**Query executed:**
select * from subscription s1 join offering o1_0 on o1_0.sku=s1.sku join offering o2_0 on o2_0.sku=s1.sku join sku_product_tag pt1 on o2_0.sku=pt1.sku left join subscription_measurements sm1_0 on s1.start_date=sm1_0.start_date and s1.subscription_id=sm1_0.subscription_id 

where s1.start_date<=? and (s1.end_date is null or s1.end_date>=?) and s1.org_id=? and s1.billing_provider_id is not null and s1.billing_provider_id<>? and pt1.product_tag=? and o1_0.sla=? and s1.billing_provider=? order by s1.start_date desc
