### PR TITLE
Add Spring hot deployment to Clowdapps without it

### DIFF
--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: JAVA_OPTS_APPEND
+    value: ''
   - name: SERVER_MAX_HTTP_HEADER_SIZE
     value: '48000'
   - name: LOGGING_LEVEL_ROOT
@@ -190,6 +192,10 @@ objects:
                   cpu: ${CPU_LIMIT}
                   memory: ${MEMORY_LIMIT}
           env:
+            - name: JAVA_DEBUG
+              value: ${JAVA_DEBUG}
+            - name: JAVA_OPTS_APPEND
+              value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
             - name: SPRING_LIQUIBASE_ENABLED
               value: 'false'
             - name: ENABLE_SPLUNK_HEC

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: JAVA_OPTS_APPEND
+    value: ''
   - name: ENV_NAME
     value: env-swatch-subscription-sync
   - name: DEV_MODE
@@ -236,6 +238,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
+            - name: JAVA_OPTS_APPEND
+              value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
             - name: SPRING_LIQUIBASE_ENABLED
               value: 'false'
             - name: ENABLE_SPLUNK_HEC

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: JAVA_OPTS_APPEND
+    value: ''
   - name: ENV_NAME
     value: env-swatch-tally
   - name: SERVER_MAX_HTTP_HEADER_SIZE
@@ -295,6 +297,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
+            - name: JAVA_OPTS_APPEND
+              value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
             - name: ENABLE_SPLUNK_HEC
               value: ${ENABLE_SPLUNK_HEC}
             - name: SPLUNKMETA_namespace

--- a/swatchdog/README.md
+++ b/swatchdog/README.md
@@ -24,18 +24,67 @@
 This subcommand provides functionality dealing with the ephemeral environments.
 
 ### `deploy`
+#### Prerequisites
+In order for hot-deploy to work, your containers must be built in a specific
+way.  Namely, `-Dquarkus.package.type=mutable-jar` needs to be passed in during
+the build and the Gradle `snapshot` task needs to be invoked so you get a
+consistent JAR name rather than one that has the git hash in it.  (If the JAR
+has the git hash in it, every time you do a git commit, the rsync that copies
+your build artifact to the pod would just lay down a JAR with the new name
+instead of replacing the running JAR).
 
+The easiest way to meet these requirements is to **use the `bin/build-images.sh`
+script**.  This script requires that you have created a user in quay.io and that
+all the image repos have been marked as public since Openshift can't pull the
+image if it is private.  The repos are marked as private by default so after you
+do your first build go to your repos and set "Repository Visibility" to public
+under the settings section.
+
+If you don't want to use `bin/build-images.sh`, then you need to make sure that
+your image builds incorporate the `--build-arg-file bin/dev-argfile.conf` (or
+specify all the arguments in that file directly with `--build-arg`).
+
+The easiest way to make sure your image is built correctly is to simply look at
+the built container.  If it has a `/deployments/lib/deployment` directory,
+you're golden.
+
+Finally, you need to deploy your containers via `bonfire` so that hot-deployment
+is enabled.  This is controlled with the
+`JAVA_OPTS_APPEND=-Dspring.devtools.restart.enabled=true` and
+`QUARKUS_LAUNCH_DEVMODE=true` parameter settings.  Specifying these over and
+over in `bonfire` for each component we have is tedious, so I recommend editing
+your `~/.config/bonfire/config.yaml` file and adding the pertinent parameter for
+each component.
+
+**Edit your `~/.config/bonfire/config.yaml`** and add
+`JAVA_OPTS_APPEND=-Dspring.devtools.restart.enabled=true` as a parameter under
+each Spring component, currently `swatch-tally`,
+`swatch-producer-red-hat-marketplace`, `swatch-subscription-sync`,
+`swatch-system-conduit`, and `swatch-api`.  Then add
+`QUARKUS_LAUNCH_DEVMODE=true` to the parameter list for each Quarkus project.
+
+### Usage
 Use `deploy` to do a hot-deploy of the Spring code.  (Quarkus support will be in
 a later version).
 
 Options:
 * `--clean`/`--no-clean`: Whether to run a `gradle clean` as part of the build
   process.  Defaults to `--clean`
-* `-p`/`--project`: The gradle project to build and deploy.  Use `:` for the
-  root project.
-* `-p`/`--pod-prefix`: The pod prefix to deploy to.  E.g. `swatch-api-service`
+* `--project`: The gradle project to build and deploy.
+* `--pod-prefix`: The pod prefix to deploy to.  E.g. `swatch-api-service`
 * `--container`: The container within the pod to deploy to.  Useful because some
-  of our pods use sidecars.
+  of our pods use sidecars.  If you don't specify, `swatchdog` will look at all
+  the containers in a pod and pick the one that has a `containerPort` named
+  `web`.
+
+The `--project` and `--pod-prefix` flags use [`fzf`'s search syntax](https://github.com/junegunn/fzf?tab=readme-ov-file#search-syntax).
+I recommend reading the documentation there, but the short summary is
+
+* Prefix your argument with `'` if you want an exact-match, e.g. `--project
+  "'root"` to match only the word "root" rather than just any string containing
+  the characters "r", "o", "o", and "t".
+* Prefix your argument with `^` for a prefix exact-match, e.g. `--pod-prefix
+  "^swatch"` to view only the pods that *start* with the string "swatch".
 
 ## Resolving Conflicts
 If you get a merge conflict in `poetry.lock` (generally due to Dependabot


### PR DESCRIPTION
Also required since the splunk-otel-javaagent.jar is no longer set in the Dockerfile itself.

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This PR commit is a piece that was missing from #3179

## Testing

### Setup
1.  Perform an EE deployment.  You can use the pattern below (but be sure to replace the `-i` with the tags for your quay.io namespace.
    ```
    $ bin/build-images.sh
    $ VER=$(git rev-parse --short=7 HEAD) ;  bonfire deploy rhsm \
    --source=appsre \
    --ref-env insights-production \
    --optional-deps-method none \
    --frontends false \
    --no-remove-resources app:rhsm \
    --timeout 1800 \
    -i quay.io/awood/swatch-metrics=$VER \
    -i quay.io/awood/rhsm-subscriptions=$VER \
    -i quay.io/awood/swatch-contracts=$VER \
    -i quay.io/awood/swatch-producer-aws=$VER \
    -i quay.io/awood/swatch-producer-azure=$VER \
    -i quay.io/awood/swatch-system-conduit=$VER \
    -p swatch-metrics/IMAGE=quay.io/awood/swatch-metrics \
    -p swatch-tally/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-api/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-contracts/IMAGE=quay.io/awood/swatch-contracts \
    -p swatch-producer-aws/IMAGE=quay.io/awood/swatch-producer-aws \
    -p swatch-producer-azure/IMAGE=quay.io/awood/swatch-producer-azure \
    -p swatch-system-conduit/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-system-conduit/CONDUIT_IMAGE=quay.io/awood/swatch-system-conduit \
    -p swatch-producer-red-hat-marketplace/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-subscription-sync/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-api/JAVA_OPTS_APPEND=-Dspring.devtools.restart.enabled=true \
    -p swatch-contracts/QUARKUS_LAUNCH_DEVMODE=true \
    -p swatch-producer-aws/QUARKUS_LAUNCH_DEVMODE=true \
    -p swatch-producer-azure/QUARKUS_LAUNCH_DEVMODE=true \
    -p swatch-metrics/QUARKUS_LAUNCH_DEVMODE=true
    ```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.  A successful deployment with the swatch-producer-red-hat-marketplace, swatch-tally, and swatch-subscription-sync pods having `-javaagent:/opt/splunk-otel-javaagent.jar` set for `JAVA_OPTS_APPEND` in the environment.