### PR TITLE
SWATCH-1840: Use product tag for subscription query instead of product name

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/CapacityResource.java
@@ -205,7 +205,7 @@ public class CapacityResource implements CapacityApi {
     var dbReportCriteria =
         DbReportCriteria.builder()
             .orgId(orgId)
-            .productId(productId.toString())
+            .productTag(productId.toString())
             .serviceLevel(sla)
             .usage(usage)
             .beginning(reportBegin)

--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -24,14 +24,12 @@ import static org.candlepin.subscriptions.resource.ResourceUtils.*;
 
 import com.redhat.swatch.configuration.registry.ProductId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
-import com.redhat.swatch.configuration.registry.Variant;
 import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.Min;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -132,7 +130,7 @@ public class SubscriptionTableController {
     var reportCriteria =
         DbReportCriteria.builder()
             .orgId(orgId)
-            .productId(productId.toString())
+            .productTag(productId.toString())
             .serviceLevel(sanitizedServiceLevel)
             .usage(sanitizedUsage)
             .beginning(reportStart)
@@ -269,19 +267,13 @@ public class SubscriptionTableController {
       OffsetDateTime reportStart,
       OffsetDateTime reportEnd) {
 
-    var productNames =
-        new HashSet<>(
-            Variant.findByTag(productId.toString())
-                .map(Variant::getProductNames)
-                .orElse(new ArrayList<>()));
-
     Map<String, SkuCapacity> inventories = new HashMap<>();
 
     var subscriptions =
         subscriptionRepository.findByCriteria(
             DbReportCriteria.builder()
                 .orgId(getOrgId())
-                .productNames(productNames)
+                .productTag(productId.getValue())
                 .serviceLevel(serviceLevel)
                 .usage(usage)
                 .billingProvider(billingProvider)

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -23,7 +23,6 @@ package org.candlepin.subscriptions.subscription;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.MoreCollectors;
-import com.redhat.swatch.configuration.registry.Variant;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -628,16 +627,9 @@ public class SubscriptionSyncController {
     Assert.isTrue(Usage._ANY != usageKey.getUsage(), "Usage cannot be _ANY");
     Assert.isTrue(ServiceLevel._ANY != usageKey.getSla(), "Service Level cannot be _ANY");
 
-    String productId = usageKey.getProductId();
-    Set<String> productNames = Variant.getProductNamesForTag(productId);
-    if (productNames.isEmpty()) {
-      log.warn("No product names configured for tag: {}", productId);
-      return Collections.emptyList();
-    }
-
     DbReportCriteria.DbReportCriteriaBuilder reportCriteriaBuilder =
         DbReportCriteria.builder()
-            .productNames(productNames)
+            .productTag(usageKey.getProductId())
             .serviceLevel(usageKey.getSla())
             // NOTE(khowell) due to an oversight PAYG SKUs don't currently have a usage set -
             // at some point we should use usageKey.getUsage() instead of "_ANY"

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/DbReportCriteria.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/DbReportCriteria.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.db.model;
 
 import java.time.OffsetDateTime;
-import java.util.Set;
 import lombok.Builder;
 import lombok.Data;
 import org.candlepin.subscriptions.db.HypervisorReportCategory;
@@ -32,8 +31,6 @@ import org.candlepin.subscriptions.db.HypervisorReportCategory;
 public class DbReportCriteria {
   private String orgId;
   private String productTag;
-  // TODO: ENT-5042 should move away from using product name values here //NOSONAR
-  private Set<String> productNames;
   private String productId;
   private ServiceLevel serviceLevel;
   private Usage usage;


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-1840

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Since ProductName is a deprecated field we need to query subscriptions using product_tag instead.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert test data:
```
INSERT INTO public.offering VALUES ('MW01485', 'OpenShift Container Platform', 'OpenShift Enterprise', NULL, NULL, NULL, NULL, NULL, 'Premium', '', 'Red Hat OpenShift Container Platform (Hourly)', false, NULL, false);
INSERT INTO public.sku_product_tag VALUES ('MW01485', 'OpenShift Container Platform');
INSERT INTO public.subscription VALUES ('MW01485', 'org123', '957592', 1, '2024-02-26 00:20:46.986+00', '2025-03-07 00:20:46.986+00', 'testProductCode;testbyf;1234567', '4454946', 'azure', 'testbyf');
INSERT INTO public.subscription_measurements VALUES ('957592', '2024-02-26 00:20:46.986+00', 'Cores', 'PHYSICAL', 1);

```
### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Run these 3 API curl commands and each should return a result:
```
  curl -X 'GET'   "localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/OpenShift%20Container%20Platform?uom=cores"   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='

  curl -X 'GET' \
  "localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext?orgId=org123&sla=Premium&date=2024-10-31T00%3A00%3A00Z&productId=OpenShift%20Container%20Platform" \
  -H 'accept: application/json' \
  -H 'x-rh-swatch-psk: placeholder'

curl -X 'GET' \
  "localhost:8000/api/rhsm-subscriptions/v1/capacity/products/OpenShift%20Container%20Platform/Cores?granularity=Daily&beginning=2024-10-01T17%3A32%3A28Z&ending=2024-10-03T17%3A32%3A28Z" \
	-H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```
