### PR TITLE
SWATCH-2381: Clear billable usage suppress store topic during account

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -34,6 +34,9 @@ import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.validation.Validator;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.candlepin.subscriptions.actuator.CertInfoContributor;
 import org.candlepin.subscriptions.capacity.CapacityIngressConfiguration;
 import org.candlepin.subscriptions.capacity.CapacityReconciliationWorkerConfiguration;
@@ -59,6 +62,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.info.ConditionalOnEnabledInfoContributor;
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorFallback;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -66,6 +70,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -207,5 +212,14 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
   @Bean
   public ConsoleCloudEventParser cloudEventParser(@Autowired ObjectMapper objectMapper) {
     return new ConsoleCloudEventParser(objectMapper);
+  }
+
+  @Bean
+  public KafkaAdmin kafkaAdmin(KafkaProperties kafkaProperties) {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+    KafkaAdmin kafkaAdmin = new KafkaAdmin(configs);
+    kafkaAdmin.setModifyTopicConfigs(true);
+    return kafkaAdmin;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
@@ -20,7 +20,17 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import static java.util.stream.Collectors.toMap;
+
 import jakarta.transaction.Transactional;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.RecordsToDelete;
+import org.apache.kafka.common.TopicPartition;
 import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceRepository;
 import org.candlepin.subscriptions.db.EventRecordRepository;
@@ -29,10 +39,16 @@ import org.candlepin.subscriptions.db.SubscriptionRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.TallyStateRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class AccountResetService {
+
+  private static final String BILLABLE_USAGE_AGGREGATE_SUPPRESS_STORE_TOPIC =
+      "platform.rhsm-subscriptions.swatch-billable-usage-aggregator-billable-usage-suppress-store-changelog";
 
   private final EventRecordRepository eventRecordRepo;
   private final HostRepository hostRepo;
@@ -41,6 +57,7 @@ public class AccountResetService {
   private final SubscriptionRepository subscriptionRepository;
   private final BillableUsageRemittanceRepository remittanceRepository;
   private final TallyStateRepository tallyStateRepository;
+  private final KafkaAdmin kafkaAdmin;
 
   @Autowired
   public AccountResetService(
@@ -50,7 +67,8 @@ public class AccountResetService {
       AccountServiceInventoryRepository accountServiceInventoryRepository,
       SubscriptionRepository subscriptionRepository,
       BillableUsageRemittanceRepository remittanceRepository,
-      TallyStateRepository tallyStateRepository) {
+      TallyStateRepository tallyStateRepository,
+      KafkaAdmin kafkaAdmin) {
     this.eventRecordRepo = eventRecordRepo;
     this.hostRepo = hostRepo;
     this.tallySnapshotRepository = tallySnapshotRepository;
@@ -58,6 +76,7 @@ public class AccountResetService {
     this.subscriptionRepository = subscriptionRepository;
     this.remittanceRepository = remittanceRepository;
     this.tallyStateRepository = tallyStateRepository;
+    this.kafkaAdmin = kafkaAdmin;
   }
 
   @Transactional
@@ -69,5 +88,37 @@ public class AccountResetService {
     subscriptionRepository.deleteByOrgId(orgId);
     remittanceRepository.deleteByOrgId(orgId);
     tallyStateRepository.deleteByOrgId(orgId);
+    deleteKafkaData();
+  }
+
+  private void deleteKafkaData() {
+    NewTopic billableUsageSuppressStoreEmpty =
+        TopicBuilder.name(BILLABLE_USAGE_AGGREGATE_SUPPRESS_STORE_TOPIC)
+            .config("cleanup.policy", "delete")
+            .build();
+    kafkaAdmin.createOrModifyTopics(billableUsageSuppressStoreEmpty);
+    deleteAllMessages(Set.of(BILLABLE_USAGE_AGGREGATE_SUPPRESS_STORE_TOPIC));
+    NewTopic billableUsageSuppressStoreReset =
+        TopicBuilder.name(BILLABLE_USAGE_AGGREGATE_SUPPRESS_STORE_TOPIC)
+            .config("cleanup.policy", "compact")
+            .build();
+    kafkaAdmin.createOrModifyTopics(billableUsageSuppressStoreReset);
+  }
+
+  void deleteAllMessages(Collection<String> topics) {
+    try (AdminClient adminClient = AdminClient.create(kafkaAdmin.getConfigurationProperties())) {
+      Map<TopicPartition, RecordsToDelete> recordsToDelete =
+          topics.stream()
+              .collect(
+                  toMap(
+                      name -> new TopicPartition(name, 0),
+                      name -> RecordsToDelete.beforeOffset(-1)));
+      adminClient.deleteRecords(recordsToDelete).all().get();
+      log.info("Deleted records in topics: {}", topics);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (Exception e) {
+      log.error("Error during deleting topics.", e);
+    }
   }
 }

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 SERVER_PORT=${clowder.endpoints.swatch-contracts.port:8000}
+MANAGEMENT_PORT=9000
 SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=${clowder.endpoints.swatch-subscription-sync-service.url}
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
@@ -93,7 +94,7 @@ quarkus.http.port=${SERVER_PORT}
 quarkus.http.test-port=0
 # Exposing the health checks and metrics on :9000.
 quarkus.management.enabled=true
-quarkus.management.port=9000
+quarkus.management.port=${MANAGEMENT_PORT}
 quarkus.management.root-path=/
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2381

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
The windowed billable usage aggregate kafka messages cause issues with IQE tests because they leave lingering messages between tests. This update allows us to delete all messages from that topic between tests.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Start contract service: `SERVER_PORT=8001 MANAGEMENT_PORT=9002 ./gradlew :swatch-contracts:quarkusDev`
1. Start tally service: `DEV_MODE=true  ./gradlew :bootRun`

### Steps
<!-- Enter each step of the test below -->
1. Insert a record (any or no data is fine) into `platform.rhsm-subscriptions.swatch-billable-usage-aggregator-billable-usage-suppress-store-changelog`
1. Run curl command: 
`curl -X 'DELETE'     "localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/org345"     -H 'accept: application/json'     -H 'x-rh-swatch-psk: placeholder'`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Using a kafka consumer starting at the earliest offset (or past hour) consume messages from `platform.rhsm-subscriptions.swatch-billable-usage-aggregator-billable-usage-suppress-store-changelog` and none should appear.