### PR TITLE
SWATCH-2387: Update tag on postgresql-12-centos7 database

### DIFF
--- a/.github/workflows/validate-floorplan-queries.yaml
+++ b/.github/workflows/validate-floorplan-queries.yaml
@@ -25,7 +25,7 @@ jobs:
           jbang trust add https://github.com/yaml-path/jbang/
           curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force yamlpath@yaml-path/jbang
       - name: Setup Postgresql Database
-        run: docker run -d -v ./init_dbs.sh:/usr/share/container-scripts/postgresql/start/set_passwords.sh:z -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=admin quay.io/centos7/postgresql-12-centos7
+        run: docker run -d -v ./init_dbs.sh:/usr/share/container-scripts/postgresql/start/set_passwords.sh:z -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=admin quay.io/centos7/postgresql-12-centos7:centos7
       - name: Setup Postgresql Client
         run: sudo apt-get install -y postgresql-client
       - name: Execute migrations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     # When updating the image, remember to also update the following locations:
     # - SwatchPostgreSQLContainer.POSTGRESQL_IMAGE
     # - .github/workflows/validate-floorplan-queries.yaml (step "Setup Postgresql Database")
-    image: quay.io/centos7/postgresql-12-centos7
+    image: quay.io/centos7/postgresql-12-centos7:centos7
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRESQL_MAX_CONNECTIONS=5000

--- a/swatch-common-testcontainers/src/main/java/org/candlepin/testcontainers/SwatchPostgreSQLContainer.java
+++ b/swatch-common-testcontainers/src/main/java/org/candlepin/testcontainers/SwatchPostgreSQLContainer.java
@@ -32,7 +32,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @EqualsAndHashCode(callSuper = true)
 public class SwatchPostgreSQLContainer extends PostgreSQLContainer<SwatchPostgreSQLContainer> {
-  private static final String POSTGRESQL_IMAGE = "quay.io/centos7/postgresql-12-centos7";
+  private static final String POSTGRESQL_IMAGE = "quay.io/centos7/postgresql-12-centos7:centos7";
 
   public SwatchPostgreSQLContainer(String database) {
     super(DockerImageName.parse(POSTGRESQL_IMAGE).asCompatibleSubstituteFor("postgres"));


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2387

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
The `latest` tag was removed on this container as the container image is no longer maintained.  The patch adds the `centos7` tag as a stop-gap until we can upgrade.

This issue is what's causing the floorist query validation task to fail.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
1. **Be sure you are willing to destroy your database**.  Do a `pg_dump` if you are not so you can import later.
1. `podman-compose down`

### Steps
<!-- Enter each step of the test below -->
1. `podman-compose up -d`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.  You'll see the `quay.io/centos7/postgresql-12-centos7:centos7` image get pulled.
