### PR TITLE
SWATCH-2381: Add heartbeat service to produce billable usages

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageHeartbeatProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageHeartbeatProducer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.billing;
+
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.json.BillableUsage;
+import org.candlepin.subscriptions.task.TaskQueueProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Scheduled billable_usage kafka producer which is used to ensure billable-usage-suppress-store
+ * kstream topic is flushed frequently during testing.
+ */
+@Service
+@Slf4j
+@ConditionalOnProperty(
+    prefix = "rhsm-subscriptions.billing-producer",
+    name = "heartbeat-enabled",
+    havingValue = "true")
+public class BillableUsageHeartbeatProducer {
+
+  private final KafkaTemplate<String, BillableUsage> billableUsageKafkaTemplate;
+  private final String billableUsageTopic;
+
+  private final BillableUsage flushUsage = new BillableUsage().withOrgId("flush");
+
+  @Autowired
+  public BillableUsageHeartbeatProducer(
+      @Qualifier("billableUsageTopicProperties") TaskQueueProperties billableUsageTopicProperties,
+      @Qualifier("billableUsageKafkaTemplate")
+          KafkaTemplate<String, BillableUsage> billableUsageKafkaTemplate) {
+    this.billableUsageKafkaTemplate = billableUsageKafkaTemplate;
+    this.billableUsageTopic = billableUsageTopicProperties.getTopic();
+  }
+
+  @Scheduled(fixedRate = 500)
+  public void produce() {
+    billableUsageKafkaTemplate.send(billableUsageTopic, flushUsage);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingProducerConfiguration.java
@@ -52,9 +52,11 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.retry.support.RetryTemplateBuilder;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableRetry
+@EnableScheduling
 public class BillingProducerConfiguration {
 
   @Bean

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -71,6 +71,7 @@ rhsm-subscriptions:
       kafka-group-id: swatch-producer-billing
       seek-override-end: ${KAFKA_SEEK_OVERRIDE_END:false}
       seek-override-timestamp: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP:}
+    heartbeat-enabled: ${BILLABLE_USAGE_HEARTBEAT_ENABLED:false}
     outgoing:
       topic: ${BILLABLE_USAGE_TOPIC}
     contracts:


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2381

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Billable usages being aggregated by kstreams cause issues for our IQE tests because they often leave messages behind between tests. In order to ensure no kafka messages are suppressed between tests this new scheduled producer will create billable-usage messages every half second.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Start app with `DEV_MODE=true BILLABLE_USAGE_HEARTBEAT_ENABLED=true ./gradlew :bootRun`


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. View messages coming in on `platform.rhsm-subscriptions.billable-usage`
