### PR TITLE
SWATCH-2390: Disable separate Quarkus management port during testing

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -93,6 +93,8 @@ quarkus.http.port=${SERVER_PORT}
 quarkus.http.test-port=0
 # Exposing the health checks and metrics on :9000.
 quarkus.management.enabled=true
+# But disable during testing to prevent port conflict during parallel runs
+%test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
 

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -33,6 +33,9 @@ SERVICE_INSTANCE_INGRESS_TOPIC: platform.rhsm-subscriptions.service-instance-ing
   ENABLE_SPLUNK_HEC: ${%dev.ENABLE_SPLUNK_HEC}
   HOST_NAME: unit_tests
   quarkus:
+    management:
+      # disable during testing to prevent port conflict during parallel runs
+      enabled: false
     log:
       console:
         json: false

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -56,6 +56,8 @@ quarkus.http.port=${SERVER_PORT}
 quarkus.http.test-port=0
 # Exposing the health checks and metrics on :9000.
 quarkus.management.enabled=true
+# But disable during testing to prevent port conflict during parallel runs
+%test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
 

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -77,6 +77,8 @@ quarkus.http.port=${SERVER_PORT}
 quarkus.http.test-port=0
 # Exposing the health checks and metrics on :9000.
 quarkus.management.enabled=true
+# But disable during testing to prevent port conflict during parallel runs
+%test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
 


### PR DESCRIPTION
The tests all contend over the same port during parallel testing and test failures result.  This patch just disables the separate management port during testing so the tests aren't squabbling amongst each other.

<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2390

## Description
The tests fail when running in parallel because of resource contention over port 9000.

## Testing

### Steps
<!-- Enter each step of the test below -->
1. Run `./gradlew test` on the `main` branch
1. Run `./gradlew test` on this branch

### Verification
1.  On `main` the tests will fail and you'll see a message like 
    ```
    java.lang.RuntimeException: java.lang.RuntimeException: Failed to start quarkus
    Caused by: java.lang.RuntimeException: Failed to start quarkus
    Caused by: java.lang.RuntimeException: Unable to start HTTP server
    Caused by: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Unable to start the management interface
    Caused by: java.lang.IllegalStateException: Unable to start the management interface
    Caused by: java.net.BindException: Address already in use
    ```
1. On this branch, tests run successfully.
