### PR TITLE
SWATCH-2317: Move use of UOM to MetricId in tally

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -126,10 +126,10 @@ public class BillableUsageController {
 
   private BillableUsage produceMonthlyBillable(BillableUsage usage) {
     log.info(
-        "Processing monthly billable usage for orgId={} productId={} uom={} provider={}, billingAccountId={} snapshotDate={}",
+        "Processing monthly billable usage for orgId={} productId={} metric={} provider={}, billingAccountId={} snapshotDate={}",
         usage.getOrgId(),
         usage.getProductId(),
-        usage.getUom(),
+        usage.getMetricId(),
         usage.getBillingProvider(),
         usage.getBillingAccountId(),
         usage.getSnapshotDate());
@@ -204,10 +204,10 @@ public class BillableUsageController {
     usage.setSnapshotDate(usageCalc.getRemittanceDate());
 
     log.info(
-        "Finished producing monthly billable for orgId={} productId={} uom={} provider={}, snapshotDate={}",
+        "Finished producing monthly billable for orgId={} productId={} metric={} provider={}, snapshotDate={}",
         usage.getOrgId(),
         usage.getProductId(),
-        usage.getUom(),
+        usage.getMetricId(),
         usage.getBillingProvider(),
         usage.getSnapshotDate());
     return usage;
@@ -220,7 +220,7 @@ public class BillableUsageController {
             .billingAccountId(usage.getBillingAccountId())
             .billingProvider(usage.getBillingProvider().value())
             .accumulationPeriod(InstanceMonthlyTotalKey.formatMonthId(usage.getSnapshotDate()))
-            .metricId(MetricId.fromString(usage.getUom()).getValue())
+            .metricId(MetricId.fromString(usage.getMetricId()).getValue())
             .productId(usage.getProductId())
             .sla(usage.getSla().value())
             .usage(usage.getUsage().value())
@@ -242,7 +242,7 @@ public class BillableUsageController {
             .map(HardwareMeasurementType::fromString)
             .orElse(HardwareMeasurementType.PHYSICAL);
     TallyMeasurementKey measurementKey =
-        new TallyMeasurementKey(hardwareMeasurementType, usage.getUom());
+        new TallyMeasurementKey(hardwareMeasurementType, usage.getMetricId());
     return snapshotRepository.sumMeasurementValueForPeriod(
         usage.getOrgId(),
         usage.getProductId(),

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageMapper.java
@@ -111,7 +111,6 @@ public class BillableUsageMapper {
                                     BillableUsage.BillingProvider.fromValue(
                                         snapshot.getBillingProvider().value()))
                                 .withBillingAccountId(snapshot.getBillingAccountId())
-                                .withUom(measurement.getUom())
                                 .withMetricId(measurement.getMetricId())
                                 .withValue(measurement.getValue())
                                 .withHardwareMeasurementType(

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillingUnit.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillingUnit.java
@@ -28,7 +28,7 @@ import lombok.Getter;
 import lombok.ToString;
 import org.candlepin.subscriptions.json.BillableUsage;
 
-/** UOM with the currently configured billingFactor applied. */
+/** Metric with the currently configured billingFactor applied. */
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -42,7 +42,7 @@ public class BillingUnit implements Unit {
             .flatMap(
                 subscriptionDefinition ->
                     subscriptionDefinition.getMetric(
-                        MetricId.fromString(usage.getUom()).getValue()));
+                        MetricId.fromString(usage.getMetricId()).getValue()));
     billingFactor =
         metricOptional
             .map(Metric::getBillingFactor)

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/ContractsController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/ContractsController.java
@@ -71,13 +71,15 @@ public class ContractsController {
 
     String contractMetricId =
         getContractMetricId(
-            usage.getBillingProvider(), usage.getProductId(), MetricId.fromString(usage.getUom()));
+            usage.getBillingProvider(),
+            usage.getProductId(),
+            MetricId.fromString(usage.getMetricId()));
 
     if (ObjectUtils.isEmpty(contractMetricId)) {
       throw new IllegalStateException(
           String.format(
-              "Contract metric ID is not configured for billingProvider=%s product=%s uom=%s",
-              usage.getBillingProvider(), usage.getProductId(), usage.getUom()));
+              "Contract metric ID is not configured for billingProvider=%s product=%s metric=%s",
+              usage.getBillingProvider(), usage.getProductId(), usage.getMetricId()));
     }
 
     log.debug("Looking up contract information for usage {}", usage);

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageMapperTest.java
@@ -194,7 +194,6 @@ class BillableUsageMapperTest {
             .withSla(BillableUsage.Sla.STANDARD)
             .withBillingProvider(BillableUsage.BillingProvider.AWS)
             .withBillingAccountId("bill123")
-            .withUom("Storage-gibibytes")
             .withMetricId("Storage-gibibytes")
             .withValue(42.0)
             .withHardwareMeasurementType(HardwareMeasurementType.PHYSICAL.toString());
@@ -259,13 +258,11 @@ class BillableUsageMapperTest {
                     .withTallyMeasurements(
                         List.of(
                             new TallyMeasurement()
-                                .withUom(STORAGE_GIBIBYTES)
                                 .withMetricId(STORAGE_GIBIBYTES)
                                 .withHardwareMeasurementType(
                                     HardwareMeasurementType.PHYSICAL.toString())
                                 .withValue(42.0),
                             new TallyMeasurement()
-                                .withUom(STORAGE_GIBIBYTES)
                                 .withMetricId(STORAGE_GIBIBYTES)
                                 .withHardwareMeasurementType(
                                     HardwareMeasurementType.TOTAL.toString())

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/ContractsControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/ContractsControllerTest.java
@@ -119,7 +119,7 @@ class ContractsControllerTest {
   void testThrowsIllegalStateExceptionWhenProductIsNotContractEnabled() throws Exception {
     BillableUsage usage = defaultUsage();
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getUom().toString(), CONTRACT_METRIC_ID, null, false);
+        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, false);
     IllegalStateException e =
         assertThrows(IllegalStateException.class, () -> controller.getContractCoverage(usage));
     assertEquals(
@@ -136,7 +136,7 @@ class ContractsControllerTest {
 
     // Make sure product is contract enabled.
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getUom().toString(), CONTRACT_METRIC_ID, null, true);
+        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, true);
 
     when(contractsApi.getContract(
             usage.getOrgId(),
@@ -169,7 +169,7 @@ class ContractsControllerTest {
 
     // Make sure product is contract enabled.
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getUom().toString(), null, CONTRACT_METRIC_ID, true);
+        usage.getProductId(), usage.getMetricId(), null, CONTRACT_METRIC_ID, true);
 
     when(contractsApi.getContract(
             usage.getOrgId(),
@@ -199,7 +199,7 @@ class ContractsControllerTest {
     // Make sure product is contract enabled.
     var variant = Variant.builder().tag(usage.getProductId()).build();
     var metric = new com.redhat.swatch.configuration.registry.Metric();
-    metric.setId(usage.getUom());
+    metric.setId(usage.getMetricId());
     var subscriptionDefinition =
         SubscriptionDefinition.builder()
             .contractEnabled(true)
@@ -220,7 +220,7 @@ class ContractsControllerTest {
   @Test
   void testIllegalStateExceptionThrownWhenMetricIdIsConfiguredAsEmptyForBillingProvider() {
     BillableUsage usage = defaultUsage();
-    createSubscriptionDefinition(usage.getProductId(), usage.getUom().toString(), null, "", true);
+    createSubscriptionDefinition(usage.getProductId(), usage.getMetricId(), null, "", true);
 
     assertThrows(
         IllegalStateException.class,
@@ -243,7 +243,7 @@ class ContractsControllerTest {
 
     // Make sure product is contract enabled.
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getUom().toString(), CONTRACT_METRIC_ID, null, true);
+        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, true);
 
     when(contractsApi.getContract(
             usage.getOrgId(),
@@ -284,7 +284,7 @@ class ContractsControllerTest {
 
     // Make sure product is contract enabled.
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getUom().toString(), CONTRACT_METRIC_ID, null, true);
+        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, true);
 
     // Contract coverage should be the sum of all matching Cores metrics in the contracts.
     Double contractCoverage = controller.getContractCoverage(usage);
@@ -317,7 +317,7 @@ class ContractsControllerTest {
 
     // Make sure product is contract enabled.
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getUom().toString(), CONTRACT_METRIC_ID, null, true);
+        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, true);
 
     when(contractsApi.getContract(
             usage.getOrgId(),
@@ -337,7 +337,7 @@ class ContractsControllerTest {
   void throwsExternalServiceExceptionWhenApiCallFails() throws Exception {
     BillableUsage usage = defaultUsage();
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getUom().toString(), CONTRACT_METRIC_ID, null, true);
+        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, true);
     doThrow(ApiException.class)
         .when(contractsApi)
         .getContract(any(), any(), any(), any(), any(), any());
@@ -356,7 +356,7 @@ class ContractsControllerTest {
   void throwsContractMissingExceptionWhenNoContractsFound() throws Exception {
     BillableUsage usage = defaultUsage();
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getUom().toString(), CONTRACT_METRIC_ID, null, true);
+        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, true);
     when(contractsApi.getContract(any(), any(), any(), any(), any(), any()))
         .thenReturn(new ArrayList<>());
     ContractMissingException e =
@@ -383,7 +383,6 @@ class ContractsControllerTest {
         .withBillingAccountId("ba123")
         .withSla(Sla.PREMIUM)
         .withBillingProvider(BillingProvider.AWS)
-        .withUom("Cores")
         .withMetricId("Cores")
         .withVendorProductCode("vendor_product_code")
         .withSnapshotDate(clock.now());
@@ -400,13 +399,17 @@ class ContractsControllerTest {
   }
 
   private void createSubscriptionDefinition(
-      String tag, String uom, String awsDimension, String rhmDimension, boolean contractEnabled) {
+      String tag,
+      String metricId,
+      String awsDimension,
+      String rhmDimension,
+      boolean contractEnabled) {
     var variant = Variant.builder().tag(tag).build();
     var awsMetric =
         com.redhat.swatch.configuration.registry.Metric.builder()
             .awsDimension(awsDimension)
             .rhmMetricId(rhmDimension)
-            .id(uom)
+            .id(metricId)
             .build();
     var subscriptionDefinition =
         SubscriptionDefinition.builder()

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/QuantityTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/QuantityTest.java
@@ -74,13 +74,13 @@ class QuantityTest {
     }
   }
 
-  private void createSubscriptionDefinition(String tag, String uom) {
+  private void createSubscriptionDefinition(String tag, String metricId) {
     var variant = Variant.builder().tag(tag).build();
     var awsMetric =
         com.redhat.swatch.configuration.registry.Metric.builder()
             .awsDimension("AWS_METRIC_ID")
             .billingFactor(0.25)
-            .id(uom)
+            .id(metricId)
             .build();
     var subscriptionDefinition =
         SubscriptionDefinition.builder()
@@ -109,9 +109,9 @@ class QuantityTest {
   @Test
   void testQuantityFromBillableUsage() {
     var billableUsage = new BillableUsage();
-    billableUsage.setUom(SOCKETS);
+    billableUsage.setMetricId(SOCKETS);
     billableUsage.setProductId("foo");
-    createSubscriptionDefinition(billableUsage.getProductId(), billableUsage.getUom().toString());
+    createSubscriptionDefinition(billableUsage.getProductId(), billableUsage.getMetricId());
     var billingUnit = new BillingUnit(billableUsage);
     assertEquals(0.25, billingUnit.getBillingFactor());
     var billableQuantity = Quantity.of(4.0).to(billingUnit);
@@ -123,9 +123,9 @@ class QuantityTest {
   void testAddingBillableUnitToMetricUnit() {
     var quantity = Quantity.of(1.5);
     var billableUsage = new BillableUsage();
-    billableUsage.setUom(SOCKETS);
+    billableUsage.setMetricId(SOCKETS);
     billableUsage.setProductId("productId");
-    createSubscriptionDefinition(billableUsage.getProductId(), billableUsage.getUom().toString());
+    createSubscriptionDefinition(billableUsage.getProductId(), billableUsage.getMetricId());
     var billingUnit = new BillingUnit(billableUsage);
     var billable = Quantity.of(4.0).to(billingUnit);
     assertEquals(1.0, billable.getValue());
@@ -138,9 +138,9 @@ class QuantityTest {
   void testSubtractingBillableUnitFromMetricUnit() {
     var quantity = Quantity.of(1.5);
     var billableUsage = new BillableUsage();
-    billableUsage.setUom(SOCKETS);
+    billableUsage.setMetricId(SOCKETS);
     billableUsage.setProductId("productId");
-    createSubscriptionDefinition(billableUsage.getProductId(), billableUsage.getUom().toString());
+    createSubscriptionDefinition(billableUsage.getProductId(), billableUsage.getMetricId());
     var billingUnit = new BillingUnit(billableUsage);
     var billable = Quantity.of(1.0).to(billingUnit);
     assertEquals(0.25, billable.getValue());

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -44,7 +44,7 @@ properties:
       - Development/Test
       - Disaster Recovery
   uom:
-    description: Preferred unit of measure for the subject (for products with multiple possible UOM).
+    description: Preferred unit of measure for the subject (for products with multiple possible UOM). Deprecated in favor of metric_id.
     type: string
     deprecated: true
     deprecationMessage: "Use 'metric_id' instead."

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceFilter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceFilter.java
@@ -56,7 +56,7 @@ public class BillableUsageRemittanceFilter {
         .billingAccountId(usage.getBillingAccountId())
         .billingProvider(usage.getBillingProvider().value())
         .accumulationPeriod(InstanceMonthlyTotalKey.formatMonthId(usage.getSnapshotDate()))
-        .metricId(MetricId.fromString(usage.getUom()).getValue())
+        .metricId(MetricId.fromString(usage.getMetricId()).getValue())
         .productId(usage.getProductId())
         .sla(usage.getSla().value())
         .usage(usage.getUsage().value())

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/kafka/BillableUsageAggregateKey.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/kafka/BillableUsageAggregateKey.java
@@ -52,7 +52,7 @@ public class BillableUsageAggregateKey {
     this(
         billableUsage.getOrgId(),
         billableUsage.getProductId(),
-        billableUsage.getUom(),
+        billableUsage.getMetricId(),
         Optional.ofNullable(billableUsage.getSla()).orElse(SlaEnum.EMPTY).value(),
         Optional.ofNullable(billableUsage.getUsage()).orElse(UsageEnum.EMPTY).value(),
         Optional.ofNullable(billableUsage.getBillingProvider())

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/streams/BillableUsageAggregateKey.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/kafka/streams/BillableUsageAggregateKey.java
@@ -52,7 +52,7 @@ public class BillableUsageAggregateKey {
     this(
         billableUsage.getOrgId(),
         billableUsage.getProductId(),
-        billableUsage.getUom(),
+        billableUsage.getMetricId(),
         Optional.ofNullable(billableUsage.getSla()).orElse(SlaEnum.EMPTY).value(),
         Optional.ofNullable(billableUsage.getUsage()).orElse(UsageEnum.EMPTY).value(),
         Optional.ofNullable(billableUsage.getBillingProvider())

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageAggregateConsumer.java
@@ -262,7 +262,7 @@ public class BillableUsageAggregateConsumer {
     }
 
     if (aggregationKey.getMetricId() == null) {
-      log.debug("Snapshot not applicable because billable uom is empty");
+      log.debug("Snapshot not applicable because billable metric id is empty");
       return Optional.empty();
     }
 
@@ -277,7 +277,8 @@ public class BillableUsageAggregateConsumer {
             .findFirst();
 
     if (metric.isEmpty()) {
-      log.debug("Snapshot not applicable because productId and/or uom is not configured for Azure");
+      log.debug(
+          "Snapshot not applicable because productId and/or metric id is not configured for Azure");
     }
 
     return metric;
@@ -291,7 +292,7 @@ public class BillableUsageAggregateConsumer {
     billableUsage.setBillingProvider(BillingProviderEnum.fromValue(key.getBillingProvider()));
     billableUsage.setOrgId(key.getOrgId());
     billableUsage.setProductId(key.getProductId());
-    billableUsage.setUom(key.getMetricId());
+    billableUsage.setMetricId(key.getMetricId());
     billableUsage.setSla(SlaEnum.fromValue(key.getSla()));
     billableUsage.setSnapshotDate(snapshotDate);
     return billableUsage;


### PR DESCRIPTION
Jira issue: SWATCH-2317

## Description
The UOM field is no longer needed as it is redundant to the metric id field

## Testing

The CI test test_verify_remittance_of_metered_product in IQE will cover this change 

### Verification

1. Ensure the above test in specific and the  entire suite in general run successfully
