### PR TITLE
Fix tally_snapshot.yaml to remove duplicated metric_id property

### DIFF
--- a/swatch-core/schemas/tally_snapshot.yaml
+++ b/swatch-core/schemas/tally_snapshot.yaml
@@ -62,10 +62,6 @@ properties:
           description: Preferred unit of measure for the subject (for products with multiple possible UOM). Deprecated in favor of metric_id.
           type: string
           deprecated: true # Will be removed in https://issues.redhat.com/browse/SWATCH-1384
-        metric_id:
-          description: Preferred metric_id of measure for the subject (for products with multiple possible metric_ids).
-          type: string
-          deprecated: true
           deprecationMessage: Use 'metric_id' instead.
         metric_id:
           description: Preferred unit of measure for the subject (for products with multiple possible metrics).


### PR DESCRIPTION
## Description
Partially reverts https://github.com/RedHatInsights/rhsm-subscriptions/pull/3154 that added a duplicated "metric_id" property.

## Testing
Only regression testing. 