### PR TITLE
SWATCH-2285: Add swatch-billable-usage deployment

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -60,6 +60,11 @@ export COMPONENTS_W_RESOURCES="app:rhsm"
 # NOTE: this ensures that all of the other services end up deployed with the latest template
 export EXTRA_COMPONENTS="rhsm $(find -name clowdapp.yaml -exec dirname {} \; | cut -d'/' -f2 | xargs)"
 for EXTRA_COMPONENT_NAME in $EXTRA_COMPONENTS; do
+  # Skip the swatch-billable-usage service for now: will be undone in SWATCH-2285
+  if [ "$EXTRA_COMPONENT_NAME" = "swatch-billable-usage" ] ; then
+    continue
+  fi
+
   export EXTRA_DEPLOY_ARGS="${EXTRA_DEPLOY_ARGS} --set-template-ref ${EXTRA_COMPONENT_NAME}=${GIT_COMMIT}"
 done
 

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -1,0 +1,165 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: swatch-billable-usage
+parameters:
+  - name: JAVA_DEBUG
+    # Set to "true" to enable remote debugging
+    value: ''
+  - name: QUARKUS_LAUNCH_DEVMODE
+    value: ''
+  - name: IMAGE_PULL_SECRET
+    value: quay-cloudservices-pull
+  - name: MEMORY_REQUEST
+    value: 512Mi
+  - name: MEMORY_LIMIT
+    value: 512Mi
+  - name: CPU_REQUEST
+    value: 200m
+  - name: CPU_LIMIT
+    value: '1'
+  - name: ENV_NAME
+    value: env-swatch-billable-usage
+  - name: REPLICAS
+    value: '1'
+  - name: IMAGE
+    value: quay.io/cloudservices/swatch-producer-azure
+  - name: IMAGE_TAG
+    value: latest
+  - name: LOGGING_LEVEL_ROOT
+    value: 'INFO'
+  - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
+    value: 'INFO'
+  - name: KAFKA_SEEK_OVERRIDE_END
+    value: 'false'
+  - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
+    value: ''
+  - name: KAFKA_BILLABLE_USAGE_REPLICAS
+    value: '3'
+  - name: KAFKA_BILLABLE_USAGE_PARTITIONS
+    value: '3'
+  - name: QUARKUS_PROFILE
+    value: prod
+  - name: ENABLE_AZURE_DRY_RUN
+    value: 'true'
+
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdApp
+  metadata:
+    name: swatch-billable-usage
+    labels:
+      prometheus: quarkus
+  spec:
+    envName: ${ENV_NAME}
+    dependencies:
+      - swatch-subscription-sync
+
+    kafkaTopics:
+      - replicas: ${{KAFKA_BILLABLE_USAGE_REPLICAS}}
+        partitions: ${{KAFKA_BILLABLE_USAGE_PARTITIONS}}
+        topicName: platform.rhsm-subscriptions.billable-usage
+      - replicas: ${{KAFKA_BILLABLE_USAGE_REPLICAS}}
+        partitions: ${{KAFKA_BILLABLE_USAGE_PARTITIONS}}
+        topicName: platform.rhsm-subscriptions.billable-usage-hourly-aggregate
+      - replicas: ${{KAFKA_BILLABLE_USAGE_REPLICAS}}
+        partitions: ${{KAFKA_BILLABLE_USAGE_PARTITIONS}}
+        topicName: platform.rhsm-subscriptions.swatch-billable-usage-aggregator-billable-usage-store-repartition
+      - replicas: ${{KAFKA_BILLABLE_USAGE_REPLICAS}}
+        partitions: ${{KAFKA_BILLABLE_USAGE_PARTITIONS}}
+        topicName: platform.rhsm-subscriptions.swatch-billable-usage-aggregator-billable-usage-suppress-store-changelog
+
+    pullSecrets:
+      name: ${IMAGE_PULL_SECRET}
+
+    deployments:
+      - name: service
+        replicas: ${{REPLICAS}}
+        webServices:
+          public:
+            enabled: true
+        podSpec:
+          image: ${IMAGE}:${IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 9000
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 9000
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+          env:
+            - name: JAVA_DEBUG
+              value: ${JAVA_DEBUG}
+            - name: QUARKUS_LAUNCH_DEVMODE
+              value: ${QUARKUS_LAUNCH_DEVMODE}
+            - name: LOGGING_LEVEL_ROOT
+              value: ${LOGGING_LEVEL_ROOT}
+            - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
+              value: ${LOGGING_LEVEL_COM_REDHAT_SWATCH}
+            - name: SPLUNKMETA_namespace
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: SPLUNK_HEC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: splunk-hec-external
+                  key: token
+            - name: SWATCH_SELF_PSK
+              valueFrom:
+                secretKeyRef:
+                  name: swatch-psks
+                  key: self
+            - name: KAFKA_SEEK_OVERRIDE_END
+              value: ${KAFKA_SEEK_OVERRIDE_END}
+            - name: KAFKA_SEEK_OVERRIDE_TIMESTAMP
+              value: ${KAFKA_SEEK_OVERRIDE_TIMESTAMP}
+            - name: QUARKUS_PROFILE
+              value: ${QUARKUS_PROFILE}
+            - name: ENABLE_AZURE_DRY_RUN
+              value: ${ENABLE_AZURE_DRY_RUN}
+            - name: AZURE_MARKETPLACE_CREDENTIALS
+              valueFrom:
+                secretKeyRef:
+                  name: azure-marketplace-credentials
+                  key: credentials
+          volumeMounts:
+            - name: logs
+              mountPath: /logs
+          volumes:
+            - name: logs
+              emptyDir:
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: swatch-psks
+  data:
+    self: cGxhY2Vob2xkZXI=


### PR DESCRIPTION
Jira issue: [SWATCH-2285](https://issues.redhat.com/browse/SWATCH-2285)

## Description
- copy the swatch-producer-azure service into the new swatch-billable-usage service
- this is necessary to prepare the deployment of the new service in the ephemeral/stage/prod environments

## Testing
Only regression testing. 