### PR TITLE
SWATCH-2318: Use metricid instead of UOM from billable usage messages

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -163,10 +163,11 @@ public class RhMarketplacePayloadMapper {
    * @return List&lt;UsageMeasurement%gt;
    */
   protected UsageMeasurement produceUsageMeasurement(BillableUsage billableUsage) {
-
     String rhmMarketplaceMetricId =
         SubscriptionDefinition.getRhmMetricId(
-            billableUsage.getProductId(), MetricId.fromString(billableUsage.getUom()).getValue());
+            billableUsage.getProductId(),
+            // This seems redundant but the fromString does some useful format/case munging
+            MetricId.fromString(billableUsage.getMetricId()).getValue());
 
     Double value = billableUsage.getValue();
 
@@ -180,6 +181,7 @@ public class RhMarketplacePayloadMapper {
     return billableUsage.getProductId() != null
         && billableUsage.getSla() != null
         && billableUsage.getUsage() != null
+        && billableUsage.getMetricId() != null
         && billableUsage.getUom() != null
         && billableUsage.getBillingProvider() != null
         && billableUsage.getBillingAccountId() != null

--- a/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
@@ -73,6 +73,18 @@ class RhMarketplacePayloadMapperTest {
   }
 
   @Test
+  void testUsesMetricIdRatherThanUom() {
+    var mockUsage = mock(BillableUsage.class);
+    when(mockUsage.getProductId()).thenReturn("OpenShift-metrics");
+    when(mockUsage.getMetricId()).thenReturn(MetricIdUtils.getCores().toUpperCaseFormatted());
+    when(mockUsage.getValue()).thenReturn(2.0);
+
+    rhMarketplacePayloadMapper.produceUsageMeasurement(mockUsage);
+    verify(mockUsage).getMetricId();
+    verify(mockUsage, never()).getUom();
+  }
+
+  @Test
   void testProduceUsageEvents() throws Exception {
     RhmUsageContext rhmUsageContext = new RhmUsageContext();
     rhmUsageContext.setRhSubscriptionId("PLACEHOLDER");


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2318

## Description
Consumers from billable-usage now use UOM instead of metricId.

## Testing
Covered by unit test, but insight from QE on *in situ* testing would be appreciated.