### PR TITLE
SWATCH-2038: Bump Quarkus to 3.9.2 && Update the swatch-product-configuration module to be framework-agnostic

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,14 +5,15 @@
 buildscript {
   repositories {
       mavenCentral()
-      maven { url "https://plugins.gradle.org/m2/" }
       maven { url "https://packages.confluent.io/maven/" }
       maven { url "https://splunk.jfrog.io/splunk/ext-releases-local" }
+      // Needed for the Quarkus gradle plugin which is only published in the Gradle Plugin portal since Quarkus 3.6.6:
+      gradlePluginPortal()
   }
 }
 
 ext {
-    quarkusVersion='3.6.6'
+    quarkusVersion='3.9.2'
     springVersion='3.2.4'
     resteasyVersion='6.2.8.Final'
     libraries = [:]
@@ -80,3 +81,5 @@ libraries["awaitility"] = "org.awaitility:awaitility:4.2.1"
 libraries["splunk-otel-agent"] = 'com.splunk:splunk-otel-javaagent:1.31.1'
 libraries["testcontainers-postgresql"] = 'org.testcontainers:postgresql:1.19.7'
 libraries["kafka-streams-test-utils"] = "org.apache.kafka:kafka-streams-test-utils:3.7.0"
+libraries["slf4j-api"] = "org.slf4j:slf4j-api:2.0.12"
+libraries["snakeyaml"] = "org.yaml:snakeyaml:2.2"

--- a/swatch-product-configuration/build.gradle
+++ b/swatch-product-configuration/build.gradle
@@ -3,15 +3,12 @@ plugins {
 }
 
 dependencies {
-    // Intentionally marked as platform rather than enforcedPlatform as this project is a library
-    implementation platform(libraries["quarkus-bom"])
-    implementation 'org.yaml:snakeyaml'
-    implementation 'org.slf4j:slf4j-api'
-    implementation 'jakarta.validation:jakarta.validation-api'
-    implementation 'com.google.guava:guava'
-    implementation 'io.quarkus:quarkus-core'
+    implementation libraries["snakeyaml"]
+    implementation libraries["slf4j-api"]
+    implementation libraries["jakarta-validation-api"]
+    implementation libraries["guava"]
 
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation libraries["junit-jupiter"]
     testImplementation libraries["hamcrest-all"]
 }
 

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Defaults.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Defaults.java
@@ -20,7 +20,7 @@
  */
 package com.redhat.swatch.configuration.registry;
 
-import lombok.*;
+import lombok.Data;
 
 @Data
 public class Defaults {

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -21,7 +21,6 @@
 package com.redhat.swatch.configuration.registry;
 
 import com.google.common.collect.MoreCollectors;
-import io.quarkus.runtime.util.StringUtil;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -186,7 +185,7 @@ public class SubscriptionDefinition {
       String role, Collection<?> engIds, String productName) {
     Set<String> productTags = new HashSet<>();
     // Filter tags that are paygEligible
-    if (!StringUtil.isNullOrEmpty(role)) {
+    if (!isNullOrEmpty(role)) {
       SubscriptionDefinition.lookupSubscriptionByRole(role)
           .filter(SubscriptionDefinition::isPaygEligible)
           .flatMap(subDef -> subDef.findVariantForRole(role).map(Variant::getTag))
@@ -217,7 +216,7 @@ public class SubscriptionDefinition {
     }
 
     // if not found, let's use the product name
-    if ((productTags.isEmpty()) && !StringUtil.isNullOrEmpty(productName)) {
+    if ((productTags.isEmpty()) && !isNullOrEmpty(productName)) {
       productTags.addAll(
           Variant.filterVariantsByProductName(productName)
               .filter(v -> v.getSubscription().isPaygEligible())
@@ -232,7 +231,7 @@ public class SubscriptionDefinition {
     Set<String> productTags = new HashSet<>();
     // Filter tags that are nonPaygEligible
 
-    if (!StringUtil.isNullOrEmpty(role)) {
+    if (!isNullOrEmpty(role)) {
       SubscriptionDefinition.lookupSubscriptionByRole(role)
           .filter(subDef -> !subDef.isPaygEligible())
           .flatMap(subDef -> subDef.findVariantForRole(role).map(Variant::getTag))
@@ -262,7 +261,7 @@ public class SubscriptionDefinition {
                           .collect(Collectors.toSet())));
     }
     // if not found, let's use the product name
-    if ((productTags.isEmpty()) && !StringUtil.isNullOrEmpty(productName)) {
+    if ((productTags.isEmpty()) && !isNullOrEmpty(productName)) {
       productTags.addAll(
           Variant.filterVariantsByProductName(productName)
               .filter(v -> !v.getSubscription().isPaygEligible())
@@ -365,5 +364,9 @@ public class SubscriptionDefinition {
 
   public static List<SubscriptionDefinition> getSubscriptionDefinitions() {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions();
+  }
+
+  private static boolean isNullOrEmpty(String str) {
+    return str == null || str.isEmpty();
   }
 }


### PR DESCRIPTION
Jira issue: [SWATCH-2038](https://issues.redhat.com/browse/SWATCH-2038)

## Description
Dependabot stopped bumping Quarkus a while ago because the Quarkus gradle plugin dependency stopped being published at the Maven plugin site, but only at the Gradle plugin site (see question in https://github.com/quarkusio/quarkus/issues/34148).

After registering the Gradle plugin site, the Quarkus Gradle plugin can now be found.

Note that after fixing the above gradle configuration issue, the Spring Boot based services like Tally stopped working because the Jandex dependency was missing. This was caused by the swatch-product-configuration module using the Quarkus platform. Since this module is used in both Spring Boot and Quarkus services, I removed the Quarkus dependencies from it and fixed the dependency conflict issue.

## Testing
Only regression tests.

## Verify the issue in SWATCH-2038 is gone

1.- Start kafka, db, ... via:

```
podman-compose up -d
```
2.- Start otel exporter:

```
podman-compose -f config/otel/docker-compose.yml up -d
```

3.- Start rabbitmq:

```
podman-compose -f config/rabbitmq/docker-compose.yml up -d
```

4.- Build swatch contracts:

```
./gradlew clean swatch-contracts:assemble -x test
```

5.- Start the swatch contracts service:

```
java -DSWATCH_SELF_PSK=placeholder -DENABLE_SPLUNK_HEC=false -DSWATCH_TEST_APIS_ENABLED=true -DRBAC_ENABLED=false -DUMB_HOSTNAME=localhost -DUMB_PORT=5672 -DOTEL_ENDPOINT=http://localhost:4317 -DRBAC_ENDPOINT=localhost:8080 -jar swatch-contracts/build/quarkus-app/quarkus-run.jar 
```

6.- Make any calls to the contracts service:

```
curl --verbose -H 'x-rh-swatch-psk:placeholder' -H "Origin: https://console.redhat.com" -H  "Content-Type: application/json" http://localhost:8000/api/swatch-contracts/internal/contracts?org_id=16797796 
```

7.- And wait up to 10-15 seconds.

You should not see the following trace from the contracts log anylonger:

```
2023-12-14 07:12:07,599 SEVERE [io.qua.ope.run.exp.otl.VertxGrpcExporter] (vert.x-eventloop-thread-1) {} Failed to export spans. The request could not be executed. Full error message: Stream was closed
```

And also, you should see the trace in the exporter container from step 2.:

```
2024-04-04T07:23:12.719Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "logging", "resource spans": 1, "spans": 1}
2024-04-04T07:23:12.719Z        info    ResourceSpans #0
Resource SchemaURL: https://opentelemetry.io/schemas/1.21.0
Resource attributes:
     -> host.name: Str(localhost.localdomain)
     -> service.name: Str(swatch-contracts)
     -> service.version: Str(1.1.0-snapshot.202404040722+31d2f2f)
     -> telemetry.sdk.language: Str(java)
     -> telemetry.sdk.name: Str(opentelemetry)
     -> telemetry.sdk.version: Str(1.30.1)
     -> webengine.name: Str(Quarkus)
     -> webengine.version: Str(3.6.6)
ScopeSpans #0
ScopeSpans SchemaURL: 
InstrumentationScope io.quarkus.opentelemetry 
Span #0
    Trace ID       : 7e13904d174fb7578f6579c4b11f8d8d
    Parent ID      : 
    ID             : d6881aad04204d25
    Name           : GET /api/swatch-contracts/internal/contracts
    Kind           : Server
    Start time     : 2024-04-04 07:23:09.371768403 +0000 UTC
    End time       : 2024-04-04 07:23:09.377020016 +0000 UTC
    Status code    : Unset
    Status message : 
Attributes:
     -> http.client_ip: Str(127.0.0.1)
     -> http.status_code: Int(200)
     -> http.response_content_length: Int(2)
     -> net.host.port: Int(8000)
     -> http.target: Str(/api/swatch-contracts/internal/contracts?org_id=16797796)
     -> code.function: Str(getContract)
     -> user_agent.original: Str(curl/8.0.1)
     -> net.host.name: Str(localhost)
     -> http.scheme: Str(http)
     -> http.method: Str(GET)
     -> net.protocol.name: Str(http)
     -> http.route: Str(/api/swatch-contracts/internal/contracts)
     -> code.namespace: Str(com.redhat.swatch.contract.resource.ContractsTestingResource)
        {"kind": "exporter", "data_type": "traces", "name": "logging"}

```

