### PR TITLE
SWATCH-2336: Increased max header size to accomodate actual use

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -20,7 +20,7 @@ parameters:
   - name: IMAGE_TAG
     value: latest
   - name: SERVER_MAX_HTTP_HEADER_SIZE
-    value: '48000'
+    value: '96000'
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -68,7 +68,7 @@ parameters:
   - name: SPLUNK_HEC_TERMINATION_TIMEOUT
     value: '2000'
   - name: SERVER_MAX_HTTP_HEADER_SIZE
-    value: '48000'
+    value: '96000'
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -10,7 +10,7 @@ parameters:
   - name: JAVA_OPTS_APPEND
     value: ''
   - name: SERVER_MAX_HTTP_HEADER_SIZE
-    value: '48000'
+    value: '96000'
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -12,7 +12,7 @@ parameters:
   - name: ENV_NAME
     value: env-swatch-tally
   - name: SERVER_MAX_HTTP_HEADER_SIZE
-    value: '48000'
+    value: '96000'
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL


### PR DESCRIPTION
Jira issue: SWATCH-2336

## Description
Some customers have been getting the following error on the call /api/rhsm-subscriptions/v1/tally/products/RHEL for x86/Sockets:
java.lang.IllegalArgumentException: Request header is too large

As this has been "random", it is assumed that the size in error is just above the set limit of 48K. This number has been doubled. This effectiveness of the solution will be reflected in the future frequency of the exception.