### PR TITLE
SWATCH-2421 Fix event and tally_state data

### DIFF
--- a/src/main/resources/liquibase/202404051233-fix-bad-tally-state-and-event-data.xml
+++ b/src/main/resources/liquibase/202404051233-fix-bad-tally-state-and-event-data.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202404051233-01" author="mstead">
+    <comment>
+      1. Copy the record_date value into the JSON data for records that currently have
+          data->'record_date' set to null.
+      2. Set the tally_state.latest_event_record_date to the end of March for any
+         record that has a null latest_event_record_date.
+      3. Add a non-null constrain to the tally_state column.
+    </comment>
+    <sql dbms="postgresql">
+        update events
+         set data = jsonb_set(data, '{record_date}', to_jsonb(record_date))
+         where data->'record_date' is null</sql>
+    <sql dbms="postgresql">
+        update tally_state
+        set latest_event_record_date = '2024-04-01T01:00Z'
+        where latest_event_record_date is null;
+    </sql>
+    <addNotNullConstraint tableName="tally_state" columnName="latest_event_record_date" />
+    <rollback>
+      <dropNotNullConstraint tableName="tally_state" columnName="latest_event_record_date" />
+      <!-- NOTE: Unable to determine the records to roll back -->
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -148,5 +148,6 @@
     <include file="/liquibase/202401080920-remove-uniqueness-constraint-on-events.xml" />
     <include file="/liquibase/202401161133-update-instance-view-to-include-last-applied-event-record-date.xml" />
     <include file="/liquibase/202403260830-update-instance-view-to-include-inventory-id.xml" />
+    <include file="/liquibase/202404051233-fix-bad-tally-state-and-event-data.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2421

## Description
This patch adds a liquibase changeset to fix the data in the events and
tally_state tables caused by a failed deployment. The changeset is
intended to be run in a single transaction.
    
The changeset will:

1. Set the record_date in the events.data JSON column to the record's record_date when the JSON's record_date is NULL.
2. Set the tally_state.latest_event_record_date to '2024-04-01T01:00Z' when the latest_event_record_date is null.
3. Add a non-null constraint on the tally_state.latest_event_record_date
       column
    
NOTE:
Due to the offset of job runs, an Event's record_date will be
approximately 1.5h after the event timestamp. Therefore, we
set the latest_event_record_date to '2024-04-01T01:00Z' to
ensure that we do not include any events with timestamps in
March.

## Testing

To test this locally:

Set up some test data.
```
INSERT INTO public.events VALUES ('a4410ed7-82c9-4b71-b5fe-8af823aecf01', '2024-03-27 14:00:00+00', '{"sla": "Premium", "role": "moa-hostedcontrolplane", "org_id": "org123", "event_id": "a4410ed7-82c9-4b71-b5fe-8af823aecf01", "timestamp": "2024-03-27T14:00:00Z", "event_type": "snapshot_rosa_cores", "expiration": "2024-03-27T15:00:00Z", "instance_id": "instance1", "product_ids": [], "product_tag": ["rosa"], "display_name": "my-rosa", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 16.0, "metric_id": "Cores"}], "service_type": "rosa Instance", "billing_provider": "aws", "metering_batch_id": "3083087b-eaa8-40bc-bd01-fdda650e91fb", "billing_account_id": "aws_bid"}', 'snapshot_rosa_cores', 'prometheus', '2f1ba5ab-c011-4137-b983-b751b5f18ac4', 'org123', '3083087b-eaa8-40bc-bd01-fdda650e91fb', '2024-03-27 15:30:33.634921+00');
```
```
INSERT INTO public.tally_state VALUES ('org123', 'rosa Instance', null);
```

Verify that there are affected records:
```
-- 1 record should be found
select count(*) from events where data->'record_date' is null;
```
```
-- 1 record should be found
select count(*) from tally_state where latest_event_record_date is null;
```

Apply the changeset from this PR.
```
./gradlew :liquibaseUpdate
```

Validate the changes were applied:
```
-- No records should be found
select count(*) from events where data->'record_date' is null;
```
```
-- No records should be found
select count(*) from tally_state where latest_event_record_date is null;

```


**NOTE:**
The best way to test this is to pull down the `events` and `tally_state` tables from the production DB and then deploy with the changes from this PR applied.