### PR TITLE
SWATCH-2428 Update event retention policy to 6 months

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -166,7 +166,7 @@ public class InternalTallyResource implements InternalApi {
     var eventRetentionDuration = eventRecordsRetentionProperties.getEventRetentionDuration();
 
     OffsetDateTime cutoffDate =
-        OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS).minus(eventRetentionDuration);
+        clock.now().truncatedTo(ChronoUnit.DAYS).minus(eventRetentionDuration);
 
     log.info("Purging event records older than {}", cutoffDate);
     eventRecordRepository.deleteInBulkEventRecordsByTimestampBefore(cutoffDate);

--- a/src/main/java/org/candlepin/subscriptions/tally/events/EventRecordsRetentionProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/events/EventRecordsRetentionProperties.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.events;
 
-import java.time.Duration;
+import java.time.Period;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -31,5 +31,5 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "rhsm-subscriptions.event-retention-policy")
 public class EventRecordsRetentionProperties {
-  private Duration eventRetentionDuration = Duration.ofDays(90L);
+  private Period eventRetentionDuration = Period.ofMonths(6);
 }

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -29,7 +29,7 @@ rhsm-subscriptions:
         auto-commit: false  # required to enable cursor-based streaming in native queries
   account-list-resource-location: ${ACCOUNT_LIST_RESOURCE_LOCATION:}
   event-retention-policy:
-    eventRetentionDuration: ${EVENT_RECORD_RETENTION:90d}
+    eventRetentionDuration: ${EVENT_RECORD_RETENTION:P6M}
   tally-retention-policy:
     # 70 days worth
     hourly: ${TALLY_RETENTION_HOURLY:1680}

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -105,7 +105,7 @@ parameters:
   - name: PURGE_EVENTS_SCHEDULE
     value: '30 4 * * *'
   - name: EVENT_RECORD_RETENTION
-    value: '90d'
+    value: 'P6M'
   # TODO after enable individual functionality (see ENT-4487)
   - name: DEV_MODE
     value: 'false'


### PR DESCRIPTION
Jira issue: SWATCH-2428

## Description
The retention policy configuration was updated to be 6 months. The configuration property type was changed from Duration to Period to make monthly boundaries more accurate.

## Testing (smqe-tools)

### Setup
1. Check out [this version](https://gitlab.cee.redhat.com/smqe/smqe-tools/-/merge_requests/272) of smqe-tools and activate the virtual env.

### How To Test (main branch)
1. Deploy the monlith on the main branch.
2. Clean out the events table
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "truncate events"
```
3. Run the following in the smqe-tools virtual env
```
export ENV_FOR_DYNACONF=local && \
SCRIPT=$(cat << EOF
from time import sleep
from datetime import datetime, timezone
from dateutil.relativedelta import relativedelta
from smqe_tools import create_payg_data, fetch_events_in_range, purge_events
import json


def check_events(org_id, start, end):
  start_param = str(start.isoformat()).replace("+00:00", "Z")
  end_param = str(end.isoformat()).replace("+00:00", "Z")
  response = fetch_events_in_range(org_id, start_param,end_param)
  events = json.loads(response['detail'])
  print(f"Found {len(events)} events between {start} --> {end}")


test_org = 'org123'

now = datetime.now(timezone.utc)
one_hour_ago = now - relativedelta(hours=+1)
one_month_ago = now - relativedelta(months=+1)
five_months_ago = now - relativedelta(months=+5)
seven_months_ago = now - relativedelta(months=+7)
one_year_ago = now - relativedelta(years=+1)

create_payg_data(org_id=test_org, start_time=one_hour_ago)
create_payg_data(org_id=test_org, start_time=one_month_ago)
create_payg_data(org_id=test_org, start_time=five_months_ago)
create_payg_data(org_id=test_org, start_time=seven_months_ago)
create_payg_data(org_id=test_org, start_time=one_year_ago)
sleep(2)

# Should be 5 events
check_events(test_org, now - relativedelta(years=+2), now)

purge_events()

# Should be 3 events
check_events(test_org, now - relativedelta(years=+2), now)
EOF
) && \
python -c "$SCRIPT"
```
4. Verify in the output that the initial event count was 5 and that the count after the purge was 2. **Against `main` we should see that the 3 month retention policy setting should remove any events that have timestamps older than 3 months.**
```
# Output snippet after running script
-- snip --
Found 5 events between 2022-04-10 18:29:30.356245+00:00 --> 2024-04-10 18:29:30.356245+00:00
--snip --
Found 2 events between 2022-04-10 18:29:30.356245+00:00 --> 2024-04-10 18:29:30.356245+00:00
-- snip --
```


### How To Test (PR branch)
1. Deploy the monlith on the PR branch.
2. Clean out the events table
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "truncate events"
```
3. Run the test command again (see above) in the smqe-tools virtual env
4. Verify in the output that the initial event count was 5 and that the count after the purge was 3. **Against the PR branch we should see that the 6 month retention policy setting should remove any events that have timestamps older than 6 months.**
```
# Output snippet after running script
-- snip --
Found 5 events between 2022-04-10 18:29:30.356245+00:00 --> 2024-04-10 18:29:30.356245+00:00
--snip --
Found 3 events between 2022-04-10 18:29:30.356245+00:00 --> 2024-04-10 18:29:30.356245+00:00
-- snip --
```

## IQE Testing
[MR that adds test support to smqe-tools](https://gitlab.cee.redhat.com/smqe/smqe-tools/-/merge_requests/272)
[MR to test this scenario](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/640)