### PR TITLE
Remove reference to account_config table in insert-mock-hosts

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -262,8 +262,7 @@ for i in range(args.num_accounts):
         account = args.account
         org = args.org
     if args.opt_in:
-        _generate_insert('account_config',
-                         account_number=account,
+        _generate_insert('org_config',
                          org_id=org,
                          opt_in_type='API',
                          created='2021-01-01',


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: None

## Description
Fixes the `insert-mock-hosts` script (which has been broken for like 6 months since we dropped `account_config` :upside_down_face:)

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Steps
<!-- Enter each step of the test below -->
1.  Run `bin/insert-mock-hosts --org org123 --opt-in`
1.  On `main` this command will fail.  On this branch, it will run.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. `psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select * from org_config"`
