### PR TITLE
SWATCH-2408: Return both cores and sockets by default in the instances API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/InstancesResource.java
@@ -331,6 +331,9 @@ public class InstancesResource implements InstancesApi {
       if (MetricIdUtils.getSockets().equals(MetricId.fromString(metric))) {
         measurementList.add(
             Double.valueOf(Optional.ofNullable(tallyInstanceView.getSockets()).orElse(0)));
+      } else if (MetricIdUtils.getCores().equals(MetricId.fromString(metric))) {
+        measurementList.add(
+            Double.valueOf(Optional.ofNullable(tallyInstanceView.getCores()).orElse(0)));
       } else if (!isPAYG && tallyInstanceView.getKey().getMetricId().equalsIgnoreCase(metric)) {
         measurementList.add(Optional.ofNullable(tallyInstanceView.getValue()).orElse(0.0));
       } else {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -61,7 +61,7 @@ public interface TallyInstanceViewRepository
    *     or empty string to ignore)
    * @param minCores Filter to Hosts with at least this number of cores.
    * @param minSockets Filter to Hosts with at least this number of sockets.
-   * @param month Filter to Hosts with with monthly instance totals in provided month
+   * @param month Filter to Hosts with monthly instance totals in provided month
    * @param referenceUom Uom used when filtering to a specific month.
    * @param pageable the current paging info for this query.
    * @return a page of Host entities matching the criteria.


### PR DESCRIPTION
Jira issue: [SWATCH-2408](https://issues.redhat.com/browse/SWATCH-2408)

## Description
Only the sockets were being returned by default. We also need to provide the cores. 

## IQE Testing
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/642

## Manual Testing
1.- podman-compose up
2.- Add host to Insight DB:

```
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) 
VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6", "provider_id": "d125f119"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "290"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123', '{}');
```

The important part of the above query is `provider_id` which id contains the value "d125f119".

3.- DEV_MODE=true ./gradlew :bootRun
4.- Run nightly Tally using command below:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" \
Origin:console.redhat.com \
x-rh-swatch-psk:placeholder
```

5.- Verification in RHSM subscription database:

```
echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w 0
-- eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19
```

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/opt-in?org_id=org123' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19'
```

```
http GET ":8000/api/rhsm-subscriptions/v1/instances/products/OpenShift Container Platform" x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19 | jq
```

It should return:

```json
{
  "data": [
    {
      "id": "89c82a6f-ad4b-498d-a628-1d04b99931e3",
      "instance_id": "d125f119",
      "display_name": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55",
      "measurements": [
        4.0,
        2.0
      ],
      "last_seen": "1993-03-26T00:00:00Z",
      "number_of_guests": 0,
      "category": "physical",
      "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6",
      "inventory_id": "e5406d59-5cf3-4e83-abf8-84c149f8b6ba"
    }
  ],
  "meta": {
    "count": 1,
    "product": "OpenShift Container Platform",
    "measurements": [
      "Cores",
      "Sockets"
    ]
  }
}
```

Where `data.*.measurements` must be `[4.0, 2.0]`.