### PR TITLE
SWATCH-2287 Add properties to billable usage remittance DB records

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -35,6 +35,7 @@ import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.RemittanceStatus;
 import org.candlepin.subscriptions.db.model.RemittanceSummaryProjection;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
@@ -227,6 +228,7 @@ public class BillableUsageController {
             .remittancePendingDate(clock.now())
             .tallyId(usage.getId())
             .hardwareMeasurementType(usage.getHardwareMeasurementType())
+            .status(RemittanceStatus.PENDING)
             .build();
     // Remitted value should be set to usages metric_value rather than billing_value
     newRemittance.setRemittedPendingValue(usageCalc.getRemittedValue());
@@ -235,6 +237,7 @@ public class BillableUsageController {
     // using saveAndFlush to validate the entity against the database and raise constraints
     // exception before moving forward.
     billableUsageRemittanceRepository.saveAndFlush(newRemittance);
+    usage.setStatus(BillableUsage.Status.PENDING);
   }
 
   private Double getCurrentlyMeasuredTotal(

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingController.java
@@ -100,7 +100,8 @@ public class InternalBillingController {
         .withUom(remittance.getMetricId())
         .withMetricId(remittance.getMetricId())
         .withValue(remittance.getRemittedPendingValue())
-        .withHardwareMeasurementType(remittance.getHardwareMeasurementType());
+        .withHardwareMeasurementType(remittance.getHardwareMeasurementType())
+        .withStatus(BillableUsage.Status.fromValue(remittance.getStatus().getValue()));
   }
 
   private List<MonthlyRemittance> transformUsageToMonthlyRemittance(

--- a/src/main/resources/liquibase/202404121601-add-new-columns-billable-usage-remittance.xml
+++ b/src/main/resources/liquibase/202404121601-add-new-columns-billable-usage-remittance.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+  <changeSet id="202404121601-1" author="karshah">
+    <comment>Add new columns for billable usage retries</comment>
+    <addColumn tableName="billable_usage_remittance">
+      <column name="billed_on" type="TIMESTAMP WITH TIME ZONE" />
+    </addColumn>
+
+    <addColumn tableName="billable_usage_remittance">
+      <column name="error_code" type="VARCHAR(255)" />
+    </addColumn>
+
+    <addColumn tableName="billable_usage_remittance">
+      <column name="status" type="VARCHAR(255)" />
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -149,5 +149,6 @@
     <include file="/liquibase/202401161133-update-instance-view-to-include-last-applied-event-record-date.xml" />
     <include file="/liquibase/202403260830-update-instance-view-to-include-inventory-id.xml" />
     <include file="/liquibase/202404051233-fix-bad-tally-state-and-event-data.xml"/>
+    <include file="/liquibase/202404121601-add-new-columns-billable-usage-remittance.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/spec/internal-billing-api-spec.yaml
+++ b/src/main/spec/internal-billing-api-spec.yaml
@@ -185,6 +185,8 @@ components:
         remittanceDate:
           type: string
           format: date-time
+        remittanceStatus:
+          type: string
     OrgIds:
       type: string
       properties:

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -57,6 +57,7 @@ import org.candlepin.subscriptions.db.model.BillableUsageRemittanceEntity;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.candlepin.subscriptions.db.model.RemittanceStatus;
 import org.candlepin.subscriptions.db.model.RemittanceSummaryProjection;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
@@ -513,6 +514,7 @@ class BillableUsageControllerTest {
         .withSla(Sla.STANDARD)
         .withMetricId("STORAGE_GIBIBYTES")
         .withSnapshotDate(date)
+        .withStatus(BillableUsage.Status.PENDING)
         .withValue(value);
   }
 
@@ -549,6 +551,7 @@ class BillableUsageControllerTest {
         .remittedPendingValue(value)
         .tallyId(usage.getId())
         .hardwareMeasurementType(usage.getHardwareMeasurementType())
+        .status(RemittanceStatus.PENDING)
         .build();
   }
 

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -43,6 +43,23 @@ properties:
       - Production
       - Development/Test
       - Disaster Recovery
+  status:
+    description: Intended to be used for reporting remittance status
+    type: string
+    enum:
+      - pending
+      - succeeded
+      - failed
+  error_code:
+    description: Intended to be used for reporting remittance error code in case of failure
+    type: string
+    enum:
+      - inactive
+      - redundant
+      - unknown
+  billed_on:
+    type: string
+    format: date-time
   uom:
     description: Preferred unit of measure for the subject (for products with multiple possible UOM). Deprecated in favor of metric_id.
     type: string

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/BillableUsageRemittanceRepository.java
@@ -73,7 +73,8 @@ public interface BillableUsageRemittanceRepository
           root.get(BillableUsageRemittanceEntity_.BILLING_ACCOUNT_ID),
           root.get(BillableUsageRemittanceEntity_.METRIC_ID),
           root.get(BillableUsageRemittanceEntity_.ORG_ID),
-          root.get(BillableUsageRemittanceEntity_.PRODUCT_ID));
+          root.get(BillableUsageRemittanceEntity_.PRODUCT_ID),
+          root.get(BillableUsageRemittanceEntity_.STATUS));
     }
     query.select(
         criteriaBuilder.construct(
@@ -87,7 +88,8 @@ public interface BillableUsageRemittanceRepository
             criteriaBuilder.max(root.get(BillableUsageRemittanceEntity_.REMITTANCE_PENDING_DATE)),
             root.get(BillableUsageRemittanceEntity_.BILLING_PROVIDER),
             root.get(BillableUsageRemittanceEntity_.BILLING_ACCOUNT_ID),
-            root.get(BillableUsageRemittanceEntity_.METRIC_ID)));
+            root.get(BillableUsageRemittanceEntity_.METRIC_ID),
+            root.get(BillableUsageRemittanceEntity_.STATUS)));
     return entityManager.createQuery(query).getResultList();
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillableUsageRemittanceEntity.java
@@ -87,4 +87,13 @@ public class BillableUsageRemittanceEntity implements Serializable {
 
   @Column(name = "hardware_measurement_type")
   private String hardwareMeasurementType;
+
+  @Column(name = "status")
+  private RemittanceStatus status;
+
+  @Column(name = "error_code")
+  private RemittanceErrorCode errorCode;
+
+  @Column(name = "billed_on")
+  private OffsetDateTime billedOn;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceErrorCode.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceErrorCode.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public enum RemittanceErrorCode {
+  INACTIVE("inactive"),
+  REDUNDANT("redundant"),
+  UNKNOWN("unknown");
+
+  private static final Map<String, RemittanceErrorCode> VALUE_ENUM_MAP =
+      Arrays.stream(RemittanceErrorCode.values())
+          .collect(Collectors.toMap(RemittanceErrorCode::getValue, Function.identity()));
+
+  private final String value;
+
+  RemittanceErrorCode(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Parse the RemittanceErrorCode from its string representation
+   *
+   * @param value String representation of the RemittanceErrorCode, as seen in a host record
+   * @return the RemittanceErrorCode enum
+   */
+  public static RemittanceErrorCode fromString(String value) {
+    return VALUE_ENUM_MAP.get(value);
+  }
+
+  /** JPA converter for RemittanceErrorCode */
+  @Converter(autoApply = true)
+  public static class EnumConverter implements AttributeConverter<RemittanceErrorCode, String> {
+
+    @Override
+    public String convertToDatabaseColumn(RemittanceErrorCode attribute) {
+      if (attribute == null) {
+        return null;
+      }
+      return attribute.getValue();
+    }
+
+    @Override
+    public RemittanceErrorCode convertToEntityAttribute(String dbData) {
+      return Objects.nonNull(dbData) ? RemittanceErrorCode.fromString(dbData) : null;
+    }
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceStatus.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceStatus.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public enum RemittanceStatus {
+  PENDING("pending"),
+  FAILED("failed"),
+  SUCCEEDED("succeeded");
+
+  private static final Map<String, RemittanceStatus> VALUE_ENUM_MAP =
+      Arrays.stream(RemittanceStatus.values())
+          .collect(Collectors.toMap(RemittanceStatus::getValue, Function.identity()));
+
+  private final String value;
+
+  RemittanceStatus(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Parse the RemittanceStatus from its string representation
+   *
+   * @param value String representation of the RemittanceStatus, as seen in a host record
+   * @return the RemittanceStatus enum
+   */
+  public static RemittanceStatus fromString(String value) {
+    return VALUE_ENUM_MAP.get(value);
+  }
+
+  /** JPA converter for RemittanceStatus */
+  @Converter(autoApply = true)
+  public static class EnumConverter implements AttributeConverter<RemittanceStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(RemittanceStatus attribute) {
+      if (attribute == null) {
+        return null;
+      }
+      return attribute.getValue();
+    }
+
+    @Override
+    public RemittanceStatus convertToEntityAttribute(String dbData) {
+      return Objects.nonNull(dbData) ? RemittanceStatus.fromString(dbData) : null;
+    }
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceSummaryProjection.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/RemittanceSummaryProjection.java
@@ -41,4 +41,5 @@ public class RemittanceSummaryProjection {
   private String billingProvider;
   private String billingAccountId;
   private String metricId;
+  private RemittanceStatus status;
 }

--- a/swatch-model-billable-usage/src/main/java/org/candlepin/subscriptions/billable/usage/BillableUsageAggregate.java
+++ b/swatch-model-billable-usage/src/main/java/org/candlepin/subscriptions/billable/usage/BillableUsageAggregate.java
@@ -46,6 +46,9 @@ public class BillableUsageAggregate {
   private UUID aggregateId;
   private BillableUsageAggregateKey aggregateKey;
   private Set<OffsetDateTime> snapshotDates = new HashSet<>();
+  private BillableUsage.Status status;
+  private BillableUsage.ErrorCode errorCode;
+  private OffsetDateTime billedOn;
 
   public BillableUsageAggregate updateFrom(BillableUsage billableUsage) {
     if (aggregateId == null) {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2287

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

- Add and maintain a status property to billable usage remittance DB records & messages (having possible values of `pending`, `failed`, `succeeded`).

- Add a `billed_on` property (timestamp) to record the time of successful remittance.

- Add an `error_code` property to record the failure reason if applicable. Error code should have possible values of `inactive`, `redundant`, `unknown` (we'll expand later as needed).

- `GET /internal/remittance/accountRemittances`
Should only show different summary per status like successful , null state{} etc

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/646>

`iqe tests plugin rhsm_subscriptions  -k test_verify_rhel_payg_via_cost_mgmt`

### Setup
<!-- Add any steps required to set up the test case -->
1. Run swatch-core:
`RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8003 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun`

2. Run swatch-billable-usage:
`SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 KSTREAM_BILLABLE_USAGE_AGGREGATION_WINDOW_DURATION=10s KSTREAM_BILLABLE_USAGE_AGGREGATION_GRACE_DURATION=2s ./gradlew :swatch-billable-usage:quarkusDev`

3. Run  swatch-producer-aws:
`SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 ./gradlew :swatch-producer-aws:quarkusDev`

4. Run swatch-contracts like #3089:
`ENABLE_SPLUNK_HEC=false ENTITLEMENT_GATEWAY_URL=https://ibm-entitlement-gateway.api.redhat.com KEYSTORE_PASSWORD=<PWD> KEYSTORE_RESOURCE=file:/home/../rhsm-subscriptions/config/certs/bkpcerts_prod/keystore.jks QUARKUS_PROFILE=prod SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8001 SWATCH_SELF_PSK=placeholder UMB_ENABLED=false RBAC_ENABLED=false RBAC_ENDPOINT=http://localhost:8080 UMB_HOSTNAME=localhost  SERVER_PORT=8003 ./gradlew  :swatch-contracts:quarkusDev `

Do this if mocking subscription like #3016:
`SUBSCRIPTION_URL=http://localhost:8102/ ENTITLEMENT_GATEWAY_URL=http://localhost:8102/mock/partnerApi ./gradlew :swatch-contracts:quarkusDev`


### A.  Steps & Verification for setting the remittance status in billable_usage_remittance:
<!-- Enter each step of the test below -->
1. Run the core app:
6. Produce Kafka message to service-instance-ingress
`{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "13259775", "event_id": "527e29b6-321c-4021-a1f4-fcff4326ae2d", "timestamp": "2023-10-18T19:00:00Z", "event_type": "snapshot", "expiration": "2023-10-18T20:00:00Z", "instance_id": "i-0d8d5297e354051db", "product_ids": ["69", "204"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 1.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "746157280291"}`
7. Execute hourly tally
`http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=13259775&start=2023-10-19T15:00Z&end=2023-10-19T16:00Z" x-rh-swatch-psk:placeholder`

**Verification:**
You should see **pending** status record in billable_usage_remittance:
```
account_number,org_id,product_id,metric_id,accumulation_period,sla,usage,billing_provider,billing_account_id,remitted_pending_value,remittance_pending_date,retry_after,tally_id,hardware_measurement_type,uuid,billed_on,error_code,status
,13259775,rhel-for-x86-els-payg,vCPUs,2023-10,Premium,Production,aws,746157280291,8,2024-04-15 12:49:05.079411 +00:00,,f2eb03bc-d1f6-4e32-8a3e-435683f4edd1,AWS,596baac2-327a-42c2-97ec-9fdd86140cb0,,,pending
```

You can also see the message in Kafka` billable-usage`:
```
{
  "org_id": "13259775",
  "id": "f2eb03bc-d1f6-4e32-8a3e-435683f4edd1",
  "billing_provider": "aws",
  "billing_account_id": "746157280291",
  "snapshot_date": "2024-04-15T12:58:19.557152014Z",
  "product_id": "rhel-for-x86-els-payg",
  "sla": "Premium",
  "usage": "Production",
  "status": "pending",
  "metric_id": "VCPUS",
  "value": 9.0,
  "billing_factor": 1.0,
  "hardware_measurement_type": "AWS"
} 
```


### B. Steps & Verification for remittance status response from table:
```

INSERT INTO public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date, retry_after, tally_id, hardware_measurement_type, uuid, billed_on, error_code, status) VALUES (null, '13259775', 'rhel-for-x86-els-payg', 'vCPUs', '2023-10', 'Premium', 'Production', 'aws', '746157280291', 9, '2024-04-15 12:58:19.557152 +00:00', null, 'f2eb03bc-d1f6-4e32-8a3e-435683f4edd1', 'AWS', '37dbee9c-658a-45ac-ac8e-d28fa316d7b3', null, null, 'pending');
INSERT INTO public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date, retry_after, tally_id, hardware_measurement_type, uuid, billed_on, error_code, status) VALUES (null, '13259775', 'rhel-for-x86-els-payg', 'vCPUs', '2023-10', 'Premium', 'Production', 'aws', '746157280291', 9, '2024-04-15 12:58:20.557000 +00:00', null, '527e29b6-321c-4021-a1f4-fcff4326ae2d', 'AWS', '527e29b6-321c-4021-a1f4-fcff4326ae2d', null, null, 'failed');
INSERT INTO public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date, retry_after, tally_id, hardware_measurement_type, uuid, billed_on, error_code, status) VALUES (null, '13259775', 'rhel-for-x86-els-payg', 'vCPUs', '2023-10', 'Premium', 'Production', 'aws', '746157280292', 1, '2024-04-15 14:37:47.191017 +00:00', null, 'ffad4f16-b22d-44a6-a3c9-5cd2a4b18fd2', 'AWS', '2067c298-f73d-405c-af7e-f99c56fe7989', null, null, 'pending');
INSERT INTO public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date, retry_after, tally_id, hardware_measurement_type, uuid, billed_on, error_code, status) VALUES (null, '13259775', 'rhel-for-x86-els-payg', 'vCPUs', '2023-10', 'Premium', 'Production', 'aws', '746157280291', 2, '2024-04-15 14:51:48.299738 +00:00', null, '7c8d6fd3-434a-448a-bd06-9ae60243c94a', 'AWS', 'da8552f6-0fd2-46e6-905b-82b396f876ca', null, null, 'pending');

```

Execute:
` http GET :8000/api/rhsm-subscriptions/v1/internal/remittance/accountRemittances orgId==13259775  productId==rhel-for-x86-els-payg  x-rh-swatch-psk:placeholder`

Response Verification:
```
[
    {
        "accumulationPeriod": "2023-10",
        "billingAccountId": "746157280291",
        "billingProvider": "aws",
        "metricId": "vCPUs",
        "orgId": "13259775",
        "productId": "rhel-for-x86-els-payg",
        "remittanceDate": "2024-04-15T12:58:20.557Z",
        "remittanceStatus": "failed",
        "remittedValue": 9.0
    },
    {
        "accumulationPeriod": "2023-10",
        "billingAccountId": "746157280291",
        "billingProvider": "aws",
        "metricId": "vCPUs",
        "orgId": "13259775",
        "productId": "rhel-for-x86-els-payg",
        "remittanceDate": "2024-04-15T14:51:48.299738Z",
        "remittanceStatus": "pending",
        "remittedValue": 11.0
    },
    {
        "accumulationPeriod": "2023-10",
        "billingAccountId": "746157280292",
        "billingProvider": "aws",
        "metricId": "vCPUs",
        "orgId": "13259775",
        "productId": "rhel-for-x86-els-payg",
        "remittanceDate": "2024-04-15T14:37:47.191017Z",
        "remittanceStatus": "pending",
        "remittedValue": 1.0
    }
]
```

Query executed:
```
select sum(bure1_0.remitted_pending_value),bure1_0.org_id,bure1_0.product_id,bure1_0.accumulation_period,bure1_0.sla,bure1_0.usage,
       max(bure1_0.remittance_pending_date),bure1_0.billing_provider,bure1_0.billing_account_id,bure1_0.metric_id,bure1_0.status
from billable_usage_remittance bure1_0 
where bure1_0.product_id='rhel-for-x86-els-payg' and bure1_0.org_id='13259775'   group by 4,5,6,8,9,10,2,3,11
```