### PR TITLE
SWATCH-2444: Fix bug with multiple azure API credentials 

### DIFF
--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureMarketplaceClientFactory.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureMarketplaceClientFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.service;
+
+import com.redhat.swatch.azure.file.AzureMarketplaceCredentials;
+import com.redhat.swatch.azure.file.AzureMarketplaceProperties;
+import com.redhat.swatch.azure.http.AzureMarketplaceHeaderProvider;
+import com.redhat.swatch.clients.azure.marketplace.api.resources.AzureMarketplaceApi;
+import io.quarkus.oidc.client.OidcClients;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+@Slf4j
+@ApplicationScoped
+public class AzureMarketplaceClientFactory {
+
+  AzureMarketplaceProperties azureMarketplaceProperties;
+  AzureMarketplaceCredentials azureMarketplaceCredentials;
+  private OidcClients oidcClients;
+
+  @Inject
+  public AzureMarketplaceClientFactory(
+      AzureMarketplaceProperties azureMarketplaceProperties,
+      AzureMarketplaceCredentials azureMarketplaceCredentials,
+      OidcClients oidcClients) {
+    this.azureMarketplaceProperties = azureMarketplaceProperties;
+    this.azureMarketplaceCredentials = azureMarketplaceCredentials;
+    this.oidcClients = oidcClients;
+  }
+
+  public List<AzureMarketplaceApi> createClientForEachTenant() {
+    return azureMarketplaceCredentials.getClients().stream()
+        .map(
+            client -> {
+              try {
+                return RestClientBuilder.newBuilder()
+                    .baseUri(new URI(azureMarketplaceProperties.getMarketplaceBaseUrl()))
+                    .register(
+                        new AzureMarketplaceHeaderProvider(
+                            azureMarketplaceProperties, client, oidcClients))
+                    .build(AzureMarketplaceApi.class);
+              } catch (URISyntaxException ex) {
+                log.error("Unable to create URI for Azure authentication for client.", ex);
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+}

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureMarketplaceClientFactory.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureMarketplaceClientFactory.java
@@ -25,15 +25,14 @@ import com.redhat.swatch.azure.file.AzureMarketplaceProperties;
 import com.redhat.swatch.azure.http.AzureMarketplaceHeaderProvider;
 import com.redhat.swatch.clients.azure.marketplace.api.resources.AzureMarketplaceApi;
 import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
 @Slf4j
 @ApplicationScoped
@@ -58,7 +57,7 @@ public class AzureMarketplaceClientFactory {
         .map(
             client -> {
               try {
-                return RestClientBuilder.newBuilder()
+                return QuarkusRestClientBuilder.newBuilder()
                     .baseUri(new URI(azureMarketplaceProperties.getMarketplaceBaseUrl()))
                     .register(
                         new AzureMarketplaceHeaderProvider(
@@ -70,6 +69,6 @@ public class AzureMarketplaceClientFactory {
               }
             })
         .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .toList();
   }
 }

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureMarketplaceServiceTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureMarketplaceServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.redhat.swatch.azure.exception.AzureMarketplaceRequestFailedException;
+import com.redhat.swatch.azure.file.AzureMarketplaceProperties;
+import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEvent;
+import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventOkResponse;
+import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventStatusEnum;
+import com.redhat.swatch.clients.azure.marketplace.api.resources.AzureMarketplaceApi;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.ProcessingException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+class AzureMarketplaceServiceTest {
+
+  @InjectMock AzureMarketplaceClientFactory azureMarketplaceClientFactory;
+  AzureMarketplaceApi acceptedClient;
+  AzureMarketplaceApi failedClient;
+
+  @BeforeEach
+  void setup() throws Exception {
+    acceptedClient = mock(AzureMarketplaceApi.class);
+    failedClient = mock(AzureMarketplaceApi.class);
+    Mockito.when(azureMarketplaceClientFactory.createClientForEachTenant())
+        .thenReturn(List.of(acceptedClient, failedClient));
+    Mockito.when(acceptedClient.submitUsageEvents(any(), any(), any(), any()))
+        .thenReturn(new UsageEventOkResponse().status(UsageEventStatusEnum.ACCEPTED));
+    Mockito.when(failedClient.submitUsageEvents(any(), any(), any(), any()))
+        .thenThrow(new ProcessingException("error"));
+  }
+
+  @Test
+  void testSendUsageEventToMarketplaceAcceptedFirstCredentials() throws Exception {
+    AzureMarketplaceProperties azureMarketplaceProperties = new AzureMarketplaceProperties();
+    var service =
+        new AzureMarketplaceService(azureMarketplaceProperties, azureMarketplaceClientFactory);
+    var response = service.sendUsageEventToAzureMarketplace(new UsageEvent());
+    assertNotNull(response);
+    verify(acceptedClient).submitUsageEvents(any(), any(), any(), any());
+    verifyNoInteractions(failedClient);
+  }
+
+  @Test
+  void testSendUsageEventToMarketplaceAcceptedSecondCredentials() throws Exception {
+    Mockito.when(azureMarketplaceClientFactory.createClientForEachTenant())
+        .thenReturn(List.of(failedClient, acceptedClient));
+    AzureMarketplaceProperties azureMarketplaceProperties = new AzureMarketplaceProperties();
+    var service =
+        new AzureMarketplaceService(azureMarketplaceProperties, azureMarketplaceClientFactory);
+    var response = service.sendUsageEventToAzureMarketplace(new UsageEvent());
+    assertNotNull(response);
+    verify(acceptedClient).submitUsageEvents(any(), any(), any(), any());
+    verify(failedClient).submitUsageEvents(any(), any(), any(), any());
+  }
+
+  @Test
+  void testSendUsageEventToMarketplaceFails() {
+    Mockito.when(azureMarketplaceClientFactory.createClientForEachTenant())
+        .thenReturn(List.of(failedClient, failedClient));
+    AzureMarketplaceProperties azureMarketplaceProperties = new AzureMarketplaceProperties();
+    var service =
+        new AzureMarketplaceService(azureMarketplaceProperties, azureMarketplaceClientFactory);
+    assertThrows(
+        AzureMarketplaceRequestFailedException.class,
+        () -> service.sendUsageEventToAzureMarketplace(new UsageEvent()));
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2444

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
When we have multiple sets of api credentials to use against azure, the code was calling the api with both credentials every time. This code change makes it so we only try the next set of credentials if the first one fails instead of continuing to try more credentials.

To test this you need to use credentials from stage, updated to have another invalid entry.
