### PR TITLE
Add .gitleaks.toml to reduce false positives on credential leak scans

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+    description = "Global Allowlist"
+    paths = [
+    # Ignore podman-compose Kafka container keys
+    '''^config/kafka/.*.key$'''
+  ]


### PR DESCRIPTION
Jira issue: No issue as this is just a very quick fix

## Description
Scans for credential leaks were picking up the keys we have in `config/kafka`.  These keys are used for the certificates used for testing TLS connections and are only used on locally running containers, so it's a false positive for a real leak.

## Testing

### Setup
1.  You need to have `rh-pre-commit` installed.  Instructions for doing so are on the intranet but contact me if you need help.  It's actually a good idea for everyone to do this, so consider this PR review a little nudge in the right direction.

### Steps
1.  On `main`, run `rh-gitleaks --path=. -v --additional-config=.gitleaks.toml`
1.  Run the same command on this branch

### Verification
1.  On this branch, no credentials are identified as being leaked.
