### PR TITLE
Add LICENSE to container as required by OpenShift Container Policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ COPY --from=0 /stage/META-INF /deployments/META-INF
 COPY --from=0 /stage/BOOT-INF/classes /deployments/
 
 COPY --from=0 /stage/build/javaagent/* /opt/
+
+# Required by Red Hat OpenShift Software Certification Policy Guide
+COPY --from=0 /stage/LICENSE /licenses/
+
 RUN chmod -R g=u /deployments
 
 USER default

--- a/swatch-billable-usage/src/main/docker/Dockerfile.jvm
+++ b/swatch-billable-usage/src/main/docker/Dockerfile.jvm
@@ -131,6 +131,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-billable-usage/buil
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-billable-usage/build/quarkus-app/app/ /deployments/app/
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-billable-usage/build/quarkus-app/quarkus/ /deployments/quarkus/
 
+# Required by Red Hat OpenShift Software Certification Policy Guide
+COPY --from=0 /stage/LICENSE /licenses/
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -130,6 +130,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-contracts/build/qua
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-contracts/build/quarkus-app/app/ /deployments/app/
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-contracts/build/quarkus-app/quarkus/ /deployments/quarkus/
 
+# Required by Red Hat OpenShift Software Certification Policy Guide
+COPY --from=0 /stage/LICENSE /licenses/
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 

--- a/swatch-metrics/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics/src/main/docker/Dockerfile.jvm
@@ -130,6 +130,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-metrics/build/quark
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-metrics/build/quarkus-app/app/ /deployments/app/
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-metrics/build/quarkus-app/quarkus/ /deployments/quarkus/
 
+# Required by Red Hat OpenShift Software Certification Policy Guide
+COPY --from=0 /stage/LICENSE /licenses/
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -130,6 +130,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-producer-aws/build/
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-producer-aws/build/quarkus-app/app/ /deployments/app/
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-producer-aws/build/quarkus-app/quarkus/ /deployments/quarkus/
 
+# Required by Red Hat OpenShift Software Certification Policy Guide
+COPY --from=0 /stage/LICENSE /licenses/
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 

--- a/swatch-producer-azure/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-azure/src/main/docker/Dockerfile.jvm
@@ -130,6 +130,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-producer-azure/buil
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-producer-azure/build/quarkus-app/app/ /deployments/app/
 COPY --from=0 --chown=default:root --chmod=775 /stage/swatch-producer-azure/build/quarkus-app/quarkus/ /deployments/quarkus/
 
+# Required by Red Hat OpenShift Software Certification Policy Guide
+COPY --from=0 /stage/LICENSE /licenses/
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 


### PR DESCRIPTION
See https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: related to SWATCH-2133

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing

### Setup
<!-- Add any steps required to set up the test case -->
1. run `/bin/build-images.sh -k`

### Steps
<!-- Enter each step of the test below -->
1. `podman run -ti -rm <container> /bin/ls -al /licenses`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. The `LICENSE` file is present.
