### PR TITLE
SWATCH-2460: Move the /remittance/purge endpoint to the billing API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -31,7 +31,6 @@ import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.resource.ResourceUtils;
-import org.candlepin.subscriptions.retention.RemittanceRetentionController;
 import org.candlepin.subscriptions.retention.TallyRetentionController;
 import org.candlepin.subscriptions.security.SecurityProperties;
 import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
@@ -65,7 +64,6 @@ public class InternalTallyResource implements InternalApi {
   private final MarketplaceResendTallyController resendTallyController;
   private final CaptureSnapshotsTaskManager snapshotsTaskManager;
   private final TallyRetentionController tallyRetentionController;
-  private final RemittanceRetentionController remittanceRetentionController;
   private final InternalTallyDataController internalTallyDataController;
   private final SecurityProperties properties;
   private final EventRecordRepository eventRecordRepository;
@@ -78,7 +76,6 @@ public class InternalTallyResource implements InternalApi {
       MarketplaceResendTallyController resendTallyController,
       CaptureSnapshotsTaskManager snapshotsTaskManager,
       TallyRetentionController tallyRetentionController,
-      RemittanceRetentionController remittanceRetentionController,
       InternalTallyDataController internalTallyDataController,
       SecurityProperties properties,
       EventRecordRepository eventRecordRepository,
@@ -88,7 +85,6 @@ public class InternalTallyResource implements InternalApi {
     this.resendTallyController = resendTallyController;
     this.snapshotsTaskManager = snapshotsTaskManager;
     this.tallyRetentionController = tallyRetentionController;
-    this.remittanceRetentionController = remittanceRetentionController;
     this.internalTallyDataController = internalTallyDataController;
     this.properties = properties;
     this.eventRecordRepository = eventRecordRepository;
@@ -112,18 +108,6 @@ public class InternalTallyResource implements InternalApi {
     try {
       log.info("Initiating tally snapshot purge.");
       tallyRetentionController.purgeSnapshotsAsync();
-    } catch (TaskRejectedException e) {
-      log.warn("A tally snapshots purge job is already running.");
-      return getDefaultResponse(REJECTED_STATUS);
-    }
-    return getDefaultResponse(SUCCESS_STATUS);
-  }
-
-  @Override
-  public DefaultResponse purgeRemittances() {
-    try {
-      log.info("Initiating remittance purge.");
-      remittanceRetentionController.purgeRemittancesAsync();
     } catch (TaskRejectedException e) {
       log.warn("A tally snapshots purge job is already running.");
       return getDefaultResponse(REJECTED_STATUS);

--- a/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/admin/InternalBillingResource.java
@@ -32,6 +32,8 @@ import org.candlepin.subscriptions.billing.admin.api.InternalApi;
 import org.candlepin.subscriptions.billing.admin.api.model.DefaultResponse;
 import org.candlepin.subscriptions.billing.admin.api.model.MonthlyRemittance;
 import org.candlepin.subscriptions.db.BillableUsageRemittanceFilter;
+import org.candlepin.subscriptions.retention.RemittanceRetentionController;
+import org.springframework.core.task.TaskRejectedException;
 import org.springframework.stereotype.Component;
 
 /** This resource is for exposing administrator REST endpoints for Remittance. */
@@ -42,11 +44,15 @@ public class InternalBillingResource implements InternalApi {
   private static final String REJECTED_STATUS = "Rejected";
 
   private final InternalBillingController billingController;
+  private final RemittanceRetentionController remittanceRetentionController;
   private final ApplicationClock clock;
 
   public InternalBillingResource(
-      InternalBillingController billingController, ApplicationClock clock) {
+      InternalBillingController billingController,
+      RemittanceRetentionController remittanceRetentionController,
+      ApplicationClock clock) {
     this.billingController = billingController;
+    this.remittanceRetentionController = remittanceRetentionController;
     this.clock = clock;
   }
 
@@ -113,6 +119,18 @@ public class InternalBillingResource implements InternalApi {
               "No record found for billable usage remittance for productId %s and between start %s and end date %s and orgIds %s",
               productId, start, end, orgIds));
     }
+  }
+
+  @Override
+  public DefaultResponse purgeRemittances() {
+    try {
+      log.info("Initiating remittance purge.");
+      remittanceRetentionController.purgeRemittancesAsync();
+    } catch (TaskRejectedException e) {
+      log.warn("A tally snapshots purge job is already running.");
+      return getDefaultResponse(REJECTED_STATUS);
+    }
+    return getDefaultResponse(SUCCESS_STATUS);
   }
 
   private DefaultResponse getDefaultResponse(String status) {

--- a/src/main/spec/internal-billing-api-spec.yaml
+++ b/src/main/spec/internal-billing-api-spec.yaml
@@ -154,6 +154,22 @@ paths:
                 $ref: "#/components/schemas/DefaultResponse"
           description: Accepted request to retry billable usage remittance
       tags: ['internalBilling']
+  /internal/rpc/remittance/purge:
+    post:
+      operationId: purgeRemittances
+      summary: 'Purge existing remittances matching the configured retention policy.'
+      responses:
+        '201':
+          description: 'The process for purging remittances was started.'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultResponse"
+        '401':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Unauthorized"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags: ['internalBilling']
   /internal-billing-openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
   /internal-billing-openapi.yaml:

--- a/src/main/spec/internal-tally-api-spec.yaml
+++ b/src/main/spec/internal-tally-api-spec.yaml
@@ -46,23 +46,6 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags:
         - internalTally
-  /internal/rpc/tally/remittance/purge:
-    description: 'Operations to purge existing tally snapshots matching the configured retention policy.'
-    post:
-      operationId: purgeRemittances
-      summary: 'Purge existing remittances matching the configured retention policy.'
-      responses:
-        '201':
-          description: 'The process for purging remittances was started.'
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DefaultResponse"
-        '401':
-          $ref: "../../../spec/error-responses.yaml#/$defs/Unauthorized"
-        '500':
-          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
-      tags: [internalTally]
   /internal/tally/hourly:
     description: 'Operations pertaining to the hourly tally.'
     post:

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalBillingResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalBillingResourceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import static org.mockito.Mockito.verify;
+
+import org.candlepin.subscriptions.retention.RemittanceRetentionController;
+import org.candlepin.subscriptions.tally.billing.admin.InternalBillingResource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InternalBillingResourceTest {
+  @Mock RemittanceRetentionController remittanceRetentionController;
+
+  @InjectMocks InternalBillingResource resource;
+
+  @Test
+  void testPurgeRemittances() {
+    resource.purgeRemittances();
+    verify(remittanceRetentionController).purgeRemittancesAsync();
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -30,7 +30,6 @@ import java.time.temporal.ChronoUnit;
 import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.EventRecordRepository;
-import org.candlepin.subscriptions.retention.RemittanceRetentionController;
 import org.candlepin.subscriptions.retention.TallyRetentionController;
 import org.candlepin.subscriptions.security.SecurityProperties;
 import org.candlepin.subscriptions.tally.MarketplaceResendTallyController;
@@ -51,7 +50,6 @@ class InternalTallyResourceTest {
   @Mock private MarketplaceResendTallyController resendTallyController;
   @Mock private CaptureSnapshotsTaskManager snapshotTaskManager;
   @Mock private TallyRetentionController tallyRetentionController;
-  @Mock private RemittanceRetentionController remittanceRetentionController;
   @Mock private InternalTallyDataController internalTallyDataController;
   @Mock private SecurityProperties properties;
   @Mock private EventRecordRepository eventRecordRepository;
@@ -73,7 +71,6 @@ class InternalTallyResourceTest {
             resendTallyController,
             snapshotTaskManager,
             tallyRetentionController,
-            remittanceRetentionController,
             internalTallyDataController,
             properties,
             eventRecordRepository,
@@ -123,12 +120,6 @@ class InternalTallyResourceTest {
     appProps.setEnableSynchronousOperations(true);
     resource.tallyOrg(ORG_ID, true);
     verify(internalTallyDataController).tallyOrgSync(ORG_ID);
-  }
-
-  @Test
-  void testPurgeRemittances() {
-    resource.purgeRemittances();
-    verify(remittanceRetentionController).purgeRemittancesAsync();
   }
 
   @Test

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -583,7 +583,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/remittance/purge"
+              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/remittance/purge"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:


### PR DESCRIPTION
Jira issue: [SWATCH-2460](https://issues.redhat.com/browse/SWATCH-2460)

## Description
Move the endpoint "/internal/rpc/tally/remittance/purge" from internal tally API to the internal billing API. The new path should be "/internal/rpc/remittance/purge" instead.

## Testing
1.- setup an EE environment using bonfire
2.- update the swatch-tally-purge-remittances cronJob to be executed every 5 min:

```
spec:
  schedule: "*/5 * * * *"
```

Wait up to 5 min and verify that the job invocation of the cronjob was success:

```
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0100 20 100 20 0 0 1538 0 --:--:-- --:--:-- --:--:-- 1538
{"status":"Success"}
```

From: <OCP cluster>/k8s/ns/<OCP project>/pods/swatch-tally-purge-remittances-<POD>/logs