### PR TITLE
SWATCH-2288: Capture billable usage uuids in billable usage hourly aggregates

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -238,6 +238,7 @@ public class BillableUsageController {
     // exception before moving forward.
     billableUsageRemittanceRepository.saveAndFlush(newRemittance);
     usage.setStatus(BillableUsage.Status.PENDING);
+    usage.setUuid(newRemittance.getUuid());
   }
 
   private Double getCurrentlyMeasuredTotal(

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -137,7 +137,7 @@ class BillableUsageControllerTest {
 
   @Test
   void monthlyWindowNoCurrentRemittance() {
-    BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 0.0003);
+    BillableUsage usage = billable(CLOCK.startOfCurrentMonth(), 0.0003).withUuid(UUID.randomUUID());
     List<RemittanceSummaryProjection> summaries = new ArrayList<>();
     summaries.add(RemittanceSummaryProjection.builder().totalRemittedPendingValue(0.0).build());
 
@@ -147,7 +147,7 @@ class BillableUsageControllerTest {
     controller.submitBillableUsage(usage);
 
     BillableUsageRemittanceEntity expectedRemittance = remittance(usage, CLOCK.now(), 1.0);
-    BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 1.0);
+    BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 1.0).withUuid(usage.getUuid());
     expectedUsage.setId(usage.getId()); // Id will be regenerated above.
     verify(remittanceRepo).saveAndFlush(expectedRemittance);
     verify(producer).produce(expectedUsage);

--- a/swatch-model-billable-usage/src/main/java/org/candlepin/subscriptions/billable/usage/BillableUsageAggregate.java
+++ b/swatch-model-billable-usage/src/main/java/org/candlepin/subscriptions/billable/usage/BillableUsageAggregate.java
@@ -24,7 +24,9 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -50,6 +52,7 @@ public class BillableUsageAggregate {
   private BillableUsage.Status status;
   private BillableUsage.ErrorCode errorCode;
   private OffsetDateTime billedOn;
+  private List<String> remittanceUuids = new ArrayList<>();
 
   public BillableUsageAggregate updateFrom(BillableUsage billableUsage) {
     // Flush org used only to force publish suppressed messages.
@@ -66,13 +69,18 @@ public class BillableUsageAggregate {
     if (windowTimestamp == null) {
       windowTimestamp = OffsetDateTime.now().truncatedTo(ChronoUnit.HOURS);
     }
+    if (billableUsage.getUuid() != null) {
+      remittanceUuids.add(billableUsage.getUuid().toString());
+    }
     totalValue = totalValue.add(BigDecimal.valueOf(billableUsage.getValue()));
     snapshotDates.add(billableUsage.getSnapshotDate());
     log.info(
-        "Adding billableUsage: {} to aggregate with aggregateId: {}, totalValue:{} and windowTimestamp: {}",
+        "Adding billableUsage: {} to aggregate with aggregateId: {}, totalValue:{}, remittanceUuids:{} "
+            + "and windowTimestamp: {}",
         billableUsage,
         aggregateId,
         totalValue,
+        remittanceUuids,
         windowTimestamp);
     return this;
   }


### PR DESCRIPTION
Jira issue: SWATCH-2288

## Description
The uuid from the remittance is passed through the BillableUsage message to the BillableUsageAggregator where it is incorporated into the aggregator message.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Run swatch-core:
`RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8003 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun`

2. Run swatch-billable-usage:
`SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 KSTREAM_BILLABLE_USAGE_AGGREGATION_WINDOW_DURATION=10s KSTREAM_BILLABLE_USAGE_AGGREGATION_GRACE_DURATION=2s ./gradlew :swatch-billable-usage:quarkusDev`


### Steps
<!-- Enter each step of the test below -->
1. Run the core app:
2. Produce Kafka message to service-instance-ingress
`{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "13259775", "event_id": "527e29b6-321c-4021-a1f4-fcff4326ae2d", "timestamp": "2023-10-18T19:00:00Z", "event_type": "snapshot", "expiration": "2023-10-18T20:00:00Z", "instance_id": "i-0d8d5297e354051db", "product_ids": ["69", "204"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 1.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "746157280291"}`
3. Execute hourly tally
`http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=13259775&start=2023-10-19T15:00Z&end=2023-10-19T16:00Z" x-rh-swatch-psk:placeholder`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. A Kafka message consumer on billable_usage will see the "uuid" field populated
2. A Kafka message consumer on billable_usage_hourly_aggregate will see the new field "remittanceUuids" populated with the aforementioned uuid value(s)
