### PR TITLE
SWATCH-2461: Add new field "currentTotal" into the snapshot model

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -136,9 +136,18 @@ public class BillableUsageController {
         usage.getSnapshotDate());
     log.debug("Usage: {}", usage);
 
+    // For old messages, the total value for period is not set yet, so we need to keep using the
+    // getCurrentlyMeasuredTotal method
+    // After SWATCH-2368, we will fully use the provided total value for period from the usage and
+    // the getCurrentlyMeasuredTotal method is to be removed.
     Double currentlyMeasuredTotal =
-        getCurrentlyMeasuredTotal(
-            usage, clock.startOfMonth(usage.getSnapshotDate()), usage.getSnapshotDate());
+        Optional.ofNullable(usage.getCurrentTotal())
+            .orElseGet(
+                () ->
+                    getCurrentlyMeasuredTotal(
+                        usage,
+                        clock.startOfMonth(usage.getSnapshotDate()),
+                        usage.getSnapshotDate()));
 
     Optional<Double> contractValue = Optional.of(0.0);
     if (SubscriptionDefinition.isContractEnabled(usage.getProductId())) {

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.candlepin.clock.ApplicationClock;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -50,6 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -59,6 +62,9 @@ import org.springframework.retry.support.RetryTemplate;
 class SnapshotSummaryProducerTest {
 
   @Mock private KafkaTemplate<String, TallySummary> kafka;
+  @Mock TallySnapshotRepository snapshotRepository;
+  @Mock ApplicationClock clock;
+  @InjectMocks TallySummaryMapper tallySummaryMapper;
 
   @Captor private ArgumentCaptor<TallySummary> summaryCaptor;
 
@@ -71,8 +77,7 @@ class SnapshotSummaryProducerTest {
     props = new TallySummaryProperties();
     props.setTopic("summary-topic");
     RetryTemplate retryTemplate = new RetryTemplate();
-    this.producer =
-        new SnapshotSummaryProducer(kafka, retryTemplate, props, new TallySummaryMapper());
+    this.producer = new SnapshotSummaryProducer(kafka, retryTemplate, props, tallySummaryMapper);
   }
 
   @Test

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -80,3 +80,6 @@ properties:
   hardware_measurement_type:
     type: string
     format: string
+  currentTotal:
+    description: Sum of all measurements between the start of the month to the snapshot date.
+    type: number

--- a/swatch-core/schemas/tally_snapshot.yaml
+++ b/swatch-core/schemas/tally_snapshot.yaml
@@ -69,3 +69,6 @@ properties:
         value:
           description: Measurement value.
           type: number
+        currentTotal:
+          description: Sum of all measurements between the start of the month to the snapshot date.
+          type: number


### PR DESCRIPTION
Jira issue: [SWATCH-2461](https://issues.redhat.com/browse/SWATCH-2461)

## Description
The billable usage and snapshot measurements models should contain a new field for the "currentTotal" value. The snapshot measurement one is calculated via SQL query and it's copied over the new billable usage field.

## Testing
1.- podman-compose up
2.- start the tally service:

```
LOGGING_LEVEL_ORG_CANDLEPIN_SUBSCRIPTIONS_TALLY_BILLING=DEBUG \
  SUBSCRIPTION_USE_STUB=true \
  USER_USE_STUB=true \
  CONTRACT_USE_STUB=true \
  DEV_MODE=true \
  ./gradlew :bootRun
```

3.- send tally summary message into the topic "platform.rhsm-subscriptions.tally":

```
{"org_id": "org123", "tally_snapshots": [{"billing_provider":"aws", "billing_account_id": "123", "snapshot_date": "2023-12-21T01:10:28Z", "product_id": "rosa", "sla": "Premium", "usage": "Production", "granularity": "Hourly", "tally_measurements": [{"hardware_measurement_type": "AWS", "metric_id": "Cores", "value": 12}]}]}
```

And you should see the following message in the tally service:

```
[DEBUG] [org.candlepin.subscriptions.tally.billing.BillingProducer] - Sending billable usage org.candlepin.subscriptions.json.BillableUsage@4471ce00[uuid=<null>,orgId=org123,id=<null>,billingProvider=aws,billingAccountId=123,snapshotDate=2024-04-18T08:29:36.237472693Z,productId=rosa,sla=Premium,usage=Production,status=<null>,errorCode=<null>,billedOn=<null>,uom=<null>,metricId=Cores,value=0.0,billingFactor=0.25,vendorProductCode=<null>,hardwareMeasurementType=AWS,currentTotal=0.0] to topic platform.rhsm-subscriptions.billable-usage
```

Note the new field **currentTotal**.