### PR TITLE
SWATCH-2464 Allow Kafka to use the system truststore

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -56,7 +56,10 @@ kafka.bootstrap.servers=localhost:9092
 # Kafka security configuration.  These properties must be present so that
 # clowder-quarkus-config-source will populate them from the Clowder provided configuration JSON.
 # If the properties are simply absent from this file, then clowder-quarkus-config-source will not
-# set values for the property even if a value is present in the Clowder JSON.
+# set values for the property even if a value is present in the Clowder JSON.  The exception is the
+# kafka.ssl.truststore.location which needs to evaluate to null for Kafka to use the system
+# truststore.  Only specify kafka.ssl.truststore.location when you have an actual location to
+# point to.  Don't set it to empty string.
 #
 # Additionally, Kafka has a bug, https://issues.apache.org/jira/browse/KAFKA-4090, where if a
 # client attempts to connect to a TLS enabled port using PLAINTEXT, an OutOfMemoryException gets
@@ -64,8 +67,8 @@ kafka.bootstrap.servers=localhost:9092
 kafka.sasl.jaas.config = ""
 kafka.sasl.mechanism = PLAIN
 kafka.security.protocol = PLAINTEXT
-kafka.ssl.truststore.location = ""
-kafka.ssl.truststore.type = PEM
+#kafka.ssl.truststore.location = ""
+#kafka.ssl.truststore.type = PEM
 
 quarkus.kafka-streams.bootstrap-servers=${kafka.bootstrap.servers:localhost:9092}
 quarkus.kafka-streams.application-server=${HOST}:${SERVER_PORT}

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -125,7 +125,10 @@ kafka:
 # Kafka security configuration.  These properties must be present so that
 # clowder-quarkus-config-source will populate them from the Clowder provided configuration JSON.
 # If the properties are simply absent from this file, then clowder-quarkus-config-source will not
-# set values for the property even if a value is present in the Clowder JSON.
+# set values for the property even if a value is present in the Clowder JSON.  The exception is the
+# kafka.ssl.truststore.location which needs to evaluate to null for Kafka to use the system
+# truststore.  Only specify kafka.ssl.truststore.location when you have an actual location to
+# point to.  Don't set it to empty string.
 #
 # Additionally, Kafka has a bug, https://issues.apache.org/jira/browse/KAFKA-4090, where if a
 # client attempts to connect to a TLS enabled port using PLAINTEXT, an OutOfMemoryException gets

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -75,7 +75,10 @@ kafka.bootstrap.servers=localhost:9092
 # Kafka security configuration.  These properties must be present so that
 # clowder-quarkus-config-source will populate them from the Clowder provided configuration JSON.
 # If the properties are simply absent from this file, then clowder-quarkus-config-source will not
-# set values for the property even if a value is present in the Clowder JSON.
+# set values for the property even if a value is present in the Clowder JSON.  The exception is the
+# kafka.ssl.truststore.location which needs to evaluate to null for Kafka to use the system
+# truststore.  Only specify kafka.ssl.truststore.location when you have an actual location to
+# point to.  Don't set it to empty string.
 #
 # Additionally, Kafka has a bug, https://issues.apache.org/jira/browse/KAFKA-4090, where if a
 # client attempts to connect to a TLS enabled port using PLAINTEXT, an OutOfMemoryException gets

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -86,7 +86,10 @@ kafka.bootstrap.servers=localhost:9092
 # Kafka security configuration.  These properties must be present so that
 # clowder-quarkus-config-source will populate them from the Clowder provided configuration JSON.
 # If the properties are simply absent from this file, then clowder-quarkus-config-source will not
-# set values for the property even if a value is present in the Clowder JSON.
+# set values for the property even if a value is present in the Clowder JSON.  The exception is the
+# kafka.ssl.truststore.location which needs to evaluate to null for Kafka to use the system
+# truststore.  Only specify kafka.ssl.truststore.location when you have an actual location to
+# point to.  Don't set it to empty string.
 #
 # Additionally, Kafka has a bug, https://issues.apache.org/jira/browse/KAFKA-4090, where if a
 # client attempts to connect to a TLS enabled port using PLAINTEXT, an OutOfMemoryException gets
@@ -94,8 +97,8 @@ kafka.bootstrap.servers=localhost:9092
 kafka.sasl.jaas.config = ""
 kafka.sasl.mechanism = PLAIN
 kafka.security.protocol = PLAINTEXT
-kafka.ssl.truststore.location = ""
-kafka.ssl.truststore.type = PEM
+#kafka.ssl.truststore.location = ""
+#kafka.ssl.truststore.type = PEM
 
 # Consumer settings
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.fail-on-deserialization-failure=${USAGE_AGGREGATE_FAIL_ON_DESER_FAILURE}

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions;
 
+import org.candlepin.subscriptions.clowder.KafkaSslBeanPostProcessor;
 import org.candlepin.subscriptions.clowder.RdsSslBeanPostProcessor;
 import org.candlepin.subscriptions.validator.IpAddressValidator;
 import org.candlepin.subscriptions.validator.MacAddressValidator;
@@ -29,6 +30,19 @@ import org.springframework.core.env.Environment;
 
 @Configuration
 public class SystemConduitConfiguration {
+  /**
+   * A bean post-processor responsible for setting up Kafka truststores correctly. It's declared
+   * here so that this bean will always be created. In other words, the creation of this bean isn't
+   * dependent on the web of Import annotations that we have declared across our Configuration
+   * classes. ApplicationConfiguration is the one Configuration class we can always count on to
+   * load.
+   *
+   * @return a KafkaJaasBeanPostProcessor object
+   */
+  @Bean
+  public KafkaSslBeanPostProcessor kafkaJaasBeanPostProcessor() {
+    return new KafkaSslBeanPostProcessor();
+  }
 
   /**
    * An instance of the MacAddressValidator that we use to detect NICs with bad MAC addresses.


### PR DESCRIPTION
Jira issue: SWATCH-2464

## Description
Kafka in Stage and Production needs to use the system truststore.  We tried to address this with SWATCH-2088 (PR #2950) but missed a few things:
* I forgot to add a necessary bean to `swatch-system-conduit`
* `swatch-producer-azure` and `swatch-billable-usage` were never tested as part of SWATCH-2088 and there were flaws in the configuration of those two components.

## Testing

### Setup
1. Add the Kafka server certificate to the system truststore
   ```
   sudo cp config/kafka/test-ca.crt  /etc/pki/ca-trust/source/anchors/ && sudo update-ca-trust
   ```
   **IMPORTANT**: You will need to remove this certificate and re-run `update-ca-trust` after you are finished testing.  If you don't, you'll a) have a certificate in your system truststore that doesn't belong there and b) you'll get a failing unit test in `HttpClientTest` since that test actually uses `test-ca.crt` as a example of a CA that is not expected to be in the system truststore.
1. Create a clowder configuration meant to use the system truststore
   ```shell
   cat <<EOF > /tmp/cdappconfig.json
    {
    "kafka": {
     "brokers": [
       {
         "hostname": "localhost",
         "port": 9094,
         "authtype": "sasl",
         "sasl": {
             "username": "client",
             "password": "dummy",
             "securityProtocol":"SASL_SSL",
             "saslMechanism":"PLAIN"
         }
       }
     ],
     "topics": []
    },
    "endpoints": [
    {
      "apiPath": "/api/swatch-api-service/",
      "apiPaths": [
        "/api/swatch-api-service/"
      ],
      "app": "swatch-api",
      "hostname": "swatch-api-service.ephemeral-40wugc.svc",
      "name": "service",
      "port": 8000,
      "tlsPort": 0
    }
    ],
    "metricsPath": "/metrics",
    "metricsPort": 9000,
    "privatePort": 10000,
    "publicPort": 8000,
    "webPort": 8000
    }
    ```

### Steps
1. Running on `origin/main`, start the applications with the Clowder configuration
   ```
   ACG_CONFIG=/tmp/cdappconfig.json  ./gradlew :bootRun
   ```
   then
   ```
   ACG_CONFIG=/tmp/cdappconfig.json ./gradlew :swatch-producer-azure:quarkusDev
   ```
   then
   ```
   ACG_CONFIG=/tmp/cdappconfig.json ./gradlew :swatch-billable-usage:quarkusDev
   ```
1.  The applications will fail to start and you'll see a stack trace with the bottom cause reading "Caused by: org.apache.kafka.common.KafkaException: org.apache.kafka.common.errors.InvalidConfigurationException: SSL trust store certs can be specified only for PEM, but trust store type is .".  Or for the Quarkus applications "Caused by: org.apache.kafka.common.errors.InvalidConfigurationException: Failed to load PEM SSL keystore ""                                                                                                                                                 
1.  Check out this branch and rerun the command from step 1.

### Verification
1.  The applications start correctly and you see the connection to Kafka is made over port 9094.
1.  ***IMPORTANT***: remove the `test-ca.crt` from your system truststore:
    ```
    sudo rm /etc/pki/ca-trust/source/anchors/test-ca.crt && sudo update-ca-trust
    ```
