### PR TITLE
SWATCH-1384: Drop UOM from tally summary messages

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
@@ -21,7 +21,6 @@
 package org.candlepin.subscriptions.tally;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
@@ -47,8 +46,7 @@ public class TallySummaryMapper {
   }
 
   private TallySummary createTallySummary(String orgId, List<TallySnapshot> tallySnapshots) {
-    var mappedSnapshots =
-        tallySnapshots.stream().map(this::mapTallySnapshot).collect(Collectors.toList());
+    var mappedSnapshots = tallySnapshots.stream().map(this::mapTallySnapshot).toList();
     return new TallySummary().withOrgId(orgId).withTallySnapshots(mappedSnapshots);
   }
 
@@ -89,7 +87,6 @@ public class TallySummaryMapper {
             entry ->
                 new TallyMeasurement()
                     .withHardwareMeasurementType(entry.getKey().getMeasurementType().toString())
-                    .withUom(entry.getKey().getMetricId())
                     .withMetricId(entry.getKey().getMetricId())
                     .withValue(entry.getValue())
                     .withCurrentTotal(getCurrentlyMeasuredTotal(snapshot, entry.getKey())))

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -197,7 +197,7 @@ class SnapshotSummaryProducerTest {
     TallyMeasurement measurement = optionalTotal.get().get(0);
 
     assertEquals(hardwareType, measurement.getHardwareMeasurementType());
-    assertEquals(metricId.toUpperCaseFormatted(), measurement.getUom());
+    assertEquals(metricId.toUpperCaseFormatted(), measurement.getMetricId());
     assertEquals(value, measurement.getValue());
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySummaryMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySummaryMapperTest.java
@@ -116,7 +116,7 @@ class TallySummaryMapperTest {
         m -> {
           HardwareMeasurementType type =
               HardwareMeasurementType.valueOf(m.getHardwareMeasurementType());
-          TallyMeasurementKey key = new TallyMeasurementKey(type, m.getUom());
+          TallyMeasurementKey key = new TallyMeasurementKey(type, m.getMetricId());
           assertTrue(expectedMeasurements.containsKey(key));
           Double expectedValue = expectedMeasurements.get(key);
           assertEquals(expectedValue, m.getValue());

--- a/swatch-core/schemas/tally_snapshot.yaml
+++ b/swatch-core/schemas/tally_snapshot.yaml
@@ -58,11 +58,6 @@ properties:
       properties:
         hardware_measurement_type:
           type: string
-        uom:
-          description: Preferred unit of measure for the subject (for products with multiple possible UOM). Deprecated in favor of metric_id.
-          type: string
-          deprecated: true # Will be removed in https://issues.redhat.com/browse/SWATCH-1384
-          deprecationMessage: Use 'metric_id' instead.
         metric_id:
           description: Preferred unit of measure for the subject (for products with multiple possible metrics).
           type: string


### PR DESCRIPTION
Jira issue: [SWATCH-1384](https://issues.redhat.com/browse/SWATCH-1384)

## Description
UOM field dropped from message schema.

## Testing

Only regression testing. 
