### PR TITLE
Drop productName from rhel els identification

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
@@ -10,8 +10,6 @@ variants:
   - tag: rhel-for-x86-els-payg
     engineeringIds:
       - 204
-    productNames:
-      - RHEL Server
 
 defaults:
   variant: rhel-for-x86-els-payg


### PR DESCRIPTION
Unneeded and misidentifies some things it shouldn't.