### PR TITLE
SWATCH-2465: Do not filter by metric if not set in the Instances API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -63,7 +63,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
   public static final String PRODUCT_ID = "product_id";
   public static final String BEGINNING = "beginning";
   private static final int BAD_REQUEST = Response.Status.BAD_REQUEST.getStatusCode();
-  private static final int MAX_GUESTS_PER_QUERY = 20;
+
   private static final Map<
           String,
           BiConsumer<TallyInstancesDbReportCriteria.TallyInstancesDbReportCriteriaBuilder, String>>

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -59,10 +59,11 @@ import org.springframework.stereotype.Component;
 @Profile("worker")
 public class InstancesDataExporterService implements DataExporterService<TallyInstanceView> {
 
-  static final String INSTANCES_DATA = "instances";
-  static final String PRODUCT_ID = "product_id";
-  static final String BEGINNING = "beginning";
-  static final int BAD_REQUEST = Response.Status.BAD_REQUEST.getStatusCode();
+  public static final String INSTANCES_DATA = "instances";
+  public static final String PRODUCT_ID = "product_id";
+  public static final String BEGINNING = "beginning";
+  private static final int BAD_REQUEST = Response.Status.BAD_REQUEST.getStatusCode();
+  private static final int MAX_GUESTS_PER_QUERY = 20;
   private static final Map<
           String,
           BiConsumer<TallyInstancesDbReportCriteria.TallyInstancesDbReportCriteriaBuilder, String>>

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesJsonDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesJsonDataMapperService.java
@@ -152,8 +152,8 @@ public class InstancesJsonDataMapperService implements DataMapperService<TallyIn
       return item.getSockets();
     } else if (metricId.equals(MetricIdUtils.getCores())) {
       return item.getCores();
-    } else if (!isPayg && item.getKey().getMetricId().equalsIgnoreCase(metricId.toString())) {
-      return item.getValue();
+    } else if (!isPayg && item.getMetrics().containsKey(metricId)) {
+      return item.getMetrics().get(metricId);
     }
 
     return Optional.ofNullable(item.getMonthlyTotal(month, metricId)).orElse(0.0);

--- a/src/main/resources/liquibase/202404240830-update-instance-view-to-aggregate-metrics.xml
+++ b/src/main/resources/liquibase/202404240830-update-instance-view-to-aggregate-metrics.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202404240830-1" author="jcarvaja" dbms="postgresql">
+    <comment>
+      Update the tally_instance_view to aggregate records by metrics
+    </comment>
+    <dropView viewName="tally_instance_view"/>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_view">
+      select distinct h.org_id,
+                      h.id,
+                      h.instance_id as instance_id,
+                      h.display_name,
+                      h.billing_provider as host_billing_provider,
+                      h.billing_account_id as host_billing_account_id,
+                      b.billing_provider as bucket_billing_provider,
+                      b.billing_account_id as bucket_billing_account_id,
+                      h.last_seen,
+                      h.last_applied_event_record_date,
+                      coalesce(h.num_of_guests, 0) AS num_of_guests,
+                      b.product_id,
+                      b.sla,
+                      b.usage,
+                      coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                      jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics,
+                      b.sockets,
+                      b.cores,
+                      h.subscription_manager_id,
+                      h.inventory_id
+      from hosts h
+      join host_tally_buckets b on h.id = b.host_id
+      left outer join instance_measurements m on h.id = m.host_id
+      group by h.org_id,
+               h.id,
+               h.instance_id,
+               h.display_name,
+               h.billing_provider,
+               h.billing_account_id,
+               b.billing_provider,
+               b.billing_account_id,
+               h.last_seen,
+               h.last_applied_event_record_date,
+               h.num_of_guests,
+               b.product_id,
+               b.sla,
+               b."usage",
+               b.measurement_type,
+               b.sockets,
+               b.cores,
+               h.subscription_manager_id,
+               h.inventory_id
+    </createView>
+    <rollback>
+      <dropView viewName="tally_instance_view"/>
+      <createView
+              replaceIfExists="true"
+              viewName="tally_instance_view">
+        select
+        distinct org_id,
+        h.id,
+        h.instance_id as instance_id,
+        h.display_name,
+        h.billing_provider as host_billing_provider,
+        h.billing_account_id as host_billing_account_id,
+        b.billing_provider as bucket_billing_provider,
+        b.billing_account_id as bucket_billing_account_id,
+        h.last_seen,
+        h.last_applied_event_record_date,
+        coalesce(h.num_of_guests, 0) AS num_of_guests,
+        b.product_id,
+        b.sla,
+        b.usage,
+        coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+        m.metric_id,
+        m.value,
+        b.sockets,
+        b.cores,
+        h.subscription_manager_id,
+        h.inventory_id
+        from hosts h
+        join host_tally_buckets b on h.id = b.host_id
+        left outer join instance_measurements m on h.id = m.host_id;
+      </createView>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202404240830-2" author="jcarvaja" dbms="hsqldb">
+    <comment>
+        jsonb is not supported in hsql, so we will get duplicates when testing
+    </comment>
+      <createView
+              replaceIfExists="true"
+              viewName="tally_instance_view">
+          select distinct h.org_id,
+                          h.id,
+                          h.instance_id as instance_id,
+                          h.display_name,
+                          h.billing_provider as host_billing_provider,
+                          h.billing_account_id as host_billing_account_id,
+                          b.billing_provider as bucket_billing_provider,
+                          b.billing_account_id as bucket_billing_account_id,
+                          h.last_seen,
+                          h.last_applied_event_record_date,
+                          coalesce(h.num_of_guests, 0) AS num_of_guests,
+                          b.product_id,
+                          b.sla,
+                          b.usage,
+                          coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                          CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics,
+                          b.sockets,
+                          b.cores,
+                          h.subscription_manager_id,
+                          h.inventory_id
+          from hosts h
+          join host_tally_buckets b on h.id = b.host_id
+          left outer join instance_measurements m on h.id = m.host_id
+      </createView>
+    <rollback>
+        <dropView viewName="tally_instance_view"/>
+        <createView
+                  replaceIfExists="true"
+                  viewName="tally_instance_view">
+              select
+              distinct org_id,
+              h.id,
+              h.instance_id as instance_id,
+              h.display_name,
+              h.billing_provider as host_billing_provider,
+              h.billing_account_id as host_billing_account_id,
+              b.billing_provider as bucket_billing_provider,
+              b.billing_account_id as bucket_billing_account_id,
+              h.last_seen,
+              h.last_applied_event_record_date,
+              coalesce(h.num_of_guests, 0) AS num_of_guests,
+              b.product_id,
+              b.sla,
+              b.usage,
+              coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+              m.metric_id,
+              m.value,
+              b.sockets,
+              b.cores,
+              h.subscription_manager_id,
+              h.inventory_id
+              from hosts h
+              join host_tally_buckets b on h.id = b.host_id
+              left outer join instance_measurements m on h.id = m.host_id;
+        </createView>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -150,5 +150,6 @@
     <include file="/liquibase/202403260830-update-instance-view-to-include-inventory-id.xml" />
     <include file="/liquibase/202404051233-fix-bad-tally-state-and-event-data.xml"/>
     <include file="/liquibase/202404121601-add-new-columns-billable-usage-remittance.xml"/>
+    <include file="/liquibase/202404240830-update-instance-view-to-aggregate-metrics.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/InstancesResourceTest.java
@@ -35,6 +35,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.OrgConfigRepository;
@@ -45,7 +46,6 @@ import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.HostHardwareType;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.TallyInstanceView;
-import org.candlepin.subscriptions.db.model.TallyInstanceViewKey;
 import org.candlepin.subscriptions.resteasy.PageLinkCreator;
 import org.candlepin.subscriptions.security.WithMockRedHatPrincipal;
 import org.candlepin.subscriptions.utilization.api.model.BillingProviderType;
@@ -93,7 +93,6 @@ class InstancesResourceTest {
     double expectedInstanceHoursValue = 0.0;
 
     var tallyInstanceView = new TallyInstanceView();
-    tallyInstanceView.setKey(new TallyInstanceViewKey());
     tallyInstanceView.setId("testHostId");
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
@@ -103,7 +102,7 @@ class InstancesResourceTest {
     tallyInstanceView.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
-    tallyInstanceView.getKey().setMetricId(MetricIdUtils.getSockets().toString());
+    tallyInstanceView.setMetrics(Map.of(MetricIdUtils.getSockets(), 10.0));
     tallyInstanceView.setCores((int) expectedCoresValue);
 
     Mockito.when(
@@ -176,28 +175,24 @@ class InstancesResourceTest {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
 
     var tallyInstanceViewPhysical = new TallyInstanceView();
-    tallyInstanceViewPhysical.setKey(new TallyInstanceViewKey());
     tallyInstanceViewPhysical.setDisplayName("rhv.example.com");
     tallyInstanceViewPhysical.setNumOfGuests(3);
     tallyInstanceViewPhysical.setLastSeen(OffsetDateTime.now());
     tallyInstanceViewPhysical.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     tallyInstanceViewPhysical.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceViewPhysical.getKey().setMeasurementType(HardwareMeasurementType.PHYSICAL);
-    tallyInstanceViewPhysical.getKey().setMetricId(MetricIdUtils.getSockets().toString());
-    tallyInstanceViewPhysical.setValue(4.0);
+    tallyInstanceViewPhysical.setMetrics(Map.of(MetricIdUtils.getSockets(), 4.0));
     // Measurement should come from sockets value
     tallyInstanceViewPhysical.setSockets(2);
 
     var tallyInstanceViewHypervisor = new TallyInstanceView();
-    tallyInstanceViewHypervisor.setKey(new TallyInstanceViewKey());
     tallyInstanceViewHypervisor.setDisplayName("rhv.example.com");
     tallyInstanceViewHypervisor.setNumOfGuests(3);
     tallyInstanceViewHypervisor.setLastSeen(OffsetDateTime.now());
     tallyInstanceViewHypervisor.getKey().setInstanceId("d6214a0bb3444778831cd53dcacb2da3");
     tallyInstanceViewHypervisor.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceViewHypervisor.getKey().setMeasurementType(HardwareMeasurementType.HYPERVISOR);
-    tallyInstanceViewHypervisor.getKey().setMetricId(MetricIdUtils.getSockets().toString());
-    tallyInstanceViewHypervisor.setValue(8.0);
+    tallyInstanceViewHypervisor.setMetrics(Map.of(MetricIdUtils.getSockets(), 8.0));
     // Measurement should come from sockets value
     tallyInstanceViewHypervisor.setSockets(4);
 
@@ -276,14 +271,13 @@ class InstancesResourceTest {
     BillingProvider expectedBillingProvider = BillingProvider.AWS;
 
     var tallyInstanceView = new TallyInstanceView();
-    tallyInstanceView.setKey(new TallyInstanceViewKey());
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
     tallyInstanceView.getKey().setInstanceId("d6214a0b-b344-4778-831c-d53dcacb2da3");
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.AWS);
-    tallyInstanceView.getKey().setMetricId(MetricIdUtils.getCores().getValue());
+    tallyInstanceView.setMetrics(Map.of(MetricIdUtils.getCores(), 8.0));
 
     String month = InstanceMonthlyTotalKey.formatMonthId(tallyInstanceView.getLastSeen());
 
@@ -373,7 +367,6 @@ class InstancesResourceTest {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
 
     var tallyInstanceView = new TallyInstanceView();
-    tallyInstanceView.setKey(new TallyInstanceViewKey());
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
@@ -381,7 +374,7 @@ class InstancesResourceTest {
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
     tallyInstanceView.getKey().setProductId("RHEL");
-    tallyInstanceView.getKey().setMetricId(MetricIdUtils.getSockets().getValue());
+    tallyInstanceView.setMetrics(Map.of(MetricIdUtils.getSockets(), 8.0));
 
     Mockito.when(
             repository.findAllBy(
@@ -475,7 +468,6 @@ class InstancesResourceTest {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
 
     var tallyInstanceView = new TallyInstanceView();
-    tallyInstanceView.setKey(new TallyInstanceViewKey());
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
@@ -483,7 +475,7 @@ class InstancesResourceTest {
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
     tallyInstanceView.getKey().setProductId("RHEL");
-    tallyInstanceView.getKey().setMetricId(MetricIdUtils.getCores().getValue());
+    tallyInstanceView.setMetrics(Map.of(MetricIdUtils.getCores(), 8.0));
 
     Mockito.when(
             repository.findAllBy(
@@ -542,7 +534,6 @@ class InstancesResourceTest {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
 
     var tallyInstanceView = new TallyInstanceView();
-    tallyInstanceView.setKey(new TallyInstanceViewKey());
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
@@ -550,7 +541,7 @@ class InstancesResourceTest {
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
     tallyInstanceView.getKey().setProductId("RHEL");
-    tallyInstanceView.getKey().setMetricId(MetricIdUtils.getCores().getValue());
+    tallyInstanceView.setMetrics(Map.of(MetricIdUtils.getCores(), 8.0));
 
     Mockito.when(
             repository.findAllBy(
@@ -609,7 +600,6 @@ class InstancesResourceTest {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
 
     var tallyInstanceView = new TallyInstanceView();
-    tallyInstanceView.setKey(new TallyInstanceViewKey());
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
@@ -617,7 +607,7 @@ class InstancesResourceTest {
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
     tallyInstanceView.getKey().setProductId("RHEL");
-    tallyInstanceView.getKey().setMetricId(MetricIdUtils.getSockets().getValue());
+    tallyInstanceView.setMetrics(Map.of(MetricIdUtils.getSockets(), 8.0));
 
     Mockito.when(
             repository.findAllBy(
@@ -676,7 +666,6 @@ class InstancesResourceTest {
     BillingProvider expectedBillingProvider = BillingProvider.RED_HAT;
 
     var tallyInstanceView = new TallyInstanceView();
-    tallyInstanceView.setKey(new TallyInstanceViewKey());
     tallyInstanceView.setDisplayName("rhv.example.com");
     tallyInstanceView.setNumOfGuests(3);
     tallyInstanceView.setLastSeen(OffsetDateTime.now());
@@ -684,7 +673,7 @@ class InstancesResourceTest {
     tallyInstanceView.setHostBillingProvider(expectedBillingProvider);
     tallyInstanceView.getKey().setMeasurementType(HardwareMeasurementType.VIRTUAL);
     tallyInstanceView.getKey().setProductId("RHEL");
-    tallyInstanceView.getKey().setMetricId(MetricIdUtils.getSockets().getValue());
+    tallyInstanceView.setMetrics(Map.of(MetricIdUtils.getSockets(), 8.0));
 
     Mockito.when(
             repository.findAllBy(

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.eq;
@@ -57,6 +58,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
+import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.db.HostTallyBucketRepository;
@@ -77,15 +79,15 @@ import org.candlepin.subscriptions.tally.collector.ProductUsageCollectorFactory;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.util.StringUtils;
 
-@SpringBootTest
-@ActiveProfiles({"worker", "test"})
+@ExtendWith(MockitoExtension.class)
 class InventoryAccountUsageCollectorTallyTest {
   private static final String TEST_PRODUCT = "RHEL for x86";
   public static final Integer TEST_PRODUCT_ID = 69;
@@ -97,13 +99,19 @@ class InventoryAccountUsageCollectorTallyTest {
   private static final String BILLING_ACCOUNT_ID_ANY = "_ANY";
   public static final String ORG_ID = "org123";
 
-  @MockBean private InventoryRepository inventoryRepo;
-  @MockBean private HostTallyBucketRepository hostBucketRepository;
-  @MockBean private AccountServiceInventoryRepository accountServiceInventoryRepository;
-  @Autowired private InventoryAccountUsageCollector collector;
-  @Autowired private InventoryDatabaseOperations inventory;
-  @Autowired private FactNormalizer factNormalizer;
-  @Autowired private ApplicationProperties props;
+  @Mock(strictness = LENIENT)
+  private InventoryRepository inventoryRepo;
+
+  @Mock private HostTallyBucketRepository hostBucketRepository;
+
+  @Mock(strictness = LENIENT)
+  private AccountServiceInventoryRepository accountServiceInventoryRepository;
+
+  @Mock private ApplicationProperties props;
+  @Spy private ApplicationClock clock = new ApplicationClock();
+  @InjectMocks private InventoryAccountUsageCollector collector;
+  @InjectMocks private InventoryDatabaseOperations inventory;
+  @InjectMocks private FactNormalizer factNormalizer;
 
   @Test
   void hypervisorCountsIgnoredForNonRhelProduct() {

--- a/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.tally.export;
 import static org.candlepin.subscriptions.resource.InstancesResource.getCategoryByMeasurementType;
 import static org.candlepin.subscriptions.resource.InstancesResource.getCloudProviderByMeasurementType;
 import static org.candlepin.subscriptions.resource.ResourceUtils.ANY;
+import static org.candlepin.subscriptions.tally.export.InstancesDataExporterService.BEGINNING;
 import static org.candlepin.subscriptions.tally.export.InstancesDataExporterService.PRODUCT_ID;
 
 import com.redhat.cloud.event.apps.exportservice.v1.Format;
@@ -61,6 +62,8 @@ import org.springframework.test.context.ActiveProfiles;
 class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
 
   private static final String RHEL_FOR_X86 = "RHEL for x86";
+  private static final String ROSA = "rosa";
+  private static final String APRIL = "2024-04-16T07:12:52.426707Z";
 
   private final List<HostWithGuests> itemsToBeExported = new ArrayList<>();
 
@@ -85,7 +88,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
 
   @Test
   void testRequestShouldFailIfItDoesNotFilterByProductId() {
-    givenInstanceWithMetrics();
+    givenInstanceWithMetrics(RHEL_FOR_X86);
     givenExportRequestWithPermissions(Format.JSON);
     whenReceiveExportRequest();
     verifyRequestWasSentToExportServiceWithError(request);
@@ -93,7 +96,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
 
   @Test
   void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductId() {
-    givenInstanceWithMetrics();
+    givenInstanceWithMetrics(RHEL_FOR_X86);
     givenExportRequestWithPermissions(Format.JSON);
     givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
     whenReceiveExportRequest();
@@ -101,8 +104,18 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
   }
 
   @Test
+  void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductIdAndMonth() {
+    givenInstanceWithMetrics(ROSA);
+    givenExportRequestWithPermissions(Format.JSON);
+    givenFilterInExportRequest(PRODUCT_ID, ROSA);
+    givenFilterInExportRequest(BEGINNING, APRIL);
+    whenReceiveExportRequest();
+    verifyRequestWasSentToExportService();
+  }
+
+  @Test
   void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByWrongProductId() {
-    givenInstanceWithMetrics();
+    givenInstanceWithMetrics(RHEL_FOR_X86);
     givenExportRequestWithPermissions(Format.JSON);
     givenFilterInExportRequest(PRODUCT_ID, "wrong!");
     whenReceiveExportRequest();
@@ -112,7 +125,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
 
   @Test
   void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductIdAndReturnsNoData() {
-    givenInstanceWithMetrics();
+    givenInstanceWithMetrics(RHEL_FOR_X86);
     givenExportRequestWithPermissions(Format.JSON);
     givenFilterInExportRequest(PRODUCT_ID, "rosa");
     whenReceiveExportRequest();
@@ -122,7 +135,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
 
   @Test
   void testRequestShouldBeUploadedWithInstancesAsCsv() {
-    givenInstanceWithMetrics();
+    givenInstanceWithMetrics(RHEL_FOR_X86);
     givenExportRequestWithPermissions(Format.CSV);
     whenReceiveExportRequest();
     // Since this is not implemented yet, we send an error:
@@ -141,7 +154,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
         "display_name_contains,ho"
       })
   void testFiltersFoundData(String filterName, String exists) {
-    givenInstanceWithMetrics();
+    givenInstanceWithMetrics(RHEL_FOR_X86);
     givenExportRequestWithPermissions(Format.JSON);
     givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
     givenFilterInExportRequest(filterName, exists);
@@ -162,7 +175,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
         "display_name_contains,another host"
       })
   void testFiltersDoesNotFoundDataAndReportIsEmpty(String filterName, String doesNotExist) {
-    givenInstanceWithMetrics();
+    givenInstanceWithMetrics(RHEL_FOR_X86);
     givenExportRequestWithPermissions(Format.JSON);
     givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
     givenFilterInExportRequest(filterName, doesNotExist);
@@ -172,9 +185,9 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"usage", "category", "sla", "metric_id", "billing_provider", "beginning"})
+  @ValueSource(strings = {"usage", "category", "sla", "metric_id", "billing_provider", BEGINNING})
   void testFiltersAreInvalid(String filterName) {
-    givenInstanceWithMetrics();
+    givenInstanceWithMetrics(RHEL_FOR_X86);
     givenExportRequestWithPermissions(Format.JSON);
     givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
     givenFilterInExportRequest(filterName, "wrong!");
@@ -184,11 +197,11 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
   }
 
   @Transactional
-  void givenInstanceWithMetrics() {
+  void givenInstanceWithMetrics(String productId) {
     Host guest = new Host();
     guest.setOrgId(ORG_ID);
     guest.setDisplayName("this is the guest");
-    guest.setLastSeen(OffsetDateTime.parse("2024-04-16T07:12:52.426707Z"));
+    guest.setLastSeen(OffsetDateTime.parse(APRIL));
     guest.setHardwareType(HostHardwareType.PHYSICAL);
     guest.setInstanceType(INSTANCE_TYPE);
     guest.setInstanceId(UUID.randomUUID().toString());
@@ -205,11 +218,12 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     instance.setInstanceType(INSTANCE_TYPE);
     instance.setSubscriptionManagerId(guest.getHypervisorUuid());
     instance.addToMonthlyTotal(OffsetDateTime.now(), MetricIdUtils.getSockets(), 6.0);
+    instance.addToMonthlyTotal(OffsetDateTime.now(), MetricIdUtils.getCores(), 8.0);
 
     // buckets
     HostTallyBucket bucket = new HostTallyBucket();
     bucket.setKey(new HostBucketKey());
-    bucket.getKey().setProductId(RHEL_FOR_X86);
+    bucket.getKey().setProductId(productId);
     bucket.getKey().setUsage(Usage._ANY);
     bucket.getKey().setSla(ServiceLevel._ANY);
     bucket.getKey().setAsHypervisor(true);
@@ -222,7 +236,12 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     instance.addBucket(bucket);
 
     // metrics
-    instance.setMeasurements(Map.of(MetricIdUtils.getSockets().toUpperCaseFormatted(), 6.0));
+    instance.setMeasurements(
+        Map.of(
+            MetricIdUtils.getSockets().toUpperCaseFormatted(),
+            6.0,
+            MetricIdUtils.getCores().toUpperCaseFormatted(),
+            8.0));
 
     // save
     repository.save(instance);
@@ -257,17 +276,20 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
       }
 
       instance.setBillingAccountId(host.getBillingAccountId());
-      var variant = Variant.findByTag(RHEL_FOR_X86);
+      var variant = Variant.findByTag(bucket.getKey().getProductId());
       var metrics =
-          MetricIdUtils.getMetricIdsFromConfigForVariant(variant.orElse(null)).sorted().toList();
+          MetricIdUtils.getMetricIdsFromConfigForVariant(variant.orElse(null))
+              .map(MetricId::toString)
+              .sorted()
+              .toList();
       instance.setMeasurements(new ArrayList<>());
       for (var metricId : metrics) {
         instance
             .getMeasurements()
             .add(
                 new InstancesExportJsonMetric()
-                    .withMetricId(metricId.toString())
-                    .withValue(resolveMetricValue(bucket, metricId)));
+                    .withMetricId(metricId)
+                    .withValue(resolveMetricValue(bucket, MetricId.fromString(metricId))));
       }
 
       instance.setLastSeen(host.getLastSeen());

--- a/swatch-core-test/src/main/resources/application-test.yaml
+++ b/swatch-core-test/src/main/resources/application-test.yaml
@@ -38,6 +38,8 @@ spring:
   jpa:
     properties:
       hibernate:
+        # Set the dialect to
+        dialect: org.hibernate.dialect.HSQLDialect
         jdbc:
           # Force the testing database into UTC to prevent test failures when the database
           # determines the 'current' time in a query. NOTE: This is primarily when tests

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/RhsmSubscriptionsDataSourceConfiguration.java
@@ -22,8 +22,11 @@ package org.candlepin.subscriptions.db;
 
 import com.zaxxer.hikari.HikariDataSource;
 import jakarta.persistence.EntityManagerFactory;
+import java.util.Map;
 import javax.sql.DataSource;
+import org.hibernate.cfg.ManagedBeanSettings;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.TypeExcludeFilter;
@@ -35,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.hibernate5.SpringBeanContainer;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -80,11 +84,14 @@ public class RhsmSubscriptionsDataSourceConfiguration {
   @Primary
   public LocalContainerEntityManagerFactoryBean rhsmSubscriptionsEntityManagerFactory(
       EntityManagerFactoryBuilder builder,
+      ConfigurableListableBeanFactory beanFactory,
       @Qualifier("rhsmSubscriptionsDataSource") DataSource dataSource) {
     return builder
         .dataSource(dataSource)
         .packages("org.candlepin.subscriptions.db.model")
         .persistenceUnit("rhsm-subscriptions")
+        .properties(
+            Map.of(ManagedBeanSettings.BEAN_CONTAINER, new SpringBeanContainer(beanFactory)))
         .build();
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/EventRecord.java
@@ -37,6 +37,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.candlepin.subscriptions.db.model.converters.EventRecordConverter;
 import org.candlepin.subscriptions.json.Event;
 
 /**

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceViewKey.java
@@ -61,7 +61,4 @@ public class TallyInstanceViewKey implements Serializable {
   @Enumerated(EnumType.STRING)
   @Column(name = "measurement_type")
   private HardwareMeasurementType measurementType;
-
-  @Column(name = "metric_id")
-  private String metricId;
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/converters/EventRecordConverter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/converters/EventRecordConverter.java
@@ -18,32 +18,21 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.db.model;
+package org.candlepin.subscriptions.db.model.converters;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
+import lombok.AllArgsConstructor;
 import org.candlepin.subscriptions.json.Event;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** JPA AttributeConverter which uses Jackson to map to/from Event JSON. */
 @Component
+@AllArgsConstructor
 public class EventRecordConverter implements AttributeConverter<Event, String> {
 
-  private static ObjectMapper objectMapper;
-
-  public EventRecordConverter() {
-    /* intentionally left empty */
-  }
-
-  // hack to get ObjectMapper from spring context, we should remove once we're on Spring Boot 2.1 &
-  // Hibernate 5.3 per https://stackoverflow.com/a/54686119
-  @Autowired
-  @SuppressWarnings("java:S3010")
-  EventRecordConverter(ObjectMapper mapper) {
-    EventRecordConverter.objectMapper = mapper;
-  }
+  private final ObjectMapper objectMapper;
 
   @Override
   public String convertToDatabaseColumn(Event attribute) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/converters/TallyInstanceViewMetricsConverter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/converters/TallyInstanceViewMetricsConverter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model.converters;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.configuration.registry.MetricId;
+import jakarta.persistence.AttributeConverter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class TallyInstanceViewMetricsConverter
+    implements AttributeConverter<Map<MetricId, Double>, String> {
+
+  private static final String METRIC_ID = "metric_id";
+  private static final String VALUE = "value";
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public String convertToDatabaseColumn(Map<MetricId, Double> map) {
+    throw new UnsupportedOperationException(
+        "This converter should only be used in the TallyInstanceView view which is only read-only mode.");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Map<MetricId, Double> convertToEntityAttribute(String s) {
+    if (s == null || s.isEmpty()) {
+      return Map.of();
+    }
+
+    try {
+      Map<MetricId, Double> metrics = new HashMap<>();
+      objectMapper
+          .readValue(s, List.class)
+          .forEach(
+              e -> {
+                Map<String, Object> m = (Map<String, Object>) e;
+                String metricId = (String) m.get(METRIC_ID);
+                double value = Optional.ofNullable(m.get(VALUE)).map(this::toDouble).orElse(0.0);
+                if (metricId != null) {
+                  metrics.put(MetricId.fromString(metricId), value);
+                }
+              });
+      return metrics;
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Error parsing metrics", e);
+    }
+  }
+
+  private double toDouble(Object o) {
+    if (o instanceof Integer i) {
+      return i;
+    } else if (o instanceof Double d) {
+      return d;
+    } else if (o instanceof Long l) {
+      return l;
+    }
+
+    return 0.0;
+  }
+}

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
@@ -20,6 +20,7 @@
  */
 package com.redhat.swatch.configuration.registry;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
@@ -31,7 +32,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 // constructor is private so that the factory method is the only way to get a MetricId
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class MetricId {
+public class MetricId implements Serializable {
 
   private final String value;
 


### PR DESCRIPTION
Jira issue: [SWATCH-2465](https://issues.redhat.com/browse/SWATCH-2465)

## Description
Before, we were using the default (first) metric ID by product tag if the user does not specify any. After these changes, we'll be getting all the metrics if the user does not specify any.  

To avoid getting duplicates, I had to update the "tally_instance_view" to aggregate all the metrics in the host into a single record. 

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/664

### Steps

1.- podman-compose up
2.- Add host to Insight DB:

```
INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, "groups") 
VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6", "provider_id": "d125f119"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "290"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123', '{}');
```

The important part of the above query is `installed_products` which contains the value "290" to use the product "OpenShift Container Platform". This product will return both Sockets and Cores metrics.

3.- DEV_MODE=true ./gradlew :bootRun
4.- Run nightly Tally using command below:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" \
Origin:console.redhat.com \
x-rh-swatch-psk:placeholder
```

5.- Verification in RHSM subscription database:

```
echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w 0
-- eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19
```

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/opt-in?org_id=org123' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19'
```

```
http GET ":8000/api/rhsm-subscriptions/v1/instances/products/OpenShift Container Platform" x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19 | jq
```

It should return:

```json
{
  "data": [
    {
      "id": "6529c337-8b2f-48eb-8ed5-b064c725822e",
      "instance_id": "d125f119",
      "display_name": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55",
      "measurements": [
        4.0,
        2.0
      ],
      "last_seen": "1993-03-26T00:00:00Z",
      "number_of_guests": 0,
      "category": "physical",
      "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6",
      "inventory_id": "e5406d59-5cf3-4e83-abf8-84c149f8b6ba"
    }
  ],
  "meta": {
    "count": 1,
    "product": "OpenShift Container Platform",
    "measurements": [
      "Cores",
      "Sockets"
    ]
  }
}
```


