### PR TITLE
SWATCH-2333: Added attribute to subcription definition for isVdcType

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollectorFactory.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollectorFactory.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.collector;
 
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import org.springframework.util.StringUtils;
 
 /** A factory that facilitates creating a collector based on the given product. */
@@ -34,7 +35,7 @@ public class ProductUsageCollectorFactory {
       throw new IllegalArgumentException("Specified product was null or empty!");
     }
 
-    if (product.startsWith("RHEL")) {
+    if (SubscriptionDefinition.isVdcType(product)) {
       return new RHELProductUsageCollector();
     }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorReconcileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorReconcileTest.java
@@ -85,7 +85,7 @@ class InventoryAccountUsageCollectorReconcileTest {
     when(factNormalizer.normalize(any(), any())).thenReturn(new NormalizedFacts());
 
     var collector = setupCollector();
-    collector.reconcileSystemDataWithHbi("org123", Set.of("RHEL"));
+    collector.reconcileSystemDataWithHbi("org123", Set.of("RHEL for x86"));
     // at this point, the iterations haven't actually run, since we're mocking the collator.
     var processor = captor.getValue();
     var mockHbiSystem = InventoryHostFactTestHelper.createHypervisor("org", 1);
@@ -103,7 +103,7 @@ class InventoryAccountUsageCollectorReconcileTest {
     var collector = setupCollector();
     InventoryHostFacts hbiSystem = InventoryHostFactTestHelper.createHypervisor("org123", 1);
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, null, new OrgHostsData("org123"), Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, null, new OrgHostsData("org123"), Set.of("RHEL for x86"), new ArrayList<>());
     verify(entityManager).persist(any());
   }
 
@@ -115,7 +115,11 @@ class InventoryAccountUsageCollectorReconcileTest {
     InventoryHostFacts hbiSystem = InventoryHostFactTestHelper.createHypervisor("org123", 1);
     Host swatchSystem = new Host();
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, new OrgHostsData("org123"), Set.of("RHEL"), new ArrayList<>());
+        hbiSystem,
+        swatchSystem,
+        new OrgHostsData("org123"),
+        Set.of("RHEL for x86"),
+        new ArrayList<>());
     verify(entityManager).merge(swatchSystem);
   }
 
@@ -124,14 +128,14 @@ class InventoryAccountUsageCollectorReconcileTest {
     var collector = setupCollector();
     Host swatchSystem = new Host();
     collector.reconcileHbiSystemWithSwatchSystem(
-        null, swatchSystem, new OrgHostsData("org123"), Set.of("RHEL"), new ArrayList<>());
+        null, swatchSystem, new OrgHostsData("org123"), Set.of("RHEL for x86"), new ArrayList<>());
     verify(hostRepository).delete(swatchSystem);
   }
 
   @Test
   void testGuestBucketsTracked() {
     NormalizedFacts guestFacts = new NormalizedFacts();
-    guestFacts.setProducts(Set.of("RHEL"));
+    guestFacts.setProducts(Set.of("RHEL for x86"));
     guestFacts.setHardwareType(HostHardwareType.VIRTUALIZED);
     guestFacts.setHypervisorUnknown(false);
     guestFacts.setHypervisorUuid("123e4567-e89b-12d3-a456-426614174000");
@@ -147,11 +151,11 @@ class InventoryAccountUsageCollectorReconcileTest {
         "123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174000");
     orgHostsData.addHypervisorFacts("123e4567-e89b-12d3-a456-426614174000", new NormalizedFacts());
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     HostTallyBucket expectedEmptyBucket =
         new HostTallyBucket(
             swatchSystem,
-            "RHEL",
+            "RHEL for x86",
             ServiceLevel.EMPTY,
             Usage.EMPTY,
             BillingProvider._ANY,
@@ -163,7 +167,7 @@ class InventoryAccountUsageCollectorReconcileTest {
     HostTallyBucket expectedAnyBucket =
         new HostTallyBucket(
             swatchSystem,
-            "RHEL",
+            "RHEL for x86",
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -180,7 +184,7 @@ class InventoryAccountUsageCollectorReconcileTest {
   @Test
   void testHypervisorBucketsApplied() {
     NormalizedFacts hypervisorFacts = new NormalizedFacts();
-    hypervisorFacts.setProducts(Set.of("RHEL"));
+    hypervisorFacts.setProducts(Set.of("RHEL for x86"));
     hypervisorFacts.setHardwareType(HostHardwareType.PHYSICAL);
     hypervisorFacts.setSockets(4);
     hypervisorFacts.setCores(8);
@@ -210,7 +214,7 @@ class InventoryAccountUsageCollectorReconcileTest {
         "123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174000");
     orgHostsData.addHypervisorFacts("123e4567-e89b-12d3-a456-426614174000", new NormalizedFacts());
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     assertThat(expectedBucket, in(swatchSystem.getBuckets()));
     assertEquals(4, expectedBucket.getSockets());
     assertEquals(8, expectedBucket.getCores());
@@ -248,14 +252,14 @@ class InventoryAccountUsageCollectorReconcileTest {
         "123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174000");
     orgHostsData.addHypervisorFacts("123e4567-e89b-12d3-a456-426614174000", new NormalizedFacts());
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     assertTrue(swatchSystem.getBuckets().isEmpty());
   }
 
   @Test
   void testNonHypervisorBucketsApplied() {
     NormalizedFacts normalizedFacts = new NormalizedFacts();
-    normalizedFacts.setProducts(Set.of("RHEL"));
+    normalizedFacts.setProducts(Set.of("RHEL for x86"));
     normalizedFacts.setHardwareType(HostHardwareType.PHYSICAL);
     when(factNormalizer.normalize(any(), any())).thenReturn(normalizedFacts);
 
@@ -264,11 +268,11 @@ class InventoryAccountUsageCollectorReconcileTest {
     Host swatchSystem = new Host();
     OrgHostsData orgHostsData = new OrgHostsData("org123");
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     HostTallyBucket expectedEmptyBucket =
         new HostTallyBucket(
             swatchSystem,
-            "RHEL",
+            "RHEL for x86",
             ServiceLevel.EMPTY,
             Usage.EMPTY,
             BillingProvider._ANY,
@@ -280,7 +284,7 @@ class InventoryAccountUsageCollectorReconcileTest {
     HostTallyBucket expectedAnyBucket =
         new HostTallyBucket(
             swatchSystem,
-            "RHEL",
+            "RHEL for x86",
             ServiceLevel._ANY,
             Usage._ANY,
             BillingProvider._ANY,
@@ -304,7 +308,7 @@ class InventoryAccountUsageCollectorReconcileTest {
     Host swatchSystem = new Host();
     OrgHostsData orgHostsData = new OrgHostsData("org123");
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     HostTallyBucket staleBucket =
         new HostTallyBucket(
             swatchSystem,
@@ -319,7 +323,7 @@ class InventoryAccountUsageCollectorReconcileTest {
             HardwareMeasurementType.PHYSICAL);
     swatchSystem.addBucket(staleBucket);
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     assertTrue(swatchSystem.getBuckets().isEmpty());
   }
 
@@ -334,7 +338,7 @@ class InventoryAccountUsageCollectorReconcileTest {
     Host swatchSystem = new Host();
     OrgHostsData orgHostsData = new OrgHostsData("org123");
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     HostTallyBucket staleBucket =
         new HostTallyBucket(
             swatchSystem,
@@ -349,7 +353,7 @@ class InventoryAccountUsageCollectorReconcileTest {
             HardwareMeasurementType.HYPERVISOR);
     swatchSystem.addBucket(staleBucket);
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, swatchSystem, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     assertTrue(swatchSystem.getBuckets().isEmpty());
   }
 
@@ -387,11 +391,11 @@ class InventoryAccountUsageCollectorReconcileTest {
         "123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174000");
     orgHostsData.addHypervisorFacts("123e4567-e89b-12d3-a456-426614174000", new NormalizedFacts());
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, hypervisorCopy0, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, hypervisorCopy0, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     assertTrue(orgHostsData.hypervisorHostMap().isEmpty(), "placeholder was not consumed");
     assertFalse(hypervisorCopy0.getBuckets().isEmpty(), "no buckets added to hypervisor");
     collector.reconcileHbiSystemWithSwatchSystem(
-        hbiSystem, hypervisorCopy1, orgHostsData, Set.of("RHEL"), new ArrayList<>());
+        hbiSystem, hypervisorCopy1, orgHostsData, Set.of("RHEL for x86"), new ArrayList<>());
     assertTrue(hypervisorCopy1.getBuckets().isEmpty(), "buckets added to hypervisor copy");
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollectorFactoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/ProductUsageCollectorFactoryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.collector;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.configuration.registry.SubscriptionDefinitionRegistry;
+import com.redhat.swatch.configuration.registry.Variant;
+import java.awt.*;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ProductUsageCollectorFactoryTest {
+
+  @Test
+  void getRHELProductUsageCollector() {
+    SubscriptionDefinition testDef = new SubscriptionDefinition();
+    testDef.setVdcType(true);
+    Variant testVariant = new Variant();
+    testVariant.setTag("testProd1");
+    testDef.setVariants(List.of(testVariant));
+    SubscriptionDefinitionRegistry.getInstance().getSubscriptions().add(testDef);
+    assertThat(ProductUsageCollectorFactory.get("testProd1") instanceof RHELProductUsageCollector);
+  }
+
+  @Test
+  void getDefaultProductUsageCollector() {
+    SubscriptionDefinition testDef = new SubscriptionDefinition();
+    testDef.setVdcType(false);
+    Variant testVariant = new Variant();
+    testVariant.setTag("testProd2");
+    testDef.setVariants(List.of(testVariant));
+    SubscriptionDefinitionRegistry.getInstance().getSubscriptions().add(testDef);
+    assertThat(
+        ProductUsageCollectorFactory.get("testProd2") instanceof DefaultProductUsageCollector);
+  }
+
+  @Test
+  void getNoVdcTypeSet() {
+    SubscriptionDefinition testDef = new SubscriptionDefinition();
+    // vdcType is null in testDef
+    Variant testVariant = new Variant();
+    testVariant.setTag("testProd3");
+    testDef.setVariants(List.of(testVariant));
+    SubscriptionDefinitionRegistry.getInstance().getSubscriptions().add(testDef);
+    assertThat(
+        ProductUsageCollectorFactory.get("testProd3") instanceof DefaultProductUsageCollector);
+  }
+}

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -75,6 +75,7 @@ public class SubscriptionDefinition {
   @Builder.Default private List<Metric> metrics = new ArrayList<>();
   private Defaults defaults;
   private boolean contractEnabled;
+  private boolean vdcType;
 
   public Optional<Variant> findVariantForEngId(String engId) {
     return getVariants().stream()
@@ -334,6 +335,10 @@ public class SubscriptionDefinition {
     return lookupSubscriptionByTag(tag)
         .map(SubscriptionDefinition::isContractEnabled)
         .orElse(false);
+  }
+
+  public static boolean isVdcType(@NotNull @NotEmpty String id) {
+    return lookupSubscriptionByTag(id).map(SubscriptionDefinition::isVdcType).orElse(false);
   }
 
   public boolean isPaygEligible() {

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_ARM.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_ARM.yaml
@@ -3,6 +3,8 @@ platform: RHEL
 
 id: rhel-for-arm
 
+vdcType: true
+
 variants:
   - tag: RHEL for ARM
     engineeringIds:

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_IBM_Power.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_IBM_Power.yaml
@@ -3,6 +3,8 @@ platform: RHEL
 
 id: rhel-for-ibm-power
 
+vdcType: true
+
 variants:
   - tag: RHEL for IBM Power
     engineeringIds:

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_IBM_z.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_IBM_z.yaml
@@ -3,6 +3,8 @@ platform: RHEL
 
 id: rhel-for-ibm-z
 
+vdcType: true
+
 variants:
   - tag: RHEL for IBM z
     engineeringIds:

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_SAP_x86.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_SAP_x86.yaml
@@ -3,6 +3,8 @@ platform: RHEL
 
 id: rhel-for-sap-x86
 
+vdcType: true
+
 variants:
   - tag: rhel-for-sap-x86
     engineeringIds:

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86.yaml
@@ -3,6 +3,8 @@ platform: RHEL
 
 id: rhel-for-x86
 
+vdcType: true
+
 variants:
   - tag: RHEL for x86
     engineeringIds:

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_EUS.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_EUS.yaml
@@ -2,6 +2,9 @@
 platform: RHEL
 
 id: rhel-for-x86-eus
+
+vdcType: true
+
 # TODO: https://issues.redhat.com/browse/SWATCH-1692 keep this commented out until UI updates are in place.
 #includedSubscriptions:
 #  - rhel-for-x86

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
@@ -3,6 +3,8 @@ platform: RHEL
 
 id: rhel-for-x86-els-payg
 
+vdcType: true
+
 #includedSubscriptions:
 #  - rhel-for-x86
 

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_ha.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_ha.yaml
@@ -3,6 +3,8 @@ platform: RHEL
 
 id: rhel-for-x86-ha
 
+vdcType: true
+
 variants:
   - tag: rhel-for-x86-ha
     engineeringIds:

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_rs.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_rs.yaml
@@ -3,6 +3,8 @@ platform: RHEL
 
 id: rhel-for-x86-rs
 
+vdcType: true
+
 variants:
   - tag: rhel-for-x86-rs
     engineeringIds:


### PR DESCRIPTION
- This replaces the use of the id field as the indicator in the factory of which  UsageCollector is needed for processing

Jira issue: SWATCH-2333

## Description
The usage collection method's determination is based on the variant tag in the subscription definition. This method is not sufficient as this tag varies between "RHEL for ..." and "rhel-for-...". Instead of relying on that field which is not constrained, the field 'vdcType' is introduced in the definition. This way the determination is based on a boolean value with a specific purpose.

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/672


### Verification
1. The test is structured to use the known variations of the variant tag. The test will show that the hypervisor usage is properly collected in both cases.
