### PR TITLE
SWATCH-2483: Fix export subscriptions service to filter by payg

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -192,12 +192,7 @@ public class SubscriptionTableController {
       }
     }
 
-    boolean isOnDemand =
-        SubscriptionDefinition.lookupSubscriptionByTag(productId.toString())
-            .filter(SubscriptionDefinition::isPrometheusEnabled)
-            .stream()
-            .findFirst()
-            .isPresent();
+    boolean isOnDemand = SubscriptionDefinition.isPrometheusEnabled(productId.toString());
 
     SubscriptionType subscriptionType =
         isOnDemand ? SubscriptionType.ON_DEMAND : SubscriptionType.ANNUAL;

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionCsvDataMapperService.java
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class SubscriptionCsvDataMapperService implements DataMapperService<Subscription> {
 
-  private static final Uom NO_UOM = null;
+  protected static final Uom NO_UOM = null;
 
   @Override
   public List<Object> mapDataItem(Subscription dataItem, ExportServiceRequest request) {

--- a/src/test/java/org/candlepin/subscriptions/export/BaseDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/export/BaseDataExporterServiceTest.java
@@ -69,6 +69,8 @@ import org.springframework.kafka.core.KafkaTemplate;
 public abstract class BaseDataExporterServiceTest
     implements ExtendWithExportServiceWireMock, ExtendWithEmbeddedKafka {
 
+  protected static final String RHEL_FOR_X86 = "RHEL for x86";
+  protected static final String ROSA = "rosa";
   protected static final String ORG_ID = "13259775";
   protected static final String INSTANCE_TYPE = "HBI_HOST";
 
@@ -182,6 +184,10 @@ public abstract class BaseDataExporterServiceTest
   protected void verifyRequestWasSentToExportServiceWithNoDataFound() {
     verifyRequestWasSentToExportServiceWithUploadData(
         request, toJson(new SubscriptionsExportJson().withData(new ArrayList<>())));
+  }
+
+  protected void updateOffering() {
+    offeringRepository.save(offering);
   }
 
   protected String toJson(Object data) {

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -127,6 +127,12 @@ public class SubscriptionDefinition {
         .collect(Collectors.toSet());
   }
 
+  public static boolean isPrometheusEnabled(@NotNull @NotEmpty String tag) {
+    return lookupSubscriptionByTag(tag).filter(SubscriptionDefinition::isPrometheusEnabled).stream()
+        .findFirst()
+        .isPresent();
+  }
+
   public boolean isPrometheusEnabled() {
     return this.getMetrics().stream().anyMatch(metric -> Objects.nonNull(metric.getPrometheus()));
   }


### PR DESCRIPTION
Jira issue: [SWATCH-2483](https://issues.redhat.com/browse/SWATCH-2483)

## Description
The unlimited subscriptions query is used to populate the total capacity of the skus, and since we are not gathering this information in the export service, we don't need it.
To retrieve the payg subscriptions, the difference is how to filter by product (it's being done one way if the product is non payg, and in a different way if the product is payg). I have a fix for this to retrieve both.

## Testing

Steps to reproduce and verify using QE tooling:

1.- app.rhsm_subscriptions.create_mock_subscription(product_id="rosa",billing_provider="aws",quantity=10)
2.- app.rhsm_subscriptions.get_skus_report(product_id="rosa")
3.- filters = {"product_id": "rosa"}
4.- export = app.rhsm_subscriptions.create_swatch_export_request(filters=filters)
5.- data, _ = app.rhsm_subscriptions.download_export_to_json(export.id)

The subscriptions from step 2 and step 5 should match.

IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/670