### PR TITLE
SWATCH-2486: Include KAFKA_BILLABLE_USAGE_PARTITIONS in billable usage deployment

### DIFF
--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -147,6 +147,8 @@ objects:
                   key: self
             - name: QUARKUS_PROFILE
               value: ${QUARKUS_PROFILE}
+            - name: KAFKA_BILLABLE_USAGE_PARTITIONS
+              value: ${KAFKA_BILLABLE_USAGE_PARTITIONS}
           volumeMounts:
             - name: logs
               mountPath: /logs


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2486

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
KAFKA_BILLABLE_USAGE_PARTITIONS env var is used by the aggregate flush service and was not being added to the deployment.
