### PR TITLE
SWATCH-2494: Add all status of billable usage remittance together

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/billing/BillableUsageController.java
@@ -76,8 +76,8 @@ public class BillableUsageController {
   public double getTotalRemitted(BillableUsage billableUsage) {
     var filter = BillableUsageRemittanceFilter.fromUsage(billableUsage);
     return billableUsageRemittanceRepository.getRemittanceSummaries(filter).stream()
-        .findFirst()
         .map(RemittanceSummaryProjection::getTotalRemittedPendingValue)
+        .reduce(Double::sum)
         .orElse(0.0);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/billing/BillableUsageControllerTest.java
@@ -470,6 +470,35 @@ class BillableUsageControllerTest {
         false);
   }
 
+  @Test
+  // See SWATCH-2494
+  void testGetTotalRemittedConsidersAllStatuses() {
+    record RemittanceTuple(double value, RemittanceStatus status, OffsetDateTime date) {}
+    ;
+
+    OffsetDateTime startOfUsage = CLOCK.startOfCurrentMonth().plusDays(4);
+    var t1 = new RemittanceTuple(1.0, RemittanceStatus.SUCCEEDED, startOfUsage);
+    var t2 = new RemittanceTuple(5.0, RemittanceStatus.PENDING, startOfUsage.plusDays(2));
+    var t3 = new RemittanceTuple(10.0, RemittanceStatus.FAILED, startOfUsage.plusDays(4));
+    var t4 = new RemittanceTuple(20.0, null, startOfUsage.plusDays(4));
+
+    List<RemittanceSummaryProjection> summaries = new ArrayList<>();
+    for (var tuple : List.of(t1, t2, t3, t4)) {
+      summaries.add(
+          RemittanceSummaryProjection.builder()
+              .totalRemittedPendingValue(tuple.value)
+              .status(tuple.status)
+              .remittancePendingDate(tuple.date)
+              .build());
+    }
+
+    when(remittanceRepo.getRemittanceSummaries(any())).thenReturn(summaries);
+
+    BillableUsage usage = billable(CLOCK.endOfCurrentMonth(), 0.0);
+    var result = controller.getTotalRemitted(usage);
+    assertEquals(36.0, result);
+  }
+
   static Stream<Arguments> remittanceBillingFactorParameters() {
     OffsetDateTime startOfUsage = CLOCK.startOfCurrentMonth().plusDays(4);
     return Stream.of(


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2494

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

With the addition of the `status` column to billable usage remittance, we now have several different "types" of billable usage. It's necessary to consider each one as contributing to the total remittance for an accumulation period. Future work can amend what counts as necessary (e.g. fatal failures should not counted towards what was remitted for the accumulation period).

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/684

See iqe test (easiest to just let it run against EE).