### PR TITLE
Configure logging SQL queries by deployment property

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -25,6 +25,8 @@ parameters:
     value: WARN
   - name: LOGGING_LEVEL
     value: INFO
+  - name: LOGGING_SHOW_SQL_QUERIES
+    value: 'false'
   - name: REPLICAS
     value: '1'
   - name: MEMORY_REQUEST
@@ -163,6 +165,8 @@ objects:
                 value: ${LOGGING_LEVEL_ROOT}
               - name: LOGGING_LEVEL_ORG_CANDLEPIN
                 value: ${LOGGING_LEVEL}
+              - name: LOGGING_SHOW_SQL_QUERIES
+                value: ${LOGGING_SHOW_SQL_QUERIES}
               - name: DATABASE_HOST
                 valueFrom:
                   secretKeyRef:

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -47,6 +47,8 @@ parameters:
     value: 'INFO'
   - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
     value: 'INFO'
+  - name: LOGGING_SHOW_SQL_QUERIES
+    value: 'false'
   # allow overriding to support independent deploy with bonfire
   - name: DB_POD
     value: swatch-tally
@@ -126,6 +128,8 @@ objects:
                 value: ${LOGGING_LEVEL_ROOT}
               - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
                 value: ${LOGGING_LEVEL_COM_REDHAT_SWATCH}
+              - name: LOGGING_SHOW_SQL_QUERIES
+                value: ${LOGGING_SHOW_SQL_QUERIES}
               - name: DATABASE_HOST
                 valueFrom:
                   secretKeyRef:

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -78,12 +78,11 @@ quarkus.datasource.username=${DATABASE_USERNAME}
 quarkus.datasource.password=${DATABASE_PASSWORD}
 quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}
 
-
-
 %test.quarkus.datasource.db-kind=h2
 # NOTE: because some of the entities use columns named "value", it is necessary to configure h2 to *not* treat it as a keyword.
 %test.quarkus.datasource.jdbc.url=jdbc:h2:mem:db;NON_KEYWORDS=VALUE
 %test.quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.log.sql=${LOGGING_SHOW_SQL_QUERIES:false}
 
 quarkus.liquibase.database-change-log-lock-table-name=DATABASECHANGELOGLOCK_SWATCH_CONTRACTS
 quarkus.liquibase.database-change-log-table-name=DATABASECHANGELOG_SWATCH_CONTRACTS

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -85,9 +85,11 @@ management:
 spring:
   # general hibernate configurations
   jpa:
+    show-sql: ${LOGGING_SHOW_SQL_QUERIES:false}
     open-in-view: false
     properties:
       hibernate:
+        format_sql: ${LOGGING_SHOW_SQL_QUERIES:false}
         jdbc:
           batch_size: ${JDBC_BATCH_SIZE}
         order_inserts: true

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -15,6 +15,8 @@ parameters:
     value: WARN
   - name: LOGGING_LEVEL
     value: INFO
+  - name: LOGGING_SHOW_SQL_QUERIES
+    value: 'false'
   - name: KAFKA_MESSAGE_THREADS
     value: '24'
   - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
@@ -243,6 +245,8 @@ objects:
               value: ${LOGGING_LEVEL_ROOT}
             - name: LOGGING_LEVEL_ORG_CANDLEPIN
               value: ${LOGGING_LEVEL}
+            - name: LOGGING_SHOW_SQL_QUERIES
+              value: ${LOGGING_SHOW_SQL_QUERIES}
             - name: KAFKA_MESSAGE_THREADS
               value: ${KAFKA_MESSAGE_THREADS}
             - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -17,6 +17,8 @@ parameters:
     value: WARN
   - name: LOGGING_LEVEL
     value: INFO
+  - name: LOGGING_SHOW_SQL_QUERIES
+    value: 'false'
   - name: KAFKA_MESSAGE_THREADS
     value: '24'
   - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
@@ -287,6 +289,8 @@ objects:
               value: ${LOGGING_LEVEL_ROOT}
             - name: LOGGING_LEVEL_ORG_CANDLEPIN
               value: ${LOGGING_LEVEL}
+            - name: LOGGING_SHOW_SQL_QUERIES
+              value: ${LOGGING_SHOW_SQL_QUERIES}
             - name: KAFKA_MESSAGE_THREADS
               value: ${KAFKA_MESSAGE_THREADS}
             - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -17,6 +17,8 @@ parameters:
     value: WARN
   - name: LOGGING_LEVEL
     value: INFO
+  - name: LOGGING_SHOW_SQL_QUERIES
+    value: 'false'
   - name: KAFKA_MESSAGE_THREADS
     value: '24'
   - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
@@ -357,6 +359,8 @@ objects:
               value: ${LOGGING_LEVEL_ROOT}
             - name: LOGGING_LEVEL_ORG_CANDLEPIN
               value: ${LOGGING_LEVEL}
+            - name: LOGGING_SHOW_SQL_QUERIES
+              value: ${LOGGING_SHOW_SQL_QUERIES}
             - name: KAFKA_MESSAGE_THREADS
               value: ${KAFKA_MESSAGE_THREADS}
             - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS


### PR DESCRIPTION
## Description
Adding a common property `LOGGING_SHOW_SQL_QUERIES` in spring boot and quarkus services which is by default false.

In the Spring Boot services, this property will configure:
```
spring.jpa.show-sql: true
spring.jpa.properties.hibernate.format_sql: true
```

In the Quarkus services:
```
quarkus.hibernate-orm.log.sql=true
```

When enabled, this property will be helpful when troubleshooting issues in EE environments.

## Testing
No needed. 