### PR TITLE
SWATCH-2504: Replace the fact normalizer identification

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -23,8 +23,6 @@ package org.candlepin.subscriptions.tally.facts;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import java.time.OffsetDateTime;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -67,16 +65,18 @@ public class FactNormalizer {
    * Normalize the FactSets of the given host.
    *
    * @param hostFacts the collection of facts to normalize.
+   * @param isMetered
    * @return a normalized version of the host's facts.
    */
-  public NormalizedFacts normalize(InventoryHostFacts hostFacts, OrgHostsData guestData) {
+  public NormalizedFacts normalize(
+      InventoryHostFacts hostFacts, OrgHostsData guestData, boolean isMetered) {
 
     NormalizedFacts normalizedFacts = new NormalizedFacts();
     normalizeClassification(normalizedFacts, hostFacts, guestData);
     normalizeHardwareType(normalizedFacts, hostFacts);
-    normalizeSystemProfileFacts(normalizedFacts, hostFacts);
+    normalizeSystemProfileFacts(normalizedFacts, hostFacts, isMetered);
     normalizeSatelliteFacts(normalizedFacts, hostFacts);
-    normalizeRhsmFacts(normalizedFacts, hostFacts);
+    normalizeRhsmFacts(normalizedFacts, hostFacts, isMetered);
     normalizeQpcFacts(normalizedFacts, hostFacts);
     normalizeSocketCount(normalizedFacts, hostFacts);
     normalizeMarketplace(normalizedFacts, hostFacts);
@@ -210,7 +210,7 @@ public class FactNormalizer {
   }
 
   private void normalizeSystemProfileFacts(
-      NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
+      NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts, boolean isMetered) {
     String cloudProvider = hostFacts.getCloudProvider();
     if (HardwareMeasurementType.isSupportedCloudProvider(cloudProvider)) {
       normalizedFacts.setCloudProviderType(HardwareMeasurementType.fromString(cloudProvider));
@@ -227,7 +227,7 @@ public class FactNormalizer {
     }
     normalizedFacts
         .getProducts()
-        .addAll(getProductsFromProductIds(hostFacts.getSystemProfileProductIds()));
+        .addAll(getProductsFromProductIds(hostFacts.getSystemProfileProductIds(), isMetered));
     if ("x86_64".equals(hostFacts.getSystemProfileArch())
         && HardwareMeasurementType.VIRTUAL
             .toString()
@@ -300,31 +300,19 @@ public class FactNormalizer {
     return (int) Math.ceil(cpu / threadsPerCore);
   }
 
-  private Set<String> getProductsFromProductIds(Collection<String> productIds) {
+  private Set<String> getProductsFromProductIds(Collection<String> productIds, boolean isMetered) {
     if (productIds == null) {
       return Set.of();
     }
-
-    Set<String> products = new HashSet<>();
-    for (String productId : productIds) {
-      try {
-        var subscriptions = SubscriptionDefinition.lookupSubscriptionByEngId(productId);
-        if (Objects.nonNull(subscriptions)) {
-          subscriptions.forEach(
-              subscriptionDefinition ->
-                  subscriptionDefinition
-                      .findVariantForEngId(productId)
-                      .ifPresent(v -> products.add(v.getTag())));
-        }
-      } catch (NumberFormatException e) {
-        log.debug("Skipping non-numeric productId: {}", productId);
-      }
-    }
-
-    return products;
+    return isMetered
+        ? SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds(
+            null, productIds, null)
+        : SubscriptionDefinition.getAllProductTagsWithNonPaygEligibleByRoleOrEngIds(
+            null, productIds, null);
   }
 
-  private void normalizeRhsmFacts(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
+  private void normalizeRhsmFacts(
+      NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts, boolean isMetered) {
     // If the host hasn't been seen by rhsm-conduit, consider the host as unregistered, and do not
     // apply this host's facts.
     //
@@ -339,13 +327,17 @@ public class FactNormalizer {
                         && hostUnregistered(OffsetDateTime.parse(syncTimestamp)))
             .orElse(false);
     if (!skipRhsmFacts) {
-      normalizedFacts.getProducts().addAll(getProductsFromProductIds(hostFacts.getProducts()));
+      normalizedFacts
+          .getProducts()
+          .addAll(
+              isMetered
+                  ? SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds(
+                      hostFacts.getSyspurposeRole(), hostFacts.getProducts(), null)
+                  : SubscriptionDefinition.getAllProductTagsWithNonPaygEligibleByRoleOrEngIds(
+                      hostFacts.getSyspurposeRole(), hostFacts.getProducts(), null));
 
       // Check for cores and sockets. If not included, default to 0.
-
       normalizedFacts.setOrgId(hostFacts.getOrgId());
-
-      handleRole(normalizedFacts, hostFacts.getSyspurposeRole());
       handleSla(normalizedFacts, hostFacts, hostFacts.getSyspurposeSla());
       handleUsage(normalizedFacts, hostFacts, hostFacts.getSyspurposeUsage());
     }

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
@@ -886,7 +886,7 @@ class InventoryAccountUsageCollectorTallyTest {
         orgId,
         props.getCullingOffsetDays(),
         hostFacts -> {
-          NormalizedFacts facts = factNormalizer.normalize(hostFacts, orgHostsData);
+          NormalizedFacts facts = factNormalizer.normalize(hostFacts, orgHostsData, false);
           Host existingHost = inventoryHostMap.remove(hostFacts.getInventoryId().toString());
           Host host;
 


### PR DESCRIPTION
Jira issue: SWATCH-2504

## Description
- now uses the new product tag identification methods
  SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds
  and
  SubscriptionDefinition.getAllProductTagsWithNonPaygEligibleByRoleOrEngIds
- Added unit tests to cover new code

This ensures a common code path for this decision making.


## Testing
Existing unit and iqe tests cover the code changes.

Please test the statement from the Jira card:
 "If data comes from telemetry then treat as metered: Y, if from HBI then metered N, if there is data in both streams then metered Y wins."

### Verification
The successful run of the test suite.
Confirmation of the above statement.
