### PR TITLE
Update unit test for first day of month failure

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -213,8 +213,10 @@ class TallySnapshotControllerTest implements ExtendWithEmbeddedKafka {
     // Host 1: monthly totals should be amended.
     // Host 2: monthly totals should remain the same.
     Host instance1 = hosts.get(instance1Id);
+    double instance1ExpectedMonthyTotal =
+        monthId.equals(InstanceMonthlyTotalKey.formatMonthId(firstSnapshotHour)) ? 350.0 : 50.0;
     assertEquals(
-        350.0,
+        instance1ExpectedMonthyTotal,
         instance1.getMonthlyTotal(
             InstanceMonthlyTotalKey.formatMonthId(instance1Event1.getTimestamp()),
             MetricIdUtils.getCores()));


### PR DESCRIPTION
## Description
The test was checked by using "yesterday". This causes a different result in a monthly calculation when the test is run on the first of a month.

## Testing
The unit test will need to pass on the first day of the month

### Verification
1. Run on the first day of a month

