### PR TITLE
SWATCH-2475: Update docker-compose

### DIFF
--- a/bin/wait-for
+++ b/bin/wait-for
@@ -1,0 +1,192 @@
+#!/bin/sh
+
+# Courtesy of https://github.com/Unleash/unleash-docker
+# The MIT License (MIT)
+#
+# Copyright (c) 2017 Eficode Oy
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+VERSION="2.2.3"
+
+set -- "$@" -- "$TIMEOUT" "$QUIET" "$PROTOCOL" "$HOST" "$PORT" "$result"
+TIMEOUT=15
+QUIET=0
+# The protocol to make the request with, either "tcp" or "http"
+PROTOCOL="tcp"
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $0 host:port|url [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -v | --version                      Show the version of this tool
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  case "$PROTOCOL" in
+    tcp)
+      if ! command -v nc >/dev/null; then
+        echoerr 'nc command is missing!'
+        exit 1
+      fi
+      ;;
+    http)
+      if ! command -v wget >/dev/null; then
+        echoerr 'wget command is missing!'
+        exit 1
+      fi
+      ;;
+  esac
+
+  TIMEOUT_END=$(($(date +%s) + TIMEOUT))
+
+  while :; do
+    case "$PROTOCOL" in
+      tcp)
+        nc -w 1 -z "$HOST" "$PORT" > /dev/null 2>&1
+        ;;
+      http)
+        wget --timeout=1 -q "$HOST" -O /dev/null > /dev/null 2>&1
+        ;;
+      *)
+        echoerr "Unknown protocol '$PROTOCOL'"
+        exit 1
+        ;;
+    esac
+
+    result=$?
+
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 7 ] ; then
+        for result in $(seq $(($# - 7))); do
+          result=$1
+          shift
+          set -- "$@" "$result"
+        done
+
+        TIMEOUT=$2 QUIET=$3 PROTOCOL=$4 HOST=$5 PORT=$6 result=$7
+        shift 7
+        exec "$@"
+      fi
+      exit 0
+    fi
+
+    if [ $TIMEOUT -ne 0 -a $(date +%s) -ge $TIMEOUT_END ]; then
+      echo "Operation timed out" >&2
+      exit 1
+    fi
+
+    sleep 1
+  done
+}
+
+while :; do
+  case "$1" in
+    http://*|https://*)
+    HOST="$1"
+    PROTOCOL="http"
+    shift 1
+    ;;
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -v | --version)
+    echo $VERSION
+    exit
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -q-*)
+    QUIET=0
+    echoerr "Unknown option: $1"
+    usage 1
+    ;;
+    -q*)
+    QUIET=1
+    result=$1
+    shift 1
+    set -- -"${result#-q}" "$@"
+    ;;
+    -t | --timeout)
+    TIMEOUT="$2"
+    shift 2
+    ;;
+    -t*)
+    TIMEOUT="${1#-t}"
+    shift 1
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    -*)
+    QUIET=0
+    echoerr "Unknown option: $1"
+    usage 1
+    ;;
+    *)
+    QUIET=0
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if ! [ "$TIMEOUT" -ge 0 ] 2>/dev/null; then
+  echoerr "Error: invalid timeout '$TIMEOUT'"
+  usage 3
+fi
+
+case "$PROTOCOL" in
+  tcp)
+    if [ "$HOST" = "" ] || [ "$PORT" = "" ]; then
+      echoerr "Error: you need to provide a host and port to test."
+      usage 2
+    fi
+  ;;
+  http)
+    if [ "$HOST" = "" ]; then
+      echoerr "Error: you need to provide a host to test."
+      usage 2
+    fi
+  ;;
+esac
+
+wait_for "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.1'
+version: '3.8'
 services:
   db:
     # Use the same version as in https://gitlab.cee.redhat.com/service/app-interface/-/blob/ff61d457898da76ebd4abf21fe3ce7b5c74c87a5/data/services/insights/rhsm/namespaces/rhsm-prod.yml#L179
@@ -11,8 +11,14 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRESQL_MAX_CONNECTIONS=5000
       - POSTGRESQL_ADMIN_PASSWORD=admin
+    healthcheck:
+      test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]
+      interval: 2s
+      timeout: 1m
+      retries: 5
+      start_period: 10s
     volumes:
-      - ./init_dbs.sh:/usr/share/container-scripts/postgresql/start/set_passwords.sh:z
+      - ./init_dbs.sh:/usr/share/container-scripts/postgresql/init/init_dbs.sh:z
       - ./postgresql.conf:/opt/app-root/src/postgresql-cfg/postgresql.conf:z
       - ./pg_hba.conf:/pg_hba.conf:z
     ports:
@@ -41,6 +47,12 @@ services:
       - KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf
         # Note that as of this writing (20 Jul 2022), Kraft mode does not support SCRAM
       - KAFKA_SASL_MECHANISM=PLAIN
+    healthcheck:
+      test: ./bin/kafka-cluster.sh cluster-id --bootstrap-server 127.0.0.1:9092 || exit 1
+      interval: 2s
+      timeout: 1m
+      retries: 5
+      start_period: 10s
     ports:
       - "127.0.0.1:9092:9092"
       # Port 9093 is used by the Kraft configuration
@@ -54,13 +66,14 @@ services:
       swatch-network:
         aliases:
           - kafka
-    user: 0
+    user: root
   kafka-rest:
     image: docker.io/confluentinc/cp-kafka-rest
     environment:
       - KAFKA_REST_BOOTSTRAP_SERVERS=kafka:29092
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
   kafka-topics-ui:
     image: docker.io/landoop/kafka-topics-ui
     environment:
@@ -73,7 +86,7 @@ services:
   inventory:
     image: quay.io/cloudservices/insights-inventory
     entrypoint: /bin/bash -c
-    command: ["FLASK_APP=./manage.py flask db upgrade; gunicorn -c gunicorn.conf.py -b 0.0.0.0:8000 -t 60 run"]
+    command: ["make upgrade_db && ./run_gunicorn.py"]
     environment:
       - INVENTORY_LOG_LEVEL=DEBUG
       - INVENTORY_DB_HOST=db
@@ -82,47 +95,74 @@ services:
       - BYPASS_RBAC=true
       - FLASK_APP=./manage.py
       - UNLEASH_TOKEN=*:*.placeholder
+      - UNLEASH_URL=http://unleash:4242/api
       - UNLEASH_CACHE_DIR=/tmp/.unleashcache
     depends_on:
-      - kafka
-      - db
+      kafka:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      unleash:
+        condition: service_healthy
     ports:
       - "127.0.0.1:8050:8000"
-    user: 0
+    user: root
   inventory-mq:
     image: quay.io/cloudservices/insights-inventory
     entrypoint: /bin/bash -c
-    command: ["./inv_mq_service.py"]
+    command: ["make run_inv_mq_service"]
     environment:
       - INVENTORY_LOG_LEVEL=DEBUG
-      - INVENTORY_DB_HOST=db
+      - INVENTORY_DB_HOST=127.0.0.1
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - prometheus_multiproc_dir=/tmp
       - BYPASS_RBAC=true
       - FLASK_APP=./manage.py
       - UNLEASH_TOKEN=*:*.placeholder
+      - UNLEASH_URL=http://unleash:4242
       - UNLEASH_CACHE_DIR=/tmp/.unleashcache
     depends_on:
-      - kafka
-      - db
-    user: 0
+      kafka:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+    user: root
   unleash:
-    image: quay.io/cloudservices/unleash-server:4.21.0
+    image: quay.io/cloudservices/unleash-server:5.8.2
     environment:
-      - INIT_ADMIN_API_TOKENS=*:*.placeholder
+      - INIT_CLIENT_API_TOKENS=default:development.unleash-insecure-api-token
+      - INIT_ADMIN_API_TOKENS=*:*.unleash-insecure-admin-api-token
       - CHECK_VERSION=false
       - DATABASE_HOST=db
       - DATABASE_NAME=unleash
-      - DATABASE_USERNAME=${DATABASE_USER-insights}
-      - DATABASE_PASSWORD=${DATABASE_PASSWORD-insights}
+      - DATABASE_USERNAME=${DATABASE_USER:-unleash}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD:-unleash}
       - DATABASE_SSL=false
       - IMPORT_DROP_BEFORE_IMPORT=false
       - IMPORT_FILE=/.unleash/flags.json
       - IMPORT_DROP_BEFORE_IMPORT=true
       - LOG_LEVEL=INFO
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:4242/health || exit 1
+      interval: 2s
+      timeout: 1m
+      retries: 5
+      start_period: 10s
+    # Why do we do this?  Because there is an issue around the postgresql container where it
+    # starts, runs some initialization scripts, and then restarts itself.  See
+    # https://github.com/sclorg/postgresql-container/blob/master/12/root/usr/bin/run-postgresql#L54-L58
+    # This fools the healthcheck into reporting that the container is ready, only for the
+    # postgresql process to stop and restart.  Meanwhile, the unleash container tries to connect,
+    # fails, and doesn't start.  So we add this shim script to wait until the connection is stable.
+    # The script itself is sourced from the https://github.com/Unleash/unleash-docker container
+    command: ["/bin/sh", "/unleash/wait-for", "db:5432", "--", "node", "index.js"]
+    depends_on:
+      db:
+        condition: service_healthy
     ports:
-      - 4242:4242
+      - "127.0.0.1:4242:4242"
     volumes:
+      - './bin/wait-for:/unleash/wait-for:z'
       - './.unleash:/.unleash:z'
 networks:
   swatch-network:

--- a/init_dbs.sh
+++ b/init_dbs.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
 
-_psql () { psql --set ON_ERROR_STOP=0 "$@" ; }
+if [[ -v POSTGRESQL_USER || -v POSTGRESQL_PASSWORD || -v POSTGRESQL_DATABASE ]]; then
+  cat >&2 <<EOF
+  You have mounted the RHSM init_dbs.sh script.
 
-_psql --set=adminpass="$POSTGRESQL_ADMIN_PASSWORD" \
-<<<"ALTER USER \"postgres\" WITH ENCRYPTED PASSWORD :'adminpass';"
+  This script is *incompatible* with setting the POSTGRESL_USER/POSTGRESQL_DATABASE environment
+  variables.  This script runs very early and later, the container scripts attempt to run
+  createuser $POSTGRESQL_USER and if the user already exists, createuser fails and the container
+  stops.
+
+  Either do not mount init_dbs.sh or do not set the POSTGRESQL_USER and POSTGRESQL_DATABASE
+  environment variables.
+EOF
+  exit 1
+fi
 
 for db in rhsm-subscriptions insights unleash; do
-  _psql --set=adminpass="$POSTGRESQL_ADMIN_PASSWORD" <<-EOSQL
+  psql --set ON_ERROR_STOP=1 <<-EOSQL
       CREATE USER "$db" WITH PASSWORD '$db';
       CREATE DATABASE "$db";
       GRANT ALL PRIVILEGES ON DATABASE "$db" TO "$db";

--- a/postgresql.conf
+++ b/postgresql.conf
@@ -1,1 +1,2 @@
 hba_file = '/pg_hba.conf'
+listen_addresses = '*'


### PR DESCRIPTION
Jira issue: Part of SWATCH-2475

## Description
This patch adds several items:

* The unleash server now starts and runs properly.
* Health checks have been added to the db and kafka containers
* The command for the inventory containers has been altered to better reflect the commands used by the inventory development Dockerfile
* The postgresql container now listens for connections external to the compose network and internal to the compose network
* We no longer override the set_passwords.sh script in the postgresql container.  Instead we add an additional script into a directory where it will be run automatically by the container entrypoint.

## Testing
### Steps
1.  If you have a compose already running, `podman-compose down`.  This will **destroy** your database, so if you have data you want to save, do a `pg_dump`
1. `podman-compose up -d`

### Verification
1. `podman-compose ps` should show that all the containers are up and running.  You can also go to `http://localhost:4242` to see the Unleash web UI.
