### PR TITLE
SWATCH-2145: Prevent tallies from creating duplicate system/host entries

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -74,7 +74,7 @@ import lombok.Setter;
             @ColumnResult(name = "guest_id"),
             @ColumnResult(name = "subscription_manager_id"),
             @ColumnResult(name = "insights_id"),
-            @ColumnResult(name = "provider_id"),
+            @ColumnResult(name = "instance_id"),
             @ColumnResult(name = "cloud_provider"),
             @ColumnResult(name = "stale_timestamp", type = OffsetDateTime.class),
             @ColumnResult(name = "hardware_subman_id")
@@ -122,7 +122,13 @@ import lombok.Setter;
         h.system_profile_facts->>'is_marketplace' as is_marketplace,
         h.canonical_facts->>'subscription_manager_id' as subscription_manager_id,
         h.canonical_facts->>'insights_id' as insights_id,
-        h.canonical_facts->>'provider_id' as provider_id,
+        coalesce(
+            h.canonical_facts->>'provider_id',
+            -- fallback logic to set the instance ID if and only if the instanceId is not set yet:
+            -- We assume that the instance ID for any given HBI host record is the inventory ID; compare
+            -- to an OpenShift Cluster from Prometheus data, where we use the cluster ID.
+            cast(h.id as text)
+        ) as instance_id,
         rhsm_products.products,
         qpc_prods.qpc_products,
         system_profile.system_profile_product_ids,
@@ -150,7 +156,7 @@ import lombok.Setter;
            and (h.system_profile_facts->>'host_type' IS NULL OR h.system_profile_facts->>'host_type' <> 'edge')
            and NOW() < stale_timestamp + make_interval(days => :culledOffsetDays)
         -- NOTE: ordering is crucial for correct streaming reconciliation of HBI data
-        order by provider_id, hardware_subman_id, any_hypervisor_uuid, inventory_id
+        order by instance_id, hardware_subman_id, any_hypervisor_uuid, inventory_id
     """,
     resultSetMapping = "inventoryHostFactsMapping")
 @Getter

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -150,7 +150,7 @@ import lombok.Setter;
            and (h.system_profile_facts->>'host_type' IS NULL OR h.system_profile_facts->>'host_type' <> 'edge')
            and NOW() < stale_timestamp + make_interval(days => :culledOffsetDays)
         -- NOTE: ordering is crucial for correct streaming reconciliation of HBI data
-        order by hardware_subman_id, any_hypervisor_uuid, inventory_id
+        order by provider_id, hardware_subman_id, any_hypervisor_uuid, inventory_id
     """,
     resultSetMapping = "inventoryHostFactsMapping")
 @Getter

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -55,7 +55,7 @@ public class InventoryHostFacts {
   private String guestId;
   private String subscriptionManagerId;
   private String insightsId;
-  private String providerId;
+  private String instanceId;
   private Set<String> qpcProducts;
   private Set<String> systemProfileProductIds;
   private String syspurposeRole;
@@ -107,7 +107,7 @@ public class InventoryHostFacts {
       String guestId,
       String subscriptionManagerId,
       String insightsId,
-      String providerId,
+      String instanceId,
       String cloudProvider,
       OffsetDateTime staleTimestamp,
       String hardwareSubmanId) {
@@ -140,7 +140,7 @@ public class InventoryHostFacts {
     this.guestId = guestId;
     this.subscriptionManagerId = subscriptionManagerId;
     this.insightsId = insightsId;
-    this.providerId = providerId;
+    this.instanceId = instanceId;
     this.billingModel = billingModel;
     this.cloudProvider = cloudProvider;
     this.staleTimestamp = staleTimestamp;

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -180,22 +180,10 @@ public class InventoryAccountUsageCollector {
   public static void populateHostFieldsFromHbi(
       Host host, InventoryHostFacts inventoryHostFacts, NormalizedFacts normalizedFacts) {
 
-    if (inventoryHostFacts.getProviderId() != null) {
-      // will use the provider ID from HBI
-      host.setInstanceId(inventoryHostFacts.getProviderId());
-    }
-
+    host.setInstanceId(inventoryHostFacts.getInstanceId());
     if (inventoryHostFacts.getInventoryId() != null) {
       host.setInventoryId(inventoryHostFacts.getInventoryId().toString());
-
-      // fallback logic to set the instance ID if and only if the instanceId is not set yet:
-      if (host.getInstanceId() == null) {
-        // We assume that the instance ID for any given HBI host record is the inventory ID; compare
-        // to an OpenShift Cluster from Prometheus data, where we use the cluster ID.
-        host.setInstanceId(inventoryHostFacts.getInventoryId().toString());
-      }
     }
-
     host.setInsightsId(inventoryHostFacts.getInsightsId());
     host.setOrgId(inventoryHostFacts.getOrgId());
     host.setDisplayName(inventoryHostFacts.getDisplayName());
@@ -271,7 +259,7 @@ public class InventoryAccountUsageCollector {
         log.debug(
             "Updating system w/ inventoryId={} and instanceId={}",
             hbiSystem.getInventoryId(),
-            hbiSystem.getProviderId());
+            hbiSystem.getInstanceId());
         Host updatedSwatchSystem =
             updateSwatchSystem(hbiSystem, normalizedFacts, swatchSystem, usageKeys);
         hosts.add(updatedSwatchSystem);
@@ -279,7 +267,7 @@ public class InventoryAccountUsageCollector {
         log.debug(
             "Creating system w/ inventoryId={} and instanceId={}",
             hbiSystem.getInventoryId(),
-            hbiSystem.getProviderId());
+            hbiSystem.getInstanceId());
         swatchSystem = createSwatchSystem(hbiSystem, normalizedFacts, usageKeys);
         hosts.add(swatchSystem);
       }

--- a/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
@@ -265,8 +265,8 @@ public class InventorySwatchDataCollator {
     @Override
     public int compareTo(@NotNull SortKey other) {
       var instanceIdResult = compare(instanceId, other.getInstanceId());
-      if (instanceIdResult == 0) {
-        return 0;
+      if (instanceIdResult != 0) {
+        return instanceIdResult;
       }
       var hardwareSubmanIdResult = compare(hardwareSubmanId, other.getHardwareSubmanId());
       if (hardwareSubmanIdResult != 0) {

--- a/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
@@ -115,7 +115,7 @@ public class InventorySwatchDataCollator {
     counts and tally buckets, between iterations.
      */
     OrgHostsData orgHostsData = new OrgHostsData("placeholder"); // orgId not used
-    String previousProviderId = null;
+    String previousInstanceId = null;
     int iterationCount = 0;
 
     while (inventoryDataIterator.hasNext() || swatchDataIterator.hasNext()) {
@@ -162,12 +162,12 @@ public class InventorySwatchDataCollator {
       // process iteration if and only if the hbi system is null or the previous provider ID is not
       // equal to the current provider ID (because it would be a duplicated host)
       if (activeHbiSystem == null
-          || activeHbiSystem.getProviderId() == null
-          || !activeHbiSystem.getProviderId().equals(previousProviderId)) {
+          || activeHbiSystem.getInstanceId() == null
+          || !activeHbiSystem.getInstanceId().equals(previousInstanceId)) {
         processor.accept(activeHbiSystem, activeSwatchSystem, orgHostsData, iterationCount);
       }
-      previousProviderId =
-          Optional.ofNullable(activeHbiSystem).map(InventoryHostFacts::getProviderId).orElse(null);
+      previousInstanceId =
+          Optional.ofNullable(activeHbiSystem).map(InventoryHostFacts::getInstanceId).orElse(null);
     }
     return iterationCount;
   }
@@ -239,6 +239,7 @@ public class InventorySwatchDataCollator {
       return SortKey.builder()
           .hardwareSubmanId(hardwareSubmanId)
           .inventoryId(system.getInventoryId())
+          .instanceId(system.getInstanceId())
           .hypervisorUuid(system.getHypervisorUuid())
           .build();
     }
@@ -258,7 +259,7 @@ public class InventorySwatchDataCollator {
           .hardwareSubmanId(hardwareSubmanId)
           .hypervisorUuid(hypervisorUuid)
           .inventoryId(system.getInventoryId().toString())
-          .instanceId(system.getProviderId())
+          .instanceId(system.getInstanceId())
           .build();
     }
 

--- a/src/main/resources/liquibase/202405061230-remove-duplicated-hosts.xml
+++ b/src/main/resources/liquibase/202405061230-remove-duplicated-hosts.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+  <!--
+  To know more about the pattern we're using to delete duplicate records, go to: https://wiki.postgresql.org/wiki/Deleting_duplicates
+  -->
+  <changeSet id="202405061230-1" author="jcarvaja" dbms="postgresql">
+    <comment>Remove the duplicated hosts by inventory_id based on the billing_account_id and the more recent last_seen and add the unique constraint</comment>
+    <delete tableName="hosts">
+      <where>
+        id in (select d.id from (
+          select h.id, row_number() over (partition by h.org_id, h.inventory_id order by h.billing_account_id desc nulls last, last_seen desc) as duplicated_row_number
+          from hosts h
+          inner join (
+            select count(*) as duplicated, org_id, inventory_id
+            from hosts
+            group by org_id,inventory_id
+          ) d on d.org_id=h.org_id and d.inventory_id=h.inventory_id and d.duplicated > 1
+        ) d
+        where d.duplicated_row_number > 1)
+      </where>
+    </delete>
+    <addUniqueConstraint columnNames="org_id, inventory_id"
+                         constraintName="hosts_org_id_inventory_id_unique" tableName="hosts"/>
+    <rollback>
+      <dropUniqueConstraint tableName="hosts" constraintName="hosts_org_id_inventory_id_unique"/>
+    </rollback>
+  </changeSet>
+
+  <!--
+  To know more about the pattern we're using to delete duplicate records, go to: https://wiki.postgresql.org/wiki/Deleting_duplicates
+  -->
+  <changeSet id="202405061230-2" author="jcarvaja" dbms="postgresql">
+    <comment>Remove the duplicated hosts by instance_id based on the billing_account_id and the more recent last_seen and add the unique constraint</comment>
+    <delete tableName="hosts">
+      <where>
+        id in (select d.id from (
+          select h.id, row_number() over (partition by h.org_id, h.instance_id order by h.billing_account_id desc nulls last, last_seen desc) as duplicated_row_number
+          from hosts h
+          inner join (
+            select count(*) as duplicated, org_id, instance_id
+            from hosts
+            group by org_id,instance_id
+            ) d on d.org_id=h.org_id and d.instance_id=h.instance_id and d.duplicated > 1
+          ) d
+          where d.duplicated_row_number > 1)
+      </where>
+    </delete>
+    <addUniqueConstraint columnNames="org_id, instance_id"
+                         constraintName="hosts_org_id_instance_id_unique" tableName="hosts"/>
+    <rollback>
+      <dropUniqueConstraint tableName="hosts" constraintName="hosts_org_id_instance_id_unique"/>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -154,5 +154,6 @@
     <include file="/liquibase/202404240830-update-instance-view-to-aggregate-metrics.xml"/>
     <include file="/liquibase/202404301614-terminate-duplicate-azure-subscriptions.xml"/>
     <include file="/liquibase/202405080950-copy-uom-to-metric-id-events-table.xml"/>
+    <include file="/liquibase/202405061230-remove-duplicated-hosts.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
@@ -113,7 +113,7 @@ class HostTest {
   void populateFieldsFromHbiMappedGuest() {
     Host host = new Host();
     InventoryHostFacts inventoryHostFacts = getInventoryHostFactsFull();
-    NormalizedFacts normalizedFacts = getNormalizedFactsUnmappedGuest();
+    NormalizedFacts normalizedFacts = getNormalizedFactsMappedGuest();
 
     populateHostFieldsFromHbi(host, inventoryHostFacts, normalizedFacts);
     assertEquals(host.getInventoryId(), inventoryHostFacts.getInventoryId().toString());
@@ -240,34 +240,13 @@ class HostTest {
   }
 
   @Test
-  void testPopulateHostFieldsFromHbiShouldSetInstanceIdFromProviderId() {
+  void testPopulateHostFieldsFromHbiShouldSetInstanceId() {
     Host host = new Host();
     InventoryHostFacts inventoryHostFacts = new InventoryHostFacts();
-    inventoryHostFacts.setProviderId(UUID.randomUUID().toString());
+    inventoryHostFacts.setInstanceId(UUID.randomUUID().toString());
 
     populateHostFieldsFromHbi(host, inventoryHostFacts, new NormalizedFacts());
-    assertEquals(inventoryHostFacts.getProviderId(), host.getInstanceId());
-  }
-
-  @Test
-  void testPopulateHostFieldsFromHbiShouldOverwriteInstanceId() {
-    Host host = new Host();
-    host.setInstanceId(UUID.randomUUID().toString());
-    InventoryHostFacts inventoryHostFacts = new InventoryHostFacts();
-    inventoryHostFacts.setProviderId(UUID.randomUUID().toString());
-
-    populateHostFieldsFromHbi(host, inventoryHostFacts, new NormalizedFacts());
-    assertEquals(inventoryHostFacts.getProviderId(), host.getInstanceId());
-  }
-
-  @Test
-  void testPopulateHostFieldsFromHbiShouldUseInventoryIdWhenProviderIdIsNotSet() {
-    Host host = new Host();
-    InventoryHostFacts inventoryHostFacts = new InventoryHostFacts();
-    inventoryHostFacts.setInventoryId(UUID.randomUUID());
-
-    populateHostFieldsFromHbi(host, inventoryHostFacts, new NormalizedFacts());
-    assertEquals(inventoryHostFacts.getInventoryId().toString(), host.getInstanceId());
+    assertEquals(inventoryHostFacts.getInstanceId(), host.getInstanceId());
   }
 
   private InventoryHostFacts getInventoryHostFactsFull() {

--- a/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
+++ b/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
@@ -121,7 +121,7 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
     assertEquals(ARCH, fact.getSystemProfileArch());
     assertTrue(fact.isMarketplace());
     assertEquals(INSIGHTS_ID, fact.getInsightsId());
-    assertEquals(PROVIDER_ID, fact.getProviderId());
+    assertEquals(PROVIDER_ID, fact.getInstanceId());
     assertEquals(VIRTUAL_HOST_UUID, fact.getHardwareSubmanId());
     assertEquals(RH_PROD, fact.getProducts());
     assertEquals(RH_PRODUCTS_INSTALLED, fact.getQpcProducts());

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorReconcileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorReconcileTest.java
@@ -146,6 +146,7 @@ class InventoryAccountUsageCollectorReconcileTest {
   void testDelete() {
     var collector = setupCollector();
     Host swatchSystem = new Host();
+    swatchSystem.setInstanceType(InventoryAccountUsageCollector.HBI_INSTANCE_TYPE);
     collector.reconcileHbiSystemWithSwatchSystem(
         null, swatchSystem, new OrgHostsData("org123"), Set.of("RHEL for x86"), new ArrayList<>());
     verify(hostRepository).delete(swatchSystem);

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
@@ -210,12 +210,11 @@ class InventoryAccountUsageCollectorTallyTest {
   @Test
   void physicalSystemTotalsForRHEL() {
     List<Integer> products = List.of(TEST_PRODUCT_ID);
-
     InventoryHostFacts host = createRhsmHost(ORG_ID, products, "", OffsetDateTime.now());
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileSockets(3);
-    mockReportedHypervisors(ORG_ID, new HashMap<>());
 
+    mockReportedHypervisors(ORG_ID, new HashMap<>());
     when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
@@ -623,41 +622,18 @@ class InventoryAccountUsageCollectorTallyTest {
   }
 
   @Test
-  void accountsWithNullInventoryIdFiltered() {
-    List<Integer> products = List.of(TEST_PRODUCT_ID);
-    InventoryHostFacts host = createRhsmHost(ORG_ID, products, "", OffsetDateTime.now());
-    host.setSystemProfileCoresPerSocket(4);
-    host.setSystemProfileSockets(3);
-
-    mockReportedHypervisors(ORG_ID, new HashMap<>());
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host));
-
-    whenProcessHost(RHEL_PRODUCTS, ORG_ID);
-    mockBucketRepositoryFromAccountService();
-
-    AccountUsageCalculation calc = collector.tally(ORG_ID);
-    // odd sockets are rounded up.
-    checkTotalsCalculation(calc, ORG_ID, TEST_PRODUCT, 12, 4, 1);
-    checkPhysicalTotalsCalculation(calc, ORG_ID, TEST_PRODUCT, 12, 4, 1);
-    assertNull(
-        calc.getCalculation(createUsageKey(TEST_PRODUCT))
-            .getTotals(HardwareMeasurementType.VIRTUAL));
-  }
-
-  @Test
   void ensureStaleHostsAreDeleted() {
     List<Integer> products = List.of(TEST_PRODUCT_ID);
     InventoryHostFacts host = createRhsmHost(ORG_ID, products, "", OffsetDateTime.now());
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileSockets(3);
     Host orig = new Host(host.getInventoryId().toString(), "insights1", host.getOrgId(), null);
-    orig.setInstanceId(host.getInventoryId().toString());
     Host noLongerReported = new Host("i2-inventory-id", "insights2", host.getOrgId(), null);
     noLongerReported.setInstanceId("i2");
 
     AccountServiceInventory accountServiceInventory =
         new AccountServiceInventory(ORG_ID, "HBI_HOST");
-    accountServiceInventory.getServiceInstances().put(host.getInventoryId().toString(), orig);
+    accountServiceInventory.getServiceInstances().put(host.getInstanceId(), orig);
     accountServiceInventory.getServiceInstances().put("i2", noLongerReported);
 
     when(accountServiceInventoryRepository.findById(

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryHostFactTestHelper.java
@@ -137,6 +137,7 @@ public class InventoryHostFactTestHelper {
   public static InventoryHostFacts createBaseHost(String orgId) {
     InventoryHostFacts baseFacts = new InventoryHostFacts();
     baseFacts.setInventoryId(UUID.randomUUID());
+    baseFacts.setInstanceId(UUID.randomUUID().toString());
     baseFacts.setDisplayName("Test System");
     baseFacts.setOrgId(orgId);
     baseFacts.setSyncTimestamp(OffsetDateTime.now().toString());

--- a/src/test/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollatorTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -110,6 +111,36 @@ class InventorySwatchDataCollatorTest {
 
     verify(processor).accept(hbiSystem, swatchSystem, new OrgHostsData("placeholder"), 1);
     assertEquals(1, iterations);
+  }
+
+  @Test
+  void testCollatorProcessesHostsInSeveralIterations() {
+    InventoryHostFacts first = new InventoryHostFacts();
+    first.setInventoryId(UUID.randomUUID());
+    first.setInstanceId("i1");
+
+    InventoryHostFacts second = new InventoryHostFacts();
+    second.setInventoryId(UUID.randomUUID());
+    second.setInstanceId("i2");
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(first, second));
+
+    Host swatchSystemForSecond = new Host();
+    swatchSystemForSecond.setInventoryId(second.getInventoryId().toString());
+    swatchSystemForSecond.setInstanceId(second.getInstanceId());
+
+    Host swatchSystemOrphan = new Host();
+    swatchSystemOrphan.setInventoryId(second.getInventoryId().toString());
+
+    when(hostRepository.streamHbiHostsByOrgId(any()))
+        .thenReturn(Stream.of(swatchSystemForSecond, swatchSystemOrphan));
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    collator.collateData("foo", 7, processor);
+
+    verify(processor).accept(eq(first), isNull(), any(), eq(1));
+    verify(processor).accept(eq(second), eq(swatchSystemForSecond), any(), eq(2));
+    verify(processor).accept(isNull(), eq(swatchSystemOrphan), any(), eq(3));
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -160,6 +160,7 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
     InventoryHostFacts host = new InventoryHostFacts();
     host.setOrgId(ORG_ID);
     host.setInventoryId(inventoryId);
+    host.setInstanceId(UUID.randomUUID().toString());
     host.setSystemProfileSockets(2);
     host.setSystemProfileCoresPerSocket(4);
     host.setSystemProfileProductIds(String.join(",", productIds));

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -70,7 +70,7 @@ public interface HostRepository
       left join fetch h.buckets
       left join fetch h.monthlyTotals
       where h.orgId=:orgId
-      order by coalesce(h.hypervisorUuid, h.subscriptionManagerId), h.instanceId, h.hypervisorUuid, h.inventoryId, h.id
+      order by h.instanceId, coalesce(h.hypervisorUuid, h.subscriptionManagerId), h.hypervisorUuid, h.inventoryId, h.id
           """)
   @QueryHints(value = {@QueryHint(name = HINT_FETCH_SIZE, value = "1024")})
   Stream<Host> streamHbiHostsByOrgId(@Param("orgId") String orgId);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -70,8 +70,7 @@ public interface HostRepository
       left join fetch h.buckets
       left join fetch h.monthlyTotals
       where h.orgId=:orgId
-        and h.instanceType='HBI_HOST'
-      order by coalesce(h.hypervisorUuid, h.subscriptionManagerId), h.hypervisorUuid, h.inventoryId, h.id
+      order by coalesce(h.hypervisorUuid, h.subscriptionManagerId), h.instanceId, h.hypervisorUuid, h.inventoryId, h.id
           """)
   @QueryHints(value = {@QueryHint(name = HINT_FETCH_SIZE, value = "1024")})
   Stream<Host> streamHbiHostsByOrgId(@Param("orgId") String orgId);
@@ -283,15 +282,6 @@ public interface HostRepository
     } else {
       query.orderBy(criteriaBuilder.desc(root.get(order.getProperty())));
     }
-  }
-
-  static <T> Join<Host, T> findJoin(Root<Host> root, String alias) {
-    for (Join<Host, ?> join : root.getJoins()) {
-      if (join.getAlias().equals(alias)) {
-        return (Join<Host, T>) join;
-      }
-    }
-    throw new IllegalArgumentException("Cannot find join w/ alias: " + alias);
   }
 
   static <T, S, U> MapJoin<T, S, U> findMapJoin(Root<Host> root, String alias) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -38,6 +38,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
@@ -60,7 +61,12 @@ import lombok.ToString;
 @Getter
 @Entity
 @ToString
-@Table(name = "hosts")
+@Table(
+    name = "hosts",
+    uniqueConstraints = {
+      @UniqueConstraint(columnNames = {"org_id", "instance_id"}),
+      @UniqueConstraint(columnNames = {"org_id", "inventory_id"})
+    })
 public class Host implements Serializable {
 
   @Id


### PR DESCRIPTION
Jira issue: [SWATCH-2145](https://issues.redhat.com/browse/SWATCH-2145)

## Description
- Add a migration script to remove the duplicates based on (1) the presence of the billing_account_id, (2) the more recent last_seen.
- Add an unique constraint for org_id and inventory_id.
- Add an unique constraint for org_id and instance_id.
- When upserting a system during HBI tally, look for possible duplicates via org_id/instance_id. If there is an existing record, it should be treated as a matching system.

Note that this PR adds a performance killer when reconciling the hosts with HBI. 
Also note that I added the list of hosts to be deleted in the linked JIRA ticket. 

I ran the migration scripts using the stage data in local and it took less than 60 seconds. 

## Testing

### Verify the migration scripts
1.- podman-compose up
2.- load the stage data into your local database
3.- check that you have duplicated hosts by:

```sql
select * from hosts h inner join (select count(*) as duplicated, org_id, instance_id from hosts group by org_id,instance_id) d on d.org_id=h.org_id and d.instance_id=h.instance_id where d.duplicated > 1 order by d.org_id, d.instance_id;
```

4.- run the migration script by `./gradlew liquibaseUpdate`
5.- run again the above query and now you should get no results.

### Verify that the reconciliation of hosts work with the new unique constraints

1.- podman-compose up
2.- insert two hosts with the same provider ID (which is our instance_id in swatch) into the insights db:

```sql
insert into hosts(id, org_id, created_on, modified_on, account, display_name, facts, system_profile_facts,
                  canonical_facts, stale_timestamp, reporter, "groups")
values ('c0000000-0000-0000-0000-000000000000', 'org123', now(), now(), 'account123', 'system1', '{
  "satellite": {
    "system_purpose_role": "Red Hat Enterprise Linux Server"
  }
}', '{
  "infrastructure_type": "virtual",
  "cores_per_socket": "2",
  "number_of_sockets": "1",
  "arch": "x86_64",
  "installed_products": [
    {
      "id": "69"
    },
    {
      "id": "408"
    }
  ]
}', '{
  "subscription_manager_id": "05000000-0000-0000-0000-000000000000",
  "insights_id": "80000000-0000-0000-0000-000000000000",
  "provider_id": "instance_id_xxx"
}', now() + interval '30 days', 'reporter', '{}');

insert into hosts(id, org_id, created_on, modified_on, account, display_name, facts, system_profile_facts,
                  canonical_facts, stale_timestamp, reporter, "groups")
values ('40000000-0000-0000-0000-000000000000', 'org123', '2023-06-07T14:40:37.079023Z', '2023-06-07T14:40:37.079023Z',
        'account123', 'system2', '{
    "satellite": {
      "virtual_host_uuid": "05d00000-0000-0000-0000-000000000000"
    }
  }', '{
    "infrastructure_type": "virtual",
    "cores_per_socket": "6",
    "number_of_sockets": "1",
    "arch": "x86_64",
    "installed_products": [
      {
        "id": "69"
      },
      {
        "id": "408"
      }
    ]
  }', '{
    "subscription_manager_id": "b0000000-0000-0000-0000-000000000000",
    "insights_id": "70000000-0000-0000-0000-000000000000",
	"provider_id": "instance_id_xxx"
  }', now() + interval '30 days', 'reporter', '{}');
```

3.- start the service `DEV_MODE=true ./gradlew :bootRun`
4.- run the reconciliation: `http PUT :8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123 x-rh-swatch-psk:placeholder`

Verify that no unique constraints are thrown and only one host record in our swatch database exists.