### PR TITLE
SWATCH-431: Update event data json to copy uom to metric_id

### DIFF
--- a/src/main/resources/liquibase/202405080950-copy-uom-to-metric-id-events-table.xml
+++ b/src/main/resources/liquibase/202405080950-copy-uom-to-metric-id-events-table.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202405080950-01" author="wpoteat">
+    <comment>
+      Copy data from uom field to metric_id field where no value exists in metric_id field
+    </comment>
+    <sql dbms="postgresql">
+      update events
+      set data = jsonb_set(data::jsonb, '{"measurements", 0, "metric_id"}', data -> 'measurements' -> 0 -> 'uom')
+      where data -> 'measurements' -> 0 -> 'metric_id' is null and data -> 'measurements' -> 0 -> 'uom' is not null
+    </sql>
+    <rollback>empty</rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -152,5 +152,6 @@
     <include file="/liquibase/202404121601-add-new-columns-billable-usage-remittance.xml"/>
     <include file="/liquibase/202404240830-update-instance-view-to-aggregate-metrics.xml"/>
     <include file="/liquibase/202404301614-terminate-duplicate-azure-subscriptions.xml"/>
+    <include file="/liquibase/202405080950-copy-uom-to-metric-id-events-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -111,7 +111,7 @@ class MetricUsageCollectorTest {
   @Test
   void testUpdateHostsCreatesAccountServiceInventoryWhenItDoesNotExist() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -141,7 +141,7 @@ class MetricUsageCollectorTest {
   @Test
   void testUpdateHostsCreatesNewInstanceRecords() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -161,6 +161,82 @@ class MetricUsageCollectorTest {
   @Test
   void updateHostsOnlyUpdatesLastSeenAndMeasurementsWhenEventTimestampMostRecent() {
     Measurement coresMeasurement =
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
+    Event event1 =
+        createEvent()
+            .withEventId(UUID.randomUUID())
+            .withProductIds(List.of(RHEL_FOR_X86))
+            .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
+            .withServiceType("RHEL System")
+            .withMeasurements(List.of(coresMeasurement))
+            .withSla(Event.Sla.PREMIUM)
+            .withBillingProvider(Event.BillingProvider.RED_HAT)
+            .withBillingAccountId(Optional.of("sellerAcctId"));
+
+    Measurement oldCoresMeasurement =
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(100.0);
+    Event event2 =
+        createEvent(event1.getInstanceId())
+            .withEventId(UUID.randomUUID())
+            .withProductIds(List.of(RHEL_FOR_X86))
+            .withTimestamp(event1.getTimestamp().minusMonths(1))
+            .withServiceType("RHEL System")
+            .withMeasurements(List.of(oldCoresMeasurement))
+            .withSla(Event.Sla.PREMIUM)
+            .withBillingProvider(Event.BillingProvider.RED_HAT)
+            .withBillingAccountId(Optional.of("sellerAcctId"));
+
+    Measurement instanceHoursMeasurement =
+        new Measurement().withMetricId(MetricIdUtils.getInstanceHours().toString()).withValue(5.0);
+    Event event3 =
+        createEvent(event1.getInstanceId())
+            .withEventId(UUID.randomUUID())
+            .withProductIds(List.of(RHEL_FOR_X86))
+            .withTimestamp(event1.getTimestamp())
+            .withServiceType("RHEL System")
+            .withMeasurements(List.of(instanceHoursMeasurement))
+            .withSla(Event.Sla.PREMIUM)
+            .withBillingProvider(Event.BillingProvider.RED_HAT)
+            .withBillingAccountId(Optional.of("sellerAcctId"));
+
+    OffsetDateTime instanceDate = event1.getTimestamp().minusDays(1);
+    Host activeInstance = new Host();
+    activeInstance.setInstanceId(event1.getInstanceId());
+    activeInstance.setInstanceType(SERVICE_TYPE);
+    activeInstance.setLastSeen(instanceDate);
+
+    doAnswer(invocation -> Stream.of(activeInstance))
+        .when(hostRepository)
+        .findAllByOrgIdAndInstanceIdIn(ORG_ID, Set.of(event1.getInstanceId()));
+
+    // First update should change the date.
+    metricUsageCollector.updateHosts(ORG_ID, SERVICE_TYPE, List.of(event1));
+    assertEquals(event1.getTimestamp(), activeInstance.getLastSeen());
+    assertTrue(activeInstance.getMeasurements().containsKey("CORES"));
+    assertEquals(coresMeasurement.getValue(), activeInstance.getMeasurement("CORES"));
+
+    // Second update should have the Event applied, but the lastSeen date should
+    // not change since this event represents older usage.
+    metricUsageCollector.updateHosts(ORG_ID, SERVICE_TYPE, List.of(event2));
+    assertEquals(event1.getTimestamp(), activeInstance.getLastSeen());
+    assertTrue(activeInstance.getMeasurements().containsKey("CORES"));
+    // Should remain the same as the first event.
+    assertEquals(coresMeasurement.getValue(), activeInstance.getMeasurement("CORES"));
+
+    // Third update should have the third event applied because it's the same timestamp, but
+    // includes
+    // a different measurement.
+    metricUsageCollector.updateHosts(ORG_ID, SERVICE_TYPE, List.of(event3));
+    assertEquals(event1.getTimestamp(), activeInstance.getLastSeen());
+    assertEquals(coresMeasurement.getValue(), activeInstance.getMeasurement("CORES"));
+    assertEquals(
+        instanceHoursMeasurement.getValue(), activeInstance.getMeasurement("INSTANCE_HOURS"));
+  }
+
+  // Redundant test to show that the fallback to UOM is working
+  @Test
+  void updateHostsOnlyUpdatesLastSeenAndMeasurementsWhenEventTimestampMostRecentUOMVersion() {
+    Measurement coresMeasurement =
         new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event1 =
         createEvent()
@@ -174,7 +250,7 @@ class MetricUsageCollectorTest {
             .withBillingAccountId(Optional.of("sellerAcctId"));
 
     Measurement oldCoresMeasurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(100.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(100.0);
     Event event2 =
         createEvent(event1.getInstanceId())
             .withEventId(UUID.randomUUID())
@@ -187,7 +263,7 @@ class MetricUsageCollectorTest {
             .withBillingAccountId(Optional.of("sellerAcctId"));
 
     Measurement instanceHoursMeasurement =
-        new Measurement().withUom(MetricIdUtils.getInstanceHours().toString()).withValue(5.0);
+        new Measurement().withMetricId(MetricIdUtils.getInstanceHours().toString()).withValue(5.0);
     Event event3 =
         createEvent(event1.getInstanceId())
             .withEventId(UUID.randomUUID())
@@ -257,7 +333,7 @@ class MetricUsageCollectorTest {
   void testCollectHandlesAllHardwareTypes(
       Event.HardwareType hardwareType, HardwareMeasurementType expectedType) {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -325,7 +401,7 @@ class MetricUsageCollectorTest {
   void testCalculateUsageHandlesAllCloudProviders(
       Event.CloudProvider cloudProvider, HardwareMeasurementType expectedMeasurementType) {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
 
     // If CloudProvider is __EMPTY__ the hardware type can not be CLOUD.
     HardwareType hardwareType =
@@ -370,7 +446,7 @@ class MetricUsageCollectorTest {
   @Test
   void testUpdateHostsAddsBucketsForApplicableUsageKeys() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -423,7 +499,7 @@ class MetricUsageCollectorTest {
   @Test
   void testCalculateUsageAddsAnySlaToBuckets() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -464,7 +540,7 @@ class MetricUsageCollectorTest {
   @Test
   void testCalculateUsageAddsAnyUsageToBuckets() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -505,7 +581,7 @@ class MetricUsageCollectorTest {
   @Test
   void productsDefinedInRolesAreIncludedInBucketsWhenSetOnEventWhileCalculating() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -551,7 +627,7 @@ class MetricUsageCollectorTest {
   @Test
   void productsAreIncludedInBucketsWhenEngIdIsSetOnEventWhileCalculating() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -611,7 +687,7 @@ class MetricUsageCollectorTest {
   @ParameterizedTest
   @MethodSource("generateDuplicateEventTestData")
   void testHandlesDuplicateEvents(MetricId metricId) {
-    Measurement measurement = new Measurement().withUom(metricId.toString()).withValue(42.0);
+    Measurement measurement = new Measurement().withMetricId(metricId.toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -663,9 +739,9 @@ class MetricUsageCollectorTest {
     OffsetDateTime usageTimestamp = OffsetDateTime.parse("2021-02-26T00:00:00Z");
 
     Measurement coresMeasurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Measurement instanceHoursMeasurement =
-        new Measurement().withUom(MetricIdUtils.getInstanceHours().toString()).withValue(43.0);
+        new Measurement().withMetricId(MetricIdUtils.getInstanceHours().toString()).withValue(43.0);
 
     // Events can have the same timestamp, and will be applied if the
     // record date is different. Order of creation matters for the following
@@ -723,7 +799,7 @@ class MetricUsageCollectorTest {
   @Test
   void testUpdatesMonthlyTotalWhenEventsAreOldButRecordDateIsValid() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     String instanceId = UUID.randomUUID().toString();
     OffsetDateTime eventDate = clock.startOfCurrentHour();
 
@@ -770,7 +846,7 @@ class MetricUsageCollectorTest {
   @Test
   void testHandleMonthlyTotalWhenDuplicateInstanceIDFromHBIAndCost() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     String instanceId = UUID.randomUUID().toString();
     OffsetDateTime eventDate = clock.startOfCurrentHour();
 
@@ -828,7 +904,7 @@ class MetricUsageCollectorTest {
   void testEventWithNullFieldsProcessedDuringUpdateHosts() {
     // NOTE: null in the JSON gets represented as Optional.empty()
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -853,7 +929,7 @@ class MetricUsageCollectorTest {
   @Test
   void testCreateInstanceDefaultBillingProvider() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -874,7 +950,7 @@ class MetricUsageCollectorTest {
   @Test
   void testInstanceHasOrgIdSet() {
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
@@ -911,7 +987,7 @@ class MetricUsageCollectorTest {
     cache.getCalculations().put(eventTimestamp, existingCalc);
 
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event1 =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -952,7 +1028,7 @@ class MetricUsageCollectorTest {
         .thenReturn(Stream.of(snapshot));
 
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(42.0);
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -995,7 +1071,9 @@ class MetricUsageCollectorTest {
     for (var value : Set.of(1, 2)) {
       var billingAccountId = "billingAccount" + value;
       Measurement measurement =
-          new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue((double) value);
+          new Measurement()
+              .withMetricId(MetricIdUtils.getCores().toString())
+              .withValue((double) value);
       Event event =
           createEvent()
               .withEventId(UUID.randomUUID())
@@ -1064,7 +1142,9 @@ class MetricUsageCollectorTest {
   private void assertUsageCalculationForEvent(Event event) {
     double expectedValue = 42.0;
     Measurement measurement =
-        new Measurement().withUom(MetricIdUtils.getCores().toString()).withValue(expectedValue);
+        new Measurement()
+            .withMetricId(MetricIdUtils.getCores().toString())
+            .withValue(expectedValue);
     event.withMeasurements(List.of(measurement));
     AccountUsageCalculationCache cache = new AccountUsageCalculationCache();
     metricUsageCollector.calculateUsage(List.of(event), cache);


### PR DESCRIPTION
Jira issue: SWATCH-431

## Description
In the transition from UOM to exclusively using metric_id, we need to update the event data. Where there is not currently a value for metric_id in the "measurements" block, but there is one for UOM, the data will be copied to the metric_id. 
The data will be left in the UOM field for now. The code has been modified to look for metricId first and then fall back to UOM.  

## Testing

### Setup
1. Start the podman-compose for rhsm-subscriptions while using the main branch.
2. Transfer data from production using ```./import-from-gabi.py --org-id <org_id> --events``` from the swatch-support-scripts directory.
3. Examine the data value json to see that about half of them have uom but not metric_id:
    ```select count(*) from events;```
    ```select count(*) from events where data->'measurements'->0->'uom' = data->'measurements'->0->'metric_id';```

### Steps
1. Check out this branch
2. Run ```./gradle liquibaseUpdate```

### Verification

1. Examine the data values again to see that all data has uom and metric_id:
```select count(*) from events;```
```select count(*) from events where data->'measurements'->0->'uom' = data->'measurements'->0->'metric_id';```

## Note
I imported the events/latest/full_data.csv file from AWS S3 which contains 961,500 records to my local db.
```ChangeSet liquibase/202405080950-copy-uom-to-metric-id-events-table.xml::202405080950-01::wpoteat ran successfully in 15388ms```
