### PR TITLE
SWATCH-2492: Remove use of Azure Tenent Id in the billing account id

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProvider.java
@@ -25,11 +25,8 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response.Status;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Subscription;
@@ -67,19 +64,13 @@ public class UsageContextSubscriptionProvider {
       String billingAccountId,
       OffsetDateTime subscriptionDate) {
 
-    // If billingAccountId is multipart, find all matching first part (ex: azureTenantId)
-    var searchByBillingAccountId = billingAccountId;
-    if (StringUtils.isNotBlank(billingAccountId) && billingAccountId.contains(";")) {
-      searchByBillingAccountId = billingAccountId.split(";")[0];
-    }
-
     UsageCalculation.Key usageKey =
         new Key(
             productId,
             ServiceLevel.fromString(sla),
             Usage.fromString(usage),
             billingProvider,
-            searchByBillingAccountId);
+            billingAccountId);
 
     // Set start date one hour in past to pickup recently terminated subscriptions
     var start = subscriptionDate.minusHours(1);
@@ -87,11 +78,8 @@ public class UsageContextSubscriptionProvider {
         subscriptionSyncController.findSubscriptions(
             Optional.ofNullable(orgId), usageKey, start, subscriptionDate);
 
-    var bestMatchSubscriptions =
-        filterByClosestMatchingMultipartBillingAccountId(subscriptions, billingAccountId);
-
     var existsRecentlyTerminatedSubscription =
-        bestMatchSubscriptions.stream()
+        subscriptions.stream()
             .anyMatch(
                 subscription ->
                     subscription.getEndDate() != null
@@ -99,7 +87,7 @@ public class UsageContextSubscriptionProvider {
 
     // Filter out any terminated subscriptions
     var activeSubscriptions =
-        bestMatchSubscriptions.stream()
+        subscriptions.stream()
             .filter(
                 subscription ->
                     subscription.getEndDate() == null
@@ -107,7 +95,7 @@ public class UsageContextSubscriptionProvider {
                         || subscription.getEndDate().equals(subscriptionDate))
             .toList();
 
-    if (bestMatchSubscriptions.isEmpty()) {
+    if (subscriptions.isEmpty()) {
       missingSubscriptionCounter.increment();
       throw new NotFoundException();
     }
@@ -121,14 +109,6 @@ public class UsageContextSubscriptionProvider {
     }
 
     if (activeSubscriptions.size() > 1) {
-      // If this is a multipart ID, throw an error since correct result could not be determined.
-      if (billingAccountId.contains(";")) {
-        throw new SubscriptionsException(
-            ErrorCode.SUBSCRIPTION_CANNOT_BE_DETERMINED,
-            Status.NOT_FOUND,
-            "Subscription could not be determined. Likely multiple subscriptions exist missing partial billingAccountId information.",
-            "");
-      }
       ambiguousSubscriptionCounter.increment();
       log.warn(
           "Multiple subscriptions found for billing provider {} or for org {} with key {} and product tag {}."
@@ -139,36 +119,5 @@ public class UsageContextSubscriptionProvider {
           usageKey.getProductId());
     }
     return activeSubscriptions.stream().findFirst();
-  }
-
-  // Filter out subscriptions if we have an exact match on a multipart billingAccountId.
-  private List<Subscription> filterByClosestMatchingMultipartBillingAccountId(
-      List<Subscription> subscriptions, String billingAccountId) {
-    if (Objects.nonNull(billingAccountId) && billingAccountId.contains(";")) {
-      var exactMatchingSubscriptions =
-          subscriptions.stream()
-              .filter(
-                  subscription ->
-                      Objects.equals(billingAccountId, subscription.getBillingAccountId()))
-              .collect(Collectors.toList());
-      if (!exactMatchingSubscriptions.isEmpty()) {
-        return exactMatchingSubscriptions;
-      }
-      // If exact billingAccountId doesn't match and there is only one subscription matching the
-      // partial id, return that subscription
-      else {
-        var billingAccountIdPartOne = billingAccountId.split(";")[0];
-        var closestMatch =
-            subscriptions.stream()
-                .filter(
-                    subscription ->
-                        subscription.getBillingAccountId().equals(billingAccountIdPartOne))
-                .collect(Collectors.toList());
-        if (closestMatch.size() == 1) {
-          return closestMatch;
-        }
-      }
-    }
-    return subscriptions;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -47,7 +47,6 @@ import org.candlepin.subscriptions.db.model.EventRecord;
 import org.candlepin.subscriptions.db.model.config.OptInType;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.json.Event;
-import org.candlepin.subscriptions.json.Event.BillingProvider;
 import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.security.OptInController;
 import org.candlepin.subscriptions.util.TransactionHandler;
@@ -255,19 +254,11 @@ public class EventController {
       ensureOptIn(eventToProcess.getOrgId());
     }
 
-    if (BillingProvider.AZURE.equals(eventToProcess.getBillingProvider())) {
-      setAzureBillingAccountId(eventToProcess);
+    Optional<String> azureSubscriptionId = eventToProcess.getAzureSubscriptionId();
+    if (azureSubscriptionId != null && azureSubscriptionId.isPresent()) { // NOSONAR
+      eventToProcess.setBillingAccountId(eventToProcess.getAzureSubscriptionId());
     }
     return Optional.of(eventToProcess);
-  }
-
-  private void setAzureBillingAccountId(Event event) {
-    if (event.getAzureTenantId().isPresent() && event.getAzureSubscriptionId().isPresent()) {
-      String billingAccountId =
-          String.format(
-              "%s;%s", event.getAzureTenantId().get(), event.getAzureSubscriptionId().get());
-      event.setBillingAccountId(Optional.of(billingAccountId));
-    }
   }
 
   public boolean validateServiceInstanceEvent(Event event) {

--- a/src/main/resources/liquibase/202405151547-update-events-azure-billable-account-id.xml
+++ b/src/main/resources/liquibase/202405151547-update-events-azure-billable-account-id.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202405151547-01" author="wpoteat">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="events"/>
+    </preConditions>
+    <comment>
+      Copy data from azure_subscription_id field to billing_account_id field
+    </comment>
+    <sql dbms="postgresql">
+      update events
+      set data = jsonb_set(data::jsonb, '{"billing_account_id"}', data -> 'azure_subscription_id')
+      where jsonb_path_exists(data -> 'billing_provider', '$.** ? (@ == "azure")')
+      and data -> 'azure_subscription_id' is not null
+    </sql>
+    <rollback>empty</rollback>
+  </changeSet>
+  <changeSet id="202405151547-02" author="wpoteat">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="tally_snapshots"/>
+    </preConditions>
+    <comment>
+      Update billing_account_id field for azure billable account change
+    </comment>
+    <sql dbms="postgresql">
+      update tally_snapshots
+      set billing_account_id = regexp_replace(billing_account_id,'.*;(.*)', '\1')
+      where billing_provider='azure'
+    </sql>
+  </changeSet>
+  <changeSet id="202405151547-03" author="wpoteat">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="subscription"/>
+    </preConditions>
+    <comment>
+      Update billing_account_id field for azure billable account change
+    </comment>
+    <sql dbms="postgresql">
+      update subscription
+      set billing_account_id = regexp_replace(billing_account_id,'.*;(.*)', '\1')
+      where billing_provider='azure'
+    </sql>
+    <rollback>empty</rollback>
+  </changeSet>
+  <changeSet id="202405151547-04" author="wpoteat">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="contracts"/>
+    </preConditions>
+    <comment>
+      Update billing_account_id field for azure billable account change
+    </comment>
+    <sql dbms="postgresql">
+      update contracts
+      set billing_account_id = regexp_replace(billing_account_id,'.*;(.*)', '\1')
+      where billing_provider='azure'
+    </sql>
+    <rollback>empty</rollback>
+  </changeSet>
+  <changeSet id="202405151547-05" author="wpoteat">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="billing_usage_remittance"/>
+    </preConditions>
+    <comment>
+      Update billing_account_id field for azure billable account change
+    </comment>
+    <sql dbms="postgresql">
+      update billing_usage_remittance
+      set billing_account_id = regexp_replace(billing_account_id,'.*;(.*)', '\1')
+      where billing_provider='azure'
+    </sql>
+    <rollback>empty</rollback>
+  </changeSet>
+  <changeSet id="202405151547-06" author="wpoteat">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="host_tally_buckets"/>
+    </preConditions>
+    <comment>
+      Update billing_account_id field for azure billing account change
+    </comment>
+    <sql dbms="postgresql">
+      update host_tally_buckets
+      set billing_account_id = regexp_replace(billing_account_id,'.*;(.*)', '\1')
+      where billing_provider='azure'
+    </sql>
+    <rollback>empty</rollback>
+  </changeSet>
+  <changeSet id="202405151547-07" author="wpoteat">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="hosts"/>
+    </preConditions>
+    <comment>
+      Update billing_account_id field for azure billing account change
+    </comment>
+    <sql dbms="postgresql">
+      update hosts
+      set billing_account_id = regexp_replace(billing_account_id,'.*;(.*)', '\1')
+      where billing_provider='azure'
+    </sql>
+    <rollback>empty</rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -155,6 +155,7 @@
     <include file="/liquibase/202404301614-terminate-duplicate-azure-subscriptions.xml"/>
     <include file="/liquibase/202405080950-copy-uom-to-metric-id-events-table.xml"/>
     <include file="/liquibase/202405061230-remove-duplicated-hosts.xml"/>
+    <include file="/liquibase/202405151547-update-events-azure-billable-account-id.xml"/>
     <include file="/liquibase/202405160950-add-subscription-capacity-view.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -346,79 +346,21 @@ class InternalSubscriptionResourceTest {
   }
 
   @Test
-  void shouldThrowSubscriptionsExceptionForAmbiguousAzureBillingAccountId() {
-    Subscription sub1 = new Subscription();
-    sub1.setBillingProviderId("resourceId;planId;offerId");
-    sub1.setBillingAccountId("azureTenantId");
-    sub1.setEndDate(OffsetDateTime.now());
-    Subscription sub2 = new Subscription();
-    sub2.setBillingProviderId("resourceId2;planId;offerId");
-    sub2.setBillingAccountId("azureTenantId");
-    sub2.setEndDate(OffsetDateTime.now());
-    when(syncController.findSubscriptions(any(), any(), any(), any()))
-        .thenReturn(List.of(sub1, sub2));
-
-    var lookupDate = OffsetDateTime.now().minusMinutes(30);
-    var exception =
-        assertThrows(
-            SubscriptionsException.class,
-            () -> {
-              resource.getAzureMarketplaceContext(
-                  lookupDate,
-                  "rosa",
-                  "org123",
-                  "Premium",
-                  "Production",
-                  "azureTenantId;azureSubscriptionId");
-            });
-
-    assertEquals(
-        ErrorCode.SUBSCRIPTION_CANNOT_BE_DETERMINED.getDescription(),
-        exception.getCode().getDescription());
-  }
-
-  @Test
-  void testShouldReturnSubscriptionWithPartialBillingAccountIdMatch() {
-    Subscription sub1 = new Subscription();
-    sub1.setBillingProviderId("resourceId1;planId;offerId");
-    sub1.setBillingAccountId("azureTenantId");
-    sub1.setEndDate(OffsetDateTime.now());
-    Subscription sub2 = new Subscription();
-    sub2.setBillingProviderId("resourceId2;planId;offerId");
-    sub2.setBillingAccountId("azureTenantId;azureSubscriptionId2");
-    sub2.setEndDate(OffsetDateTime.now());
-    when(syncController.findSubscriptions(any(), any(), any(), any()))
-        .thenReturn(List.of(sub1, sub2));
-
-    var lookupDate = OffsetDateTime.now().minusMinutes(30);
-    var azureUsageContext =
-        resource.getAzureMarketplaceContext(
-            lookupDate, "BASILISK", "org123", "Premium", "Production", "azureTenantId");
-    assertEquals("resourceId1", azureUsageContext.getAzureResourceId());
-  }
-
-  @Test
   void testShouldReturnSubscriptionWithExactBillingAccountIdMatch() {
     Subscription sub1 = new Subscription();
     sub1.setBillingProviderId("resourceId1;planId;offerId");
-    sub1.setBillingAccountId("azureTenantId");
+    sub1.setBillingAccountId("azureSubscriptionId1");
     sub1.setEndDate(OffsetDateTime.now());
     Subscription sub2 = new Subscription();
     sub2.setBillingProviderId("resourceId2;planId;offerId");
-    sub2.setBillingAccountId("azureTenantId;azureSubscriptionId2");
+    sub2.setBillingAccountId("azureSubscriptionId2");
     sub2.setEndDate(OffsetDateTime.now());
-    when(syncController.findSubscriptions(any(), any(), any(), any()))
-        .thenReturn(List.of(sub1, sub2));
+    when(syncController.findSubscriptions(any(), any(), any(), any())).thenReturn(List.of(sub2));
 
     var lookupDate = OffsetDateTime.now().minusMinutes(30);
     var azureUsageContext =
         resource.getAzureMarketplaceContext(
-            lookupDate,
-            "BASILISK",
-            "org123",
-            "Premium",
-            "Production",
-            "azureTenantId;azureSubscriptionId2");
+            lookupDate, "BASILISK", "org123", "Premium", "Production", "azureSubscriptionId2");
     assertEquals("resourceId2", azureUsageContext.getAzureResourceId());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -382,9 +382,7 @@ class EventControllerTest {
     verify(eventRecordRepository).saveAll(eventsSaved.capture());
     List<EventRecord> events = eventsSaved.getAllValues().get(0).stream().toList();
     assertEquals(1, events.size());
-    assertEquals(
-        "TestAzureTenantId;TestAzureSubscriptionId",
-        events.get(0).getEvent().getBillingAccountId().get());
+    assertEquals("TestAzureSubscriptionId", events.get(0).getEvent().getBillingAccountId().get());
   }
 
   @Test

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
@@ -104,11 +104,8 @@ public interface ContractEntityMapper {
   default String extractBillingAccountId(PartnerIdentityV1 accountId) {
     if (accountId.getCustomerAwsAccountId() != null) {
       return accountId.getCustomerAwsAccountId();
-    } else if (accountId.getAzureTenantId() != null && accountId.getAzureSubscriptionId() != null) {
-      return String.format(
-          "%s;%s", accountId.getAzureTenantId(), accountId.getAzureSubscriptionId());
-    } else if (accountId.getAzureTenantId() != null) {
-      return accountId.getAzureTenantId();
+    } else if (accountId.getAzureSubscriptionId() != null) {
+      return accountId.getAzureSubscriptionId();
     }
     return null;
   }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
@@ -61,7 +61,6 @@ class AzureContractLifecycleIntegrationTest {
 
   @Inject OfferingRepository offeringRepository;
 
-  static String AZURE_TENANT_ID = "256af912-d792-4dd4-811d-1152375f1f41";
   static String AZURE_CUSTOMER_ID = "azure_customer_id_placeholder";
   static String AZURE_SUBSCRIPTION_ID = "d351b825-7e4b-4bfb-aad3-28441b34b5f1";
   static String AZURE_RESOURCE_ID = "f226c862-dbc3-4f91-b8ed-1eba40dcdc59";
@@ -78,12 +77,11 @@ class AzureContractLifecycleIntegrationTest {
               "azureResourceId":"%s",
               "azureOfferId":"azureOfferId",
               "planId":"vcpu-hours",
-              "azureTenantId":"%s",
               "partner":"azure_marketplace"
             }
           }
           """,
-          AZURE_RESOURCE_ID, AZURE_TENANT_ID);
+          AZURE_RESOURCE_ID);
 
   static String AZURE_PARTNER_API_RESPONSE_CONTRACT_CREATED =
       String.format(
@@ -96,7 +94,6 @@ class AzureContractLifecycleIntegrationTest {
                   "startDate": "2024-01-01T00:00:00.000000Z"
                 },
                 "partnerIdentities": {
-                  "azureTenantId": "%s",
                   "azureCustomerId": "%s"
                 },
                 "purchase": {
@@ -127,7 +124,7 @@ class AzureContractLifecycleIntegrationTest {
             }
           }
           """,
-          AZURE_TENANT_ID, AZURE_CUSTOMER_ID, AZURE_RESOURCE_ID, RH_SUBSCRIPTION_NUMBER);
+          AZURE_CUSTOMER_ID, AZURE_RESOURCE_ID, RH_SUBSCRIPTION_NUMBER);
 
   static String AZURE_UMB_MESSAGE_ORG_ASSOCIATED =
       String.format(
@@ -140,13 +137,12 @@ class AzureContractLifecycleIntegrationTest {
               "azureResourceId":"%s",
               "azureOfferId":"azureOfferId",
               "planId":"vcpu-hours",
-              "azureTenantId":"%s",
               "partner":"azure_marketplace"
             },
             "redHatSubscriptionNumber":"%s"
           }
           """,
-          AZURE_RESOURCE_ID, AZURE_TENANT_ID, RH_SUBSCRIPTION_NUMBER);
+          AZURE_RESOURCE_ID, RH_SUBSCRIPTION_NUMBER);
 
   static String AZURE_PARTNER_API_RESPONSE_SKU_MISSING =
       String.format(
@@ -159,7 +155,6 @@ class AzureContractLifecycleIntegrationTest {
                   "startDate": "2024-01-01T00:00:00.000000Z"
                 },
                 "partnerIdentities": {
-                  "azureTenantId": "%s",
                   "azureCustomerId": "%s"
                 },
                 "purchase": {
@@ -191,7 +186,7 @@ class AzureContractLifecycleIntegrationTest {
             }
           }
           """,
-          AZURE_TENANT_ID, AZURE_CUSTOMER_ID, AZURE_RESOURCE_ID, RH_ORG_ID, RH_SUBSCRIPTION_NUMBER);
+          AZURE_CUSTOMER_ID, AZURE_RESOURCE_ID, RH_ORG_ID, RH_SUBSCRIPTION_NUMBER);
 
   static String AZURE_PARTNER_API_RESPONSE_ORG_ASSOCIATED =
       String.format(
@@ -204,73 +199,7 @@ class AzureContractLifecycleIntegrationTest {
                   "startDate": "2024-01-01T00:00:00.000000Z"
                 },
                 "partnerIdentities": {
-                  "azureTenantId": "%s",
-                  "azureCustomerId": "%s"
-                },
-                "purchase": {
-                  "azureResourceId": "%s",
-                  "contracts": [
-                    {
-                      "endDate": "2030-01-01T00:00:00.000000Z",
-                      "planId": "vcpu-hours",
-                      "startDate": "2024-01-01T00:00:00.000000Z"
-                    }
-                  ],
-                  "vendorProductCode": "azureOfferId"
-                },
-                "rhAccountId": "%s",
-                "rhEntitlements": [
-                  {
-                    "sku": "BASILISK",
-                    "subscriptionNumber": "%s"
-                  }
-                ],
-                "sourcePartner": "azure_marketplace",
-                "status": "SUBSCRIBED"
-              }
-            ],
-            "page": {
-              "size": 0,
-              "totalElements": 0,
-              "totalPages": 0,
-              "number": 0
-            }
-          }
-          """,
-          AZURE_TENANT_ID, AZURE_CUSTOMER_ID, AZURE_RESOURCE_ID, RH_ORG_ID, RH_SUBSCRIPTION_NUMBER);
-
-  static String AZURE_UMB_MESSAGE_AZURE_SUBSCRIPTION_ID_ADDED =
-      String.format(
-          """
-          {
-            "action":"contract-updated",
-            "currentDimensions":[{"dimensionName":"vcpu_hours","dimensionValue":"0"}],
-            "cloudIdentifiers":{
-              "type":"saas",
-              "azureResourceId":"%s",
-              "azureSubscriptionId":"%s",
-              "azureOfferId":"azureOfferId",
-              "planId":"vcpu-hours",
-              "azureTenantId":"%s",
-              "partner":"azure_marketplace"
-            }
-          }
-          """,
-          AZURE_RESOURCE_ID, AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID);
-
-  static String AZURE_PARTNER_API_RESPONSE_AZURE_SUBSCRIPTION_ID_ADDED =
-      String.format(
-          """
-          {
-            "content": [
-              {
-                "entitlementDates": {
-                  "endDate": "2030-01-01T00:00:00.000000Z",
-                  "startDate": "2024-01-01T00:00:00.000000Z"
-                },
-                "partnerIdentities": {
                   "azureSubscriptionId": "%s",
-                  "azureTenantId": "%s",
                   "azureCustomerId": "%s"
                 },
                 "purchase": {
@@ -304,7 +233,74 @@ class AzureContractLifecycleIntegrationTest {
           }
           """,
           AZURE_SUBSCRIPTION_ID,
-          AZURE_TENANT_ID,
+          AZURE_CUSTOMER_ID,
+          AZURE_RESOURCE_ID,
+          RH_ORG_ID,
+          RH_SUBSCRIPTION_NUMBER);
+
+  static String AZURE_UMB_MESSAGE_AZURE_SUBSCRIPTION_ID_ADDED =
+      String.format(
+          """
+          {
+            "action":"contract-updated",
+            "currentDimensions":[{"dimensionName":"vcpu_hours","dimensionValue":"0"}],
+            "cloudIdentifiers":{
+              "type":"saas",
+              "azureResourceId":"%s",
+              "azureSubscriptionId":"%s",
+              "azureOfferId":"azureOfferId",
+              "planId":"vcpu-hours",
+              "partner":"azure_marketplace"
+            }
+          }
+          """,
+          AZURE_RESOURCE_ID, AZURE_SUBSCRIPTION_ID);
+
+  static String AZURE_PARTNER_API_RESPONSE_AZURE_SUBSCRIPTION_ID_ADDED =
+      String.format(
+          """
+          {
+            "content": [
+              {
+                "entitlementDates": {
+                  "endDate": "2030-01-01T00:00:00.000000Z",
+                  "startDate": "2024-01-01T00:00:00.000000Z"
+                },
+                "partnerIdentities": {
+                  "azureSubscriptionId": "%s",
+                  "azureCustomerId": "%s"
+                },
+                "purchase": {
+                  "azureResourceId": "%s",
+                  "contracts": [
+                    {
+                      "endDate": "2030-01-01T00:00:00.000000Z",
+                      "planId": "vcpu-hours",
+                      "startDate": "2024-01-01T00:00:00.000000Z"
+                    }
+                  ],
+                  "vendorProductCode": "azureOfferId"
+                },
+                "rhAccountId": "%s",
+                "rhEntitlements": [
+                  {
+                    "sku": "BASILISK",
+                    "subscriptionNumber": "%s"
+                  }
+                ],
+                "sourcePartner": "azure_marketplace",
+                "status": "SUBSCRIBED"
+              }
+            ],
+            "page": {
+              "size": 0,
+              "totalElements": 0,
+              "totalPages": 0,
+              "number": 0
+            }
+          }
+          """,
+          AZURE_SUBSCRIPTION_ID,
           AZURE_CUSTOMER_ID,
           AZURE_RESOURCE_ID,
           RH_ORG_ID,
@@ -372,12 +368,8 @@ class AzureContractLifecycleIntegrationTest {
     assertEquals(1, subscriptionRepository.count());
     var contract = contractRepository.findAll().stream().findFirst().orElseThrow();
     var subscription = subscriptionRepository.findAll().stream().findFirst().orElseThrow();
-    assertEquals(
-        String.format("%s;%s", AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID),
-        contract.getBillingAccountId());
-    assertEquals(
-        String.format("%s;%s", AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID),
-        subscription.getBillingAccountId());
+    assertEquals(AZURE_SUBSCRIPTION_ID, contract.getBillingAccountId());
+    assertEquals(AZURE_SUBSCRIPTION_ID, subscription.getBillingAccountId());
     assertEquals(
         String.format(
             "%s;%s;%s;%s", AZURE_RESOURCE_ID, "vcpu-hours", "azureOfferId", AZURE_CUSTOMER_ID),

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
@@ -53,7 +53,6 @@ class ContractEntityMapperTest {
     entitlement.getPurchase().addContractsItem(contract);
     entitlement.getPurchase().azureResourceId("azure_resource_id_placeholder");
     entitlement.setPartnerIdentities(new PartnerIdentityV1());
-    entitlement.getPartnerIdentities().azureTenantId("azure_tenant_id_placeholder");
     entitlement.getPartnerIdentities().azureCustomerId("azure_customer_id_placeholder");
     entitlement.sourcePartner(PartnerEntitlementV1.SourcePartnerEnum.AZURE_MARKETPLACE);
     contract.planId("vcpu-hours");

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/WireMockResource.java
@@ -184,7 +184,6 @@ public class WireMockResource
                                                          "sourcePartner": "azure_marketplace",
                                                          "partnerIdentities": {
                                                              "azureSubscriptionId": "fa650050-dedd-4958-b901-d8e5118c0a5f",
-                                                             "azureTenantId": "64dc69e4-d083-49fc-9569-ebece1dd1408",
                                                              "azureCustomerId": "eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31"
                                                          },
                                                          "rhEntitlements": [

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -247,7 +247,6 @@ class ContractServiceTest extends BaseUnitTest {
         new PartnerEntitlementContractCloudIdentifiers()
             .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
-            .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .azureOfferId("azureProductCode")
             .planId("rh-rhel-sub-1yr"));
 
@@ -278,7 +277,6 @@ class ContractServiceTest extends BaseUnitTest {
         new PartnerEntitlementContractCloudIdentifiers()
             .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
-            .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .azureOfferId("azureProductCode")
             .planId("rh-rhel-sub-1yr"));
 
@@ -306,7 +304,6 @@ class ContractServiceTest extends BaseUnitTest {
         new PartnerEntitlementContractCloudIdentifiers()
             .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
-            .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .azureOfferId("azureProductCode")
             .planId("rh-rhel-sub-1yr"));
 
@@ -384,7 +381,6 @@ class ContractServiceTest extends BaseUnitTest {
         new PartnerEntitlementContractCloudIdentifiers()
             .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
-            .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .azureOfferId("azureProductCode")
             .planId("rh-rhel-sub-1yr"));
     return contract;
@@ -496,7 +492,6 @@ class ContractServiceTest extends BaseUnitTest {
             .partnerIdentities(
                 new PartnerIdentityV1()
                     .azureSubscriptionId("fa650050-dedd-4958-b901-d8e5118c0a5f")
-                    .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
                     .azureCustomerId("eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31"))
             .rhEntitlements(List.of(new RhEntitlementV1().sku(SKU).subscriptionNumber("testSubId")))
             .purchase(

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -267,10 +267,9 @@ public class PrometheusMeteringController {
     String billingAccountId;
 
     // extract azure IDs
-    String azureTenantId = labels.get("azure_tenant_id");
     String azureSubscriptionId = labels.get("azure_subscription_id");
-    if (StringUtils.isNotEmpty(azureTenantId) && StringUtils.isNotEmpty(azureSubscriptionId)) {
-      billingAccountId = String.format("%s;%s", azureTenantId, azureSubscriptionId);
+    if (StringUtils.isNotEmpty(azureSubscriptionId)) {
+      billingAccountId = azureSubscriptionId;
     } else {
       billingAccountId = labels.get("billing_marketplace_account");
     }

--- a/swatch-model-events/schemas/event.yaml
+++ b/swatch-model-events/schemas/event.yaml
@@ -179,6 +179,7 @@ properties:
     type: string
     existingJavaType: java.util.Optional<String>
     required: false
+    deprecationMessage: This field is no longer used in billing logic
   azure_resource_id:
     description: The azure resource ID used for billing
     type: string

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
@@ -92,11 +92,7 @@ class BillableUsageConsumerTest {
           BASILISK, STORAGE_GIB_MONTHS, OffsetDateTime.now(Clock.systemUTC()).minusHours(73), 42);
 
   public static final AzureUsageContext MOCK_AZURE_USAGE_CONTEXT =
-      new AzureUsageContext()
-          .azureResourceId("id")
-          .azureTenantId("tenant")
-          .offerId("product")
-          .planId("plan");
+      new AzureUsageContext().azureResourceId("id").offerId("product").planId("plan");
   public static final UsageEventOkResponse USAGE_EVENT_RESPONSE = getDefaultUsageEventResponse();
 
   @InjectMock @RestClient InternalSubscriptionsApi internalSubscriptionsApi;


### PR DESCRIPTION
Jira issue: SWATCH-2492

## Description
The billing account id was a concatenation of the Azure Tenent id and the Azure Subscription id. This was used because the Tenent id was supposed to be immediate while the Subscription id can take as much as 72 hours. The existence of the Tenent id field has been deemed unreliable.

This update only uses the Subscription id for the billing account id field. If no value is available, then the operation is delayed until the value is in place.

## Testing

1. Run swatch-core:
`RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8003 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun`
2. Run swatch-billable-usage:
`SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 KSTREAM_BILLABLE_USAGE_AGGREGATION_WINDOW_DURATION=10s KSTREAM_BILLABLE_USAGE_AGGREGATION_GRACE_DURATION=2s ./gradlew :swatch-billable-usage:quarkusDev`

### Steps
1. Produce Kafka message to service-instance-ingress
`{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "13259775", "event_id": "527e29b6-321c-4021-a1f4-fcff4326af3b", "timestamp": "2024-05-15T19:00:00Z", "event_type": "snapshot", "expiration": "2024-05-15T20:00:00Z", "instance_id": "i-0d8d5297e354051db", "product_ids": ["69", "204"], "event_source": "cost-management", "measurements": [{"uom": "vCPUs", "value": 1.0}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "Azure", "billing_provider": "azure", "azure_subscription_id": "746157280291"}`
3. Execute hourly tally
`http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=13259775&start=2023-10-19T15:00Z&end=2023-10-19T16:00Z" x-rh-swatch-psk:placeholder`

### Verification
1. There will be a row in the events table for the above event.
2. The data field will have "billing_account_id" populated:
`  "cloud_provider": "Azure",
  "billing_provider": "azure",
  "billing_account_id": "746157280291",
  "azure_subscription_id": "746157280291"`
3. The billable_usage_remittance table will show a matching entry
