### PR TITLE
SWATCH-2531 Populate unleash in EEs

### DIFF
--- a/.unleash/Dockerfile.unleash
+++ b/.unleash/Dockerfile.unleash
@@ -1,0 +1,25 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+
+USER root
+
+# Disable all repos except for ubi repos, as ubi repos don't require auth;
+# this makes the container buildable without needing RHEL repos.
+RUN microdnf \
+  --disablerepo=* \
+  --enablerepo=ubi-9-appstream-rpms \
+  --enablerepo=ubi-9-baseos-rpms \
+  install -y jq bash
+
+RUN mkdir /unleash
+
+WORKDIR /opt/unleash
+
+COPY bin/import-features.sh .
+
+# Alternate arrangement if we want the container to be a little more self-contained.  With
+# this set-up user's wouldn't need to know the name of the script or anything; they'd just need to
+# pass in the path of the import file if it differed from the default given with CMD
+# ENTRYPOINT ["/bin/bash", "/opt/unleash/import-features.sh"]
+# CMD ["/unleash/flags.json"]
+
+CMD ["/bin/bash", "/opt/unleash/import-features.sh", "/unleash/flags.json"]

--- a/bin/import-features.sh
+++ b/bin/import-features.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# https://github.com/olivergondza/bash-strict-mode
+set -eEuo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+trap cleanup EXIT
+
+# Note that Unleash will only issue up to a maximum of 10 tokens, so we'll clean up after ourselves
+function cleanup() {
+  # So we don't get a warning about an undefined variable if the trap runs before AUTH_ID is defined
+  AUTH_ID=${AUTH_ID:-}
+  if [ -n "${AUTH_ID}" ]; then
+    curl -v -L -X DELETE "${UNLEASH_URL}/api/admin/user/tokens/${AUTH_ID}" \
+      --header "Authorization: $AUTH_TOKEN"
+  fi
+
+  COOKIE_JAR=${COOKIE_JAR:-}
+  if [ -n "${COOKIE_JAR}" ]; then
+    rm "${COOKIE_JAR}"
+  fi
+}
+
+# Here's how resolution works:
+# * If UNLEASH_HOST is set in the environment, that's the value that's going to be used, period.
+# * If not and the CLOWDER_CONFIG file has featureFlags.hostname, that's the value that will be used
+# * If the CLOWDER_CONFIG file isn't readable or doesn't have featureFlags.hostname, and
+#   UNLEASH_HOST isn't in the environment, default to localhost.
+
+: "${CLOWDER_CONFIG:=/cdapp/cdappconfig.json}"
+if [ -r "${CLOWDER_CONFIG}" ]; then
+  # jq returns "null" instead of the empty string if something isn't there.  We want the empty
+  # string so that later down we can still use parameter substitution to set a default value.  Use
+  # the "//" operator and "empty" operator to effect this.
+  # See https://github.com/jqlang/jq/issues/354#issuecomment-43147898
+  : "${UNLEASH_SCHEME:=$(jq -r '.featureFlags.scheme // empty' "${CLOWDER_CONFIG}")}"
+  : "${UNLEASH_HOST:=$(jq -r '.featureFlags.hostname // empty' "${CLOWDER_CONFIG}")}"
+  : "${UNLEASH_PORT:=$(jq -r '.featureFlags.port // empty' "${CLOWDER_CONFIG}")}"
+fi
+
+: "${UNLEASH_USER:=admin}"
+: "${UNLEASH_PASSWORD:=unleash4all}"
+: "${UNLEASH_SCHEME:=http}"
+: "${UNLEASH_HOST:=localhost}"
+: "${UNLEASH_PORT:=4242}"
+: "${UNLEASH_ADMIN_TOKEN:=}"
+
+UNLEASH_URL="${UNLEASH_SCHEME}://${UNLEASH_HOST}:${UNLEASH_PORT}"
+
+IMPORT_FILE=${1:-}
+if [ -z "$IMPORT_FILE" ]; then
+  echo "Usage: $(basename "$0") JSON_FILE"
+  exit 1
+fi
+
+# Unleash offers multiple types of authentication tokens: admin tokens (deprecated), personal
+# access tokens (PATs), and client tokens.  The tokens we care about are the first two.  The
+# problem is that some APIs require PATs and some do not.  Notably the environment import endpoint
+# /api/admin/features-batch/import (see
+# https://docs.getunleash.io/reference/api/unleash/import-toggles and
+# https://docs.getunleash.io/how-to/how-to-environment-import-export#import) *requires* a PAT.
+#
+# We are using an older, deprecated import API /api/admin/state/import (see
+# https://docs.getunleash.io/reference/api/unleash/import and
+# https://docs.getunleash.io/how-to/how-to-import-export) which accepts admin tokens.  We're
+# using this API since it uses the same JSON format as the start-up import (see
+# https://docs.getunleash.io/how-to/how-to-import-export#startup-import) that we use for the local
+# container during development.
+#
+# The expected flow for using PATs seems to be that tokens are created via the web UI.  This won't
+# work for us since we need the whole process to be automated.  PATs can be created via the
+# /api/admin/user/tokens endpoint, but it requires a session cookie.  We can acquire one of
+# those by logging in at /api/admin/user/tokens. The bad part is it requires a user name and
+# password which are *not* provided via clowder!  Nevertheless, I'm adding the code to login and
+# acquire a PAT for the future case when we need to move off of the deprecated import API.
+
+# See https://stackoverflow.com/a/13864829
+if [ -z "${UNLEASH_ADMIN_TOKEN}" ]; then
+  COOKIE_JAR=$(mktemp -t cookie.XXXXX)
+
+  curl -s -S -c "$COOKIE_JAR" -L "${UNLEASH_URL}/auth/simple/login" \
+    --header "Content-Type: application/json" \
+    --data @- > /dev/null <<EOF
+    {
+    "username": "$UNLEASH_USER",
+    "password": "$UNLEASH_PASSWORD"
+    }
+EOF
+
+  AUTH_JSON=$(curl -s -S -b "$COOKIE_JAR" -L "${UNLEASH_URL}/api/admin/user/tokens" \
+    --header "Content-Type: application/json" \
+    --data @- <<EOF
+    {
+    "description": "Admin PAT $(date +%s.%N)",
+    "expiresAt": "$(date -d '+100 years' --utc +%Y-%m-%dT%H:%M:%S)Z"
+    }
+EOF
+  )
+  AUTH_TOKEN="$(echo $AUTH_JSON | jq -r '.secret')"
+  AUTH_ID="$(echo $AUTH_JSON | jq -r '.id')"
+else
+  AUTH_TOKEN="${UNLEASH_ADMIN_TOKEN}"
+fi
+
+curl -L -X POST "${UNLEASH_URL}/api/admin/state/import" \
+  --header "Content-Type: application/json" \
+  --header "Authorization: ${AUTH_TOKEN}" \
+  --data @"${IMPORT_FILE}"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,3 +83,5 @@ libraries["testcontainers-postgresql"] = 'org.testcontainers:postgresql:1.19.7'
 libraries["kafka-streams-test-utils"] = "org.apache.kafka:kafka-streams-test-utils:3.7.0"
 libraries["slf4j-api"] = "org.slf4j:slf4j-api:2.0.13"
 libraries["snakeyaml"] = "org.yaml:snakeyaml:2.2"
+libraries["unleash-spring-boot-starter"] = "io.getunleash:springboot-unleash-starter:1.1.0"
+libraries["unleash-quarkus"] = "io.quarkiverse.unleash:quarkus-unleash:1.5.0"

--- a/deploy/unleash-import-clowdapp.yaml
+++ b/deploy/unleash-import-clowdapp.yaml
@@ -1,0 +1,199 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: unleash-import
+parameters:
+  - name: IMAGE_PULL_SECRET
+    value: quay-cloudservices-pull
+  - name: ENV_NAME
+    value: env-rhsm
+  # When needed bump UNLEASH_IMPORT_RUN_NUMBER
+  - name: UNLEASH_IMPORT_RUN_NUMBER
+    value: "1"
+  - name: UNLEASH_IMPORT_IMAGE
+    value: quay.io/awood/unleash-import
+  - name: UNLEASH_IMPORT_IMAGE_TAG
+    value: latest
+  - name: UNLEASH_IMPORT_MEMORY_REQUEST
+    value: 500Mi
+  - name: UNLEASH_IMPORT_MEMORY_LIMIT
+    value: 800Mi
+  - name: UNLEASH_IMPORT_CPU_REQUEST
+    value: 350m
+  - name: UNLEASH_IMPORT_CPU_LIMIT
+    value: 500m
+  - name: UNLEASH_USER
+    value: admin
+  - name: UNLEASH_PASSWORD
+    value: unleash4all
+
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    metadata:
+      name: unleash-import
+    spec:
+      envName: ${ENV_NAME}
+      featureFlags: true
+      pullSecrets:
+        name: ${IMAGE_PULL_SECRET}
+
+      jobs:
+        - name: unleash-import-job-${UNLEASH_IMPORT_RUN_NUMBER}
+          activeDeadlineSeconds: 1800
+          successfulJobsHistoryLimit: 1
+          podSpec:
+            image: ${UNLEASH_IMPORT_IMAGE}:${UNLEASH_IMPORT_IMAGE_TAG}
+            command: ["/bin/bash", "-x"]
+            args:
+              - /opt/unleash/import-features.sh
+              - /unleash/flags.json
+            env:
+              - name: UNLEASH_USER
+                value: ${UNLEASH_USER}
+              - name: UNLEASH_PASSWORD
+                value: ${UNLEASH_PASSWORD}
+            resources:
+              requests:
+                cpu: ${UNLEASH_IMPORT_CPU_REQUEST}
+                memory: ${UNLEASH_IMPORT_MEMORY_REQUEST}
+              limits:
+                cpu: ${UNLEASH_IMPORT_CPU_LIMIT}
+                memory: ${UNLEASH_IMPORT_MEMORY_LIMIT}
+            volumeMounts:
+              - name: unleash-json
+                mountPath: /unleash
+            volumes:
+              - name: unleash-json
+                configMap:
+                  name: unleash-json
+
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdJobInvocation
+    metadata:
+      name: unleash-import-${UNLEASH_IMPORT_RUN_NUMBER}
+    spec:
+      appName: unleash-import
+      jobs:
+        - unleash-import-job-${UNLEASH_IMPORT_RUN_NUMBER}
+
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: unleash-json
+    data:
+      flags.json: |-
+        {
+            "version": 1,
+            "features": [
+                {
+                    "name": "hbi.api.disable-xjoin-test",
+                    "description": "A list of org_id for customers allow listed for postgres direct querying.",
+                    "type": "operational",
+                    "project": "default",
+                    "enabled": true,
+                    "stale": false,
+                    "strategies": [
+                        {
+                            "name": "default",
+                            "parameters": {}
+                        }
+                    ],
+                    "variants": [],
+                    "createdAt": "2024-01-09T18:49:38.445Z"
+                },
+                {
+                    "name": "hbi.api.disable-xjoin",
+                    "description": "A list of org_id for customers allow listed for postgres direct querying.",
+                    "type": "operational",
+                    "project": "default",
+                    "enabled": true,
+                    "stale": false,
+                    "strategies": [
+                        {
+                            "name": "default",
+                            "parameters": {}
+                        }
+                    ],
+                    "variants": [],
+                    "createdAt": "2024-01-09T18:49:38.445Z"
+                },
+                {
+                    "name": "hbi.group-assignment-rules",
+                    "description": "If active, newly-created hosts will automatically be assigned to groups based on the account's assignment rules.",
+                    "type": "release",
+                    "project": "default",
+                    "stale": false,
+                    "enabled": true,
+                    "strategies": [
+                        {
+                            "name": "default",
+                            "parameters": {}
+                        }
+                    ],
+                    "variants": [],
+                    "createdAt": "2024-01-10T20:16:35.042Z"
+                },
+                {
+                    "name": "hbi.custom-staleness",
+                    "description": "If active, Custom host staleness/culling features will be enabled in the API and UI",
+                    "type": "release",
+                    "project": "default",
+                    "stale": false,
+                    "enabled": true,
+                    "strategies": [
+                        {
+                            "name": "default",
+                            "parameters": {}
+                        }
+                    ],
+                    "variants": [],
+                    "createdAt": "2024-01-10T20:18:18.842Z"
+                },
+                {
+                    "name": "hbi.api.hide-edge-by-default",
+                    "description": "If this is toggled, the HBI API will hide Edge hosts by default on all requests. If the request has a host-type filter, that is used instead.",
+                    "type": "release",
+                    "project": "default",
+                    "stale": false,
+                    "strategies": [
+                        {
+                            "name": "default",
+                            "parameters": {}
+                        }
+                    ],
+                    "variants": [],
+                    "createdAt": "2024-01-10T20:19:30.848Z"
+                },
+                {
+                    "name": "edgeParity.groups-migration",
+                    "description": "In the context of edge-parity, enables the migrate of edge management groups to insights inventory groups.",
+                    "type": "release",
+                    "project": "default",
+                    "stale": false,
+                    "strategies": [
+                        {
+                            "name": "default",
+                            "parameters": {}
+                        }
+                    ],
+                    "variants": [],
+                    "createdAt": "2024-01-10T20:20:42.531Z"
+                }
+            ],
+            "strategies": [
+                {
+                    "name": "schema-strategy",
+                    "description": "Enablement based on account/schema number",
+                    "parameters": [
+                        {
+                            "name": "schema-name",
+                            "type": "list",
+                            "description": "values must begin with `acct` or `org`",
+                            "required": false
+                        }
+                    ]
+                }
+            ]
+        }


### PR DESCRIPTION
Jira issue: SWATCH-2531

## Description
This PR creates a container that can be deployed in the ephemeral environments to populate an Unleash instance from a JSON file.

## Testing
There are a couple components to this.  One is a shell script that populates an Unleash instance and one is a ClowdApp that creates a job that performs the import in the ephemeral environments.  I'm going to describe the test scenario for the ephemeral environment here but at the end I'll write a little note about running locally.

### Setup
1.  Build the container that runs the import script and push it to quay.io
    ```
    podman build . -f .unleash/Dockerfile.unleash -t quay.io/awood/unleash-import:latest && podman push quay.io/awood/unleash-import:latest
    ```
1. You'll need to go to the quay.io URL for that image and mark the repository visibility as public
![Selection_025](https://github.com/RedHatInsights/rhsm-subscriptions/assets/17975/b7ce749e-9da7-4648-8ba3-2c9a0b8ebf89)
1. You'll need to add `unleash-import` to your Bonfire configuration `~/.config/bonfire/config.yaml`.  Add the following stanza under `-name: rhsm` (but correct the path section to be accurate for your machine)
    ```yaml
     - name: unleash-import
       host: local
       repo: /home/awood/devel/rhsm-subscriptions
       path: /deploy/unleash-import-clowdapp.yaml
       parameters:
        REPLICAS: 1
    ```

### Steps
1. Bring up an ephemeral environment and deploy RHSM to it.  Here is bonfire command that I use.
    ```shell
    bin/build-images.sh ; REPO=$(whoami); VER=$(git rev-parse --short=7 HEAD) ; \                                                                                                                        
    bonfire deploy rhsm \                                                                                                                                                                               
    --source=appsre \                                                                                                                                                                                      
    --ref-env insights-production \                                                                                                                                                                        
    --optional-deps-method none \                                                                                                                                                                          
    --frontends false \                                                                                                                                                                                    
    --no-remove-resources app:rhsm \                                                                                                                                                                       
    --timeout 1800 \                                                                                                                                                                                       
    -i quay.io/${REPO}/swatch-metrics=$VER \                                                                                                                                                               
    -i quay.io/${REPO}/rhsm-subscriptions=$VER \
    -i quay.io/${REPO}/swatch-contracts=$VER \
    -i quay.io/${REPO}/swatch-producer-aws=$VER \
    -i quay.io/${REPO}/swatch-producer-azure=$VER \
    -i quay.io/${REPO}/swatch-system-conduit=$VER \   
    -p swatch-metrics/IMAGE=quay.io/${REPO}/swatch-metrics \
    -p swatch-tally/IMAGE=quay.io/${REPO}/rhsm-subscriptions \
    -p swatch-api/IMAGE=quay.io/${REPO}/rhsm-subscriptions \                                          
    -p swatch-contracts/IMAGE=quay.io/${REPO}/swatch-contracts \
    -p swatch-producer-aws/IMAGE=quay.io/${REPO}/swatch-producer-aws \                                
    -p swatch-producer-azure/IMAGE=quay.io/${REPO}/swatch-producer-azure \
    -p swatch-system-conduit/IMAGE=quay.io/${REPO}/rhsm-subscriptions \                               
    -p swatch-system-conduit/CONDUIT_IMAGE=quay.io/${REPO}/swatch-system-conduit \                    
    -p swatch-producer-red-hat-marketplace/IMAGE=quay.io/${REPO}/rhsm-subscriptions \
    -p swatch-subscription-sync/IMAGE=quay.io/${REPO}/rhsm-subscriptions
    ```
1. Bonfire will automatically deploy and run the job to do the unleash import.    

### Verification
1.  Port-forward the ephemeral Unleash instance 
    ```
    oc port-forward pods/$(oc get pods | cut -d' ' -f1 | grep 'env.*featureflags') 4243:4242
    ```
    and log in on http://localhost:4243 as `admin/unleash4all`
1.  You should see all the flags from `.unleash/flags.json` populated within the instance.
1.  You can also verify that the import job ran by looking at the output from `oc get jobs` and look for the `unleash-import-unleash-import-job-1-...` run.

### Running Locally
1. Bring up the podman compose with `podman-compose up -d`.  If you've already got a compose running, ***make sure you do an export of your database if you want to keep it***.
3. You'll now have an Unleash instance exposed on port 4242 on localhost.
4. You'll need to create some flags to import to Unleash.  We have some flags in `.unleash/flags.json` but those are imported automatically when the container comes up.  Here's a file you can use:
    ```shell
    cat <<EOF > test.json
    {
        "version": 1,
        "features": [
            {
                "name": "testFlag",
                "description": "I am a test flag",
                "type": "operational",
                "project": "default",
                "enabled": true,
                "stale": false,
                "strategies": [
                    {
                        "name": "default",
                        "parameters": {}
                    }
                ],
                "variants": [],
                "createdAt": "2024-01-09T18:49:38.445Z"
            }
        ],
        "strategies": [
            {
                "name": "schema-strategy",
                "description": "Enablement based on account/schema number",
                "parameters": [
                    {
                        "name": "schema-name",
                        "type": "list",
                        "description": "values must begin with `acct` or `org`",
                        "required": false
                    }
                ]
            }
        ]
    }
    EOF
    ```
5. Run the import script:
    ```
    bin/import-features.sh test.json
    ```
6. Log in to the Unleash instance at http://localhost:4242 as "admin/unleash4all".  Click the "Default" project and you should see a flag called "testFlag".
7. You can also try the import using the admin token:
    ```
    UNLEASH_ADMIN_TOKEN='*:*.unleash-insecure-admin-api-token' bin/import-features.sh test.json
    ```
8.  If you run it a second time, it won't actually do anything since the flag is already there, but it will succeed.  You can change the flag name in `test.json` if you want to see it appear.