### PR TITLE
SWATCH-2520: Calculate capacity for all the metrics

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/SubscriptionTableController.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions.resource;
 
+import static org.candlepin.subscriptions.resource.CapacityResource.HYPERVISOR;
+import static org.candlepin.subscriptions.resource.CapacityResource.PHYSICAL;
 import static org.candlepin.subscriptions.resource.ResourceUtils.*;
 
 import com.redhat.swatch.configuration.registry.ProductId;
@@ -377,39 +379,29 @@ public class SubscriptionTableController {
 
     var metric = key.getMetricId();
     var type = key.getMeasurementType();
-
-    var sockets =
-        (SOCKETS.equalsIgnoreCase(metric) && "PHYSICAL".equals(type)) ? value.intValue() : 0;
-    var cores = (CORES.equalsIgnoreCase(metric) && "PHYSICAL".equals(type)) ? value.intValue() : 0;
-
-    var hypervisorSockets =
-        (SOCKETS.equalsIgnoreCase(metric) && "HYPERVISOR".equals(type)) ? value.intValue() : 0;
-    var hypervisorCores =
-        (CORES.equalsIgnoreCase(metric) && "HYPERVISOR".equals(type)) ? value.intValue() : 0;
-
-    if (skuCapacity.getUom() == Uom.SOCKETS || SOCKETS.equals(skuCapacity.getMetricId())) {
-      skuCapacity.setCapacity(skuCapacity.getCapacity() + sockets);
-      skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + hypervisorSockets);
-    } else if (skuCapacity.getUom() == Uom.CORES || CORES.equals(skuCapacity.getMetricId())) {
-      skuCapacity.setCapacity(skuCapacity.getCapacity() + cores);
-      skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + hypervisorCores);
-    } else if (sockets != 0 || hypervisorSockets != 0) {
-      skuCapacity.setCapacity(skuCapacity.getCapacity() + sockets);
-      skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + hypervisorSockets);
-      if (skuCapacity.getUom() == null) {
-        skuCapacity.setUom(Uom.SOCKETS);
-      }
+    // we only initialize the metric for measurements with a value higher than zero.
+    if (value > 0) {
+      // initialize metric ID using the current metric if it's not set
       if (skuCapacity.getMetricId() == null) {
-        skuCapacity.setMetricId(SOCKETS);
+        skuCapacity.setMetricId(metric);
       }
-    } else if (cores != 0 || hypervisorCores != 0) {
-      skuCapacity.setCapacity(skuCapacity.getCapacity() + cores);
-      skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + hypervisorCores);
+      // initialize uom using the current metric if it's not set
       if (skuCapacity.getUom() == null) {
-        skuCapacity.setUom(Uom.CORES);
+        if (SOCKETS.equalsIgnoreCase(metric)) {
+          skuCapacity.setUom(Uom.SOCKETS);
+        } else if (CORES.equalsIgnoreCase(metric)) {
+          skuCapacity.setUom(Uom.CORES);
+        }
       }
-      if (skuCapacity.getMetricId() == null) {
-        skuCapacity.setMetricId(CORES);
+    }
+
+    // accumulate the value
+    if ((skuCapacity.getUom() != null && skuCapacity.getUom().toString().equalsIgnoreCase(metric))
+        || metric.equals(skuCapacity.getMetricId())) {
+      if (PHYSICAL.equals(type)) {
+        skuCapacity.setCapacity(skuCapacity.getCapacity() + value.intValue());
+      } else if (HYPERVISOR.equals(type)) {
+        skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + value.intValue());
       }
     }
 

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -21,7 +21,10 @@
 package org.candlepin.subscriptions.subscription;
 
 import static java.util.Arrays.asList;
+import static org.candlepin.subscriptions.resource.CapacityResource.HYPERVISOR;
+import static org.candlepin.subscriptions.resource.CapacityResource.PHYSICAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -120,6 +123,18 @@ class SubscriptionTableControllerTest {
           ServiceLevel.STANDARD,
           Usage.PRODUCTION,
           false);
+  private static final MeasurementSpec RH0180193_INSTANCE_HOURS =
+      MeasurementSpec.offering(
+              "RH0180193",
+              "RHEL Server",
+              null,
+              null,
+              null,
+              null,
+              ServiceLevel.STANDARD,
+              Usage.PRODUCTION,
+              false)
+          .withMetric(MetricIdUtils.getInstanceHours().toString(), 5);
   private static final MeasurementSpec RH0180194_SOCKETS_AND_CORES =
       MeasurementSpec.offering(
           "RH0180194", "RHEL Server", 2, 2, 2, 2, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
@@ -198,7 +213,7 @@ class SubscriptionTableControllerTest {
     SkuCapacity actualItem = actual.getData().get(0);
     assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU");
     assertEquals(4, actualItem.getQuantity(), "Incorrect quantity");
-    assertCapacities(8, 0, Uom.SOCKETS, actualItem);
+    assertCapacities(8, 0, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
     assertSubscription(expectedSub, actualItem.getSubscriptions().get(0));
     assertEquals(
         SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
@@ -237,7 +252,7 @@ class SubscriptionTableControllerTest {
     assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU");
     assertEquals(
         9, actualItem.getQuantity(), "Item should contain the sum of all subs' quantities");
-    assertCapacities(18, 0, Uom.SOCKETS, actualItem);
+    assertCapacities(18, 0, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
     assertEquals(
         SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
     assertEquals(
@@ -297,7 +312,7 @@ class SubscriptionTableControllerTest {
         5,
         actualItem.getQuantity(),
         "Sub quantity should come from only sub(s) providing the SKU.");
-    assertCapacities(10, 10, Uom.SOCKETS, actualItem);
+    assertCapacities(10, 10, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
     assertSubscription(expectedOlderSub, actualItem.getSubscriptions().get(0));
     assertEquals(
         SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
@@ -310,7 +325,7 @@ class SubscriptionTableControllerTest {
         4,
         actualItem.getQuantity(),
         "Sub quantity should come from only sub(s) providing the SKU.");
-    assertCapacities(8, 0, Uom.SOCKETS, actualItem);
+    assertCapacities(8, 0, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
     assertSubscription(expectedNewerSub, actualItem.getSubscriptions().get(0));
     assertEquals(
         SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
@@ -902,7 +917,7 @@ class SubscriptionTableControllerTest {
     assertEquals(1, actual.getData().size(), "Wrong number of items returned");
     SkuCapacity actualItem = actual.getData().get(0);
     assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU");
-    assertCapacities(0, 8, Uom.SOCKETS, actualItem);
+    assertCapacities(0, 8, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
   }
 
   @Test
@@ -928,7 +943,33 @@ class SubscriptionTableControllerTest {
     assertEquals(1, actual.getData().size(), "Wrong number of items returned");
     SkuCapacity actualItem = actual.getData().get(0);
     assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU");
-    assertCapacities(0, 8, Uom.CORES, actualItem);
+    assertCapacities(0, 8, MetricIdUtils.getCores().toUpperCaseFormatted(), actualItem);
+  }
+
+  @Test
+  void testGetSkuCapacityReportInstanceHours() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a
+    // physical instance hours of 5,
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var spec1 = RH0180193_INSTANCE_HOURS.withSub(expectedSub);
+
+    givenCapacities(Org.STANDARD, productId, spec1);
+    givenSubscriptionsInRepository(expectedSub);
+
+    givenOfferings(spec1);
+
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReport actual =
+        subscriptionTableController.capacityReportBySku(
+            productId, null, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    SkuCapacity actualItem = actual.getData().get(0);
+    assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU");
+    assertCapacities(20, 0, MetricIdUtils.getInstanceHours().toUpperCaseFormatted(), actualItem);
   }
 
   private void givenOfferings(MeasurementSpec... specs) {
@@ -941,8 +982,16 @@ class SubscriptionTableControllerTest {
   }
 
   private static void assertCapacities(
-      int expectedCap, int expectedHypCap, Uom expectedUom, SkuCapacity actual) {
-    assertEquals(expectedUom, actual.getUom(), "Wrong UOM");
+      int expectedCap, int expectedHypCap, String expectedMetricId, SkuCapacity actual) {
+    if (MetricIdUtils.getCores().toString().equalsIgnoreCase(expectedMetricId)) {
+      assertEquals(Uom.CORES, actual.getUom(), "Wrong UOM");
+    } else if (MetricIdUtils.getSockets().toString().equalsIgnoreCase(expectedMetricId)) {
+      assertEquals(Uom.SOCKETS, actual.getUom(), "Wrong UOM");
+    } else {
+      assertNull(actual.getUom());
+    }
+
+    assertEquals(expectedMetricId, actual.getMetricId(), "Wrong Metric ID");
     assertEquals(expectedCap, actual.getCapacity(), "Wrong Standard Capacity");
     assertEquals(expectedHypCap, actual.getHypervisorCapacity(), "Wrong Hypervisor Capacity");
     assertEquals(expectedCap + expectedHypCap, actual.getTotalCapacity(), "Wrong Total Capacity");
@@ -985,6 +1034,7 @@ class SubscriptionTableControllerTest {
     final Integer cores;
     final Integer hypervisorSockets;
     final Integer hypervisorCores;
+    final Map<String, Integer> otherMetrics;
     final ServiceLevel serviceLevel;
     final Usage usage;
     final boolean hasUnlimitedUsage;
@@ -996,6 +1046,7 @@ class SubscriptionTableControllerTest {
         Integer cores,
         Integer hypervisorSockets,
         Integer hypervisorCores,
+        Map<String, Integer> otherMetrics,
         ServiceLevel serviceLevel,
         Usage usage,
         boolean hasUnlimitedUsage,
@@ -1006,10 +1057,16 @@ class SubscriptionTableControllerTest {
       this.cores = cores;
       this.hypervisorSockets = hypervisorSockets;
       this.hypervisorCores = hypervisorCores;
+      this.otherMetrics = otherMetrics;
       this.serviceLevel = serviceLevel;
       this.usage = usage;
       this.hasUnlimitedUsage = hasUnlimitedUsage;
       this.subscription = subscription;
+    }
+
+    public MeasurementSpec withMetric(String metric, Integer value) {
+      otherMetrics.put(metric, value);
+      return this;
     }
 
     /*
@@ -1034,6 +1091,7 @@ class SubscriptionTableControllerTest {
           cores,
           hypervisorSockets,
           hypervisorCores,
+          new HashMap<>(),
           serviceLevel,
           usage,
           hasUnlimitedUsage,
@@ -1053,6 +1111,7 @@ class SubscriptionTableControllerTest {
           cores,
           hypervisorSockets,
           hypervisorCores,
+          otherMetrics,
           serviceLevel,
           usage,
           hasUnlimitedUsage,
@@ -1090,15 +1149,20 @@ class SubscriptionTableControllerTest {
       var socketsMetric = MetricId.fromString("Sockets");
 
       var measurements = new HashMap<SubscriptionMeasurementKey, Double>();
+      measurements.putAll(buildMeasurement(PHYSICAL, coresMetric, totalCapacity(cores, quantity)));
       measurements.putAll(
-          buildMeasurement("PHYSICAL", coresMetric, totalCapacity(cores, quantity)));
+          buildMeasurement(PHYSICAL, socketsMetric, totalCapacity(sockets, quantity)));
       measurements.putAll(
-          buildMeasurement("PHYSICAL", socketsMetric, totalCapacity(sockets, quantity)));
+          buildMeasurement(HYPERVISOR, coresMetric, totalCapacity(hypervisorCores, quantity)));
       measurements.putAll(
-          buildMeasurement("HYPERVISOR", coresMetric, totalCapacity(hypervisorCores, quantity)));
-      measurements.putAll(
-          buildMeasurement(
-              "HYPERVISOR", socketsMetric, totalCapacity(hypervisorSockets, quantity)));
+          buildMeasurement(HYPERVISOR, socketsMetric, totalCapacity(hypervisorSockets, quantity)));
+      for (Map.Entry<String, Integer> otherMetric : otherMetrics.entrySet()) {
+        measurements.putAll(
+            buildMeasurement(
+                PHYSICAL,
+                MetricId.fromString(otherMetric.getKey()),
+                totalCapacity(otherMetric.getValue(), quantity)));
+      }
 
       var productIds = new HashSet<>(subscription.getSubscriptionProductIds());
       productIds.add(productId.toString());


### PR DESCRIPTION
Jira issue: SWATCH-2520

## Description
Before, the capacity and total capacity was only calculated for cores and sockets.

## Testing

### Steps
1. podman-compose up
2. start service `DEV_MODE=true ./gradlew :bootRun`
3. insert test data:

```
INSERT INTO public.offering VALUES ('MW01486', 'rosa', 'OpenShift Enterprise', NULL, NULL, NULL, NULL, NULL, 'Premium', '', 'Red Hat OpenShift Container Platform (Hourly)', false, NULL, false);
INSERT INTO public.sku_product_tag VALUES ('MW01486', 'rosa');
INSERT INTO public.subscription VALUES ('MW01486', 'org123', '957592', 1, '2024-02-26 00:20:46.986+00', '2025-03-07 00:20:46.986+00', 'testProductCode;testbyf;1234567', '4454946', 'azure', 'testbyf');
insert into public.subscription_product_ids values ('rosa','957592','2024-02-26 01:20:46.986 +0100');
INSERT INTO public.subscription_measurements VALUES ('957592', '2024-02-26 00:20:46.986+00', 'Instance-hours', 'PHYSICAL', 10);
INSERT INTO public.subscription_measurements VALUES ('957592', '2024-02-26 00:20:46.986+00', 'Cores', 'PHYSICAL', 20);
```

4. run the opt-in: 

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo='
```

5. verify the capacity for Instance Hours is 10:
```
curl -X GET "http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/rosa?metric_id=Instance-hours"       -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' | jq
```

It should return:

```json
{
  "data": [
    {
      "sku": "MW01486",
      "product_name": "Red Hat OpenShift Container Platform (Hourly)",
      "service_level": "Premium",
      "usage": "",
      "subscriptions": [
        {
          "id": "957592",
          "number": "4454946"
        }
      ],
      "billing_provider": "azure",
      "next_event_date": "2025-03-07T00:20:46.986Z",
      "next_event_type": "Subscription End",
      "quantity": 1,
      "capacity": 10,
      "hypervisor_capacity": 0,
      "total_capacity": 10,
      "has_infinite_quantity": false,
      "metric_id": "Instance-hours"
    }
  ],
  "meta": {
    "count": 1,
    "product": "rosa",
    "subscription_type": "On-demand"
  }
}
```

6. verify the capacity for Cores is 20:
```
curl -X GET "http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/rosa?metric_id=Cores"       -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=' | jq
```

It should return:

```json
{
  "data": [
    {
      "sku": "MW01486",
      "product_name": "Red Hat OpenShift Container Platform (Hourly)",
      "service_level": "Premium",
      "usage": "",
      "subscriptions": [
        {
          "id": "957592",
          "number": "4454946"
        }
      ],
      "billing_provider": "azure",
      "next_event_date": "2025-03-07T00:20:46.986Z",
      "next_event_type": "Subscription End",
      "quantity": 1,
      "capacity": 20,
      "hypervisor_capacity": 0,
      "total_capacity": 20,
      "has_infinite_quantity": false,
      "uom": "cores",
      "metric_id": "Cores"
    }
  ],
  "meta": {
    "count": 1,
    "product": "rosa",
    "subscription_type": "On-demand"
  }
}
```

Note that if the metric_id is not provided, it will use the metric of the first found measurement record. 