### PR TITLE
SWATCH-2542: Port the process remittance cronjob to the billable usage

### DIFF
--- a/src/main/spec/internal-billing-api-spec.yaml
+++ b/src/main/spec/internal-billing-api-spec.yaml
@@ -130,30 +130,6 @@ paths:
           $ref: "../../../spec/error-responses.yaml#/$defs/Forbidden"
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
-  /internal/rpc/remittance/processRetries:
-    post:
-      operationId: processRetries
-      summary: Trigger retry of reprocessing billable usages
-      description: Reprocess billable usages with as_of parameter AFTER billable_usage_remittance.retry_after column.
-      parameters:
-        - examples:
-            this_century:
-              value: 2000-01-01T00:00Z
-          name: as_of
-          description: Defaults to current timestamp if left empty
-          schema:
-            format: date-time
-            type: string
-          in: query
-          required: false
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DefaultResponse"
-          description: Accepted request to retry billable usage remittance
-      tags: ['internalBilling']
   /internal-billing-openapi.json:
     $ref: "../../../spec/openapi-paths.yaml#/openapi-json"
   /internal-billing-openapi.yaml:

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -63,6 +63,8 @@ parameters:
     value: '@hourly'
   - name: PURGE_REMITTANCE_SCHEDULE
     value: 0 3 * * *
+  - name: RETRY_REMITTANCE_SCHEDULE
+    value: '@hourly'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -231,6 +233,32 @@ objects:
             limits:
               cpu: ${CURL_CRON_CPU_LIMIT}
               memory: ${CURL_CRON_MEMORY_LIMIT}
+
+      - name: retry-remittances
+        schedule: ${RETRY_REMITTANCE_SCHEDULE}
+        activeDeadlineSeconds: 1800
+        successfulJobsHistoryLimit: 2
+        restartPolicy: Never
+        podSpec:
+          image: ${CURL_CRON_IMAGE}:${CURL_CRON_IMAGE_TAG}
+          command:
+            - /usr/bin/bash
+            - -c
+            - >
+              /usr/bin/curl --fail -H "Origin: https://swatch-bilable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/remittance/processRetries"
+          env:
+            - name: SWATCH_SELF_PSK
+              valueFrom:
+                secretKeyRef:
+                  name: swatch-psks
+                  key: self
+        resources:
+          requests:
+            cpu: ${CURL_CRON_CPU_REQUEST}
+            memory: ${CURL_CRON_MEMORY_REQUEST}
+          limits:
+            cpu: ${CURL_CRON_CPU_LIMIT}
+            memory: ${CURL_CRON_MEMORY_LIMIT}
 
 - apiVersion: v1
   kind: Secret

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -193,7 +193,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-bilable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/topics/flush"
+              /usr/bin/curl --fail -H "Origin: https://swatch-billable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/topics/flush"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:
@@ -219,7 +219,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-bilable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/remittance/purge"
+              /usr/bin/curl --fail -H "Origin: https://swatch-billable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/remittance/purge"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:
@@ -245,7 +245,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-bilable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/remittance/processRetries"
+              /usr/bin/curl --fail -H "Origin: https://swatch-billable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/remittance/processRetries"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
@@ -24,11 +24,16 @@ import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @ApplicationScoped
 public class BillableUsageRemittanceRepository
     implements PanacheRepositoryBase<BillableUsageRemittanceEntity, UUID> {
+
+  public List<BillableUsageRemittanceEntity> findByRetryAfterLessThan(OffsetDateTime asOf) {
+    return find("retryAfter < ?1", asOf).list();
+  }
 
   public void deleteAllByOrgIdAndRemittancePendingDateBefore(
       String orgId, OffsetDateTime cutoffDate) {

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillingProducer.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillingProducer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.billable.usage.services;
+
+import static com.redhat.swatch.billable.usage.configuration.Channels.BILLABLE_USAGE_OUT;
+
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+/**
+ * Component that produces BillableUsage messages based on TallySnapshots.
+ *
+ * <p>NOTE: We are currently just forwarding TallySummary messages, but will transition to sending
+ * BillableUsage.
+ */
+@Slf4j
+@ApplicationScoped
+public class BillingProducer {
+
+  private final MutinyEmitter<BillableUsage> emitter;
+
+  public BillingProducer(@Channel(BILLABLE_USAGE_OUT) MutinyEmitter<BillableUsage> emitter) {
+    this.emitter = emitter;
+  }
+
+  public void produce(BillableUsage usage) {
+    if (usage == null) {
+      log.debug("Skipping billable usage; see previous errors/warnings.");
+      return;
+    }
+    emitter.sendAndAwait(usage);
+  }
+}

--- a/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
@@ -61,6 +61,30 @@ paths:
           $ref: "../../../../../spec/error-responses.yaml#/$defs/Unauthorized"
         '500':
           $ref: "../../../../../spec/error-responses.yaml#/$defs/InternalServerError"
+
+  /api/swatch-billable-usage/internal/rpc/remittance/processRetries:
+    post:
+      operationId: processRetries
+      summary: Trigger retry of reprocessing billable usages
+      description: Reprocess billable usages with as_of parameter AFTER billable_usage_remittance.retry_after column.
+      parameters:
+        - examples:
+            this_century:
+              value: 2000-01-01T00:00Z
+          name: as_of
+          description: Defaults to current timestamp if left empty
+          schema:
+            format: date-time
+            type: string
+          in: query
+          required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultResponse"
+          description: Accepted request to retry billable usage remittance
 components:
   schemas:
     Error:

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -103,6 +103,10 @@ kafka-streams.commit.interval.ms=1000
 kafka-streams.metadata.max.age.ms=500
 kafka-streams.auto.offset.reset=latest
 
+mp.messaging.outgoing.billable-usage-out.connector=smallrye-kafka
+mp.messaging.outgoing.billable-usage-out.topic=${BILLABLE_USAGE_TOPIC}
+mp.messaging.outgoing.billable-usage-out.value.serializer=org.candlepin.subscriptions.billable.usage.BillableUsageSerializer
+
 mp.messaging.outgoing.billable-usage-aggregation-repartition-out.connector=smallrye-kafka
 mp.messaging.outgoing.billable-usage-aggregation-repartition-out.topic=platform.rhsm-subscriptions.swatch-billable-usage-aggregator-billable-usage-store-repartition
 mp.messaging.outgoing.billable-usage-aggregation-repartition-out.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/kafka/InMemoryMessageBrokerKafkaResource.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/kafka/InMemoryMessageBrokerKafkaResource.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.billable.usage.kafka;
 
 import static com.redhat.swatch.billable.usage.configuration.Channels.BILLABLE_USAGE_AGGREGATION_OUT;
+import static com.redhat.swatch.billable.usage.configuration.Channels.BILLABLE_USAGE_OUT;
 import static com.redhat.swatch.billable.usage.configuration.Channels.ENABLED_ORGS;
 import static com.redhat.swatch.billable.usage.configuration.Channels.REMITTANCES_PURGE_TASK;
 
@@ -37,6 +38,7 @@ public class InMemoryMessageBrokerKafkaResource implements QuarkusTestResourceLi
     env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory(ENABLED_ORGS));
     env.putAll(InMemoryConnector.switchIncomingChannelsToInMemory(REMITTANCES_PURGE_TASK));
     env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory(BILLABLE_USAGE_AGGREGATION_OUT));
+    env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory(BILLABLE_USAGE_OUT));
     return env;
   }
 

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillingProducerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillingProducerTest.java
@@ -18,15 +18,27 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.billable.usage.configuration;
+package com.redhat.swatch.billable.usage.services;
 
-public final class Channels {
+import static org.mockito.Mockito.verify;
 
-  public static final String ENABLED_ORGS = "enabled-orgs";
-  public static final String REMITTANCES_PURGE_TASK = "remittances-purge-task";
-  public static final String BILLABLE_USAGE_OUT = "billable-usage-out";
-  public static final String BILLABLE_USAGE_AGGREGATION_OUT =
-      "billable-usage-aggregation-repartition-out";
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-  private Channels() {}
+@ExtendWith(MockitoExtension.class)
+class BillingProducerTest {
+  @Mock MutinyEmitter<BillableUsage> emitter;
+  @InjectMocks BillingProducer producer;
+
+  @Test
+  void testBillableUsageIsSentToTopic() {
+    BillableUsage usage = new BillableUsage();
+    producer.produce(usage);
+    verify(emitter).sendAndAwait(usage);
+  }
 }

--- a/swatch-model-billable-usage/src/main/java/org/candlepin/subscriptions/billable/usage/AccumulationPeriodFormatter.java
+++ b/swatch-model-billable-usage/src/main/java/org/candlepin/subscriptions/billable/usage/AccumulationPeriodFormatter.java
@@ -18,15 +18,18 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.billable.usage.configuration;
+package org.candlepin.subscriptions.billable.usage;
 
-public final class Channels {
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 
-  public static final String ENABLED_ORGS = "enabled-orgs";
-  public static final String REMITTANCES_PURGE_TASK = "remittances-purge-task";
-  public static final String BILLABLE_USAGE_OUT = "billable-usage-out";
-  public static final String BILLABLE_USAGE_AGGREGATION_OUT =
-      "billable-usage-aggregation-repartition-out";
+public final class AccumulationPeriodFormatter {
+  private static final DateTimeFormatter MONTH_ID_FORMATTER =
+      DateTimeFormatter.ofPattern("uuuu-MM");
 
-  private Channels() {}
+  private AccumulationPeriodFormatter() {}
+
+  public static String toMonthId(OffsetDateTime reference) {
+    return reference.format(MONTH_ID_FORMATTER);
+  }
 }

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -96,8 +96,6 @@ parameters:
     value: 30h
   - name: PURGE_SNAPSHOT_SCHEDULE
     value: 0 3 * * *
-  - name: RETRY_REMITTANCE_SCHEDULE
-    value: '@hourly'
   - name: CAPTURE_SNAPSHOT_SCHEDULE
     value: 0 6 * * *
   - name: CAPTURE_HOURLY_SNAPSHOT_SCHEDULE
@@ -612,31 +610,7 @@ objects:
             cpu: ${CURL_CRON_CPU_LIMIT}
             memory: ${CURL_CRON_MEMORY_LIMIT}
 
-      - name: retry-remittances
-        schedule: ${RETRY_REMITTANCE_SCHEDULE}
-        activeDeadlineSeconds: 1800
-        successfulJobsHistoryLimit: 2
-        restartPolicy: Never
-        podSpec:
-          image: ${CURL_CRON_IMAGE}:${CURL_CRON_IMAGE_TAG}
-          command:
-            - /usr/bin/bash
-            - -c
-            - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/remittance/processRetries"
-          env:
-            - name: SWATCH_SELF_PSK
-              valueFrom:
-                secretKeyRef:
-                  name: swatch-psks
-                  key: self
-        resources:
-          requests:
-            cpu: ${CURL_CRON_CPU_REQUEST}
-            memory: ${CURL_CRON_MEMORY_REQUEST}
-          limits:
-            cpu: ${CURL_CRON_CPU_LIMIT}
-            memory: ${CURL_CRON_MEMORY_LIMIT}
+
 
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp


### PR DESCRIPTION
Jira issue: SWATCH-2542

## Description
- Moved the process remittance cronjob to the billable usage service
- API changes: 

| Old | New  |
|---|---|
|http://swatch-tally-service:8000/api/rhsm-subscriptions/v1/internal/rpc/remittance/processRetries | http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/remittance/processRetries |

## Testing

You need first to deploy the billable usage and the tally services into an EE environment:
```
bonfire deploy ...
```

1.- update the "swatch-billable-usage-retry-remittances" cronjob with:
```
spec:
  schedule: '* * * * *'
```

This will run the job every minute. 

2.- wait for the job to be triggered (up to 1 min). See jobs in `https://<OCP>/k8s/ns/ephemeral-xciphz/cronjobs/
swatch-billable-usage-retry-remittances/jobs`

3.- the pod should see that the HTTP call finished successfully.