### PR TITLE
SWATCH-2518: Create subscription capacity view for the export service

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/export/CsvExportFileWriter.java
+++ b/src/main/java/org/candlepin/subscriptions/export/CsvExportFileWriter.java
@@ -54,6 +54,7 @@ public class CsvExportFileWriter implements ExportFileWriter {
                   handleIOException(item, request, e);
                 }
               });
+      writer.close();
     } catch (IOException e) {
       log.error("Error writing the CSV payload for request {}", request.getExportRequestUUID(), e);
       throw new ExportServiceException(

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionDataExporterService.java
@@ -20,62 +20,72 @@
  */
 package org.candlepin.subscriptions.subscription.export;
 
+import static org.candlepin.subscriptions.resource.ResourceUtils.ANY;
+
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.ProductId;
-import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.BiConsumer;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.db.HypervisorReportCategory;
-import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
-import org.candlepin.subscriptions.db.model.DbReportCriteria;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
-import org.candlepin.subscriptions.db.model.Subscription;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacityView;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacityViewMetric;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacityView_;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.ExportServiceException;
 import org.candlepin.subscriptions.export.DataExporterService;
 import org.candlepin.subscriptions.export.DataMapperService;
 import org.candlepin.subscriptions.export.ExportServiceRequest;
+import org.candlepin.subscriptions.json.SubscriptionsExportJsonMeasurement;
 import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @Profile("capacity-ingress")
 @AllArgsConstructor
-public class SubscriptionDataExporterService implements DataExporterService<Subscription> {
+public class SubscriptionDataExporterService
+    implements DataExporterService<SubscriptionCapacityView> {
   static final String SUBSCRIPTIONS_DATA = "subscriptions";
   static final String PRODUCT_ID = "product_id";
-  private static final Map<String, BiConsumer<DbReportCriteria.DbReportCriteriaBuilder, String>>
+  static final String METRIC_ID = "metric_id";
+  static final String CATEGORY = "category";
+  static final String PHYSICAL = "PHYSICAL";
+  static final String HYPERVISOR = "HYPERVISOR";
+  private static final Map<String, Function<String, Specification<SubscriptionCapacityView>>>
       FILTERS =
           Map.of(
               PRODUCT_ID,
               SubscriptionDataExporterService::handleProductIdFilter,
               "usage",
               SubscriptionDataExporterService::handleUsageFilter,
-              "category",
+              CATEGORY,
               SubscriptionDataExporterService::handleCategoryFilter,
               "sla",
               SubscriptionDataExporterService::handleSlaFilter,
-              "metric_id",
+              METRIC_ID,
               SubscriptionDataExporterService::handleMetricIdFilter,
               "billing_provider",
               SubscriptionDataExporterService::handleBillingProviderFilter,
               "billing_account_id",
               SubscriptionDataExporterService::handleBillingAccountIdFilter);
 
-  private final SubscriptionRepository subscriptionRepository;
+  private final SubscriptionCapacityViewRepository repository;
   private final SubscriptionJsonDataMapperService jsonDataMapperService;
   private final SubscriptionCsvDataMapperService csvDataMapperService;
-  private final ApplicationClock clock;
 
   @Override
   public boolean handles(ExportServiceRequest request) {
@@ -83,26 +93,22 @@ public class SubscriptionDataExporterService implements DataExporterService<Subs
   }
 
   @Override
-  public Stream<Subscription> fetchData(ExportServiceRequest request) {
+  public Stream<SubscriptionCapacityView> fetchData(ExportServiceRequest request) {
     log.debug("Fetching data for {}", request.getOrgId());
-    var reportCriteria = extractExportFilter(request);
-    return subscriptionRepository.streamBy(reportCriteria);
+    return repository.streamBy(extractExportFilter(request));
   }
 
   @Override
-  public DataMapperService<Subscription> getMapper(ExportServiceRequest request) {
+  public DataMapperService<SubscriptionCapacityView> getMapper(ExportServiceRequest request) {
     return switch (request.getFormat()) {
       case JSON -> jsonDataMapperService;
       case CSV -> csvDataMapperService;
     };
   }
 
-  private DbReportCriteria extractExportFilter(ExportServiceRequest request) {
-    var report =
-        DbReportCriteria.builder()
-            .orgId(request.getOrgId())
-            .beginning(clock.now())
-            .ending(clock.now());
+  private Specification<SubscriptionCapacityView> extractExportFilter(
+      ExportServiceRequest request) {
+    Specification<SubscriptionCapacityView> criteria = Specification.where(null);
     if (request.getFilters() != null) {
       var filters = request.getFilters().entrySet();
       try {
@@ -111,7 +117,10 @@ public class SubscriptionDataExporterService implements DataExporterService<Subs
           if (filterHandler == null) {
             log.warn("Filter '{}' isn't currently supported. Ignoring.", entry.getKey());
           } else if (entry.getValue() != null) {
-            filterHandler.accept(report, entry.getValue().toString());
+            var condition = filterHandler.apply(entry.getValue().toString());
+            if (condition != null) {
+              criteria = criteria.and(condition);
+            }
           }
         }
 
@@ -122,63 +131,165 @@ public class SubscriptionDataExporterService implements DataExporterService<Subs
       }
     }
 
-    return report.build();
+    return criteria;
   }
 
-  private static void handleProductIdFilter(
-      DbReportCriteria.DbReportCriteriaBuilder builder, String value) {
+  private static Specification<SubscriptionCapacityView> handleProductIdFilter(String value) {
     var productId = ProductId.fromString(value).getValue();
-    if (SubscriptionDefinition.isPrometheusEnabled(productId)) {
-      builder.productTag(productId);
-    } else {
-      builder.productId(productId);
-    }
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.productTag), productId);
   }
 
-  private static void handleUsageFilter(
-      DbReportCriteria.DbReportCriteriaBuilder builder, String value) {
+  private static Specification<SubscriptionCapacityView> handleUsageFilter(String value) {
     Usage usage = Usage.fromString(value);
     if (value.equalsIgnoreCase(usage.getValue())) {
-      builder.usage(usage);
+      if (!Usage._ANY.equals(usage)) {
+        return (root, query, builder) ->
+            builder.equal(root.get(SubscriptionCapacityView_.usage), usage.getValue());
+      }
     } else {
       throw new IllegalArgumentException(String.format("usage: %s not supported", value));
     }
+
+    return null;
   }
 
-  private static void handleCategoryFilter(
-      DbReportCriteria.DbReportCriteriaBuilder builder, String value) {
-    builder.hypervisorReportCategory(
-        HypervisorReportCategory.mapCategory(ReportCategory.fromString(value)));
+  private static Specification<SubscriptionCapacityView> handleCategoryFilter(String value) {
+    String measurementType = getMeasurementTypeFromCategory(value);
+    if (measurementType != null) {
+      return (root, query, builder) ->
+          builder.like(
+              builder.upper(builder.function("jsonb_pretty", String.class, root.get("metrics"))),
+              "%" + measurementType.toUpperCase(Locale.ROOT) + "%");
+    }
+
+    return null;
   }
 
-  private static void handleSlaFilter(
-      DbReportCriteria.DbReportCriteriaBuilder builder, String value) {
+  private static Specification<SubscriptionCapacityView> handleSlaFilter(String value) {
     ServiceLevel serviceLevel = ServiceLevel.fromString(value);
     if (value.equalsIgnoreCase(serviceLevel.getValue())) {
-      builder.serviceLevel(serviceLevel);
+      if (!ServiceLevel._ANY.equals(serviceLevel)) {
+        return (root, query, builder) ->
+            builder.equal(
+                root.get(SubscriptionCapacityView_.serviceLevel), serviceLevel.getValue());
+      }
     } else {
       throw new IllegalArgumentException(String.format("sla: %s not supported", value));
     }
+
+    return null;
   }
 
-  private static void handleMetricIdFilter(
-      DbReportCriteria.DbReportCriteriaBuilder builder, String value) {
-    builder.metricId(MetricId.fromString(value).toString());
+  private static Specification<SubscriptionCapacityView> handleMetricIdFilter(String value) {
+    String metricId = MetricId.fromString(value).toUpperCaseFormatted();
+    return (root, query, builder) ->
+        builder.like(
+            builder.upper(builder.function("jsonb_pretty", String.class, root.get("metrics"))),
+            "%" + metricId + "%");
   }
 
-  private static void handleBillingProviderFilter(
-      DbReportCriteria.DbReportCriteriaBuilder builder, String value) {
+  private static Specification<SubscriptionCapacityView> handleBillingProviderFilter(String value) {
     BillingProvider billingProvider = BillingProvider.fromString(value);
     if (value.equalsIgnoreCase(billingProvider.getValue())) {
-      builder.billingProvider(billingProvider);
+      if (!BillingProvider._ANY.equals(billingProvider)) {
+        return (root, query, builder) ->
+            builder.equal(root.get(SubscriptionCapacityView_.billingProvider), billingProvider);
+      }
     } else {
       throw new IllegalArgumentException(
           String.format("billing_provider: %s not supported", value));
     }
+
+    return null;
   }
 
-  private static void handleBillingAccountIdFilter(
-      DbReportCriteria.DbReportCriteriaBuilder builder, String value) {
-    builder.billingAccountId(value);
+  private static Specification<SubscriptionCapacityView> handleBillingAccountIdFilter(
+      String value) {
+    if (!ANY.equalsIgnoreCase(value)) {
+      return (root, query, builder) ->
+          builder.like(root.get(SubscriptionCapacityView_.billingAccountId), value + "%");
+    }
+
+    return null;
+  }
+
+  protected static List<SubscriptionsExportJsonMeasurement> groupMetrics(
+      SubscriptionCapacityView dataItem, ExportServiceRequest request) {
+    List<SubscriptionsExportJsonMeasurement> metrics = new ArrayList<>();
+
+    // metric filters: metric_id and measurement_type
+    String filterByMetricId = getMetricIdFilter(request);
+    String filterByMeasurementType = getMeasurementTypeFilter(request);
+
+    for (var metric : dataItem.getMetrics()) {
+      if (metric.getMetricId() != null
+          && isFilterByMetricId(metric, filterByMetricId)
+          && isFilterByMeasurementType(metric, filterByMeasurementType)) {
+        var measurement = getOrCreateMeasurement(metrics, metric);
+        measurement.setCapacity(measurement.getCapacity() + metric.getCapacity());
+      }
+    }
+
+    return metrics;
+  }
+
+  private static boolean isFilterByMetricId(SubscriptionCapacityViewMetric metric, String filter) {
+    return filter == null || filter.equalsIgnoreCase(metric.getMetricId());
+  }
+
+  private static boolean isFilterByMeasurementType(
+      SubscriptionCapacityViewMetric metric, String filter) {
+    return filter == null || filter.equalsIgnoreCase(metric.getMeasurementType());
+  }
+
+  private static String getMetricIdFilter(ExportServiceRequest request) {
+    if (request == null || request.getFilters() == null) {
+      return null;
+    }
+
+    return Optional.ofNullable(request.getFilters().get(METRIC_ID))
+        .map(String.class::cast)
+        .orElse(null);
+  }
+
+  private static String getMeasurementTypeFilter(ExportServiceRequest request) {
+    if (request != null
+        && request.getFilters() != null
+        && request.getFilters().get(CATEGORY) instanceof String value) {
+      return getMeasurementTypeFromCategory(value);
+    }
+
+    return null;
+  }
+
+  private static String getMeasurementTypeFromCategory(String value) {
+    var category = HypervisorReportCategory.mapCategory(ReportCategory.fromString(value));
+    if (category != null) {
+      return switch (category) {
+        case NON_HYPERVISOR -> PHYSICAL;
+        case HYPERVISOR -> HYPERVISOR;
+      };
+    }
+    return null;
+  }
+
+  private static SubscriptionsExportJsonMeasurement getOrCreateMeasurement(
+      List<SubscriptionsExportJsonMeasurement> metrics, SubscriptionCapacityViewMetric metric) {
+    return metrics.stream()
+        .filter(
+            m ->
+                Objects.equals(m.getMetricId(), metric.getMetricId())
+                    && Objects.equals(m.getMeasurementType(), metric.getMeasurementType()))
+        .findFirst()
+        .orElseGet(
+            () -> {
+              var m = new SubscriptionsExportJsonMeasurement();
+              m.setMeasurementType(metric.getMeasurementType());
+              m.setCapacity(0.0);
+              m.setMetricId(metric.getMetricId());
+              metrics.add(m);
+              return m;
+            });
   }
 }

--- a/src/main/resources/liquibase/202405160950-add-subscription-capacity-view.xml
+++ b/src/main/resources/liquibase/202405160950-add-subscription-capacity-view.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202405160950-01" author="jcarvaja" dbms="postgresql">
+    <comment>
+      Add subscription_capacity_view that aggregates all the capacities by sku
+    </comment>
+    <createView
+            replaceIfExists="true"
+            viewName="subscription_capacity_view">
+        <![CDATA[select s.subscription_id,
+               s.subscription_number,
+               s.sku,
+               o.product_name,
+               coalesce(o.sla, '') as service_level,
+               coalesce(o."usage", '') as "usage",
+               s.org_id,
+               s.billing_provider,
+               s.billing_account_id,
+               s.start_date,
+               s.end_date,
+               jsonb_agg(jsonb_build_object('metric_id',sm.metric_id,'value', sm.value, 'measurement_type', sm.measurement_type)) as metrics,
+               spt.product_tag,
+               s.quantity as quantity
+        from (select org_id,
+                     subscription_id,
+                     subscription_number,
+                     sku,
+                     billing_provider,
+                     billing_account_id,
+                     start_date,
+                     end_date,
+                     quantity,
+                     row_number() over (partition by subscription_id order by start_date asc) as duplicated_sub_id
+              from "subscription") s
+        inner join offering o on s.sku=o.sku
+        inner join sku_product_tag spt on s.sku = spt.sku
+        left join subscription_measurements sm on s.subscription_id = sm.subscription_id
+        where s.start_date <= now() and (s.end_date is null or s.end_date >= now()) and duplicated_sub_id=1
+        group by s.subscription_id, s.subscription_number, s.sku, o.product_name, o.sla, o."usage" , s.org_id, s.billing_provider, s.billing_account_id, spt.product_tag,s.quantity,s.start_date,s.end_date
+        order by s.subscription_id asc
+        ]]>
+    </createView>
+    <rollback>
+      <dropView viewName="subscription_capacity_view"/>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202405160950-02" author="jcarvaja" dbms="hsqldb">
+    <comment>
+      Add subscription_capacity_view that aggregates all the capacities by sku (test version)
+    </comment>
+    <createView
+            replaceIfExists="true"
+            viewName="subscription_capacity_view">
+        <![CDATA[select s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.product_name,
+                        o.sla as service_level,
+                        o.usage,
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        CONCAT('[{"metric_id":"', sm.metric_id, '","value":',sm.value, '","measurement_type":',sm.measurement_type , '}]') as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from subscription s
+                 inner join offering o on s.sku=o.sku
+                 inner join sku_product_tag spt on s.sku = spt.sku
+                 left join subscription_measurements sm on s.subscription_id = sm.subscription_id and s.start_date=sm.start_date
+                 where s.start_date <= now() and (s.end_date is null or s.end_date >= now())
+                 group by s.subscription_id, s.subscription_number, s.sku, o.product_name, o.sla, o.usage , s.org_id, s.billing_provider, s.billing_account_id, spt.product_tag,s.quantity, sm.metric_id, sm.value, sm.measurement_type, s.start_date, s.end_date
+                 order by s.subscription_id asc
+      ]]>
+    </createView>
+    <rollback>
+      <dropView viewName="subscription_capacity_view"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -155,5 +155,6 @@
     <include file="/liquibase/202404301614-terminate-duplicate-azure-subscriptions.xml"/>
     <include file="/liquibase/202405080950-copy-uom-to-metric-id-events-table.xml"/>
     <include file="/liquibase/202405061230-remove-duplicated-hosts.xml"/>
+    <include file="/liquibase/202405160950-add-subscription-capacity-view.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/export/BaseDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/export/BaseDataExporterServiceTest.java
@@ -55,6 +55,7 @@ import org.candlepin.subscriptions.rbac.RbacService;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.test.ExtendWithEmbeddedKafka;
 import org.candlepin.subscriptions.test.ExtendWithExportServiceWireMock;
+import org.candlepin.subscriptions.test.ExtendWithSwatchDatabase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,7 +68,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 
 @SpringBootTest
 public abstract class BaseDataExporterServiceTest
-    implements ExtendWithExportServiceWireMock, ExtendWithEmbeddedKafka {
+    implements ExtendWithExportServiceWireMock, ExtendWithEmbeddedKafka, ExtendWithSwatchDatabase {
 
   protected static final String RHEL_FOR_X86 = "RHEL for x86";
   protected static final String ROSA = "rosa";

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerTest.java
@@ -68,7 +68,6 @@ import org.candlepin.subscriptions.utilization.api.model.SubscriptionEventType;
 import org.candlepin.subscriptions.utilization.api.model.SubscriptionType;
 import org.candlepin.subscriptions.utilization.api.model.Uom;
 import org.candlepin.subscriptions.utilization.api.model.UsageType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,12 +87,6 @@ class SubscriptionTableControllerTest {
   @MockBean SubscriptionRepository subscriptionRepository;
   @Autowired ApplicationClock clock;
   @Autowired SubscriptionTableController subscriptionTableController;
-
-  @BeforeEach
-  void setup() {
-    // The @ReportingAccessRequired annotation checks if the org of the user is allowlisted
-    // to receive reports or not. This org will be used throughout most tests.
-  }
 
   private static final MeasurementSpec RH0180191 =
       MeasurementSpec.offering(

--- a/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
@@ -49,7 +49,6 @@ import org.candlepin.subscriptions.json.InstancesExportJson;
 import org.candlepin.subscriptions.json.InstancesExportJsonGuest;
 import org.candlepin.subscriptions.json.InstancesExportJsonItem;
 import org.candlepin.subscriptions.json.InstancesExportJsonMetric;
-import org.candlepin.subscriptions.test.ExtendWithSwatchDatabase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -59,8 +58,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"worker", "kafka-queue", "test-inventory"})
-class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest
-    implements ExtendWithSwatchDatabase {
+class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
 
   private static final String RHEL_FOR_X86 = "RHEL for x86";
   private static final String ROSA = "rosa";

--- a/swatch-core/schemas/subscriptions_export_csv_item.yaml
+++ b/swatch-core/schemas/subscriptions_export_csv_item.yaml
@@ -14,9 +14,11 @@ properties:
   quantity:
     type: number
   capacity:
-    type: integer
+    type: number
+    default: 0
   hypervisor_capacity:
-    type: integer
+    type: number
+    default: 0
   metric_id:
     type: string
   sku:

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacityView;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.query.FluentQuery;
+
+public interface SubscriptionCapacityViewRepository
+    extends JpaRepository<SubscriptionCapacityView, String>,
+        JpaSpecificationExecutor<SubscriptionCapacityView> {
+  default Stream<SubscriptionCapacityView> streamBy(
+      Specification<SubscriptionCapacityView> criteria) {
+    return findBy(criteria, FluentQuery.FetchableFluentQuery::stream);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+import org.candlepin.subscriptions.db.model.converters.SubscriptionCapacityViewMetricConverter;
+import org.springframework.data.annotation.Immutable;
+
+@Setter
+@Getter
+@Entity
+@Immutable
+@Table(name = "subscription_capacity_view")
+public class SubscriptionCapacityView implements Serializable {
+
+  @Id
+  @Column(name = "subscription_id")
+  private String subscriptionId;
+
+  @Column(name = "subscription_number")
+  private String subscriptionNumber;
+
+  @Column(name = "start_date")
+  private OffsetDateTime startDate;
+
+  @Column(name = "end_date")
+  private OffsetDateTime endDate;
+
+  @Column(name = "sku")
+  private String sku;
+
+  @Column(name = "product_name")
+  private String productName;
+
+  @Column(name = "service_level")
+  private String serviceLevel;
+
+  @Column(name = "usage")
+  private String usage;
+
+  @Column(name = "org_id")
+  private String orgId;
+
+  @Column(name = "billing_provider")
+  private BillingProvider billingProvider;
+
+  @Column(name = "billing_account_id")
+  private String billingAccountId;
+
+  @Column(name = "product_tag")
+  private String productTag;
+
+  @Column(name = "quantity")
+  private long quantity;
+
+  @Column(name = "metrics", insertable = false, updatable = false)
+  @Convert(converter = SubscriptionCapacityViewMetricConverter.class)
+  private Set<SubscriptionCapacityViewMetric> metrics = new HashSet<>();
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityViewMetric.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityViewMetric.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubscriptionCapacityViewMetric implements Serializable {
+  private String metricId;
+  private String measurementType;
+  private Double capacity;
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/converters/SubscriptionCapacityViewMetricConverter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/converters/SubscriptionCapacityViewMetricConverter.java
@@ -89,6 +89,8 @@ public class SubscriptionCapacityViewMetricConverter
       return d;
     } else if (o instanceof Long l) {
       return l;
+    } else if (o instanceof Float f) {
+      return f;
     }
 
     return 0.0;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/converters/SubscriptionCapacityViewMetricConverter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/converters/SubscriptionCapacityViewMetricConverter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model.converters;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacityViewMetric;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class SubscriptionCapacityViewMetricConverter
+    implements AttributeConverter<Set<SubscriptionCapacityViewMetric>, String> {
+
+  private static final String METRIC_ID = "metric_id";
+  private static final String VALUE = "value";
+  private static final String MEASUREMENT_TYPE = "measurement_type";
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public String convertToDatabaseColumn(Set<SubscriptionCapacityViewMetric> collection) {
+    throw new UnsupportedOperationException(
+        "This converter should only be used in the SubscriptionCapacityView view which is only read-only mode.");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Set<SubscriptionCapacityViewMetric> convertToEntityAttribute(String s) {
+    if (s == null || s.isEmpty()) {
+      return Set.of();
+    }
+
+    try {
+      Set<SubscriptionCapacityViewMetric> metrics = new HashSet<>();
+      objectMapper
+          .readValue(s, List.class)
+          .forEach(
+              e -> {
+                Map<String, Object> m = (Map<String, Object>) e;
+                metrics.add(
+                    SubscriptionCapacityViewMetric.builder()
+                        .metricId(
+                            Optional.ofNullable(m.get(METRIC_ID))
+                                .map(String.class::cast)
+                                .orElse(null))
+                        .capacity(Optional.ofNullable(m.get(VALUE)).map(this::toDouble).orElse(0.0))
+                        .measurementType(
+                            Optional.ofNullable(m.get(MEASUREMENT_TYPE))
+                                .map(String.class::cast)
+                                .orElse(null))
+                        .build());
+              });
+      return metrics;
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Error parsing metrics", e);
+    }
+  }
+
+  private double toDouble(Object o) {
+    if (o instanceof Integer i) {
+      return i;
+    } else if (o instanceof Double d) {
+      return d;
+    } else if (o instanceof Long l) {
+      return l;
+    }
+
+    return 0.0;
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-2518

## Description
The new view is used by the export service to process and aggregate all the metrics in a single entry. In the future, the same logic should be used by the Subscription API.

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/706

### Setup
1.- deploy the app into an EE
2.- create a contract via API. Instructions using the iqe tooling:

```
import random
product_id = "rosa"

// create contract:
contract_data = {
    "instance_hours": random.randint(0, 10),
    "cores": random.randint(0, 7),
    "billing_provider": "aws",
    "billing_account_id": "AAA",
}
contract = app.rhsm_subscriptions.create_contract(
    product_id=product_id,
    **contract_data,
)
```

3.- confirm that the above API creates two subscriptions
4.- create measurements for both subscriptions (there is one that does not have any). For example:

```
insert into subscription_measurements(subscription_id, start_date, metric_id, measurement_type)
values ('488052','2024-05-16 10:01:08.000 +0200', 'Cores', '50');
```

5.- confirm the capacity that is returned from the subscription API.

Assuming that the cores values for the subscriptions are 10 and 50 and org ID is 3340851:

```
echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"3340851"}}}' | base64 -w 0
-- eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIzMzQwODUxIn19fQ==
```

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIzMzQwODUxIn19fQ=='
```

```
curl -X GET \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/rosa' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIzMzQwODUxIn19fQ==' | jq
```

Output:

```json
[{'billing_provider': 'aws',
  'capacity': 60,
  'has_infinite_quantity': False,
  'hypervisor_capacity': 0,
  'metric_id': 'Cores',
  'next_event_date': datetime.datetime(2024, 6, 16, 7, 16, 7, tzinfo=tzlocal()),
  'next_event_type': 'Subscription End',
  'product_name': 'Red Hat OpenShift Service on AWS Hosted Control Planes '
                  '(Hourly)',
  'quantity': 1,
  'service_level': 'Premium',
  'sku': 'MW02393',
  'subscriptions': [{'id': '320888', 'number': '3938546'}],
  'total_capacity': 60,
  'uom': 'cores',
  'usage': ''}]
```

6.- finally, verify that the export service returns the same capacity. Using iqe tooling:

```
filters = {
    "product_id": product_id
}
export = app.rhsm_subscriptions.create_swatch_export_request(filters=filters)
data, _ = app.rhsm_subscriptions.download_export_to_json(export.id)
data
```