### PR TITLE
Stop older CI run when a new one is started  for the same branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,7 @@
+def buildNumber = env.BUILD_NUMBER as int
+if (buildNumber > 1) milestone(buildNumber - 1)
+milestone(buildNumber)
+
 pipeline {
     options { buildDiscarder(logRotator(numToKeepStr: '50')) }
     environment {


### PR DESCRIPTION
The ci.ext.devshift.net run is stopped immediately. The continuous-integration/jenkins/pr-merge run seems to happen when it gets to a transition.

Either way, it should save a lot of processing time.