### PR TITLE
SWATCH-2578 Offering should get updated when special_pricing_flag is updated

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingEntity.java
@@ -159,6 +159,9 @@ public class OfferingEntity implements Serializable {
   @Column(name = "metered")
   private Boolean metered;
 
+  @Column(name = "special_pricing_flag")
+  private String specialPricingFlag;
+
   public Boolean getHasUnlimitedUsage() {
     return hasUnlimitedUsage;
   }
@@ -186,7 +189,8 @@ public class OfferingEntity implements Serializable {
         && Objects.equals(hasUnlimitedUsage, offering.hasUnlimitedUsage)
         && Objects.equals(derivedSku, offering.derivedSku)
         && Objects.equals(metered, offering.metered)
-        && Objects.equals(productTags, offering.productTags);
+        && Objects.equals(productTags, offering.productTags)
+        && Objects.equals(specialPricingFlag, offering.specialPricingFlag);
   }
 
   @Override
@@ -206,6 +210,7 @@ public class OfferingEntity implements Serializable {
         hasUnlimitedUsage,
         derivedSku,
         metered,
-        productTags);
+        productTags,
+        specialPricingFlag);
   }
 }

--- a/swatch-contracts/src/main/resources/db/202405222240_add_offering_special_product_tag_h2_only.xml
+++ b/swatch-contracts/src/main/resources/db/202405222240_add_offering_special_product_tag_h2_only.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202405222240-01" author="lburnett" dbms="h2">
+    <comment>Add SPECIAL_PRICING_FLAG column to the OFFERING table for tests only (since it is still
+      managed by the
+      monolith)
+    </comment>
+    <addColumn tableName="offering">
+      <column name="special_pricing_flag" type="VARCHAR(255)"/>
+    </addColumn>
+    <rollback>
+      <dropColumn tableName="offering" columnName="special_pricing_flag"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>
+
+
+  <!-- vim: set expandtab sts=4 sw=4 ai: -->
+

--- a/swatch-contracts/src/main/resources/db/changeLog.xml
+++ b/swatch-contracts/src/main/resources/db/changeLog.xml
@@ -15,5 +15,5 @@
   <include file="db/202402151611_add_offering_sku_product_tag_h2_only.xml"/>
   <include file="db/202402161401_fix_contract_product_for_rosa.xml"/>
   <include file="db/202405031420_terminate_azure_testing_subscriptions.xml"/>
-
+  <include file="db/202405222240_add_offering_special_product_tag_h2_only.xml"/>
 </databaseChangeLog>

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Offering.java
@@ -215,7 +215,8 @@ public class Offering implements Serializable {
         && Objects.equals(hasUnlimitedUsage, offering.hasUnlimitedUsage)
         && Objects.equals(derivedSku, offering.derivedSku)
         && Objects.equals(metered, offering.metered)
-        && Objects.equals(productTags, offering.productTags);
+        && Objects.equals(productTags, offering.productTags)
+        && Objects.equals(specialPricingFlag, offering.specialPricingFlag);
   }
 
   @Override
@@ -235,6 +236,7 @@ public class Offering implements Serializable {
         hasUnlimitedUsage,
         derivedSku,
         metered,
-        productTags);
+        productTags,
+        specialPricingFlag);
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2578

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
During subscription sync it was not checking for special_pricing_flag hence it was skipping the update.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->
Steps are mentioned in Jira card but, copying same here. Partly its manual because we never update the offering table.

### Setup
<!-- Add any steps required to set up the test case -->
1.  Run the swatch-core app:
```
RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1
 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun 
```

2. Since stage refresh is going we have make some tweaks and get creative.  Point product_url to qa instead of stage in `application.yaml` 
`url: ${PRODUCT_URL:https://product.stage.api.redhat.com/svcrest/product/v3}`

3. Setting up of IQE environment will be in a separate doc but, setup IQE environment and execute: 
`from smqe_tools import sync_sku_for_capacity`

### Steps and Verification
<!-- Enter each step of the test below -->
1.  When the sku is not present in offering table. This will create a new entry in sku_product_tag table:
`
sync_sku_for_capacity('RH02781MO')
`

2. Once synced delete the special pricing flag:
`UPDATE offering SET special_pricing_flag = null WHERE sku='RH02781MO'`

3. `
sync_sku_for_capacity('RH02781MO')
`

When we run third step on main it wasn't updating special_pricing_flag in offering table but, that gets resolved in current PR.