### PR TITLE
SWATCH-2588: Do not clear measurements for offerings with metered

### DIFF
--- a/clients/quarkus/contracts-client/src/main/java/com/redhat/swatch/contracts/client/StubContractsApi.java
+++ b/clients/quarkus/contracts-client/src/main/java/com/redhat/swatch/contracts/client/StubContractsApi.java
@@ -187,6 +187,12 @@ public class StubContractsApi implements DefaultApi {
   }
 
   @Override
+  public StatusResponse syncSubscriptionsForContractsByOrg(String orgId)
+      throws ProcessingException {
+    return null;
+  }
+
+  @Override
   public OfferingResponse syncOffering(String sku) throws ProcessingException {
     return null;
   }

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
@@ -20,6 +20,9 @@
  */
 package org.candlepin.subscriptions.capacity;
 
+import static org.candlepin.subscriptions.resource.CapacityResource.HYPERVISOR;
+import static org.candlepin.subscriptions.resource.CapacityResource.PHYSICAL;
+
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.transaction.Transactional;
@@ -111,23 +114,25 @@ public class CapacityReconciliationController {
   private void reconcileSubscriptionCapacities(Subscription subscription) {
     Offering offering = subscription.getOffering();
     var existingKeys = new HashSet<>(subscription.getSubscriptionMeasurements().keySet());
-    upsertMeasurement(subscription, offering.getCores(), "PHYSICAL", CORES)
+    upsertMeasurement(subscription, offering.getCores(), PHYSICAL, CORES)
         .ifPresent(existingKeys::remove);
-    upsertMeasurement(subscription, offering.getHypervisorCores(), "HYPERVISOR", CORES)
+    upsertMeasurement(subscription, offering.getHypervisorCores(), HYPERVISOR, CORES)
         .ifPresent(existingKeys::remove);
-    upsertMeasurement(subscription, offering.getSockets(), "PHYSICAL", SOCKETS)
+    upsertMeasurement(subscription, offering.getSockets(), PHYSICAL, SOCKETS)
         .ifPresent(existingKeys::remove);
-    upsertMeasurement(subscription, offering.getHypervisorSockets(), "HYPERVISOR", SOCKETS)
+    upsertMeasurement(subscription, offering.getHypervisorSockets(), HYPERVISOR, SOCKETS)
         .ifPresent(existingKeys::remove);
-    // existingKeys now contains only stale SubscriptionMeasurement keys (i.e. measurements no
-    // longer provided).
-    existingKeys.forEach(subscription.getSubscriptionMeasurements()::remove);
-    if (!existingKeys.isEmpty()) {
-      measurementsDeleted.increment(existingKeys.size());
-      log.info(
-          "Update for subscription ID {} removed {} incorrect capacity measurements.",
-          subscription.getSubscriptionId(),
-          existingKeys.size());
+    if (!offering.isMetered()) {
+      // existingKeys now contains only stale SubscriptionMeasurement keys (i.e. measurements no
+      // longer provided).
+      existingKeys.forEach(subscription.getSubscriptionMeasurements()::remove);
+      if (!existingKeys.isEmpty()) {
+        measurementsDeleted.increment(existingKeys.size());
+        log.info(
+            "Update for subscription ID {} removed {} incorrect capacity measurements.",
+            subscription.getSubscriptionId(),
+            existingKeys.size());
+      }
     }
   }
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformer.java
@@ -28,12 +28,10 @@ import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.repository.BillingProvider;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
-import com.redhat.swatch.contract.repository.SubscriptionMeasurementEntity;
 import com.redhat.swatch.contract.repository.SubscriptionProductIdEntity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.ProcessingException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -144,14 +142,9 @@ public class MeasurementMetricIdTransformer {
       // Will check for correct metrics before translating awsDimension to Metrics UOM
       log.debug("Checking for unsupported metricIds");
       var supportedSet = metrics.stream().map(Metric::getAwsDimension).collect(Collectors.toSet());
-      List<SubscriptionMeasurementEntity> supportedMeasurements = new ArrayList<>();
-      // compare set of metric.awsDimension to measurements.metricId (pre Transformation state)
-      for (SubscriptionMeasurementEntity sub : subscription.getSubscriptionMeasurements()) {
-        if (supportedSet.contains(sub.getMetricId())) {
-          supportedMeasurements.add(sub);
-        }
-      }
-      subscription.setSubscriptionMeasurements(supportedMeasurements);
+      subscription
+          .getSubscriptionMeasurements()
+          .removeIf(m -> !supportedSet.contains(m.getMetricId()));
     }
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsTestingResource.java
@@ -88,7 +88,7 @@ public class ContractsTestingResource implements DefaultApi {
    * Get a list of saved contracts based on URL query parameters
    *
    * @param orgId
-   * @param productId
+   * @param productTag
    * @param billingProvider
    * @param billingAccountId
    * @return List<Contract> dtos
@@ -129,6 +129,13 @@ public class ContractsTestingResource implements DefaultApi {
   public StatusResponse syncContractsByOrg(String orgId, Boolean isPreCleanup)
       throws ProcessingException {
     return service.syncContractByOrgId(orgId, isPreCleanup);
+  }
+
+  @Override
+  @RolesAllowed({"test", "support"})
+  public StatusResponse syncSubscriptionsForContractsByOrg(String orgId)
+      throws ProcessingException {
+    return service.syncSubscriptionsForContractsByOrg(orgId);
   }
 
   @Override

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -314,6 +314,20 @@ public class ContractService {
   }
 
   @Transactional
+  public StatusResponse syncSubscriptionsForContractsByOrg(String orgId) {
+    StatusResponse statusResponse = new StatusResponse();
+
+    contractRepository
+        .findContracts(ContractEntity.orgIdEquals(orgId))
+        // we only want to update existing subscriptions, so we don't need to provide the
+        // subscriptionId here.
+        .forEach(contract -> syncSubscriptionForContract(contract, null));
+
+    statusResponse.setStatus(SUCCESS_MESSAGE);
+    return statusResponse;
+  }
+
+  @Transactional
   public StatusResponse deleteContractsByOrgId(String orgId) {
     StatusResponse statusResponse = new StatusResponse();
 
@@ -365,6 +379,8 @@ public class ContractService {
   private ContractMessageProcessingResult updateContractRecord(
       ContractEntity existingContract, ContractEntity entity, String subscriptionId) {
     if (Objects.equals(entity, existingContract)) {
+      syncSubscriptionForContract(existingContract, subscriptionId);
+
       log.info(
           "Duplicate contract found that matches the record for uuid {}",
           existingContract.getUuid());
@@ -394,13 +410,19 @@ public class ContractService {
       // updated).
       contractEntityMapper.updateContract(existingContract, entity);
       persistContract(existingContract, OffsetDateTime.now());
-      if (existingContract.getSubscriptionNumber() != null) {
-        SubscriptionEntity subscription =
-            createOrUpdateSubscription(existingContract, subscriptionId);
-        subscriptionRepository.persist(subscription);
-      }
+      syncSubscriptionForContract(existingContract, subscriptionId);
       log.info("Contract metadata updated");
       return ContractMessageProcessingResult.METADATA_UPDATED.withContract(existingContract);
+    }
+  }
+
+  private void syncSubscriptionForContract(ContractEntity existingContract, String subscriptionId) {
+    if (existingContract.getSubscriptionNumber() != null) {
+
+      log.debug("Synchronizing the subscription for contract {}", existingContract);
+      SubscriptionEntity subscription =
+          createOrUpdateSubscription(existingContract, subscriptionId);
+      subscriptionRepository.persist(subscription);
     }
   }
 

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -261,6 +261,33 @@ paths:
         - support: []
         - test: []
       operationId: syncContractsByOrg
+  /api/swatch-contracts/internal/rpc/sync/contracts/{org_id}/subscriptions:
+    description: "Trigger a subscription sync for all contracts of a given Org ID"
+    post:
+      parameters:
+        - name: org_id
+          description: ""
+          schema:
+            type: string
+          in: path
+          required: true
+      summary: "Sync subscriptions for all contracts for given org_id."
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+              examples:
+                status response:
+                  value:
+                    status: 'Success'
+                    message: "Subscriptions Synced for given org_id"
+          description: success
+      security:
+        - support: [ ]
+        - test: [ ]
+      operationId: syncSubscriptionsForContractsByOrg
   /api/swatch-contracts/internal/rpc/reset/contracts/{org_id}:
     description: "Clear all contracts for a given org ID. "
     delete:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -201,6 +201,7 @@ class ContractServiceTest extends BaseUnitTest {
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
     assertEquals("Redundant message ignored", statusResponse.getMessage());
+    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -345,6 +346,14 @@ class ContractServiceTest extends BaseUnitTest {
     contractService.deleteContractsByOrgId(ORG_ID);
     verify(contractRepository).delete(any());
     verify(subscriptionRepository).delete(any());
+  }
+
+  @Test
+  void testSyncSubscriptionsForContractsByOrg() {
+    givenExistingContract();
+    var expectedSubscription = givenExistingSubscription();
+    contractService.syncSubscriptionsForContractsByOrg(ORG_ID);
+    verify(subscriptionRepository).persist(expectedSubscription);
   }
 
   private static PartnerEntitlementV1 givenContractWithoutRequiredData() {


### PR DESCRIPTION
Jira issue: SWATCH-2588

## Description
These changes will involve the following services:
- subscription sync to not clear the subscription measurements when the offering is metered and has no sockets and/or no cores.
- contracts service: synchronize the subscription data even when the contract has no changed
- contracts service: new API to force synchronize all the subscriptions for contracts given an org ID. This is necessary to fix the data in stage.

## Testing
1.- load stage data into your local 
2.- start the API service: `DEV_MODE=true SPRING_PROFILES_ACTIVE=api ./gradlew :bootRun`
3.- confirm you see no capacity for rosa:

```
echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"17496113"}}}' | base64 -w 0
-- eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzQ5NjExMyJ9fX0=
```

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzQ5NjExMyJ9fX0='
```

```
curl -X GET \
  'http://localhost:8000/api/rhsm-subscriptions/v1/capacity/products/rosa/Cores?granularity=Daily&beginning=2024-05-21T11%3A14%3A15.330417%2B00%3A00&ending=2024-05-28T11%3A23%3A46.022128%2B00%3A00' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzQ5NjExMyJ9fX0=' | jq
```

and you should see no capacity:

```json
{
  "data": [
    {
      "date": "2024-05-21T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-22T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-23T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-24T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-25T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-26T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-27T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-28T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    }
  ],
  "meta": {
    "count": 8,
    "product": "rosa",
    "metric_id": "Cores",
    "granularity": "Daily"
  }
}
```

4.- synchronize the contracts metrics with the subscription (fix the data):

start the contracts service: `SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8000 SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 ./gradlew :swatch-contracts:quarkusDev`
run the new sync service: `curl -X POST http://localhost:8001/api/swatch-contracts/internal/rpc/sync/contracts/17496113/subscriptions`

5.- verify that the capacity is fixed:

```
curl -X GET \
  'http://localhost:8000/api/rhsm-subscriptions/v1/capacity/products/rosa/Cores?granularity=Daily&beginning=2024-05-21T11%3A14%3A15.330417%2B00%3A00&ending=2024-05-28T11%3A23%3A46.022128%2B00%3A00' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzQ5NjExMyJ9fX0=' | jq
```

and now we should see:

```json
{
  "data": [
    {
      "date": "2024-05-21T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-22T00:00:00Z",
      "has_data": false,
      "value": 0,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-23T00:00:00Z",
      "has_data": true,
      "value": 2976,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-24T00:00:00Z",
      "has_data": true,
      "value": 2976,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-25T00:00:00Z",
      "has_data": true,
      "value": 2976,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-26T00:00:00Z",
      "has_data": true,
      "value": 2976,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-27T00:00:00Z",
      "has_data": true,
      "value": 2976,
      "has_infinite_quantity": false
    },
    {
      "date": "2024-05-28T00:00:00Z",
      "has_data": true,
      "value": 2976,
      "has_infinite_quantity": false
    }
  ],
  "meta": {
    "count": 8,
    "product": "rosa",
    "metric_id": "Cores",
    "granularity": "Daily"
  }
}
```