### PR TITLE
SWATCH-2586: Change sourcePartner type to string

### DIFF
--- a/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
+++ b/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
@@ -92,9 +92,6 @@ components:
         sourcePartner:
           description: Where the entitlement/contract came from (e.g. aws_marketplace)
           type: string
-          enum:
-            - aws_marketplace
-            - azure_marketplace
         partnerIdentities:
           $ref: '#/components/schemas/PartnerIdentityV1'
         rhEntitlements:

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
@@ -20,9 +20,11 @@
  */
 package com.redhat.swatch.contract.model;
 
+import static com.redhat.swatch.contract.model.ContractSourcePartnerEnum.isAwsMarketplace;
+import static com.redhat.swatch.contract.model.ContractSourcePartnerEnum.isAzureMarketplace;
+
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.DimensionV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1;
-import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1.SourcePartnerEnum;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerIdentityV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.RhEntitlementV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.SaasContractV1;
@@ -117,13 +119,13 @@ public interface ContractEntityMapper {
   @Named("billingProviderId")
   default String extractBillingProviderId(PartnerEntitlementV1 entitlement) {
     var partner = entitlement.getSourcePartner();
-    if (partner == SourcePartnerEnum.AWS_MARKETPLACE) {
+    if (isAwsMarketplace(partner)) {
       return String.format(
           "%s;%s;%s",
           entitlement.getPurchase().getVendorProductCode(),
           entitlement.getPartnerIdentities().getAwsCustomerId(),
           entitlement.getPartnerIdentities().getSellerAccountId());
-    } else if (partner == SourcePartnerEnum.AZURE_MARKETPLACE) {
+    } else if (isAzureMarketplace(partner)) {
       var azurePlanId =
           entitlement.getPurchase().getContracts().stream()
               .map(SaasContractV1::getPlanId)
@@ -139,8 +141,8 @@ public interface ContractEntityMapper {
   }
 
   @Named("billingProvider")
-  default String extractBillingProvider(SourcePartnerEnum sourcePartner) {
-    return ContractSourcePartnerEnum.getByCode(sourcePartner.value());
+  default String extractBillingProvider(String sourcePartner) {
+    return ContractSourcePartnerEnum.getByCode(sourcePartner);
   }
 
   default String extractValueFromRhEntitlements(

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractSourcePartnerEnum.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractSourcePartnerEnum.java
@@ -45,4 +45,16 @@ public enum ContractSourcePartnerEnum {
     }
     return null;
   }
+
+  public static boolean isAwsMarketplace(String sourcePartner) {
+    return ContractSourcePartnerEnum.AWS.code.equals(sourcePartner);
+  }
+
+  public static boolean isAzureMarketplace(String sourcePartner) {
+    return ContractSourcePartnerEnum.AZURE.code.equals(sourcePartner);
+  }
+
+  public static boolean isSupported(String sourcePartner) {
+    return getByCode(sourcePartner) != null;
+  }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
@@ -23,10 +23,10 @@ package com.redhat.swatch.contract;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1.SourcePartnerEnum;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.QueryPartnerEntitlementV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.resources.ApiException;
 import com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi;
+import com.redhat.swatch.contract.model.ContractSourcePartnerEnum;
 import com.redhat.swatch.contract.resource.WireMockResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -50,7 +50,7 @@ class RhPartnerClientIntegrationTest {
     assertEquals(2, partnerEntitlements.size());
     var entitlement = partnerEntitlements.get(0);
     assertEquals("org123", entitlement.getRhAccountId());
-    assertEquals(SourcePartnerEnum.AWS_MARKETPLACE, entitlement.getSourcePartner());
+    assertEquals(ContractSourcePartnerEnum.AWS.getCode(), entitlement.getSourcePartner());
 
     var rhEntitlements = entitlement.getRhEntitlements();
     assertNotNull(rhEntitlements);

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
@@ -55,7 +55,7 @@ class ContractEntityMapperTest {
     entitlement.setPartnerIdentities(new PartnerIdentityV1());
     entitlement.getPartnerIdentities().azureTenantId("azure_tenant_id_placeholder");
     entitlement.getPartnerIdentities().azureCustomerId("azure_customer_id_placeholder");
-    entitlement.sourcePartner(PartnerEntitlementV1.SourcePartnerEnum.AZURE_MARKETPLACE);
+    entitlement.sourcePartner(ContractSourcePartnerEnum.AZURE.getCode());
     contract.planId("vcpu-hours");
 
     contract.addDimensionsItem(new DimensionV1().name(metricId).value("0"));

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -39,7 +39,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.DimensionV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1;
-import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1.SourcePartnerEnum;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1EntitlementDates;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlements;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerIdentityV1;
@@ -51,6 +50,7 @@ import com.redhat.swatch.clients.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
 import com.redhat.swatch.contract.BaseUnitTest;
 import com.redhat.swatch.contract.exception.ContractValidationFailedException;
+import com.redhat.swatch.contract.model.ContractSourcePartnerEnum;
 import com.redhat.swatch.contract.model.MeasurementMetricIdTransformer;
 import com.redhat.swatch.contract.openapi.model.Contract;
 import com.redhat.swatch.contract.openapi.model.ContractRequest;
@@ -245,7 +245,7 @@ class ContractServiceTest extends BaseUnitTest {
         List.of(new Dimension().dimensionName("vCPU").dimensionValue("4")));
     contract.setCloudIdentifiers(
         new PartnerEntitlementContractCloudIdentifiers()
-            .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
+            .partner(ContractSourcePartnerEnum.AZURE.getCode())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
             .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .azureOfferId("azureProductCode")
@@ -276,7 +276,7 @@ class ContractServiceTest extends BaseUnitTest {
         List.of(new Dimension().dimensionName("vCPU").dimensionValue("4")));
     contract.setCloudIdentifiers(
         new PartnerEntitlementContractCloudIdentifiers()
-            .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
+            .partner(ContractSourcePartnerEnum.AZURE.getCode())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
             .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .azureOfferId("azureProductCode")
@@ -304,7 +304,7 @@ class ContractServiceTest extends BaseUnitTest {
         List.of(new Dimension().dimensionName("vCPU").dimensionValue("4")));
     contract.setCloudIdentifiers(
         new PartnerEntitlementContractCloudIdentifiers()
-            .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
+            .partner(ContractSourcePartnerEnum.AZURE.getCode())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
             .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .azureOfferId("azureProductCode")
@@ -351,7 +351,7 @@ class ContractServiceTest extends BaseUnitTest {
     PartnerEntitlementV1 entitlement = new PartnerEntitlementV1();
     entitlement.setRhAccountId(ORG_ID);
     entitlement.setPartnerIdentities(new PartnerIdentityV1());
-    entitlement.setSourcePartner(SourcePartnerEnum.AWS_MARKETPLACE);
+    entitlement.setSourcePartner(ContractSourcePartnerEnum.AWS.getCode());
     entitlement.setPurchase(new PurchaseV1());
     entitlement.getPurchase().setContracts(new ArrayList<>());
     return entitlement;
@@ -382,7 +382,7 @@ class ContractServiceTest extends BaseUnitTest {
         List.of(new Dimension().dimensionName("vCPU").dimensionValue("4")));
     contract.setCloudIdentifiers(
         new PartnerEntitlementContractCloudIdentifiers()
-            .partner(SourcePartnerEnum.AZURE_MARKETPLACE.value())
+            .partner(ContractSourcePartnerEnum.AZURE.getCode())
             .azureResourceId("a69ff71c-aa8b-43d9-dea8-822fab4bbb86")
             .azureTenantId("64dc69e4-d083-49fc-9569-ebece1dd1408")
             .azureOfferId("azureProductCode")
@@ -444,7 +444,7 @@ class ContractServiceTest extends BaseUnitTest {
         .getEntitlementDates()
         .setStartDate(OffsetDateTime.parse("2023-03-17T12:29:48.569Z"));
     entitlement.getEntitlementDates().setEndDate(OffsetDateTime.parse("2024-03-17T12:29:48.569Z"));
-    entitlement.setSourcePartner(SourcePartnerEnum.AWS_MARKETPLACE);
+    entitlement.setSourcePartner(ContractSourcePartnerEnum.AWS.getCode());
     rhEntitlement.setSku(SKU);
     purchase.setVendorProductCode("1234567890abcdefghijklmno");
     cloudIdentifiers.setProductCode("1234567890abcdefghijklmno");
@@ -492,7 +492,7 @@ class ContractServiceTest extends BaseUnitTest {
                     .startDate(OffsetDateTime.parse("2023-03-17T12:29:48.569Z"))
                     .endDate(OffsetDateTime.parse("2024-03-17T12:29:48.569Z")))
             .rhAccountId("7186626")
-            .sourcePartner(SourcePartnerEnum.AZURE_MARKETPLACE)
+            .sourcePartner(ContractSourcePartnerEnum.AZURE.getCode())
             .partnerIdentities(
                 new PartnerIdentityV1()
                     .azureSubscriptionId("fa650050-dedd-4958-b901-d8e5118c0a5f")


### PR DESCRIPTION
Jira issue: SWATCH-2586

## Description
Before, the sourcePartner was an enum with a restricted set of values (aws_marketplace and azure_marketplace).  The problem is that the IT Partner Gateway uses a string and as far as I could see, there are much more valid values like gcp_marketplace, ibm_marketplace, ... And it could be more in the future.  Therefore, we should use a free string instead and check the marketplace we support as we already do nowadays.

## Testing
Using iqe tooling:

```
from iqe_rhsm_subscriptions.smqe_tools import sync_contract
sync_contract(org_id="11789772")
```

In main, the sync_contract fails because it receives an unrecognised ibm_marketplace value. With this branch, it should fail because:

```
Request '/api/swatch-contracts/internal/rpc/sync/contracts/11789772' failed with error 'Could not find sku RH02781HR'
```

If this sku is not synced yet.

