### PR TITLE
Refactor SubscriptionDefinition and Variant lookups and Move Product Tag detection out of FactNormalizer

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -292,11 +292,11 @@ public class EventController {
     String role = event.getRole() != null ? event.getRole().toString() : null;
 
     Set<String> matchingProductTags =
-        SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds(
-            role, event.getProductIds(), null, event.getConversion());
+        SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+            role, event.getProductIds(), null, true, event.getConversion());
 
     log.info(
-        "matching product tags for role={}, productIds={}, productName={}, conversion={}: {}",
+        "matching payg product tags for role={}, productIds={}, productName={}, conversion={}: {}",
         role,
         event.getProductIds(),
         null,

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -440,8 +440,8 @@ public class MetricUsageCollector {
     // remain old logic
     String role = Optional.ofNullable(event.getRole()).map(Object::toString).orElse(null);
 
-    return SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds(
-        role, event.getProductIds(), null, event.getConversion());
+    return SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+        role, event.getProductIds(), null, true, event.getConversion());
   }
 
   private Set<String> getBillingAccountIds(String billingAcctId) {

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -41,6 +41,7 @@ import org.candlepin.subscriptions.json.TallySummary;
 import org.candlepin.subscriptions.product.ProductConfiguration;
 import org.candlepin.subscriptions.tally.billing.BillingProducerConfiguration;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
+import org.candlepin.subscriptions.tally.facts.ProductNormalizer;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.queue.TaskConsumer;
 import org.candlepin.subscriptions.task.queue.TaskConsumerConfiguration;
@@ -119,8 +120,10 @@ public class TallyWorkerConfiguration {
 
   @Bean
   public FactNormalizer factNormalizer(
-      ApplicationProperties applicationProperties, ApplicationClock clock) {
-    return new FactNormalizer(applicationProperties, clock);
+      ApplicationProperties applicationProperties,
+      ApplicationClock clock,
+      ProductNormalizer productNormalizer) {
+    return new FactNormalizer(applicationProperties, clock, productNormalizer);
   }
 
   @Bean(name = "collectorRetryTemplate")

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -20,14 +20,11 @@
  */
 package org.candlepin.subscriptions.tally.facts;
 
-import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import java.time.OffsetDateTime;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -50,10 +47,13 @@ public class FactNormalizer {
 
   private final ApplicationClock clock;
   private final ApplicationProperties props;
+  private final ProductNormalizer productNormalizer;
 
-  public FactNormalizer(ApplicationProperties props, ApplicationClock clock) {
+  public FactNormalizer(
+      ApplicationProperties props, ApplicationClock clock, ProductNormalizer productNormalizer) {
     this.clock = clock;
     this.props = props;
+    this.productNormalizer = productNormalizer;
     log.info("rhsm-conduit stale threshold: {}", props.getHostLastSyncThreshold());
   }
 
@@ -71,25 +71,42 @@ public class FactNormalizer {
    */
   public NormalizedFacts normalize(
       InventoryHostFacts hostFacts, OrgHostsData guestData, boolean isMetered) {
+
+    // If the host hasn't been seen by rhsm-conduit, consider the host as unregistered, and do not
+    // apply this host's facts.
+    // NOTE: This logic is applied since currently the inventory service does not prune inventory
+    // records once a host no longer exists.
+    var syncTimestampOptional = Optional.ofNullable(hostFacts.getSyncTimestamp());
+    boolean skipRhsmFacts =
+        syncTimestampOptional
+            .map(
+                syncTimestamp ->
+                    StringUtils.hasText(syncTimestamp)
+                        && hostUnregistered(OffsetDateTime.parse(syncTimestamp)))
+            .orElse(false);
+
     NormalizedFacts normalizedFacts = new NormalizedFacts();
+
+    normalizedFacts.setProducts(
+        productNormalizer.normalizeProducts(hostFacts, isMetered, skipRhsmFacts));
+
     normalizeClassification(normalizedFacts, hostFacts, guestData);
     normalizeHardwareType(normalizedFacts, hostFacts);
-    normalizeSystemProfileFacts(normalizedFacts, hostFacts, isMetered);
-    normalizeSatelliteFacts(normalizedFacts, hostFacts, isMetered);
-    normalizeRhsmFacts(normalizedFacts, hostFacts, isMetered);
-    normalizeQpcFacts(normalizedFacts, hostFacts);
+    normalizeSystemProfileFacts(normalizedFacts, hostFacts);
+    normalizeSatelliteFacts(normalizedFacts, hostFacts);
+    if (!skipRhsmFacts) {
+      normalizeRhsmFacts(normalizedFacts, hostFacts);
+    }
     normalizeSocketCount(normalizedFacts, hostFacts);
     normalizeMarketplace(normalizedFacts, hostFacts);
-    normalizeConflictingOrMissingRhelVariants(normalizedFacts);
-    pruneProducts(normalizedFacts);
     normalizeNullSocketsAndCores(normalizedFacts, hostFacts);
     normalizeUnits(normalizedFacts, hostFacts);
     return normalizedFacts;
   }
 
   private void normalizeSatelliteFacts(
-      NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts, boolean isMetered) {
-    handleRole(normalizedFacts, hostFacts.getSatelliteRole(), isMetered);
+      NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
+
     handleSla(normalizedFacts, hostFacts, hostFacts.getSatelliteSla());
     handleUsage(normalizedFacts, hostFacts, hostFacts.getSatelliteUsage());
   }
@@ -159,21 +176,6 @@ public class FactNormalizer {
     normalizedFacts.setHardwareType(hardwareType);
   }
 
-  @SuppressWarnings("indentation")
-  private void pruneProducts(NormalizedFacts normalizedFacts) {
-    var exclusions =
-        normalizedFacts.getProducts().stream()
-            .map(SubscriptionDefinition::lookupSubscriptionByTag)
-            .filter(Optional::isPresent)
-            .flatMap(s -> s.get().getIncludedSubscriptions().stream())
-            // map productId to product tag
-            .flatMap(
-                productId ->
-                    SubscriptionDefinition.getAllProductTagsByProductId(productId).stream())
-            .collect(Collectors.toSet());
-    normalizedFacts.getProducts().removeIf(exclusions::contains);
-  }
-
   private void normalizeSocketCount(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
     // modulo-2 rounding only applied to physical or hypervisors
     if (normalizedFacts.isHypervisor() || !isVirtual(hostFacts)) {
@@ -198,19 +200,8 @@ public class FactNormalizer {
     }
   }
 
-  private void normalizeConflictingOrMissingRhelVariants(NormalizedFacts normalizedFacts) {
-    long variantCount =
-        normalizedFacts.getProducts().stream().filter(FactNormalizer::isRhelVariant).count();
-
-    boolean hasRhel = normalizedFacts.getProducts().contains("RHEL");
-
-    if ((variantCount == 0 && hasRhel) || variantCount > 1) {
-      normalizedFacts.addProduct("RHEL Ungrouped");
-    }
-  }
-
   private void normalizeSystemProfileFacts(
-      NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts, boolean isMetered) {
+      NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
     String cloudProvider = hostFacts.getCloudProvider();
     if (HardwareMeasurementType.isSupportedCloudProvider(cloudProvider)) {
       normalizedFacts.setCloudProviderType(HardwareMeasurementType.fromString(cloudProvider));
@@ -226,15 +217,6 @@ public class FactNormalizer {
           hostFacts.getSystemProfileCoresPerSocket() * hostFacts.getSystemProfileSockets());
     }
 
-    // To be handled during SWATCH-2360
-    boolean is3rdPartyMigrated = false;
-
-    normalizedFacts
-        .getProducts()
-        .addAll(
-            getProductsFromProductIds(
-                hostFacts.getSystemProfileProductIds(), isMetered, is3rdPartyMigrated));
-
     if ("x86_64".equals(hostFacts.getSystemProfileArch())
         && HardwareMeasurementType.VIRTUAL
             .toString()
@@ -245,13 +227,13 @@ public class FactNormalizer {
   }
 
   private void normalizeMarketplace(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
-    if (!hostFacts.isMarketplace()) {
-      return;
-    }
+    boolean isMarketplace = hostFacts.isMarketplace();
+    normalizedFacts.setMarketplace(isMarketplace);
 
-    normalizedFacts.setMarketplace(true);
-    normalizedFacts.setCores(0);
-    normalizedFacts.setSockets(0);
+    if (isMarketplace) {
+      normalizedFacts.setCores(0);
+      normalizedFacts.setSockets(0);
+    }
   }
 
   private void normalizeNullSocketsAndCores(
@@ -307,69 +289,12 @@ public class FactNormalizer {
     return (int) Math.ceil(cpu / threadsPerCore);
   }
 
-  private Set<String> getProductsFromProductIds(
-      Collection<String> productIds, boolean isMetered, boolean is3rdPartyMigrated) {
-    if (productIds == null) {
-      return Set.of();
-    }
+  private void normalizeRhsmFacts(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
 
-    return SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
-        null, productIds, null, isMetered, is3rdPartyMigrated);
-  }
-
-  private void normalizeRhsmFacts(
-      NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts, boolean isMetered) {
-    // If the host hasn't been seen by rhsm-conduit, consider the host as unregistered, and do not
-    // apply this host's facts.
-    //
-    // NOTE: This logic is applied since currently the inventory service does not prune inventory
-    //       records once a host no longer exists.
-    var syncTimestampOptional = Optional.ofNullable(hostFacts.getSyncTimestamp());
-    boolean skipRhsmFacts =
-        syncTimestampOptional
-            .map(
-                syncTimestamp ->
-                    StringUtils.hasText(syncTimestamp)
-                        && hostUnregistered(OffsetDateTime.parse(syncTimestamp)))
-            .orElse(false);
-    if (!skipRhsmFacts) {
-
-      // To be handled during SWATCH-2360
-      boolean is3rdPartyMigrated = false;
-
-      normalizedFacts
-          .getProducts()
-          .addAll(
-              SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
-                  hostFacts.getSyspurposeRole(),
-                  hostFacts.getProducts(),
-                  null,
-                  isMetered,
-                  is3rdPartyMigrated));
-
-      // Check for cores and sockets. If not included, default to 0.
-      normalizedFacts.setOrgId(hostFacts.getOrgId());
-      handleSla(normalizedFacts, hostFacts, hostFacts.getSyspurposeSla());
-      handleUsage(normalizedFacts, hostFacts, hostFacts.getSyspurposeUsage());
-    }
-  }
-
-  private void handleRole(NormalizedFacts normalizedFacts, String role, boolean isMetered) {
-    if (role != null) {
-      normalizedFacts.getProducts().removeIf(FactNormalizer::isRhelVariant);
-
-      var subscription = SubscriptionDefinition.lookupSubscriptionByRole(role);
-      if (subscription.isPresent()) {
-        // To be handled during SWATCH-2360
-        boolean is3rdPartyMigrated = false;
-
-        normalizedFacts
-            .getProducts()
-            .addAll(
-                SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
-                    role, Set.of(), null, isMetered, is3rdPartyMigrated));
-      }
-    }
+    // Check for cores and sockets. If not included, default to 0.
+    normalizedFacts.setOrgId(hostFacts.getOrgId());
+    handleSla(normalizedFacts, hostFacts, hostFacts.getSyspurposeSla());
+    handleUsage(normalizedFacts, hostFacts, hostFacts.getSyspurposeUsage());
   }
 
   private void handleUsage(
@@ -404,29 +329,6 @@ public class FactNormalizer {
     }
   }
 
-  private void normalizeQpcFacts(NormalizedFacts normalizedFacts, InventoryHostFacts hostFacts) {
-    // Check if this is a RHEL host and set product.
-    if (hostFacts.getQpcProducts() != null && hostFacts.getQpcProducts().contains("RHEL")) {
-      if (hostFacts.getSystemProfileArch() != null
-          && CollectionUtils.isEmpty(hostFacts.getSystemProfileProductIds())) {
-        switch (hostFacts.getSystemProfileArch()) {
-          case "x86_64", "i686", "i386":
-            normalizedFacts.addProduct("RHEL for x86");
-            break;
-          case "aarch64":
-            normalizedFacts.addProduct("RHEL for ARM");
-            break;
-          case "ppc64le":
-            normalizedFacts.addProduct("RHEL for IBM Power");
-            break;
-          default:
-            break;
-        }
-      }
-      normalizedFacts.addProduct("RHEL");
-    }
-  }
-
   /**
    * A host is considered unregistered if the last time it was synced passes the configured number
    * of hours.
@@ -447,12 +349,6 @@ public class FactNormalizer {
   }
 
   private boolean isGreaterThanZero(Integer... values) {
-    for (Integer value : values) {
-      if (value == null || value == 0) {
-        return false;
-      }
-    }
-
-    return true;
+    return Arrays.stream(values).allMatch(value -> value != null && value > 0);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/NormalizedFacts.java
@@ -54,10 +54,6 @@ public class NormalizedFacts {
     products = new HashSet<>();
   }
 
-  public void addProduct(String product) {
-    products.add(product);
-  }
-
   /**
    * Get the Subscription-manager ID (UUID) of the hypervisor for this system, if it's a guest and
    * its hypervisor is known.

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/ProductNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/ProductNormalizer.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.facts;
+
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ProductNormalizer {
+
+  private Set<String> getSystemProfileProducts(
+      InventoryHostFacts hostFacts, boolean isMetered, boolean is3rdPartyMigrated) {
+    Collection<String> systemProfileProductIds = hostFacts.getSystemProfileProductIds();
+    if (systemProfileProductIds != null) {
+      return SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+          null, systemProfileProductIds, null, isMetered, is3rdPartyMigrated);
+    }
+    return Set.of();
+  }
+
+  private Set<String> getSatelliteRoleProducts(
+      InventoryHostFacts hostFacts, boolean isMetered, boolean is3rdPartyMigrated) {
+    String satelliteRole = hostFacts.getSatelliteRole();
+    if (satelliteRole != null) {
+      return SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+          satelliteRole, Set.of(), null, isMetered, is3rdPartyMigrated);
+    }
+    return Set.of();
+  }
+
+  private Set<String> getRhsmProducts(
+      InventoryHostFacts hostFacts, boolean isMetered, boolean is3rdPartyMigrated) {
+    String syspurposeRole = hostFacts.getSyspurposeRole();
+    Set<String> products = hostFacts.getProducts();
+    return SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+        syspurposeRole, products, null, isMetered, is3rdPartyMigrated);
+  }
+
+  private void addQpcProducts(Set<String> products, InventoryHostFacts hostFacts) {
+    Set<String> qpcProducts = hostFacts.getQpcProducts();
+    if (qpcProducts != null && qpcProducts.contains("RHEL")) {
+      if (hostFacts.getSystemProfileArch() != null
+          && CollectionUtils.isEmpty(hostFacts.getSystemProfileProductIds())) {
+        switch (hostFacts.getSystemProfileArch()) {
+          case "x86_64", "i686", "i386":
+            products.add("RHEL for x86");
+            break;
+          case "aarch64":
+            products.add("RHEL for ARM");
+            break;
+          case "ppc64le":
+            products.add("RHEL for IBM Power");
+            break;
+          default:
+            break;
+        }
+      }
+      products.add("RHEL");
+    }
+  }
+
+  private void normalizeRhelVariants(Set<String> products) {
+    long variantCount = products.stream().filter(FactNormalizer::isRhelVariant).count();
+    boolean hasRhel = products.contains("RHEL");
+    if ((variantCount == 0 && hasRhel) || variantCount > 1) {
+      products.add("RHEL Ungrouped");
+    }
+  }
+
+  private void pruneExcludedProducts(Set<String> products) {
+    Set<String> exclusions =
+        products.stream()
+            .map(SubscriptionDefinition::lookupSubscriptionByTag)
+            .filter(Optional::isPresent)
+            .flatMap(s -> s.get().getIncludedSubscriptions().stream())
+            .flatMap(
+                productId ->
+                    SubscriptionDefinition.getAllProductTagsByProductId(productId).stream())
+            .collect(Collectors.toSet());
+    products.removeIf(exclusions::contains);
+  }
+
+  public Set<String> normalizeProducts(
+      InventoryHostFacts hostFacts, boolean isMetered, boolean skipRhsmFacts) {
+
+    Set<String> products = new HashSet<>();
+    boolean is3rdPartyMigrated = false;
+
+    products.addAll(getSystemProfileProducts(hostFacts, isMetered, is3rdPartyMigrated));
+    products.addAll(getSatelliteRoleProducts(hostFacts, isMetered, is3rdPartyMigrated));
+
+    if (!skipRhsmFacts) {
+      products.addAll(getRhsmProducts(hostFacts, isMetered, is3rdPartyMigrated));
+    }
+
+    addQpcProducts(products, hostFacts);
+    normalizeRhelVariants(products);
+    pruneExcludedProducts(products);
+
+    return products;
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/util/OfferingProductTagLookupService.java
+++ b/src/main/java/org/candlepin/subscriptions/util/OfferingProductTagLookupService.java
@@ -59,22 +59,14 @@ public class OfferingProductTagLookupService {
   }
 
   private static void processProductTagsBySku(Offering offering, OfferingProductTags productTags) {
-    if (offering.isMetered()) {
-      // lookup product tags by either role or eng IDs
-      SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds(
-              offering.getRole(),
-              offering.getProductIds(),
-              offering.getProductName(),
-              offering.isMigrationOffering())
-          .forEach(productTags::addDataItem);
-    } else {
-      SubscriptionDefinition.getAllProductTagsWithNonPaygEligibleByRoleOrEngIds(
-              offering.getRole(),
-              offering.getProductIds(),
-              offering.getProductName(),
-              offering.isMigrationOffering())
-          .forEach(productTags::addDataItem);
-    }
+    // lookup product tags by either role or eng IDs
+    SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+            offering.getRole(),
+            offering.getProductIds(),
+            offering.getProductName(),
+            offering.isMetered(),
+            offering.isMigrationOffering())
+        .forEach(productTags::addDataItem);
   }
 
   public OfferingProductTags findPersistedProductTagsBySku(String sku) {

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
@@ -78,6 +78,7 @@ import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollectorFactory;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.candlepin.subscriptions.tally.facts.ProductNormalizer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -112,6 +113,7 @@ class InventoryAccountUsageCollectorTallyTest {
   @InjectMocks private InventoryAccountUsageCollector collector;
   @InjectMocks private InventoryDatabaseOperations inventory;
   @InjectMocks private FactNormalizer factNormalizer;
+  @Spy private ProductNormalizer productNormalizer;
 
   @Test
   void hypervisorCountsIgnoredForNonRhelProduct() {

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -851,38 +851,6 @@ class FactNormalizerTest {
     assertEquals(0, normalizedFacts.getSockets());
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"x86_64", "i386", "i686"})
-  void testQpcSystemArchSetRhelForX86Product(String arch) {
-    NormalizedFacts normalized =
-        normalizer.normalize(createQpcHost("RHEL", arch, clock.now()), hypervisorData(), false);
-    assertThat(normalized.getProducts(), Matchers.hasItem("RHEL for x86"));
-  }
-
-  @Test
-  void testQpcSystemArchSetRhelForArm() {
-    NormalizedFacts normalized =
-        normalizer.normalize(
-            createQpcHost("RHEL", "aarch64", clock.now()), hypervisorData(), false);
-    assertThat(normalized.getProducts(), Matchers.hasItem("RHEL for ARM"));
-  }
-
-  @Test
-  void testQpcSystemArchSetRhelForIbmPower() {
-    NormalizedFacts normalized =
-        normalizer.normalize(
-            createQpcHost("RHEL", "ppc64le", clock.now()), hypervisorData(), false);
-    assertThat(normalized.getProducts(), Matchers.hasItem("RHEL for IBM Power"));
-  }
-
-  @Test
-  void testQpcProductIdFromEngId() {
-    var host = createQpcHost("RHEL", "Test", clock.now());
-    host.setSystemProfileProductIds("69");
-    NormalizedFacts normalized = normalizer.normalize(host, hypervisorData(), false);
-    assertThat(normalized.getProducts(), Matchers.hasItem("RHEL for x86"));
-  }
-
   private InventoryHostFacts givenInventoryHostFactsForX86AndVirtual() {
     InventoryHostFacts facts = createBaseHost("01");
     facts.setSystemProfileArch("x86_64");

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -128,8 +128,8 @@ class FactNormalizerTest {
     normalizer.normalize(rhsmHost, hypervisorData(), true);
     subscriptionDefinitionMockedStatic.verify(
         () ->
-            SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds(
-                any(), any(), any(), anyBoolean()),
+            SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+                any(), any(), any(), anyBoolean(), anyBoolean()),
         times(1));
   }
 
@@ -144,8 +144,8 @@ class FactNormalizerTest {
     normalizer.normalize(rhsmHost, hypervisorData(), false);
     subscriptionDefinitionMockedStatic.verify(
         () ->
-            SubscriptionDefinition.getAllProductTagsWithNonPaygEligibleByRoleOrEngIds(
-                any(), any(), any(), anyBoolean()),
+            SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+                any(), any(), any(), anyBoolean(), anyBoolean()),
         times(1));
   }
 
@@ -163,8 +163,8 @@ class FactNormalizerTest {
     normalizer.normalize(rhsmHost, hypervisorData(), true);
     subscriptionDefinitionMockedStatic.verify(
         () ->
-            SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds(
-                any(), any(), any(), anyBoolean()),
+            SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+                any(), any(), any(), anyBoolean(), anyBoolean()),
         times(1));
   }
 
@@ -182,8 +182,8 @@ class FactNormalizerTest {
     normalizer.normalize(rhsmHost, hypervisorData(), false);
     subscriptionDefinitionMockedStatic.verify(
         () ->
-            SubscriptionDefinition.getAllProductTagsWithNonPaygEligibleByRoleOrEngIds(
-                any(), any(), any(), anyBoolean()),
+            SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+                any(), any(), any(), anyBoolean(), anyBoolean()),
         times(1));
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/ProductNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/ProductNormalizerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.facts;
+
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createQpcHost;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ProductNormalizerTest {
+
+  static final String RHEL_FOR_X86 = "RHEL for x86";
+  static final String RHEL_FOR_ARM = "RHEL for ARM";
+  static final String RHEL_FOR_IBM_POWER = "RHEL for IBM Power";
+
+  ProductNormalizer productNormalizer = new ProductNormalizer();
+
+  @ParameterizedTest
+  @MethodSource("provideArchCombinations")
+  void testQpcSystemArchProduct(String arch, String expectedProduct) {
+    var inventoryHostFacts = createQpcHost("RHEL", arch, OffsetDateTime.now(Clock.systemUTC()));
+
+    var isMetered = false;
+    var skipRhsm = false;
+    assertThat(
+        productNormalizer.normalizeProducts(inventoryHostFacts, isMetered, skipRhsm),
+        Matchers.hasItem(expectedProduct));
+  }
+
+  private static Stream<Arguments> provideArchCombinations() {
+
+    return Stream.of(
+        Arguments.of("x86_64", RHEL_FOR_X86),
+        Arguments.of("i386", RHEL_FOR_X86),
+        Arguments.of("i686", RHEL_FOR_X86),
+        Arguments.of("i686", RHEL_FOR_X86),
+        Arguments.of("ppc64le", RHEL_FOR_IBM_POWER),
+        Arguments.of("aarch64", RHEL_FOR_ARM));
+  }
+
+  @Test
+  void testQpcProductIdFromEngId() {
+    var host = createQpcHost("RHEL", "Test", OffsetDateTime.now(Clock.systemUTC()));
+    host.setSystemProfileProductIds("69");
+
+    var isMetered = false;
+    var skipRhsm = false;
+
+    var actual = productNormalizer.normalizeProducts(host, isMetered, skipRhsm);
+    var expected = Set.of("RHEL Ungrouped", "RHEL for x86", "RHEL");
+    assertEquals(expected, actual);
+  }
+}

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -242,8 +242,8 @@ public class PrometheusMeteringController {
     boolean is3rdPartyMigrated = Boolean.parseBoolean(labels.get("conversions_success"));
 
     var matchingTags =
-        SubscriptionDefinition.getAllProductTagsWithPaygEligibleByRoleOrEngIds(
-            role, productIds, null, is3rdPartyMigrated);
+        SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
+            role, productIds, null, true, is3rdPartyMigrated);
 
     if (matchingTags.size() != 1) {
       log.warn(

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/Variant.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.*;
 
@@ -51,17 +53,15 @@ public class Variant {
   @Builder.Default private List<String> engineeringIds = new ArrayList<>();
   @Builder.Default private List<String> productNames = new ArrayList<>();
 
-  public static Optional<Variant> findByRole(String role, boolean isMigrationProduct) {
-    return SubscriptionDefinition.lookupSubscriptionByRole(role)
-        .flatMap(
-            subscription ->
-                subscription.getVariants().stream()
-                    .filter(
-                        variant ->
-                            !variant.getRoles().isEmpty()
-                                && variant.getRoles().contains(role)
-                                && Objects.equals(variant.isMigrationProduct, isMigrationProduct))
-                    .findFirst());
+  protected static Set<Variant> findByRole(String role, boolean isMigrationProduct) {
+    return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
+        .flatMap(subscription -> subscription.getVariants().stream())
+        .filter(
+            variant ->
+                !variant.getRoles().isEmpty()
+                    && variant.getRoles().contains(role)
+                    && Objects.equals(variant.isMigrationProduct, isMigrationProduct))
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -73,7 +73,7 @@ public class Variant {
    * @param isMigrationProduct
    * @return Optional<Variant>
    */
-  public static Optional<Variant> findByEngProductId(
+  protected static Set<Variant> findByEngProductId(
       String engProductId, boolean isMigrationProduct) {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
         .flatMap(subscription -> subscription.getVariants().stream())
@@ -82,7 +82,7 @@ public class Variant {
                 !variant.getEngineeringIds().isEmpty()
                     && variant.getEngineeringIds().contains(engProductId)
                     && Objects.equals(variant.isMigrationProduct, isMigrationProduct))
-        .findFirst();
+        .collect(Collectors.toSet());
   }
 
   public static Optional<Variant> findByTag(String defaultVariantTag) {
@@ -102,7 +102,7 @@ public class Variant {
                 subscriptionDefinition.getSupportedGranularity().contains(granularity));
   }
 
-  public static Stream<Variant> filterVariantsByProductName(
+  protected static Stream<Variant> filterVariantsByProductName(
       String productName, boolean isMigrationProduct) {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
         .map(SubscriptionDefinition::getVariants)

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
@@ -46,7 +46,7 @@ class SubscriptionDefinitionRegistryTest {
   void testLoadAllTheThings() {
 
     var actual = subscriptionDefinitionRegistry.getSubscriptions().size();
-    var expected = 19;
+    var expected = 18;
 
     assertEquals(expected, actual);
   }

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
@@ -46,7 +46,7 @@ class SubscriptionDefinitionRegistryTest {
   void testLoadAllTheThings() {
 
     var actual = subscriptionDefinitionRegistry.getSubscriptions().size();
-    var expected = 18;
+    var expected = 19;
 
     assertEquals(expected, actual);
   }

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.configuration.registry;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class VariantTest {
@@ -35,15 +36,17 @@ class VariantTest {
   void testMigrationProductFlagTrueWithRole() {
     var variant = Variant.findByRole("Red Hat Enterprise Linux Server", true);
 
-    assertFalse(variant.isPresent());
+    assertTrue(variant.isEmpty());
   }
 
   @Test
   void testMigrationProductFlagFalseWithRole() {
     var variant = Variant.findByRole("Red Hat Enterprise Linux Server", false);
 
+    assertEquals(1, variant.size());
+
     var expected = "RHEL for x86";
-    var actual = variant.get().getTag();
+    var actual = variant.iterator().next().getTag();
 
     assertEquals(expected, actual);
   }
@@ -51,31 +54,33 @@ class VariantTest {
   @Test
   void testMigrationProductFlagWithEngIds() {
 
-    var elsMigratedVariant = Variant.findByTag("rhel-for-x86-els-payg");
+    var expected = Set.of(Variant.findByTag("rhel-for-x86-els-trad-unconverted").get());
 
-    var variant =
-        Variant.findByEngProductId(elsMigratedVariant.get().getEngineeringIds().get(0), false);
+    var actual = Variant.findByEngProductId("204", false);
 
-    assertFalse(variant.isPresent());
+    assertEquals(expected, actual);
   }
 
   @Test
   void testMigrationProductFlagTrueWithEngIds() {
+    var expected =
+        Set.of(
+            Variant.findByTag("rhel-for-x86-els-payg").get(),
+            Variant.findByTag("rhel-for-x86-els-trad-converted").get());
 
-    var elsMigratedVariant = Variant.findByTag("rhel-for-x86-els-payg");
+    var variant = Variant.findByEngProductId("204", true);
 
-    var variant =
-        Variant.findByEngProductId(elsMigratedVariant.get().getEngineeringIds().get(0), true);
-
-    assertEquals(elsMigratedVariant, variant);
+    assertEquals(expected, variant);
   }
 
   @Test
   void testGetParentSubscription() {
-    var variant = Variant.findByRole("Red Hat Enterprise Linux Compute Node", false).get();
+    var variant = Variant.findByRole("Red Hat Enterprise Linux Compute Node", false);
     var expected = "rhel-for-x86";
-    var actual = variant.getSubscription().getId();
 
+    assertEquals(1, variant.size());
+
+    var actual = variant.iterator().next().getSubscription().getId();
     assertEquals(expected, actual);
   }
 
@@ -84,7 +89,9 @@ class VariantTest {
 
     var actual = Variant.findByEngProductId("69", false);
 
-    assertEquals("RHEL for x86", actual.get().getTag());
+    assertEquals(1, actual.size());
+
+    assertEquals("RHEL for x86", actual.iterator().next().getTag());
   }
 
   @Test

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/VariantTest.java
@@ -54,7 +54,7 @@ class VariantTest {
   @Test
   void testMigrationProductFlagWithEngIds() {
 
-    var expected = Set.of(Variant.findByTag("rhel-for-x86-els-trad-unconverted").get());
+    var expected = Set.of();
 
     var actual = Variant.findByEngProductId("204", false);
 
@@ -63,10 +63,7 @@ class VariantTest {
 
   @Test
   void testMigrationProductFlagTrueWithEngIds() {
-    var expected =
-        Set.of(
-            Variant.findByTag("rhel-for-x86-els-payg").get(),
-            Variant.findByTag("rhel-for-x86-els-trad-converted").get());
+    var expected = Set.of(Variant.findByTag("rhel-for-x86-els-payg").get());
 
     var variant = Variant.findByEngProductId("204", true);
 


### PR DESCRIPTION
Why? Housekeeping mostly and I needed to make some of these changes for #3362 anyway, but pulled them out into its own branch for review purposes.  There should be no noticeable behavior changes with this PR.


## Refactor SubscriptionDefinition and Variant lookups

- Combined `getAllProductTagsWithPaygEligibleByRoleOrEngIds` and `getAllProductTagsWithNonPaygEligibleByRoleOrEngIds` into a single method that takes `isMetered` as a parameter
- Updated lookup methods in Variant that were still using findFirst() and returning Optional<String>.  They now return a Set<String> that may or may not be empty.

These are quality of life / maintenance changes.  There should be no noticeable change of behavior - even with that findFirst() change.  There isn't be data in swatch yet that findFirst() wouldn't work on, but would be a bug for ELS if not addressed.

## Move Product Tag detection out of FactNormalizer

Instead of having several places in FactNormalizer that is modifying the normalizedFacts.getProducts() list.

I've extracted logic for determining the swatch product tags to its own class.
