### PR TITLE
SWATCH-2576 Fix LazyInitializationException during subscription sync

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityReconciliationController.java
@@ -151,7 +151,8 @@ public class CapacityReconciliationController {
     return Optional.empty();
   }
 
-  private void reconcileSubscriptionProductIds(Subscription subscription) {
+  @Transactional
+  public void reconcileSubscriptionProductIds(Subscription subscription) {
     Offering offering = subscription.getOffering();
 
     Set<String> expectedProducts = offering.getProductTags();

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Subscription.java
@@ -51,7 +51,11 @@ import lombok.*;
     subgraphs = {
       @NamedSubgraph(
           name = "subgraph.offering",
-          attributeNodes = {@NamedAttributeNode("childSkus"), @NamedAttributeNode("productIds")})
+          attributeNodes = {
+            @NamedAttributeNode("childSkus"),
+            @NamedAttributeNode("productIds"),
+            @NamedAttributeNode("productTags")
+          })
     })
 public class Subscription implements Serializable {
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2576

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
I wasn't able to reproduce issue but, Lazy initialization happens due to following reason. We don't have it on stage and on prod it happens very randomly. Hopefully this resolves the issue.

1) Use FetchType.EAGER: Fetch the collections eagerly. N/A for now since we use EntityGraph.

2) Use Entity Graphs: Specify the collections to be loaded using an EntityGraph. This is what we use and it eagerly loads the producttag.

3) Open Session in View: In web applications, keep the Hibernate session open until the view is rendered. N/A

4) Join Fetch in JPQL/HQL: Explicitly fetch the collections in your queries. - N/A

5) Access Collections within a Transactional Method: Ensure that any access to the lazy collections happens within a method annotated with @ Transactional. - Done

I am able to remove n+1 query when we have subscription object it wasn't loading product tag in the same query. 
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Steps

0. Set Up Wiremock for mocking IT Subscription Service responses
```bash
podman run -it -d --rm -p 8101:8080 --name wiremock -v $PWD/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose
```
```bash
cat > stub/__files/swatch-1983-subscription-api.json <<EOF
[
    {
        "id": 123456,
        "renewedId": null,
        "masterEndSystemName": "SUBSCRIPTION",
        "createdEndSystemName": "SUBSCRIPTION",
        "createdByUserName": null,
        "createdDate": 1672556530000,
        "lastUpdateEndSystemName": "SUBSCRIPTION",
        "lastUpdateUserName": null,
        "lastUpdateDate": 1672556530000,
        "externalCreatedDate": null,
        "externalLastUpdateDate": null,
        "installBaseStartDate": 1672549200000,
        "installBaseEndDate": 1704085199000,
        "inactiveDate": null,
        "oracleAccountNumber": "5456371",
        "oracleMSANumber": null,
        "oracleIBInstanceNumber": null,
        "webCustomerId": 7237138,
        "registrationNumber": null,
        "installationNumber": null,
        "subscriptionNumber": "123456",
        "quantity": 10,
        "subscriptionProducts": [
            {"sku": "MW02393"}
        ],
        "customer": {
            "id": 7237138,
            "name": "Dummy Customer",
            "password": null,
            "creditApplicationCompleted": false,
            "customerType": "organization",
            "oracleCustomerNumber": 5456371,
            "namedAccount": false,
            "createdDate": 1397548100000,
            "updatedDate": 1612591188913
        },
        "effectiveStartDate": 1672549200000,
        "effectiveEndDate": 1729998800000,
        "externalReferences": {
            "awsMarketplace": {
                "productCode": "6n58d3s3qpvk22dgew2gal7w3",
                "customerID": "EK57ooq39qs",
                "sellerAccount": "568056954830",
                "customerAccountID": "568056954830"
            }
        }
    }
]
EOF
```
```bash
curl -X POST --data '{ "priority": 1, "request": { "method": "GET", "urlPattern": "/search/criteria;.+=6550988.*" }, "response": { "status": 200, "bodyFileName": "swatch-1983-subscription-api.json", "headers": { "Content-Type": "application/json" } } }' http://localhost:8101/__admin/mappings/new
```

<!-- Enter each step of the test below -->
2. Run the app:

Add this to application.properties
```yaml
#Properties for debugging and get more hibernate logs with parameters
logging.level.org.hibernate.SQL: DEBUG
###log parameters
logging.level.org.hibernate.orm.jdbc.bind: trace
```

```bash
SUBSCRIPTION_URL=http://localhost:8101/ RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun
```

3. Do a subscription sync:
```bash
curl -X 'PUT'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/6550988'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiNjU1MDk4OCJ9fX0='
```
### Verification
<!-- Enter the steps needed to verify the test passed -->
1. On main n+1 issue:
```
2024-05-30 15:15:13,192 [thread=SimpleAsyncTaskExecutor-1] [DEBUG] [org.hibernate.SQL] - select s1_0.start_date,s1_0.subscription_id,s1_0.billing_account_id,s1_0.billing_provider,s1_0.billing_provider_id,s1_0.end_date,o1_0.sku,cs1_0.sku,cs1_0.child_sku,o1_0.cores,o1_0.derived_sku,o1_0.description,o1_0.has_unlimited_usage,o1_0.hypervisor_cores,o1_0.hypervisor_sockets,o1_0.metered,o1_0.product_family,pi1_0.sku,pi1_0.oid,o1_0.product_name,o1_0.role,o1_0.sla,o1_0.sockets,o1_0.special_pricing_flag,o1_0.usage,s1_0.org_id,s1_0.quantity,sm1_0.start_date,sm1_0.subscription_id,sm1_0.measurement_type,sm1_0.metric_id,sm1_0.value,s1_0.subscription_number,spi1_0.start_date,spi1_0.subscription_id,spi1_0.product_id from subscription s1_0 left join offering o1_0 on o1_0.sku=s1_0.sku left join sku_child_sku cs1_0 on o1_0.sku=cs1_0.sku left join sku_oid pi1_0 on o1_0.sku=pi1_0.sku left join subscription_measurements sm1_0 on s1_0.start_date=sm1_0.start_date and s1_0.subscription_id=sm1_0.subscription_id left join subscription_product_ids spi1_0 on s1_0.start_date=spi1_0.start_date and s1_0.subscription_id=spi1_0.subscription_id where s1_0.org_id=? order by s1_0.subscription_id,s1_0.start_date
2024-05-30 15:15:13,194 [thread=SimpleAsyncTaskExecutor-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [6550988]

```

2. PR fixes and has product tag in same query:
```
2024-05-30 15:08:13,847 [thread=SimpleAsyncTaskExecutor-1] [DEBUG] [org.hibernate.SQL] - select s1_0.start_date,s1_0.subscription_id,s1_0.billing_account_id,s1_0.billing_provider,s1_0.billing_provider_id,s1_0.end_date,o1_0.sku,cs1_0.sku,cs1_0.child_sku,o1_0.cores,o1_0.derived_sku,o1_0.description,o1_0.has_unlimited_usage,o1_0.hypervisor_cores,o1_0.hypervisor_sockets,o1_0.metered,o1_0.product_family,pi1_0.sku,pi1_0.oid,o1_0.product_name,pt1_0.sku,pt1_0.product_tag,o1_0.role,o1_0.sla,o1_0.sockets,o1_0.special_pricing_flag,o1_0.usage,s1_0.org_id,s1_0.quantity,sm1_0.start_date,sm1_0.subscription_id,sm1_0.measurement_type,sm1_0.metric_id,sm1_0.value,s1_0.subscription_number,spi1_0.start_date,spi1_0.subscription_id,spi1_0.product_id from subscription s1_0 left join offering o1_0 on o1_0.sku=s1_0.sku left join sku_child_sku cs1_0 on o1_0.sku=cs1_0.sku left join sku_oid pi1_0 on o1_0.sku=pi1_0.sku left join sku_product_tag pt1_0 on o1_0.sku=pt1_0.sku left join subscription_measurements sm1_0 on s1_0.start_date=sm1_0.start_date and s1_0.subscription_id=sm1_0.subscription_id left join subscription_product_ids spi1_0 on s1_0.start_date=spi1_0.start_date and s1_0.subscription_id=spi1_0.subscription_id where s1_0.org_id=? order by s1_0.subscription_id,s1_0.start_date
2024-05-30 15:08:13,849 [thread=SimpleAsyncTaskExecutor-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [6550988]

```