### PR TITLE
SWATCH-2590: Split tally_instance_view into two versions for payg

### DIFF
--- a/src/main/resources/liquibase/202405300830-split-instance-view-to-payg-and-non-payg-versions.xml
+++ b/src/main/resources/liquibase/202405300830-split-instance-view-to-payg-and-non-payg-versions.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="202405300830-1" author="jcarvaja" dbms="postgresql">
+    <comment>
+      Remove the metrics column for the tally_instance_view view, and created the payg and non-payg versions.
+    </comment>
+    <dropView viewName="tally_instance_view"/>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_view">
+      select distinct h.org_id,
+                      h.id,
+                      h.instance_id as instance_id,
+                      h.display_name,
+                      h.billing_provider as host_billing_provider,
+                      h.billing_account_id as host_billing_account_id,
+                      b.billing_provider as bucket_billing_provider,
+                      b.billing_account_id as bucket_billing_account_id,
+                      h.last_seen,
+                      h.last_applied_event_record_date,
+                      coalesce(h.num_of_guests, 0) AS num_of_guests,
+                      b.product_id,
+                      b.sla,
+                      b.usage,
+                      coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                      b.sockets,
+                      b.cores,
+                      h.subscription_manager_id,
+                      h.inventory_id
+      from hosts h
+      join host_tally_buckets b on h.id = b.host_id
+    </createView>
+    <createView
+              replaceIfExists="true"
+              viewName="tally_instance_non_payg_view">
+          select distinct v.*,
+                          jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+          from tally_instance_view v
+          left outer join instance_measurements m on v.id = m.host_id
+          group by v.org_id,
+                   v.id,
+                   v.instance_id,
+                   v.display_name,
+                   v.host_billing_provider,
+                   v.host_billing_account_id,
+                   v.bucket_billing_provider,
+                   v.bucket_billing_account_id,
+                   v.last_seen,
+                   v.last_applied_event_record_date,
+                   v.num_of_guests,
+                   v.product_id,
+                   v.sla,
+                   v."usage",
+                   v.measurement_type,
+                   v.sockets,
+                   v.cores,
+                   v.subscription_manager_id,
+                   v.inventory_id
+    </createView>
+    <createView
+              replaceIfExists="true"
+              viewName="tally_instance_payg_view">
+          select distinct v.*,
+                          m."month",
+                          jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+          from tally_instance_view v
+          left outer join instance_monthly_totals m on v.id = m.host_id
+          group by v.org_id,
+                   v.id,
+                   v.instance_id,
+                   v.display_name,
+                   v.host_billing_provider,
+                   v.host_billing_account_id,
+                   v.bucket_billing_provider,
+                   v.bucket_billing_account_id,
+                   v.last_seen,
+                   v.last_applied_event_record_date,
+                   v.num_of_guests,
+                   v.product_id,
+                   v.sla,
+                   v."usage",
+                   v.measurement_type,
+                   v.sockets,
+                   v.cores,
+                   v.subscription_manager_id,
+                   v.inventory_id,
+                   m."month"
+    </createView>
+    <rollback>
+      <dropView viewName="tally_instance_view"/>
+      <createView
+              replaceIfExists="true"
+              viewName="tally_instance_view">
+          select distinct h.org_id,
+              h.id,
+              h.instance_id as instance_id,
+              h.display_name,
+              h.billing_provider as host_billing_provider,
+              h.billing_account_id as host_billing_account_id,
+              b.billing_provider as bucket_billing_provider,
+              b.billing_account_id as bucket_billing_account_id,
+              h.last_seen,
+              h.last_applied_event_record_date,
+              coalesce(h.num_of_guests, 0) AS num_of_guests,
+              b.product_id,
+              b.sla,
+              b.usage,
+              coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+              jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics,
+              b.sockets,
+              b.cores,
+              h.subscription_manager_id,
+              h.inventory_id
+          from hosts h
+          join host_tally_buckets b on h.id = b.host_id
+          left outer join instance_measurements m on h.id = m.host_id
+          group by h.org_id,
+              h.id,
+              h.instance_id,
+              h.display_name,
+              h.billing_provider,
+              h.billing_account_id,
+              b.billing_provider,
+              b.billing_account_id,
+              h.last_seen,
+              h.last_applied_event_record_date,
+              h.num_of_guests,
+              b.product_id,
+              b.sla,
+              b."usage",
+              b.measurement_type,
+              b.sockets,
+              b.cores,
+              h.subscription_manager_id,
+              h.inventory_id
+      </createView>
+      <dropView viewName="tally_instance_payg_view"/>
+      <dropView viewName="tally_instance_non_payg_view"/>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202405300830-2" author="jcarvaja" dbms="hsqldb">
+        <comment>
+            Remove the metrics column for the tally_instance_view view, and created the payg and non-payg versions.
+        </comment>
+        <dropView viewName="tally_instance_view"/>
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_view">
+            select distinct h.org_id,
+                            h.id,
+                            h.instance_id as instance_id,
+                            h.display_name,
+                            h.billing_provider as host_billing_provider,
+                            h.billing_account_id as host_billing_account_id,
+                            b.billing_provider as bucket_billing_provider,
+                            b.billing_account_id as bucket_billing_account_id,
+                            h.last_seen,
+                            h.last_applied_event_record_date,
+                            coalesce(h.num_of_guests, 0) AS num_of_guests,
+                            b.product_id,
+                            b.sla,
+                            b.usage,
+                            coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                            b.sockets,
+                            b.cores,
+                            h.subscription_manager_id,
+                            h.inventory_id
+            from hosts h
+            join host_tally_buckets b on h.id = b.host_id
+        </createView>
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_non_payg_view">
+            select distinct v.*,
+                            CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+            from tally_instance_view v
+            left outer join instance_measurements m on v.id = m.host_id
+        </createView>
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_payg_view">
+            select distinct v.*,
+                            m.month,
+                            CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+            from tally_instance_view v
+            left outer join instance_monthly_totals m on v.id = m.host_id
+        </createView>
+        <rollback>
+            <dropView viewName="tally_instance_view"/>
+            <createView
+                    replaceIfExists="true"
+                    viewName="tally_instance_view">
+                select distinct h.org_id,
+                    h.id,
+                    h.instance_id as instance_id,
+                    h.display_name,
+                    h.billing_provider as host_billing_provider,
+                    h.billing_account_id as host_billing_account_id,
+                    b.billing_provider as bucket_billing_provider,
+                    b.billing_account_id as bucket_billing_account_id,
+                    h.last_seen,
+                    h.last_applied_event_record_date,
+                    coalesce(h.num_of_guests, 0) AS num_of_guests,
+                    b.product_id,
+                    b.sla,
+                    b.usage,
+                    coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                    CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics,
+                    b.sockets,
+                    b.cores,
+                    h.subscription_manager_id,
+                    h.inventory_id
+                from hosts h
+                join host_tally_buckets b on h.id = b.host_id
+                left outer join instance_measurements m on h.id = m.host_id
+            </createView>
+            <dropView viewName="tally_instance_payg_view"/>
+            <dropView viewName="tally_instance_non_payg_view"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -159,5 +159,6 @@
     <include file="/liquibase/202405160950-add-subscription-capacity-view.xml"/>
     <include file="/liquibase/202406030700-drop-unique-constraints-in-hosts.xml"/>
     <include file="/liquibase/202405081325-delete-duplicate-aws-subscriptions.xml"/>
+    <include file="/liquibase/202405300830-split-instance-view-to-payg-and-non-payg-versions.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
@@ -124,6 +124,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     }
     Page<TallyInstanceView> results =
         repo.findAllBy(
+            true,
             DEFAULT_ORG_ID,
             OPENSHIFT_CONTAINER_PLATFORM,
             ServiceLevel._ANY,
@@ -139,12 +140,6 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
             page);
 
     assertEquals(2, results.getTotalElements());
-
-    if (sortValue.equals("monthlyTotals")) {
-      List<TallyInstanceView> payload = results.toList();
-      assertEquals(0.0, payload.get(0).getMonthlyTotals().get(0));
-      assertEquals(100.0, payload.get(1).getMonthlyTotals().get(0));
-    }
   }
 
   @Test
@@ -206,6 +201,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> results =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -224,6 +220,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> allResults =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -335,6 +332,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> results =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -393,6 +391,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> results =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -412,6 +411,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> allResults =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -462,6 +462,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> results =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -527,6 +528,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> results =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -602,6 +604,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> coresResults =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -622,6 +625,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
 
     Page<TallyInstanceView> socketsResults =
         repo.findAllBy(
+            false,
             "a1",
             COOL_PROD,
             ServiceLevel.PREMIUM,
@@ -646,6 +650,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
   void testWithoutAnyFilterForMetricId() {
     Page<TallyInstanceView> results =
         repo.findAllBy(
+            false,
             DEFAULT_ORG_ID,
             OPENSHIFT_CONTAINER_PLATFORM,
             ServiceLevel._ANY,

--- a/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.export;
 
+import static org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey.formatMonthId;
 import static org.candlepin.subscriptions.resource.InstancesResource.getCategoryByMeasurementType;
 import static org.candlepin.subscriptions.resource.InstancesResource.getCloudProviderByMeasurementType;
 import static org.candlepin.subscriptions.resource.ResourceUtils.ANY;
@@ -34,6 +35,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
@@ -232,7 +234,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
             .add(
                 new InstancesExportJsonMetric()
                     .withMetricId(metricId)
-                    .withValue(resolveMetricValue(bucket, MetricId.fromString(metricId))));
+                    .withValue(resolveMetricValue(item, MetricId.fromString(metricId))));
       }
 
       instance.setLastSeen(host.getLastSeen());
@@ -279,8 +281,6 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     instance.setBillingAccountId("123");
     instance.setInstanceType(INSTANCE_TYPE);
     instance.setSubscriptionManagerId(guest.getHypervisorUuid());
-    instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getSockets(), 6.0);
-    instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getCores(), 8.0);
 
     // buckets
     HostTallyBucket bucket = new HostTallyBucket();
@@ -292,39 +292,58 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     bucket.getKey().setBillingProvider(BillingProvider._ANY);
     bucket.getKey().setBillingAccountId(ANY);
     bucket.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+    // in non-payg products, buckets metrics should be used over the instance measurements
     bucket.setCores(5);
     bucket.setSockets(6);
     bucket.setHost(instance);
     instance.addBucket(bucket);
+    boolean isPayg = !productId.equals(RHEL_FOR_X86);
 
-    // metrics
-    instance.setMeasurements(
-        Map.of(
-            MetricIdUtils.getSockets().toUpperCaseFormatted(),
-            6.0,
-            MetricIdUtils.getCores().toUpperCaseFormatted(),
-            8.0));
+    if (isPayg) {
+      // metrics for payg
+      instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getSockets(), 7.0);
+      instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getCores(), 8.0);
+    } else {
+      // metrics for non-payg
+      instance.setMeasurements(
+          Map.of(
+              MetricIdUtils.getSockets().toUpperCaseFormatted(),
+              9.0,
+              MetricIdUtils.getCores().toUpperCaseFormatted(),
+              10.0));
+    }
 
     // save
     repository.save(instance);
     HostWithGuests item = new HostWithGuests();
     item.host = instance;
     item.guests = List.of(guest);
+    item.usePaygProduct = isPayg;
     itemsToBeExported.add(item);
   }
 
-  private static double resolveMetricValue(HostTallyBucket bucket, MetricId metricId) {
-    if (metricId.equals(MetricIdUtils.getSockets())) {
-      return bucket.getSockets();
-    } else if (metricId.equals(MetricIdUtils.getCores())) {
-      return bucket.getCores();
+  private static double resolveMetricValue(HostWithGuests item, MetricId metricId) {
+    Double value = null;
+    if (item.usePaygProduct) {
+      // then use the monthly totals
+      value = item.host.getMonthlyTotal(formatMonthId(OffsetDateTime.parse(APRIL)), metricId);
+      System.out.println(
+          "Looking for " + metricId + " in " + item.host.getMonthlyTotals() + ". Found: " + value);
+    } else {
+      // for non payg products:
+      if (metricId.equals(MetricIdUtils.getSockets())) {
+        value = Double.valueOf(item.host.getBuckets().iterator().next().getSockets());
+      } else if (metricId.equals(MetricIdUtils.getCores())) {
+        value = Double.valueOf(item.host.getBuckets().iterator().next().getCores());
+      }
     }
 
-    return 0;
+    return Optional.ofNullable(value).orElse(0.0);
   }
 
   private static class HostWithGuests {
     Host host;
     List<Host> guests;
+    boolean usePaygProduct;
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -433,12 +433,12 @@ public interface HostRepository
         monthlyTotalCoresJoin.on(
             builder.equal(
                 monthlyTotalCoresJoin.key(),
-                new InstanceMonthlyTotalKey(month, MetricIdUtils.getCores().toString())));
+                new InstanceMonthlyTotalKey(month, MetricIdUtils.getCores())));
         var monthlyTotalInstanceHoursJoin = findMapJoin(root, MONTHLY_TOTAL_JOIN_INSTANCE_HOURS);
         monthlyTotalInstanceHoursJoin.on(
             builder.equal(
                 monthlyTotalInstanceHoursJoin.key(),
-                new InstanceMonthlyTotalKey(month, MetricIdUtils.getInstanceHours().toString())));
+                new InstanceMonthlyTotalKey(month, MetricIdUtils.getInstanceHours())));
       }
       return null;
     };
@@ -470,8 +470,7 @@ public interface HostRepository
           Optional.ofNullable(referenceUom).orElse(getDefaultMetricIdForProduct(productId));
       if (Objects.nonNull(effectiveUom)) {
         searchCriteria =
-            searchCriteria.and(
-                monthlyKeyEquals(new InstanceMonthlyTotalKey(month, effectiveUom.toString())));
+            searchCriteria.and(monthlyKeyEquals(new InstanceMonthlyTotalKey(month, effectiveUom)));
       }
     }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygViewRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.UUID;
+import org.candlepin.subscriptions.db.model.TallyInstanceNonPaygView;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+/** Provides access to TallyInstanceView database entities. */
+@SuppressWarnings({"linelength", "indentation"})
+public interface TallyInstanceNonPaygViewRepository
+    extends JpaRepository<TallyInstanceNonPaygView, UUID>,
+        JpaSpecificationExecutor<TallyInstanceNonPaygView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstancePaygViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstancePaygViewRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db;
+
+import java.util.UUID;
+import org.candlepin.subscriptions.db.model.TallyInstancePaygView;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+/** Provides access to TallyInstanceView database entities. */
+@SuppressWarnings({"linelength", "indentation"})
+public interface TallyInstancePaygViewRepository
+    extends JpaRepository<TallyInstancePaygView, UUID>,
+        JpaSpecificationExecutor<TallyInstancePaygView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -21,15 +21,13 @@
 package org.candlepin.subscriptions.db;
 
 import com.redhat.swatch.configuration.registry.MetricId;
-import jakarta.persistence.criteria.JoinType;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
-import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey_;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyInstancePaygView_;
 import org.candlepin.subscriptions.db.model.TallyInstanceView;
 import org.candlepin.subscriptions.db.model.TallyInstanceViewKey_;
 import org.candlepin.subscriptions.db.model.TallyInstanceView_;
@@ -38,16 +36,17 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.repository.query.FluentQuery;
+import org.springframework.stereotype.Repository;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
-/** Provides access to TallyInstanceView database entities. */
-@SuppressWarnings({"linelength", "indentation"})
-public interface TallyInstanceViewRepository
-    extends JpaRepository<TallyInstanceView, UUID>, JpaSpecificationExecutor<TallyInstanceView> {
+@SuppressWarnings({"linelength", "indentation", "unchecked"})
+@Repository
+@AllArgsConstructor
+public class TallyInstanceViewRepository {
+
+  private final TallyInstancePaygViewRepository paygViewRepository;
+  private final TallyInstanceNonPaygViewRepository nonPaygViewRepository;
 
   /**
    * Find all Hosts by bucket criteria and return a page of TallyInstanceView objects. A
@@ -68,7 +67,8 @@ public interface TallyInstanceViewRepository
    * @return a page of Host entities matching the criteria.
    */
   @SuppressWarnings("java:S107")
-  default Page<TallyInstanceView> findAllBy(
+  public Page<TallyInstanceView> findAllBy(
+      boolean isPayg,
       String orgId,
       String productId,
       ServiceLevel sla,
@@ -82,30 +82,28 @@ public interface TallyInstanceViewRepository
       String billingAccountId,
       List<HardwareMeasurementType> hardwareMeasurementTypes,
       Pageable pageable) {
-    return findAll(
-        buildSearchSpecification(
-            TallyInstancesDbReportCriteria.builder()
-                .orgId(orgId)
-                .productId(productId)
-                .sla(sla)
-                .usage(usage)
-                .displayNameSubstring(displayNameSubstring)
-                .minCores(minCores)
-                .minSockets(minSockets)
-                .month(month)
-                .metricId(referenceMetricId)
-                .billingProvider(billingProvider)
-                .billingAccountId(billingAccountId)
-                .hardwareMeasurementTypes(hardwareMeasurementTypes)
-                .build()),
-        pageable);
+    var repository = isPayg ? paygViewRepository : nonPaygViewRepository;
+    return (Page<TallyInstanceView>)
+        repository.findAll(
+            buildSearchSpecification(
+                TallyInstancesDbReportCriteria.builder()
+                    .orgId(orgId)
+                    .productId(productId)
+                    .sla(sla)
+                    .usage(usage)
+                    .displayNameSubstring(displayNameSubstring)
+                    .minCores(minCores)
+                    .minSockets(minSockets)
+                    .month(month)
+                    .metricId(referenceMetricId)
+                    .billingProvider(billingProvider)
+                    .billingAccountId(billingAccountId)
+                    .hardwareMeasurementTypes(hardwareMeasurementTypes)
+                    .build()),
+            pageable);
   }
 
-  default Stream<TallyInstanceView> streamBy(TallyInstancesDbReportCriteria criteria) {
-    return findBy(buildSearchSpecification(criteria), FluentQuery.FetchableFluentQuery::stream);
-  }
-
-  static Specification<TallyInstanceView> socketsAndCoresGreaterThanOrEqualTo(
+  static <T extends TallyInstanceView> Specification<T> socketsAndCoresGreaterThanOrEqualTo(
       Integer minCores, Integer minSockets) {
     return (root, query, builder) -> {
       if (Objects.nonNull(minCores) && Objects.nonNull(minSockets)) {
@@ -120,46 +118,48 @@ public interface TallyInstanceViewRepository
     };
   }
 
-  static Specification<TallyInstanceView> productIdEquals(String productId) {
+  static <T extends TallyInstanceView> Specification<T> productIdEquals(String productId) {
     return (root, query, builder) -> {
       var key = root.get(TallyInstanceView_.key);
       return builder.equal(key.get(TallyInstanceViewKey_.productId), productId);
     };
   }
 
-  static Specification<TallyInstanceView> slaEquals(ServiceLevel sla) {
+  static <T extends TallyInstanceView> Specification<T> slaEquals(ServiceLevel sla) {
     return (root, query, builder) -> {
       var key = root.get(TallyInstanceView_.key);
       return builder.equal(key.get(TallyInstanceViewKey_.sla), sla);
     };
   }
 
-  static Specification<TallyInstanceView> usageEquals(Usage usage) {
+  static <T extends TallyInstanceView> Specification<T> usageEquals(Usage usage) {
     return (root, query, builder) -> {
       var key = root.get(TallyInstanceView_.key);
       return builder.equal(key.get(TallyInstanceViewKey_.usage), usage);
     };
   }
 
-  static Specification<TallyInstanceView> billingProviderEquals(BillingProvider billingProvider) {
+  static <T extends TallyInstanceView> Specification<T> billingProviderEquals(
+      BillingProvider billingProvider) {
     return (root, query, builder) -> {
       var key = root.get(TallyInstanceView_.key);
       return builder.equal(key.get(TallyInstanceViewKey_.bucketBillingProvider), billingProvider);
     };
   }
 
-  static Specification<TallyInstanceView> billingAccountIdEquals(String billingAccountId) {
+  static <T extends TallyInstanceView> Specification<T> billingAccountIdEquals(
+      String billingAccountId) {
     return (root, query, builder) -> {
       var key = root.get(TallyInstanceView_.key);
       return builder.equal(key.get(TallyInstanceViewKey_.bucketBillingAccountId), billingAccountId);
     };
   }
 
-  static Specification<TallyInstanceView> orgEquals(String orgId) {
+  static <T extends TallyInstanceView> Specification<T> orgEquals(String orgId) {
     return (root, query, builder) -> builder.equal(root.get(TallyInstanceView_.orgId), orgId);
   }
 
-  static Specification<TallyInstanceView> hardwareMeasurementTypeIn(
+  static <T extends TallyInstanceView> Specification<T> hardwareMeasurementTypeIn(
       List<HardwareMeasurementType> types) {
     return (root, query, builder) -> {
       var key = root.get(TallyInstanceView_.key);
@@ -167,38 +167,27 @@ public interface TallyInstanceViewRepository
     };
   }
 
-  static Specification<TallyInstanceView> metricIdContains(MetricId effectiveMetricId) {
+  static <T extends TallyInstanceView> Specification<T> metricIdContains(
+      MetricId effectiveMetricId) {
     return (root, query, builder) ->
         builder.like(
             builder.upper(builder.function("jsonb_pretty", String.class, root.get("metrics"))),
             "%" + effectiveMetricId.toUpperCaseFormatted() + "%");
   }
 
-  static Specification<TallyInstanceView> displayNameContains(String displayNameSubstring) {
+  static <T extends TallyInstanceView> Specification<T> displayNameContains(
+      String displayNameSubstring) {
     return (root, query, builder) ->
         builder.like(
             builder.lower(root.get(TallyInstanceView_.displayName)),
             "%" + displayNameSubstring.toLowerCase() + "%");
   }
 
-  static Specification<TallyInstanceView> monthlyKeyEquals(String month, MetricId metricId) {
-    return (root, query, builder) -> {
-      var instanceMonthlyTotalRoot = root.join(TallyInstanceView_.monthlyTotals, JoinType.LEFT);
-      var monthPredicate =
-          builder.equal(instanceMonthlyTotalRoot.key().get(InstanceMonthlyTotalKey_.MONTH), month);
-      if (Objects.nonNull(metricId)) {
-        return builder.and(
-            monthPredicate,
-            builder.equal(
-                instanceMonthlyTotalRoot.key().get(InstanceMonthlyTotalKey_.METRIC_ID),
-                metricId.toUpperCaseFormatted()));
-      }
-
-      return monthPredicate;
-    };
+  static <T extends TallyInstanceView> Specification<T> monthEquals(String month) {
+    return (root, query, builder) -> builder.equal(root.get(TallyInstancePaygView_.MONTH), month);
   }
 
-  static Specification<TallyInstanceView> distinct() {
+  static <T extends TallyInstanceView> Specification<T> distinct() {
     return (root, query, builder) -> {
       query.distinct(true);
       return null;
@@ -206,12 +195,12 @@ public interface TallyInstanceViewRepository
   }
 
   @SuppressWarnings("java:S107")
-  default Specification<TallyInstanceView> buildSearchSpecification(
+  public static <T extends TallyInstanceView> Specification<T> buildSearchSpecification(
       TallyInstancesDbReportCriteria criteria) {
     /* The where call allows us to build a Specification object to operate on even if the
      * first specification method we call returns null which is does because we're using the
      * Specification call to set the query to return distinct results */
-    var searchCriteria = Specification.where(distinct());
+    var searchCriteria = Specification.<T>where(distinct());
     searchCriteria =
         searchCriteria.and(
             socketsAndCoresGreaterThanOrEqualTo(criteria.getMinCores(), criteria.getMinSockets()));
@@ -241,8 +230,7 @@ public interface TallyInstanceViewRepository
       searchCriteria = searchCriteria.and(metricIdContains(criteria.getMetricId()));
     }
     if (StringUtils.hasText(criteria.getMonth())) {
-      searchCriteria =
-          searchCriteria.and(monthlyKeyEquals(criteria.getMonth(), criteria.getMetricId()));
+      searchCriteria = searchCriteria.and(monthEquals(criteria.getMonth()));
     }
     if (!ObjectUtils.isEmpty(criteria.getHardwareMeasurementTypes())) {
       searchCriteria =

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -246,18 +246,18 @@ public class Host implements Serializable {
   }
 
   public Double getMonthlyTotal(String monthId, MetricId metricId) {
-    var key = new InstanceMonthlyTotalKey(monthId, metricId.getValue());
+    var key = new InstanceMonthlyTotalKey(monthId, metricId);
     return monthlyTotals.get(key);
   }
 
   public void addToMonthlyTotal(String monthId, MetricId metricId, Double value) {
-    var key = new InstanceMonthlyTotalKey(monthId, metricId.toString());
+    var key = new InstanceMonthlyTotalKey(monthId, metricId);
     Double currentValue = monthlyTotals.getOrDefault(key, 0.0);
     monthlyTotals.put(key, currentValue + value);
   }
 
   public void addToMonthlyTotal(OffsetDateTime timestamp, MetricId metricId, Double value) {
-    var key = new InstanceMonthlyTotalKey(timestamp, metricId.toString());
+    var key = new InstanceMonthlyTotalKey(timestamp, metricId);
     Double currentValue = monthlyTotals.getOrDefault(key, 0.0);
     monthlyTotals.put(key, currentValue + value);
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceNonPaygView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceNonPaygView.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import static java.util.Optional.ofNullable;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Immutable;
+
+@Setter
+@Getter
+@Entity
+@Immutable
+@Table(name = "tally_instance_non_payg_view")
+public class TallyInstanceNonPaygView extends TallyInstanceView {
+
+  @Override
+  public double getMetricValue(MetricId metricId) {
+    if (MetricIdUtils.getSockets().equals(metricId)) {
+      return Double.valueOf(ofNullable(getSockets()).orElse(0));
+    } else if (MetricIdUtils.getCores().equals(metricId)) {
+      return Double.valueOf(ofNullable(getCores()).orElse(0));
+    } else if (getMetrics().containsKey(metricId)) {
+      return ofNullable(getMetrics().get(metricId)).orElse(0.0);
+    }
+
+    return 0;
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancePaygView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancePaygView.java
@@ -20,40 +20,32 @@
  */
 package org.candlepin.subscriptions.db.model;
 
+import static java.util.Optional.ofNullable;
+
 import com.redhat.swatch.configuration.registry.MetricId;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import java.io.Serializable;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Immutable;
 
-/** Key for instance monthly totals */
-@Data
-@NoArgsConstructor
-@Embeddable
-public class InstanceMonthlyTotalKey implements Serializable {
-  private static final DateTimeFormatter MONTH_ID_FORMATTER =
-      DateTimeFormatter.ofPattern("uuuu-MM");
+@Setter
+@Getter
+@Entity
+@Immutable
+@Table(name = "tally_instance_payg_view")
+public class TallyInstancePaygView extends TallyInstanceView {
 
-  /** month in YYYY-MM format */
-  @Column(nullable = false) // ENT-4622 needed to avoid recreating collections
+  @Column(name = "month")
   private String month;
 
-  @Column(name = "metric_id", nullable = false)
-  private String metricId;
+  @Override
+  public double getMetricValue(MetricId metricId) {
+    if (getMetrics().containsKey(metricId)) {
+      return ofNullable(getMetrics().get(metricId)).orElse(0.0);
+    }
 
-  public static String formatMonthId(OffsetDateTime reference) {
-    return reference.format(MONTH_ID_FORMATTER);
-  }
-
-  public InstanceMonthlyTotalKey(OffsetDateTime reference, MetricId metricId) {
-    this(formatMonthId(reference), metricId);
-  }
-
-  public InstanceMonthlyTotalKey(String month, MetricId metricId) {
-    this.month = month;
-    this.metricId = metricId.toUpperCaseFormatted();
+    return 0;
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -21,15 +21,10 @@
 package org.candlepin.subscriptions.db.model;
 
 import com.redhat.swatch.configuration.registry.MetricId;
-import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Table;
+import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
@@ -38,14 +33,11 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.candlepin.subscriptions.db.model.converters.TallyInstanceViewMetricsConverter;
-import org.springframework.data.annotation.Immutable;
 
 @Setter
 @Getter
-@Entity
-@Immutable
-@Table(name = "tally_instance_view")
-public class TallyInstanceView implements Serializable {
+@MappedSuperclass
+public abstract class TallyInstanceView implements Serializable {
 
   @EmbeddedId private TallyInstanceViewKey key = new TallyInstanceViewKey();
 
@@ -89,15 +81,5 @@ public class TallyInstanceView implements Serializable {
   @Column(name = "inventory_id")
   private String inventoryId;
 
-  @ElementCollection(fetch = FetchType.LAZY)
-  @CollectionTable(
-      name = "instance_monthly_totals",
-      joinColumns = @JoinColumn(name = "host_id", referencedColumnName = "id"))
-  @Column(name = "value", insertable = false, updatable = false)
-  private Map<InstanceMonthlyTotalKey, Double> monthlyTotals = new HashMap<>();
-
-  public Double getMonthlyTotal(String monthId, MetricId metricId) {
-    var totalKey = new InstanceMonthlyTotalKey(monthId, metricId.toString());
-    return monthlyTotals.get(totalKey);
-  }
+  public abstract double getMetricValue(MetricId metricId);
 }


### PR DESCRIPTION
Jira issue: SWATCH-2590

## Description
Since the way to resolve the metrics is different depending on whether the product is payg or not, and also we need this logic to be done in the export service, we need to move this logic onto the query itself. 

Changes:
- Split tally_instance_view into tally_instance_payg_view and tally_instance_non_payg_view (because the way to resolve the metrics is different). 
- Ensure the export service also works

## Testing
Added tests to cover the changes.
For using the IQE tooling, see the JIRA ticket for the instructions.