### PR TITLE
SWATCH-2594: Ensure ordering of streams when collating hosts

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
@@ -91,10 +91,15 @@ public class InventorySwatchDataCollator {
    */
   public int collateData(String orgId, int culledOffsetDays, Processor processor) {
     Stream<InventoryHostFacts> inventorySystemStream =
-        inventoryRepository.streamFacts(orgId, culledOffsetDays);
+        inventoryRepository
+            .streamFacts(orgId, culledOffsetDays)
+            .sorted(Comparator.comparing(SortKey::fromHbiSystem));
     Stream<String> activeSubmanIdStream =
         inventoryRepository.streamActiveSubscriptionManagerIds(orgId, culledOffsetDays);
-    Stream<Host> swatchSystemStream = hostRepository.streamHbiHostsByOrgId(orgId);
+    Stream<Host> swatchSystemStream =
+        hostRepository
+            .streamHbiHostsByOrgId(orgId)
+            .sorted(Comparator.comparing(SortKey::fromSwatchSystem));
 
     /*
     Setup peeking iterators for each of HBI systems, HBI subman IDs, and swatch systems.


### PR DESCRIPTION
Jira issue: SWATCH-2594

## Description
The problem is that when querying the hosts in stage, we're retrieving the following hosts at this order:

First iteration:
- Inventory Host with InventoryId=YYY
- Swatch Host with InventoryId=AAA

Second iteration: 
- Inventory Host with InventoryId=ANY
- Swatch Host with InventoryId=YYY (it should be found in the first iteration!)

I don't see how we could possible resolve the issue by tweaking the order by statement in the HostRepository.streamHbiHostsByOrgId since the InventoryId is ordered alphabetically, so the above is a realistic scenario).

The only solution that I can think of is to sorting the streams using the SortKey.

## Testing
I reproduced the scenario using unit tests. 