### PR TITLE
Revert "SWATCH-2145: Prevent tallies from creating duplicate system/host entries (#3330)"

### DIFF
--- a/src/main/resources/liquibase/202406030700-drop-unique-constraints-in-hosts.xml
+++ b/src/main/resources/liquibase/202406030700-drop-unique-constraints-in-hosts.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+  <changeSet id="202406030700-1" author="jcarvaja" dbms="postgresql">
+    <comment>Drop the unique constraint by org_id, inventory_id in hosts table</comment>
+    <dropUniqueConstraint tableName="hosts" constraintName="hosts_org_id_inventory_id_unique"/>
+    <rollback>
+      <addUniqueConstraint columnNames="org_id, inventory_id"
+                           constraintName="hosts_org_id_inventory_id_unique" tableName="hosts"/>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202406030700-2" author="jcarvaja" dbms="postgresql">
+    <comment>Drop the unique constraint by org_id, instance_id in hosts table</comment>
+    <dropUniqueConstraint tableName="hosts" constraintName="hosts_org_id_instance_id_unique"/>
+    <rollback>
+      <addUniqueConstraint columnNames="org_id, instance_id"
+                           constraintName="hosts_org_id_instance_id_unique" tableName="hosts"/>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -157,5 +157,6 @@
     <include file="/liquibase/202405061230-remove-duplicated-hosts.xml"/>
     <include file="/liquibase/202405151547-update-events-azure-billable-account-id.xml"/>
     <include file="/liquibase/202405160950-add-subscription-capacity-view.xml"/>
+    <include file="/liquibase/202406030700-drop-unique-constraints-in-hosts.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: SWATCH-2594

## Description
The existing reconciliation logic limits us to add unique constraints because the logic needs to first (1) insert a host and then (2) delete it, and the unique constraint will be issued at (1).
Since there seems not to be an easy way to fix it, we would need to first adopt the event-driven design logic that will be done in [SWATCH-512](https://issues.redhat.com/browse/SWATCH-512) to prevent inserting duplicated hosts in our systems. 

This pull request adds a migration script to drop the unique constraints.

## Testing
No need.