### PR TITLE
SWATCH-2579 Prevent subscription duplication on quantity change

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/liquibase/PopulateSubscriptionMeasurements.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/PopulateSubscriptionMeasurements.java
@@ -47,7 +47,6 @@ public class PopulateSubscriptionMeasurements extends LiquibaseCustomTask {
 
   @Override
   public void executeTask(Database database) throws DatabaseException, SQLException {
-
     int total = 0;
 
     ResultSet socketsSet =

--- a/src/main/java/org/candlepin/subscriptions/liquibase/RemoveIncorrectlySegmentedSubscriptions.java
+++ b/src/main/java/org/candlepin/subscriptions/liquibase/RemoveIncorrectlySegmentedSubscriptions.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.liquibase;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import liquibase.database.Database;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.RollbackImpossibleException;
+
+/** Migration class to fix duplicate subscription records caused by SWATCH-2579. */
+public class RemoveIncorrectlySegmentedSubscriptions extends LiquibaseCustomTask {
+  // language=PostgreSQL
+  public static final String FIND_CANDIDATES =
+      """
+      SELECT s2.subscription_id, s2.quantity, s2.start_date, s2.end_date FROM (
+          SELECT subscription_id FROM subscription GROUP BY subscription_id HAVING COUNT(*) > 2
+      ) s
+      INNER JOIN subscription s2 ON s2.subscription_id = s.subscription_id
+      ORDER BY s2.subscription_id, s2.start_date ASC;
+      """;
+
+  // language=PostgreSQL
+  public static final String DELETE_DEPENDENT_MEASUREMENTS =
+      """
+      DELETE
+      FROM subscription_measurements sm
+      WHERE (sm.subscription_id, sm.start_date) NOT IN
+          (
+              SELECT subscription_id, start_date
+              FROM subscription
+              WHERE subscription_id = ?
+              ORDER BY start_date ASC
+              LIMIT 2
+          )
+        AND sm.subscription_id = ?;
+      """;
+
+  // Possibly these statements could be improved using anti-joins (LEFT JOIN ... WHERE
+  // l.subscription_id IS NULL)
+  // but using the IN clause has pretty good performance
+
+  // language=PostgreSQL
+  public static final String DELETE_DEPENDENT_PRODUCT_IDS =
+      """
+      DELETE
+      FROM subscription_product_ids spi
+      WHERE (spi.subscription_id, spi.start_date) NOT IN
+          (
+              SELECT subscription_id, start_date
+              FROM subscription
+              WHERE subscription_id = ?
+              ORDER BY start_date ASC
+              LIMIT 2
+          )
+        AND spi.subscription_id = ?;
+      """;
+
+  // Delete all segments except for the initial subscription and first
+  // segment swatch created
+  // language=PostgreSQL
+  public static final String DELETE_ALL_BUT_TWO_SEGMENTS =
+      """
+      DELETE
+      FROM subscription
+      WHERE (subscription_id, start_date) NOT IN
+          (
+              SELECT subscription_id, start_date
+              FROM subscription
+              WHERE subscription_id = ?
+              ORDER BY start_date ASC
+              LIMIT 2
+          )
+      AND subscription_id = ?
+      """;
+
+  // Set the end date of segment 1 to the start date of segment 2
+  // language=PostgreSQL
+  public static final String UPDATE_SEGMENT =
+      """
+      UPDATE subscription
+      SET end_date=subquery.start_date
+      FROM (
+          SELECT s1.start_date FROM subscription s1 WHERE s1.subscription_id = ? ORDER BY s1.start_date DESC LIMIT 1
+      ) subquery
+      WHERE (subscription.subscription_id, subscription.start_date) IN
+          (
+              SELECT s2.subscription_id, s2.start_date
+              FROM subscription s2
+              WHERE s2.subscription_id = ?
+              ORDER BY s2.start_date ASC
+              LIMIT 1
+          )
+        AND subscription_id = ?
+      """;
+
+  public static final String LOG_PREFIX = "SWATCH-2579: ";
+
+  protected record SubscriptionRecord(
+      String subscriptionId, long quantity, Instant startDate, Instant endDate) {}
+
+  @Override
+  public void executeTask(Database database) throws DatabaseException, SQLException {
+    ResultSet effectedSubscriptions = executeQuery(FIND_CANDIDATES);
+
+    Map<String, List<SubscriptionRecord>> subscriptionMap = new HashMap<>();
+
+    try (effectedSubscriptions) {
+      while (effectedSubscriptions.next()) {
+        SubscriptionRecord subRecord = map(effectedSubscriptions);
+        subscriptionMap
+            .computeIfAbsent(subRecord.subscriptionId(), k -> new ArrayList<>())
+            .add(subRecord);
+      }
+    }
+    logger.info(LOG_PREFIX + subscriptionMap.size() + " candidate subscriptions");
+
+    List<String> qualifyingSubscriptions =
+        subscriptionMap.entrySet().stream()
+            .filter(e -> subscriptionQualifies(e.getValue()))
+            .map(Map.Entry::getKey)
+            .toList();
+
+    logger.info(
+        LOG_PREFIX + qualifyingSubscriptions.size() + " subscriptions qualify for migration");
+
+    for (String s : qualifyingSubscriptions) {
+      executeUpdate(DELETE_DEPENDENT_MEASUREMENTS, s, s);
+      executeUpdate(DELETE_DEPENDENT_PRODUCT_IDS, s, s);
+      int r = executeUpdate(DELETE_ALL_BUT_TWO_SEGMENTS, s, s);
+      logger.info(LOG_PREFIX + r + " duplicate records removed for subscription ID " + s);
+
+      executeUpdate(UPDATE_SEGMENT, s, s, s);
+    }
+  }
+
+  protected boolean subscriptionQualifies(List<SubscriptionRecord> records) {
+    // our HAVING count(*) > 2 clause should ensure this is never the case, but we'll check anyway.
+    if (records.size() < 3) {
+      return false;
+    }
+
+    SubscriptionRecord first = records.get(0);
+    SubscriptionRecord second = records.get(1);
+    if (first.quantity == second.quantity) {
+      // No quantity change means while we have duplicate subscription records; they aren't a result
+      // of SWATCH-2579
+      return false;
+    }
+
+    boolean eligible = true;
+    // Start the iterator at the point when the quantity changed
+    ListIterator<SubscriptionRecord> iterator = records.listIterator(1);
+    while (iterator.hasNext()) {
+      SubscriptionRecord r1 = iterator.next();
+      if (iterator.hasNext()) {
+        SubscriptionRecord r2 = records.get(iterator.nextIndex());
+        long delta = r2.startDate.getEpochSecond() - r1.startDate.getEpochSecond();
+        // if r2's start is more than 28 hours ahead of r1's, then this collection of duplicates
+        // isn't a result
+        // of daily syncing.  I picked 28 hours to give a bit of a buffer around the vagaries of
+        // sync timing
+        eligible &= delta < (28 * 60 * 60);
+      }
+    }
+
+    return eligible;
+  }
+
+  protected SubscriptionRecord map(ResultSet resultSet) throws SQLException {
+    Instant endDate;
+    // Some subscriptions have no end date.  Set to 100 years in the future and hope our grandkids
+    // figure it out
+    if (resultSet.getTimestamp("end_date") == null) {
+      endDate = OffsetDateTime.now().plusYears(100).toInstant();
+    } else {
+      endDate = resultSet.getTimestamp("end_date").toInstant();
+    }
+    return new SubscriptionRecord(
+        resultSet.getString("subscription_id"),
+        resultSet.getLong("quantity"),
+        resultSet.getTimestamp("start_date").toInstant(),
+        endDate);
+  }
+
+  @Override
+  public boolean disableAutoCommit() {
+    return true;
+  }
+
+  @Override
+  public String getConfirmationMessage() {
+    return "Clean-up of extraneous subscription segments complete";
+  }
+
+  @Override
+  public void rollback(Database database)
+      throws CustomChangeException, RollbackImpossibleException {
+    throw new RollbackImpossibleException("No rollback is possible for this migration");
+  }
+}

--- a/src/main/resources/liquibase/202406051539-remove-erroneously-duplicated-subscriptions.xml
+++ b/src/main/resources/liquibase/202406051539-remove-erroneously-duplicated-subscriptions.xml
@@ -5,10 +5,18 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="202406051539-01" author="awood" dbms="postgresql">
+    <createIndex tableName="subscription" indexName="subscription_start_date_idx">
+        <column name="start_date"/>
+    </createIndex>
+  </changeSet>
+  <changeSet id="202406051539-02" author="awood" dbms="postgresql">
     <comment>
       See SWATCH-2579.  Quantity changes on a subscription were resulting in the
       creation of a new subscription for that quantity after every subscription sync
     </comment>
     <customChange class="org.candlepin.subscriptions.liquibase.RemoveIncorrectlySegmentedSubscriptions"/>
+  </changeSet>
+  <changeSet id="202406051539-03" author="awood" dbms="postgresql">
+    <dropIndex tableName="subscription" indexName="subscription_start_date_idx"/>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/202406051539-remove-erroneously-duplicated-subscriptions.xml
+++ b/src/main/resources/liquibase/202406051539-remove-erroneously-duplicated-subscriptions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202406051539-01" author="awood" dbms="postgresql">
+    <comment>
+      See SWATCH-2579.  Quantity changes on a subscription were resulting in the
+      creation of a new subscription for that quantity after every subscription sync
+    </comment>
+    <customChange class="org.candlepin.subscriptions.liquibase.RemoveIncorrectlySegmentedSubscriptions"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -161,5 +161,6 @@
     <include file="/liquibase/202405081325-delete-duplicate-aws-subscriptions.xml"/>
     <include file="/liquibase/202405300830-split-instance-view-to-payg-and-non-payg-versions.xml"/>
     <include file="/liquibase/202406130700-add-index-in-sku-product-tag.xml"/>
+    <include file="/liquibase/202406051539-remove-erroneously-duplicated-subscriptions.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -29,13 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -126,13 +120,107 @@ class SubscriptionSyncControllerTest {
   void shouldCreateNewRecordOnQuantityChange() {
     Mockito.when(offeringRepository.existsById(SKU)).thenReturn(true);
     Offering offering = Offering.builder().sku(SKU).build();
+    var dto = createDto("456", 10);
+    var subscription = createSubscription();
     when(offeringRepository.getReferenceById(SKU)).thenReturn(offering);
     when(denylist.productIdMatches(any())).thenReturn(false);
-    var dto = createDto("456", 10);
-    subscriptionSyncController.syncSubscription(dto, Optional.of(createSubscription()));
+    subscriptionSyncController.syncSubscription(dto, Optional.of(subscription));
     verify(subscriptionRepository, Mockito.times(2)).save(Mockito.any(Subscription.class));
     verify(capacityReconciliationController, Mockito.times(2))
         .reconcileCapacityForSubscription(Mockito.any(Subscription.class));
+  }
+
+  /** Test for SWATCH-2579 */
+  @Test
+  void shouldSegmentSubscriptionOnQuantityChangeOnlyOnce() {
+    var initialSub = createSubscription();
+    // Change quantity from 4 to 10
+    var dto = createDto("456", 10);
+
+    var aWeekAgo = toEpochMillis(NOW.minusDays(7L));
+    var twoDaysAgo = NOW.minusDays(2L);
+    dto.setEffectiveStartDate(aWeekAgo);
+    initialSub.setStartDate(clock.dateFromMilliseconds(aWeekAgo));
+    initialSub.setEndDate(twoDaysAgo);
+
+    // Simulate the brief delay between when a subscription is terminated and when the
+    // continuation subscription is written to the database.  In reality, this should be just a
+    // millisecond or less
+    var continuationStartTime = twoDaysAgo.plusSeconds(1L);
+
+    // This simulates a subscription that has been segmented due to quantity change
+    var quantityChangedSub =
+        Subscription.builder()
+            .subscriptionId(initialSub.getSubscriptionId())
+            .subscriptionNumber(initialSub.getSubscriptionNumber())
+            .orgId(initialSub.getOrgId())
+            .quantity(10) // same as DTO quantity
+            .offering(initialSub.getOffering())
+            .startDate(continuationStartTime)
+            .endDate(initialSub.getEndDate())
+            .build();
+
+    // Order the subscriptions by start date descending as the database does
+    var initialSubSpy = spy(initialSub);
+    var subscriptions = List.of(quantityChangedSub, initialSubSpy);
+
+    // Subscription watch should not perform any termination since the quantity has not changed
+    // from the value in the quantityChangedSub.
+    when(denylist.productIdMatches(any())).thenReturn(false);
+    when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(List.of(dto));
+    when(subscriptionRepository.findByOrgId("123")).thenReturn(subscriptions.stream());
+    subscriptionSyncController.reconcileSubscriptionsWithSubscriptionService("123", false);
+
+    verify(initialSubSpy, never()).endSubscription();
+  }
+
+  @Test
+  void shouldHandleMultipleQuantityChanges() {
+    var initialSub = createSubscription();
+    // Change quantity from 4 to 10
+    var dto = createDto("456", 10);
+
+    var aWeekAgo = toEpochMillis(NOW.minusDays(7L));
+    var twoDaysAgo = NOW.minusDays(2L);
+    dto.setEffectiveStartDate(aWeekAgo);
+    initialSub.setStartDate(clock.dateFromMilliseconds(aWeekAgo));
+    initialSub.setEndDate(twoDaysAgo);
+
+    // Simulate the brief delay between when a subscription is terminated and when the
+    // continuation subscription is written to the database.  In reality, this should be just a
+    // millisecond or less
+    var firstContinuationStartTime = twoDaysAgo.plusSeconds(1L);
+
+    var firstQuantityChangedSub =
+        Subscription.builder()
+            .subscriptionId(initialSub.getSubscriptionId())
+            .subscriptionNumber(initialSub.getSubscriptionNumber())
+            .orgId(initialSub.getOrgId())
+            .quantity(10) // same as DTO quantity
+            .offering(initialSub.getOffering())
+            .startDate(firstContinuationStartTime)
+            .endDate(initialSub.getEndDate())
+            .build();
+
+    // Order the subscriptions by start date descending as the database does
+    var initialSubSpy = spy(initialSub);
+    var firstQuantityChangedSubSpy = spy(firstQuantityChangedSub);
+    var subscriptions = List.of(firstQuantityChangedSubSpy, initialSubSpy);
+
+    // Change the quantity AGAIN
+    dto.setQuantity(20);
+
+    // Subscription watch should terminate firstQuantityChangedSub and create a new segment since
+    // the quantity has changed for a second time
+    when(denylist.productIdMatches(any())).thenReturn(false);
+    when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(List.of(dto));
+    when(subscriptionRepository.findByOrgId("123")).thenReturn(subscriptions.stream());
+    subscriptionSyncController.reconcileSubscriptionsWithSubscriptionService("123", false);
+
+    // We don't want to modify the original subscription that has already been ended.  We want to
+    // end the current operative subscription and create a new segment.
+    verify(initialSubSpy, never()).endSubscription();
+    verify(firstQuantityChangedSubSpy, times(1)).endSubscription();
   }
 
   @Test
@@ -209,7 +297,7 @@ class SubscriptionSyncControllerTest {
 
   @Test
   void shouldUpdateSubscriptionWhenUpdateProductIds() {
-    var dto = createDto(123, "456", 4);
+    var dto = createDto(123, "456", "890", 4);
     givenOfferingWithProductIds(290);
     subscriptionSyncController.syncSubscription(dto, Optional.empty());
     verify(subscriptionRepository).save(any());
@@ -384,28 +472,6 @@ class SubscriptionSyncControllerTest {
   }
 
   @Test
-  void shouldForceSubscriptionSyncForOrgWithSameIdButDifferentStartDates() {
-    var dto1 = createDto("234", 3);
-    var dto2 = createDto("234", 3);
-    dto2.setEffectiveStartDate(dto1.getEffectiveStartDate() - (24 * 60 * 60 * 1000));
-
-    var dtoList = Arrays.asList(dto1, dto2);
-    var subList = dtoList.stream().map(this::convertDto).toList();
-    subList.forEach(
-        x -> {
-          x.setQuantity(9999L);
-          x.setOffering(new Offering());
-        }); // Change the quantity so the sync will actually do something
-
-    when(subscriptionService.getSubscriptionsByOrgId("123")).thenReturn(dtoList);
-    when(subscriptionRepository.findByOrgId(anyString())).thenReturn(subList.stream());
-    when(denylist.productIdMatches(any())).thenReturn(false);
-    when(offeringRepository.existsById(any())).thenReturn(true);
-    subscriptionSyncController.forceSyncSubscriptionsForOrg("123", false);
-    verify(subscriptionRepository, times(4)).save(any());
-  }
-
-  @Test
   void shouldForcePAYGSubscriptionsOnlySyncForOrg() {
     var dto1 = createDto("234", 3);
     var dto2 = createDto("345", 3);
@@ -477,7 +543,7 @@ class SubscriptionSyncControllerTest {
             Usage.PRODUCTION,
             BillingProvider.RED_HAT,
             "xyz");
-    Subscription s = createSubscription("org123", "sku", "foo");
+    Subscription s = createSubscription("org123", "sku", "foo", "890");
     s.setStartDate(OffsetDateTime.now().minusDays(7));
     s.setEndDate(OffsetDateTime.now().plusDays(7));
     s.setBillingProvider(BillingProvider.RED_HAT);
@@ -502,7 +568,7 @@ class SubscriptionSyncControllerTest {
             Usage.PRODUCTION,
             BillingProvider.RED_HAT,
             "xyz");
-    Subscription s = createSubscription("org123", "sku", "foo");
+    Subscription s = createSubscription("org123", "sku", "foo", "890");
     s.setStartDate(OffsetDateTime.now().minusDays(7));
     s.setEndDate(OffsetDateTime.now().plusDays(7));
     s.setBillingProvider(BillingProvider.RED_HAT);
@@ -570,7 +636,7 @@ class SubscriptionSyncControllerTest {
 
   @Test
   void testSubscriptionEnrichedFromSubscriptionServiceWhenDbRecordAbsentAndSubscriptionIdMissing() {
-    Subscription incoming = createConvertedDtoSubscription("123", null);
+    Subscription incoming = createConvertedDtoSubscription("123", null, null);
     incoming.setSubscriptionNumber("subnum");
     var serviceResponse = createDto("456", 1);
     serviceResponse.setExternalReferences(
@@ -600,7 +666,7 @@ class SubscriptionSyncControllerTest {
 
   @Test
   void testSubscriptionEnrichedFromDbWhenSubscriptionIdMissing() {
-    Subscription incoming = createConvertedDtoSubscription("123", null);
+    Subscription incoming = createConvertedDtoSubscription("123", null, null);
     Subscription existing = createSubscription();
     existing.setBillingAccountId("billingAccountId");
     existing.setBillingProvider(BillingProvider.RED_HAT);
@@ -622,7 +688,7 @@ class SubscriptionSyncControllerTest {
 
   @Test
   void testSubscriptionNotEnrichedWhenSubscriptionIdPresent() {
-    Subscription incoming = createConvertedDtoSubscription("123", "456");
+    Subscription incoming = createConvertedDtoSubscription("123", "456", "890");
     Subscription existing = createSubscription();
     existing.setBillingAccountId("billingAccountId");
 
@@ -638,7 +704,7 @@ class SubscriptionSyncControllerTest {
 
   @Test
   void testBillingFieldsUpdatedOnChange() {
-    Subscription incoming = createConvertedDtoSubscription("123", "456");
+    Subscription incoming = createConvertedDtoSubscription("123", "456", "890");
     incoming.setBillingProvider(BillingProvider.RED_HAT);
     incoming.setBillingProviderId("newBillingProviderId");
     incoming.setBillingAccountId("newBillingAccountId");
@@ -663,7 +729,7 @@ class SubscriptionSyncControllerTest {
 
   @Test
   void testOfferingSyncedWhenMissing() {
-    Subscription incoming = createConvertedDtoSubscription("123", "456");
+    Subscription incoming = createConvertedDtoSubscription("123", "456", "890");
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(offeringRepository.existsById(SKU)).thenReturn(false);
@@ -680,7 +746,7 @@ class SubscriptionSyncControllerTest {
 
   @Test
   void testOfferingSyncFailsAndProcessingStops() {
-    Subscription incoming = createConvertedDtoSubscription("123", "456");
+    Subscription incoming = createConvertedDtoSubscription("123", "456", "890");
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(offeringRepository.existsById(SKU)).thenReturn(false);
@@ -723,7 +789,7 @@ class SubscriptionSyncControllerTest {
     when(subscriptionRepository.findByOrgId(any())).thenReturn(Stream.of(subscription));
     when(subscriptionService.getSubscriptionsByOrgId(any())).thenReturn(List.of(subServiceSub));
     when(denylist.productIdMatches(any())).thenReturn(false);
-    subscriptionSyncController.reconcileSubscriptionsWithSubscriptionService("org123", false);
+    subscriptionSyncController.reconcileSubscriptionsWithSubscriptionService("org124", false);
     verify(subscriptionRepository).deleteAll(subscriptionsCaptor.capture());
     assertFalse(subscriptionsCaptor.getValue().iterator().hasNext());
   }
@@ -754,15 +820,15 @@ class SubscriptionSyncControllerTest {
   }
 
   private Subscription createSubscription() {
-    return createSubscription("123", SKU, "456");
+    return createSubscription("123", SKU, "456", "890");
   }
 
   private Subscription createSubscriptionFrom(
       Offering offering, org.candlepin.subscriptions.subscription.api.model.Subscription dto) {
     return Subscription.builder()
-        .subscriptionId("" + dto.getId())
+        .subscriptionId(dto.getId().toString())
         .subscriptionNumber(dto.getSubscriptionNumber())
-        .orgId("" + dto.getWebCustomerId())
+        .orgId(dto.getWebCustomerId().toString())
         .quantity(dto.getQuantity())
         .offering(offering)
         .startDate(clock.dateFromMilliseconds(dto.getEffectiveStartDate()))
@@ -770,11 +836,12 @@ class SubscriptionSyncControllerTest {
         .build();
   }
 
-  private Subscription createSubscription(String orgId, String sku, String subId) {
+  private Subscription createSubscription(String orgId, String sku, String subId, String subNum) {
     Offering offering = Offering.builder().sku(sku).build();
 
     return Subscription.builder()
         .subscriptionId(subId)
+        .subscriptionNumber(subNum)
         .orgId(orgId)
         .quantity(4L)
         .offering(offering)
@@ -783,29 +850,36 @@ class SubscriptionSyncControllerTest {
         .build();
   }
 
+  private OffsetDateTime toMillisecondPrecision(OffsetDateTime time) {
+    return clock.dateFromMilliseconds(toEpochMillis(time));
+  }
+
   /** Converted DTOs will not have an offering set */
-  private Subscription createConvertedDtoSubscription(String orgId, String subId) {
+  private Subscription createConvertedDtoSubscription(String orgId, String subId, String subNum) {
     return Subscription.builder()
         .subscriptionId(subId)
+        .subscriptionNumber(subNum)
         .orgId(orgId)
         .quantity(4L)
-        .startDate(NOW)
-        .endDate(NOW.plusDays(30))
+        // Converted DTOs will only ever have millisecond precision because that's what we get from
+        // the subscription service
+        .startDate(toMillisecondPrecision(NOW))
+        .endDate(toMillisecondPrecision(NOW.plusDays(30)))
         .build();
   }
 
   private org.candlepin.subscriptions.subscription.api.model.Subscription createDto(
       String subId, int quantity) {
 
-    return createDto(1234, subId, quantity);
+    return createDto(123, subId, "890", quantity);
   }
 
   private org.candlepin.subscriptions.subscription.api.model.Subscription createDto(
-      Integer orgId, String subId, int quantity) {
+      Integer orgId, String subId, String subNum, int quantity) {
     final var dto = new org.candlepin.subscriptions.subscription.api.model.Subscription();
     dto.setQuantity(quantity);
     dto.setId(Integer.valueOf(subId));
-    dto.setSubscriptionNumber("123");
+    dto.setSubscriptionNumber(subNum);
     dto.setEffectiveStartDate(toEpochMillis(NOW));
     dto.setEffectiveEndDate(toEpochMillis(NOW.plusDays(30)));
     dto.setWebCustomerId(orgId);

--- a/swatch-billable-usage/build.gradle
+++ b/swatch-billable-usage/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-compileJava.dependsOn tasks.openApiGenerate
+compileJava.dependsOn tasks.openApiGenerate, tasks.compileQuarkusGeneratedSourcesJava
 
 openApiGenerate {
     generatorName = "java"

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionRepository.java
@@ -63,7 +63,7 @@ public interface SubscriptionRepository
         SELECT s FROM Subscription s
         WHERE (s.endDate IS NULL OR s.endDate > CURRENT_TIMESTAMP)
           AND s.subscriptionId = :subscriptionId
-        ORDER BY s.subscriptionId, s.startDate
+        ORDER BY s.subscriptionId, s.startDate DESC
       """)
   @EntityGraph(value = "graph.SubscriptionSync")
   List<Subscription> findActiveSubscription(@Param("subscriptionId") String subscriptionId);
@@ -71,19 +71,21 @@ public interface SubscriptionRepository
   @EntityGraph(value = "graph.SubscriptionSync")
   // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(
-      "SELECT s FROM Subscription s WHERE s.subscriptionNumber = :subscriptionNumber ORDER BY s.subscriptionId, s.startDate")
+      "SELECT s FROM Subscription s WHERE s.subscriptionNumber = :subscriptionNumber"
+          + " ORDER BY s.subscriptionId, s.startDate DESC")
   List<Subscription> findBySubscriptionNumber(String subscriptionNumber);
 
   // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(
-      "SELECT s FROM Subscription s LEFT JOIN FETCH s.offering o WHERE o.sku = :sku ORDER BY s.subscriptionId, s.startDate")
+      "SELECT s FROM Subscription s LEFT JOIN FETCH s.offering o WHERE o.sku = :sku"
+          + " ORDER BY s.subscriptionId, s.startDate DESC")
   Page<Subscription> findByOfferingSku(String sku, Pageable pageable);
 
   @QueryHints(value = {@QueryHint(name = HINT_FETCH_SIZE, value = "1024")})
   @EntityGraph(value = "graph.SubscriptionSync")
   // Added an order by clause to avoid Hibernate issue HHH-17040
   @Query(
-      "SELECT s FROM Subscription s WHERE s.orgId = :orgId ORDER BY s.subscriptionId, s.startDate")
+      "SELECT s FROM Subscription s WHERE s.orgId = :orgId ORDER BY s.subscriptionId, s.startDate DESC")
   Stream<Subscription> findByOrgId(String orgId);
 
   default Stream<Subscription> streamBy(DbReportCriteria dbReportCriteria) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillingProvider.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/BillingProvider.java
@@ -67,6 +67,10 @@ public enum BillingProvider implements StringValueEnum<BillingProviderType> {
     return openApiEnum;
   }
 
+  public boolean nonEmptyBillingProvider() {
+    return this != EMPTY;
+  }
+
   /** JPA converter for BillingProvider */
   @Converter(autoApply = true)
   public static class EnumConverter implements AttributeConverter<BillingProvider, String> {

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     testImplementation project(':swatch-common-testcontainers')
 }
 
-compileJava.dependsOn tasks.openApiGenerate
+compileJava.dependsOn tasks.openApiGenerate, tasks.compileQuarkusGeneratedSourcesJava
 
 openApiGenerate {
     generatorName = "java"

--- a/swatch-producer-azure/build.gradle
+++ b/swatch-producer-azure/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     annotationProcessor libraries["lombok-mapstruct-binding"]
 }
 
-compileJava.dependsOn tasks.openApiGenerate
+compileJava.dependsOn tasks.openApiGenerate, tasks.compileQuarkusGeneratedSourcesJava
 
 openApiGenerate {
     generatorName = "java"


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2579

## Description
A single quantity changes on a subscription was resulting in the subscription being duplicated on every sync.  When the quantity on a subscription changes, we segment the subscription.  I.e. we terminate the subscription, giving it an end date of `now()`, create a new subscription with the new quantity, same subscription number, and same end date as the original subscription.

Prior to this patch, if the quantity in the subscription service ever changed from the quantity we had on a `subscription` table row, we would segment the subscription on every sync.

## Testing
IQE Test MR: <!-- IQE MR link here -->

### Setup
1. Place the [swatch-2579.json](https://github.com/user-attachments/files/15537832/swatch-2579.json) wiremock scenario in `stub/mappings` as `swatch-2579.json`
1. Ensure you have `RH00001` in `offerings`
    ```sql
    INSERT INTO offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered, special_pricing_flag) VALUES ('RH00001', 'RHEL Server', 'Red Hat Enterprise Linux', null, null, null, 2, 'Red Hat Enterprise Linux Server', 'Premium', 'Production', 'Red Hat Enterprise Linux for Virtual Datacenters, Premium', false, 'RH00049', false, null);
    ```
1. Create a wiremock container
    ```shell
    podman run -it --rm -p 8101:8080 --name wiremock -v $(git rev-parse --show-toplevel)/stub:/home/wiremock:z wiremock/wiremock:2.32.0 --verbose
    ```
   The scenario will automatically be loaded.

### Steps
1. Make sure you are on `main` and start the application like so
    ```shell
    DEV_MODE=true RHSM_SUBSCRIPTIONS_SUBSCRIPTION_URL=http://localhost:8101/svcrest/subscription/v5 ./gradlew :bootRun
    ```
1. Run
    ```shell
    for x in $(seq 1 6); do http PUT \
    :8000/api/rhsm-subscriptions/v1/internal/subscriptions/sync/org/123456 \
    x-rh-swatch-psk:placeholder; done
    ```
1. Examine the `subscription` table to see how many records there are for subscription 1111.  We are expecting 3: one for quantity 4, one for quantity 10, and one for quantity 20.
    ```shell
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select s.subscription_id, s.start_date, s.end_date, s.quantity from subscription s where s.subscription_id = '1111'"
    ```
    Instead there are 6 rows and 4 of those rows have quantity 20.
1. Reset the database
    ```shell
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c \
    "
    DELETE FROM subscription_product_ids WHERE subscription_id = '1111';
    DELETE FROM subscription_measurements WHERE subscription_id = '1111';
    DELETE FROM subscription WHERE subscription_id = '1111'
    "
    ```
    and reset WireMock
    ```shell
    http POST :8101/__admin/scenarios/reset
    ```
1. Switch to `awood/SWATCH-2579-subscription-duplication`
1. Restart the application and run again the same as in step 1.

### Verification
1. Re-run the `for` loop from step 2 in the Steps section.
1. Re-run the `select` query from step 3.  There should only be 3 rows.