### PR TITLE
SWATCH-2217: Add ocp cluster data floorplan

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -740,3 +740,20 @@ objects:
           ('CORES', 'Cores'),
           ('INSTANCE_HOURS', 'Instance-hours')
         ) as metric_id_normalized(value, normalized) on subscription_measurements.metric_id=metric_id_normalized.value
+    - prefix: swatch/ocp_cluster_data
+      query: >-
+        select
+          org_id,
+          subscription_manager_id as cluster_id,
+          display_name,
+          last_seen,
+          usage,
+          sla,
+          product_id,
+          cores,
+          sockets
+        from hosts h
+        join host_tally_buckets b on h.id = b.host_id
+        where product_id='OpenShift Container Platform'
+        and usage!='_ANY'
+        and sla!='_ANY'


### PR DESCRIPTION
Jira issue: SWATCH-2217

Description
-----------

Add a query to retrieve OCP cluster data

Testing
-------

To smoke-test, copy paste the query and try via gabi.

Also note that we have a GH workflow that validates floorplan queries.