### PR TITLE
SWATCH-2583: Do not remove unseen finest granularity measurements

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/CombiningRollupSnapshotStrategy.java
@@ -298,14 +298,6 @@ public class CombiningRollupSnapshotStrategy {
           }
         });
 
-    // Reset remaining snaps, as they didn't have any calculations/events
-    affectedSnaps
-        .values()
-        .forEach(
-            snapshot -> {
-              snapshot.getTallyMeasurements().clear();
-              toSave.add(tallyRepo.save(snapshot));
-            });
     return toSave;
   }
 


### PR DESCRIPTION
Jira issue: SWATCH-2583

## Description
The CombiningRollupStrategy relies on a DateRange to lookup and catalog
the existing affected snapshots when creating/updating the finest granularity
snapshots. BEFORE the new tally changes, the strategy could always make the
assumption that all Events in that range were (re)pulled and calculated, and
if an existing snapshot does not have a calculation based on an Event,
the tally measurements could be cleared. The new tally changes, however,
does not make that guarantee. Before producing snapshots, it determines the
affected synthetic range based on the produced account calcs (start from the oldest,
end on the newest). Because there may not be a calc for a date in the middle
of this range, it assumes that the affected snapshots will be everything in
between, and removes the tally measurements for any snaps not represented by
a calculation.

This patch removes the logic that removes the measurements of the finest granularity
snapshots when a calculation did not occur on a specific hour. This is
justified since there was no change to that specific hour.


## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/734

**Reproducer Description**
1. Create a series of events from 2024-06-05T00:00Z to 2024-06-05T10:00Z
2. Perform and hourly tally for the org.
3. Create 2 events that create a range over the total span of the initial events created.
    - 2024-06-05T00:00Z
    - 2024-06-05T10:00Z
4. Perform an hourly tally for the org.
5. Use the tally report API to get the hourly values for the total range of events.
6. Only the hours at the start and end of the date range will have values, all in between will be 0.

## Steps To Reproduce
From the **main** branch, start fresh.
```
dropdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && createdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && SPRING_PROFILES_ACTIVE=api,worker,kafka-queue DEV_MODE=true ./gradlew clean :bootRun
```

Run an initial tally to populate the tally_state table so that we can reset it to ensure that the events get picked up.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=17795559" x-rh-swatch-psk:placeholder
```

```
update tally_state set latest_event_record_date='2023-05-28 00:00:00+00' where org_id='17795559';
```

Insert some initial events:
```
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('deedaae2-3c1a-4a3d-8b00-7f7046542618', '2024-06-05 13:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "deedaae2-3c1a-4a3d-8b00-7f7046542618", "timestamp": "2024-06-05T13:00:00Z", "conversion": false, "event_type": "snapshot_Cores", "expiration": "2024-06-05T14:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.260156901Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 10.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Cores', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.260157+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('2dd014d1-7af4-4b1f-86c1-789c66aa94f0', '2024-06-05 15:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "2dd014d1-7af4-4b1f-86c1-789c66aa94f0", "timestamp": "2024-06-05T15:00:00Z", "conversion": false, "event_type": "snapshot_Instance-hours", "expiration": "2024-06-05T16:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.26889264Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Instance-hours', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.268893+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('b11ee432-06f2-4459-b8ed-340d73085524', '2024-06-05 17:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "b11ee432-06f2-4459-b8ed-340d73085524", "timestamp": "2024-06-05T17:00:00Z", "conversion": false, "event_type": "snapshot_Instance-hours", "expiration": "2024-06-05T18:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.269295714Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Instance-hours', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.269296+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('3a7868a2-bba9-48a0-9b38-67b51b258493', '2024-06-05 14:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "3a7868a2-bba9-48a0-9b38-67b51b258493", "timestamp": "2024-06-05T14:00:00Z", "conversion": false, "event_type": "snapshot_Instance-hours", "expiration": "2024-06-05T15:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.269617536Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Instance-hours', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.269618+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('9042eb0b-40dd-4362-a2e2-81bb319b4721', '2024-06-05 16:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "9042eb0b-40dd-4362-a2e2-81bb319b4721", "timestamp": "2024-06-05T16:00:00Z", "conversion": false, "event_type": "snapshot_Instance-hours", "expiration": "2024-06-05T17:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.270038563Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Instance-hours', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.270039+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('b6fce46d-6363-4435-b628-cd65bdaa1cbb', '2024-06-05 16:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "b6fce46d-6363-4435-b628-cd65bdaa1cbb", "timestamp": "2024-06-05T16:00:00Z", "conversion": false, "event_type": "snapshot_Cores", "expiration": "2024-06-05T17:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.270354274Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 10.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Cores', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.270354+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('ed3527d1-ddd1-401e-8f0e-48dfe699a9d8', '2024-06-05 14:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "ed3527d1-ddd1-401e-8f0e-48dfe699a9d8", "timestamp": "2024-06-05T14:00:00Z", "conversion": false, "event_type": "snapshot_Cores", "expiration": "2024-06-05T15:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.270634558Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 10.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Cores', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.270635+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('43241230-0b02-4ec2-9b48-1ebdd60314aa', '2024-06-05 13:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "43241230-0b02-4ec2-9b48-1ebdd60314aa", "timestamp": "2024-06-05T13:00:00Z", "conversion": false, "event_type": "snapshot_Instance-hours", "expiration": "2024-06-05T14:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.270922807Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Instance-hours', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.270923+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('612e45c8-46dc-4c43-ae30-7d2ba78d24b1', '2024-06-05 15:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "612e45c8-46dc-4c43-ae30-7d2ba78d24b1", "timestamp": "2024-06-05T15:00:00Z", "conversion": false, "event_type": "snapshot_Cores", "expiration": "2024-06-05T16:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.27120791Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 10.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Cores', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.271208+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('06108e98-582d-49ed-ba71-1475a8f897d8', '2024-06-05 17:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "06108e98-582d-49ed-ba71-1475a8f897d8", "timestamp": "2024-06-05T17:00:00Z", "conversion": false, "event_type": "snapshot_Cores", "expiration": "2024-06-05T18:00:00Z", "instance_id": "12c4916b-7e17-4252-ac8e-8b832ff326b3", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:14:26.271573805Z", "display_name": "automation_osd_cluster_12c4916b-7e17-4252-ac8e-8b832ff326b3", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 10.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Cores', 'prometheus', '12c4916b-7e17-4252-ac8e-8b832ff326b3', '17795559', NULL, '2024-06-05 18:14:26.271574+00');
```

Run an initial hourly tally:
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=17795559" x-rh-swatch-psk:placeholder
```

Determine identity:
```
echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"17795559"}}}' | base64 -w 0
eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzc5NTU1OSJ9fX0=
```

Opt in the org:
```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzc5NTU1OSJ9fX0='
```

Check the HOURLY tally Cores and instance-hours report for the current events for the affect range of events. **There should be data present for each hour!!**
```
http :8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Cores granularity==Hourly beginning=='2024-06-05T13:00Z' ending=='2024-06-05T17:00Z' accept:application/vnd.api+json x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzc5NTU1OSJ9fX0=
```

```
http :8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Instance-hours granularity==Hourly beginning=='2024-06-05T13:00Z' ending=='2024-06-05T17:00Z' accept:application/vnd.api+json x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzc5NTU1OSJ9fX0=
```

Add events to create a change to trigger a snapshot update over the sythetic date range of the events.
```
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('33003577-bfa1-415c-8f0d-af9a7b1cd1bf', '2024-06-05 13:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "33003577-bfa1-415c-8f0d-af9a7b1cd1bf", "timestamp": "2024-06-05T13:00:00Z", "conversion": false, "event_type": "snapshot_Cores", "expiration": "2024-06-05T14:00:00Z", "instance_id": "576e5d89-d7ca-49e6-adbf-539ceb20121d", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:22:35.930468418Z", "display_name": "automation_osd_cluster_576e5d89-d7ca-49e6-adbf-539ceb20121d", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 200.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Cores', 'prometheus', '576e5d89-d7ca-49e6-adbf-539ceb20121d', '17795559', NULL, '2024-06-05 18:22:35.930468+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('1ae54f93-1d87-4b96-9825-dbef75d9fb5f', '2024-06-05 13:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "1ae54f93-1d87-4b96-9825-dbef75d9fb5f", "timestamp": "2024-06-05T13:00:00Z", "conversion": false, "event_type": "snapshot_Instance-hours", "expiration": "2024-06-05T14:00:00Z", "instance_id": "576e5d89-d7ca-49e6-adbf-539ceb20121d", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:22:35.930962733Z", "display_name": "automation_osd_cluster_576e5d89-d7ca-49e6-adbf-539ceb20121d", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Instance-hours', 'prometheus', '576e5d89-d7ca-49e6-adbf-539ceb20121d', '17795559', NULL, '2024-06-05 18:22:35.930963+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('266d9bf4-ba6a-4eac-be2c-1bdfe4528366', '2024-06-05 17:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "266d9bf4-ba6a-4eac-be2c-1bdfe4528366", "timestamp": "2024-06-05T17:00:00Z", "conversion": false, "event_type": "snapshot_Instance-hours", "expiration": "2024-06-05T18:00:00Z", "instance_id": "7f0e24e4-a0ec-4598-9e30-bd1ae6bfe06c", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:22:35.965407835Z", "display_name": "automation_osd_cluster_7f0e24e4-a0ec-4598-9e30-bd1ae6bfe06c", "event_source": "prometheus", "measurements": [{"uom": "Instance-hours", "value": 1.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Instance-hours', 'prometheus', '7f0e24e4-a0ec-4598-9e30-bd1ae6bfe06c', '17795559', NULL, '2024-06-05 18:22:35.965408+00');
INSERT INTO public.events (event_id, "timestamp", data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('2e577125-6ec2-45c9-9755-2f084b54132e', '2024-06-05 17:00:00+00', '{"sla": "Premium", "role": "osd", "org_id": "17795559", "event_id": "2e577125-6ec2-45c9-9755-2f084b54132e", "timestamp": "2024-06-05T17:00:00Z", "conversion": false, "event_type": "snapshot_Cores", "expiration": "2024-06-05T18:00:00Z", "instance_id": "7f0e24e4-a0ec-4598-9e30-bd1ae6bfe06c", "product_tag": ["OpenShift-dedicated-metrics"], "record_date": "2024-06-05T18:22:35.965874498Z", "display_name": "automation_osd_cluster_7f0e24e4-a0ec-4598-9e30-bd1ae6bfe06c", "event_source": "prometheus", "measurements": [{"uom": "Cores", "value": 200.0}], "service_type": "OpenShift Cluster"}', 'snapshot_Cores', 'prometheus', '7f0e24e4-a0ec-4598-9e30-bd1ae6bfe06c', '17795559', NULL, '2024-06-05 18:22:35.965874+00');
```

Run the hourly tally again:
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=17795559" x-rh-swatch-psk:placeholder
```

Check the Cores and Instance-hours report again. You should see that only the starting and ending hours have valid values, but all hours in between are zeroed out. THEY SHOULD NOT BE!!
```
http :8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Cores granularity==Hourly beginning=='2024-06-05T13:00Z' ending=='2024-06-05T17:00Z' accept:application/vnd.api+json x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzc5NTU1OSJ9fX0=
```

```
http :8000/api/rhsm-subscriptions/v1/tally/products/OpenShift-dedicated-metrics/Instance-hours granularity==Hourly beginning=='2024-06-05T13:00Z' ending=='2024-06-05T17:00Z' accept:application/vnd.api+json x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNzc5NTU1OSJ9fX0=
```

Re-run these steps with a fresh DB from this PR's branch. The middle hours should contain the correct values.