### PR TITLE
Normalize event measurements to metric_id on receipt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       start_period: 10s
     ports:
       - "127.0.0.1:9092:9092"
+      - "[::1]:9092:9092"
       # Port 9093 is used by the Kraft configuration
       - "127.0.0.1:9094:9094"
       - "127.0.0.1:29092:29092"

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyDataController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyDataController.java
@@ -89,10 +89,15 @@ public class InternalTallyDataController {
     try {
       events =
           objectMapper.readValue(jsonListOfEvents, new TypeReference<List<Event>>() {}).stream()
+              .map(eventController::normalizeEvent)
               .filter(
                   e -> {
-                    log.warn("Invalid event in batch: {}", e);
-                    return eventController.validateServiceInstanceEvent(e);
+                    if (eventController.validateServiceInstanceEvent(e)) {
+                      return true;
+                    } else {
+                      log.warn("Invalid event in batch: {}", e);
+                      return false;
+                    }
                   })
               .toList();
     } catch (Exception e) {

--- a/swatch-model-events/schemas/event.yaml
+++ b/swatch-model-events/schemas/event.yaml
@@ -87,12 +87,13 @@ properties:
         uom:
           description: Metric ID for the measurement. (e.g. Cores, Sockets)
           type: string
-          required: true
+          required: false
           deprecated: true
           deprecationMessage: Use 'metric_id' instead.
         metric_id:
           description: Metric ID for the measurement. (e.g. Cores, Sockets)
           type: string
+          required: true
     required: false
   cloud_provider:
     description: Identifier for the cloud provider of the subject.


### PR DESCRIPTION
Jira issue: SWATCH-2601

Description
===========

When events are ingested either through the testing API or via kafka, normalize the attribute used for metric identification to `metric_id`. If an event is ingested having `uom`, then the value is set on `metric_id`, and removed from `uom`.

Testing
=======

IQE Test MR: [!736](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/736)