### PR TITLE
Work around HBI DB connection failure on startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
         condition: service_healthy
       unleash:
         condition: service_healthy
+    restart: unless-stopped
     ports:
       - "127.0.0.1:8050:8000"
     user: root


### PR DESCRIPTION
Sometimes when the HBI container is starting up via podman-compose, it fails to connect to the DB becuase the DB service isn't fully up. This patch tells HBI to attempt to restart on failure so that DB will be ready on the next attempt.

# Testing
Bring up all services via podman-compose and ensure that the inventory services are up and running.
```
podman-compose up -d 
```
```
podman ps
```