### PR TITLE
SWATCH-2624: Don't log errors after missing permissions in exports

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/subscription/export/SubscriptionDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/export/SubscriptionDataExporterServiceTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.subscription.export;
 
+import static org.candlepin.subscriptions.export.ExportSubscriptionListener.MISSING_PERMISSIONS;
 import static org.candlepin.subscriptions.subscription.export.SubscriptionDataExporterService.PRODUCT_ID;
 
 import com.redhat.cloud.event.apps.exportservice.v1.Format;
@@ -72,7 +73,7 @@ class SubscriptionDataExporterServiceTest extends BaseDataExporterServiceTest {
   void testRequestWithoutPermissions() {
     givenExportRequestWithoutPermissions();
     whenReceiveExportRequest();
-    verifyRequestWasSentToExportServiceWithError(request);
+    verifyRequestWasSentToExportServiceWithError(request, MISSING_PERMISSIONS);
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/test/ExtendWithExportServiceWireMock.java
+++ b/src/test/java/org/candlepin/subscriptions/test/ExtendWithExportServiceWireMock.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.test;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -65,16 +66,22 @@ public interface ExtendWithExportServiceWireMock {
 
   default void verifyRequestWasSentToExportServiceWithError(
       GenericConsoleCloudEvent<ResourceRequest> request) {
+    verifyRequestWasSentToExportServiceWithError(request, "");
+  }
+
+  default void verifyRequestWasSentToExportServiceWithError(
+      GenericConsoleCloudEvent<ResourceRequest> request, String message) {
     Awaitility.await()
         .untilAsserted(
             () ->
                 EXPORT_SERVICE_WIRE_MOCK_SERVER.verify(
                     postRequestedFor(
-                        urlEqualTo(
-                            String.format(
-                                "/app/export/v1/%s/subscriptions/%s/error",
-                                request.getData().getResourceRequest().getExportRequestUUID(),
-                                request.getData().getResourceRequest().getUUID())))));
+                            urlEqualTo(
+                                String.format(
+                                    "/app/export/v1/%s/subscriptions/%s/error",
+                                    request.getData().getResourceRequest().getExportRequestUUID(),
+                                    request.getData().getResourceRequest().getUUID())))
+                        .withRequestBody(containing(message))));
   }
 
   default void verifyNoRequestsWereSentToExportServiceWithUploadData(


### PR DESCRIPTION
Jira issue: SWATCH-2624

## Description
Instead, print a warning trace and properly mark the request as error using the Export API.

## Testing
Added unit tests for covering this change.