### PR TITLE
SWATCH-2644: Add filter for orgId ++ increase performance of view

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionCsvDataMapperService.java
@@ -20,12 +20,14 @@
  */
 package org.candlepin.subscriptions.subscription.export;
 
-import static org.candlepin.subscriptions.subscription.export.SubscriptionDataExporterService.PHYSICAL;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.PHYSICAL;
 import static org.candlepin.subscriptions.subscription.export.SubscriptionDataExporterService.groupMetrics;
 
 import java.util.List;
 import java.util.Optional;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityView;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.export.DataMapperService;
 import org.candlepin.subscriptions.export.ExportServiceRequest;
 import org.candlepin.subscriptions.json.SubscriptionsExportCsvItem;
@@ -59,8 +61,12 @@ public class SubscriptionCsvDataMapperService
 
               // map offering
               item.setSku(dataItem.getSku());
-              Optional.ofNullable(dataItem.getUsage()).ifPresent(item::setUsage);
-              Optional.ofNullable(dataItem.getServiceLevel()).ifPresent(item::setServiceLevel);
+              Optional.ofNullable(dataItem.getUsage())
+                  .map(Usage::getValue)
+                  .ifPresent(item::setUsage);
+              Optional.ofNullable(dataItem.getServiceLevel())
+                  .map(ServiceLevel::getValue)
+                  .ifPresent(item::setServiceLevel);
               item.setProductName(dataItem.getProductName());
               return (Object) item;
             })

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionDataExporterService.java
@@ -20,6 +20,15 @@
  */
 package org.candlepin.subscriptions.subscription.export;
 
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.billingAccountIdStartsWith;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.billingProviderEquals;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.buildSearchSpecification;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.getMeasurementTypeFromCategory;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.hasCategory;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.hasMetricId;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.productIdEquals;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.slaEquals;
+import static org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository.usageEquals;
 import static org.candlepin.subscriptions.resource.ResourceUtils.ANY;
 
 import com.redhat.swatch.configuration.registry.MetricId;
@@ -37,13 +46,11 @@ import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
-import org.candlepin.subscriptions.db.HypervisorReportCategory;
 import org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityView;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityViewMetric;
-import org.candlepin.subscriptions.db.model.SubscriptionCapacityView_;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.exception.ExportServiceException;
 import org.candlepin.subscriptions.export.DataExporterService;
@@ -65,8 +72,6 @@ public class SubscriptionDataExporterService
   static final String PRODUCT_ID = "product_id";
   static final String METRIC_ID = "metric_id";
   static final String CATEGORY = "category";
-  static final String PHYSICAL = "PHYSICAL";
-  static final String HYPERVISOR = "HYPERVISOR";
   private static final Map<String, Function<String, Specification<SubscriptionCapacityView>>>
       FILTERS =
           Map.of(
@@ -110,7 +115,7 @@ public class SubscriptionDataExporterService
 
   private Specification<SubscriptionCapacityView> extractExportFilter(
       ExportServiceRequest request) {
-    Specification<SubscriptionCapacityView> criteria = Specification.where(null);
+    Specification<SubscriptionCapacityView> criteria = buildSearchSpecification(request.getOrgId());
     if (request.getFilters() != null) {
       var filters = request.getFilters().entrySet();
       try {
@@ -137,17 +142,14 @@ public class SubscriptionDataExporterService
   }
 
   private static Specification<SubscriptionCapacityView> handleProductIdFilter(String value) {
-    var productId = ProductId.fromString(value).getValue();
-    return (root, query, builder) ->
-        builder.equal(root.get(SubscriptionCapacityView_.productTag), productId);
+    return productIdEquals(ProductId.fromString(value));
   }
 
   private static Specification<SubscriptionCapacityView> handleUsageFilter(String value) {
     Usage usage = Usage.fromString(value);
     if (value.equalsIgnoreCase(usage.getValue())) {
       if (!Usage._ANY.equals(usage)) {
-        return (root, query, builder) ->
-            builder.equal(root.get(SubscriptionCapacityView_.usage), usage.getValue());
+        return usageEquals(usage);
       }
     } else {
       throw new IllegalArgumentException(String.format("usage: %s not supported", value));
@@ -160,9 +162,7 @@ public class SubscriptionDataExporterService
     ServiceLevel serviceLevel = ServiceLevel.fromString(value);
     if (value.equalsIgnoreCase(serviceLevel.getValue())) {
       if (!ServiceLevel._ANY.equals(serviceLevel)) {
-        return (root, query, builder) ->
-            builder.equal(
-                root.get(SubscriptionCapacityView_.serviceLevel), serviceLevel.getValue());
+        return slaEquals(serviceLevel);
       }
     } else {
       throw new IllegalArgumentException(String.format("sla: %s not supported", value));
@@ -172,35 +172,18 @@ public class SubscriptionDataExporterService
   }
 
   private static Specification<SubscriptionCapacityView> handleCategoryFilter(String value) {
-    String measurementType = getMeasurementTypeFromCategory(value);
-    if (measurementType != null) {
-      return handleMetricsFilter("measurement_type", measurementType);
-    }
-
-    return null;
+    return hasCategory(ReportCategory.fromValue(value));
   }
 
   private static Specification<SubscriptionCapacityView> handleMetricIdFilter(String value) {
-    return handleMetricsFilter(METRIC_ID, MetricId.fromString(value).toString());
-  }
-
-  private static Specification<SubscriptionCapacityView> handleMetricsFilter(
-      String key, String value) {
-    return (root, query, builder) ->
-        builder.isTrue(
-            builder.function(
-                "jsonb_path_exists",
-                Boolean.class,
-                root.get("metrics"),
-                builder.literal("$[*] ? (@." + key + " == \"" + value + "\")")));
+    return hasMetricId(MetricId.fromString(value).toString());
   }
 
   private static Specification<SubscriptionCapacityView> handleBillingProviderFilter(String value) {
     BillingProvider billingProvider = BillingProvider.fromString(value);
     if (value.equalsIgnoreCase(billingProvider.getValue())) {
       if (!BillingProvider._ANY.equals(billingProvider)) {
-        return (root, query, builder) ->
-            builder.equal(root.get(SubscriptionCapacityView_.billingProvider), billingProvider);
+        return billingProviderEquals(billingProvider);
       }
     } else {
       throw new IllegalArgumentException(
@@ -213,8 +196,7 @@ public class SubscriptionDataExporterService
   private static Specification<SubscriptionCapacityView> handleBillingAccountIdFilter(
       String value) {
     if (!ANY.equalsIgnoreCase(value)) {
-      return (root, query, builder) ->
-          builder.like(root.get(SubscriptionCapacityView_.billingAccountId), value + "%");
+      return billingAccountIdStartsWith(value);
     }
 
     return null;
@@ -263,20 +245,9 @@ public class SubscriptionDataExporterService
     if (request != null
         && request.getFilters() != null
         && request.getFilters().get(CATEGORY) instanceof String value) {
-      return getMeasurementTypeFromCategory(value);
+      return getMeasurementTypeFromCategory(ReportCategory.fromValue(value));
     }
 
-    return null;
-  }
-
-  private static String getMeasurementTypeFromCategory(String value) {
-    var category = HypervisorReportCategory.mapCategory(ReportCategory.fromString(value));
-    if (category != null) {
-      return switch (category) {
-        case NON_HYPERVISOR -> PHYSICAL;
-        case HYPERVISOR -> HYPERVISOR;
-      };
-    }
     return null;
   }
 

--- a/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionJsonDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionJsonDataMapperService.java
@@ -25,7 +25,9 @@ import static org.candlepin.subscriptions.subscription.export.SubscriptionDataEx
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityView;
+import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.export.DataMapperService;
 import org.candlepin.subscriptions.export.ExportServiceRequest;
 import org.candlepin.subscriptions.json.SubscriptionsExportJsonItem;
@@ -42,8 +44,10 @@ public class SubscriptionJsonDataMapperService
 
     // map offering
     item.setSku(dataItem.getSku());
-    Optional.ofNullable(dataItem.getUsage()).ifPresent(item::setUsage);
-    Optional.ofNullable(dataItem.getServiceLevel()).ifPresent(item::setServiceLevel);
+    Optional.ofNullable(dataItem.getUsage()).map(Usage::getValue).ifPresent(item::setUsage);
+    Optional.ofNullable(dataItem.getServiceLevel())
+        .map(ServiceLevel::getValue)
+        .ifPresent(item::setServiceLevel);
     item.setProductName(dataItem.getProductName());
     item.setSubscriptionNumber(dataItem.getSubscriptionNumber());
     item.setQuantity((double) dataItem.getQuantity());

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -22,12 +22,10 @@ package org.candlepin.subscriptions.tally.export;
 
 import static org.candlepin.subscriptions.db.TallyInstanceViewRepository.buildSearchSpecification;
 import static org.candlepin.subscriptions.resource.InstancesResource.getHardwareMeasurementTypesFromCategory;
-import static org.candlepin.subscriptions.resource.InstancesResource.isPayg;
 import static org.candlepin.subscriptions.resource.ResourceUtils.ANY;
 
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.ProductId;
-import com.redhat.swatch.configuration.registry.Variant;
 import jakarta.ws.rs.core.Response;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -106,7 +104,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
   public Stream<TallyInstanceView> fetchData(ExportServiceRequest request) {
     log.debug("Fetching data for {}", request.getOrgId());
     var reportCriteria = extractExportFilter(request);
-    boolean isPayg = isPayg(Variant.findByTag(reportCriteria.getProductId()));
+    boolean isPayg = ProductId.fromString(reportCriteria.getProductId()).isPayg();
     var repository = isPayg ? paygViewRepository : nonPaygViewRepository;
     return repository
         .findBy(buildSearchSpecification(reportCriteria), FluentQuery.FetchableFluentQuery::stream)
@@ -157,7 +155,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
     }
 
     // special handling of the month for non payg products
-    if (!isPayg(Variant.findByTag(report.build().getProductId()))) {
+    if (!ProductId.fromString(report.build().getProductId()).isPayg()) {
       report.month(null);
     }
 

--- a/src/main/resources/liquibase/202406120950-update-subscription-capacity-view.xml
+++ b/src/main/resources/liquibase/202406120950-update-subscription-capacity-view.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202405160950-01" author="jcarvaja" dbms="postgresql">
+    <comment>
+      Add subscription_capacity_view that aggregates all the capacities by sku
+    </comment>
+    <dropView viewName="subscription_capacity_view" />
+    <createView
+            replaceIfExists="true"
+            viewName="subscription_capacity_view">
+        <![CDATA[with active_subscriptions as
+                        (
+                          select subscription_id, MAX(start_date) as start_date
+                          from "subscription"
+                          where start_date <= now() and (end_date is null or end_date >= now())
+                          group by subscription_id
+                        )
+                 select s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.has_unlimited_usage,
+                        o.product_name,
+                        coalesce(o.sla, '') as service_level,
+                        coalesce(o."usage", '') as "usage",
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_provider_id,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        jsonb_agg(jsonb_build_object('metric_id',sm.metric_id,'value', sm.value, 'measurement_type', sm.measurement_type)) as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from active_subscriptions a
+                 inner join "subscription" s on a.subscription_id=s.subscription_id and a.start_date=s.start_date
+                 inner join offering o on s.sku=o.sku
+                 inner join sku_product_tag spt on s.sku = spt.sku
+                 left join subscription_measurements sm on s.subscription_id = sm.subscription_id
+                 group by s.subscription_id, s.subscription_number, s.sku, o.has_unlimited_usage, o.product_name, o.sla, o."usage" , s.org_id, s.billing_provider, s.billing_provider_id, s.billing_account_id, spt.product_tag,s.quantity,s.start_date,s.end_date
+        ]]>
+    </createView>
+    <rollback>
+      <createView
+              replaceIfExists="true"
+              viewName="subscription_capacity_view">
+        <![CDATA[select s.subscription_id,
+               s.subscription_number,
+               s.sku,
+               o.product_name,
+               coalesce(o.sla, '') as service_level,
+               coalesce(o."usage", '') as "usage",
+               s.org_id,
+               s.billing_provider,
+               s.billing_account_id,
+               s.start_date,
+               s.end_date,
+               jsonb_agg(jsonb_build_object('metric_id',sm.metric_id,'value', sm.value, 'measurement_type', sm.measurement_type)) as metrics,
+               spt.product_tag,
+               s.quantity as quantity
+        from (select org_id,
+                     subscription_id,
+                     subscription_number,
+                     sku,
+                     billing_provider,
+                     billing_account_id,
+                     start_date,
+                     end_date,
+                     quantity,
+                     row_number() over (partition by subscription_id order by start_date asc) as duplicated_sub_id
+              from "subscription") s
+        inner join offering o on s.sku=o.sku
+        inner join sku_product_tag spt on s.sku = spt.sku
+        left join subscription_measurements sm on s.subscription_id = sm.subscription_id
+        where s.start_date <= now() and (s.end_date is null or s.end_date >= now()) and duplicated_sub_id=1
+        group by s.subscription_id, s.subscription_number, s.sku, o.product_name, o.sla, o."usage" , s.org_id, s.billing_provider, s.billing_account_id, spt.product_tag,s.quantity,s.start_date,s.end_date
+        order by s.subscription_id asc
+        ]]>
+      </createView>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202405160950-02" author="jcarvaja" dbms="hsqldb">
+    <comment>
+      Add subscription_capacity_view that aggregates all the capacities by sku (test version)
+    </comment>
+    <dropView viewName="subscription_capacity_view" />
+    <createView
+            replaceIfExists="true"
+            viewName="subscription_capacity_view">
+        <![CDATA[select s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.has_unlimited_usage,
+                        o.product_name,
+                        o.sla as service_level,
+                        o.usage,
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_provider_id,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        CONCAT('[{"metric_id":"', sm.metric_id, '","value":',sm.value, '","measurement_type":',sm.measurement_type , '}]') as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from subscription s
+                 inner join offering o on s.sku=o.sku
+                 inner join sku_product_tag spt on s.sku = spt.sku
+                 left join subscription_measurements sm on s.subscription_id = sm.subscription_id and s.start_date=sm.start_date
+                 where s.start_date <= now() and (s.end_date is null or s.end_date >= now())
+                 group by s.subscription_id, s.subscription_number, s.sku, o.has_unlimited_usage, o.product_name, o.sla, o.usage , s.org_id, s.billing_provider, s.billing_provider_id, s.billing_account_id, spt.product_tag,s.quantity, sm.metric_id, sm.value, sm.measurement_type, s.start_date, s.end_date
+                 order by s.subscription_id asc
+      ]]>
+    </createView>
+    <rollback>
+      <createView
+              replaceIfExists="true"
+              viewName="subscription_capacity_view">
+        <![CDATA[select s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.product_name,
+                        o.sla as service_level,
+                        o.usage,
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        CONCAT('[{"metric_id":"', sm.metric_id, '","value":',sm.value, '","measurement_type":',sm.measurement_type , '}]') as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from subscription s
+                 inner join offering o on s.sku=o.sku
+                 inner join sku_product_tag spt on s.sku = spt.sku
+                 left join subscription_measurements sm on s.subscription_id = sm.subscription_id and s.start_date=sm.start_date
+                 where s.start_date <= now() and (s.end_date is null or s.end_date >= now())
+                 group by s.subscription_id, s.subscription_number, s.sku, o.product_name, o.sla, o.usage , s.org_id, s.billing_provider, s.billing_account_id, spt.product_tag,s.quantity, sm.metric_id, sm.value, sm.measurement_type, s.start_date, s.end_date
+                 order by s.subscription_id asc
+      ]]>
+      </createView>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -162,5 +162,6 @@
     <include file="/liquibase/202405300830-split-instance-view-to-payg-and-non-payg-versions.xml"/>
     <include file="/liquibase/202406130700-add-index-in-sku-product-tag.xml"/>
     <include file="/liquibase/202406051539-remove-erroneously-duplicated-subscriptions.xml"/>
+    <include file="/liquibase/202406120950-update-subscription-capacity-view.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/export/BaseDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/export/BaseDataExporterServiceTest.java
@@ -110,11 +110,7 @@ public abstract class BaseDataExporterServiceTest
     offering.setServiceLevel(ServiceLevel.PREMIUM);
     offeringRepository.save(offering);
 
-    accountServiceInventory = new AccountServiceInventory();
-    accountServiceInventory.setId(new AccountServiceInventoryId());
-    accountServiceInventory.getId().setServiceType(INSTANCE_TYPE);
-    accountServiceInventory.getId().setOrgId(ORG_ID);
-    accountServiceInventoryRepository.save(accountServiceInventory);
+    accountServiceInventory = givenHostInAccountServices(ORG_ID);
   }
 
   protected abstract String resourceType();
@@ -168,6 +164,15 @@ public abstract class BaseDataExporterServiceTest
     } catch (RbacApiException e) {
       Assertions.fail("Failed to call the get permissions method", e);
     }
+  }
+
+  protected AccountServiceInventory givenHostInAccountServices(String orgId) {
+    AccountServiceInventory inventory = new AccountServiceInventory();
+    inventory.setId(new AccountServiceInventoryId());
+    inventory.getId().setServiceType(INSTANCE_TYPE);
+    inventory.getId().setOrgId(orgId);
+    accountServiceInventoryRepository.save(inventory);
+    return inventory;
   }
 
   protected void whenReceiveExportRequest() {

--- a/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
@@ -197,6 +197,16 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     verifyRequestWasSentToExportServiceWithError(request);
   }
 
+  @Test
+  void testRequestShouldFilterByOrgId() {
+    givenInstanceWithMetricsForAnotherOrgId(RHEL_FOR_X86);
+    givenInstanceWithMetrics(RHEL_FOR_X86);
+    givenExportRequestWithPermissions(Format.JSON);
+    givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
+    whenReceiveExportRequest();
+    verifyRequestWasSentToExportService();
+  }
+
   @Override
   protected void verifyRequestWasSentToExportService() {
     var expected = new InstancesExportJson();
@@ -261,9 +271,20 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     verifyRequestWasSentToExportServiceWithUploadData(request, toJson(expected));
   }
 
+  private void givenInstanceWithMetricsForAnotherOrgId(String productId) {
+    var account = givenHostInAccountServices(UUID.randomUUID().toString());
+    HostWithGuests instance = givenInstanceWithMetrics(account.getOrgId(), productId);
+    // removing it as we don't expect this host from being exported.
+    itemsToBeExported.remove(instance);
+  }
+
   private void givenInstanceWithMetrics(String productId) {
+    givenInstanceWithMetrics(ORG_ID, productId);
+  }
+
+  private HostWithGuests givenInstanceWithMetrics(String orgId, String productId) {
     Host guest = new Host();
-    guest.setOrgId(ORG_ID);
+    guest.setOrgId(orgId);
     guest.setDisplayName("this is the guest");
     guest.setLastSeen(OffsetDateTime.parse(APRIL));
     guest.setHardwareType(HostHardwareType.PHYSICAL);
@@ -273,7 +294,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     repository.save(guest);
 
     Host instance = new Host();
-    instance.setOrgId(ORG_ID);
+    instance.setOrgId(orgId);
     instance.setNumOfGuests(1);
     instance.setInstanceId("456");
     instance.setDisplayName("my host");
@@ -320,6 +341,7 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     item.guests = List.of(guest);
     item.usePaygProduct = isPayg;
     itemsToBeExported.add(item);
+    return item;
   }
 
   private static double resolveMetricValue(HostWithGuests item, MetricId metricId) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
@@ -20,8 +20,25 @@
  */
 package org.candlepin.subscriptions.db;
 
+import static org.candlepin.subscriptions.resource.ResourceUtils.ANY;
+import static org.candlepin.subscriptions.resource.ResourceUtils.sanitizeBillingAccountId;
+import static org.candlepin.subscriptions.resource.ResourceUtils.sanitizeBillingProvider;
+import static org.candlepin.subscriptions.resource.ResourceUtils.sanitizeServiceLevel;
+import static org.candlepin.subscriptions.resource.ResourceUtils.sanitizeUsage;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
+import java.util.Objects;
 import java.util.stream.Stream;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.SubscriptionCapacityView;
+import org.candlepin.subscriptions.db.model.SubscriptionCapacityView_;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.utilization.api.model.BillingProviderType;
+import org.candlepin.subscriptions.utilization.api.model.ReportCategory;
+import org.candlepin.subscriptions.utilization.api.model.ServiceLevelType;
+import org.candlepin.subscriptions.utilization.api.model.UsageType;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -30,8 +47,141 @@ import org.springframework.data.repository.query.FluentQuery;
 public interface SubscriptionCapacityViewRepository
     extends JpaRepository<SubscriptionCapacityView, String>,
         JpaSpecificationExecutor<SubscriptionCapacityView> {
+
+  String PHYSICAL = "PHYSICAL";
+  String HYPERVISOR = "HYPERVISOR";
+
   default Stream<SubscriptionCapacityView> streamBy(
       Specification<SubscriptionCapacityView> criteria) {
     return findBy(criteria, FluentQuery.FetchableFluentQuery::stream);
+  }
+
+  static Specification<SubscriptionCapacityView> buildSearchSpecification(String orgId) {
+    return buildSearchSpecification(orgId, null, null, null, null, null, null, null);
+  }
+
+  static Specification<SubscriptionCapacityView> buildSearchSpecification( // NOSONAR
+      String orgId,
+      ProductId productId,
+      ReportCategory category,
+      ServiceLevelType serviceLevel,
+      UsageType usage,
+      BillingProviderType billingProviderType,
+      String billingAccountId,
+      String metricId) {
+    ServiceLevel sanitizedServiceLevel = sanitizeServiceLevel(serviceLevel);
+    Usage sanitizedUsage = sanitizeUsage(usage);
+    BillingProvider sanitizedBillingProvider = sanitizeBillingProvider(billingProviderType);
+    String sanitizedBillingAccountId = sanitizeBillingAccountId(billingAccountId);
+
+    /* The where call allows us to build a Specification object to operate on even if the first
+     * specification method we call returns null (which it won't in this case, but it's good
+     * practice to handle it). */
+    Specification<SubscriptionCapacityView> searchCriteria =
+        Specification.where(orgIdEquals(orgId));
+    if (productId != null) {
+      searchCriteria = searchCriteria.and(productIdEquals(productId));
+      if (productId.isPayg() || productId.isPrometheusEnabled()) {
+        searchCriteria = searchCriteria.and(hasBillingProviderId());
+      }
+    }
+    if (Objects.nonNull(sanitizedServiceLevel)
+        && !sanitizedServiceLevel.equals(ServiceLevel._ANY)) {
+      searchCriteria = searchCriteria.and(slaEquals(sanitizedServiceLevel));
+    }
+    if (Objects.nonNull(sanitizedUsage) && !sanitizedUsage.equals(Usage._ANY)) {
+      searchCriteria = searchCriteria.and(usageEquals(sanitizedUsage));
+    }
+    if (Objects.nonNull(sanitizedBillingProvider)
+        && !sanitizedBillingProvider.equals(BillingProvider._ANY)) {
+      searchCriteria = searchCriteria.and(billingProviderEquals(sanitizedBillingProvider));
+    }
+    if (Objects.nonNull(metricId)) {
+      searchCriteria = searchCriteria.and(hasMetricId(metricId));
+    }
+    if (Objects.nonNull(category)) {
+      searchCriteria = searchCriteria.and(hasCategory(category));
+    }
+    if (Objects.nonNull(sanitizedBillingAccountId)
+        && !ANY.equalsIgnoreCase(sanitizedBillingAccountId)
+        && productId != null
+        && productId.isPrometheusEnabled()) {
+      searchCriteria = searchCriteria.and(billingAccountIdStartsWith(sanitizedBillingAccountId));
+    }
+
+    return searchCriteria;
+  }
+
+  static Specification<SubscriptionCapacityView> productIdEquals(ProductId productId) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.productTag), productId.getValue());
+  }
+
+  static Specification<SubscriptionCapacityView> hasBillingProviderId() {
+    return (root, query, builder) ->
+        builder.and(
+            builder.isNotNull(root.get(SubscriptionCapacityView_.billingProviderId)),
+            builder.notEqual(root.get(SubscriptionCapacityView_.billingProviderId), ""));
+  }
+
+  static Specification<SubscriptionCapacityView> billingAccountIdStartsWith(String value) {
+    return (root, query, builder) ->
+        builder.like(root.get(SubscriptionCapacityView_.billingAccountId), value + "%");
+  }
+
+  static Specification<SubscriptionCapacityView> slaEquals(ServiceLevel sla) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.serviceLevel), sla);
+  }
+
+  static Specification<SubscriptionCapacityView> usageEquals(Usage usage) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.usage), usage);
+  }
+
+  static Specification<SubscriptionCapacityView> billingProviderEquals(
+      BillingProvider billingProvider) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.billingProvider), billingProvider);
+  }
+
+  static Specification<SubscriptionCapacityView> hasCategory(ReportCategory value) {
+    String measurementType = getMeasurementTypeFromCategory(value);
+    if (measurementType != null) {
+      return handleMetricsFilter("measurement_type", measurementType);
+    }
+
+    return null;
+  }
+
+  static Specification<SubscriptionCapacityView> hasMetricId(String value) {
+    return handleMetricsFilter("metric_id", MetricId.fromString(value).toString());
+  }
+
+  static String getMeasurementTypeFromCategory(ReportCategory value) {
+    var category = HypervisorReportCategory.mapCategory(value);
+    if (category != null) {
+      return switch (category) {
+        case NON_HYPERVISOR -> PHYSICAL;
+        case HYPERVISOR -> HYPERVISOR;
+      };
+    }
+    return null;
+  }
+
+  static Specification<SubscriptionCapacityView> orgIdEquals(String orgId) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.orgId), orgId);
+  }
+
+  private static Specification<SubscriptionCapacityView> handleMetricsFilter(
+      String key, String value) {
+    return (root, query, builder) ->
+        builder.isTrue(
+            builder.function(
+                "jsonb_path_exists",
+                Boolean.class,
+                root.get("metrics"),
+                builder.literal("$[*] ? (@." + key + " == \"" + value + "\")")));
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/SubscriptionCapacityView.java
@@ -57,20 +57,26 @@ public class SubscriptionCapacityView implements Serializable {
   @Column(name = "sku")
   private String sku;
 
+  @Column(name = "has_unlimited_usage")
+  private Boolean hasUnlimitedUsage;
+
   @Column(name = "product_name")
   private String productName;
 
   @Column(name = "service_level")
-  private String serviceLevel;
+  private ServiceLevel serviceLevel;
 
   @Column(name = "usage")
-  private String usage;
+  private Usage usage;
 
   @Column(name = "org_id")
   private String orgId;
 
   @Column(name = "billing_provider")
   private BillingProvider billingProvider;
+
+  @Column(name = "billing_provider_id")
+  private BillingProvider billingProviderId;
 
   @Column(name = "billing_account_id")
   private String billingAccountId;


### PR DESCRIPTION
Jira issue: SWATCH-2644

## Description
Changes:
- moved the specification to the view repository, so it can be reused in https://github.com/RedHatInsights/rhsm-subscriptions/pull/3423
- improved the view performance by using the WITH clause
- added the has_infinity_quantity and billing_provider_id that will be needed for [SWATCH-2410](https://github.com/RedHatInsights/rhsm-subscriptions/pull/3423)

## Testing
Added new integration tests to reproduce the bug.
For IQE tooling, follow the instructions from the linked JIRA ticket.