### PR TITLE
SWATCH-2647: swatch-metrics no longer skips event creation for els-payg-addon

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -314,8 +314,8 @@ public class EventController {
         isValid = false;
       } else {
         log.debug("matching payg product tags for event={}: {}", event, matchingProductTags);
-        log.info("event.product_tags={}", event.getProductTag());
         event.setProductTag(matchingProductTags);
+        log.info("event.product_tags={}", event.getProductTag());
       }
     }
 

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.configuration.registry.Variant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -263,10 +264,22 @@ public class EventController {
   }
 
   public boolean validateServiceInstanceEvent(Event event) {
+    return isValidInstanceId(event) && isValidMeasurement(event) && isValidProductTag(event);
+  }
+
+  private boolean isValidInstanceId(Event event) {
+    boolean isValid = true;
+
     if (Objects.isNull(event.getInstanceId())) {
       log.warn("Event.instanceId must not be null. event={}", event);
-      return false;
+      isValid = false;
     }
+
+    return isValid;
+  }
+
+  private boolean isValidMeasurement(Event event) {
+    boolean isValid = true;
 
     List<Measurement> invalidMeasurements =
         Optional.ofNullable(event.getMeasurements()).orElse(Collections.emptyList()).stream()
@@ -275,31 +288,48 @@ public class EventController {
 
     if (!invalidMeasurements.isEmpty()) {
       log.warn("Event measurement value(s) must be >= 0. event={}", event);
-      return false;
+      isValid = false;
     }
 
-    // Determine whether the product is payg or non-payg, and then add the appropriate tag in
-    // SWATCH-1993. We are only checking for payg at this time because we only support payg in this
-    // flow, and we don't have a way to distinguish between payg and non-payg through events.
-    String role = event.getRole() != null ? event.getRole().toString() : null;
+    return isValid;
+  }
 
-    Set<String> matchingProductTags = filterOnApplicableTags(event, role);
+  private boolean isValidProductTag(Event event) {
+    boolean isValid = true;
 
-    if (matchingProductTags.isEmpty()) {
-      log.warn("Event data doesn't match configured product tags in swatch. event={}", event);
-      return false;
+    // If product tag is already present in the event then verify whether it is present in our
+    // config
+    if (Objects.nonNull(event.getProductTag()) && !event.getProductTag().isEmpty()) {
+      isValid =
+          event.getProductTag().stream().findFirst().map(Variant::isValidProductTag).orElse(false);
+      if (!isValid) {
+        log.warn("Product tag {} is invalid.", event.getProductTag().stream().findFirst());
+      }
+    } else {
+      // Determine whether the product is payg or non-payg, and then add the appropriate tag in
+      // SWATCH-1993.  We are only checking for payg at this time because we only support payg in
+      // this flow, and we don't have a way to distinguish between payg and non-payg through events.
+      String role = event.getRole() != null ? event.getRole().toString() : null;
+
+      Set<String> matchingProductTags = filterOnApplicableTags(event, role);
+
+      if (matchingProductTags.isEmpty()) {
+        log.warn("Event data doesn't match configured product tags in swatch. event={}", event);
+        isValid = false;
+      } else {
+        log.info(
+            "matching payg product tags for role={}, productIds={}, productName={}, conversion={}: {}",
+            role,
+            event.getProductIds(),
+            null,
+            event.getConversion(),
+            matchingProductTags);
+        log.info("event.product_tags={}", event.getProductTag());
+        event.setProductTag(matchingProductTags);
+      }
     }
 
-    log.info(
-        "matching payg product tags for role={}, productIds={}, productName={}, conversion={}: {}",
-        role,
-        event.getProductIds(),
-        null,
-        event.getConversion(),
-        matchingProductTags);
-    log.info("event.product_tags={}", event.getProductTag());
-    event.setProductTag(matchingProductTags);
-    return true;
+    return isValid;
   }
 
   protected Set<String> filterOnApplicableTags(Event event, String role) {

--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -306,24 +306,14 @@ public class EventController {
         log.warn("Product tag {} is invalid.", event.getProductTag().stream().findFirst());
       }
     } else {
-      // Determine whether the product is payg or non-payg, and then add the appropriate tag in
-      // SWATCH-1993.  We are only checking for payg at this time because we only support payg in
-      // this flow, and we don't have a way to distinguish between payg and non-payg through events.
-      String role = event.getRole() != null ? event.getRole().toString() : null;
 
-      Set<String> matchingProductTags = filterOnApplicableTags(event, role);
+      Set<String> matchingProductTags = filterOnApplicableTags(event);
 
       if (matchingProductTags.isEmpty()) {
         log.warn("Event data doesn't match configured product tags in swatch. event={}", event);
         isValid = false;
       } else {
-        log.info(
-            "matching payg product tags for role={}, productIds={}, productName={}, conversion={}: {}",
-            role,
-            event.getProductIds(),
-            null,
-            event.getConversion(),
-            matchingProductTags);
+        log.debug("matching payg product tags for event={}: {}", event, matchingProductTags);
         log.info("event.product_tags={}", event.getProductTag());
         event.setProductTag(matchingProductTags);
       }
@@ -332,7 +322,11 @@ public class EventController {
     return isValid;
   }
 
-  protected Set<String> filterOnApplicableTags(Event event, String role) {
+  protected Set<String> filterOnApplicableTags(Event event) {
+    // Determine whether the product is payg or non-payg, and then add the appropriate tag in
+    // SWATCH-1993.  We are only checking for payg at this time because we only support payg in
+    // this flow, and we don't have a way to distinguish between payg and non-payg through events.
+    String role = event.getRole() != null ? event.getRole().toString() : null;
     Set<String> matchingProductTags =
         SubscriptionDefinition.getAllProductTagsByRoleOrEngIds(
             role, event.getProductIds(), null, true, event.getConversion());

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -388,6 +388,71 @@ class EventControllerTest {
   }
 
   @Test
+  void testPersistServiceInstances_WhenProductTagExists() {
+    List<String> eventRecords = new ArrayList<>();
+
+    var invalidProductTagEventRecord1 =
+        """
+                    {
+                     "sla":"Premium",
+                     "org_id":"111111111",
+                     "timestamp":"2024-06-10T10:00:00Z",
+                     "conversion":false,
+                     "event_type":"snapshot_rhel-for-x86-els-payg-addon_vCPUs",
+                     "expiration":"2024-06-10T11:00:00Z",
+                     "instance_id":"d147ddf2-be4a-4a59-acf7-7f222758b47c",
+                     "product_tag":[
+                        "dummy"
+                     ],
+                     "display_name":"automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c",
+                     "event_source":"Premium",
+                     "measurements":[
+                        {
+                           "uom":"vCPUs",
+                           "value":4.0,
+                           "metric_id":"vCPUs"
+                        }
+                     ],
+                     "service_type":"RHEL System"
+                  }
+            """;
+
+    var validProductTagEventRecord1 =
+        """
+                    {
+                     "sla":"Premium",
+                     "org_id":"111111111",
+                     "timestamp":"2024-06-10T10:00:00Z",
+                     "conversion":false,
+                     "event_type":"snapshot_rhel-for-x86-els-payg-addon_vCPUs",
+                     "expiration":"2024-06-10T11:00:00Z",
+                     "instance_id":"d147ddf2-be4a-4a59-acf7-7f222758b47c",
+                     "product_tag":[
+                        "rhel-for-x86-els-payg-addon"
+                     ],
+                     "display_name":"automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c",
+                     "event_source":"Premium",
+                     "measurements":[
+                        {
+                           "uom":"vCPUs",
+                           "value":4.0,
+                           "metric_id":"vCPUs"
+                        }
+                     ],
+                     "service_type":"RHEL System"
+                  }
+            """;
+    eventRecords.add(validProductTagEventRecord1);
+    eventRecords.add(invalidProductTagEventRecord1);
+    eventController.persistServiceInstances(eventRecords);
+    when(eventRecordRepository.saveAll(any())).thenReturn(new ArrayList<>());
+
+    verify(eventRecordRepository).saveAll(eventsSaved.capture());
+    List<EventRecord> events = eventsSaved.getAllValues().get(0).stream().toList();
+    assertEquals(1, events.size());
+  }
+
+  @Test
   void testProcessEventsInBatches_processesAllEvents() {
     List<EventRecord> all = new LinkedList<>();
     for (int i = 0; i < 10; i++) {

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -544,7 +544,7 @@ class EventControllerTest {
     event.setConversion(false);
 
     var expected = Set.of("rhel-for-x86-els-payg-addon");
-    var actual = eventController.filterOnApplicableTags(event, null);
+    var actual = eventController.filterOnApplicableTags(event);
 
     assertEquals(expected, actual);
   }

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import org.candlepin.subscriptions.db.EventRecordRepository;
 import org.candlepin.subscriptions.db.model.EventRecord;
 import org.candlepin.subscriptions.json.Event;
@@ -469,5 +470,17 @@ class EventControllerTest {
     List<Integer> getCounts() {
       return counts;
     }
+  }
+
+  @Test
+  void testFilterOnApplicableTags() {
+    Event event = new Event();
+    event.setProductIds(List.of("204", "479"));
+    event.setConversion(false);
+
+    var expected = Set.of("rhel-for-x86-els-payg-addon");
+    var actual = eventController.filterOnApplicableTags(event, null);
+
+    assertEquals(expected, actual);
   }
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -161,13 +161,21 @@ public class SubscriptionDefinition {
             });
   }
 
-  public static Set<String> getAllNonPaygTags() {
+  /**
+   * @param isPaygEligible
+   * @return Set<String> variant tags
+   */
+  public static Set<String> getAllTags(boolean isPaygEligible) {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions().stream()
-        .filter(subscriptionDefinition -> !subscriptionDefinition.isPaygEligible())
+        .filter(subscriptionDefinition -> subscriptionDefinition.isPaygEligible() == isPaygEligible)
         .map(SubscriptionDefinition::getVariants)
         .flatMap(Collection::stream)
         .map(Variant::getTag)
         .collect(Collectors.toUnmodifiableSet());
+  }
+
+  public static Set<String> getAllNonPaygTags() {
+    return getAllTags(false);
   }
 
   public static Set<String> getAllProductTagsByProductId(String id) {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2647

## Description
During metric collection, SubscriptionDefinition.getAllProductTagsByRoleOrEngIds returns `RHEL for x86` and `rhel-for-x86-els-payg-addon`.  This was part of the work that ended up getting split out into SWATCH-2634.

There was a condition in the code that said if the productTags.size() != 1, skip creating the event.

Updated the logic to just make sure the product tag we're collecting metrics for appears in the tags returned by getAllProductTagsByRoleOrEngIds.

A more elegant solution will be part of SWATCH-2634.

## Testing

Run swatch-metrics against stage rhelemeter
```
EVENT_SOURCE=rhelemeter PROM_URL="http://10.0.150.94/api/v1" ./gradlew :swatch-metrics:quarkusDev
```

Kick off metrics gathering
```
curl -X 'PUT' \
  'http://localhost:8000/api/swatch-metrics/v1/internal/metering/sync' \
  -H 'accept: */*' \
  -H 'x-rh-swatch-psk: placeholder'
```

You can inspect the **platform.rhsm-subscriptions.service-instance-ingress** topic at this point

http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.service-instance-ingress/

Stop swatch-metrics and start swatch-tally
```
DEV_MODE=true ./gradlew clean :bootRun
```

Inspect the swatch **events** table to confirm 

```sql
select data -> 'product_tag' as "product_tag",
       event_type,
       event_source,
       timestamp,
       record_date
from events
where org_id = '13259775';
```

| product\_tag | event\_type | event\_source | timestamp | record\_date |
| :--- | :--- | :--- | :--- | :--- |
| \["rhel-for-x86-els-payg"\] | snapshot\_rhel-for-x86-els-payg\_vcpus | rhelemeter | 2024-06-13 14:00:00.000000 +00:00 | 2024-06-13 15:20:55.688670 +00:00 |
| \["rhel-for-x86-els-payg-addon"\] | snapshot\_rhel-for-x86-els-payg-addon\_vcpus | rhelemeter | 2024-06-13 14:00:00.000000 +00:00 | 2024-06-13 15:20:55.691906 +00:00 |
