### PR TITLE
SWATCH-2658: Use billing_marketplace_instance_id as instance key for rhelemeter

### DIFF
--- a/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
+++ b/swatch-metrics/src/test/java/com/redhat/swatch/metrics/service/PrometheusMeteringControllerTest.java
@@ -167,7 +167,7 @@ class PrometheusMeteringControllerTest {
         List.of(
             MeteringEventFactory.createMetricEvent(
                 externalOrganization,
-                clusterId,
+                billingMarketplaceInstanceId,
                 expectedSla,
                 expectedUsage,
                 null,
@@ -186,7 +186,7 @@ class PrometheusMeteringControllerTest {
                 is3rdPartyMigrationFlag),
             MeteringEventFactory.createMetricEvent(
                 externalOrganization,
-                clusterId,
+                billingMarketplaceInstanceId,
                 expectedSla,
                 expectedUsage,
                 null,

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg.yaml
@@ -34,4 +34,4 @@ metrics:
       queryParams:
         productLabelRegex: .*(^|,)(204)($|,).* # this regex is used to fetch metrics for the product label that contains the product/engineering ID 204. the number here needs to map to a tag defined in the variant section of this file
         metric: system_cpu_logical_count
-        instanceKey: _id
+        instanceKey: billing_marketplace_instance_id


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2658

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

CostManagement reports a billing_marketplace_instance_id as *instance_id*
Rhelemeter reports subman id as *instance_id*
 
During event reconciliation, a `billing_marketplace_instance_id` is never going to match a `subman_id`, so deduplication wouldn't happen.

We want to use `billing_marketplace_instance_id` as the `instance_id` when swatch-metrics produces Event messages on the service-instance-ingress topic.

## Testing

```
./bin/metering-promql.py --product rhel-for-x86-els-payg
```

```
rhel-for-x86-els-payg
---------------------
  Accounts PromQL: group(min_over_time({product=~'.*(^|,)(204)($|,).*', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)
  vCPUs PromQL: sum_over_time((max by (billing_marketplace_instance_id) (system_cpu_logical_count))[1h:10m]) / scalar(count_over_time(vector(1)[1h:10m]))
* on (billing_marketplace_instance_id) group_right topk by (billing_marketplace_instance_id) (
  1,
    group without (swatch_placeholder_label) (
      min_over_time(
      system_cpu_logical_count{
      product=~".*(^|,)(204)($|,).*",
      external_organization=~".*",
      billing_model="marketplace",
      support=~"Premium|Standard|Self-Support|None|"
      }[1h]
    )
  )
)
```

Note: It's returning slightly different results if you run the query before and after.  There seems to be metrics where `_id` is the same, but with different `billing_marketplace_instance_id`.  Those should be counted separately, so working as intended.