### PR TITLE
SWATCH-2020: Add CSV support to instances export

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
@@ -20,7 +20,7 @@
  */
 package org.candlepin.subscriptions.tally.export;
 
-import static org.candlepin.subscriptions.resource.InstancesResource.getCategoryByMeasurementType;
+import static org.candlepin.subscriptions.resource.api.v1.InstancesResource.getCategoryByMeasurementType;
 
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.Variant;

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
@@ -74,7 +74,7 @@ public class InstancesCsvDataMapperService implements DataMapperService<TallyIns
       instance.setCategory(category.toString());
     }
     instance.setLastSeen(item.getLastSeen());
-    // instance.setHypervisorUuid(item.getHypervisorUuid());
+    instance.setHypervisorUuid(item.getHypervisorUuid());
     return List.of(instance);
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.export;
+
+import static org.candlepin.subscriptions.resource.InstancesResource.getCategoryByMeasurementType;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.Variant;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.candlepin.subscriptions.db.model.TallyInstanceView;
+import org.candlepin.subscriptions.export.DataMapperService;
+import org.candlepin.subscriptions.export.ExportServiceRequest;
+import org.candlepin.subscriptions.json.InstancesExportCsvItem;
+import org.candlepin.subscriptions.json.InstancesExportJsonMetric;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class InstancesCsvDataMapperService implements DataMapperService<TallyInstanceView> {
+
+  @Override
+  public List<Object> mapDataItem(TallyInstanceView item, ExportServiceRequest request) {
+    var instance = new InstancesExportCsvItem();
+    instance.setId(item.getId());
+    instance.setInstanceId(item.getKey().getInstanceId());
+    instance.setDisplayName(item.getDisplayName());
+    if (item.getHostBillingProvider() != null) {
+      instance.setBillingProvider(item.getHostBillingProvider().getValue());
+    }
+    var category = getCategoryByMeasurementType(item.getKey().getMeasurementType());
+    if (category != null) {
+      instance.setCategory(category.toString());
+    }
+
+    instance.setBillingAccountId(item.getHostBillingAccountId());
+    var variant = Variant.findByTag(item.getKey().getProductId());
+    var metrics = MetricIdUtils.getMetricIdsFromConfigForVariant(variant.orElse(null)).toList();
+    for (var metric : metrics) {
+      poplulateMetric(
+          instance,
+          toInstanceExportMetric(
+              metric, Optional.ofNullable(item.getMetricValue(metric)).orElse(0.0)));
+    }
+    instance.setLastSeen(item.getLastSeen());
+    return List.of(instance);
+  }
+
+  private static void poplulateMetric(
+      InstancesExportCsvItem instance, InstancesExportJsonMetric metric) {
+    switch (metric.getMetricId().toLowerCase().replace('-', '_')) {
+      case ("cores"):
+        instance.setMeasurementCores(metric.getValue());
+        break;
+      case ("instances"):
+        instance.setMeasurementInstances(metric.getValue());
+        break;
+      case ("instance_hours"):
+        instance.setMeasurementInstanceHours(metric.getValue());
+        break;
+      case ("sockets"):
+        instance.setMeasurementSockets(metric.getValue());
+        break;
+      case ("storage_gibibytes"):
+        instance.setMeasurementStorageGibibytes(metric.getValue());
+        break;
+      case ("storage_gibibyte_months"):
+        instance.setMeasurementStorageGibibyteMonths(metric.getValue());
+        break;
+      case ("transfer_gibibytes"):
+        instance.setMeasurementTransferGibibytes(metric.getValue());
+        break;
+      case ("vcpus"):
+        instance.setMeasurementVcpus(metric.getValue());
+        break;
+      default:
+    }
+  }
+
+  @Override
+  public Class<TallyInstanceView> getDataClass() {
+    return TallyInstanceView.class;
+  }
+
+  @Override
+  public Class<?> getExportItemClass() {
+    return InstancesExportCsvItem.class;
+  }
+
+  private static InstancesExportJsonMetric toInstanceExportMetric(MetricId metric, double value) {
+    return new InstancesExportJsonMetric().withMetricId(metric.toString()).withValue(value);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -94,6 +94,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
   private final TallyInstancePaygViewRepository paygViewRepository;
   private final TallyInstanceNonPaygViewRepository nonPaygViewRepository;
   private final InstancesJsonDataMapperService jsonDataMapperService;
+  private final InstancesCsvDataMapperService csvDataMapperService;
 
   @Override
   public boolean handles(ExportServiceRequest request) {
@@ -115,7 +116,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
   public DataMapperService<TallyInstanceView> getMapper(ExportServiceRequest request) {
     return switch (request.getFormat()) {
       case JSON -> jsonDataMapperService;
-      case CSV -> throw new UnsupportedOperationException("CSV is not supported yet for instances");
+      case CSV -> csvDataMapperService;
     };
   }
 

--- a/src/main/resources/liquibase/202406191500-add-hypervisor_uuid-to-tally-instance-view.xml
+++ b/src/main/resources/liquibase/202406191500-add-hypervisor_uuid-to-tally-instance-view.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202406191500-1" author="jcarvaja" dbms="postgresql">
+        <comment>
+            Add hypervisor_uuid to tally_instance_view
+        </comment>
+        <dropView viewName="tally_instance_non_payg_view" />
+        <dropView viewName="tally_instance_payg_view" />
+        <dropView viewName="tally_instance_view" />
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_view">
+            select distinct h.org_id,
+                            h.id,
+                            h.instance_id as instance_id,
+                            h.display_name,
+                            h.billing_provider as host_billing_provider,
+                            h.billing_account_id as host_billing_account_id,
+                            b.billing_provider as bucket_billing_provider,
+                            b.billing_account_id as bucket_billing_account_id,
+                            h.last_seen,
+                            h.last_applied_event_record_date,
+                            coalesce(h.num_of_guests, 0) AS num_of_guests,
+                            b.product_id,
+                            b.sla,
+                            b.usage,
+                            coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                            b.sockets,
+                            b.cores,
+                            h.subscription_manager_id,
+                            h.inventory_id,
+                            h.hypervisor_uuid
+            from hosts h
+            join host_tally_buckets b on h.id = b.host_id
+        </createView>
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_non_payg_view">
+            select distinct v.*,
+                            jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+            from tally_instance_view v
+            left outer join instance_measurements m on v.id = m.host_id
+            group by v.org_id,
+                     v.id,
+                     v.instance_id,
+                     v.display_name,
+                     v.host_billing_provider,
+                     v.host_billing_account_id,
+                     v.bucket_billing_provider,
+                     v.bucket_billing_account_id,
+                     v.last_seen,
+                     v.last_applied_event_record_date,
+                     v.num_of_guests,
+                     v.product_id,
+                     v.sla,
+                     v."usage",
+                     v.measurement_type,
+                     v.sockets,
+                     v.cores,
+                     v.subscription_manager_id,
+                     v.inventory_id,
+                     v.hypervisor_uuid
+        </createView>
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_payg_view">
+            select distinct v.*,
+                            m."month",
+                            jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+            from tally_instance_view v
+            left outer join instance_monthly_totals m on v.id = m.host_id
+            group by v.org_id,
+                     v.id,
+                     v.instance_id,
+                     v.display_name,
+                     v.host_billing_provider,
+                     v.host_billing_account_id,
+                     v.bucket_billing_provider,
+                     v.bucket_billing_account_id,
+                     v.last_seen,
+                     v.last_applied_event_record_date,
+                     v.num_of_guests,
+                     v.product_id,
+                     v.sla,
+                     v."usage",
+                     v.measurement_type,
+                     v.sockets,
+                     v.cores,
+                     v.subscription_manager_id,
+                     v.inventory_id,
+                     v.hypervisor_uuid,
+                     m."month"
+        </createView>
+        <rollback>
+            <dropView viewName="tally_instance_non_payg_view" />
+            <dropView viewName="tally_instance_payg_view" />
+            <dropView viewName="tally_instance_view" />
+            <createView
+                    replaceIfExists="true"
+                    viewName="tally_instance_view">
+                select distinct h.org_id,
+                h.id,
+                h.instance_id as instance_id,
+                h.display_name,
+                h.billing_provider as host_billing_provider,
+                h.billing_account_id as host_billing_account_id,
+                b.billing_provider as bucket_billing_provider,
+                b.billing_account_id as bucket_billing_account_id,
+                h.last_seen,
+                h.last_applied_event_record_date,
+                coalesce(h.num_of_guests, 0) AS num_of_guests,
+                b.product_id,
+                b.sla,
+                b.usage,
+                coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                b.sockets,
+                b.cores,
+                h.subscription_manager_id,
+                h.inventory_id
+                from hosts h
+                join host_tally_buckets b on h.id = b.host_id
+            </createView>
+            <createView
+                    replaceIfExists="true"
+                    viewName="tally_instance_non_payg_view">
+                select distinct v.*,
+                jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+                from tally_instance_view v
+                left outer join instance_measurements m on v.id = m.host_id
+                group by v.org_id,
+                v.id,
+                v.instance_id,
+                v.display_name,
+                v.host_billing_provider,
+                v.host_billing_account_id,
+                v.bucket_billing_provider,
+                v.bucket_billing_account_id,
+                v.last_seen,
+                v.last_applied_event_record_date,
+                v.num_of_guests,
+                v.product_id,
+                v.sla,
+                v."usage",
+                v.measurement_type,
+                v.sockets,
+                v.cores,
+                v.subscription_manager_id,
+                v.inventory_id
+            </createView>
+            <createView
+                    replaceIfExists="true"
+                    viewName="tally_instance_payg_view">
+                select distinct v.*,
+                m."month",
+                jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+                from tally_instance_view v
+                left outer join instance_monthly_totals m on v.id = m.host_id
+                group by v.org_id,
+                v.id,
+                v.instance_id,
+                v.display_name,
+                v.host_billing_provider,
+                v.host_billing_account_id,
+                v.bucket_billing_provider,
+                v.bucket_billing_account_id,
+                v.last_seen,
+                v.last_applied_event_record_date,
+                v.num_of_guests,
+                v.product_id,
+                v.sla,
+                v."usage",
+                v.measurement_type,
+                v.sockets,
+                v.cores,
+                v.subscription_manager_id,
+                v.inventory_id,
+                m."month"
+            </createView>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="202406191500-2" author="jcarvaja" dbms="hsqldb">
+        <comment>
+            Add hypervisor_uuid to payg and non-payg views
+        </comment>
+        <dropView viewName="tally_instance_non_payg_view" />
+        <dropView viewName="tally_instance_payg_view" />
+        <dropView viewName="tally_instance_view" />
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_view">
+            select distinct h.org_id,
+                            h.id,
+                            h.instance_id as instance_id,
+                            h.display_name,
+                            h.billing_provider as host_billing_provider,
+                            h.billing_account_id as host_billing_account_id,
+                            b.billing_provider as bucket_billing_provider,
+                            b.billing_account_id as bucket_billing_account_id,
+                            h.last_seen,
+                            h.last_applied_event_record_date,
+                            coalesce(h.num_of_guests, 0) AS num_of_guests,
+                            b.product_id,
+                            b.sla,
+                            b.usage,
+                            coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                            b.sockets,
+                            b.cores,
+                            h.subscription_manager_id,
+                            h.inventory_id,
+                            h.hypervisor_uuid
+            from hosts h
+            join host_tally_buckets b on h.id = b.host_id
+        </createView>
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_non_payg_view">
+            select distinct v.*,
+                            CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+            from tally_instance_view v
+            left outer join instance_measurements m on v.id = m.host_id
+        </createView>
+        <createView
+                replaceIfExists="true"
+                viewName="tally_instance_payg_view">
+            select distinct v.*,
+                            m.month,
+                            CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+            from tally_instance_view v
+                     left outer join instance_monthly_totals m on v.id = m.host_id
+        </createView>
+        <rollback>
+            <dropView viewName="tally_instance_non_payg_view" />
+            <dropView viewName="tally_instance_payg_view" />
+            <dropView viewName="tally_instance_view" />
+            <createView
+                    replaceIfExists="true"
+                    viewName="tally_instance_view">
+                select distinct h.org_id,
+                    h.id,
+                    h.instance_id as instance_id,
+                    h.display_name,
+                    h.billing_provider as host_billing_provider,
+                    h.billing_account_id as host_billing_account_id,
+                    b.billing_provider as bucket_billing_provider,
+                    b.billing_account_id as bucket_billing_account_id,
+                    h.last_seen,
+                    h.last_applied_event_record_date,
+                    coalesce(h.num_of_guests, 0) AS num_of_guests,
+                    b.product_id,
+                    b.sla,
+                    b.usage,
+                    coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                    b.sockets,
+                    b.cores,
+                    h.subscription_manager_id,
+                    h.inventory_id
+                from hosts h
+                join host_tally_buckets b on h.id = b.host_id
+            </createView>
+            <createView
+                    replaceIfExists="true"
+                    viewName="tally_instance_non_payg_view">
+                select distinct v.*,
+                CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+                from tally_instance_view v
+                left outer join instance_measurements m on v.id = m.host_id
+            </createView>
+            <createView
+                    replaceIfExists="true"
+                    viewName="tally_instance_payg_view">
+                select distinct v.*,
+                m.month,
+                CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+                from tally_instance_view v
+                left outer join instance_monthly_totals m on v.id = m.host_id
+            </createView>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -165,5 +165,6 @@
     <include file="/liquibase/202406120950-update-subscription-capacity-view.xml"/>
     <include file="/liquibase/202406240700-add-subscription-number-index.xml" />
     <include file="/liquibase/202406261514-alter-event-instance-id-length.xml"/>
+    <include file="/liquibase/202406191500-add-hypervisor_uuid-to-tally-instance-view.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-core/schemas/instances_export_csv_item.yaml
+++ b/swatch-core/schemas/instances_export_csv_item.yaml
@@ -14,16 +14,10 @@ properties:
   measurement_cores:
     type: number
     format: double
-  measurement_instances:
-    type: number
-    format: double
   measurement_instance_hours:
     type: number
     format: double
   measurement_sockets:
-    type: number
-    format: double
-  measurement_storage_gibibytes:
     type: number
     format: double
   measurement_storage_gibibyte_months:

--- a/swatch-core/schemas/instances_export_csv_item.yaml
+++ b/swatch-core/schemas/instances_export_csv_item.yaml
@@ -1,0 +1,44 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: InstancesExportCsvItem
+properties:
+  id:
+    type: string
+  instance_id:
+    type: string
+  display_name:
+    type: string
+  billing_provider:
+    type: string
+  billing_account_id:
+    type: string
+  measurement_cores:
+    type: number
+    format: double
+  measurement_instances:
+    type: number
+    format: double
+  measurement_instance_hours:
+    type: number
+    format: double
+  measurement_sockets:
+    type: number
+    format: double
+  measurement_storage_gibibytes:
+    type: number
+    format: double
+  measurement_storage_gibibyte_months:
+    type: number
+    format: double
+  measurement_transfer_gibibytes:
+    type: number
+    format: double
+  measurement_vcpus:
+    type: number
+    format: double
+  category:
+    type: string
+  last_seen:
+    format: date-time
+    type: string
+  hypervisor_uuid:
+    type: string

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceView.java
@@ -81,5 +81,8 @@ public abstract class TallyInstanceView implements Serializable {
   @Column(name = "inventory_id")
   private String inventoryId;
 
+  @Column(name = "hypervisor_uuid")
+  private String hypervisorUuid;
+
   public abstract double getMetricValue(MetricId metricId);
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/util/MetricIdUtils.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/util/MetricIdUtils.java
@@ -46,6 +46,18 @@ public class MetricIdUtils {
     return MetricId.fromString("Instance-hours");
   }
 
+  public static MetricId getVCpus() {
+    return MetricId.fromString("vCPUs");
+  }
+
+  public static MetricId getStorageGibibyteMonths() {
+    return MetricId.fromString("Storage-gibibyte-months");
+  }
+
+  public static MetricId getTransferGibibytes() {
+    return MetricId.fromString("Transfer-gibibytes");
+  }
+
   public static Stream<MetricId> getMetricIdsFromConfigForTag(String tag) {
     return getMetricIdsFromConfigForVariant(Variant.findByTag(tag).orElse(null));
   }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2020

## Description
- added capability to create CSV output for instances 

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/755

1.- start kafka and postgresql: `podman-compose up -d`
2.- start export-service: `podman-compose -f config/export-service/docker-compose.yml up -d`
3.- start the tally service: `RHSM_RBAC_USE_STUB=true DEV_MODE=true SPRING_PROFILES_ACTIVE="worker,api,kafka-queue" ./gradlew :bootRun`
4.- load some data:

```
insert into account_services(org_id, service_type) values ('123', 'test');

insert into hosts(id, org_id, num_of_guests, instance_id, display_name, billing_provider, billing_account_id, instance_type) 
values ('b870dc34-53a3-4634-bfd1-56c227bc36ac','123', 3, '456', 'my host', 'AWS', '789', 'test');

insert into host_tally_buckets (host_id, product_id, "usage", sla, as_hypervisor, billing_provider, billing_account_id, measurement_type, cores, sockets) 
values ('b870dc34-53a3-4634-bfd1-56c227bc36ac', 'RHEL for x86', 'PRODUCTION', 'PREMIUM', true, 'AWS', '789', 'PHYSICAL', 3, 6);

insert into instance_measurements (host_id, metric_id, value)
values ('b870dc34-53a3-4634-bfd1-56c227bc36ac', 'SOCKETS', 4.8);
```

5.- create a new export request from Export Service:

get the identifier first:
```
echo -n '{"identity":{"account_number":"10001","org_id":"123","internal":{"org_id":"13259775"},"type":"User","user":{"username":"user_dev"}}}' | base64 -w 0
> eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTIzIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTMyNTk3NzUifSwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoidXNlcl9kZXYifX19
```

call the export service:
```
curl -sS -X POST http://localhost:8002/api/export/v1/exports -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTIzIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTMyNTk3NzUifSwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoidXNlcl9kZXYifX19" -H "Content-Type: application/json" -d '{
    "name": "Test Export Request",
    "format": "csv",
    "expires_at": "2025-01-01T00:00:00Z",
    "sources": [
        {
            "application": "subscriptions",
            "resource": "instances",
            "filters": {
                "product_id": "RHEL for x86"
            }
        }
    ]
}'
```

Expected output is:
```
{"id":"78244e87-2abe-49af-8821-67b14128c5c3","created_at":"2024-04-05T06:30:01.034156787Z","expires_at":"2025-01-01T00:00:00Z","name":"Test Export Request","format":"csv","status":"pending","sources":[{"id":"2008873d-916d-4240-8cd8-55ca00141c55","application":"subscriptions","status":"pending","resource":"instances","filters":{"product_id":"RHEL for x86"}}]}
```

The export-service should have uploaded the generated report by the subscription sync service into S3 (minio instance). 
You can verify that this report has been uploaded by checking the folder 'config/export-service/tmp/minio/exports-bucket' where should be a file at `<BUCKET ID>.json/xl.meta`. The `xl.meta` file is binary, but if you open the txt plain editor, you should see (as an example):

```
id,instance_id,display_name,billing_provider,billing_account_id,measurement_cores,measurement_instances,"measurement_instance_hours",measurement_sockets,"measurement_storage_gibibytes","measurement_storage_gibibyte_months","measurement_transfer_gibibytes",measurement_vcpus,category,last_seen,hypervisor_uuid
"1cbadb23-e86d-4574-b46f-e218eda8aa74","62228bfa-cee9-4ecf-8880-8cc4b526fed4",rosa-hcp,aws,168911171442,336.0,,42.0,,,,,,,2024-06-17T16:00:00Z,
```