### PR TITLE
SWATCH-2670 Group RemittanceSummaryProjections by hardware measurement type

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventConflictResolver.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventConflictResolver.java
@@ -99,6 +99,9 @@ public class EventConflictResolver {
           // Include the incoming event since this event will be the new value.
           resolvedEvents.add(new EventRecord(event));
         });
+
+    log.info("Resolved {} events", resolvedEvents.size());
+
     return resolvedEvents;
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
@@ -95,6 +95,7 @@ public class TallySummaryMapper {
 
   private Double getCurrentlyMeasuredTotal(
       TallySnapshot snapshot, TallyMeasurementKey measurementKey) {
+
     return snapshotRepository.sumMeasurementValueForPeriod(
         snapshot.getOrgId(),
         snapshot.getProductId(),

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceFilter.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceFilter.java
@@ -45,6 +45,7 @@ public class BillableUsageRemittanceFilter {
   private String metricId;
   private String billingProvider;
   private String billingAccountId;
+  private String hardwareMeasurementType;
   private OffsetDateTime beginning;
   private OffsetDateTime ending;
   private String accumulationPeriod;
@@ -59,6 +60,7 @@ public class BillableUsageRemittanceFilter {
         .productId(usage.getProductId())
         .sla(usage.getSla().value())
         .usage(usage.getUsage().value())
+        .hardwareMeasurementType(usage.getHardwareMeasurementType())
         .build();
   }
 }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
@@ -63,6 +63,7 @@ public class BillableUsageRemittanceRepository
           root.get(BillableUsageRemittanceEntity_.METRIC_ID),
           root.get(BillableUsageRemittanceEntity_.ORG_ID),
           root.get(BillableUsageRemittanceEntity_.PRODUCT_ID),
+          root.get(BillableUsageRemittanceEntity_.HARDWARE_MEASUREMENT_TYPE),
           root.get(BillableUsageRemittanceEntity_.STATUS));
     }
     query.select(
@@ -78,6 +79,7 @@ public class BillableUsageRemittanceRepository
             root.get(BillableUsageRemittanceEntity_.BILLING_PROVIDER),
             root.get(BillableUsageRemittanceEntity_.BILLING_ACCOUNT_ID),
             root.get(BillableUsageRemittanceEntity_.METRIC_ID),
+            root.get(BillableUsageRemittanceEntity_.HARDWARE_MEASUREMENT_TYPE),
             root.get(BillableUsageRemittanceEntity_.STATUS)));
     return entityManager.createQuery(query).getResultList();
   }
@@ -152,7 +154,20 @@ public class BillableUsageRemittanceRepository
     if (Objects.nonNull(filter.getSla())) {
       searchCriteria = searchCriteria.and(matchingSla(filter.getSla()));
     }
+
+    if (Objects.nonNull(filter.getHardwareMeasurementType())) {
+      searchCriteria =
+          searchCriteria.and(matchingHardwareMeasurementType(filter.getHardwareMeasurementType()));
+    }
     return searchCriteria;
+  }
+
+  private Specification<BillableUsageRemittanceEntity> matchingHardwareMeasurementType(
+      String hardwareMeasurementType) {
+    return (root, query, builder) ->
+        builder.equal(
+            root.get(BillableUsageRemittanceEntity_.hardwareMeasurementType),
+            hardwareMeasurementType);
   }
 
   private static Specification<BillableUsageRemittanceEntity> matchingProductId(String productId) {

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceSummaryProjection.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceSummaryProjection.java
@@ -41,5 +41,6 @@ public class RemittanceSummaryProjection {
   private String billingProvider;
   private String billingAccountId;
   private String metricId;
+  private String hardwareMeasurementType;
   private RemittanceStatus status;
 }


### PR DESCRIPTION
Jira issue: SWATCH-2670

## Description
**Group RemittanceSummaryProjections by hardware measurement type**

When hardware measurement type was added to the remittance table,
we did not update the get remittance totals projection to include
it. Because of this, the remittance totals query was returning the
remittance total matching remittance records with similar criteria
resulting in 0 required remittance (no record created).

This patch adds hardware measurement type to the projection and the
supporting query filter so that the correct totals are returned.


# How To Test
**Start by testing on the main branch to reproduce. Stop at the main branch validation step below. Then test the same against the branch.**

Start with a clean DB.
```
dropdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && createdb -h localhost -U rhsm-subscriptions rhsm-subscriptions
```

Launch the tally service.
```
DEV_MODE=true ./gradlew :bootRun
```

Launch the billable usage service.
```
QUARKUS_MANAGEMENT_PORT=9002 SERVER_PORT=8002 DEV_MODE=true ./gradlew :swatch-billable-usage:quarkusDev
```

Run an hourly tally to prep the tally_state table and reset it.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=123456" x-rh-swatch-psk:placeholder
```

```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "update tally_state set latest_event_record_date='2023-05-28 00:00:00+00';"
```


Add an event representing a cost-management measurement (hardware measurement type: AWS)
```
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('461285d3-21c0-42b2-aa40-4e5c5e1422a8', '2024-06-16 00:00:00.000000 +00:00', '{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "123456", "event_id": "461285d3-21c0-42b2-aa40-4e5c5e1422a8", "timestamp": "2024-06-16T00:00:00Z", "conversion": true, "event_type": "snapshot", "expiration": "2024-06-16T01:00:00Z", "instance_id": "i-123456", "product_ids": ["69", "204"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-06-17T13:04:13.339270402Z", "event_source": "cost-management", "measurements": [{"value": 1.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "billing_account_id": "ba123456"}', 'snapshot', 'cost-management', 'i-123456', '123456', '02bcc97c-a5f0-4cc1-8e57-0d6782b351e3', '2024-06-17 13:04:13.339270 +00:00');
```

Run an hourly tally and you should see 32 tally summary messages get sent.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=123456" x-rh-swatch-psk:placeholder
```

Check that a remittance was added with a value of 1.0 vCPUs for AWS.
```
rhsm-subscriptions=# select * from billable_usage_remittance ;

 account_number | org_id |      product_id       | metric_id | accumulation_period |   sla   |   usage    | billing_provider | b
illing_account_id | remitted_pending_value |   remittance_pending_date    | retry_after |               tally_id               |
 hardware_measurement_type |                 uuid                 | billed_on | error_code | status  
----------------+--------+-----------------------+-----------+---------------------+---------+------------+------------------+--
------------------+------------------------+------------------------------+-------------+--------------------------------------+
---------------------------+--------------------------------------+-----------+------------+---------
                | 123456 | rhel-for-x86-els-payg | vCPUs     | 2024-06             | Premium | Production | aws              | b
a123456           |                      1 | 2024-06-19 22:40:12.63838+00 |             | baa3b97d-eafa-4d9a-85d5-3fc60bcf0fcf |
 AWS                       | d663f780-da7a-4128-94f6-3fd13e1c5e21 |           |            | pending
(1 row)
```


# Validation

Add an event representing a rhelemeter measurement (hardware measurement type: PHYSICAL)
```
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('27b3e5d8-0e13-43b7-b891-2b8f90a00809', '2024-06-16 00:00:00.000000 +00:00', '{"sla": "Premium", "usage": "Production", "org_id": "123456", "event_id": "27b3e5d8-0e13-43b7-b891-2b8f90a00809", "timestamp": "2024-06-16T00:00:00Z", "conversion": true, "event_type": "snapshot_rhel-for-x86-els-payg_vcpus", "expiration": "2024-06-16T01:00:00Z", "instance_id": "i-123456", "product_ids": ["204", "69"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-06-18T07:29:34.543162309Z", "display_name": "ip-10-31-97-115.us-east-1.aws.redhat.com", "event_source": "rhelemeter", "measurements": [{"value": 1.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "billing_provider": "aws", "metering_batch_id": "1b702db8-9f01-4a4e-8bdf-c0b1398c34dc", "billing_account_id": "ba123456"}', 'snapshot_rhel-for-x86-els-payg_vcpus', 'rhelemeter', 'i-123456', '123456', '1b702db8-9f01-4a4e-8bdf-c0b1398c34dc', '2024-06-18 07:29:34.543162 +00:00');
```

Run an hourly tally and you should see 32 tally summary messages get sent.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=123456" x-rh-swatch-psk:placeholder
```

## On the main branch
No remittance was added for the incoming event with PHYSICAL hardware type. Check the remittance table and the existing record should exist unchanged.
```
rhsm-subscriptions=# select * from billable_usage_remittance ;
 account_number | org_id |      product_id       | metric_id | accumulation_period |   sla   |   usage    | billing_provider | billing_account_id | remitted_pending_value |    remittance_pending_date    | retry_after |               tally_id             
  | hardware_measurement_type |                 uuid                 | billed_on | error_code | status  
----------------+--------+-----------------------+-----------+---------------------+---------+------------+------------------+--------------------+------------------------+-------------------------------+-------------+------------------------------------
--+---------------------------+--------------------------------------+-----------+------------+---------
                | 123456 | rhel-for-x86-els-payg | vCPUs     | 2024-06             | Premium | Production | aws              | ba123456           |                      1 | 2024-06-19 23:12:13.216095+00 |             | a2b17dd2-2e0f-4fe6-8444-fa8f64a190e
8 | AWS                       | 85981cc6-b35c-42a8-b26b-cf4e2177afe3 |           |            | pending
(1 row)

```

## On the PR branch

Check that a remittance was added for PHYSICAL hardware type with a value of 1.0 vCPUs
```
rhsm-subscriptions=# select * from billable_usage_remittance ;
 account_number | org_id |      product_id       | metric_id | accumulation_period |   sla   |   usage    | billing_provider | billing_account_id | remitted_pending_value |    remittance_pending_da
te    | retry_after |               tally_id               | hardware_measurement_type |                 uuid                 | billed_on | error_code | status  
----------------+--------+-----------------------+-----------+---------------------+---------+------------+------------------+--------------------+------------------------+-------------------------
------+-------------+--------------------------------------+---------------------------+--------------------------------------+-----------+------------+---------
                | 123456 | rhel-for-x86-els-payg | vCPUs     | 2024-06             | Premium | Production | aws              | ba123456           |                      1 | 2024-06-19 22:40:12.6383
8+00  |             | baa3b97d-eafa-4d9a-85d5-3fc60bcf0fcf | AWS                       | d663f780-da7a-4128-94f6-3fd13e1c5e21 |           |            | pending
                | 123456 | rhel-for-x86-els-payg | vCPUs     | 2024-06             | Premium | Production | aws              | ba123456           |                      1 | 2024-06-19 22:49:23.9428
98+00 |             | baa3b97d-eafa-4d9a-85d5-3fc60bcf0fcf | PHYSICAL                  | ed75d902-c8f8-44a9-b167-050ea0133688 |           |            | pending
(2 rows)

```

