### PR TITLE
SWATCH-2671 Set CloudProvider and hardware type on Event messages

### DIFF
--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/util/MeteringEventFactory.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/util/MeteringEventFactory.java
@@ -29,6 +29,8 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Event.BillingProvider;
+import org.candlepin.subscriptions.json.Event.CloudProvider;
+import org.candlepin.subscriptions.json.Event.HardwareType;
 import org.candlepin.subscriptions.json.Event.Role;
 import org.candlepin.subscriptions.json.Event.Sla;
 import org.candlepin.subscriptions.json.Event.Usage;
@@ -123,6 +125,7 @@ public final class MeteringEventFactory {
       List<String> productIds,
       String displayName,
       boolean is3rdPartyMigrated) {
+
     toUpdate
         .withServiceType(serviceType)
         .withTimestamp(measuredTime)
@@ -130,7 +133,6 @@ public final class MeteringEventFactory {
         .withDisplayName(Optional.of(displayName))
         .withSla(getSla(serviceLevel, orgId, instanceId))
         .withUsage(getUsage(usage, orgId, instanceId))
-        .withBillingProvider(getBillingProvider(billingProvider, orgId, instanceId))
         .withBillingAccountId(Optional.ofNullable(billingAccountId))
         .withMeasurements(
             List.of(
@@ -147,6 +149,25 @@ public final class MeteringEventFactory {
         .withProductTag(Set.of(productTag))
         .withProductIds(productIds)
         .withConversion(is3rdPartyMigrated);
+
+    BillingProvider billingProviderEnum = getBillingProvider(billingProvider, orgId, instanceId);
+    toUpdate.withBillingProvider(billingProviderEnum);
+
+    if (billingProviderEnum != null) {
+      var cloudProvider = getCloudProvider(billingProviderEnum);
+      cloudProvider.ifPresent(
+          x -> toUpdate.withHardwareType(HardwareType.CLOUD).withCloudProvider(x));
+    }
+  }
+
+  static Optional<CloudProvider> getCloudProvider(BillingProvider billingProvider) {
+
+    return switch (billingProvider) {
+      case AWS -> Optional.of(CloudProvider.AWS);
+      case GCP -> Optional.of(CloudProvider.GOOGLE);
+      case AZURE -> Optional.of(CloudProvider.AZURE);
+      default -> Optional.empty();
+    };
   }
 
   public static String getEventType(String metricId, String productTag) {


### PR DESCRIPTION
Jira issue: SWATCH-2671

# Summary
swatch-metrics was producing messages with billing_provider, but not cloud_provider or hardware_type

When hourly tally reads the events, it was defaulting the hardware type to PHYSICAL (org.candlepin.subscriptions.tally.MetricUsageCollector#getHardwareMeasurementType)

Now events from swatch-metrics should include a `cloud_provider` and `hardware_type: 'Cloud'`
# Part 1 - Verify swatch-metrics produces Events with cloud_provider

This will be happening for Events produced by both **swatch-metrics** and **swatch-metrics-rhel**

# swatch-metrics-rhel using rhel-for-x86-els-payg

```bash
EVENT_SOURCE=rhelemeter PROM_URL="http://10.0.150.94/api/v1" ./gradlew :swatch-metrics:quarkusDev
```

```bash
http POST :8000/api/swatch-metrics/v1/internal/metering/rhel-for-x86-els-payg \
orgId==$ORG_ID$ \
endDate==$(date -d '-2 hours' --utc +%Y-%m-%dT%H:00:00Z) \
rangeInMinutes==180 \
x-rh-swatch-psk:placeholder
```
## swatch-metrics test using ROSA

find an org reporting ROSA data in stage openshift observatorium: 
```promql
group(min_over_time(ocm_subscription{product='moa-hostedcontrolplane', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)
```


```bash
EVENT_SOURCE=prometheus PROM_URL="http://10.0.151.243:80/api/v1" ./gradlew :swatch-metrics:quarkusDev
```

```bash
http POST :8000/api/swatch-metrics/v1/internal/metering/rosa \
orgId==$ORG_ID \
endDate==$(date -d '-2 hours' --utc +%Y-%m-%dT%H:00:00Z) \
x-rh-swatch-psk:placeholder
```

Check service-instance-ingress topic for events.  We're looking to verify that messages now include hardware type and a cloud provider
```json
  "hardware_type": "Cloud",
  "cloud_provider": "AWS",
```

http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.servietce-instance-ingress/data/rawdata

# Part 2 - Verify snapshot & billable remittance reconciles appropriately with pre-existing data

We want to make sure that usages reconcile correctly for instances that were previously being defaulted to PHYSICAL during an hourly tally.

See attached [test_helpers.zip](https://github.com/user-attachments/files/15964480/test_helpers.zip) file for helper scripts being referred to in these steps.


### On main branch

```bash
EVENT_SOURCE=prometheus PROM_URL="http://10.0.151.243:80/api/v1" ./gradlew :swatch-metrics:quarkusDev
```


- Create Events for a ROSA instance that does NOT include the `hardware_type` or `cloud_provider` attributes.  You can do this one of two ways with the helper script...
	- `sh produce_rosa_physical_message.sh` will put a message on the service-instance-ingress topic
	- `sh create_rosa_event.sh physical` this will directly insert it into the swatch events table.  it's the same instance as the kafka message version (i actually pulled this right from my database after i did the kafka message as a test and i was consumed by swatch-tally.  this direct database insert has less moving parts, but putting a message on the kafka topic would be the test more representative of how it actually works)
- Run an hourly tally
	- `sh hourly_tally.sh`
- Inspect the snapshots/measurements and billable usage
	- `sh snapshots_sql.sh`
	- `sh monthly_totals_sql.sh`
	- `sh billable_remittance_sql.sh`

### Switch branches
* Restart swatch-metrics

```bash
EVENT_SOURCE=prometheus PROM_URL="http://10.0.151.243:80/api/v1" ./gradlew :swatch-metrics:quarkusDev
```

* create a new Event (new timestamp) for that instance, but this time include the hardware type & cloud provider.  This is going to represent what the next hourly metric gathering is going to do after the code changes.
	* Again, two methods to do this...direct db insert is more convenient:
		* kafka message: `sh create_rosa_event.sh cloud`
		* direct db insert: `sh produce_rosa_cloud_message.sh`
- Run an hourly tally again
	- `sh hourly_tally.sh`
- Inspect the snapshots/measurements and billable usage again
	- `sh snapshots_sql.sh`
	- `sh monthly_totals_sql.sh`
	- `sh billable_remittance_sql.sh`

We're expecting to see measurements and billable usages for both PHYSICAL and AWS, but the totals should sum up properly (ie, not double count the old PHYSICAL ones as part of the new AWS one)