### PR TITLE
SWATCH-2323: Add BillableUsage.tally_id to replace BillableUsage.id

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.json.BillableUsage;
@@ -99,7 +100,7 @@ public class RhMarketplacePayloadMapper {
     }
 
     OffsetDateTime snapshotDate = billableUsage.getSnapshotDate();
-    String eventId = billableUsage.getId().toString();
+    String eventId = getTallyIdFromUsage(billableUsage).toString();
 
     /*
     This will need to be updated if we expand the criteria defined in the
@@ -185,6 +186,10 @@ public class RhMarketplacePayloadMapper {
         && billableUsage.getBillingProvider() != null
         && billableUsage.getBillingAccountId() != null
         && billableUsage.getSnapshotDate() != null
-        && billableUsage.getId() != null;
+        && getTallyIdFromUsage(billableUsage) != null;
+  }
+
+  private UUID getTallyIdFromUsage(BillableUsage usage) {
+    return Optional.ofNullable(usage.getTallyId()).orElse(usage.getId());
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapperTest.java
@@ -92,7 +92,7 @@ class RhMarketplacePayloadMapperTest {
     String orgId = "org123";
     var usage =
         new BillableUsage()
-            .withId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
+            .withTallyId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
             .withOrgId(orgId)
             .withProductId("OpenShift-metrics")
             .withSnapshotDate(snapshotDate)
@@ -141,7 +141,7 @@ class RhMarketplacePayloadMapperTest {
     String orgId = "org123";
     var usage =
         new BillableUsage()
-            .withId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
+            .withTallyId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
             .withProductId("OpenShift-metrics")
             .withOrgId(orgId)
             .withSnapshotDate(snapshotDate)

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
@@ -104,7 +104,7 @@ public class InternalBillableUsageController {
             : null;
     return new BillableUsage()
         .withOrgId(remittance.getOrgId())
-        .withId(remittance.getTallyId())
+        .withTallyId(remittance.getTallyId())
         .withUuid(remittance.getUuid())
         .withSnapshotDate(remittance.getRemittancePendingDate())
         .withProductId(remittance.getProductId())

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageMapper.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageMapper.java
@@ -102,7 +102,7 @@ public class BillableUsageMapper {
       TallyMeasurement measurement, TallySummary summary, TallySnapshot snapshot) {
     return new BillableUsage()
         .withOrgId(summary.getOrgId())
-        .withId(snapshot.getId())
+        .withTallyId(snapshot.getId())
         .withSnapshotDate(snapshot.getSnapshotDate())
         .withProductId(snapshot.getProductId())
         .withSla(BillableUsage.Sla.fromValue(snapshot.getSla().value()))

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
@@ -212,7 +212,7 @@ public class BillableUsageService {
             .sla(usage.getSla().value())
             .usage(usage.getUsage().value())
             .remittancePendingDate(clock.now())
-            .tallyId(usage.getId())
+            .tallyId(Optional.ofNullable(usage.getTallyId()).orElse(usage.getId()))
             .hardwareMeasurementType(usage.getHardwareMeasurementType())
             .status(RemittanceStatus.PENDING)
             .build();

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
@@ -140,7 +140,7 @@ class BillableUsageServiceTest {
         remittance(usage, usage.getSnapshotDate(), 1.0);
     BillableUsage expectedUsage =
         billable(usage.getSnapshotDate(), 1.0, usage.getCurrentTotal()).withUuid(usage.getUuid());
-    expectedUsage.setId(usage.getId()); // Id will be regenerated above.
+    expectedUsage.setTallyId(usage.getTallyId()); // Id will be regenerated above.
     verify(remittanceRepo).persistAndFlush(expectedRemittance);
     verify(producer).produce(expectedUsage);
   }
@@ -159,7 +159,7 @@ class BillableUsageServiceTest {
     BillableUsageRemittanceEntity expectedRemittance =
         remittance(usage, usage.getSnapshotDate(), 2.0);
     BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 2.0, usage.getCurrentTotal());
-    expectedUsage.setId(usage.getId()); // Id will be regenerated above.
+    expectedUsage.setTallyId(usage.getTallyId()); // Id will be regenerated above.
     verify(remittanceRepo).persistAndFlush(expectedRemittance);
     verify(producer).produce(expectedUsage);
   }
@@ -183,7 +183,7 @@ class BillableUsageServiceTest {
     BillableUsageRemittanceEntity expectedRemittance =
         remittance(usage, usage.getSnapshotDate(), 72.0);
     BillableUsage expectedUsage = billable(usage.getSnapshotDate(), 18.0, usage.getCurrentTotal());
-    expectedUsage.setId(usage.getId()); // Id will be regenerated above.
+    expectedUsage.setTallyId(usage.getTallyId()); // Id will be regenerated above.
     expectedUsage.setProductId("osd");
     expectedUsage.setMetricId(MetricIdUtils.getCores().getValue());
     expectedUsage.setBillingFactor(0.25);
@@ -203,7 +203,7 @@ class BillableUsageServiceTest {
 
     BillableUsage expectedUsage =
         billable(usage.getSnapshotDate(), 0.0, usage.getCurrentTotal()); // Nothing billed
-    expectedUsage.setId(usage.getId()); // Id will be regenerated above.
+    expectedUsage.setTallyId(usage.getTallyId()); // Id will be regenerated above.
     verify(producer).produce(expectedUsage);
   }
 
@@ -225,7 +225,7 @@ class BillableUsageServiceTest {
         remittance(usage, usage.getSnapshotDate(), 12.0);
     BillableUsage expectedUsage =
         billable(usage.getSnapshotDate(), usage.getValue(), usage.getCurrentTotal());
-    expectedUsage.setId(usage.getId()); // Id will be regenerated above.
+    expectedUsage.setTallyId(usage.getTallyId()); // Id will be regenerated above.
     expectedUsage.setProductId("osd");
     expectedUsage.setMetricId(usage.getMetricId());
     expectedUsage.setBillingFactor(0.25);
@@ -252,7 +252,7 @@ class BillableUsageServiceTest {
         remittance(usage, usage.getSnapshotDate(), 28.00);
     BillableUsage expectedUsage =
         billable(usage.getSnapshotDate(), usage.getValue(), usage.getCurrentTotal());
-    expectedUsage.setId(usage.getId()); // Id will be regenerated above.
+    expectedUsage.setTallyId(usage.getTallyId()); // Id will be regenerated above.
     expectedUsage.setProductId("osd");
     expectedUsage.setMetricId(usage.getMetricId());
     expectedUsage.setBillingFactor(0.25);
@@ -534,7 +534,7 @@ class BillableUsageServiceTest {
   private BillableUsage billable(OffsetDateTime date, Double value, Double currentTotal) {
     return new BillableUsage()
         .withUsage(BillableUsage.Usage.PRODUCTION)
-        .withId(UUID.randomUUID())
+        .withTallyId(UUID.randomUUID())
         .withBillingAccountId("aws-account1")
         .withBillingFactor(1.0)
         .withBillingProvider(BillableUsage.BillingProvider.AWS)
@@ -561,7 +561,7 @@ class BillableUsageServiceTest {
         .accumulationPeriod(AccumulationPeriodFormatter.toMonthId(usage.getSnapshotDate()))
         .remittancePendingDate(remittedDate)
         .remittedPendingValue(value)
-        .tallyId(usage.getId())
+        .tallyId(usage.getTallyId())
         .hardwareMeasurementType(usage.getHardwareMeasurementType())
         .status(RemittanceStatus.PENDING)
         .build();
@@ -626,7 +626,7 @@ class BillableUsageServiceTest {
 
     BillableUsage expectedUsage =
         billable(usage.getSnapshotDate(), expectedBilledValue, usage.getCurrentTotal());
-    expectedUsage.setId(usage.getId());
+    expectedUsage.setTallyId(usage.getTallyId());
     expectedUsage.setBillingFactor(billingFactor);
     ArgumentCaptor<BillableUsage> usageCaptor = ArgumentCaptor.forClass(BillableUsage.class);
     verify(producer).produce(usageCaptor.capture());

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -9,6 +9,11 @@ properties:
     description: Preferred identifier for the relevant account (if present).
     type: string
   id:
+    description: Tally snapshot ID that resulted in this billable usage (for tracking) (Deprecated).
+    type: string
+    format: uuid
+    deprecationMessage: Use "tally_id" instead. To be removed in SWATCH-2674.
+  tally_id:
     description: Tally snapshot ID that resulted in this billable usage (for tracking).
     type: string
     format: uuid

--- a/swatch-producer-aws/.openapi-generator-ignore
+++ b/swatch-producer-aws/.openapi-generator-ignore
@@ -1,0 +1,2 @@
+# Exclude BillableUsage class to be generated in this module
+**/BillableUsage.java

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -48,6 +48,7 @@ openApiGenerate {
     modelPackage = "com.redhat.swatch.aws.openapi.model"
     invokerPackage = "com.redhat.swatch.aws.openapi"
     groupId = "com.redhat.swatch.aws"
+    ignoreFileOverride = "${projectDir}/.openapi-generator-ignore"
     configOptions = [
             sourceFolder         : "src/gen/java",
             interfaceOnly        : "true",

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -26,7 +26,6 @@ import com.redhat.swatch.aws.exception.AwsUsageContextLookupException;
 import com.redhat.swatch.aws.exception.DefaultApiException;
 import com.redhat.swatch.aws.exception.SubscriptionRecentlyTerminatedException;
 import com.redhat.swatch.aws.exception.UsageTimestampOutOfBoundsException;
-import com.redhat.swatch.aws.openapi.model.BillableUsage.BillingProviderEnum;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.model.AwsUsageContext;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi;
@@ -45,6 +44,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -291,7 +291,8 @@ public class AwsBillableUsageAggregateConsumer {
   }
 
   private Optional<Metric> validateUsageAndLookupMetric(BillableUsageAggregateKey aggregationKey) {
-    if (!Objects.equals(aggregationKey.getBillingProvider(), BillingProviderEnum.AWS.value())) {
+    if (!Objects.equals(
+        aggregationKey.getBillingProvider(), BillableUsage.BillingProvider.AWS.value())) {
       log.debug("Snapshot not applicable because billingProvider is not AWS");
       return Optional.empty();
     }

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsUsageContextLookupApiTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsUsageContextLookupApiTest.java
@@ -25,13 +25,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
-import com.redhat.swatch.aws.openapi.model.BillableUsage.BillingProviderEnum;
 import com.redhat.swatch.aws.test.resources.WireMockResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.junit.jupiter.api.Test;
@@ -53,7 +53,7 @@ class AwsUsageContextLookupApiTest {
             null,
             "Premium",
             "Production",
-            BillingProviderEnum.AWS.value(),
+            BillableUsage.BillingProvider.AWS.value(),
             "billingAccountId");
     aggregate.setAggregateKey(key);
     try {

--- a/swatch-producer-azure/.openapi-generator-ignore
+++ b/swatch-producer-azure/.openapi-generator-ignore
@@ -1,0 +1,2 @@
+# Exclude BillableUsage class to be generated in this module
+**/BillableUsage.java

--- a/swatch-producer-azure/build.gradle
+++ b/swatch-producer-azure/build.gradle
@@ -52,6 +52,7 @@ openApiGenerate {
     modelPackage = "com.redhat.swatch.azure.openapi.model"
     invokerPackage = "com.redhat.swatch.azure.openapi"
     groupId = "com.redhat.swatch.azure"
+    ignoreFileOverride = "${projectDir}/.openapi-generator-ignore"
     configOptions = [sourceFolder     : "src/gen/java",
                      interfaceOnly    : "true",
                      library          : "microprofile",

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -27,10 +27,6 @@ import com.redhat.swatch.azure.exception.DefaultApiException;
 import com.redhat.swatch.azure.exception.SubscriptionCanNotBeDeterminedException;
 import com.redhat.swatch.azure.exception.SubscriptionRecentlyTerminatedException;
 import com.redhat.swatch.azure.exception.UsageTimestampOutOfBoundsException;
-import com.redhat.swatch.azure.openapi.model.BillableUsage;
-import com.redhat.swatch.azure.openapi.model.BillableUsage.BillingProviderEnum;
-import com.redhat.swatch.azure.openapi.model.BillableUsage.SlaEnum;
-import com.redhat.swatch.azure.openapi.model.BillableUsage.UsageEnum;
 import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEvent;
 import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventStatusEnum;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.model.AzureUsageContext;
@@ -54,6 +50,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -269,7 +266,8 @@ public class AzureBillableUsageAggregateConsumer {
   }
 
   private Optional<Metric> validateUsageAndLookupMetric(BillableUsageAggregateKey aggregationKey) {
-    if (!Objects.equals(aggregationKey.getBillingProvider(), BillingProviderEnum.AZURE.value())) {
+    if (!Objects.equals(
+        aggregationKey.getBillingProvider(), BillableUsage.BillingProvider.AZURE.value())) {
       log.debug("Snapshot not applicable because billingProvider is not Azure");
       return Optional.empty();
     }
@@ -299,13 +297,14 @@ public class AzureBillableUsageAggregateConsumer {
 
   private BillableUsage billableUsageFromAggregateKey(BillableUsageAggregateKey key, String uuid) {
     var billableUsage = new BillableUsage();
-    billableUsage.setUsage(UsageEnum.fromValue(key.getUsage()));
+    billableUsage.setUsage(BillableUsage.Usage.fromValue(key.getUsage()));
     billableUsage.setBillingAccountId(key.getBillingAccountId());
-    billableUsage.setBillingProvider(BillingProviderEnum.fromValue(key.getBillingProvider()));
+    billableUsage.setBillingProvider(
+        BillableUsage.BillingProvider.fromValue(key.getBillingProvider()));
     billableUsage.setOrgId(key.getOrgId());
     billableUsage.setProductId(key.getProductId());
     billableUsage.setMetricId(key.getMetricId());
-    billableUsage.setSla(SlaEnum.fromValue(key.getSla()));
+    billableUsage.setSla(BillableUsage.Sla.fromValue(key.getSla()));
     billableUsage.setUuid(UUID.fromString(uuid));
     return billableUsage;
   }

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageDeadLetterTopicProducer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/BillableUsageDeadLetterTopicProducer.java
@@ -20,12 +20,12 @@
  */
 package com.redhat.swatch.azure.service;
 
-import com.redhat.swatch.azure.openapi.model.BillableUsage;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
@@ -35,9 +35,6 @@ import com.redhat.swatch.azure.exception.AzureUsageContextLookupException;
 import com.redhat.swatch.azure.exception.DefaultApiException;
 import com.redhat.swatch.azure.exception.SubscriptionCanNotBeDeterminedException;
 import com.redhat.swatch.azure.exception.SubscriptionRecentlyTerminatedException;
-import com.redhat.swatch.azure.openapi.model.BillableUsage;
-import com.redhat.swatch.azure.openapi.model.BillableUsage.BillingProviderEnum;
-import com.redhat.swatch.azure.openapi.model.BillableUsage.SlaEnum;
 import com.redhat.swatch.azure.test.resources.InMemoryMessageBrokerKafkaResource;
 import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEvent;
 import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventOkResponse;
@@ -65,6 +62,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
@@ -128,9 +126,9 @@ class BillableUsageConsumerTest {
             "testOrg",
             BASILISK,
             INSTANCE_HOURS,
-            SlaEnum.PREMIUM.value(),
+            BillableUsage.Sla.PREMIUM.value(),
             Usage.PRODUCTION.getValue(),
-            BillingProviderEnum.RED_HAT.value(),
+            BillableUsage.BillingProvider.RED_HAT.value(),
             "testBillingAccountId");
     aggregate.setAggregateKey(key);
     consumer.process(aggregate);
@@ -320,9 +318,9 @@ class BillableUsageConsumerTest {
             "testOrg",
             productId,
             metricId,
-            SlaEnum.PREMIUM.value(),
+            BillableUsage.Sla.PREMIUM.value(),
             Usage.PRODUCTION.getValue(),
-            BillingProviderEnum.AZURE.value(),
+            BillableUsage.BillingProvider.AZURE.value(),
             "testBillingAccountId");
     aggregate.setAggregateKey(key);
     return aggregate;


### PR DESCRIPTION
Jira issue: SWATCH-2323

## Description
- Add BillableUsage.tally_id to replace BillableUsage.id
- Deprecate BillableUsage.id
- Found that the BillableUsage class was also generated in the swatch-producer-aws and swatch-producer-azure even when the used by the API is the expected one from the swatch-model-billable-usage. This seems to be a known behaviour of the openapi generator but it causes confusion, so to avoid it, I made use of https://github.com/OpenAPITools/openapi-generator/blob/master/docs/customization.md#ignore-file-format.

## Testing
Only regression testing since the billable_usage.id and billable_usage.tally_id are both supported. This is going to be fully removed in SWATCH-2674.

Adding the QE label to update the iqe steps to make use of the tally_id instead. 