### PR TITLE
SWATCH-2618 Add better logging for AWS Azure usage

### DIFF
--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/processors/BillableUsageAggregateProcessor.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/processors/BillableUsageAggregateProcessor.java
@@ -88,7 +88,7 @@ public class BillableUsageAggregateProcessor {
   @Incoming("billable-usage-hourly-aggregate-in")
   @Blocking
   public void process(BillableUsageAggregate billableUsageAggregate) {
-    log.debug("Picked up billable usage message {} to process", billableUsageAggregate);
+    log.info("Picked up billable usage message {} to process", billableUsageAggregate);
     if (billableUsageAggregate == null || billableUsageAggregate.getAggregateKey() == null) {
       log.warn("Skipping null billable usage: deserialization failure?");
       return;
@@ -109,15 +109,17 @@ public class BillableUsageAggregateProcessor {
       context = lookupAwsUsageContext(billableUsageAggregate);
     } catch (SubscriptionRecentlyTerminatedException e) {
       log.info(
-          "Subscription recently terminated for billableUsageAggregateId={} orgId={}",
+          "Subscription recently terminated for billableUsageAggregateId={} orgId={} remittanceUUIDs={}",
           billableUsageAggregate.getAggregateId(),
-          billableUsageAggregate.getAggregateKey().getOrgId());
+          billableUsageAggregate.getAggregateKey().getOrgId(),
+          billableUsageAggregate.getRemittanceUuids());
       return;
     } catch (AwsUsageContextLookupException e) {
       log.error(
-          "Error looking up usage context for tallySnapshotId={} orgId={}",
+          "Error looking up aws usage context for aggregateId={} orgId={} remittanceUUIDs={}",
           billableUsageAggregate.getAggregateId(),
           billableUsageAggregate.getAggregateKey().getOrgId(),
+          billableUsageAggregate.getRemittanceUuids(),
           e);
       return;
     }
@@ -125,9 +127,10 @@ public class BillableUsageAggregateProcessor {
       transformAndSend(context, billableUsageAggregate, metric.get());
     } catch (UsageTimestampOutOfBoundsException e) {
       log.warn(
-          "{} orgId={} aggregateId={} productId={} windowTimestamp={} rhSubscriptionId={} awsCustomerId={} awsProductCode={} subscriptionStartDate={} value={}",
+          "{} orgId={} remittanceUUIDs={} aggregateId={} productId={} windowTimestamp={} rhSubscriptionId={} awsCustomerId={} awsProductCode={} subscriptionStartDate={} value={}",
           e.getMessage(),
           billableUsageAggregate.getAggregateKey().getOrgId(),
+          billableUsageAggregate.getRemittanceUuids(),
           billableUsageAggregate.getAggregateId(),
           billableUsageAggregate.getAggregateKey().getProductId(),
           billableUsageAggregate.getWindowTimestamp(),
@@ -139,12 +142,13 @@ public class BillableUsageAggregateProcessor {
       ignoreCounter.increment();
     } catch (Exception e) {
       log.error(
-          "Error sending usage for rhSubscriptionId={} aggregateId={} awsCustomerId={} awsProductCode={} orgId={}",
+          "Error sending aws usage for rhSubscriptionId={} aggregateId={} awsCustomerId={} awsProductCode={} orgId={} remittanceUUIDs={}",
           context.getRhSubscriptionId(),
           billableUsageAggregate.getAggregateId(),
           context.getCustomerId(),
           context.getProductCode(),
           billableUsageAggregate.getAggregateKey().getOrgId(),
+          billableUsageAggregate.getRemittanceUuids(),
           e);
     }
   }
@@ -187,16 +191,18 @@ public class BillableUsageAggregateProcessor {
 
     if (isDryRun.isPresent() && Boolean.TRUE.equals(isDryRun.get())) {
       log.info(
-          "[DRY RUN] Sending usage request to AWS: {}, organization={}, product_id={}",
+          "[DRY RUN] Sending usage request to AWS: {}, organization={}, remittanceUUIDs={}, product_id={}",
           request,
           billableUsageAggregate.getAggregateKey().getOrgId(),
+          billableUsageAggregate.getRemittanceUuids(),
           billableUsageAggregate.getAggregateKey().getProductId());
       return;
     } else {
       log.info(
-          "Sending usage request to AWS: {}, organization={}, product_id={}",
+          "Sending usage request to AWS: {}, organization={}, remittanceUUIDs={}, product_id={}",
           request,
           billableUsageAggregate.getAggregateKey().getOrgId(),
+          billableUsageAggregate.getRemittanceUuids(),
           billableUsageAggregate.getAggregateKey().getProductId());
     }
 
@@ -211,20 +217,23 @@ public class BillableUsageAggregateProcessor {
               result -> {
                 if (result.status() == UsageRecordResultStatus.CUSTOMER_NOT_SUBSCRIBED) {
                   log.warn(
-                      "No subscription found for organization={}, product_id={}, result={}",
+                      "No subscription found for organization={}, remittanceUUIDs={} product_id={}, result={}",
                       billableUsageAggregate.getAggregateKey().getOrgId(),
+                      billableUsageAggregate.getRemittanceUuids(),
                       billableUsageAggregate.getAggregateKey().getProductId(),
                       result);
                 } else if (result.status() != UsageRecordResultStatus.SUCCESS) {
                   log.warn(
-                      "{}, organization={}",
+                      "{}, organization={} remittanceUUIDs={}",
                       result,
-                      billableUsageAggregate.getAggregateKey().getOrgId());
+                      billableUsageAggregate.getAggregateKey().getOrgId(),
+                      billableUsageAggregate.getRemittanceUuids());
                 } else {
                   log.info(
-                      "{}, organization={},",
+                      "{}, organization={}, remittanceUUIDs={},",
                       result,
-                      billableUsageAggregate.getAggregateKey().getOrgId());
+                      billableUsageAggregate.getAggregateKey().getOrgId(),
+                      billableUsageAggregate.getRemittanceUuids());
                   acceptedCounter.increment(response.results().size());
                 }
               });
@@ -237,9 +246,10 @@ public class BillableUsageAggregateProcessor {
       throw new AwsUnprocessedRecordsException(request.usageRecords().size(), e);
     } catch (AwsMissingCredentialsException e) {
       log.warn(
-          "{} for organization={}, awsCustomerId={}",
+          "{} for organization={}, remittanceUUIDs={}, awsCustomerId={}",
           e.getMessage(),
           billableUsageAggregate.getAggregateKey().getOrgId(),
+          billableUsageAggregate.getRemittanceUuids(),
           context.getCustomerId());
     }
   }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2618

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

Steps:
```
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('6c57046a-7071-4fc9-a543-650b868edcc0', '2024-06-12 16:00:00.000000 +00:00', '{"sla": "Premium", "org_id": "12345678", "event_id": "6c57046a-7071-4fc9-a543-650b868edcc0", "timestamp": "2024-06-12T16:00:00Z", "conversion": false, "event_type": "snapshot_rhel-for-x86-els-payg_vcpus", "expiration": "2024-06-12T17:00:00Z", "instance_id": "efe37aa6-ac56-41df-8c8a-c260bd498f5b", "product_ids": ["204", "69"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-06-21T18:37:40.540859342Z", "display_name": "ip-10-128-200-231.ec2.internal", "event_source": "rhelemeter", "measurements": [{"value": 2.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "billing_provider": "aws", "metering_batch_id": "6f4611df-8acf-48c8-9bf4-4a439ff59034", "billing_account_id": "customerAccount12345678"}', 'snapshot_rhel-for-x86-els-payg_vcpus', 'rhelemeter', 'efe37aa6-ac56-41df-8c8a-c260bd498f5b', '12345678', '6f4611df-8acf-48c8-9bf4-4a439ff59034', '2024-06-21 18:37:40.540859 +00:00');
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('8c57046a-7071-4fc9-a543-650b868edcc0', '2024-06-21 16:00:00.000000 +00:00', '{"sla": "Premium", "org_id": "12345678", "event_id": "8c57046a-7071-4fc9-a543-650b868edcc0", "timestamp": "2024-06-21T16:00:00Z", "conversion": false, "event_type": "snapshot_rhel-for-x86-els-payg_vcpus", "expiration": "2024-06-21T17:00:00Z", "instance_id": "efe37aa6-ac56-41df-8c8a-c260bd498f5b", "product_ids": ["204", "69"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-06-21T18:40:04.224170097Z", "display_name": "ip-10-128-200-231.ec2.internal", "event_source": "rhelemeter", "measurements": [{"value": 5.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "billing_provider": "aws", "metering_batch_id": "6f4611df-8acf-48c8-9bf4-4a439ff59034", "billing_account_id": "customerAccount12345678"}', 'snapshot_rhel-for-x86-els-payg_vcpus', 'rhelemeter', 'efe37aa6-ac56-41df-8c8a-c260bd498f5b', '12345678', '6f4611df-8acf-48c8-9bf4-4a439ff59034', '2024-06-21 18:40:04.224170 +00:00');

```

`INSERT INTO public.sku_product_tag (sku, product_tag) VALUES ('RH02781MO', 'rhel-for-x86-els-payg');`
`
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH02781MO', '12345678', '14991902', 1, '2024-05-31 12:36:06.963022 +00:00', '2024-06-30 03:59:59.000000 +00:00', 'd67yst1e8dt3xhv06zc0szqkk;hNshhHtAo5L;904488025337', '14992059', 'aws', 'customerAccount12345678');
`

```
DEV_MODE=true ./gradlew clean :bootRun

SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 DEV_MODE=true ./gradlew :swatch-billable-usage:quarkusDev

SERVER_PORT=8003 QUARKUS_MANAGEMENT_PORT=9003 ./gradlew :swatch-producer-aws:quarkusDev
```

Flush inorder to see results immediately or tally another event
`http PUT :8002/api/swatch-billable-usage/internal/rpc/topics/flush`

### Verification
<!-- Enter the steps needed to verify the test passed -->
Logs:
`Picked up billable usage message BillableUsageAggregate(totalValue=7.0, windowTimestamp=2024-06-25T11:00Z, aggregateId=b9f6dc9b-51db-48fa-9f34-fb54672370fa, aggregateKey=BillableUsageAggregateKey(orgId=12345678, productId=rhel-for-x86-els-payg, metricId=VCPUS, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=customerAccount12345678), snapshotDates=[2024-06-25T11:55:25.518874354Z, 2024-06-25T11:55:25.363389198Z], status=null, errorCode=null, billedOn=null, remittanceUuids=[4a04797e-7f95-42cf-a422-1b88b8ecc225, 4e6037f2-7069-4078-9000-9ed97af2c274]) to process`

Success
```
2024-06-25 08:03:13,325 INFO  [com.red.swa.aws.pro.BillableUsageAggregateProcessor] (vert.x-worker-thread-1) Picked up billable usage message BillableUsageAggregate(totalValue=7.0, windowTimestamp=2024-06-25T12:00Z, aggregateId=312240f8-5aba-4adc-81fb-666e6ef375a3, aggregateKey=BillableUsageAggregateKey(orgId=12345678, productId=rhel-for-x86-els-payg, metricId=VCPUS, sla=Premium, usage=Production, billingProvider=aws, billingAccountId=customerAccount12345678), snapshotDates=[2024-06-25T12:03:01.771513157Z, 2024-06-25T12:03:01.866078107Z], status=null, errorCode=null, billedOn=null, remittanceUuids=[610dc3f0-ecb3-4c00-8fc3-04d60f3d2666, 010fd6fa-212b-4d80-8f4e-e236dd2f85a5]) to process
2024-06-25 08:03:13,359 INFO  [com.red.swa.aws.pro.BillableUsageAggregateProcessor] (vert.x-worker-thread-1) Sending usage request to AWS: BatchMeterUsageRequest(UsageRecords=[UsageRecord(Timestamp=2024-06-25T12:00:00Z, CustomerIdentifier=hNshhHtAo5L, Dimension=vCPU_hours, Quantity=7)], ProductCode=d67yst1e8dt3xhv06zc0szqkk), organization=12345678, remittanceUUIDs=[610dc3f0-ecb3-4c00-8fc3-04d60f3d2666, 010fd6fa-212b-4d80-8f4e-e236dd2f85a5], product_id=rhel-for-x86-els-payg
2024-06-25 08:03:13,360 WARN  [com.red.swa.aws.pro.BillableUsageAggregateProcessor] (vert.x-worker-thread-1) SWATCHAWS1003: AWS credentials missing: sellerAccount=904488025337 for organization=12345678, remittanceUUIDs=[610dc3f0-ecb3-4c00-8fc3-04d60f3d2666, 010fd6fa-212b-4d80-8f4e-e236dd2f85a5], awsCustomerId=hNshhHtAo5L

```

Failure:
`Error looking up aws usage context for aggregateId=b9f6dc9b-51db-48fa-9f34-fb54672370fa orgId=12345678 remittanceUUIDs=[4a04797e-7f95-42cf-a422-1b88b8ecc225, 4e6037f2-7069-4078-9000-9ed97af2c274]`


