### PR TITLE
SWATCH-2686: Add index for subscription-number to the subscription table

### DIFF
--- a/src/main/resources/liquibase/202406240700-add-subscription-number-index.xml
+++ b/src/main/resources/liquibase/202406240700-add-subscription-number-index.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+  <changeSet id="202406240700-1" author="bcourt">
+    <comment>Create an index on subscription_number for subscription</comment>
+    <createIndex indexName="subscription_subscription_number_idx" tableName="subscription"
+                 unique="false">
+      <column name="subscription_number"/>
+    </createIndex>
+    <rollback>
+            <dropIndex tableName="subscription" indexName="subscription_subscription_number_idx" />
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -163,5 +163,6 @@
     <include file="/liquibase/202406130700-add-index-in-sku-product-tag.xml"/>
     <include file="/liquibase/202406051539-remove-erroneously-duplicated-subscriptions.xml"/>
     <include file="/liquibase/202406120950-update-subscription-capacity-view.xml"/>
+    <include file="/liquibase/202406240700-add-subscription-number-index.xml" />
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
This is being done to speed up a query during subscription-sync which is consuming almost 100% of CPU.
