### PR TITLE
Support E2E testing of els unconverted with AWS

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg_awsdimension.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/RHEL_for_x86_els_payg_awsdimension.yaml
@@ -1,18 +1,19 @@
 ---
 platform: RHEL
 
-id: rhel-for-x86-els-payg
+id: rhel-for-x86-els-payg-addon
 
 vdcType: true
 
 variants:
-  - tag: rhel-for-x86-els-payg
-    isMigrationProduct: true
+  - tag: rhel-for-x86-els-payg-addon
+    isMigrationProduct: false
     engineeringIds:
       - 204
+    additionalTags: [ "RHEL for x86" ]
 
 defaults:
-  variant: rhel-for-x86-els-payg
+  variant: rhel-for-x86-els-payg-addon
   sla: PREMIUM
   usage: PRODUCTION
 
@@ -22,7 +23,7 @@ contractEnabled: false #There is no need to generate an AWS contract listing bec
 
 metrics:
   - id: vCPUs
-    awsDimension: vCPU_hours
+    awsDimension: vcpu_hourly
     azureDimension: vcpu_hours
     prometheus:
       queryKey: rhelemeter

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
@@ -46,7 +46,7 @@ class SubscriptionDefinitionRegistryTest {
   void testLoadAllTheThings() {
 
     var actual = subscriptionDefinitionRegistry.getSubscriptions().size();
-    var expected = 19;
+    var expected = 20;
 
     assertEquals(expected, actual);
   }


### PR DESCRIPTION
The test listing in AWS has an incorrect dimension identifier (vcpu_hourly) for unconverted ELS.

We've requested this to be updated, but in the meantime we can pull out that product tag into its own file in order to give it a different dimension identifier than the converted version

This commit should be reverted after the AWS ticket is complete.

Unit test results

```
./gradlew clean test
```

```
> Task :test

SUCCESS: Executed 979 tests in 7m 35s (5 skipped)


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 7m 39s
265 actionable tasks: 164 executed, 91 from cache, 10 up-to-date
```
