### PR TITLE
SWATCH-2424: Limit the snapshots to purge in batches

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
@@ -25,6 +25,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
+import lombok.AllArgsConstructor;
 import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.springframework.stereotype.Component;
@@ -37,16 +38,11 @@ import org.springframework.stereotype.Component;
  * addition to the current incomplete month.
  */
 @Component
+@AllArgsConstructor
 public class TallyRetentionPolicy {
 
   private final ApplicationClock applicationClock;
   private final TallyRetentionPolicyProperties config;
-
-  public TallyRetentionPolicy(
-      ApplicationClock applicationClock, TallyRetentionPolicyProperties config) {
-    this.applicationClock = applicationClock;
-    this.config = config;
-  }
 
   /**
    * Get the cutoff date for the passed granularity.
@@ -102,5 +98,9 @@ public class TallyRetentionPolicy {
         throw new IllegalArgumentException(
             String.format("Unsupported granularity: %s", granularity));
     }
+  }
+
+  public long getSnapshotsToDeleteInBatches() {
+    return config.getSnapshotsToDeleteInBatches();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyProperties.java
@@ -20,16 +20,19 @@
  */
 package org.candlepin.subscriptions.retention;
 
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 /** Retention policies for supported granularities. */
 @Component
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "rhsm-subscriptions.tally-retention-policy")
+@Validated
 public class TallyRetentionPolicyProperties {
   /**
    * Number of historic hourly snapshots to keep. Actual number kept will include an additional hour
@@ -66,4 +69,6 @@ public class TallyRetentionPolicyProperties {
    * year (the current incomplete year).
    */
   private Integer yearly;
+
+  @Positive private long snapshotsToDeleteInBatches;
 }

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -41,6 +41,7 @@ rhsm-subscriptions:
     # Five years' worth
     quarterly: ${TALLY_RETENTION_QUARTERLY:20}
     yearly: ${TALLY_RETENTION_YEARLY:5}
+    snapshots-to-delete-in-batches: 1000000
   tally-summary-producer:
     back-off-initial-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL:1s}
     back-off-max-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_MAX_INTERVAL:1m}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -85,12 +85,22 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
       @Param("pageable") Pageable pageable);
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  @Modifying
   @Query(
       value =
-          "delete from TallySnapshot where orgId in (select distinct c.orgId from OrgConfig c) and granularity=:granularity and snapshotDate < :cutoffDate")
-  void deleteAllByGranularityAndSnapshotDateBefore(
+          "select count(*) from TallySnapshot where orgId in (select distinct c.orgId from OrgConfig c) and granularity=:granularity and snapshotDate < :cutoffDate")
+  long countAllByGranularityAndSnapshotDateBefore(
       Granularity granularity, OffsetDateTime cutoffDate);
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Modifying
+  @Query(
+      nativeQuery = true,
+      value =
+          "delete from tally_snapshots where id in (select id from tally_snapshots where org_id in (select distinct c.org_id from org_config c) and granularity=:granularity and snapshot_date < :cutoffDate limit :limit)")
+  void deleteAllByGranularityAndSnapshotDateBefore(
+      @Param("granularity") String granularity,
+      @Param("cutoffDate") OffsetDateTime cutoffDate,
+      @Param("limit") long limit);
 
   @Query(
       value =


### PR DESCRIPTION
Jira issue: SWATCH-2424

## Description
I checked the production database and it seems that there are an huge number (we're speaking about more of millions for every month up to 2022) of snapshots that is being tried to be deleted in a single delete query. 

So, we can't split up the delete query to be done by org_id, because we would have the same problem. The only trustable approach is to limit the query by the number of snapshots. This can be defined using a property and by default is 1000000. 

I could test these changes with such amount of data locally, but yes using the stage data. 

Note that to use this limit, I had to turn the delete query into a native query.

## Testing

### Using small dataset

0. podman-compose up
1. create schema `./gradlew liquibaseUpdate`
2. insert the small dataset:

```
insert into org_config values ('10000177','DB','2020-04-14T20:31:41.660008Z','2020-04-14T20:31:41.660008Z');

insert into tally_snapshots values ('80f53b83-3919-4e15-a97e-884e28817e12','RHEL for x86','DAILY','10000177','1950-03-05T00:00:00Z','','_ANY','','_ANY','_ANY');

insert into tally_measurements values ('80f53b83-3919-4e15-a97e-884e28817e12','VIRTUAL','INSTANCES','11');
insert into tally_measurements values ('80f53b83-3919-4e15-a97e-884e28817e12','VIRTUAL','SOCKETS','63');
```

3. start the service: `DEV_MODE=true ./gradlew :bootRun`
4. run the purge: `curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: placeholder" -X POST "http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge"`

Since the snapshot_date is very old, the tally_snapshot and measurements should be gone now.

### Using large data

0. download the data and script from https://drive.google.com/file/d/1vlHzCmPIoy8jov9g-qXGhYKC0VHRBX2g/view?usp=sharing.

6. start the postgresql instance:

```
podman-compose up
```

7. initialize the schema:

```
./gradlew liquibaseUpdate
```

8. load the data (script in the above link):

```
./load_data.sh
```

This file contains:
- 53255 orgs
- 2000000 snapshots
- 4000000 measurements

9. start the service:

```
DEV_MODE=true ./gradlew :bootRun
```

10. run the purge:

```
curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: placeholder" -X POST "http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge"
```

11. wait until the tally snapshot purge task is finished.
When the task is done, you should see the following in the app logs:

```
2024-03-19 16:05:39,969 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.security.LogPrincipalFilter] self- Internal API: /api/rhsm-subscriptions/v1/internal/rpc/tally/purge requested by user: self
2024-03-19 16:05:40,081 [thread=http-nio-8000-exec-1] [INFO ] [org.candlepin.subscriptions.tally.admin.InternalTallyResource] self- Initiating tally snapshot purge.
2024-03-19 16:05:40,086 [thread=purge-tally-snapshots-1] [INFO ] [org.candlepin.subscriptions.retention.TallyRetentionController] - Starting tally snapshot purge.
2024-03-19 16:06:05,634 [thread=purge-tally-snapshots-1] [INFO ] [org.candlepin.subscriptions.retention.TallyRetentionController] - Tally snapshot purge completed successfully.
```

Note that it took 30 seconds to finish.

12. Verify that the data in the tally_snapshots and in the tally_measurements tables.

```
select count(*) from tally_snapshots; -- expected: 2308