### PR TITLE
Set the measurement type when creating buckets

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -160,6 +160,13 @@ public class MetricUsageCollector {
   }
 
   private void updateInstanceFromEvent(Event event, Host instance) {
+    // Only update the instance type if it hasn't already been set (new host)
+    // so that if the host originated from a different source (HBI) it does
+    // not change.
+    if (StringUtils.isBlank(instance.getInstanceType())) {
+      instance.setInstanceType(event.getServiceType());
+    }
+
     // Always process buckets, measurements and set the lastAppliedEventRecordDate
     // on the host.
     Optional.ofNullable(event.getMeasurements())
@@ -182,6 +189,7 @@ public class MetricUsageCollector {
                           : measurement.getUom()),
                   measurement.getValue());
             });
+
     addBucketsFromEvent(instance, event);
     instance.setLastAppliedEventRecordDate(event.getRecordDate());
 
@@ -194,7 +202,6 @@ public class MetricUsageCollector {
 
     // Update the Host instance's meta-data
     instance.setOrgId(event.getOrgId());
-    instance.setInstanceType(event.getServiceType());
     instance.setInstanceId(event.getInstanceId());
     instance.setDisplayName(event.getInstanceId()); // may be overridden later
     instance.setGuest(instance.getHardwareType() == HostHardwareType.VIRTUALIZED);

--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -319,6 +319,12 @@ public class MetricUsageCollector {
 
   private void addBucketsFromEvent(Host host, Event event) {
     Set<List<Object>> bucketTuples = buildBucketTuples(event);
+
+    HardwareMeasurementType hardwareMeasurementType =
+        getHardwareMeasurementType(
+            getHostHardwareType(event.getHardwareType()),
+            getCloudProviderAsString(event.getCloudProvider()));
+
     Set<HostBucketKey> activeHostBucketKeys = new HashSet<>();
     bucketTuples.forEach(
         tuple -> {
@@ -347,7 +353,9 @@ public class MetricUsageCollector {
                   billingProvider,
                   billingAccountId,
                   false);
+
           bucket.setKey(key);
+          bucket.setMeasurementType(hardwareMeasurementType);
           activeHostBucketKeys.add(key);
           bucket.setCores(cores);
           bucket.setSockets(sockets);

--- a/src/main/resources/liquibase/202407091543-set-default-bucket-measurement-type.xml
+++ b/src/main/resources/liquibase/202407091543-set-default-bucket-measurement-type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202407091543-01" author="mstead">
+    <comment>Update NULL bucket measurement_type to PHYSICAL.</comment>
+    <update tableName="host_tally_buckets">
+      <column name="measurement_type" value="PHYSICAL" />
+      <where>measurement_type IS NULL</where>
+    </update>
+    <rollback>
+      <!-- Unable to roll back this change since we can not identify the records we have updated. -->
+    </rollback>
+  </changeSet>
+  <changeSet id="202407091543-02" author="mstead">
+    <comment>Set the default value for host_tally_buckets.measurement_type.</comment>
+    <addDefaultValue tableName="host_tally_buckets" columnName="measurement_type" defaultValue="PHYSICAL" />
+    <rollback>
+      <dropDefaultValue tableName="host_tally_buckets" columnName="measurement_type" />
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -166,5 +166,6 @@
     <include file="/liquibase/202406240700-add-subscription-number-index.xml" />
     <include file="/liquibase/202406261514-alter-event-instance-id-length.xml"/>
     <include file="/liquibase/202406191500-add-hypervisor_uuid-to-tally-instance-view.xml"/>
+    <include file="/liquibase/202407091543-set-default-bucket-measurement-type.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -454,6 +454,7 @@ class MetricUsageCollectorTest {
             .withProductTag(Set.of(RHEL_FOR_X86_ELS_PAYG))
             .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
             .withServiceType("RHEL System")
+            .withHardwareType(HardwareType.VIRTUAL)
             .withMeasurements(Collections.singletonList(measurement))
             .withSla(Event.Sla.PREMIUM)
             .withBillingProvider(Event.BillingProvider.RED_HAT)
@@ -491,6 +492,7 @@ class MetricUsageCollectorTest {
           bucket.setKey(key);
           bucket.setCores(measurement.getValue().intValue());
           bucket.setHost(instance);
+          bucket.setMeasurementType(HardwareMeasurementType.VIRTUAL);
           expected.add(bucket);
         });
     assertEquals(expected, new HashSet<>(instance.getBuckets()));


### PR DESCRIPTION
Jira issue: SWATCH-2712

## Description
Properly set the measurement type on buckets while updating hosts during the hourly tally. Prior to this patch the bucket measurement type was always getting set to null.

A liquibase changeset was added that updates the measurement_type of any records with a NULL measurement_type to PHYSICAL, since this is our default in code logic.

The changeset also defaults the measurement_type column to PHYSICAL.


## Reproducing The Issue
The key to reproducing this issue is to have the nightly tally create a host with an instance_type of HBI_HOST with a last_seen date that is more recent than ANY event targeting a host with the same instance_id that will be processed during an hourly tally.

When this happens, the hourly tally does not update the host's metadata (i.e instance_type), but does update any buckets (based on the event) that should be associated with the host.

The next time that the hourly tally runs, it picks up the buckets created via the event. These events have the null measurement_type and causes the NPE.

## Testing

### Setup
1. Checkout the **main** branch.

2. Reset the HBI DB
```
psql -h localhost -U insights insights -c "truncate hosts cascade;"
```

3. Insert a single host into the HBI DB.
```
INSERT INTO public.hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) VALUES ('54e25247-3f80-496b-97ea-75e95b5f4830', '', 'fqdn123456', '2024-07-03 21:54:14.517152 +00:00', '2024-07-03 21:59:04.808071 +00:00', '{}', '{}', '{"fqdn": "l5003u0d13ct314", "bios_uuid": "12345-6850-d844-a576-ec70aabb1f60", "provider_id": "test-instance", "ip_addresses": ["127.0.0.1"], "mac_addresses": [], "provider_type": "azure", "subscription_manager_id": "90db0ceb-ea92-720f-9569-6709bda25e81"}', '{"arch": "x86_64", "owner_id": "1234", "yum_repos": [{"id": "rhel-7-server-rpms", "name": "Red Hat Enterprise Linux 7 Server (RPMs)", "enabled": true}], "os_release": "7.9", "dnf_modules": [], "installed_packages": ["krb5-libs-0:1.15.1-55.el7_9.x86_64", "jansson-0:2.10-1.el7.x86_64", "words-0:3.0-22.el7.noarch", "perl-Carp-0:1.26-244.el7.noarch", "libreport-cli-0:2.1.11-53.el7.x86_64", "libgudev1-0:219-78.el7_9.9.x86_64", "perl-Socket-0:2.010-5.el7.x86_64", "sg3_utils-libs-1:1.37-19.el7.x86_64", "python2-pyasn1-0:0.1.9-7.el7.noarch", "rpm-0:4.11.3-48.el7_9.x86_64", "libteam-0:1.29-3.el7.x86_64", "python-urlgrabber-0:3.10-10.el7.noarch", "libgomp-0:4.8.5-44.el7.x86_64", "libdb-utils-0:5.3.21-25.el7.x86_64", "libselinux-0:2.5-15.el7.x86_64", "hostname-0:3.13-3.el7_7.1.x86_64", "pinentry-0:0.8.1-17.el7.x86_64", "gettext-0:0.19.8.1-3.el7_9.x86_64", "libproxy-0:0.4.11-11.el7.x86_64", "gdisk-0:0.8.10-3.el7.x86_64", "alsa-firmware-0:1.0.28-2.el7.noarch", "libyaml-0:0.1.4-11.el7_0.x86_64", "libsmartcols-0:2.23.2-65.el7_9.1.x86_64", "ipset-libs-0:7.1-1.el7.x86_64", "libsysfs-0:2.1.0-16.el7.x86_64", "device-mapper-event-libs-7:1.02.170-6.el7_9.5.x86_64", "firewalld-0:0.6.3-13.el7_9.noarch", "shared-mime-info-0:1.8-5.el7.x86_64", "cryptsetup-reencrypt-0:2.0.3-6.el7.x86_64", "libss-0:1.42.9-19.el7.x86_64", "python-gobject-base-0:3.22.0-1.el7_4.1.x86_64", "patch-0:2.7.1-12.el7_7.x86_64", "ncurses-0:5.9-14.20130511.el7_4.x86_64", "grub2-tools-1:2.02-0.87.el7_9.14.x86_64", "tcp_wrappers-libs-0:7.6-77.el7.x86_64", "usbutils-0:007-5.el7.x86_64", "python-libs-0:2.7.5-94.el7_9.x86_64", "net-tools-0:2.0-0.25.20131004git.el7.x86_64", "grubby-0:8.28-26.el7.x86_64", "gnutls-0:3.3.29-9.el7_6.x86_64", "cryptsetup-0:2.0.3-6.el7.x86_64", "rhnlib-0:2.5.65-8.el7.noarch", "libreport-plugin-rhtsupport-0:2.1.11-53.el7.x86_64", "gobject-introspection-0:1.56.1-1.el7.x86_64", "redhat-support-lib-python-0:0.14.0-1.el7_9.noarch", "python-firewall-0:0.6.3-13.el7_9.noarch", "grub2-tools-extra-1:2.02-0.87.el7_9.14.x86_64", "grub2-pc-1:2.02-0.87.el7_9.14.x86_64", "abrt-addon-vmcore-0:2.1.11-60.el7.x86_64", "nss-0:3.90.0-2.el7_9.x86_64", "lz4-0:1.8.3-1.el7.x86_64", "openssl-1:1.0.2k-26.el7_9.x86_64", "python-magic-0:5.11-37.el7.noarch", "NessusAgent-0:10.5.1-el7.x86_64", "ed-0:1.9-4.el7.x86_64", "gdb-0:7.6.1-120.el7.x86_64", "hypervfcopyd-0:0-0.34.20180415git.el7.x86_64", "python-chardet-0:2.2.1-3.el7.noarch", "kernel-0:3.10.0-1160.118.1.el7.x86_64", "abrt-tui-0:2.1.11-60.el7.x86_64", "cronie-anacron-0:1.4.11-25.el7_9.x86_64", "openssh-server-0:7.4p1-23.el7_9.x86_64", "teamd-0:1.29-3.el7.x86_64", "mailx-0:12.5-19.el7.x86_64", "rh-dotnetcore11-runtime-0:1.0-1.el7.x86_64", "libpcap-14:1.5.3-13.el7_9.x86_64", "bind-license-32:9.11.4-26.P2.el7_9.16.noarch", "WALinuxAgent-0:2.3.0.2-4.el7_9.noarch", "tar-2:1.26-35.el7.x86_64", "dhcp-libs-12:4.2.5-83.el7_9.2.x86_64", "python-jsonpointer-0:1.9-2.el7.noarch", "quota-1:4.01-19.el7.x86_64", "bind-export-libs-32:9.11.4-26.P2.el7_9.16.x86_64", "pyserial-0:2.6-6.el7.noarch", "vdo-0:6.1.3.23-5.el7.x86_64", "less-0:458-10.el7_9.x86_64", "util-linux-0:2.23.2-65.el7_9.1.x86_64", "authconfig-0:6.2.8-30.el7.x86_64", "iwl2000-firmware-0:18.168.6.1-83.el7_9.noarch", "libstdc++-devel-0:4.8.5-44.el7.x86_64", "lsscsi-0:0.27-6.el7.x86_64", "iwl105-firmware-0:18.168.6.1-83.el7_9.noarch", "chrony-0:3.4-1.el7.x86_64", "iwl6000g2a-firmware-0:18.168.6.1-83.el7_9.noarch", "xz-libs-0:5.2.2-2.el7_9.x86_64", "nspr-0:4.35.0-1.el7_9.x86_64", "iwl3945-firmware-0:15.32.2.9-83.el7_9.noarch", "perl-macros-4:5.16.3-299.el7_9.x86_64", "pam-0:1.1.8-23.el7.x86_64", "pexpect-0:2.3-11.el7.noarch", "btrfs-progs-0:4.9.1-1.el7.x86_64", "ntp-0:4.2.6p5-29.el7_8.2.x86_64", "sg3_utils-1:1.37-19.el7.x86_64", "rpm-libs-0:4.11.3-48.el7_9.x86_64", "grub2-pc-modules-1:2.02-0.87.el7_9.14.noarch", "initscripts-0:9.49.53-1.el7_9.1.x86_64", "rdate-0:1.4-25.el7.x86_64", "python-slip-0:0.4.0-4.el7.noarch", "gettext-libs-0:0.19.8.1-3.el7_9.x86_64", "subscription-manager-rhsm-0:1.24.54-1.el7_9.x86_64", "python-pyudev-0:0.15-9.el7.noarch", "systemd-python-0:219-78.el7_9.9.x86_64", "nmap-ncat-2:6.40-19.el7.x86_64", "grub2-1:2.02-0.87.el7_9.14.x86_64", "abrt-addon-ccpp-0:2.1.11-60.el7.x86_64", "libuser-0:0.60-9.el7.x86_64", "NetworkManager-team-1:1.18.8-2.el7_9.x86_64", "langtable-data-0:0.0.31-4.el7.noarch", "fprintd-pam-0:0.8.1-2.el7.x86_64", "setuptool-0:1.19.11-8.el7.x86_64", "libstdc++-0:4.8.5-44.el7.x86_64", "perl-Pod-Escapes-1:1.04-299.el7_9.noarch", "unzip-0:6.0-24.el7_9.x86_64", "ustr-0:1.0.4-16.el7.x86_64", "crda-0:3.18_2018.05.31-4.el7.x86_64", "sgpio-0:1.2.0.10-13.el7.x86_64", "tcpdump-14:4.9.2-4.el7_7.1.x86_64", "popt-0:1.13-16.el7.x86_64", "wget-0:1.14-18.el7_6.1.x86_64", "apr-0:1.4.8-7.el7.x86_64", "nano-0:2.3.1-10.el7.x86_64", "avahi-libs-0:0.6.31-20.el7.x86_64", "bridge-utils-0:1.5-9.el7.x86_64", "libdb-0:5.3.21-25.el7.x86_64", "hyperv-daemons-license-0:0-0.34.20180415git.el7.noarch", "pakchois-0:0.4-10.el7.x86_64", "libtar-0:1.2.11-29.el7.x86_64", "passwd-0:0.79-6.el7.x86_64", "polkit-pkla-compat-0:0.1-4.el7.x86_64", "tzdata-0:2024a-1.el7.noarch", "lua-0:5.1.4-15.el7.x86_64", "lm_sensors-libs-0:3.4.0-8.20160601gitf9185e5.el7_9.1.x86_64", "iputils-0:20160308-10.el7.x86_64", "file-0:5.11-37.el7.x86_64", "cloud-init-0:19.4-7.el7_9.6.x86_64", "perl-podlators-0:2.5.1-3.el7.noarch", "libattr-0:2.4.46-13.el7.x86_64", "perl-threads-0:1.87-4.el7.x86_64", "kernel-debug-devel-0:3.10.0-1160.118.1.el7.x86_64", "perl-constant-0:1.27-2.el7.noarch", "dwz-0:0.11-3.el7.x86_64", "abrt-python-0:2.1.11-60.el7.x86_64", "sqlite-0:3.7.17-8.el7_7.1.x86_64", "abrt-addon-xorg-0:2.1.11-60.el7.x86_64", "bash-0:4.2.46-35.el7_9.x86_64", "usb_modeswitch-data-0:20170806-1.el7.noarch", "perl-XML-Parser-0:2.41-10.el7.x86_64", "python-slip-dbus-0:0.4.0-4.el7.noarch", "perl-libs-4:5.16.3-299.el7_9.x86_64", "kmod-kvdo-0:6.1.3.23-5.el7.x86_64", "geoipupdate-0:2.5.0-2.el7.x86_64", "rpcbind-0:0.2.0-49.el7.x86_64", "shim-x64-0:15.8-1.el7.x86_64", "efivar-libs-0:36-12.el7.x86_64", "sos-0:3.9-5.el7_9.12.noarch", "libnfnetlink-0:1.0.1-4.el7.x86_64", "basesystem-0:10.0-7.el7.noarch", "yajl-0:2.0.4-4.el7.x86_64", "libunwind-2:1.2-2.el7.x86_64", "ethtool-2:4.8-10.el7.x86_64", "fxload-0:2002_04_11-16.el7.x86_64", "GeoIP-0:1.5.0-14.el7.x86_64", "iproute-0:4.11.0-30.el7.x86_64", "audit-libs-python-0:2.8.5-4.el7.x86_64", "ipset-0:7.1-1.el7.x86_64", "tcp_wrappers-0:7.6-77.el7.x86_64", "hardlink-1:1.0-19.el7.x86_64", "acl-0:2.2.51-15.el7.x86_64", "strace-0:4.24-7.el7_9.x86_64", "libdwarf-0:20130207-4.el7.x86_64", "libutempter-0:1.1.6-4.el7.x86_64", "make-1:3.82-24.el7.x86_64", "python-jinja2-0:2.7.2-4.el7.noarch", "libconfig-0:1.4.9-5.el7.x86_64", "libmpc-0:1.0.1-3.el7.x86_64", "snappy-0:1.1.0-3.el7.x86_64", "procps-ng-0:3.3.10-28.el7.x86_64", "pixman-0:0.34.0-1.el7.x86_64", "apr-util-0:1.5.2-6.el7_9.1.x86_64", "libndp-0:1.2-9.el7.x86_64", "dracut-0:033-572.el7.x86_64", "numactl-libs-0:2.0.12-5.el7.x86_64", "libgfortran-0:4.8.5-44.el7.x86_64", "p11-kit-trust-0:0.23.5-3.el7.x86_64", "elfutils-libs-0:0.176-5.el7.x86_64", "python-dateutil-0:1.5-7.el7.noarch", "python-srpm-macros-0:3-34.el7.noarch", "newt-python-0:0.52.15-4.el7.x86_64", "dbus-1:1.10.24-15.el7.x86_64", "zlib-0:1.2.7-21.el7_9.x86_64", "nss-util-0:3.90.0-1.el7_9.x86_64", "libreport-python-0:2.1.11-53.el7.x86_64", "libpwquality-0:1.2.3-5.el7.x86_64", "systemtap-client-0:4.0-13.el7.x86_64", "python-augeas-0:0.5.0-2.el7.noarch", "vim-filesystem-2:7.4.629-8.el7_9.x86_64", "python-lxml-0:3.2.1-4.el7.x86_64", "perl-TermReadKey-0:2.30-20.el7.x86_64", "openssh-0:7.4p1-23.el7_9.x86_64", "perl-Test-Harness-0:3.28-3.el7.noarch", "hunspell-en-US-0:0.20121024-6.el7.noarch", "python-ply-0:3.4-11.el7.noarch", "libxml2-0:2.9.1-6.el7_9.6.x86_64", "python-cffi-0:1.6.0-5.el7.x86_64", "expat-0:2.1.0-15.el7_9.x86_64", "python-syspurpose-0:1.24.54-1.el7_9.x86_64", "perl-Text-ParseWords-0:3.29-4.el7.noarch", "python2-cryptography-0:1.7.2-2.el7.x86_64", "perl-threads-shared-0:1.43-6.el7.x86_64", "python-linux-procfs-0:0.4.11-4.el7.noarch", "abrt-dbus-0:2.1.11-60.el7.x86_64", "python-backports-ssl_match_hostname-0:3.5.0.1-1.el7.noarch", "autogen-libopts-0:5.18-5.el7.x86_64", "PyYAML-0:3.10-11.el7.x86_64", "perl-Getopt-Long-0:2.40-3.el7.noarch", "python-kitchen-0:1.1.1-5.el7.noarch", "dmraid-events-0:1.0.0.rc16-28.el7.x86_64", "libcurl-0:7.29.0-59.el7_9.2.x86_64", "systemd-0:219-78.el7_9.9.x86_64", "libassuan-0:2.1.0-3.el7.x86_64", "cronie-0:1.4.11-25.el7_9.x86_64", "libstoragemgmt-python-0:1.8.1-2.el7_9.noarch", "polkit-0:0.112-26.el7_9.1.x86_64", "subscription-manager-rhsm-certificates-0:1.24.54-1.el7_9.x86_64", "wpa_supplicant-1:2.6-12.el7_9.2.x86_64", "sssd-client-0:1.16.5-10.el7_9.16.x86_64", "sysvinit-tools-0:2.88-14.dsf.el7.x86_64", "redhat-logos-0:70.7.0-1.el7.noarch", "lzo-0:2.06-8.el7.x86_64", "fipscheck-0:1.4.1-6.el7.x86_64", "iw-0:4.3-2.el7.x86_64", "redhat-indexhtml-0:7-13.el7.noarch", "boost-thread-0:1.53.0-28.el7.x86_64", "hunspell-en-GB-0:0.20121024-6.el7.noarch", "rh-dotnetcore11-libuv-1:1.9.0-1.el7.x86_64", "rhn-check-0:2.0.2-24.el7.x86_64", "rh-dotnetcore11-0:1.0-1.el7.x86_64", "elfutils-0:0.176-5.el7.x86_64", "libcgroup-0:0.41-21.el7.x86_64", "bzip2-0:1.0.6-13.el7.x86_64", "python-urllib3-0:1.10.2-7.el7.noarch", "libpng-2:1.5.13-8.el7.x86_64", "python-babel-0:0.9.6-8.el7.noarch", "python-markupsafe-0:0.11-10.el7.x86_64", "kbd-0:1.15.5-16.el7_9.x86_64", "cloud-utils-growpart-0:0.29-5.el7.noarch", "boost-date-time-0:1.53.0-28.el7.x86_64", "libmount-0:2.23.2-65.el7_9.1.x86_64", "libverto-0:0.2.5-4.el7.x86_64", "device-mapper-7:1.02.170-6.el7_9.5.x86_64", "libseccomp-0:2.3.1-4.el7.x86_64", "lvm2-7:2.02.187-6.el7_9.5.x86_64", "mlocate-0:0.26-8.el7.x86_64", "psmisc-0:22.20-17.el7.x86_64", "lshw-0:B.02.18-17.el7.x86_64", "at-0:3.1.13-25.el7_9.x86_64", "kpartx-0:0.4.9-136.el7_9.x86_64", "perl-Data-Dumper-0:2.145-3.el7.x86_64", "python-iniparse-0:0.4-9.el7.noarch", "kpatch-0:0.6.1-6.el7.noarch", "trousers-0:0.3.14-2.el7.x86_64", "man-db-0:2.6.3-11.el7.x86_64", "neon-0:0.30.0-4.el7.x86_64", "systemd-libs-0:219-78.el7_9.9.x86_64", "perl-4:5.16.3-299.el7_9.x86_64", "openssl-libs-1:1.0.2k-26.el7_9.x86_64", "coreutils-0:8.22-24.el7_9.2.x86_64", "redhat-release-server-0:7.9-10.el7_9.x86_64", "cyrus-sasl-lib-0:2.1.26-24.el7_9.x86_64", "python-idna-0:2.4-1.el7.noarch", "python-enum34-0:1.0.4-1.el7.noarch", "python-ipaddress-0:1.0.16-2.el7.noarch", "python-inotify-0:0.9.4-4.el7.noarch", "time-0:1.7-45.el7.x86_64", "nss-sysinit-0:3.90.0-2.el7_9.x86_64", "python2-futures-0:3.1.1-5.el7.noarch", "setserial-0:2.17-33.el7.x86_64", "kernel-tools-libs-0:3.10.0-1160.118.1.el7.x86_64", "python-schedutils-0:0.4-6.el7.x86_64", "rootfiles-0:8.1-11.el7.noarch", "alsa-lib-0:1.1.8-1.el7.x86_64", "systemd-sysv-0:219-78.el7_9.9.x86_64", "curl-0:7.29.0-59.el7_9.2.x86_64", "filesystem-0:3.2-25.el7.x86_64", "langtable-0:0.0.31-4.el7.noarch", "openssh-clients-0:7.4p1-23.el7_9.x86_64", "python-perf-0:3.10.0-1160.118.1.el7.x86_64", "grub2-efi-x64-1:2.02-0.87.el7_9.14.x86_64", "pygpgme-0:0.3-9.el7.x86_64", "ncurses-base-0:5.9-14.20130511.el7_4.noarch", "python-pycurl-0:7.19.0-19.el7.x86_64", "yum-0:3.4.3-168.el7.noarch", "libpipeline-0:1.2.3-3.el7.x86_64", "pcre-0:8.32-17.el7.x86_64", "shadow-utils-2:4.6-5.el7.x86_64", "libcom_err-0:1.42.9-19.el7.x86_64", "libestr-0:0.1.9-2.el7.x86_64", "bzip2-libs-0:1.0.6-13.el7.x86_64", "sed-0:4.2.2-7.el7.x86_64", "readline-0:6.2-11.el7.x86_64", "libcap-0:2.22-11.el7.x86_64", "perl-Thread-Queue-0:3.02-2.el7.noarch", "cryptsetup-libs-0:2.0.3-6.el7.x86_64", "augeas-libs-0:1.4.0-10.el7.x86_64", "libgcrypt-0:1.5.3-14.el7.x86_64", "elfutils-default-yama-scope-0:0.176-5.el7.noarch", "libreport-0:2.1.11-53.el7.x86_64", "abrt-libs-0:2.1.11-60.el7.x86_64", "libnl3-0:3.2.28-4.el7.x86_64", "hwdata-0:0.252-9.7.el7.x86_64", "kbd-legacy-0:1.15.5-16.el7_9.noarch", "findutils-1:4.5.11-6.el7.x86_64", "groff-base-0:1.22.2-8.el7.x86_64", "dbus-python-0:1.1.1-9.el7.x86_64", "usermode-0:1.111-6.el7.x86_64", "perl-parent-1:0.225-244.el7.noarch", "libreport-web-0:2.1.11-53.el7.x86_64", "perl-Encode-0:2.51-7.el7.x86_64", "perl-Filter-0:1.49-3.el7.x86_64", "dracut-network-0:033-572.el7.x86_64", "perl-Scalar-List-Utils-0:1.27-248.el7.x86_64", "perl-File-Temp-0:0.23.01-3.el7.noarch", "perl-PathTools-0:3.40-5.el7.x86_64", "perl-Pod-Simple-1:3.28-4.el7.noarch", "pciutils-libs-0:3.5.1-3.el7.x86_64", "libnl3-cli-0:3.2.28-4.el7.x86_64", "p11-kit-0:0.23.5-3.el7.x86_64", "kmod-libs-0:20-28.el7.x86_64", "libunistring-0:0.9.3-9.el7.x86_64", "boost-system-0:1.53.0-28.el7.x86_64", "perl-Pod-Usage-0:1.63-3.el7.noarch", "perl-Storable-0:2.45-3.el7.x86_64", "libreport-plugin-ureport-0:2.1.11-53.el7.x86_64", "puppet-agent-0:1.10.14-1.el7.x86_64", "abrt-addon-kerneloops-0:2.1.11-60.el7.x86_64", "mariadb-libs-1:5.5.68-1.el7.x86_64", "libnet-0:1.1.6-7.el7.x86_64", "salt-0:3005.1-4.el7.x86_64", "fprintd-0:0.8.1-2.el7.x86_64", "git-0:2.29.0-1.el7.x86_64", "slang-0:2.2.4-11.el7.x86_64", "rpm-build-libs-0:4.11.3-48.el7_9.x86_64", "libnl-0:1.1.4-3.el7.x86_64", "ebtables-0:2.0.10-16.el7.x86_64", "freetype-0:2.8-14.el7_9.1.x86_64", "iptables-0:1.4.21-35.el7.x86_64", "plymouth-core-libs-0:0.8.9-0.34.20140113.el7.x86_64", "vim-common-2:7.4.629-8.el7_9.x86_64", "rhn-setup-0:2.0.2-24.el7.x86_64", "abrt-cli-0:2.1.11-60.el7.x86_64", "quota-nls-1:4.01-19.el7.noarch", "tuned-0:2.11.0-12.el7_9.noarch", "NetworkManager-tui-1:1.18.8-2.el7_9.x86_64", "gmp-1:6.0.0-15.el7.x86_64", "pth-0:2.0.7-23.el7.x86_64", "gpm-libs-0:1.20.7-6.el7.x86_64", "audit-0:2.8.5-4.el7.x86_64", "python-decorator-0:3.4.0-3.el7.noarch", "cracklib-0:2.9.0-11.el7.x86_64", "pkgconfig-1:0.27.1-4.el7.x86_64", "systemtap-runtime-0:4.0-13.el7.x86_64", "grub2-common-1:2.02-0.87.el7_9.14.noarch", "cracklib-dicts-0:2.9.0-11.el7.x86_64", "m2crypto-0:0.21.1-17.el7.x86_64", "mtr-2:0.85-7.el7.x86_64", "yum-metadata-parser-0:1.1.4-10.el7.x86_64", "pyOpenSSL-0:0.13.1-4.el7.x86_64", "ntsysv-0:1.7.6-1.el7.x86_64", "libssh2-0:1.8.0-4.el7_9.1.x86_64", "python-backports-0:1.0-8.el7.x86_64", "traceroute-3:2.0.22-2.el7.x86_64", "nss-pem-0:1.0.3-7.el7_9.1.x86_64", "langtable-python-0:0.0.31-4.el7.noarch", "libsss_nss_idmap-0:1.16.5-10.el7_9.16.x86_64", "libsss_idmap-0:1.16.5-10.el7_9.16.x86_64", "kernel-tools-0:3.10.0-1160.118.1.el7.x86_64", "fipscheck-lib-0:1.4.1-6.el7.x86_64", "glibc-0:2.17-326.el7_9.3.x86_64", "bind-libs-lite-32:9.11.4-26.P2.el7_9.16.x86_64", "dhcp-common-12:4.2.5-83.el7_9.2.x86_64", "glibc-headers-0:2.17-326.el7_9.3.x86_64", "dhclient-12:4.2.5-83.el7_9.2.x86_64", "bind-utils-32:9.11.4-26.P2.el7_9.16.x86_64", "iwl6050-firmware-0:41.28.5.1-83.el7_9.noarch", "iwl7260-firmware-0:25.30.13.0-83.el7_9.noarch", "iwl100-firmware-0:39.31.5.1-83.el7_9.noarch", "iwl5150-firmware-0:8.24.2.2-83.el7_9.noarch", "iwl135-firmware-0:18.168.6.1-83.el7_9.noarch", "iwl3160-firmware-0:25.30.13.0-83.el7_9.noarch", "iwl5000-firmware-0:8.83.5.1_1-83.el7_9.noarch", "iwl6000g2b-firmware-0:18.168.6.1-83.el7_9.noarch", "linux-firmware-0:20200421-83.git78c0348.el7_9.noarch", "aide-0:0.15.1-13.el7_9.1.x86_64", "NetworkManager-libnm-1:1.18.8-2.el7_9.x86_64", "eventlog-0:0.2.13-4.el7.x86_64", "syslog-ng-0:3.5.6-3.el7.x86_64", "TaniumClient-0:7.4.10.1060-1.rhe7.x86_64", "salt-minion-0:3005.1-4.el7.x86_64", "falcon-sensor-0:7.02.0-15705.el7.x86_64", "rpm-python-0:4.11.3-48.el7_9.x86_64", "xz-0:5.2.2-2.el7_9.x86_64", "dmidecode-1:3.2-5.el7_9.1.x86_64", "plymouth-scripts-0:0.8.9-0.34.20140113.el7.x86_64", "rhn-client-tools-0:2.0.2-24.el7.x86_64", "rhnsd-0:5.0.13-10.el7.x86_64", "firewalld-filesystem-0:0.6.3-13.el7_9.noarch", "kernel-0:3.10.0-1160.83.1.el7.x86_64", "pm-utils-0:1.4.1-27.el7.x86_64", "abrt-console-notification-0:2.1.11-60.el7.x86_64", "hyperv-daemons-0:0-0.34.20180415git.el7.x86_64", "rsyslog-0:8.24.0-57.el7_9.3.x86_64", "cyrus-sasl-plain-0:2.1.26-24.el7_9.x86_64", "binutils-0:2.27-44.base.el7_9.1.x86_64", "psacct-0:6.6.1-13.el7.x86_64", "pciutils-0:3.5.1-3.el7.x86_64", "libreport-plugin-mailx-0:2.1.11-53.el7.x86_64", "rng-tools-0:6.3.1-5.el7.x86_64", "aic94xx-firmware-0:30-6.el7.noarch", "biosdevname-0:0.7.3-2.el7.x86_64", "parted-0:3.1-32.el7.x86_64", "bash-completion-1:2.1-8.el7.noarch", "blktrace-0:1.0.5-9.el7.x86_64", "hunspell-en-0:0.20121024-6.el7.noarch", "zip-0:3.0-11.el7.x86_64", "lsof-0:4.87-6.el7.x86_64", "rfkill-0:0.4-10.el7.x86_64", "redhat-release-eula-0:7.8-0.el7.noarch", "nss-tools-0:3.90.0-2.el7_9.x86_64", "libreport-filesystem-0:2.1.11-53.el7.x86_64", "rh-dotnetcore11-libcurl-0:7.47.1-4.el7.x86_64", "rh-dotnetcore11-dotnetcore-0:1.1.13-1.el7.x86_64", "ncurses-libs-0:5.9-14.20130511.el7_4.x86_64", "python-IPy-0:0.75-6.el7.noarch", "libsepol-0:2.5-10.el7.x86_64", "python-jsonpatch-0:1.2-4.el7.noarch", "info-0:5.1-5.el7.x86_64", "python-prettytable-0:0.7.2-3.el7.noarch", "elfutils-libelf-0:0.176-5.el7.x86_64", "libblkid-0:2.23.2-65.el7_9.1.x86_64", "perl-Error-1:0.17020-2.el7.noarch", "json-c-0:0.11-4.el7_0.x86_64", "lvm2-libs-7:2.02.187-6.el7_9.5.x86_64", "libcap-ng-0:0.7.5-4.el7.x86_64", "uuid-0:1.6.2-26.el7.x86_64", "libffi-0:3.0.13-19.el7.x86_64", "nettle-0:2.7.1-9.el7_9.x86_64", "perl-srpm-macros-0:1-8.el7.noarch", "libaio-0:0.3.109-13.el7.x86_64", "file-libs-0:5.11-37.el7.x86_64", "policycoreutils-0:2.5-34.el7.x86_64", "subversion-libs-0:1.7.14-16.el7.x86_64", "perl-Pod-Perldoc-0:3.20-4.el7.noarch", "newt-0:0.52.15-4.el7.x86_64", "setup-0:2.8.71-11.el7.noarch", "perl-Time-Local-0:1.2300-2.el7.noarch", "libpciaccess-0:0.14-1.el7.x86_64", "selinux-policy-0:3.13.1-268.el7_9.2.noarch", "libreport-rhel-0:2.1.11-53.el7.x86_64", "gpgme-0:1.3.2-5.el7.x86_64", "libmnl-0:1.0.3-7.el7.x86_64", "libnetfilter_conntrack-0:1.0.6-1.el7_3.x86_64", "libstoragemgmt-python-clibs-0:1.8.1-2.el7_9.x86_64", "python-requests-0:2.6.0-10.el7.noarch", "hypervkvpd-0:0-0.34.20180415git.el7.x86_64", "attr-0:2.4.46-13.el7.x86_64", "libsemanage-python-0:2.5-14.el7.x86_64", "libdrm-0:2.4.97-2.el7.x86_64", "mozjs17-0:17.0.0-20.el7.x86_64", "chkconfig-0:1.7.6-1.el7.x86_64", "keyutils-libs-0:1.5.8-3.el7.x86_64", "dyninst-0:9.3.1-3.el7.x86_64", "grep-0:2.20-3.el7.x86_64", "virt-what-0:1.18-4.el7_9.1.x86_64", "libfastjson-0:0.99.4-3.el7.x86_64", "libacl-0:2.2.51-15.el7.x86_64", "python-gudev-0:147.2-7.el7.x86_64", "python-six-0:1.9.0-2.el7.noarch", "libgpg-error-0:1.12-3.el7.x86_64", "bc-0:1.06.95-13.el7.x86_64", "python-dmidecode-0:3.12.2-4.el7.x86_64", "gawk-0:4.0.2-4.el7_3.1.x86_64", "libselinux-utils-0:2.5-15.el7.x86_64", "grub2-tools-minimal-1:2.02-0.87.el7_9.14.x86_64", "cpio-0:2.11-28.el7.x86_64", "kexec-tools-0:2.0.15-51.el7_9.3.x86_64", "ca-certificates-0:2023.2.60_v7.0.306-72.el7_9.noarch", "crontabs-0:1.11-6.20121102git.el7.noarch", "device-mapper-persistent-data-0:0.8.5-3.el7_9.2.x86_64", "libusbx-0:1.0.21-1.el7.x86_64", "ntpdate-0:4.2.6p5-29.el7_8.2.x86_64", "python-ipaddr-0:2.1.11-2.el7.noarch", "perl-HTTP-Tiny-0:0.033-3.el7.noarch", "rhui-azure-rhel7-0:2.3-655.noarch", "python-configobj-0:4.7.2-7.el7.noarch", "perl-Exporter-0:5.68-3.el7.noarch", "yum-langpacks-0:0.4.2-7.el7.noarch", "mokutil-0:15.8-1.el7.x86_64", "perl-File-Path-0:2.09-2.el7.noarch", "python-0:2.7.5-94.el7_9.x86_64", "nss-softokn-0:3.90.0-6.el7_9.x86_64", "ivykis-0:0.36.2-2.el7.x86_64", "python-pycparser-0:2.14-1.el7.noarch", "libselinux-python-0:2.5-15.el7.x86_64", "usb_modeswitch-0:2.5.1-1.el7.x86_64", "pyliblzma-0:0.5.3-11.el7.x86_64", "pyxattr-0:0.5.1-5.el7.x86_64", "libedit-0:3.0-12.20121213cvs.el7.x86_64", "nss-softokn-freebl-0:3.90.0-6.el7_9.x86_64", "subscription-manager-0:1.24.54-1.el7_9.x86_64", "python-hwdata-0:1.7.3-4.el7.noarch", "dosfstools-0:3.0.20-10.el7.x86_64", "microcode_ctl-2:2.1-73.20.el7_9.x86_64", "abrt-addon-python-0:2.1.11-60.el7.x86_64", "logrotate-0:3.8.6-19.el7.x86_64", "plymouth-0:0.8.9-0.34.20140113.el7.x86_64", "man-pages-0:3.53-5.el7.noarch", "libicu-0:50.2-4.el7_7.x86_64", "libxslt-0:1.1.28-6.el7.x86_64", "glibc-common-0:2.17-326.el7_9.3.x86_64", "checkpolicy-0:2.5-8.el7.x86_64", "sudo-0:1.8.23-10.el7_9.3.x86_64", "bind-libs-32:9.11.4-26.P2.el7_9.16.x86_64", "policycoreutils-python-0:2.5-34.el7.x86_64", "libmodman-0:2.0.1-8.el7.x86_64", "glibc-devel-0:2.17-326.el7_9.3.x86_64", "libuuid-0:2.23.2-65.el7_9.1.x86_64", "mdadm-0:4.1-9.el7_9.x86_64", "iwl4965-firmware-0:228.61.2.24-83.el7_9.noarch", "device-mapper-event-7:1.02.170-6.el7_9.5.x86_64", "tcsh-0:6.18.01-17.el7_9.1.x86_64", "iwl1000-firmware-1:39.31.5.1-83.el7_9.noarch", "kernel-headers-0:3.10.0-1160.118.1.el7.x86_64", "libtasn1-0:4.10-1.el7.x86_64", "iwl6000-firmware-0:9.221.4.1-83.el7_9.noarch", "gettext-common-devel-0:0.19.8.1-3.el7_9.noarch", "ledmon-0:0.92-1.el7.x86_64", "iwl2030-firmware-0:18.168.6.1-83.el7_9.noarch", "glib2-0:2.56.1-9.el7_9.x86_64", "pygobject2-0:2.28.6-11.el7.x86_64", "libcroco-0:0.6.12-6.el7_9.x86_64", "python-ethtool-0:0.8-8.el7.x86_64", "libxml2-python-0:2.9.1-6.el7_9.6.x86_64", "xfsprogs-0:4.5.0-22.el7.x86_64", "postfix-2:2.10.1-9.el7.x86_64", "python-jwcrypto-0:0.4.2-1.el7.noarch", "openldap-0:2.4.44-25.el7_9.x86_64", "python-setuptools-0:0.9.8-7.el7.noarch", "libstoragemgmt-0:1.8.1-2.el7_9.x86_64", "diffutils-0:3.3-6.el7_9.x86_64", "NetworkManager-1:1.18.8-2.el7_9.x86_64", "man-pages-overrides-0:7.9.0-1.el7.x86_64", "alsa-tools-firmware-0:1.1.0-1.el7.x86_64", "subscription-manager-plugin-container-0:1.24.54-1.el7_9.x86_64", "vim-minimal-2:7.4.629-8.el7_9.x86_64", "libgcc-0:4.8.5-44.el7.x86_64", "yum-rhn-plugin-0:2.0.1-10.el7.noarch", "redhat-support-tool-0:0.14.0-1.el7_9.noarch", "vim-enhanced-2:7.4.629-8.el7_9.x86_64", "xmlrpc-c-client-0:1.32.5-1905.svn2451.el7.x86_64", "sysstat-0:10.1.5-20.el7_9.x86_64", "bpftool-0:3.10.0-1160.118.1.el7.x86_64", "selinux-policy-targeted-0:3.13.1-268.el7_9.2.noarch", "gzip-0:1.5-11.el7_9.x86_64", "xfsdump-0:3.1.7-4.el7_9.x86_64", "iprutils-0:2.4.17.1-3.el7_7.x86_64", "smartmontools-1:7.0-2.el7.x86_64", "irqbalance-3:1.0.7-12.el7.x86_64", "qrencode-libs-0:3.4.1-3.el7.x86_64", "e2fsprogs-0:1.42.9-19.el7.x86_64", "mpfr-0:3.1.1-4.el7.x86_64", "efibootmgr-0:17-2.el7.x86_64", "m4-0:1.4.16-10.el7.x86_64", "scl-utils-0:20130529-19.el7.x86_64", "kmod-0:20-28.el7.x86_64", "ivtv-firmware-2:20080701-26.el7.noarch", "cpp-0:4.8.5-44.el7.x86_64", "gnupg2-0:2.0.22-5.el7_5.x86_64", "audit-libs-0:2.8.5-4.el7.x86_64", "which-0:2.20-7.el7.x86_64", "setools-libs-0:3.3.8-4.el7.x86_64", "kbd-misc-0:1.15.5-16.el7_9.noarch", "libtirpc-0:0.2.4-0.16.el7.x86_64", "libidn-0:1.28-4.el7.x86_64", "libsemanage-0:2.5-14.el7.x86_64", "e2fsprogs-libs-0:1.42.9-19.el7.x86_64", "libdaemon-0:0.14-7.el7.x86_64", "hunspell-0:1.3.2-16.el7.x86_64", "libquadmath-0:4.8.5-44.el7.x86_64", "os-prober-0:1.58-9.el7.x86_64", "device-mapper-libs-7:1.02.170-6.el7_9.5.x86_64", "perl-Time-HiRes-4:1.9725-3.el7.x86_64", "dbus-libs-1:1.10.24-15.el7.x86_64", "abrt-0:2.1.11-60.el7.x86_64", "satyr-0:0.13-15.el7.x86_64", "abrt-addon-pstoreoops-0:2.1.11-60.el7.x86_64", "xmlrpc-c-0:1.32.5-1905.svn2451.el7.x86_64", "dmraid-0:1.0.0.rc16-28.el7.x86_64", "dbus-glib-0:0.100-7.el7.x86_64", "libfprint-0:0.8.2-1.el7.x86_64", "gdbm-0:1.10-8.el7.x86_64", "hypervvssd-0:0-0.34.20180415git.el7.x86_64"]}', '', '2024-07-05 21:59:03.965365 +00:00', 'rhsm-system-profile-bridge', '{"rhsm-system-profile-bridge": {"last_check_in": "2024-07-03T21:59:04.008198+00:00", "stale_timestamp": "2024-07-05T21:59:03.965365+00:00", "check_in_succeeded": true}}', '12345678', '[]');
```

4. Reset the SWATCH DB
```
dropdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && \
createdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && \
./gradlew liquibaseUpdate
```

5. Run swatch-tally service:
```
DEV_MODE=true ./gradlew :bootRun
```

6. Run the hourly tally to initialize the tally_state table for the org.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=12345678" x-rh-swatch-psk:placeholder
```
7. Reset the tally_state so that the event will get picked up during the next hourly tally.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "update tally_state set latest_event_record_date='2023-05-28 00:00:00+00';"
```
8. Insert an event for a host with the same org_id/instance_id.
```
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('fb36b7b9-dc00-419e-9efe-0826af7ff06b', '2024-07-03 00:00:00.000000 +00:00', '{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "12345678", "event_id": "fb36b7b9-dc00-419e-9efe-0826af7ff06b", "timestamp": "2024-07-03T00:00:00Z", "conversion": false, "event_type": "snapshot", "expiration": "2024-07-03T01:00:00Z", "instance_id": "test-instance", "product_ids": ["69", "204"], "product_tag": ["rhel-for-x86-els-payg-addon"], "record_date": "2024-07-04T20:00:23.600908455Z", "event_source": "cost-management", "measurements": [{"value": 4.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "Azure", "azure_tenant_id": "12345678-tenant-id", "billing_provider": "azure", "billing_account_id": "12345", "azure_subscription_id": "12345"}', 'snapshot', 'cost-management', 'test-instance', '12345678', null, '2024-07-04 20:00:23.600908 +00:00');
```

### Steps
<!-- Enter each step of the test below -->
1. Run the nightly tally
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/12345678" x-rh-swatch-psk:placeholder
```
2. Run the hourly tally. This time some tally summary messages will be produced.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=12345678" x-rh-swatch-psk:placeholder
```

3. Verify that you have buckets with NULL measurement_type
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from host_tally_buckets where measurement_type is null;"
```

4. Run the nightly tally again to reproduce the NullPointerException due to the null measurement_type on the buckets.
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/12345678" x-rh-swatch-psk:placeholder
```


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Check out the branch for this PR and deploy as you did above.
2. Check the DB to make sure that you no longer have any buckets with null measurement_type
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from host_tally_buckets where measurement_type is null;"
```
3. Re-run the nightly tally. You should no longer see the NPE.
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/12345678" x-rh-swatch-psk:placeholder
```
4. Add a new event for the org.
```
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('fb36b7b9-dc00-419e-9efe-0836af7ff06b', '2024-07-03 01:00:00.000000 +00:00', '{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "12345678", "event_id": "fb36b7b9-dc00-419e-9efe-0836af7ff06b", "timestamp": "2024-07-03T01:00:00Z", "conversion": false, "event_type": "snapshot", "expiration": "2024-07-03T02:00:00Z", "instance_id": "test-instance", "product_ids": ["69", "204"], "product_tag": ["rhel-for-x86-els-payg-addon"], "record_date": "2024-07-04T20:00:23.600908455Z", "event_source": "cost-management", "measurements": [{"value": 4.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "Azure", "azure_tenant_id": "12345678-tenant-id", "billing_provider": "azure", "billing_account_id": "12345", "azure_subscription_id": "12345"}', 'snapshot', 'cost-management', 'test-instance', '12345678', null, '2024-07-04 22:00:23.600908 +00:00');
```
5. Run the hourly tally and verify summary messages were sent in the logs.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=12345678" x-rh-swatch-psk:placeholder
```
6. Make sure that there are no buckets with a null measurement_type.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from host_tally_buckets where measurement_type is null;"
```
7. Re-run the nightly tally and you should not see the nightly tally.
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/12345678" x-rh-swatch-psk:placeholder
```

**NEW STEPS AS OF LATEST PUSH**
NOTE: If these steps were attempted WITHOUT the last commit to "only update the instance_type if it is empty", you would end up with a duplicate host.

8. Add an event that has a timestamp >  the current last_seen date of the host.
```
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('fb36b7b9-dc00-419f-9efe-0836af7ff06c', '2024-07-04 01:00:00.000000 +00:00', '{"sla": "Premium", "role": "Red Hat Enterprise Linux Server", "usage": "Production", "org_id": "12345678", "event_id": "fb36b7b9-dc00-419f-9efe-0836af7ff06c", "timestamp": "2024-07-04T01:00:00Z", "conversion": false, "event_type": "snapshot", "expiration": "2024-07-04T02:00:00Z", "instance_id": "test-instance", "product_ids": ["69", "204"], "product_tag": ["rhel-for-x86-els-payg-addon"], "record_date": "2024-07-04T20:00:23.600908455Z", "event_source": "cost-management", "measurements": [{"value": 4.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "Azure", "azure_tenant_id": "12345678-tenant-id", "billing_provider": "azure", "billing_account_id": "12345", "azure_subscription_id": "12345"}', 'snapshot', 'cost-management', 'test-instance', '12345678', null, '2024-07-05 22:00:23.600908 +00:00');
```
9. Run the hourly tally. Summary messages should be produced.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=12345678" x-rh-swatch-psk:placeholder
```
10. Ensure that there is still only 1 host and that the instance_type is still HBI_HOST.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select instance_type from hosts;"
```
11. Run the nightly tally again
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/12345678" x-rh-swatch-psk:placeholder
```

12. Ensure that there is still only a single host and that the instance_type is still HBI_HOST.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select instance_type from hosts;"
```
