### PR TITLE
SWATCH-2738: Drop subscription_product_ids table that is no longer in use

### DIFF
--- a/src/main/resources/liquibase/202407160722-drop-subscription-product-ids-table.xml
+++ b/src/main/resources/liquibase/202407160722-drop-subscription-product-ids-table.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+
+  <changeSet id="202407160722-01" author="kflahert">
+    <comment>Drop subscription_product_ids table</comment>
+    <dropTable tableName="subscription_product_ids"/>
+
+    <rollback>
+      <comment>Replace empty subscription_product_ids table.</comment>
+      <createTable tableName="subscription_product_ids">
+        <column name="product_id" type="VARCHAR(32)"/>
+        <column name="subscription_id" type="VARCHAR(255)"/>
+        <column name="start_date" type="TIMESTAMP WITH TIME ZONE"/>
+      </createTable>
+      <addPrimaryKey constraintName="subscription_product_ids_pk"
+                     tableName="subscription_product_ids"
+                     columnNames="product_id, subscription_id, start_date"/>
+      <addForeignKeyConstraint constraintName="subs_product_ids_fk"
+                               baseTableName="subscription_product_ids"
+                               referencedTableName="subscription"
+                               baseColumnNames="subscription_id, start_date"
+                               referencedColumnNames="subscription_id, start_date"/>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -167,5 +167,6 @@
     <include file="/liquibase/202406261514-alter-event-instance-id-length.xml"/>
     <include file="/liquibase/202406191500-add-hypervisor_uuid-to-tally-instance-view.xml"/>
     <include file="/liquibase/202407091543-set-default-bucket-measurement-type.xml"/>
+    <include file="/liquibase/202407160722-drop-subscription-product-ids-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -725,12 +725,12 @@ objects:
         subscription.start_date,
         subscription.end_date,
         subscription.quantity,
-        subscription_product_ids.product_id,
+        sku_product_tag.product_tag,
         coalesce(metric_id_normalized.normalized, subscription_measurements.metric_id) as metric_id,
         subscription_measurements.measurement_type,
         subscription_measurements.value
         from subscription
-        left join subscription_product_ids on subscription.subscription_id = subscription_product_ids.subscription_id
+        left join sku_product_tag on subscription.sku = sku_product_tag.sku
         left join subscription_measurements on subscription.subscription_id = subscription_measurements.subscription_id
         left join (values
           ('SOCKETS', 'Sockets'),


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2738

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Some subscriptions are failing to sync because the child subscription_product_ids records are not being deleted. Since we no longer utilize this table this PR drops it.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

Regresssion.

Tested floorist change against gabi.