### PR TITLE
SWATCH-2739: Add liquibase script for RHEL non payg measurement cleanup

### DIFF
--- a/src/main/resources/liquibase/202407161214-clean-up-non-payg-measurements-on-rhel-systems.xml
+++ b/src/main/resources/liquibase/202407161214-clean-up-non-payg-measurements-on-rhel-systems.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202407161214-01" author="mstead">
+    <comment>
+      Deletes all instance measurements matching a RHEL System host with a metric_id matching
+      CORES/SOCKETS.
+    </comment>
+    <sql dbms="postgresql">
+      <!-- The "DELETE ... FROM ... USING" statement is Postgres specific.  -->
+      delete from instance_measurements m
+      using hosts h
+      where m.host_id = h.id
+        and h.instance_type = 'RHEL System'
+        and m.metric_id in ('CORES', 'SOCKETS');
+    </sql>
+    <rollback>
+      <!-- Unable to roll back. -->
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -169,5 +169,6 @@
     <include file="/liquibase/202407091543-set-default-bucket-measurement-type.xml"/>
     <include file="/liquibase/202407030751-add-level-column-for-offering-table.xml"/>
     <include file="/liquibase/202407160722-drop-subscription-product-ids-table.xml"/>
+    <include file="/liquibase/202407161214-clean-up-non-payg-measurements-on-rhel-systems.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: SWATCH-2739

## Description
There are currently RHEL host records being reported by both HBI and other event sources that resulted in non-payg measurements being created on both hosts. This causes the Instances API to return duplicate hosts when looking up the affected products.

This patch removes all non-payg CORES/SOCKETS measurements from any host that has an instance_type of RHEL Server.

## Testing
1. Do a checkout of a commit that still has the issue.
```
git checkout -b create-bad-data 487978f28ff564a0272e13487a4999772e7f3c45
```

2. Reset the HBI DB
```
psql -h localhost -U insights insights -c "truncate hosts cascade;"
```

3. Insert a single host into the HBI DB.
```
INSERT INTO public.hosts (id, account, display_name, created_on, modified_on, tags, facts, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups) VALUES ('0ec9da02-90a2-4e3d-b8c1-05e31b7f515c', '', 'test.redhat.com', '2024-06-07 09:07:41.344366 +00:00', '2024-07-16 00:23:35.736495 +00:00', '{}', '{"rhsm": {"orgId": "123456789", "MEMORY": 2, "RH_PROD": ["69", "204"], "IS_VIRTUAL": true, "ARCHITECTURE": "x86_64", "SYNC_TIMESTAMP": "2024-07-16T00:23:34.717515708Z", "SYSPURPOSE_SLA": "Premium", "SYSPURPOSE_USAGE": "Standard", "conversions.activity": "conversion"}}', '{"fqdn": "test.redhat.com", "bios_uuid": "ec22f82b-10c0-5ce5-fa99-375b9116e113", "provider_id": "test_instance_1", "ip_addresses": ["127.0.0.1"], "mac_addresses": [], "provider_type": "aws", "subscription_manager_id": "test-subman-id"}', '{"arch": "x86_64", "owner_id": "test_owner_id", "yum_repos": [{"id": "rhel-7-server-rpms", "name": "Red Hat Enterprise Linux 7 Server (RPMs)", "enabled": true}], "os_release": "7.9", "bios_vendor": "Xen", "conversions": {"activity": true}, "dnf_modules": [], "bios_version": "4.11.amazon", "cloud_provider": "aws", "number_of_cpus": 1, "cores_per_socket": 1, "operating_system": {"name": "RHEL", "major": 7, "minor": 9}, "threads_per_core": 1, "number_of_sockets": 1, "installed_packages": ["libmnl-0:1.0.3-7.el7.x86_64", "ethtool-2:4.8-10.el7.x86_64", "gdbm-0:1.10-8.el7.x86_64", "pciutils-libs-0:3.5.1-3.el7.x86_64", "libcollection-0:0.7.0-32.el7.x86_64", "iptables-0:1.4.21-35.el7.x86_64", "newt-0:0.52.15-4.el7.x86_64", "libteam-0:1.29-3.el7.x86_64", "tcp_wrappers-0:7.6-77.el7.x86_64", "acl-0:2.2.51-15.el7.x86_64", "tar-2:1.26-35.el7.x86_64", "libdb-utils-0:5.3.21-25.el7.x86_64", "libss-0:1.42.9-19.el7.x86_64", "libpng-2:1.5.13-8.el7.x86_64", "libselinux-utils-0:2.5-15.el7.x86_64", "linux-firmware-0:20200421-82.git78c0348.el7_9.noarch", "snappy-0:1.1.0-3.el7.x86_64", "sysvinit-tools-0:2.88-14.dsf.el7.x86_64", "libsmartcols-0:2.23.2-65.el7_9.1.x86_64", "json-c-0:0.11-4.el7_0.x86_64", "libpath_utils-0:0.2.1-32.el7.x86_64", "jansson-0:2.10-1.el7.x86_64", "p11-kit-trust-0:0.23.5-3.el7.x86_64", "krb5-libs-0:1.15.1-55.el7_9.x86_64", "coreutils-0:8.22-24.el7_9.2.x86_64", "python-0:2.7.5-94.el7_9.x86_64", "libmount-0:2.23.2-65.el7_9.1.x86_64", "shared-mime-info-0:1.8-5.el7.x86_64", "cracklib-0:2.9.0-11.el7.x86_64", "libpwquality-0:1.2.3-5.el7.x86_64", "libcroco-0:0.6.12-6.el7_9.x86_64", "libxml2-python-0:2.9.1-6.el7_9.6.x86_64", "python-configobj-0:4.7.2-7.el7.noarch", "libselinux-python-0:2.5-15.el7.x86_64", "cyrus-sasl-lib-0:2.1.26-24.el7_9.x86_64", "libverto-libevent-0:0.2.5-4.el7.x86_64", "gettext-libs-0:0.19.8.1-3.el7_9.x86_64", "pkgconfig-1:0.27.1-4.el7.x86_64", "python-gobject-base-0:3.22.0-1.el7_4.1.x86_64", "grubby-0:8.28-26.el7.x86_64", "python-decorator-0:3.4.0-3.el7.noarch", "python-backports-0:1.0-8.el7.x86_64", "python-urllib3-0:1.10.2-7.el7.noarch", "python-setuptools-0:0.9.8-7.el7.noarch", "python-IPy-0:0.75-6.el7.noarch", "python-babel-0:0.9.6-8.el7.noarch", "python-schedutils-0:0.4-6.el7.x86_64", "python-prettytable-0:0.7.2-3.el7.noarch", "newt-python-0:0.52.15-4.el7.x86_64", "python-jsonpatch-0:1.2-4.el7.noarch", "python-iniparse-0:0.4-9.el7.noarch", "pyxattr-0:0.5.1-5.el7.x86_64", "binutils-0:2.27-44.base.el7_9.1.x86_64", "nss-0:3.90.0-2.el7_9.x86_64", "nss-tools-0:3.90.0-2.el7_9.x86_64", "fipscheck-0:1.4.1-6.el7.x86_64", "bind-export-libs-32:9.11.4-26.P2.el7_9.15.x86_64", "libssh2-0:1.8.0-4.el7_9.1.x86_64", "curl-0:7.29.0-59.el7_9.2.x86_64", "rpm-0:4.11.3-48.el7_9.x86_64", "insights-client-0:3.1.9-1.el7_9.noarch", "libuser-0:0.60-9.el7.x86_64", "gpgme-0:1.3.2-5.el7.x86_64", "rpm-build-libs-0:4.11.3-48.el7_9.x86_64", "subscription-manager-rhsm-certificates-0:1.24.54-1.el7_9.x86_64", "passwd-0:0.79-6.el7.x86_64", "subscription-manager-0:1.24.54-1.el7_9.x86_64", "python-pycurl-0:7.19.0-19.el7.x86_64", "yum-0:3.4.3-168.el7.noarch", "qrencode-libs-0:3.4.1-3.el7.x86_64", "libfastjson-0:0.99.4-3.el7.x86_64", "ustr-0:1.0.4-16.el7.x86_64", "shadow-utils-2:4.6-5.el7.x86_64", "procps-ng-0:3.3.10-28.el7.x86_64", "kpartx-0:0.4.9-136.el7_9.x86_64", "device-mapper-libs-7:1.02.170-6.el7_9.5.x86_64", "dracut-0:033-572.el7.x86_64", "elfutils-libs-0:0.176-5.el7.x86_64", "dbus-libs-1:1.10.24-15.el7.x86_64", "dbus-1:1.10.24-15.el7.x86_64", "systemd-sysv-0:219-78.el7_9.9.x86_64", "iputils-0:20160308-10.el7.x86_64", "grub2-tools-minimal-1:2.02-0.87.el7_9.14.x86_64", "polkit-0:0.112-26.el7_9.1.x86_64", "hwdata-0:0.252-9.7.el7.x86_64", "cronie-anacron-0:1.4.11-25.el7_9.x86_64", "os-prober-0:1.58-9.el7.x86_64", "dhcp-libs-12:4.2.5-83.el7_9.1.x86_64", "dhcp-common-12:4.2.5-83.el7_9.1.x86_64", "dracut-network-0:033-572.el7.x86_64", "grub2-pc-1:2.02-0.87.el7_9.14.x86_64", "selinux-policy-0:3.13.1-268.el7_9.2.noarch", "gssproxy-0:0.7.0-30.el7_9.x86_64", "dbus-glib-0:0.100-7.el7.x86_64", "python-pyudev-0:0.15-9.el7.noarch", "grub2-common-1:2.02-0.87.el7_9.14.noarch", "libsemanage-python-0:2.5-14.el7.x86_64", "setup-0:2.8.71-11.el7.noarch", "libseccomp-0:2.3.1-4.el7.x86_64", "tzdata-0:2024a-1.el7.noarch", "checkpolicy-0:2.5-8.el7.x86_64", "grub2-pc-modules-1:2.02-0.87.el7_9.14.noarch", "numactl-libs-0:2.0.12-5.el7.x86_64", "kbd-misc-0:1.15.5-16.el7_9.noarch", "libestr-0:0.1.9-2.el7.x86_64", "nss-softokn-freebl-0:3.90.0-6.el7_9.x86_64", "kbd-0:1.15.5-16.el7_9.x86_64", "glibc-0:2.17-326.el7_9.3.x86_64", "kernel-tools-0:3.10.0-1160.119.1.el7.x86_64", "ncurses-libs-0:5.9-14.20130511.el7_4.x86_64", "cloud-init-0:19.4-7.el7_9.6.x86_64", "nspr-0:4.35.0-1.el7_9.x86_64", "chrony-0:3.4-1.el7.x86_64", "libsepol-0:2.5-10.el7.x86_64", "tuned-0:2.11.0-12.el7_9.noarch", "libselinux-0:2.5-15.el7.x86_64", "selinux-policy-targeted-0:3.13.1-268.el7_9.2.noarch", "info-0:5.1-5.el7.x86_64", "kexec-tools-0:2.0.15-51.el7_9.3.x86_64", "libcom_err-0:1.42.9-19.el7.x86_64", "openssh-clients-0:7.4p1-23.el7_9.x86_64", "sed-0:4.2.2-7.el7.x86_64", "lshw-0:B.02.18-17.el7.x86_64", "chkconfig-0:1.7.6-1.el7.x86_64", "authconfig-0:6.2.8-30.el7.x86_64", "libuuid-0:2.23.2-65.el7_9.1.x86_64", "audit-0:2.8.5-4.el7.x86_64", "grep-0:2.20-3.el7.x86_64", "rsync-0:3.1.2-12.el7_9.x86_64", "readline-0:6.2-11.el7.x86_64", "microcode_ctl-2:2.1-73.20.el7_9.x86_64", "libattr-0:2.4.46-13.el7.x86_64", "dracut-config-generic-0:033-572.el7.x86_64", "libcap-0:2.22-11.el7.x86_64", "parted-0:3.1-32.el7.x86_64", "audit-libs-0:2.8.5-4.el7.x86_64", "usermode-0:1.111-6.el7.x86_64", "tcp_wrappers-libs-0:7.6-77.el7.x86_64", "yum-utils-0:1.1.31-54.el7_8.noarch", "libffi-0:3.0.13-19.el7.x86_64", "python-dmidecode-0:3.12.2-4.el7.x86_64", "keyutils-libs-0:1.5.8-3.el7.x86_64", "btrfs-progs-0:4.9.1-1.el7.x86_64", "which-0:2.20-7.el7.x86_64", "python-ethtool-0:0.8-8.el7.x86_64", "cpio-0:2.11-28.el7.x86_64", "python-dateutil-0:1.5-7.el7.noarch", "expat-0:2.1.0-15.el7_9.x86_64", "gdisk-0:0.8.10-3.el7.x86_64", "findutils-1:4.5.11-6.el7.x86_64", "libndp-0:1.2-9.el7.x86_64", "file-0:5.11-37.el7.x86_64", "host-metering-0:1.2.0-4.el7_9.x86_64", "libnl3-cli-0:3.2.28-4.el7.x86_64", "libassuan-0:2.1.0-3.el7.x86_64", "groff-base-0:1.22.2-8.el7.x86_64", "xz-0:5.2.2-2.el7_9.x86_64", "libunistring-0:0.9.3-9.el7.x86_64", "libedit-0:3.0-12.20121213cvs.el7.x86_64", "libnfnetlink-0:1.0.1-4.el7.x86_64", "slang-0:2.2.4-11.el7.x86_64", "lzo-0:2.06-8.el7.x86_64", "hostname-0:3.13-3.el7_7.1.x86_64", "lz4-0:1.8.3-1.el7.x86_64", "libref_array-0:0.1.5-32.el7.x86_64", "libnetfilter_conntrack-0:1.0.6-1.el7_3.x86_64", "iproute-0:4.11.0-30.el7.x86_64", "less-0:458-10.el7_9.x86_64", "keyutils-0:1.5.8-3.el7.x86_64", "setools-libs-0:3.3.8-4.el7.x86_64", "vim-minimal-2:7.4.629-8.el7_9.x86_64", "bc-0:1.06.95-13.el7.x86_64", "pinentry-0:0.8.1-17.el7.x86_64", "make-1:3.82-24.el7.x86_64", "freetype-0:2.8-14.el7_9.1.x86_64", "mozjs17-0:17.0.0-20.el7.x86_64", "ncurses-0:5.9-14.20130511.el7_4.x86_64", "gmp-1:6.0.0-15.el7.x86_64", "pth-0:2.0.7-23.el7.x86_64", "libyaml-0:0.1.4-11.el7_0.x86_64", "libnl-0:1.1.4-3.el7.x86_64", "libini_config-0:1.3.1-32.el7.x86_64", "libtasn1-0:4.10-1.el7.x86_64", "ca-certificates-0:2023.2.60_v7.0.306-72.el7_9.noarch", "openssl-libs-1:1.0.2k-26.el7_9.x86_64", "python-libs-0:2.7.5-94.el7_9.x86_64", "libblkid-0:2.23.2-65.el7_9.1.x86_64", "glib2-0:2.56.1-9.el7_9.x86_64", "gzip-0:1.5-11.el7_9.x86_64", "cracklib-dicts-0:2.9.0-11.el7.x86_64", "pam-0:1.1.8-23.el7.x86_64", "python-six-0:1.9.0-2.el7.noarch", "python-ipaddress-0:1.0.16-2.el7.noarch", "python-chardet-0:2.2.1-3.el7.noarch", "libevent-0:2.0.21-4.el7.x86_64", "libtirpc-0:0.2.4-0.16.el7.x86_64", "python-kitchen-0:1.1.1-5.el7.noarch", "gettext-0:0.19.8.1-3.el7_9.x86_64", "gobject-introspection-0:1.56.1-1.el7.x86_64", "yum-metadata-parser-0:1.1.4-10.el7.x86_64", "e2fsprogs-0:1.42.9-19.el7.x86_64", "python-markupsafe-0:0.11-10.el7.x86_64", "python-backports-ssl_match_hostname-0:3.5.0.1-1.el7.noarch", "python-requests-0:2.6.0-10.el7.noarch", "PyYAML-0:3.10-11.el7.x86_64", "python-perf-0:3.10.0-1160.119.1.el7.x86_64", "python-jinja2-0:2.7.2-4.el7.noarch", "audit-libs-python-0:2.8.5-4.el7.x86_64", "pyliblzma-0:0.5.3-11.el7.x86_64", "python-jsonpointer-0:1.9-2.el7.noarch", "python-linux-procfs-0:0.4.11-4.el7.noarch", "pyserial-0:2.6-6.el7.noarch", "openssl-1:1.0.2k-26.el7_9.x86_64", "nss-pem-0:1.0.3-7.el7_9.1.x86_64", "nss-sysinit-0:3.90.0-2.el7_9.x86_64", "logrotate-0:3.8.6-19.el7.x86_64", "fipscheck-lib-0:1.4.1-6.el7.x86_64", "mariadb-libs-1:5.5.68-1.el7.x86_64", "libcurl-0:7.29.0-59.el7_9.2.x86_64", "rpm-libs-0:4.11.3-48.el7_9.x86_64", "openldap-0:2.4.44-25.el7_9.x86_64", "rhc-1:0.2.4-2.el7_9.x86_64", "gnupg2-0:2.0.22-5.el7_5.x86_64", "pygpgme-0:0.3-9.el7.x86_64", "python-syspurpose-0:1.24.54-1.el7_9.x86_64", "rpm-python-0:4.11.3-48.el7_9.x86_64", "subscription-manager-rhsm-0:1.24.54-1.el7_9.x86_64", "libnfsidmap-0:0.25-19.el7.x86_64", "rhc-worker-script-0:0.8-1.el7_9.x86_64", "python-urlgrabber-0:3.10-10.el7.noarch", "hardlink-1:1.0-19.el7.x86_64", "convert2rhel-0:1.7.1-1.el7.noarch", "libdaemon-0:0.14-7.el7.x86_64", "libpipeline-0:1.2.3-3.el7.x86_64", "libsemanage-0:2.5-14.el7.x86_64", "libutempter-0:1.1.6-4.el7.x86_64", "device-mapper-7:1.02.170-6.el7_9.5.x86_64", "util-linux-0:2.23.2-65.el7_9.1.x86_64", "cryptsetup-libs-0:2.0.3-6.el7.x86_64", "kmod-0:20-28.el7.x86_64", "systemd-libs-0:219-78.el7_9.9.x86_64", "systemd-0:219-78.el7_9.9.x86_64", "elfutils-default-yama-scope-0:0.176-5.el7.noarch", "policycoreutils-0:2.5-34.el7.x86_64", "initscripts-0:9.49.53-1.el7_9.1.x86_64", "rpcbind-0:0.2.0-49.el7.x86_64", "polkit-pkla-compat-0:0.1-4.el7.x86_64", "crontabs-0:1.11-6.20121102git.el7.noarch", "cronie-0:1.4.11-25.el7_9.x86_64", "grub2-tools-1:2.02-0.87.el7_9.14.x86_64", "openssh-0:7.4p1-23.el7_9.x86_64", "dhclient-12:4.2.5-83.el7_9.1.x86_64", "grub2-tools-extra-1:2.02-0.87.el7_9.14.x86_64", "quota-1:4.01-19.el7.x86_64", "net-tools-0:2.0-0.25.20131004git.el7.x86_64", "libcgroup-0:0.41-21.el7.x86_64", "dbus-python-0:1.1.1-9.el7.x86_64", "libgcc-0:4.8.5-44.el7.x86_64", "virt-what-0:1.18-4.el7_9.1.x86_64", "redhat-release-server-0:7.9-11.el7_9.x86_64", "efivar-libs-0:36-12.el7.x86_64", "filesystem-0:3.2-25.el7.x86_64", "sg3_utils-libs-1:1.37-19.el7.x86_64", "basesystem-0:10.0-7.el7.noarch", "policycoreutils-python-0:2.5-34.el7.x86_64", "quota-nls-1:4.01-19.el7.noarch", "kernel-tools-libs-0:3.10.0-1160.119.1.el7.x86_64", "ncurses-base-0:5.9-14.20130511.el7_4.noarch", "kbd-legacy-0:1.15.5-16.el7_9.noarch", "glibc-common-0:2.17-326.el7_9.3.x86_64", "rsyslog-0:8.24.0-57.el7_9.3.x86_64", "libstdc++-0:4.8.5-44.el7.x86_64", "irqbalance-3:1.0.7-12.el7.x86_64", "bash-0:4.2.46-35.el7_9.x86_64", "sg3_utils-1:1.37-19.el7.x86_64", "nss-util-0:3.90.0-1.el7_9.x86_64", "efibootmgr-0:17-2.el7.x86_64", "pcre-0:8.32-17.el7.x86_64", "nfs-utils-1:1.3.0-0.68.el7.2.x86_64", "zlib-0:1.2.7-21.el7_9.x86_64", "grub2-1:2.02-0.87.el7_9.14.x86_64", "xz-libs-0:5.2.2-2.el7_9.x86_64", "openssh-server-0:7.4p1-23.el7_9.x86_64", "popt-0:1.13-16.el7.x86_64", "pciutils-0:3.5.1-3.el7.x86_64", "bzip2-libs-0:1.0.6-13.el7.x86_64", "kernel-0:3.10.0-1160.119.1.el7.x86_64", "libdb-0:5.3.21-25.el7.x86_64", "postfix-2:2.10.1-9.el7.x86_64", "gawk-0:4.0.2-4.el7_3.1.x86_64", "yum-plugin-fastestmirror-0:1.1.31-54.el7_8.noarch", "wpa_supplicant-1:2.6-12.el7_9.2.x86_64", "libxml2-0:2.9.1-6.el7_9.6.x86_64", "qemu-guest-agent-10:2.12.0-3.el7.x86_64", "elfutils-libelf-0:0.176-5.el7.x86_64", "teamd-0:1.29-3.el7.x86_64", "libacl-0:2.2.51-15.el7.x86_64", "dracut-config-rescue-0:033-572.el7.x86_64", "libcap-ng-0:0.7.5-4.el7.x86_64", "cloud-utils-growpart-0:0.29-5.el7.noarch", "sqlite-0:3.7.17-8.el7_7.1.x86_64", "man-db-0:2.6.3-11.el7.x86_64", "libgpg-error-0:1.12-3.el7.x86_64", "sudo-0:1.8.23-10.el7_9.3.x86_64", "libgcrypt-0:1.5.3-14.el7.x86_64", "xfsprogs-0:4.5.0-22.el7.x86_64", "lua-0:5.1.4-15.el7.x86_64", "python-magic-0:5.11-37.el7.noarch", "diffutils-0:3.3-6.el7_9.x86_64", "pexpect-0:2.3-11.el7.noarch", "libnl3-0:3.2.28-4.el7.x86_64", "python-inotify-0:0.9.4-4.el7.noarch", "e2fsprogs-libs-0:1.42.9-19.el7.x86_64", "libsysfs-0:2.1.0-16.el7.x86_64", "file-libs-0:5.11-37.el7.x86_64", "rootfiles-0:8.1-11.el7.noarch", "libverto-0:0.2.5-4.el7.x86_64", "host-metering-selinux-0:1.2.0-4.el7_9.noarch", "p11-kit-0:0.23.5-3.el7.x86_64", "nss-softokn-0:3.90.0-6.el7_9.x86_64", "kmod-libs-0:20-28.el7.x86_64", "libgomp-0:4.8.5-44.el7.x86_64", "libidn-0:1.28-4.el7.x86_64", "dmidecode-1:3.2-5.el7_9.1.x86_64", "libbasicobjects-0:0.1.1-32.el7.x86_64"], "network_interfaces": [{"name": "eth0", "mac_address": "0A:FF:DE:BC:14:81", "ipv4_addresses": ["127.0.0.1"], "ipv6_addresses": []}, {"name": "lo", "mac_address": "00:00:00:00:00:00", "ipv4_addresses": ["127.0.0.1"]}], "infrastructure_type": "virtual", "system_memory_bytes": 1925210112}', '', '2024-07-18 00:23:34.717515 +00:00', 'rhsm-conduit', '{"rhsm-conduit": {"last_check_in": "2024-07-16T00:23:34.734455+00:00", "stale_timestamp": "2024-07-18T00:23:34.717515+00:00", "check_in_succeeded": true}, "rhsm-system-profile-bridge": {"last_check_in": "2024-06-07T10:37:41.334501+00:00", "stale_timestamp": "2024-06-09T10:37:41.294377+00:00", "check_in_succeeded": true}}', '123456789', '[]');
```

4. Reset the SWATCH DB
```
dropdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && \
createdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && \
./gradlew liquibaseUpdate
```

5. Run swatch-tally service:
```
DEV_MODE=true ./gradlew :bootRun
```

6. Run the hourly tally to initialize the tally_state table for the org.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=123456789" x-rh-swatch-psk:placeholder
```

7. Reset the tally_state so that the event will get picked up during the next hourly tally.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "update tally_state set latest_event_record_date='2023-05-28 00:00:00+00';"
```
8. Insert an event for a host with the same org_id/instance_id.
```
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('ac370856-60e6-45a9-9528-57f03bfe8eec', '2024-07-16 13:00:00.000000 +00:00', '{"sla": "Premium", "org_id": "123456789", "event_id": "ac370856-60e6-45a9-9528-57f03bfe8eec", "timestamp": "2024-07-16T13:00:00Z", "conversion": true, "event_type": "snapshot_rhel-for-x86-els-payg_vcpus", "expiration": "2024-07-16T14:00:00Z", "instance_id": "test_instance_1", "product_ids": ["69", "204"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-07-16T14:30:05.58493702Z", "display_name": "test.redhat.com", "event_source": "rhelemeter", "measurements": [{"value": 1.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "hardware_type": "Cloud", "cloud_provider": "AWS", "billing_provider": "aws", "metering_batch_id": "79dfa28f-7048-476b-aec2-04cbfdef63a4", "billing_account_id": "222222"}', 'snapshot_rhel-for-x86-els-payg_vcpus', 'rhelemeter', 'test_instance_1', '123456789', null, '2024-07-16 14:30:05.584937 +00:00');
```

9. Run the nightly tally
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/123456789" x-rh-swatch-psk:placeholder
```

10. Check the host count and measurements.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select id, instance_id, instance_type from hosts;"
```
```
                  id                  |     instance_id     | instance_type 
--------------------------------------+---------------------+---------------
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | test_instance_1 | HBI_HOST
(1 row)
```
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select host_id, metric_id, value from instance_measurements"
```
```
               host_id                | metric_id | value 
--------------------------------------+-----------+-------
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | CORES     |     1
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | SOCKETS   |     1
(2 rows)

```

11. Run the hourly tally.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=123456789" x-rh-swatch-psk:placeholder
```

12. Check the host count and measurements.
**EXPECTED RESULT:** There should still be one host, however, the instance_type will have been updated and there will be an additional VCPU measurement.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select id, instance_id, instance_type from hosts;"
```
```
                  id                  |     instance_id     | instance_type 
--------------------------------------+---------------------+---------------
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | test_instance_1 | RHEL System
```

```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select host_id, metric_id, value from instance_measurements order by host_id"
```
```
               host_id                | metric_id | value 
--------------------------------------+-----------+-------
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | CORES     |     1
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | SOCKETS   |     1
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | VCPUS     |     1
(3 rows)
```

13. Run the nightly tally
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/123456789" x-rh-swatch-psk:placeholder
```

14. Check the host count and measurements.
**EXPECTED RESULT:** There will now be an additional host created and a new set of CORES/SOCKETS measurements associated with this new host. The previous host remains the same and the CORES/SOCKETS measurements remain!
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select id, instance_id, instance_type from hosts;"
```
```
                  id                  |     instance_id     | instance_type 
--------------------------------------+---------------------+---------------
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | test_instance_1 | RHEL System
 a82aad73-d1dd-43ca-a1b3-96c9835065a8 | test_instance_1 | HBI_HOST
(2 rows)
```

```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select host_id, metric_id, value from instance_measurements order by host_id"
```
```
               host_id                | metric_id | value 
--------------------------------------+-----------+-------
 a82aad73-d1dd-43ca-a1b3-96c9835065a8 | CORES     |     1
 a82aad73-d1dd-43ca-a1b3-96c9835065a8 | SOCKETS   |     1
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | CORES     |     1
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | SOCKETS   |     1
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | VCPUS     |     1
(5 rows)
```

# Verification
Keep in mind that a fix already exists that will prevent this bad data from happening anymore and that this patch simply fixes any existing hosts that have this problem.

1. Check out the branch for the PR.
2. Check the instance_measurements to make sure that they get cleaned up.
**EXPECTED RESULTS:** The 'RHEL System' host should only have VCPUS. The HBI_HOST should have CORES/SOCKETS.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select id, instance_id, instance_type from hosts;"
```
```
                  id                  |     instance_id     | instance_type 
--------------------------------------+---------------------+---------------
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | test_instance_1 | RHEL System
 a82aad73-d1dd-43ca-a1b3-96c9835065a8 | test_instance_1 | HBI_HOST
(2 rows)
```

```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select h.id, h.instance_type, m.metric_id, m.value from hosts h join instance_measurements m on h.id=m.host_id order by host_id"
```

```
                  id                  | instance_type | metric_id | value 
--------------------------------------+---------------+-----------+-------
 a82aad73-d1dd-43ca-a1b3-96c9835065a8 | HBI_HOST      | CORES     |     1
 a82aad73-d1dd-43ca-a1b3-96c9835065a8 | HBI_HOST      | SOCKETS   |     1
 f4bfacea-461d-4a08-9d01-bc75f1350e50 | RHEL System   | VCPUS     |     1
(3 rows)
```