### PR TITLE
SWATCH-2747: Adding no-remove-resource for deployed export-service

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -55,7 +55,7 @@ EXTRA_DEPLOY_ARGS="--timeout 1800 ${IMAGES}"
 OPTIONAL_DEPS_METHOD=none
 
 # set CLI option for --no-remove-resources
-export COMPONENTS_W_RESOURCES="app:rhsm"
+export COMPONENTS_W_RESOURCES="app:rhsm app:export-service"
 
 # NOTE: this ensures that all of the other services end up deployed with the latest template
 export EXTRA_COMPONENTS="rhsm $(find -name clowdapp.yaml -exec dirname {} \; | cut -d'/' -f2 | xargs)"


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2747

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Export Service is OOMKilled and pod is restarted when we run tests. Not using the default resource limits set by bonfire/clowder seems to solve the issue. 

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: Tested all export tests in EE multiple times, no OOM observed

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.
