### PR TITLE
SWATCH-2705: Set ApplicationName on postgresql connection

### DIFF
--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -17,7 +17,7 @@ rhsm-subscriptions:
   hourlyTallyEventBatchSize: ${HOURLY_TALLY_EVENT_BATCH_SIZE:16000}
   inventory-service:
     datasource:
-      url: jdbc:postgresql://${INVENTORY_DATABASE_HOST:localhost}/${INVENTORY_DATABASE_DATABASE:insights}
+      url: jdbc:postgresql://${INVENTORY_DATABASE_HOST:localhost}/${INVENTORY_DATABASE_DATABASE:insights}?ApplicationName=${clowder.metadata.name:rhsm-subscriptions}
       username: ${INVENTORY_DATABASE_USERNAME:insights}
       password: ${INVENTORY_DATABASE_PASSWORD:insights}
       driver-class-name: org.postgresql.Driver

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -62,7 +62,7 @@ quarkus.management.root-path=/
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=${DATABASE_USERNAME}
 quarkus.datasource.password=${DATABASE_PASSWORD}
-quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}
+quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?ApplicationName=${quarkus.application.name:swatch-billable-usage}
 quarkus.hibernate-orm.database.generation=validate
 quarkus.hibernate-orm.log.sql=${LOGGING_SHOW_SQL_QUERIES:false}
 

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -76,7 +76,7 @@ quarkus.security.auth.enabled-in-dev-mode=false
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=${DATABASE_USERNAME}
 quarkus.datasource.password=${DATABASE_PASSWORD}
-quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}
+quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?ApplicationName=${quarkus.application.name:swatch-contracts}
 
 %test.quarkus.datasource.db-kind=h2
 # NOTE: because some of the entities use columns named "value", it is necessary to configure h2 to *not* treat it as a keyword.

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -142,7 +142,7 @@ rhsm-subscriptions:
     manual-event-editing-enabled: ${DEVTEST_EVENT_EDITING_ENABLED}
     reset-account-enabled: ${ENABLE_ACCOUNT_RESET}
   datasource:
-    url: jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?reWriteBatchedInserts=true&stringtype=unspecified&options=-c%20statement_timeout=${POSTGRES_STATEMENT_TIMEOUT}
+    url: jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?reWriteBatchedInserts=true&stringtype=unspecified&options=-c%20statement_timeout=${POSTGRES_STATEMENT_TIMEOUT}&ApplicationName=${clowder.metadata.name:swatch-core}
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2705

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Add the application name to the connection string so queries can be traced back to the application.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Create a file /tmp/cdappconfig.json:
```{
    "database": {
        "adminPassword": "rhsm-subscriptions",
        "adminUsername": "rhsm-subscriptions",
        "hostname": "localhost",
        "name": "rhsm-subscriptions",
        "password": "rhsm-subscriptions",
        "port": 5432,
        "sslMode": "disable",
        "username": "rhsm-subscriptions"
    },
    "kafka": {
        "brokers": [
            {
                "hostname": "localhost",
                "port": 9092
            }
        ],
        "topics": [
            {
                "name": "platform.rhsm-conduit.tasks",
                "requestedName": "platform.rhsm-conduit.tasks"
            },
            {
                "name": "platform.inventory.host-ingress",
                "requestedName": "platform.inventory.host-ingress"
            }
        ]
    },
    "endpoints": [],
    "metadata": {
        "deployments": [
            {
                "image": "quay.io/cloudservices/swatch-system-conduit:pr-3537-262ad77",
                "name": "service"
            }
        ],
        "envName": "env-ephemeral-fzyud0",
        "name": "swatch-system-conduit"
    },
    "metricsPath": "/metrics",
    "metricsPort": 9000,
    "privatePort": 10000,
    "publicPort": 8000,
    "webPort": 8000
}
 ```
2. ```export ACG_CONFIG=/tmp/cdappconfig.json```
3. Clone https://github.com/RedHatInsights/clowder-quarkus-config-source
4. Use either branch wottop/SWATCH-2705 or main if my branch is already merged
5. Go to local directory for the clowder-quarkus-config-source repo. Run ```mvn install```.
6. Change the dependencies.gradle file for the rhsm-subscriptions project so that the clowder-quarkus-config-source version matches the snapshot jar you just made, i.e.:
```libraries["clowder-quarkus-config-source"] = "com.redhat.cloud.common:clowder-quarkus-config-source:2.6.2-SNAPSHOT``` 

### Steps
<!-- Enter each step of the test below -->
1. ```podman-compose up -d```
- Spring Apps
1. ```RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,rhsm-conduit ./gradlew clean :bootRun```
- Quarkus App [run separately or change ports]
1. ```SERVER_PORT=8882 ./gradlew  :swatch-contracts:quarkusDev```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Watch the local database table for the connections
```select usename, application_name, query_start, query from pg_stat_activity```
You will see the application names in the table.

Note: only "swatch-system-conduit" will appear for Spring apps. In a real deployment, you would have a different file for each pod with the appropriate name.

