### PR TITLE
SWATCH-2726: Prevent send usages to other azure tenants if not forbidden

### DIFF
--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -105,6 +105,10 @@ mp.messaging.outgoing.tally-out.connector=smallrye-kafka
 mp.messaging.outgoing.tally-out.topic=platform.rhsm-subscriptions.billable-usage
 mp.messaging.outgoing.tally-out.value.serializer=org.candlepin.subscriptions.billable.usage.BillableUsageSerializer
 
+# Disable the auto-discovery of providers (for ex: exception mappers).
+# All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
+quarkus.rest-client-reactive.provider-autodiscovery=false
+
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}

--- a/swatch-producer-azure/build.gradle
+++ b/swatch-producer-azure/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation 'io.quarkus:quarkus-test-security'
     testImplementation libraries["junit-jupiter"]
     testImplementation project(':swatch-common-testcontainers')
+    testImplementation libraries["wiremock"]
     implementation libraries["mapstruct"]
     annotationProcessor libraries["mapstruct-processor"]
     testAnnotationProcessor libraries["mapstruct-processor"]

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/configuration/Channels.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/configuration/Channels.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.configuration;
+
+public class Channels {
+
+  public static final String BILLABLE_USAGE_HOURLY_AGGREGATE = "billable-usage-hourly-aggregate-in";
+
+  private Channels() {}
+}

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -20,6 +20,8 @@
  */
 package com.redhat.swatch.azure.service;
 
+import static com.redhat.swatch.azure.configuration.Channels.BILLABLE_USAGE_HOURLY_AGGREGATE;
+
 import com.redhat.swatch.azure.exception.AzureMarketplaceRequestFailedException;
 import com.redhat.swatch.azure.exception.AzureUnprocessedRecordsException;
 import com.redhat.swatch.azure.exception.AzureUsageContextLookupException;
@@ -88,7 +90,7 @@ public class AzureBillableUsageAggregateConsumer {
   }
 
   @SuppressWarnings("java:S3776")
-  @Incoming("billable-usage-hourly-aggregate-in")
+  @Incoming(BILLABLE_USAGE_HOURLY_AGGREGATE)
   @Blocking
   public void process(BillableUsageAggregate billableUsageAggregate) {
     log.info("Received billable usage message {}", billableUsageAggregate);

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -119,6 +119,10 @@ mp.messaging.outgoing.tally-out.value.serializer=org.candlepin.subscriptions.bil
 mp.messaging.outgoing.tally-dlt.connector=smallrye-kafka
 mp.messaging.outgoing.tally-dlt.topic=platform.rhsm-subscriptions.billable-usage.dlt
 
+# Disable the auto-discovery of providers (for ex: exception mappers).
+# All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
+quarkus.rest-client-reactive.provider-autodiscovery=false
+
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.service;
+
+import static com.redhat.swatch.azure.configuration.Channels.BILLABLE_USAGE_HOURLY_AGGREGATE;
+import static com.redhat.swatch.azure.test.resources.InMemoryMessageBrokerKafkaResource.IN_MEMORY_CONNECTOR;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.azure.test.resources.InMemoryMessageBrokerKafkaResource;
+import com.redhat.swatch.azure.test.resources.InjectWireMock;
+import com.redhat.swatch.azure.test.resources.WireMockResource;
+import com.redhat.swatch.clients.swatch.internal.subscription.api.model.AzureUsageContext;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.apache.http.HttpStatus;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
+import org.eclipse.microprofile.reactive.messaging.spi.Connector;
+import org.jboss.logmanager.LogContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+@QuarkusTest
+@QuarkusTestResource(
+    value = InMemoryMessageBrokerKafkaResource.class,
+    restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = WireMockResource.class, restrictToAnnotatedClass = true)
+class AzureBillableUsageAggregateConsumerTest {
+
+  private static final String ORG_ID = "org123";
+  private static final String PRODUCT_ID = "rosa";
+  private static final String BILLING_ACCOUNT_ID = "abc";
+  private static final LoggerCaptor LOGGER_CAPTOR = new LoggerCaptor();
+
+  @Inject
+  @Connector(IN_MEMORY_CONNECTOR)
+  InMemoryConnector connector;
+
+  @InjectWireMock WireMockResource wireMockResource;
+
+  InMemorySource<BillableUsageAggregate> source;
+  BillableUsageAggregate usage;
+  AzureUsageContext contextForUsage;
+
+  @BeforeAll
+  static void configureLogging() {
+    LogContext.getLogContext()
+        .getLogger(AzureBillableUsageAggregateConsumer.class.getName())
+        .addHandler(LOGGER_CAPTOR);
+  }
+
+  @BeforeEach
+  void setup() {
+    LOGGER_CAPTOR.clearRecords();
+    source = connector.source(BILLABLE_USAGE_HOURLY_AGGREGATE);
+  }
+
+  @Test
+  void testUsageIsSentToAzureMarketplace() {
+    givenValidUsage();
+    givenAzureContextForUsage();
+    givenAzureMarketplaceReturnsOk();
+    whenSendUsage();
+    thenUsageIsSentToAzure();
+  }
+
+  @Test
+  void testAzureMarketplaceReturnsForbiddenThenExceptionIsThrown() {
+    givenValidUsage();
+    givenAzureContextForUsage();
+    givenAzureMarketplaceReturnsForbidden();
+    whenSendUsage();
+    thenErrorLogWithMessage("Error sending azure usage for aggregateId");
+  }
+
+  @Test
+  void testAzureMarketplaceReturnsInvalidRequestThenWarningLogIsPrinted() {
+    givenValidUsage();
+    givenAzureContextForUsage();
+    givenAzureMarketplaceReturnsInvalidRequest();
+    whenSendUsage();
+    thenWarningLogWithMessage("status: Error");
+  }
+
+  private void givenAzureMarketplaceReturnsForbidden() {
+    wireMockResource.stubAzureMarketplaceSubmitUsageEventForReturnsStatus(
+        contextForUsage, HttpStatus.SC_FORBIDDEN);
+  }
+
+  private void givenAzureMarketplaceReturnsInvalidRequest() {
+    wireMockResource.stubAzureMarketplaceSubmitUsageEventForReturnsStatus(
+        contextForUsage, HttpStatus.SC_BAD_REQUEST);
+  }
+
+  private void givenAzureMarketplaceReturnsOk() {
+    wireMockResource.stubAzureMarketplaceSubmitUsageEventForReturnsOk(contextForUsage);
+  }
+
+  private void givenAzureContextForUsage() {
+    contextForUsage =
+        wireMockResource.stubInternalSubscriptionAzureMarketPlaceContextForUsage(usage);
+  }
+
+  private void givenValidUsage() {
+    var key = new BillableUsageAggregateKey();
+    key.setUsage(BillableUsage.Usage.DEVELOPMENT_TEST.toString());
+    key.setSla(BillableUsage.Sla.STANDARD.toString());
+    key.setOrgId(ORG_ID);
+    key.setMetricId(MetricIdUtils.getCores().toUpperCaseFormatted());
+    key.setProductId(PRODUCT_ID);
+    key.setBillingProvider(BillableUsage.BillingProvider.AZURE.value());
+    key.setBillingAccountId(BILLING_ACCOUNT_ID);
+
+    usage = new BillableUsageAggregate();
+    usage.setAggregateId(UUID.randomUUID());
+    usage.setAggregateKey(key);
+    usage.setWindowTimestamp(OffsetDateTime.now());
+  }
+
+  private void whenSendUsage() {
+    source.send(usage);
+  }
+
+  private void thenUsageIsSentToAzure() {
+    Awaitility.await()
+        .untilAsserted(() -> wireMockResource.verifyUsageIsSentToAzureMarketplace(contextForUsage));
+  }
+
+  private void thenWarningLogWithMessage(String str) {
+    thenLogWithMessage(Level.WARNING, str);
+  }
+
+  private void thenErrorLogWithMessage(String str) {
+    thenLogWithMessage(Level.SEVERE, str);
+  }
+
+  private void thenLogWithMessage(Level level, String str) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertTrue(
+                    LOGGER_CAPTOR.records.stream()
+                        .anyMatch(
+                            r -> r.getLevel().equals(level) && r.getMessage().contains(str))));
+  }
+
+  public static class LoggerCaptor extends Handler {
+
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord trace) {
+      records.add(trace);
+    }
+
+    @Override
+    public void flush() {
+      // no need to flush any sink
+    }
+
+    @Override
+    public void close() throws SecurityException {
+      clearRecords();
+    }
+
+    public void clearRecords() {
+      records.clear();
+    }
+  }
+}

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.azure.service;
 
 import static com.redhat.swatch.azure.service.BillableUsageDeadLetterTopicProducer.RETRY_AFTER_HEADER;
+import static com.redhat.swatch.azure.test.resources.InMemoryMessageBrokerKafkaResource.IN_MEMORY_CONNECTOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -106,7 +107,7 @@ class BillableUsageConsumerTest {
   @Inject BillableUsageDeadLetterTopicProducer deadLetterTopicProducer;
 
   @Inject
-  @Connector("smallrye-in-memory")
+  @Connector(IN_MEMORY_CONNECTOR)
   InMemoryConnector connector;
 
   @BeforeEach

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/test/resources/InMemoryMessageBrokerKafkaResource.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/test/resources/InMemoryMessageBrokerKafkaResource.java
@@ -20,6 +20,8 @@
  */
 package com.redhat.swatch.azure.test.resources;
 
+import static com.redhat.swatch.azure.configuration.Channels.BILLABLE_USAGE_HOURLY_AGGREGATE;
+
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import java.util.HashMap;
@@ -27,10 +29,13 @@ import java.util.Map;
 
 public class InMemoryMessageBrokerKafkaResource implements QuarkusTestResourceLifecycleManager {
 
+  public static final String IN_MEMORY_CONNECTOR = "smallrye-in-memory";
+
   @Override
   public Map<String, String> start() {
     Map<String, String> env = new HashMap<>();
     env.putAll(InMemoryConnector.switchIncomingChannelsToInMemory("tally-in"));
+    env.putAll(InMemoryConnector.switchIncomingChannelsToInMemory(BILLABLE_USAGE_HOURLY_AGGREGATE));
     env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory("tally-out"));
     env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory("tally-dlt"));
     return env;

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/test/resources/InjectWireMock.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/test/resources/InjectWireMock.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.test.resources;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface InjectWireMock {}

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/test/resources/WireMockResource.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/test/resources/WireMockResource.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.test.resources;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventOkResponse;
+import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventStatusEnum;
+import com.redhat.swatch.clients.swatch.internal.subscription.api.model.AzureUsageContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class WireMockResource implements QuarkusTestResourceLifecycleManager {
+
+  private static final String SUBSCRIPTIONS_AZURE_USAGE_CONTEXT =
+      "/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext";
+  private static final String AZURE_AUTHORIZATION = "/";
+  private static final String AZURE_SUBMIT_USAGE = "/api/usageEvent";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private WireMockServer wireMockServer;
+
+  @Override
+  public Map<String, String> start() {
+    wireMockServer =
+        new WireMockServer(
+            WireMockConfiguration.options().dynamicPort().notifier(new ConsoleNotifier(true)));
+    wireMockServer.start();
+    var config = new HashMap<String, String>();
+    config.put("AZURE_MARKETPLACE_BASE_URL", wireMockServer.baseUrl());
+    config.put("AZURE_OAUTH_TOKEN_URL", wireMockServer.baseUrl());
+    config.put("SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT", wireMockServer.baseUrl());
+    return config;
+  }
+
+  @Override
+  public void stop() {
+    wireMockServer.stop();
+    wireMockServer.resetAll();
+  }
+
+  @Override
+  public void inject(TestInjector testInjector) {
+    testInjector.injectIntoFields(
+        this,
+        new TestInjector.AnnotatedAndMatchesType(InjectWireMock.class, WireMockResource.class));
+  }
+
+  public AzureUsageContext stubInternalSubscriptionAzureMarketPlaceContextForUsage(
+      BillableUsageAggregate usage) {
+    AzureUsageContext context = new AzureUsageContext();
+    context.setAzureResourceId(UUID.randomUUID().toString());
+    context.setAzureTenantId(UUID.randomUUID().toString());
+    context.setOfferId(UUID.randomUUID().toString());
+    context.setPlanId(UUID.randomUUID().toString());
+    wireMockServer.stubFor(
+        get(urlPathEqualTo(SUBSCRIPTIONS_AZURE_USAGE_CONTEXT))
+            .withQueryParam("orgId", equalTo(usage.getAggregateKey().getOrgId()))
+            .willReturn(okJson(toJson(context))));
+    return context;
+  }
+
+  public void stubAzureMarketplaceSubmitUsageEventForReturnsOk(AzureUsageContext contextForUsage) {
+    stubAzureMarketplaceAuthorization();
+    UsageEventOkResponse response = new UsageEventOkResponse();
+    response.setStatus(UsageEventStatusEnum.ACCEPTED);
+    wireMockServer.stubFor(
+        post(urlPathEqualTo(AZURE_SUBMIT_USAGE))
+            .withRequestBody(containing(contextForUsage.getPlanId()))
+            .willReturn(okJson(toJson(response))));
+  }
+
+  public void stubAzureMarketplaceSubmitUsageEventForReturnsStatus(
+      AzureUsageContext contextForUsage, int status) {
+    stubAzureMarketplaceAuthorization();
+    wireMockServer.stubFor(
+        post(urlPathEqualTo(AZURE_SUBMIT_USAGE))
+            .withRequestBody(containing(contextForUsage.getPlanId()))
+            .willReturn(aResponse().withStatus(status)));
+  }
+
+  public void stubAzureMarketplaceAuthorization() {
+    wireMockServer.stubFor(
+        post(urlPathEqualTo(AZURE_AUTHORIZATION))
+            .withRequestBody(containing("client_credentials"))
+            .willReturn(
+                okJson(
+                    """
+{
+  "access_token":"%s",
+  "token_type":"Bearer",
+  "expires_in":3600,
+  "refresh_token":"%s",
+  "scope":"create"
+}
+"""
+                        .formatted(UUID.randomUUID().toString(), UUID.randomUUID().toString()))));
+  }
+
+  public void verifyUsageIsSentToAzureMarketplace(AzureUsageContext contextForUsage) {
+    wireMockServer.verify(
+        postRequestedFor(urlPathEqualTo(AZURE_SUBMIT_USAGE))
+            .withRequestBody(containing(contextForUsage.getPlanId())));
+  }
+
+  private String toJson(Object object) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(object);
+    } catch (JsonProcessingException e) {
+      Assertions.fail(e);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-2726

## Description
According to the Azure Marketplace API documentation: https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis, it can return the following HTTP error codes:
- 400: invalid request 
- 403: forbidden 
- 409: conflict, the usage event has already been successfully reported.

The problem is that we're always throwing the "AzureMarketplaceRequestFailedException: AZURE_MARKETPLACE_API_REQUEST_FAILED: Hint: Check Azure credentials" exception regardless the HTTP error code and also trying other client tenant. 

This exception only makes sense after receiving a 403 forbidden. For the rest, we should log a trace for troubleshooting and stop trying to send the usage (since azure will return the same response).

## Changes
- Do not try to send usages or throw the exception if azure returns with an error code other than 403.
- Add test using wiremock to cover integration with azure
- Disable auto discovery of providers for Quarkus rest-client in aws and azure producers (the existing clients already configure the providers using either the property and/or the annotation)

## Testing
Added junit test to reproduce the issue. 
Since we need a Azure service, I think this can't be reproduced locally or in an ephemeral environment. 