### PR TITLE
SWATCH-2744: Optimize the capacity reconciliation query via indexing

### DIFF
--- a/src/main/resources/liquibase/202407231110-subscription-capacity-index.xml
+++ b/src/main/resources/liquibase/202407231110-subscription-capacity-index.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202407231110-01" author="khowell">
+    <dropIndex indexName="subscription_sku_idx" tableName="subscription"/>
+    <rollback>
+      <createIndex tableName="subscription" indexName="subscription_sku_idx">
+        <column name="sku"/>
+      </createIndex>
+    </rollback>
+  </changeSet>
+  <changeSet id="202407231110-02" author="khowell">
+    <createIndex tableName="subscription" indexName="subscription_sku_subs_id_start_date_idx">
+      <column name="sku"/>
+      <column name="subscription_id"/>
+      <column name="start_date" descending="true"/>
+    </createIndex>
+    <!-- rollback automatically generated -->
+  </changeSet>
+  <changeSet id="202407231110-03" author="khowell">
+    <createIndex tableName="subscription" indexName="subscription_sku_sub_number_start_date_idx">
+      <column name="sku"/>
+      <column name="subscription_number"/>
+      <column name="start_date" descending="true"/>
+    </createIndex>
+    <!-- rollback automatically generated -->
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -170,5 +170,6 @@
     <include file="/liquibase/202407030751-add-level-column-for-offering-table.xml"/>
     <include file="/liquibase/202407160722-drop-subscription-product-ids-table.xml"/>
     <include file="/liquibase/202407161214-clean-up-non-payg-measurements-on-rhel-systems.xml"/>
+    <include file="/liquibase/202407231110-subscription-capacity-index.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: SWATCH-2744

Description
===========

The throughput of capacity reconciliation is too low in stage to keep up with the task backlog. By modifying indexes, we can make the primary query slowing down the operation much faster.

Setup
-----

Generate some test data (this step took a couple of minutes on my machine):

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
insert into offering(sku) (select 'SKU'||sku from generate_series(1, 1000) sku);
insert into subscription(org_id, subscription_id, sku, start_date) (select org_id, sku::text || '/' || org_id, 'SKU'|| sku, now() from generate_series(1, 1000) org_id full outer join generate_series(1, 1000) sku on 1=1);
insert into subscription(org_id, subscription_id, sku, start_date) (select 'org' || subscription_id, 'FOOBAR' || subscription_id, 'SKU1', now() from generate_series(1,500000) subscription_id);
EOF
```

View the explain analyze plan for a typical reconcile query made before applying the index:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
explain analyze select se1_0.start_date,se1_0.subscription_id,se1_0.billing_account_id,se1_0.billing_provider,se1_0.billing_provider_id,se1_0.end_date,se1_0.sku,se1_0.org_id,se1_0.quantity,se1_0.subscription_number from subscription se1_0 where se1_0.sku='SKU1' order by se1_0.subscription_id,se1_0.start_date desc offset 100 rows fetch first 100 rows only;
EOF
```

<details>
<summary>Output</summary>
<pre>
                                                                       QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=30672.59..30684.26 rows=100 width=2108) (actual time=101.301..102.977 rows=100 loops=1)
   ->  Gather Merge  (cost=30660.93..78575.54 rows=410668 width=2108) (actual time=101.224..102.969 rows=200 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=29660.90..30174.24 rows=205334 width=2108) (actual time=95.951..95.956 rows=160 loops=3)
               Sort Key: subscription_id, start_date DESC
               Sort Method: top-N heapsort  Memory: 41kB
               Worker 0:  Sort Method: top-N heapsort  Memory: 41kB
               Worker 1:  Sort Method: top-N heapsort  Memory: 41kB
               ->  Parallel Seq Scan on subscription se1_0  (cost=0.00..20786.52 rows=205334 width=2108) (actual time=0.089..64.434 rows=167000 loops=3)
                     Filter: ((sku)::text = 'SKU1'::text)
                     Rows Removed by Filter: 333001
 Planning Time: 1.020 ms
 Execution Time: 103.095 ms
(14 rows)
</pre>
</details>

Apply the index via liquibase:

```shell
./gradlew :liquibaseUpdate
```

View the explain analyze plan again:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
explain analyze select se1_0.start_date,se1_0.subscription_id,se1_0.billing_account_id,se1_0.billing_provider,se1_0.billing_provider_id,se1_0.end_date,se1_0.sku,se1_0.org_id,se1_0.quantity,se1_0.subscription_number from subscription se1_0 where se1_0.sku='SKU1' order by se1_0.subscription_id,se1_0.start_date desc offset 100 rows fetch first 100 rows only;
EOF
```

<details>
<summary>Output</summary>
<pre>
                                                                                   QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=76.74..153.05 rows=100 width=2108) (actual time=0.461..0.934 rows=100 loops=1)
   ->  Index Scan using subscription_sku_subs_id_start_date_idx on subscription se1_0  (cost=0.43..376057.89 rows=492801 width=2108) (actual time=0.089..0.924 rows=200 loops=1)
         Index Cond: ((sku)::text = 'SKU1'::text)
 Planning Time: 0.415 ms
 Execution Time: 0.956 ms
(5 rows)
</pre>
</details>

Notice that with the index, rather than a sort operation, there is an index scan, and the execution time is vastly improved.

To clean up, rollback the liquibase changesets:

```shell
./gradlew :liquibaseRollbackCount -PliquibaseCommandValue=3
```

Then remove test data if desired:

```shell
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions <<EOF
delete from subscription where sku like 'SKU%';
delete from offering where sku like 'SKU%';
EOF
```