### PR TITLE
SWATCH-2746: Adjust log message that was logging an object with no toString

### DIFF
--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -232,7 +232,7 @@ public class SubscriptionDefinition {
     }
 
     if (filteredVariants.isEmpty()) {
-      log.warn("No variants found to uniquely identify a product: {}", sequentialPredicates);
+      log.info("No variants found to uniquely identify a product based on {}", params);
       return Set.of();
     } else {
       return filteredVariants;


### PR DESCRIPTION
The Predicate class does not have an implementation of toString, so logging instances of it does not provide useful information.

Jira issue: SWATCH-2746

## Description
This is a preliminary PR related to SWATCH-2746.  The message this PR adjusts is so numerous in the logs that it makes it very difficult to actually tell what's going on, so I'm aiming to get this merged to aid the debugging effort.

## Testing
None.