### PR TITLE
SWATCH-2730: Map instance guests in in CSV format

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/export/SubscriptionDataExporterService.java
@@ -74,23 +74,22 @@ public class SubscriptionDataExporterService
   static final String PRODUCT_ID = "product_id";
   static final String METRIC_ID = "metric_id";
   static final String CATEGORY = "category";
-  private final Map<String, Function<String, Specification<SubscriptionCapacityView>>>
-      filterFuntions =
-          Map.of(
-              PRODUCT_ID,
-              SubscriptionDataExporterService::handleProductIdFilter,
-              "usage",
-              SubscriptionDataExporterService::handleUsageFilter,
-              CATEGORY,
-              this::handleCategoryFilter,
-              "sla",
-              SubscriptionDataExporterService::handleSlaFilter,
-              METRIC_ID,
-              SubscriptionDataExporterService::handleMetricIdFilter,
-              "billing_provider",
-              SubscriptionDataExporterService::handleBillingProviderFilter,
-              "billing_account_id",
-              SubscriptionDataExporterService::handleBillingAccountIdFilter);
+  private final Map<String, Function<String, Specification<SubscriptionCapacityView>>> filters =
+      Map.of(
+          PRODUCT_ID,
+          SubscriptionDataExporterService::handleProductIdFilter,
+          "usage",
+          SubscriptionDataExporterService::handleUsageFilter,
+          CATEGORY,
+          this::handleCategoryFilter,
+          "sla",
+          SubscriptionDataExporterService::handleSlaFilter,
+          METRIC_ID,
+          SubscriptionDataExporterService::handleMetricIdFilter,
+          "billing_provider",
+          SubscriptionDataExporterService::handleBillingProviderFilter,
+          "billing_account_id",
+          SubscriptionDataExporterService::handleBillingAccountIdFilter);
 
   private final ApiModelMapperV1 mapper;
   private final SubscriptionCapacityViewRepository repository;
@@ -120,10 +119,10 @@ public class SubscriptionDataExporterService
       ExportServiceRequest request) {
     Specification<SubscriptionCapacityView> criteria = buildSearchSpecification(request.getOrgId());
     if (request.getFilters() != null) {
-      var filters = request.getFilters().entrySet();
+      var requestedFilters = request.getFilters().entrySet();
       try {
-        for (var entry : filters) {
-          var filterHandler = filterFuntions.get(entry.getKey().toLowerCase(Locale.ROOT));
+        for (var entry : requestedFilters) {
+          var filterHandler = filters.get(entry.getKey().toLowerCase(Locale.ROOT));
           if (filterHandler == null) {
             log.warn("Filter '{}' isn't currently supported. Ignoring.", entry.getKey());
           } else if (entry.getValue() != null) {

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
@@ -23,22 +23,35 @@ package org.candlepin.subscriptions.tally.export;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.Variant;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.ObjDoubleConsumer;
 import lombok.AllArgsConstructor;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.Host;
 import org.candlepin.subscriptions.db.model.TallyInstanceView;
 import org.candlepin.subscriptions.export.DataMapperService;
 import org.candlepin.subscriptions.export.ExportServiceRequest;
 import org.candlepin.subscriptions.json.InstancesExportCsvItem;
 import org.candlepin.subscriptions.util.ApiModelMapperV1;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
 public class InstancesCsvDataMapperService implements DataMapperService<TallyInstanceView> {
 
+  private static final String RHEL_FOR_X86 = "RHEL for x86";
+  private static final int MAX_GUESTS_PER_QUERY = 20;
+
   private final ApiModelMapperV1 mapper;
+  private final HostRepository hostRepository;
 
   public static final Map<MetricId, ObjDoubleConsumer<InstancesExportCsvItem>> METRIC_MAPPER =
       Map.of(
@@ -53,6 +66,7 @@ public class InstancesCsvDataMapperService implements DataMapperService<TallyIns
 
   @Override
   public List<Object> mapDataItem(TallyInstanceView item, ExportServiceRequest request) {
+    List<Object> dataItems = new ArrayList<>();
     var instance = new InstancesExportCsvItem();
     instance.setId(item.getId());
     instance.setInstanceId(item.getKey().getInstanceId());
@@ -76,7 +90,16 @@ public class InstancesCsvDataMapperService implements DataMapperService<TallyIns
     }
     instance.setLastSeen(item.getLastSeen());
     instance.setHypervisorUuid(item.getHypervisorUuid());
-    return List.of(instance);
+    instance.setNumberOfGuests(item.getNumOfGuests());
+    instance.setSubscriptionManagerId(item.getSubscriptionManagerId());
+    instance.setInventoryId(item.getInventoryId());
+    dataItems.add(instance);
+
+    if (needsToExportGuests(item)) {
+      dataItems.addAll(mapGuests(item));
+    }
+
+    return dataItems;
   }
 
   @Override
@@ -87,5 +110,47 @@ public class InstancesCsvDataMapperService implements DataMapperService<TallyIns
   @Override
   public Class<?> getExportItemClass() {
     return InstancesExportCsvItem.class;
+  }
+
+  private boolean needsToExportGuests(TallyInstanceView item) {
+    return item.getNumOfGuests() > 0
+        && RHEL_FOR_X86.equals(item.getKey().getProductId())
+        && HardwareMeasurementType.HYPERVISOR.equals(item.getKey().getMeasurementType());
+  }
+
+  private List<InstancesExportCsvItem> mapGuests(TallyInstanceView item) {
+    var guestsInInstance =
+        getGuestHostsByHypervisorInstanceId(item, PageRequest.ofSize(MAX_GUESTS_PER_QUERY));
+    Set<InstancesExportCsvItem> guests =
+        new HashSet<>(toInstancesExportCsvItem(guestsInInstance.getContent()));
+    while (guestsInInstance.hasNext()) {
+      guestsInInstance = getGuestHostsByHypervisorInstanceId(item, guestsInInstance.nextPageable());
+      guests.addAll(toInstancesExportCsvItem(guestsInInstance.getContent()));
+    }
+
+    return new ArrayList<>(guests);
+  }
+
+  private List<InstancesExportCsvItem> toInstancesExportCsvItem(List<Host> guests) {
+    return guests.stream()
+        .map(
+            guest ->
+                new InstancesExportCsvItem()
+                    .withId(guest.getId().toString())
+                    .withDisplayName(guest.getDisplayName())
+                    .withInventoryId(guest.getInventoryId())
+                    .withHardwareType(
+                        guest.getHardwareType() == null ? null : guest.getHardwareType().toString())
+                    .withInstanceId(guest.getInstanceId())
+                    .withSubscriptionManagerId(guest.getSubscriptionManagerId())
+                    .withHypervisorUuid(guest.getHypervisorUuid())
+                    .withLastSeen(guest.getLastSeen()))
+        .toList();
+  }
+
+  private Page<Host> getGuestHostsByHypervisorInstanceId(
+      TallyInstanceView item, Pageable pageRequest) {
+    return hostRepository.getGuestHostsByHypervisorInstanceId(
+        item.getOrgId(), item.getKey().getInstanceId(), pageRequest);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -133,9 +133,9 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
             .month(InstanceMonthlyTotalKey.formatMonthId(OffsetDateTime.now()));
     var mandatoryFilters = new ArrayList<>(MANDATORY_FILTERS);
     if (request.getFilters() != null) {
-      var filters = request.getFilters().entrySet();
+      var requestedFilters = request.getFilters().entrySet();
       try {
-        for (var entry : filters) {
+        for (var entry : requestedFilters) {
           mandatoryFilters.remove(entry.getKey());
           var filterHandler = FILTERS.get(entry.getKey().toLowerCase(Locale.ROOT));
           if (filterHandler == null) {

--- a/swatch-core/schemas/instances_export_csv_item.yaml
+++ b/swatch-core/schemas/instances_export_csv_item.yaml
@@ -3,6 +3,10 @@ title: InstancesExportCsvItem
 properties:
   id:
     type: string
+  inventory_id:
+    type: string
+  subscription_manager_id:
+    type: string
   instance_id:
     type: string
   display_name:
@@ -35,4 +39,9 @@ properties:
     format: date-time
     type: string
   hypervisor_uuid:
+    type: string
+  number_of_guests:
+    type: integer
+  hardware_type:
+    description: (Only for guests) What the type of the host is (e.g. hypervisor, physical, etc.).
     type: string


### PR DESCRIPTION
Jira issue: SWATCH-2730

## Description
Changes:
- Export "inventory_id", "subscription_manager_id" for regular and guests instances (this data is also exported in the JSON format)
- Export "number_of_guests" for regular instances
- Export the guests data if and only if the instance is "RHEL for x86" and the category is HYPERVISOR.
- For the guests data, it will export the following information: display_name, inventory_id, inventory_id, hardware_type, instance_id, subscription_manager_id, last_seen

Note that the linked JIRA also asked to export the "hypervisor_uuid" but this was already exported.

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/806

Updated tests to verify the export of the "number_of_guests" field.