### PR TITLE
Add kafka-bridge to EE deployment

### DIFF
--- a/deploy_ephemeral_env.sh
+++ b/deploy_ephemeral_env.sh
@@ -37,4 +37,5 @@ bonfire deploy \
     ${COMPONENTS_ARG} \
     ${COMPONENTS_RESOURCES_ARG} \
     ${EXTRA_DEPLOY_ARGS}
+./deploy_kafka_bridge.sh
 set +x

--- a/deploy_kafka_bridge.sh
+++ b/deploy_kafka_bridge.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+NAMESPACE=${NAMESPACE:-$(oc project -q)}
+KAFKA_BOOTSTRAP_SERVERS=$(oc get -n $NAMESPACE kafka -o go-template --template='{{ range .items }}{{ range .status.listeners }}{{ .bootstrapServers }}{{ end }}{{ end }}')
+oc process --local=true -f kafka-bridge.yaml -p KAFKA_BOOTSTRAP_SERVERS=$KAFKA_BOOTSTRAP_SERVERS | oc apply -n $NAMESPACE -f -
+echo "In the EE, the kafka-bridge URL is http://kafka-bridge-bridge-service:8080"
+echo "To port-forward, use:"
+echo "  oc port-forward svc/kafka-bridge-bridge-service 8080:8080"

--- a/kafka-bridge.yaml
+++ b/kafka-bridge.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: kafka-bridge
+parameters:
+- name: KAFKA_BOOTSTRAP_SERVERS
+
+objects:
+- apiVersion: kafka.strimzi.io/v1beta2
+  kind: KafkaBridge
+  metadata:
+    name: kafka-bridge
+  spec:
+    bootstrapServers: ${KAFKA_BOOTSTRAP_SERVERS}
+    http:
+      port: 8080
+    replicas: 1


### PR DESCRIPTION
Testing
-------

Reserve an ephemeral environment:

```sh
bonfire namespace reserve
```

Deploy the kafka bridge

```sh
./deploy_kafka_bridge.sh
```

Note the deployment may take a few moments before being available.

Smoke test querying topics in the EE:

```sh
oc rsh $(oc get pod -o name | grep kafka-bridge) curl http://kafka-bridge-bridge-service:8080/topics
```

Port-forward and query topics locally:

```sh
oc port-forward svc/kafka-bridge-bridge-service 8080:8080&
sleep 2
curl http://localhost:8080/topics
kill %1
```

Also see EE logs for the CI pr check to confirm the bridge deployed successfully for CI.