### PR TITLE
SWATCH-2410: sort the metrics alphabetically in Subscription API v2

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableController.java
@@ -30,6 +30,7 @@ import jakarta.validation.constraints.Min;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -314,7 +315,9 @@ public class SubscriptionTableController {
     }
 
     private static List<MetricId> getMetricsFromProduct(ProductId productId) {
-      return MetricIdUtils.getMetricIdsFromConfigForTag(productId.toString()).toList();
+      return MetricIdUtils.getMetricIdsFromConfigForTag(productId.toString())
+          .sorted(Comparator.comparing(MetricId::getValue))
+          .toList();
     }
 
     public Stream<MetricId> stream() {


### PR DESCRIPTION
Jira issue: SWATCH-2410

## Description
When filtering by different products, the order the metrics might be diferent: for example, for "rosa": ['Instance-hours', 'Cores'] and for "OpenShift-dedicated-metrics": ['Cores', 'Instance-hours'].

This is because the metrics are defined at this order. 

In the Instances API, we're sorting the metrics by alphabetical order, so we should do the same in the new Subscriptions API v2. This will simplify a lot the test automation.

## Testing
Only regression testing. 