### PR TITLE
SWATCH-2701 Reduce number of tally snapshot queries load to db

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducer.java
@@ -23,14 +23,16 @@ package org.candlepin.subscriptions.tally;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.TallySummary;
+import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,54 +67,62 @@ public class SnapshotSummaryProducer {
   public void produceTallySummaryMessages(Map<String, List<TallySnapshot>> newAndUpdatedSnapshots) {
     AtomicInteger totalTallies = new AtomicInteger();
     newAndUpdatedSnapshots.forEach(
-        (orgId, snapshots) -> {
-          // Filter snapshots, as we only deal with hourly and non Any fields when we transmit the
-          // tally summary message to the BillableUsage component.
-          List<TallySnapshot> filteredSnapshots =
-              snapshots.stream()
-                  .filter(
-                      snapshot ->
-                          snapshot.getGranularity().equals(Granularity.HOURLY)
-                              && !snapshot.getServiceLevel().equals(ServiceLevel._ANY)
-                              && !snapshot.getUsage().equals(Usage._ANY)
-                              && !snapshot.getBillingProvider().equals(BillingProvider._ANY)
-                              && !snapshot.getBillingAccountId().equals("_ANY"))
-                  .sorted(Comparator.comparing(TallySnapshot::getSnapshotDate))
-                  .toList();
-
-          filteredSnapshots.forEach(
-              snapshot -> {
-                TallySummary summary = summaryMapper.mapSnapshots(orgId, List.of(snapshot));
-
-                if (validateTallySummary(summary)) {
-                  kafkaRetryTemplate.execute(
-                      ctx -> tallySummaryKafkaTemplate.send(tallySummaryTopic, orgId, summary));
-                  totalTallies.getAndIncrement();
-                }
-              });
-        });
+        (orgId, snapshots) ->
+            /* Filter snapshots, as we only deal with hourly, non Any fields
+            and measurement types other than Total
+            when we transmit the tally summary message to the BillableUsage component. */
+            snapshots.stream()
+                .filter(this::filterByHourlyAndNotAnySnapshots)
+                .map(
+                    snapshot -> {
+                      removeTotalMeasurements(snapshot);
+                      return snapshot;
+                    })
+                .sorted(Comparator.comparing(TallySnapshot::getSnapshotDate))
+                .map(snapshot -> summaryMapper.mapSnapshots(orgId, List.of(snapshot)))
+                .forEach(
+                    summary -> {
+                      kafkaRetryTemplate.execute(
+                          ctx -> tallySummaryKafkaTemplate.send(tallySummaryTopic, orgId, summary));
+                      totalTallies.getAndIncrement();
+                    }));
 
     log.info("Produced {} TallySummary messages", totalTallies);
   }
 
+  private boolean filterByHourlyAndNotAnySnapshots(TallySnapshot snapshot) {
+    return snapshot.getGranularity().equals(Granularity.HOURLY)
+        && !snapshot.getServiceLevel().equals(ServiceLevel._ANY)
+        && !snapshot.getUsage().equals(Usage._ANY)
+        && !snapshot.getBillingProvider().equals(BillingProvider._ANY)
+        && !snapshot.getBillingAccountId().equals(ResourceUtils.ANY)
+        && hasMeasurements(snapshot);
+  }
+
+  private void removeTotalMeasurements(TallySnapshot snapshot) {
+    if (Objects.nonNull(snapshot.getTallyMeasurements())) {
+      snapshot
+          .getTallyMeasurements()
+          .entrySet()
+          .removeIf(
+              entry -> HardwareMeasurementType.TOTAL.equals(entry.getKey().getMeasurementType()));
+    }
+  }
+
   /**
-   * Validates a TallySummary to make sure that it has all the information required by the RH
-   * marketplace API. Any issues will be logged.
+   * Validates TallySnapshot measurements to make sure that it has all the information required by
+   * the RH marketplace API. Any issues will be logged.
    *
-   * @param summary the summary to validate.
-   * @return true if the TallySummary is valid, false otherwise.
+   * @param snapshot the TallySnapshot to validate.
+   * @return true if the TallySnapshot is valid, false otherwise.
    */
-  private boolean validateTallySummary(TallySummary summary) {
-    // RH Marketplace requires at least one measurement be included in the Event
-    Optional<org.candlepin.subscriptions.json.TallySnapshot> invalidDueToMeasurements =
-        summary.getTallySnapshots().stream()
-            .filter(snap -> snap.getTallyMeasurements().isEmpty())
-            .findFirst();
-    if (invalidDueToMeasurements.isPresent()) {
+  private boolean hasMeasurements(TallySnapshot snapshot) {
+    if (!Objects.nonNull(snapshot.getTallyMeasurements())
+        || snapshot.getTallyMeasurements().isEmpty()) {
       log.warn(
-          "One or more tally summary snapshots did not have measurements. "
-              + "No usage will be sent to RH marketplace for this summary.\n{}",
-          summary);
+          "Tally snapshot did not have measurements. "
+              + "No usage will be sent to RH marketplace for this snapshot.\n{}",
+          snapshot);
       return false;
     }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -158,12 +158,12 @@ class SnapshotSummaryProducerTest {
     assertEquals(granularity.toString(), snapshot.getGranularity().value().toUpperCase());
     assertEquals(sla.toString(), snapshot.getSla().value().toUpperCase());
     assertEquals(usage.toString(), snapshot.getUsage().value().toUpperCase());
-    assertEquals(2, snapshot.getTallyMeasurements().size());
+    assertEquals(1, snapshot.getTallyMeasurements().size());
 
     Map<String, List<TallyMeasurement>> measurements =
         snapshot.getTallyMeasurements().stream()
             .collect(Collectors.groupingBy(TallyMeasurement::getHardwareMeasurementType));
-    assertMeasurement(measurements, "TOTAL", uom, value);
+    assertTrue(Optional.ofNullable(measurements.get("TOTAL")).isEmpty());
     assertMeasurement(measurements, "PHYSICAL", uom, value);
   }
 

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -93,6 +93,7 @@ class SnapshotSummaryProducerTest {
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
                 BillingProvider.RED_HAT,
+                "12345",
                 MetricIdUtils.getCores().getValue(),
                 20.4)));
     updateMap.put(
@@ -105,6 +106,7 @@ class SnapshotSummaryProducerTest {
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
                 BillingProvider.AWS,
+                "12345",
                 MetricIdUtils.getCores().getValue(),
                 22.2)));
     producer.produceTallySummaryMessages(updateMap);
@@ -178,6 +180,7 @@ class SnapshotSummaryProducerTest {
                 ServiceLevel.PREMIUM,
                 Usage.PRODUCTION,
                 BillingProvider.RED_HAT,
+                "12345",
                 MetricIdUtils.getCores().getValue(),
                 20.4)));
     updateMap.get("a1").get(0).getTallyMeasurements().clear();
@@ -208,6 +211,7 @@ class SnapshotSummaryProducerTest {
       ServiceLevel sla,
       Usage usage,
       BillingProvider billingProvider,
+      String billingAccountId,
       String metricId,
       double val) {
     Map<TallyMeasurementKey, Double> measurements = new HashMap<>();
@@ -222,6 +226,7 @@ class SnapshotSummaryProducerTest {
         .serviceLevel(sla)
         .usage(usage)
         .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
         .build();
   }
 }


### PR DESCRIPTION
When we were sending tally summary messages, we were unnecessarily sending 32 messages since it was getting filtered on Billable usage component. But before that it was querying table 64 times for just one instance. This update filters those messages upfront to avoid redundant processing.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2701

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->
QE decided to have it as regression only.

### Setup
<!-- Add any steps required to set up the test case -->
1.  `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun`

2.  Opt-in the org and insert record in events table for hourly tally
```
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('8c57046a-7071-4fc9-a543-650b868edcc0', '2024-06-21 16:00:00.000000 +00:00', '{"sla": "Premium", "org_id": "12345678", "event_id": "8c57046a-7071-4fc9-a543-650b868edcc0", "timestamp": "2024-06-21T16:00:00Z", "conversion": false, "event_type": "snapshot_rhel-for-x86-els-payg_vcpus", "expiration": "2024-06-21T17:00:00Z", "instance_id": "efe37aa6-ac56-41df-8c8a-c260bd498f5b", "product_ids": ["204", "69"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-07-24T18:40:04.224170097Z", "display_name": "ip-10-128-200-231.ec2.internal", "event_source": "rhelemeter", "measurements": [{"value": 5.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "billing_provider": "aws", "metering_batch_id": "6f4611df-8acf-48c8-9bf4-4a439ff59034", "billing_account_id": "customerAccount12345678"}', 'snapshot_rhel-for-x86-els-payg_vcpus', 'rhelemeter', 'efe37aa6-ac56-41df-8c8a-c260bd498f5b', '12345678', '6f4611df-8acf-48c8-9bf4-4a439ff59034', '2024-07-24 18:40:04.224000 +00:00');
```

### Steps on Main branch
<!-- Enter each step of the test below -->
1. Execute Hourly tally
```
 http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=12345678" x-rh-swatch-psk:placeholder
```

### Verification in Debug logs that will show 64 times the query is made
<!-- Enter the steps needed to verify the test passed -->
```
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,875 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,879 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,880 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,902 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,904 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,904 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,904 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,904 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,905 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,905 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,905 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,905 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,905 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,905 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,905 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,905 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,907 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,908 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,910 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,913 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,915 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,918 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,921 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,922 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,924 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,926 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,928 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,930 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,932 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,932 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,932 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,933 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,935 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,937 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,938 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,940 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,942 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,944 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,946 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,948 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,950 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,951 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,952 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,953 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,955 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,957 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,959 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,961 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,961 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [TOTAL]
2024-07-24 20:14:20,961 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,961 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,961 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,961 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,961 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,961 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,962 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,962 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-24 20:14:20,962 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,962 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T00:00Z]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [_ANY]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-24 20:14:20,964 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibern
```

Verify that you see more tally summary messages from tally to Billableusage component
```
2024-07-26 17:07:39,180 [thread=rhsm-subscriptions-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.SnapshotSummaryProducer] - Produced 32 TallySummary messages
```

---------------

### Steps on current branch with the fix
<!-- Enter each step of the test below -->
1.

### Verification in Debug logs
<!-- Enter the steps needed to verify the test passed -->
```
2024-07-26 16:34:00,395 [thread=rhsm-subscriptions-task-processor-0-C-1] [DEBUG] [org.hibernate.SQL] - select coalesce(sum(tm1_0.value),0.0) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id and (tm1_0.measurement_type,tm1_0.metric_id)=(?,?) where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date>=? and ts1_0.snapshot_date<=?
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (1:VARCHAR) <- [PHYSICAL]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (2:VARCHAR) <- [VCPUS]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (3:VARCHAR) <- [12345678]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (4:VARCHAR) <- [rhel-for-x86-els-payg]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (5:VARCHAR) <- [HOURLY]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (6:VARCHAR) <- [Premium]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (7:VARCHAR) <- [Production]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (8:VARCHAR) <- [aws]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (9:VARCHAR) <- [customerAccount12345678]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (10:TIMESTAMP_UTC) <- [2024-06-01T00:00Z]
2024-07-26 16:34:00,396 [thread=rhsm-subscriptions-task-processor-0-C-1] [TRACE] [org.hibernate.orm.jdbc.bind] - binding parameter (11:TIMESTAMP_UTC) <- [2024-06-21T16:00Z]
```

Verify only fewer tally summary messages sent:
```
2024-07-26 17:07:39,180 [thread=rhsm-subscriptions-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.tally.SnapshotSummaryProducer] - Produced 1 TallySummary messages
```

In tally Kafka message consumer:
```
{
  "org_id": "12345678",
  "tally_snapshots": [
    {
      "id": "df70c40e-a9b1-4332-945a-efc95b694e61",
      "billing_provider": "aws",
      "billing_account_id": "customerAccount12345678",
      "snapshot_date": "2024-06-21T16:00:00Z",
      "product_id": "rhel-for-x86-els-payg",
      "sla": "Premium",
      "usage": "Production",
      "granularity": "Hourly",
      "tally_measurements": [
        {
          "hardware_measurement_type": "PHYSICAL",
          "metric_id": "VCPUS",
          "value": 5.0,
          "currentTotal": 5.0
        }
      ]
    }
  ]
}
```

We should see a drop in below graph in RDS:
![Screenshot from 2024-07-30 09-48-51](https://github.com/user-attachments/assets/a974eba0-a097-4fad-866a-6a96eed25ea9)
