### PR TITLE
SWATCH-2676: Update to error handling on SKU sync

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.contract.resource;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.redhat.swatch.clients.product.api.resources.ApiException;
 import com.redhat.swatch.contract.config.ApplicationConfiguration;
 import com.redhat.swatch.contract.model.SyncResult;
 import com.redhat.swatch.contract.openapi.model.AwsUsageContext;
@@ -37,7 +38,6 @@ import com.redhat.swatch.contract.openapi.model.RpcResponse;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.openapi.model.SubscriptionResponse;
 import com.redhat.swatch.contract.openapi.model.TerminationRequest;
-import com.redhat.swatch.contract.openapi.resource.ApiException;
 import com.redhat.swatch.contract.openapi.resource.DefaultApi;
 import com.redhat.swatch.contract.product.umb.CanonicalMessage;
 import com.redhat.swatch.contract.product.umb.UmbSubscription;
@@ -67,7 +67,7 @@ import org.jboss.resteasy.reactive.common.NotImplementedYet;
 @Slf4j
 @ApplicationScoped
 @AllArgsConstructor
-public class ContractsTestingResource implements DefaultApi {
+public class ContractsResource implements DefaultApi {
 
   public static final String FEATURE_NOT_ENABLED_MESSAGE = "This feature is not currently enabled.";
   private static final String SUCCESS_STATUS = "Success";
@@ -321,14 +321,13 @@ public class ContractsTestingResource implements DefaultApi {
   @RolesAllowed({"test", "support", "service"})
   public OfferingResponse syncOffering(String sku) throws ProcessingException {
     var response = new OfferingResponse();
+    SyncResult result = null;
     try {
       log.info("Sync for offering {}", sku);
-      SyncResult result = offeringSyncService.syncOffering(sku);
+      result = offeringSyncService.syncOffering(sku);
       response.detail(String.format("%s for offeringSku=\"%s\".", result, sku));
-    } catch (Exception e) {
-      log.error("Error syncing offering", e.getMessage());
-      if (e.getCause() instanceof ApiException) {
-        ApiException apiException = (ApiException) e.getCause();
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof ApiException apiException) {
         switch (apiException.getResponse().getStatus()) {
           case 400:
             throw new BadRequestException(apiException.getMessage());
@@ -340,7 +339,12 @@ public class ContractsTestingResource implements DefaultApi {
             throw new InternalServerErrorException(apiException.getMessage());
         }
       }
-      response.setDetail("Error syncing offering");
+      throw new InternalServerErrorException(e.getMessage());
+    }
+    if (SyncResult.SKIPPED_NOT_FOUND.equals(result)) {
+      throw new NotFoundException(result.description());
+    } else if (SyncResult.SKIPPED_DENYLISTED.equals(result)) {
+      throw new ForbiddenException(result.description());
     }
     return response;
   }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.contract.resource;
 import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.exception.ServiceException;
 import com.redhat.swatch.contract.openapi.model.Error;
+import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -47,6 +48,8 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
       return Response.status(RestResponse.Status.NOT_IMPLEMENTED).build();
     } else if (exception instanceof ServiceException e) {
       return Response.status(e.getStatus()).entity(e.error()).build();
+    } else if (exception instanceof ClientErrorException clientErrorException) {
+      return Response.status(clientErrorException.getResponse().getStatus()).build();
     }
 
     var status = Status.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2676

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
The /internal/rpc/offerings/sync/{sku} always returns code 200 regardless of the outcome.
In scenarios where that is not the correct response the code will be what is expected


## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/809

### Steps
<!-- Enter each step of the test below -->
1. The unit tests have been updated for the new response. They should run correctly.
2. An IQE test is added as noted above.

### Verification
1. Tests pass

