### PR TITLE
SWATCH-2772: Set the OTEL protocol to grpc explicitly.

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -67,6 +67,8 @@ parameters:
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: 'grpc'
 
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
@@ -133,6 +135,8 @@ objects:
                         key: db.name
                   - name: OTEL_EXPORTER_OTLP_ENDPOINT
                     value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                    value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
                   - name: OTEL_SERVICE_NAME
                     value: ${OTEL_SERVICE_NAME}
                   - name: OTEL_JAVAAGENT_ENABLED
@@ -234,6 +238,8 @@ objects:
                 value: ${SPLUNK_HEC_TERMINATION_TIMEOUT}
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
               - name: OTEL_SERVICE_NAME
                 value: ${OTEL_SERVICE_NAME}
               - name: OTEL_JAVAAGENT_ENABLED
@@ -293,6 +299,8 @@ objects:
               value: ${DEV_MODE}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
             - name: OTEL_SERVICE_NAME
               value: swatch-api-nginx-proxy
             volumeMounts:

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -153,7 +153,9 @@ quarkus.otel.sdk.disabled=true
 %stage.quarkus.otel.sdk.disabled=false
 %prod.quarkus.otel.sdk.disabled=false
 
-quarkus.otel.exporter.otlp.endpoint=http://splunk-otel-collector:4317
+quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-otel-collector:4317}
+# Metrics and logging are not yet supported - 30 Jul 2024
+quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}
 
 # configuration properties for contracts client
 rhsm-subscriptions.contracts.use-stub=${CONTRACT_USE_STUB:false}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -287,8 +287,9 @@ quarkus.otel.sdk.disabled=true
 
 quarkus.hibernate-orm.mapping.timezone.default-storage=normalize-utc
 
-OTEL_ENDPOINT=http://splunk-otel-collector:4317
-quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT}
+quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-otel-collector:4317}
+# Metrics and logging are not yet supported - 30 Jul 2024
+quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}
 
 # expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
 quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -132,6 +132,8 @@ parameters:
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: 'grpc'
   - name: METRICS_HEALTH_LIVENESS_PATH
     value: /health/live
   - name: METRICS_HEALTH_READY_PATH
@@ -271,6 +273,8 @@ objects:
                 value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
               - name: OTEL_SERVICE_NAME
                 value: ${OTEL_SERVICE_NAME}
               - name: OTEL_JAVAAGENT_ENABLED
@@ -468,6 +472,8 @@ objects:
                 value: ${ENABLE_SYNCHRONOUS_OPERATIONS}
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+              - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
               - name: OTEL_SERVICE_NAME
                 value: swatch-metrics-rhel
               - name: OTEL_JAVAAGENT_ENABLED

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -100,7 +100,10 @@ quarkus:
   otel:
     exporter:
       otlp:
-        endpoint: http://splunk-otel-collector:4317
+        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-otel-collector:4317}
+        # Metrics and logging are not yet supported - 30 Jul 2024
+        traces:
+          protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}
     sdk:
       disabled: true
   kafka:

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -133,4 +133,6 @@ quarkus.otel.sdk.disabled=true
 %stage.quarkus.otel.sdk.disabled=false
 %prod.quarkus.otel.sdk.disabled=false
 
-quarkus.otel.exporter.otlp.endpoint=http://splunk-otel-collector:4317
+quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-otel-collector:4317}
+# Metrics and logging are not yet supported - 30 Jul 2024
+quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -145,4 +145,6 @@ quarkus.otel.sdk.disabled=true
 %stage.quarkus.otel.sdk.disabled=false
 %prod.quarkus.otel.sdk.disabled=false
 
-quarkus.otel.exporter.otlp.endpoint=http://splunk-otel-collector:4317
+quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-otel-collector:4317}
+# Metrics and logging are not yet supported - 30 Jul 2024
+quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -139,6 +139,8 @@ parameters:
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: 'grpc'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -375,6 +377,8 @@ objects:
               value: ${ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
             - name: OTEL_SERVICE_NAME
               value: ${OTEL_SERVICE_NAME}
             - name: OTEL_JAVAAGENT_ENABLED

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -155,6 +155,8 @@ parameters:
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: 'grpc'
 
 # allow overriding to support independent deploy with bonfire
   - name: DB_POD
@@ -444,6 +446,8 @@ objects:
                   fieldPath: metadata.namespace
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
             - name: OTEL_SERVICE_NAME
               value: ${OTEL_SERVICE_NAME}
             - name: OTEL_JAVAAGENT_ENABLED

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -112,6 +112,8 @@ parameters:
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: 'grpc'
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -188,6 +190,8 @@ objects:
                       key: db.name
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                  value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
                 - name: OTEL_SERVICE_NAME
                   value: ${OTEL_SERVICE_NAME}
                 - name: OTEL_JAVAAGENT_ENABLED
@@ -331,6 +335,8 @@ objects:
               value: ${RHSM_API_MAX_WAIT_DURATION}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
             - name: OTEL_SERVICE_NAME
               value: ${OTEL_SERVICE_NAME}
             - name: OTEL_JAVAAGENT_ENABLED

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -216,6 +216,8 @@ parameters:
     value: 'false'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'http://localhost:4317'
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: 'grpc'
   - description: database secret name
     name: FLOORIST_DB_SECRET_NAME
     value: swatch-tally-db
@@ -450,6 +452,8 @@ objects:
               value: ${HOST_LAST_SYNC_THRESHOLD}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: ${OTEL_EXPORTER_OTLP_PROTOCOL}
             - name: OTEL_SERVICE_NAME
               value: ${OTEL_SERVICE_NAME}
             - name: OTEL_JAVAAGENT_ENABLED


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2772

## Description
The update to splunk-otel-javaagent from 1.32.2 to 2.50 (e4b293d440c92c3ae4d24c717fb470d14e4a8dac) introduced a breaking change described at
https://github.com/signalfx/splunk-otel-java/blob/main/CHANGELOG.md#%EF%B8%8F%EF%B8%8F-breaking-changes-%EF%B8%8F%EF%B8%8F-2

The protocol default went from grpc to http/protobuf (seemingly without consideration for the port specified in the endpoint URL which should indicate the desired protocol).  This commit sets the protocol to grpc everywhere. It also sets our application configuration to be sensitive to the value of the OTEL_EXPORTER_OTLP_ENDPOINT environment variable. Previously, we were not respecting this environment variable in some places.

## Testing

### Setup
1. Check out the `rhsm/splunk-otel-collector` repo from Gitlab.
1. Edit the `deploy/splunk-otel-collector.yaml` and remove/comment out the `ClusterRole` and `ClusterRoleBinding`.  We don't have permissions for those in the EEs.
1. Create a `splunk-otel-collector` secret like so
    ```yaml
    apiVersion: v1                                                                                                                                                                                   
    data:                                                                                                                                                                                            
      splunk_observability_access_token: SGVsbG8gV29ybGQ=                                                                                                                                            
    kind: Secret                                                                                                                                                                                     
    metadata:                                                                                                                                                                                        
      creationTimestamp: "2024-07-30T18:36:42Z"                                                                                                                                                      
      name: splunk-otel-collector                                                                                                                                                                    
      namespace: ephemeral-zmm6xg                                                                                                                                                                    
      resourceVersion: "515984217"                                                                                                                                                                   
      uid: 4ca5de45-392e-433f-8fa3-dc1433367497                                                                                                                                                      
    type: Opaque
    ```
1. Set up a bonfire config for splunk in your `~/.config/bonfire/config.yaml`
    ```yaml
    apps:                                                                                                                                                                                                
    - name: splunk
      components:
        - name: otel-collector
          host: local
          repo: YOUR_CHECKOUT_DIRECTORY_HERE
          path: /deploy/splunk-otel-collector.yaml
    ```
1. Deploy `splunk` like so
    ```
    bonfire deploy -C otel-collector --source=appsre --ref-env=insights-production --no-remove-resources app:rhsm --frontends=false -p otel-collector/K8S_CLUSTER_NAME=ephemeral -p otel-collector/COLLECTOR_NAMESPACE=ephemeral splunk
    ```
1.  Do an EE deployment with `OTEL_JAVAAGENT_ENABLED=true` for `swatch-tally`.  Here's how I do mine
    ```
    bin/build-images.sh
    VER=$(git rev-parse --short=7 HEAD) ;  bonfire deploy rhsm \                                                                                                                                     
    --source=appsre \                                                                                                                                                                                
    --ref-env insights-production \                                                                                                                                                                  
    --optional-deps-method none \                                                                                                                                                                    
    --frontends false \                                                                                                                                                                              
    --no-remove-resources app:rhsm \                                                                                                                                                                 
    --timeout 900 \                                                                                                                                                                                  
    -i quay.io/awood/swatch-metrics=$VER \                                                                                                                                                           
    -i quay.io/awood/rhsm-subscriptions=$VER \                                                                                                                                                       
    -i quay.io/awood/swatch-contracts=$VER \                                                                                                                                                         
    -i quay.io/awood/swatch-producer-aws=$VER \                                                                                                                                                      
    -i quay.io/awood/swatch-producer-azure=$VER \                                                                                                                                                    
    -i quay.io/awood/swatch-system-conduit=$VER \                                                                                                                                                    
    -p swatch-metrics/IMAGE=quay.io/awood/swatch-metrics \                                                                                                                                           
    -p swatch-tally/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                                         
    -p swatch-api/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                                           
    -p swatch-contracts/IMAGE=quay.io/awood/swatch-contracts \                                                                                                                                       
    -p swatch-producer-aws/IMAGE=quay.io/awood/swatch-producer-aws \                                                                                                                                 
    -p swatch-producer-azure/IMAGE=quay.io/awood/swatch-producer-azure \                                                                                                                             
    -p swatch-system-conduit/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                                
    -p swatch-system-conduit/CONDUIT_IMAGE=quay.io/awood/swatch-system-conduit \                                                                                                                     
    -p swatch-producer-red-hat-marketplace/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                  
    -p swatch-subscription-sync/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                             
    -p swatch-tally/OTEL_JAVAAGENT_ENABLED=true \
    -p swatch-tally/OTEL_EXPORTER_OTLP_ENDPOINT=http://splunk-otel-collector:4317
    ```

### Steps
1.  You will see a log message in the start-up log for `tally-service` that says
    ```
     [otel.javaagent 2024-07-30 18:48:22:690 +0000] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: splunk-2.5.0-otel-2.5.0
    ```
    You'll see error messages reading
     ```
     [otel.javaagent 2024-07-30 19:09:55:038 +0000] [OkHttp http://splunk-otel-collector:4317/...] ERROR io.opentelemetry.exporter.internal.grpc.GrpcExporter - Failed to export logs. Server responded with UNIMPLEMENTED. This usually means that your collector is not configured with an otlp receiver in the "pipelines" section of the configuration. If export is not desired and you are using OpenTelemetry autoconfiguration or the javaagent, disable export by setting OTEL_LOGS_EXPORTER=none. Full error message: unknown service 
opentelemetry.proto.collector.logs.v1.LogsService
    ```
    but those are fine.  We're at least talking to the server.

1.  Now delete everything
    ```
    oc delete app swatch-api swatch-contracts swatch-metrics swatch-metrics-rhel swatch-producer-aws swatch-producer-red-hat-marketplace swatch-subscription-sync swatch-system-conduit swatch-tally swatch-db-changelog-cleanup swatch-producer-azure rhsm swatch-billable-usage
    ``` 
1. Redeploy like so
    ```
    VER=$(git rev-parse --short=7 HEAD) ;  bonfire deploy rhsm \                                                                                                                                     
    --source=appsre \                                                                                                                                                                                
    --ref-env insights-production \                                                                                                                                                                  
    --optional-deps-method none \                                                                                                                                                                    
    --frontends false \                                                                                                                                                                              
    --no-remove-resources app:rhsm \                                                                                                                                                                 
    --timeout 900 \                                                                                                                                                                                  
    -i quay.io/awood/swatch-metrics=$VER \                                                                                                                                                           
    -i quay.io/awood/rhsm-subscriptions=$VER \                                                                                                                                                       
    -i quay.io/awood/swatch-contracts=$VER \                                                                                                                                                         
    -i quay.io/awood/swatch-producer-aws=$VER \                                                                                                                                                      
    -i quay.io/awood/swatch-producer-azure=$VER \                                                                                                                                                    
    -i quay.io/awood/swatch-system-conduit=$VER \                                                                                                                                                    
    -p swatch-metrics/IMAGE=quay.io/awood/swatch-metrics \                                                                                                                                           
    -p swatch-tally/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                                         
    -p swatch-api/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                                           
    -p swatch-contracts/IMAGE=quay.io/awood/swatch-contracts \                                                                                                                                       
    -p swatch-producer-aws/IMAGE=quay.io/awood/swatch-producer-aws \                                                                                                                                 
    -p swatch-producer-azure/IMAGE=quay.io/awood/swatch-producer-azure \                                                                                                                             
    -p swatch-system-conduit/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                                
    -p swatch-system-conduit/CONDUIT_IMAGE=quay.io/awood/swatch-system-conduit \                                                                                                                     
    -p swatch-producer-red-hat-marketplace/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                  
    -p swatch-subscription-sync/IMAGE=quay.io/awood/rhsm-subscriptions \                                                                                                                             
    -p swatch-tally/OTEL_JAVAAGENT_ENABLED=true \
    -p swatch-tally/OTEL_EXPORTER_OTLP_ENDPOINT=http://splunk-otel-collector:4317 \
    -p swatch-tally/OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
    ```
### Verification
1.  With the second deployment (which is misconfigured to use `http/protobuf`), you'll immediately see 
    ```
    java.net.SocketException: Connection reset
    ```
    messages in the `swatch-tally-service` log thus indicating the mismatch in protocol

