### PR TITLE
SWATCH-2674: Remove BillableUsage.id

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.json.BillableUsage;
@@ -100,7 +99,7 @@ public class RhMarketplacePayloadMapper {
     }
 
     OffsetDateTime snapshotDate = billableUsage.getSnapshotDate();
-    String eventId = getTallyIdFromUsage(billableUsage).toString();
+    String eventId = billableUsage.getTallyId().toString();
 
     /*
     This will need to be updated if we expand the criteria defined in the
@@ -186,10 +185,6 @@ public class RhMarketplacePayloadMapper {
         && billableUsage.getBillingProvider() != null
         && billableUsage.getBillingAccountId() != null
         && billableUsage.getSnapshotDate() != null
-        && getTallyIdFromUsage(billableUsage) != null;
-  }
-
-  private UUID getTallyIdFromUsage(BillableUsage usage) {
-    return Optional.ofNullable(usage.getTallyId()).orElse(usage.getId());
+        && billableUsage.getTallyId() != null;
   }
 }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
@@ -213,7 +213,7 @@ public class BillableUsageService {
             .sla(usage.getSla().value())
             .usage(usage.getUsage().value())
             .remittancePendingDate(clock.now())
-            .tallyId(Optional.ofNullable(usage.getTallyId()).orElse(usage.getId()))
+            .tallyId(usage.getTallyId())
             .hardwareMeasurementType(usage.getHardwareMeasurementType())
             .status(RemittanceStatus.PENDING)
             .build();

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
@@ -587,7 +587,7 @@ class BillableUsageServiceTest {
             .sla(usage.getSla().value())
             .usage(usage.getUsage().value())
             .remittancePendingDate(remittancePendingDate)
-            .tallyId(usage.getId())
+            .tallyId(usage.getTallyId())
             .hardwareMeasurementType(usage.getHardwareMeasurementType())
             .status(status)
             .retryAfter(retryAfter)
@@ -645,7 +645,7 @@ class BillableUsageServiceTest {
             argThat(
                 output -> {
                   assertEquals(usage.getUuid(), output.getUuid());
-                  assertEquals(usage.getId(), output.getId());
+                  assertEquals(usage.getTallyId(), output.getTallyId());
                   assertEquals(expectedValue, output.getValue());
                   assertEquals(usage.getCurrentTotal(), output.getCurrentTotal());
                   return true;

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -8,11 +8,6 @@ properties:
   org_id:
     description: Preferred identifier for the relevant account (if present).
     type: string
-  id:
-    description: Tally snapshot ID that resulted in this billable usage (for tracking) (Deprecated).
-    type: string
-    format: uuid
-    deprecationMessage: Use "tally_id" instead. To be removed in SWATCH-2674.
   tally_id:
     description: Tally snapshot ID that resulted in this billable usage (for tracking).
     type: string


### PR DESCRIPTION
Jira issue: SWATCH-2674

## Description
Fully remove the property BillableUsage.id that was replaced by BillableUsage.tally_id
We should already be using the tally_id after [SWATCH-2323](https://issues.redhat.com/browse/SWATCH-2323) was merged/released.

## Testing
Only regression testing. 