### PR TITLE
SWATCH-2571: Implement billable usage "gratis" status

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceStatus.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceStatus.java
@@ -32,6 +32,7 @@ import lombok.Getter;
 @Getter
 public enum RemittanceStatus {
   PENDING("pending"),
+  GRATIS("gratis"),
   FAILED("failed"),
   SUCCEEDED("succeeded");
 

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/exceptions/ContractCoverageException.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/exceptions/ContractCoverageException.java
@@ -18,24 +18,10 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.configuration.registry;
+package com.redhat.swatch.billable.usage.exceptions;
 
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import lombok.*;
-
-@Data
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class Metric {
-
-  @NotNull @NotEmpty private String id; // required
-  @NotNull private MetricType type;
-  private String rhmMetricId;
-  private String awsDimension;
-  private String azureDimension;
-  private PrometheusMetric prometheus;
-  private Double billingFactor;
-  private Boolean enableGratisUsage;
+public class ContractCoverageException extends Exception {
+  public ContractCoverageException(Throwable cause) {
+    super(cause);
+  }
 }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/model/ContractCoverage.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/model/ContractCoverage.java
@@ -18,24 +18,21 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.configuration.registry;
+package com.redhat.swatch.billable.usage.services.model;
 
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
 
-@Data
+@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class Metric {
+public class ContractCoverage {
+  private final String metricId;
+  private final boolean gratis;
+  private final double total;
 
-  @NotNull @NotEmpty private String id; // required
-  @NotNull private MetricType type;
-  private String rhmMetricId;
-  private String awsDimension;
-  private String azureDimension;
-  private PrometheusMetric prometheus;
-  private Double billingFactor;
-  private Boolean enableGratisUsage;
+  @Override
+  public String toString() {
+    return String.format(
+        "Coverage for metric '%s': %s%s", metricId, total, gratis ? "(Gratis)" : "");
+  }
 }

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -50,6 +50,7 @@ properties:
       - pending
       - succeeded
       - failed
+      - gratis
   error_code:
     description: Intended to be used for reporting remittance error code in case of failure
     type: string

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -326,6 +326,14 @@ public class SubscriptionDefinition {
         .orElse(null);
   }
 
+  public static boolean isMetricGratis(String productId, MetricId metricId) {
+    String metricIdAsString = metricId.toString();
+    return lookupSubscriptionByTag(productId)
+        .flatMap(subscriptionDefinition -> subscriptionDefinition.getMetric(metricIdAsString))
+        .map(m -> Boolean.TRUE.equals(m.getEnableGratisUsage()))
+        .orElse(false);
+  }
+
   public static List<SubscriptionDefinition> getSubscriptionDefinitions() {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions();
   }

--- a/swatch-product-configuration/src/main/resources/subscription_configs/Ansible/ansible-aap-managed.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/Ansible/ansible-aap-managed.yaml
@@ -23,6 +23,7 @@ metrics:
   - id: Managed-nodes
     type: gauge
     awsDimension: managed_node
+    enableGratisUsage: true
   - id: Instance-hours
     type: counter
     awsDimension: infrastructure


### PR DESCRIPTION
Jira issue: SWATCH-2571

## Description
- support enableGratisUsage in the metrics definition
- set "enableGratisUsage" to true only for ansible and the metric "Managed-nodes"
- save the gratis remittance records if any applicable contract has the gratis flag enabled

## Testing
1. podman-compose up
2. setup database schema: `./gradlew liquibaseUpdate`
3. insert test data:

What is important here is that:
- the contract has the product 'ansible-aap-managed': because it's the only product with the gratis flag enabled
- the contract start date starts after the current month (when writing these steps is '2024-08-01')

```
insert into offering(sku) values ('MW02393');
insert into sku_product_tag(sku,product_tag) values ('MW02393','ansible-aap-managed');
INSERT INTO contracts VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', '12914277', now(), '2024-08-01 01:01:01.717275+00', NULL, 'org123', 'MW02393', 'aws', 'aws123', 'ansible-aap-managed', 'bcwuzc8ww10vvxfair55mliy8');
```
4. start contract service: `SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 ./gradlew :swatch-contracts:quarkusDev`
5. start billable usage service: `./gradlew :swatch-billable-usage:quarkusDev`
6. create message in `platform.rhsm-subscriptions.tally`:

What is important here is that:
- the usage is within the above contract time window (starts after 2024-08-01).

```
{"org_id": "org123", "tally_snapshots": [{"billing_provider":"aws", "billing_account_id": "aws123", "snapshot_date": "2024-08-10T01:10:28Z", "product_id": "ansible-aap-managed", "sla": "Premium", "usage": "Production", "granularity": "Hourly", "tally_measurements": [{"hardware_measurement_type": "AWS", "metric_id": "Managed-nodes", "value": 12, "currentTotal": 100}]}]}
``` 

7. verification: 

The billable remittance should be created with gratis status:

```
select * from billable_usage_remittance where billing_account_id='aws123'
```

There should be only one with status "gratis".

And there should not be any new messages in the topic "platform.rhsm-subscriptions.billable-usage" (note that this topic is created only when any of the swatch-producer-aws or swatch-producer-azure is started). 