### PR TITLE
SWATCH-2760 Finalize swatch-product-configuration for ansible-aap-managed

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class EventController {
 
+  private static final String AAP_CLUSTER = "AAP Cluster";
   private static final Set<String> EXCLUDE_LOG_FOR_EVENT_SOURCES =
       Set.of("prometheus", "rhelemeter");
   private final EventRecordRepository repo;
@@ -361,6 +362,12 @@ public class EventController {
   }
 
   public Event normalizeEvent(Event event) {
+    // NOTE we will probably remove the below serviceType normalization
+    // after https://issues.redhat.com/browse/SWATCH-2533
+    // placeholder card to remove it in https://issues.redhat.com/browse/SWATCH-2794
+    if (Objects.nonNull(event.getServiceType()) && event.getServiceType().equals(AAP_CLUSTER)) {
+      event.setServiceType("Ansible Managed Node");
+    }
     // normalize UOM to metric_id
     event
         .getMeasurements()

--- a/swatch-product-configuration/src/main/resources/subscription_configs/Ansible/ansible-aap-managed.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/Ansible/ansible-aap-managed.yaml
@@ -21,5 +21,8 @@ contractEnabled: true
 
 metrics:
   - id: Managed-nodes
+    type: gauge
+    awsDimension: managed_node
+  - id: Instance-hours
     type: counter
-    awsDimension: managed_nodes
+    awsDimension: infrastructure


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2760

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
![Screenshot from 2024-08-05 17-09-52](https://github.com/user-attachments/assets/a6cf4ffc-687e-4669-8f55-6cc39929967d)

This is a screenshot taken from the doc: `Ansible Metering Dimensions & Data Flows`
Ansible has two different servicetype for two metrics. This card supports that behavior with a short term fix. 

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Steps with metric-id: Managed-nodes, event_type: managed-host, service_type: Ansible Managed Node
<!-- Enter each step of the test below -->
1. Event record:
```
{"sla": "Premium", "usage": "Production", "org_id": "12345678", "event_id": "668800cf-8cb6-4066-b95f-4a2ebc52018b", "timestamp": "2024-08-01T10:00:00Z", "conversion": false, "event_type": "managed-host", "expiration": "2024-06-10T11:00:00Z", "instance_id": "d147ddf2-be4a-4a59-acf7-7f222758b47c", "product_tag": ["ansible-aap-managed"], "record_date": "2024-08-05T19:56:20.811609576Z", "display_name": "automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c", "event_source": "Premium", "measurements": [{"value": 4.0, "metric_id": "Managed-nodes"}], "service_type": "Ansible Managed Node"}
```
2. Hourly tally:
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=12345678" x-rh-swatch-psk:placeholder
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Tally summary message:
```
{
  "org_id": "12345678",
  "tally_snapshots": [
    {
      "id": "7fa84815-658d-451f-bcc9-e97c7c0dd0cd",
      "billing_provider": "red hat",
      "billing_account_id": "",
      "snapshot_date": "2024-08-01T10:00:00Z",
      "product_id": "ansible-aap-managed",
      "sla": "Premium",
      "usage": "Production",
      "granularity": "Hourly",
      "tally_measurements": [
        {
          "hardware_measurement_type": "PHYSICAL",
          "metric_id": "MANAGED_NODES",
          "value": 4.0,
          "currentTotal": 4.0
        }
      ]
    }
  ]
}
```

### Steps 2 with metric-id: Instance-hours, event_type: instance-hours, service_type: AAP Cluster
<!-- Enter each step of the test below -->
1. Event record:
```
{"sla": "Premium", "usage": "Production", "org_id": "12345678", "event_id": "668800cf-8cb6-4066-b95f-4a2ebc52018b", "timestamp": "2024-08-01T10:00:00Z", "conversion": false, "event_type": "instance-hours", "expiration": "2024-06-10T11:00:00Z", "instance_id": "d147ddf2-be4a-4a59-acf7-7f222758b47c", "product_tag": ["ansible-aap-managed"], "record_date": "2024-08-05T19:56:20.811609576Z", "display_name": "automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c", "event_source": "Premium", "measurements": [{"value": 4.0, "metric_id": "Instance-hours"}], "service_type": "AAP Cluster"}
```
2. Hourly tally:
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=12345678" x-rh-swatch-psk:placeholder
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
```
{
  "org_id": "12345678",
  "tally_snapshots": [
    {
      "id": "8ed4b29f-4081-4e2d-9610-f9deec1aca22",
      "billing_provider": "red hat",
      "billing_account_id": "",
      "snapshot_date": "2024-08-01T10:00:00Z",
      "product_id": "ansible-aap-managed",
      "sla": "Premium",
      "usage": "Production",
      "granularity": "Hourly",
      "tally_measurements": [
        {
          "hardware_measurement_type": "PHYSICAL",
          "metric_id": "INSTANCE_HOURS",
          "value": 4.0,
          "currentTotal": 4.0
        }
      ]
    }
  ]
}
```

Note:
Above steps are independent of each other but, if you perform one step on another then you should change instance id. Also we should test this with actual ansible events.

Example check in splunk: `index=rh_rhsm urn:redhat:source:console:app:aap-controller-billing| spath logger | search logger="org.candlepin.subscriptions.event.EventController"`
Event:
`{"event_source":"urn:redhat:source:console:app:aap-controller-billing","event_type":"Managed-nodes","org_id":"18064240","product_tag":["ansible-aap-managed"],"instance_id":"event_kafka_50c87c49-d789-4751-983e-2adafe75c06f/NiWexktbeV","timestamp":"2024-08-06T13:00:00Z","expiration":"2024-08-06T14:00:00Z","display_name":"automation__cluster_event_kafka_50c87c49-d789-4751-983e-2adafe75c06f","measurements":[{"value":1,"uom":"Managed-nodes"}],"sla":"Premium","service_type":"Ansible Managed Node","install_uuid":"event_kafka_50c87c49-d789-4751-983e-2adafe75c06f","usage":"Production"}`


Verify:
```
{
  "org_id": "18064240",
  "tally_snapshots": [
    {
      "id": "25213b1d-ab2b-47e5-9f27-20fd98a3ccad",
      "billing_provider": "red hat",
      "billing_account_id": "",
      "snapshot_date": "2024-08-06T13:00:00Z",
      "product_id": "ansible-aap-managed",
      "sla": "Premium",
      "usage": "Production",
      "granularity": "Hourly",
      "tally_measurements": [
        {
          "hardware_measurement_type": "PHYSICAL",
          "metric_id": "MANAGED_NODES",
          "value": 1.0,
          "currentTotal": 1.0
        }
      ]
    }
  ]
}
```