### PR TITLE
SWATCH-2790: Use saveOrUpdate when syncing subscriptions

### DIFF
--- a/clients/quarkus/subscription-client/src/main/java/com/redhat/swatch/clients/subscription/SearchApiFactory.java
+++ b/clients/quarkus/subscription-client/src/main/java/com/redhat/swatch/clients/subscription/SearchApiFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.subscription;
+
+import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@ApplicationScoped
+public class SearchApiFactory {
+
+  @SearchClient
+  @Produces
+  public SearchApi getApi(
+      @ConfigProperty(
+              name = "rhsm-subscriptions.subscription-client.use-stub",
+              defaultValue = "false")
+          boolean useStub,
+      @RestClient SearchApi searchApi) {
+    if (useStub) {
+      return new StubSearchApi();
+    }
+
+    return searchApi;
+  }
+}

--- a/clients/quarkus/subscription-client/src/main/java/com/redhat/swatch/clients/subscription/SearchClient.java
+++ b/clients/quarkus/subscription-client/src/main/java/com/redhat/swatch/clients/subscription/SearchClient.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.subscription;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to disambiguate the injection of the {@link
+ * com.redhat.swatch.clients.subscription.api.resources.SearchApi} client. When used, the CDI
+ * context the real ProductApi or the stubProductApi depending on the configuration property will
+ * use the ProductApi instance produced by {@link SearchApiFactory} that will resolve either
+ * "rhsm-subscriptions.product.use-stub".
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+public @interface SearchClient {}

--- a/clients/quarkus/subscription-client/src/main/java/com/redhat/swatch/clients/subscription/StubSearchApi.java
+++ b/clients/quarkus/subscription-client/src/main/java/com/redhat/swatch/clients/subscription/StubSearchApi.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.subscription;
+
+import com.redhat.swatch.clients.subscription.api.model.Subscription;
+import com.redhat.swatch.clients.subscription.api.model.SubscriptionProduct;
+import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
+import jakarta.ws.rs.ProcessingException;
+import java.util.List;
+
+public class StubSearchApi implements SearchApi {
+  @Override
+  public Subscription getSubscriptionById(String id) throws ProcessingException {
+    return null;
+  }
+
+  @Override
+  public List<Subscription> getSubscriptionBySubscriptionNumber(String subscriptionNumber)
+      throws ProcessingException {
+    if (subscriptionNumber.equals("6438195")) {
+      Subscription subscription = new Subscription();
+      subscription.setId(6438190);
+      subscription.setSubscriptionNumber(subscriptionNumber);
+      SubscriptionProduct product = new SubscriptionProduct();
+      product.setSku("RH00129F5");
+      subscription.setSubscriptionProducts(List.of(product));
+      subscription.setWebCustomerId(7746627);
+      subscription.setQuantity(10);
+      subscription.setEffectiveStartDate(1722849931L);
+      subscription.setEffectiveEndDate(1849080331L);
+      return List.of(subscription);
+    }
+
+    return List.of();
+  }
+
+  @Override
+  public List<Subscription> searchSubscriptionsByOrgId(
+      String orgId, Integer index, Integer pageSize) throws ProcessingException {
+    return List.of();
+  }
+}

--- a/swatch-common-panache/src/main/java/com/redhat/swatch/panache/PanacheSpecificationSupport.java
+++ b/swatch-common-panache/src/main/java/com/redhat/swatch/panache/PanacheSpecificationSupport.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.panache;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.common.Page;
 import jakarta.persistence.TypedQuery;
 import java.util.List;
@@ -66,5 +67,9 @@ public interface PanacheSpecificationSupport<Entity, Id> extends PanacheReposito
 
   default Optional<Entity> findOne(Class<Entity> clazz, Specification<Entity> specification) {
     return query(clazz, specification, Page.of(0, 1)).getResultStream().findFirst();
+  }
+
+  default void saveOrUpdate(Entity entity) {
+    JpaOperations.INSTANCE.getEntityManager().merge(entity);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingRepository.java
@@ -21,7 +21,6 @@
 package com.redhat.swatch.contract.repository;
 
 import com.redhat.swatch.panache.PanacheSpecificationSupport;
-import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -44,9 +43,5 @@ public class OfferingRepository implements PanacheSpecificationSupport<OfferingE
   public Set<String> findAllDistinctSkus() {
     return find("select distinct sku from OfferingEntity").project(String.class).stream()
         .collect(Collectors.toSet());
-  }
-
-  public void saveOrUpdate(OfferingEntity offeringEntity) {
-    JpaOperations.INSTANCE.getEntityManager().merge(offeringEntity);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -413,7 +413,7 @@ public class ContractService {
     boolean areRecordsUpdated = !subscriptionsToPersist.isEmpty();
     if (areRecordsUpdated) {
       log.info("Persisting subscriptions: {}", subscriptionsToPersist);
-      subscriptionRepository.persist(subscriptionsToPersist);
+      subscriptionsToPersist.forEach(subscriptionRepository::saveOrUpdate);
     }
     return areRecordsUpdated;
   }
@@ -567,7 +567,7 @@ public class ContractService {
       log.debug("Synchronizing the subscription for contract {}", existingContract);
       SubscriptionEntity subscription =
           createOrUpdateSubscription(existingContract, subscriptionId);
-      subscriptionRepository.persist(subscription);
+      subscriptionRepository.saveOrUpdate(subscription);
     }
   }
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionService.java
@@ -20,6 +20,7 @@
  */
 package com.redhat.swatch.contract.service;
 
+import com.redhat.swatch.clients.subscription.SearchClient;
 import com.redhat.swatch.clients.subscription.api.model.Subscription;
 import com.redhat.swatch.clients.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
@@ -38,7 +39,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 /** The Subscription Service wrapper for all subscription service interfaces. */
 @ApplicationScoped
@@ -49,7 +49,7 @@ public class SubscriptionService {
       "Error during attempt to request subscription info";
   public static final String API_EXCEPTION_FROM_SUBSCRIPTION_SERVICE =
       "Api exception from subscription service: {}";
-  @Inject @RestClient SearchApi subscriptionApi;
+  @Inject @SearchClient SearchApi subscriptionApi;
   @Inject ApplicationConfiguration properties;
 
   /**

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
@@ -75,7 +75,6 @@ public class SubscriptionSyncService {
   private final ProductDenylist productDenylist;
   private final EntityManager entityManager;
 
-  @Transactional
   public void syncSubscription(
       Subscription subscription, Optional<SubscriptionEntity> subscriptionOptional) {
     final SubscriptionEntity newOrUpdated = convertDto(subscription);
@@ -91,7 +90,6 @@ public class SubscriptionSyncService {
    *     persistence context</strong>
    * @param subscriptionOptional optional existing Subscription. Managed in the persistence context.
    */
-  @Transactional
   @SuppressWarnings("java:S3776")
   public void syncSubscription(
       String sku,
@@ -191,13 +189,13 @@ public class SubscriptionSyncService {
                 .billingProvider(newOrUpdated.getBillingProvider())
                 .build();
         capacityReconciliationService.reconcileCapacityForSubscription(newSub);
-        subscriptionRepository.persist(newSub);
+        subscriptionRepository.saveOrUpdate(newSub);
       } else {
         updateExistingSubscription(newOrUpdated, existingSubscription);
-        subscriptionRepository.persist(existingSubscription);
+        subscriptionRepository.saveOrUpdate(existingSubscription);
       }
     } else {
-      subscriptionRepository.persist(newOrUpdated);
+      subscriptionRepository.saveOrUpdate(newOrUpdated);
     }
   }
 

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -262,6 +262,7 @@ kafka.bootstrap.servers=localhost:9092
 
 mp.messaging.incoming.contracts.address=${CONTRACT_UMB_QUEUE}
 mp.messaging.incoming.contracts.client-options-name=umb
+mp.messaging.incoming.contracts.enabled=${UMB_ENABLED}
 
 mp.messaging.outgoing.contractstest.address=${CONTRACT_UMB_QUEUE}
 mp.messaging.outgoing.contractstest.client-options-name=umb
@@ -293,11 +294,13 @@ mp.messaging.incoming.offering-sync-umb.connector=smallrye-amqp
 %test.mp.messaging.incoming.offering-sync-umb.connector=smallrye-in-memory
 mp.messaging.incoming.offering-sync-umb.address=${OFFERING_UMB_QUEUE}
 mp.messaging.incoming.offering-sync-umb.client-options-name=umb
+mp.messaging.incoming.offering-sync-umb.enabled=${UMB_ENABLED}
 
 mp.messaging.incoming.subscription-sync-umb.connector=smallrye-amqp
 %test.mp.messaging.incoming.subscription-sync-umb.connector=smallrye-in-memory
 mp.messaging.incoming.subscription-sync-umb.address=${SUBSCRIPTION_UMB_QUEUE}
 mp.messaging.incoming.subscription-sync-umb.client-options-name=umb
+mp.messaging.incoming.subscription-sync-umb.enabled=${UMB_ENABLED}
 
 mp.messaging.incoming.offering-sync-task.connector=smallrye-kafka
 mp.messaging.incoming.offering-sync-task.topic=platform.rhsm-subscriptions.offering-sync

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -344,6 +344,7 @@ quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
 
 rhsm-subscriptions.subscription-sync-enabled=${SUBSCRIPTION_SYNC_ENABLED:true}
+rhsm-subscriptions.subscription-client.use-stub=${SUBSCRIPTION_CLIENT_USE_STUB:false}
 
 # Disable Micrometer JVM-Metrics for tests.
 #

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ResourceRolesAllowedTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ResourceRolesAllowedTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.clients.product.StubProductApi;
+import com.redhat.swatch.clients.subscription.StubSearchApi;
 import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.openapi.runtime.io.Format;
@@ -57,9 +58,11 @@ import org.junit.jupiter.api.TestFactory;
 
 @QuarkusTest
 class ResourceRolesAllowedTest {
-  Set<Class<? extends Annotation>> HTTP_METHOD_ANNOTATION_CLASSES =
+  private static final Set<Class<? extends Annotation>> HTTP_METHOD_ANNOTATION_CLASSES =
       Set.of(
           DELETE.class, GET.class, HEAD.class, OPTIONS.class, PATCH.class, POST.class, PUT.class);
+  private static final Set<Class<?>> IGNORE_RESOURCES =
+      Set.of(StubProductApi.class, StubSearchApi.class);
 
   @Inject OpenApiDocumentService openApiDocumentService;
 
@@ -153,7 +156,10 @@ class ResourceRolesAllowedTest {
     var allBeans = CDI.current().getBeanManager().getBeans(Object.class);
     return allBeans.stream()
         .filter(this::hasJaxRsAnnotation)
-        .filter(bean -> !bean.getBeanClass().isAssignableFrom(StubProductApi.class))
+        .filter(
+            bean ->
+                IGNORE_RESOURCES.stream()
+                    .noneMatch(clazz -> bean.getBeanClass().isAssignableFrom(clazz)))
         .flatMap(bean -> Arrays.stream(bean.getBeanClass().getDeclaredMethods()))
         .filter(this::hasJaxRsAnnotation)
         .toList();

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -132,7 +132,7 @@ class ContractServiceTest extends BaseUnitTest {
         request.getPartnerEntitlement().getRhEntitlements().get(0).getSku(),
         entity.getOffering().getSku());
     assertEquals(response.getUuid(), entity.getUuid().toString());
-    verify(subscriptionRepository).persist(any(Set.class));
+    verify(subscriptionRepository).saveOrUpdate(any());
     verify(measurementMetricIdTransformer).translateContractMetricIdsToSubscriptionMetricIds(any());
   }
 
@@ -150,7 +150,7 @@ class ContractServiceTest extends BaseUnitTest {
     var contract = givenPartnerEntitlementContractRequest();
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).persist(any(Set.class));
+    verify(subscriptionRepository, times(2)).saveOrUpdate(any());
     verify(measurementMetricIdTransformer, times(2))
         .translateContractMetricIdsToSubscriptionMetricIds(any());
   }
@@ -178,7 +178,7 @@ class ContractServiceTest extends BaseUnitTest {
     PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
-    verify(subscriptionRepository, times(2)).persist(any(Set.class));
+    verify(subscriptionRepository, times(3)).saveOrUpdate(any());
     assertEquals("New contract created", statusResponse.getMessage());
   }
 
@@ -190,7 +190,7 @@ class ContractServiceTest extends BaseUnitTest {
     PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
-    verify(subscriptionRepository, times(2)).persist(any(Set.class));
+    verify(subscriptionRepository, times(3)).saveOrUpdate(any());
 
     verify(contractRepository, times(3)).persist(any(ContractEntity.class));
 
@@ -211,7 +211,7 @@ class ContractServiceTest extends BaseUnitTest {
     assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
     // 2 instances of subscription are created, one for the original contract, and one for the
     // update
-    verify(subscriptionRepository, times(3)).persist(any(Set.class));
+    verify(subscriptionRepository, times(4)).saveOrUpdate(any());
     verify(measurementMetricIdTransformer, times(4))
         .translateContractMetricIdsToSubscriptionMetricIds(any());
   }
@@ -294,14 +294,14 @@ class ContractServiceTest extends BaseUnitTest {
 
     mockPartnerApi();
 
-    ArgumentCaptor<Set<SubscriptionEntity>> subscriptionSaveCapture =
-        ArgumentCaptor.forClass(Set.class);
+    ArgumentCaptor<SubscriptionEntity> subscriptionSaveCapture =
+        ArgumentCaptor.forClass(SubscriptionEntity.class);
     contractService.createPartnerContract(contract);
-    verify(subscriptionRepository).persist(subscriptionSaveCapture.capture());
+    verify(subscriptionRepository).saveOrUpdate(subscriptionSaveCapture.capture());
     subscriptionSaveCapture.getValue();
     assertEquals(
         "a69ff71c-aa8b-43d9-dea8-822fab4bbb86;rh-rhel-sub-1yr;azureProductCode;eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31",
-        subscriptionSaveCapture.getValue().iterator().next().getBillingProviderId());
+        subscriptionSaveCapture.getValue().getBillingProviderId());
   }
 
   @Test
@@ -334,7 +334,7 @@ class ContractServiceTest extends BaseUnitTest {
     givenExistingContract();
     var expectedSubscription = givenExistingSubscription();
     contractService.syncSubscriptionsForContractsByOrg(ORG_ID);
-    verify(subscriptionRepository).persist(expectedSubscription);
+    verify(subscriptionRepository).saveOrUpdate(expectedSubscription);
   }
 
   @Test
@@ -346,13 +346,12 @@ class ContractServiceTest extends BaseUnitTest {
     var contract = givenAzurePartnerEntitlementContract();
     mockPartnerApi();
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
-    ArgumentCaptor<Set<SubscriptionEntity>> subscriptionsSaveCapture =
-        ArgumentCaptor.forClass(Set.class);
+    ArgumentCaptor<SubscriptionEntity> subscriptionsSaveCapture =
+        ArgumentCaptor.forClass(SubscriptionEntity.class);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).persist(subscriptionsSaveCapture.capture());
+    verify(subscriptionRepository).saveOrUpdate(subscriptionsSaveCapture.capture());
     var persistedSubscriptions = subscriptionsSaveCapture.getValue();
-    assertEquals(1, persistedSubscriptions.size());
-    assertEquals(DEFAULT_END_DATE, persistedSubscriptions.iterator().next().getEndDate());
+    assertEquals(DEFAULT_END_DATE, persistedSubscriptions.getEndDate());
     verify(subscriptionRepository, times(0)).delete(any());
   }
 
@@ -366,7 +365,7 @@ class ContractServiceTest extends BaseUnitTest {
     mockPartnerApi();
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).persist(any(Set.class));
+    verify(subscriptionRepository).saveOrUpdate(any());
     verify(subscriptionRepository, times(1)).delete(subscription);
   }
 
@@ -376,7 +375,7 @@ class ContractServiceTest extends BaseUnitTest {
     var stub = mockPartnerApi(createPartnerApiResponseNoContractDimensions());
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).persist(any(Set.class));
+    verify(subscriptionRepository).saveOrUpdate(any());
     wireMockServer.removeStub(stub);
   }
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
@@ -90,7 +90,10 @@ class SubscriptionSyncServiceTest {
 
     when(denylist.productIdMatches(any())).thenReturn(false);
     subscriptionSyncService.syncSubscription(dto, Optional.of(subscription));
-    verify(subscriptionRepository, Mockito.times(2)).persist(any(SubscriptionEntity.class));
+    // for existing subscription:
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    // for the new one:
+    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
     verify(capacityReconciliationService, Mockito.times(2))
         .reconcileCapacityForSubscription(Mockito.any(SubscriptionEntity.class));
   }
@@ -196,7 +199,7 @@ class SubscriptionSyncServiceTest {
     when(denylist.productIdMatches(any())).thenReturn(false);
     var dto = createDto("456", 4);
     subscriptionSyncService.syncSubscription(dto, Optional.of(createSubscription()));
-    verify(subscriptionRepository, Mockito.times(1)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository, Mockito.times(1)).saveOrUpdate(any(SubscriptionEntity.class));
     verify(capacityReconciliationService, Mockito.times(2))
         .reconcileCapacityForSubscription(any(SubscriptionEntity.class));
   }
@@ -209,7 +212,7 @@ class SubscriptionSyncServiceTest {
     when(denylist.productIdMatches(any())).thenReturn(false);
     var dto = createDto("456", 10);
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository, Mockito.times(1)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository, Mockito.times(1)).saveOrUpdate(any(SubscriptionEntity.class));
     verify(capacityReconciliationService)
         .reconcileCapacityForSubscription(any(SubscriptionEntity.class));
   }
@@ -245,7 +248,7 @@ class SubscriptionSyncServiceTest {
     existingSubscription.setQuantity(10);
     var dto = createDto("456", 10);
     subscriptionSyncService.syncSubscription(dto, Optional.of(existingSubscription));
-    verify(subscriptionRepository, Mockito.times(1)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
     verify(capacityReconciliationService, Mockito.times(2))
         .reconcileCapacityForSubscription(any(SubscriptionEntity.class));
   }
@@ -266,14 +269,14 @@ class SubscriptionSyncServiceTest {
     var dto = createDto(123, "456", "890", 4);
     givenOfferingWithProductIds(290);
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
     verify(capacityReconciliationService).reconcileCapacityForSubscription(any());
 
     // let's update only the product IDs
     givenOfferingWithProductIds(290, 69);
     reset(subscriptionRepository, capacityReconciliationService);
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
     verify(capacityReconciliationService).reconcileCapacityForSubscription(any());
   }
 
@@ -293,7 +296,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);
 
     verify(subscriptionService).getSubscriptionsByOrgId("100");
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -365,7 +368,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);
     verify(subscriptionService).getSubscriptionsByOrgId("100");
     verify(subscriptionRepository, times(1))
-        .persist(
+        .saveOrUpdate(
             argThat(
                 (ArgumentMatcher<SubscriptionEntity>)
                     s ->
@@ -422,7 +425,7 @@ class SubscriptionSyncServiceTest {
     when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
     when(offeringRepository.findById(SKU)).thenReturn(offering);
     subscriptionSyncService.forceSyncSubscriptionsForOrg("123", false);
-    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository, times(2)).saveOrUpdate(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -441,7 +444,7 @@ class SubscriptionSyncServiceTest {
     when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
     when(offeringRepository.findById(SKU)).thenReturn(offering);
     subscriptionSyncService.forceSyncSubscriptionsForOrg("123", true);
-    verify(subscriptionRepository, atLeastOnce()).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository, atLeastOnce()).saveOrUpdate(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -528,7 +531,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.of(existing));
 
     verifyNoInteractions(subscriptionService);
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
     assertNull(incoming.getBillingAccountId());
   }
 
@@ -551,7 +554,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.of(existing));
 
     verifyNoInteractions(subscriptionService);
-    verify(subscriptionRepository).persist(existing);
+    verify(subscriptionRepository).saveOrUpdate(existing);
     assertEquals(BillingProvider.RED_HAT, existing.getBillingProvider());
     assertEquals("newBillingProviderId", existing.getBillingProviderId());
     assertEquals("newBillingAccountId", existing.getBillingAccountId());
@@ -570,7 +573,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.empty());
 
     verify(offeringSyncService).syncOffering(SKU);
-    verify(subscriptionRepository).persist(incoming);
+    verify(subscriptionRepository).saveOrUpdate(incoming);
     assertNull(incoming.getBillingAccountId());
   }
 
@@ -650,7 +653,7 @@ class SubscriptionSyncServiceTest {
     var dto = createDto("456", 10);
     subscriptionSyncService.syncSubscription(dto, Optional.of(existingSubscription));
     verify(subscriptionRepository, times(1))
-        .persist(
+        .saveOrUpdate(
             argThat(
                 (ArgumentMatcher<SubscriptionEntity>)
                     s ->


### PR DESCRIPTION
Jira issue: SWATCH-2790

## Description
The method `persist` will always perform an INSERT in database and this is causing issues when there are subscriptions with no subscription number, but the subscription ID correctly sets (it sounds weird, but it's what is happening in stage).

Using the method `saveOrUpdate` will correctly update the existing subscription if exists (so the subscription without the subscription number will be correctly fixed).

Note that because the `persist` method is a bit problematic (it happened the same when synchorinizing offerings), I replaced all the methods to `saveOrUpdate`. 

Apart from these changes:
- I created the stub search API which is by default false, because it was very convenient to reproduce the issue locally
- And disable the channels that consumed messages from umb if the property UMB_ENABLED is false: this is to avoid having a lot of exceptions locally

## Testing
1.- podman_compose up
2.- ./gradlew liquibaseUpdate
3.- load the stage data into your local database
4.- check that the following subscription is missing the subscription number:

```
select * from subscriptions where subscription_id ='6438190'
```

The subscription_number is empty.

5.- start the contracts service using the stubs: `SUBSCRIPTION_CLIENT_USE_STUB=true ./gradlew :swatch-contracts:quarkusDev`
6.- try to sync the problematic subscription:

```
<CanonicalMessage xmlns="http://esb.redhat.com/Canonical/6">
    <Payload>
        <Sync>
            <Subscription>
                <Identifiers>
                    <MasterSystem>SUBSCRIPTION</MasterSystem>
                    <Identifier entity-name="Install Base"
                        qualifier="number" system="EBS">39832705</Identifier>
                    <Identifier entity-name="Registration" qualifier="number">e401bce70edd43bd</Identifier>
                    <Identifier entity-name="Subscription"
                        qualifier="number" system="SUBSCRIPTION">6438195</Identifier>
                    <Reference entity-name="Installation" qualifier="number">c967ef3956ff3def</Reference>
                    <Reference entity-name="Customer" qualifier="number" system="EBS">customer123</Reference>
                    <Reference entity-name="Account" qualifier="number" system="EBS">account123</Reference>
                    <Reference entity-name="Customer" qualifier="id" system="WEB">7746627</Reference>
                    <Reference entity-name="Account" qualifier="id" system="WEB">16764251</Reference>
                </Identifiers>
                <Status>
                    <State>Active</State>
                    <StartDate>2023-04-24T00:00:00.000</StartDate>
                </Status>
                <Quantity>1</Quantity>
                <effectiveStartDate>2019-08-05T00:00:00.000</effectiveStartDate>
                <effectiveEndDate>2024-08-04T00:00:00.000</effectiveEndDate>
                <Product serviceable="false">
                    <CreatedBy>OSUBPRODTEST3EAC72C765804E2B8D34484E7FF8D1C8</CreatedBy>
                    <CreatedDate>2023-04-24T14:11:16.809</CreatedDate>
                    <Identifiers>
                        <MasterSystem>EBS</MasterSystem>
                        <Identifier entity-name="Product"
                            qualifier="number" system="SUBSCRIPTION">6438195</Identifier>
                    </Identifiers>
                    <Sku>RH00129F5</Sku>
                    <InventoryOperatingUnit>
                        <Number>118</Number>
                    </InventoryOperatingUnit>
                    <Product serviceable="true">
                        <CreatedBy>OSUBPRODTEST3EAC72C765804E2B8D34484E7FF8D1C8</CreatedBy>
                        <CreatedDate>2023-04-24T14:11:16.809</CreatedDate>
                        <LastUpdatedBy>SYSADMIN</LastUpdatedBy>
                        <LastUpdatedDate>2023-04-24T14:17:02.000</LastUpdatedDate>
                        <Identifiers>
                            <MasterSystem>EBS</MasterSystem>
                            <AuthoringOperatingUnit>
                                <Number>103</Number>
                            </AuthoringOperatingUnit>
                            <Identifier entity-name="Product"
                                qualifier="number" system="SUBSCRIPTION">37188550</Identifier>
                            <Reference entity-name="Contract"
                                qualifier="number" system="EBS">16612423</Reference>
                            <Reference entity-name="Contract"
                                qualifier="id" system="EBS">25565753</Reference>
                        </Identifiers>
                        <Status>
                            <State>Active</State>
                            <StartDate>2023-04-24T00:00:00.000</StartDate>
                            <EndDate>2026-04-23T00:00:00.000</EndDate>
                        </Status>
                        <Status>
                            <State>Signed</State>
                            <StartDate>2023-04-24T00:00:00.000</StartDate>
                        </Status>
                        <Status primary="true">
                            <State>Terminated</State>
                            <StartDate>2023-04-24T14:17:02.000</StartDate>
                        </Status>
                        <Sku>SVC2681</Sku>
                        <InventoryOperatingUnit>
                            <Number>118</Number>
                        </InventoryOperatingUnit>
                        <ContractDescription>Reg Number activation from Hock</ContractDescription>
                        <ContractHeaderStatus>Terminated</ContractHeaderStatus>
                    </Product>
                </Product>
            </Subscription>
        </Sync>
    </Payload>
</CanonicalMessage>
```

7.- verify that the call worked ok and the subscription entity was updated:

```
select * from subscriptions where subscription_id ='6438190'
```

The subscription_number should be `6438195`.