### PR TITLE
SWATCH-2790: Use persist instead of saveOrUpdate in existing subs

### DIFF
--- a/swatch-common-panache/src/main/java/com/redhat/swatch/panache/PanacheSpecificationSupport.java
+++ b/swatch-common-panache/src/main/java/com/redhat/swatch/panache/PanacheSpecificationSupport.java
@@ -69,7 +69,7 @@ public interface PanacheSpecificationSupport<Entity, Id> extends PanacheReposito
     return query(clazz, specification, Page.of(0, 1)).getResultStream().findFirst();
   }
 
-  default void saveOrUpdate(Entity entity) {
-    JpaOperations.INSTANCE.getEntityManager().merge(entity);
+  default Entity merge(Entity entity) {
+    return JpaOperations.INSTANCE.getEntityManager().merge(entity);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncService.java
@@ -162,7 +162,7 @@ public class OfferingSyncService {
 
     // Update to the new entry or create it.
     try {
-      offeringRepository.saveOrUpdate(newState);
+      newState = offeringRepository.merge(newState);
       offeringRepository.flush();
     } catch (PersistenceException ex) {
       log.debug(

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
@@ -189,13 +189,16 @@ public class SubscriptionSyncService {
                 .billingProvider(newOrUpdated.getBillingProvider())
                 .build();
         capacityReconciliationService.reconcileCapacityForSubscription(newSub);
-        subscriptionRepository.saveOrUpdate(newSub);
+        // merge is needed here because the existing subscription might not be found if we only use
+        // the subscription number (since primary keys are subscription ID and start date).
+        // To be fixed in SWATCH-2801.
+        subscriptionRepository.merge(newSub);
       } else {
         updateExistingSubscription(newOrUpdated, existingSubscription);
-        subscriptionRepository.saveOrUpdate(existingSubscription);
+        subscriptionRepository.persist(existingSubscription);
       }
     } else {
-      subscriptionRepository.saveOrUpdate(newOrUpdated);
+      subscriptionRepository.persist(newOrUpdated);
     }
   }
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -132,7 +132,7 @@ class ContractServiceTest extends BaseUnitTest {
         request.getPartnerEntitlement().getRhEntitlements().get(0).getSku(),
         entity.getOffering().getSku());
     assertEquals(response.getUuid(), entity.getUuid().toString());
-    verify(subscriptionRepository).saveOrUpdate(any());
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     verify(measurementMetricIdTransformer).translateContractMetricIdsToSubscriptionMetricIds(any());
   }
 
@@ -150,7 +150,7 @@ class ContractServiceTest extends BaseUnitTest {
     var contract = givenPartnerEntitlementContractRequest();
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository, times(2)).saveOrUpdate(any());
+    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
     verify(measurementMetricIdTransformer, times(2))
         .translateContractMetricIdsToSubscriptionMetricIds(any());
   }
@@ -178,7 +178,7 @@ class ContractServiceTest extends BaseUnitTest {
     PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
-    verify(subscriptionRepository, times(3)).saveOrUpdate(any());
+    verify(subscriptionRepository, times(3)).persist(any(SubscriptionEntity.class));
     assertEquals("New contract created", statusResponse.getMessage());
   }
 
@@ -190,7 +190,7 @@ class ContractServiceTest extends BaseUnitTest {
     PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
-    verify(subscriptionRepository, times(3)).saveOrUpdate(any());
+    verify(subscriptionRepository, times(3)).persist(any(SubscriptionEntity.class));
 
     verify(contractRepository, times(3)).persist(any(ContractEntity.class));
 
@@ -211,7 +211,7 @@ class ContractServiceTest extends BaseUnitTest {
     assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
     // 2 instances of subscription are created, one for the original contract, and one for the
     // update
-    verify(subscriptionRepository, times(4)).saveOrUpdate(any());
+    verify(subscriptionRepository, times(4)).persist(any(SubscriptionEntity.class));
     verify(measurementMetricIdTransformer, times(4))
         .translateContractMetricIdsToSubscriptionMetricIds(any());
   }
@@ -297,7 +297,7 @@ class ContractServiceTest extends BaseUnitTest {
     ArgumentCaptor<SubscriptionEntity> subscriptionSaveCapture =
         ArgumentCaptor.forClass(SubscriptionEntity.class);
     contractService.createPartnerContract(contract);
-    verify(subscriptionRepository).saveOrUpdate(subscriptionSaveCapture.capture());
+    verify(subscriptionRepository).persist(subscriptionSaveCapture.capture());
     subscriptionSaveCapture.getValue();
     assertEquals(
         "a69ff71c-aa8b-43d9-dea8-822fab4bbb86;rh-rhel-sub-1yr;azureProductCode;eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31",
@@ -334,7 +334,7 @@ class ContractServiceTest extends BaseUnitTest {
     givenExistingContract();
     var expectedSubscription = givenExistingSubscription();
     contractService.syncSubscriptionsForContractsByOrg(ORG_ID);
-    verify(subscriptionRepository).saveOrUpdate(expectedSubscription);
+    verify(subscriptionRepository).persist(expectedSubscription);
   }
 
   @Test
@@ -349,7 +349,7 @@ class ContractServiceTest extends BaseUnitTest {
     ArgumentCaptor<SubscriptionEntity> subscriptionsSaveCapture =
         ArgumentCaptor.forClass(SubscriptionEntity.class);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).saveOrUpdate(subscriptionsSaveCapture.capture());
+    verify(subscriptionRepository).persist(subscriptionsSaveCapture.capture());
     var persistedSubscriptions = subscriptionsSaveCapture.getValue();
     assertEquals(DEFAULT_END_DATE, persistedSubscriptions.getEndDate());
     verify(subscriptionRepository, times(0)).delete(any());
@@ -365,7 +365,7 @@ class ContractServiceTest extends BaseUnitTest {
     mockPartnerApi();
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).saveOrUpdate(any());
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     verify(subscriptionRepository, times(1)).delete(subscription);
   }
 
@@ -375,7 +375,7 @@ class ContractServiceTest extends BaseUnitTest {
     var stub = mockPartnerApi(createPartnerApiResponseNoContractDimensions());
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).saveOrUpdate(any());
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     wireMockServer.removeStub(stub);
   }
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
@@ -93,7 +93,7 @@ class SubscriptionSyncServiceTest {
     // for existing subscription:
     verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     // for the new one:
-    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).merge(any(SubscriptionEntity.class));
     verify(capacityReconciliationService, Mockito.times(2))
         .reconcileCapacityForSubscription(Mockito.any(SubscriptionEntity.class));
   }
@@ -199,7 +199,7 @@ class SubscriptionSyncServiceTest {
     when(denylist.productIdMatches(any())).thenReturn(false);
     var dto = createDto("456", 4);
     subscriptionSyncService.syncSubscription(dto, Optional.of(createSubscription()));
-    verify(subscriptionRepository, Mockito.times(1)).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     verify(capacityReconciliationService, Mockito.times(2))
         .reconcileCapacityForSubscription(any(SubscriptionEntity.class));
   }
@@ -212,7 +212,7 @@ class SubscriptionSyncServiceTest {
     when(denylist.productIdMatches(any())).thenReturn(false);
     var dto = createDto("456", 10);
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository, Mockito.times(1)).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository, Mockito.times(1)).persist(any(SubscriptionEntity.class));
     verify(capacityReconciliationService)
         .reconcileCapacityForSubscription(any(SubscriptionEntity.class));
   }
@@ -248,7 +248,7 @@ class SubscriptionSyncServiceTest {
     existingSubscription.setQuantity(10);
     var dto = createDto("456", 10);
     subscriptionSyncService.syncSubscription(dto, Optional.of(existingSubscription));
-    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     verify(capacityReconciliationService, Mockito.times(2))
         .reconcileCapacityForSubscription(any(SubscriptionEntity.class));
   }
@@ -269,14 +269,14 @@ class SubscriptionSyncServiceTest {
     var dto = createDto(123, "456", "890", 4);
     givenOfferingWithProductIds(290);
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     verify(capacityReconciliationService).reconcileCapacityForSubscription(any());
 
     // let's update only the product IDs
     givenOfferingWithProductIds(290, 69);
     reset(subscriptionRepository, capacityReconciliationService);
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     verify(capacityReconciliationService).reconcileCapacityForSubscription(any());
   }
 
@@ -296,7 +296,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);
 
     verify(subscriptionService).getSubscriptionsByOrgId("100");
-    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -367,8 +367,8 @@ class SubscriptionSyncServiceTest {
         .thenReturn(List.of(existingSub));
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);
     verify(subscriptionService).getSubscriptionsByOrgId("100");
-    verify(subscriptionRepository, times(1))
-        .saveOrUpdate(
+    verify(subscriptionRepository)
+        .persist(
             argThat(
                 (ArgumentMatcher<SubscriptionEntity>)
                     s ->
@@ -425,7 +425,7 @@ class SubscriptionSyncServiceTest {
     when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
     when(offeringRepository.findById(SKU)).thenReturn(offering);
     subscriptionSyncService.forceSyncSubscriptionsForOrg("123", false);
-    verify(subscriptionRepository, times(2)).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -444,7 +444,7 @@ class SubscriptionSyncServiceTest {
     when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
     when(offeringRepository.findById(SKU)).thenReturn(offering);
     subscriptionSyncService.forceSyncSubscriptionsForOrg("123", true);
-    verify(subscriptionRepository, atLeastOnce()).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository, atLeastOnce()).persist(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -531,7 +531,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.of(existing));
 
     verifyNoInteractions(subscriptionService);
-    verify(subscriptionRepository).saveOrUpdate(any(SubscriptionEntity.class));
+    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
     assertNull(incoming.getBillingAccountId());
   }
 
@@ -554,7 +554,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.of(existing));
 
     verifyNoInteractions(subscriptionService);
-    verify(subscriptionRepository).saveOrUpdate(existing);
+    verify(subscriptionRepository).persist(existing);
     assertEquals(BillingProvider.RED_HAT, existing.getBillingProvider());
     assertEquals("newBillingProviderId", existing.getBillingProviderId());
     assertEquals("newBillingAccountId", existing.getBillingAccountId());
@@ -573,7 +573,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.empty());
 
     verify(offeringSyncService).syncOffering(SKU);
-    verify(subscriptionRepository).saveOrUpdate(incoming);
+    verify(subscriptionRepository).persist(incoming);
     assertNull(incoming.getBillingAccountId());
   }
 
@@ -652,8 +652,8 @@ class SubscriptionSyncServiceTest {
     existingSubscription.setQuantity(10);
     var dto = createDto("456", 10);
     subscriptionSyncService.syncSubscription(dto, Optional.of(existingSubscription));
-    verify(subscriptionRepository, times(1))
-        .saveOrUpdate(
+    verify(subscriptionRepository)
+        .persist(
             argThat(
                 (ArgumentMatcher<SubscriptionEntity>)
                     s ->


### PR DESCRIPTION
Jira issue: SWATCH-2790

## Description
These changes address some concerns from Alex in https://github.com/RedHatInsights/rhsm-subscriptions/pull/3592.  Also, the saveOrUpdate method will return the entity that is attached to the transaction context.

## Testing
Only regression testing.