### PR TITLE
Fix NPE in BadRequestExceptionMapper

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/CapacityResource.java
@@ -300,9 +300,7 @@ public class CapacityResource implements CapacityApi {
     if (!Variant.isGranularityCompatible(
         productId.toString(), SubscriptionDefinitionGranularity.valueOf(granularity.name()))) {
       throw new BadRequestException(
-          String.format(
-              "%s does not support any granularity finer than %s",
-              productId, granularity.getValue()));
+          String.format("%s does not support granularity %s", productId, granularity.getValue()));
     }
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/CapacityResourceTest.java
@@ -836,9 +836,7 @@ class CapacityResourceTest {
                     null));
 
     assertEquals(
-        String.format(
-            "%s does not support any granularity finer than %s",
-            RHEL_FOR_ARM, GranularityType.HOURLY),
+        String.format("%s does not support granularity %s", RHEL_FOR_ARM, GranularityType.HOURLY),
         thrownException.getMessage());
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/BadRequestExceptionMapper.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/exception/mapper/BadRequestExceptionMapper.java
@@ -37,10 +37,16 @@ import org.springframework.stereotype.Component;
 public class BadRequestExceptionMapper extends BaseExceptionMapper<BadRequestException> {
   @Override
   protected Error buildError(BadRequestException exception) {
-    return new Error()
-        .code(ErrorCode.REQUEST_PROCESSING_ERROR.getCode())
-        .status(String.valueOf(Response.Status.BAD_REQUEST.getStatusCode()))
-        .title("Bad Request")
-        .detail(exception.getCause().getMessage());
+    var error =
+        new Error()
+            .code(ErrorCode.REQUEST_PROCESSING_ERROR.getCode())
+            .status(String.valueOf(Response.Status.BAD_REQUEST.getStatusCode()))
+            .title("Bad Request");
+    if (exception.getCause() != null) {
+      error.setDetail(exception.getCause().getMessage());
+    } else {
+      error.setDetail(exception.getMessage());
+    }
+    return error;
   }
 }


### PR DESCRIPTION
Description
===========

Certain operations currently cause a 500, when they should cause a 400. This is due to the JAX-RS exception mapper itself throwing an exception. The BadRequestExceptionMapper in particular doesn't handle when a BadRequestException doesn't have a cause.

Testing
=======

Perform the steps with both `main` and these changes.

Setup
-----

Run the application:

```shell
DEV_MODE=true RHSM_RBAC_USE_STUB=true ./gradlew :bootRun
```

Steps
-----

Request tally for an unsupported granularity

```shell
http :8000/api/rhsm-subscriptions/v1/capacity/products/RHEL%20for%20x86/Cores \
  beginning==2024-07-02T00:00:00.000Z \
  ending==2024-08-31T23:59:59.999Z \
  granularity==Hourly \
  use_running_totals_format==true \
  billing_category==on-demand \
  x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w0)
```

Notice on `main` the request returns a 500 with a messy trace. Notice with these changes, it responds with a cleaner error:

```json
{
  "errors": [
    {
      "code": "SUBSCRIPTIONS1001",
      "detail": "RHEL for x86 does not support granularity Hourly",
      "status": "400",
      "title": "Bad Request"
    }
  ]
}
```
