### PR TITLE
SWATCH-2766: Fix 500 errors due to out-of-bounds page params

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/util/InMemoryPager.java
+++ b/src/main/java/org/candlepin/subscriptions/util/InMemoryPager.java
@@ -27,7 +27,7 @@ import org.springframework.data.domain.Pageable;
 
 public class InMemoryPager {
   public static <T> Page<T> paginate(List<T> items, Pageable pageable) {
-    if (pageable == null) {
+    if (pageable == null || pageable.isUnpaged()) {
       return new PageImpl<>(items);
     }
     if (pageable.getOffset() > items.size()) {

--- a/src/main/java/org/candlepin/subscriptions/util/InMemoryPager.java
+++ b/src/main/java/org/candlepin/subscriptions/util/InMemoryPager.java
@@ -26,6 +26,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public class InMemoryPager {
+  private InMemoryPager() {
+    /* intentionally empty */
+  }
+
   public static <T> Page<T> paginate(List<T> items, Pageable pageable) {
     if (pageable == null || pageable.isUnpaged()) {
       return new PageImpl<>(items);

--- a/src/main/java/org/candlepin/subscriptions/util/InMemoryPager.java
+++ b/src/main/java/org/candlepin/subscriptions/util/InMemoryPager.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public class InMemoryPager {
+  public static <T> Page<T> paginate(List<T> items, Pageable pageable) {
+    if (pageable == null) {
+      return new PageImpl<>(items);
+    }
+    if (pageable.getOffset() > items.size()) {
+      return new PageImpl<>(List.of(), pageable, items.size());
+    }
+    int offset = pageable.getPageNumber() * pageable.getPageSize();
+    int lastIndex = Math.min(items.size(), offset + pageable.getPageSize());
+    var pageItems = items.subList(offset, lastIndex);
+    return new PageImpl<>(pageItems, pageable, items.size());
+  }
+}


### PR DESCRIPTION
Description
===========

Jira issue: SWATCH-2766

When api requests are made w/ parameters that are out-of-bounds (offset > count), some APIs currently throw exceptions.

Note, I also corrected paging implementation in CapacityResource, which was giving an incorrect `count`.

Testing
=======

Perform the steps with both `main` and these changes.

Setup
-----

Run the application:

```shell
DEV_MODE=true RHSM_RBAC_USE_STUB=true ./gradlew :bootRun
```

Steps
-----

Try each of the following requests:

```shell
http :8000/api/rhsm-subscriptions/v1/capacity/products/RHEL%20for%20x86/Cores \
  beginning==2024-07-02T00:00:00.000Z \
  ending==2024-08-31T23:59:59.999Z \
  granularity==Daily \
  use_running_totals_format==true \
  billing_category==on-demand \
  offset==1000 \
  x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w0)
```

```shell
http :8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL%20for%20x86 \
  beginning==2024-07-02T00:00:00.000Z \
  ending==2024-08-31T23:59:59.999Z \
  granularity==Daily \
  use_running_totals_format==true \
  billing_category==on-demand \
  offset==1000 \
  x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w0)
```

```shell
http :8000/api/rhsm-subscriptions/v2/subscriptions/products/RHEL%20for%20x86 \
  beginning==2024-07-02T00:00:00.000Z \
  ending==2024-08-31T23:59:59.999Z \
  granularity==Daily \
  use_running_totals_format==true \
  billing_category==on-demand \
  offset==1000 \
  x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w0)
```

Verification
------------

Notice on `main` the requests return 500s. Notice with these changes, the results are empty.
