### PR TITLE
SWATCH-2742: key constraint exception during account reset

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -69,7 +69,6 @@ def generate_host(inventory_id=None, insights_id=None, account_number=None, org_
             'instance_id': inventory_id,
             'inventory_id': inventory_id,
             'insights_id': insights_id,
-            'account_number': account,
             'org_id': org,
             'display_name': display_name or insights_id,
             'subscription_manager_id': subscription_manager_id or uuid.uuid4(),

--- a/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/AccountResetService.java
@@ -58,8 +58,8 @@ public class AccountResetService {
 
   @Transactional
   public void deleteDataForOrg(String orgId) {
-    accountServiceInventoryRepository.deleteByIdOrgId(orgId);
     hostRepo.deleteByOrgId(orgId);
+    accountServiceInventoryRepository.deleteByIdOrgId(orgId);
     eventRecordRepo.deleteByOrgId(orgId);
     tallySnapshotRepository.deleteByOrgId(orgId);
     subscriptionRepository.deleteByOrgId(orgId);

--- a/src/test/java/org/candlepin/subscriptions/tally/AccountResetServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/AccountResetServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
+import org.candlepin.subscriptions.db.EventRecordRepository;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.OfferingRepository;
+import org.candlepin.subscriptions.db.SubscriptionRepository;
+import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.TallyStateRepository;
+import org.candlepin.subscriptions.db.model.AccountServiceInventory;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.EventRecord;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.Offering;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Subscription;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.TallyState;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles({"test", "worker"})
+class AccountResetServiceTest {
+  @Autowired private EventRecordRepository eventRecordRepo;
+  @Autowired private HostRepository hostRepo;
+  @Autowired private TallySnapshotRepository tallySnapshotRepository;
+  @Autowired private AccountServiceInventoryRepository accountServiceInventoryRepository;
+  @Autowired private SubscriptionRepository subscriptionRepository;
+  @Autowired private TallyStateRepository tallyStateRepository;
+  @Autowired private OfferingRepository offeringRepository;
+  @Autowired private AccountResetService resetService;
+
+  @BeforeEach
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  void setUp() {
+    accountServiceInventoryRepository.save(new AccountServiceInventory("org123", "HBI_HOST"));
+
+    Host host = new Host("inventory123", "insights123", "org123", "subman123");
+    host.setDisplayName("host123");
+    host.addBucket(
+        "RHEL",
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        BillingProvider.EMPTY,
+        "billingAccount123",
+        false,
+        10,
+        10,
+        HardwareMeasurementType.PHYSICAL);
+    host.setMeasurement("CORES", 10.0);
+    host.addToMonthlyTotal("2024-08", MetricId.fromString("CORES"), 10.0);
+    hostRepo.save(host);
+
+    EventRecord e =
+        new EventRecord(
+            UUID.randomUUID(),
+            "org123",
+            "eventType123",
+            "eventSource123",
+            "instance123",
+            UUID.randomUUID(),
+            OffsetDateTime.now(),
+            OffsetDateTime.now(),
+            null);
+    eventRecordRepo.save(e);
+
+    TallySnapshot snapshot =
+        new TallySnapshot(
+            UUID.randomUUID(),
+            OffsetDateTime.now(),
+            "RHEL",
+            "org123",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.EMPTY,
+            "billingAccount123",
+            Granularity.DAILY,
+            Map.of(new TallyMeasurementKey(HardwareMeasurementType.PHYSICAL, "CORES"), 10.0));
+    tallySnapshotRepository.save(snapshot);
+
+    Offering o = new Offering();
+    o.setSku("awesomeos");
+    o.setCores(10);
+    o.setSockets(10);
+    o.setUsage(Usage.PRODUCTION);
+    offeringRepository.save(o);
+
+    Subscription s = new Subscription();
+    s.setOrgId("org123");
+    s.setOffering(o);
+    s.setSubscriptionId("subscription123");
+    s.setStartDate(OffsetDateTime.now());
+    subscriptionRepository.save(s);
+
+    TallyState tallyState = new TallyState("org123", "HBI_HOST", OffsetDateTime.now());
+    tallyStateRepository.save(tallyState);
+  }
+
+  @Test
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  void testReset() {
+    assertDoesNotThrow(() -> resetService.deleteDataForOrg("org123"));
+    assertEquals(0, hostRepo.findAll().size());
+    assertEquals(0, accountServiceInventoryRepository.findAll().size());
+    assertEquals(0, eventRecordRepo.findAll().size());
+    assertEquals(0, tallySnapshotRepository.findAll().size());
+    assertEquals(0, subscriptionRepository.findAll().size());
+    assertEquals(0, tallyStateRepository.findAll().size());
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-2742

## Description
Calls to ` DELETE .../api/rhsm-subscriptions/v1/internal/rpc/tally/{org_id}` were failing because the code attempted to delete the `account_services` rows while they were still referenced from `hosts`.

I also included a small fix to `insert-mock-hosts` since I discovered that script wasn't working when I was trying to replicate the issue.

## Testing
Unit test only
