### PR TITLE
SWATCH-2805: Bind the subscription client property in swatch-contracts

### DIFF
--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -56,6 +56,12 @@ parameters:
     value: prod
   - name: UMB_KEYSTORE_PATH
     value: /pinhead/keystore.jks
+  - name: UMB_ENABLED
+    value: 'false'
+  - name: UMB_PROCESSING_ENABLED
+    value: 'true'
+  - name: UMB_SERVICE_ACCOUNT_NAME
+    value: placeholder
   - name: PRODUCT_URL
     value: https://product.stage.api.redhat.com/svcrest/product/v3
   - name: SUBSCRIPTION_SYNC_ENABLED
@@ -68,6 +74,8 @@ parameters:
     value: 'true'
   - name: OFFERING_SYNC_SCHEDULE
     value: 0 2 * * *
+  - name: SUBSCRIPTION_URL
+    value: https://subscription.stage.api.redhat.com/svcrest/subscription/v5
   - name: SUBSCRIPTION_SYNC_SCHEDULE
     value: 0 10 * * *
   - name: KAFKA_ENABLED_ORGS_REPLICAS
@@ -282,10 +290,25 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: metadata.namespace
+              - name: UMB_ENABLED
+                value: ${UMB_ENABLED}
+              - name: UMB_PROCESSING_ENABLED
+                value: ${UMB_PROCESSING_ENABLED}
+              - name: UMB_SERVICE_ACCOUNT_NAME
+                value: ${UMB_SERVICE_ACCOUNT_NAME}
               - name: PRODUCT_URL
                 value: ${PRODUCT_URL}
               - name: PRODUCT_DENYLIST_RESOURCE_LOCATION
                 value: file:/denylist/product-denylist.txt
+              - name: SUBSCRIPTION_KEYSTORE
+                value: /pinhead/keystore.jks
+              - name: SUBSCRIPTION_KEYSTORE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: tls
+                    key: keystore_password
+              - name: SUBSCRIPTION_URL
+                value: ${SUBSCRIPTION_URL}
               - name: SUBSCRIPTION_SYNC_ENABLED
                 value: ${SUBSCRIPTION_SYNC_ENABLED}
               - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -161,8 +161,8 @@ quarkus.log.category."com.redhat.swatch.contract.config.DebugClientLogger".level
 %stage.quarkus.rest-client.logging.scope=request-response
 
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".url=${SUBSCRIPTION_URL:http://localhost:8102}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store=${KEYSTORE_RESOURCE:}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store-password=${KEYSTORE_PASSWORD:}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store=${SUBSCRIPTION_KEYSTORE:}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store-password=${SUBSCRIPTION_KEYSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".scope=jakarta.enterprise.context.ApplicationScoped

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/WireMockResource.java
@@ -64,6 +64,8 @@ public class WireMockResource implements QuarkusTestResourceLifecycleManager {
     var config = new HashMap<String, String>();
     config.put("KEYSTORE_RESOURCE", String.format("file:%s", CLIENT_KEYSTORE_PATH));
     config.put("KEYSTORE_PASSWORD", STORE_PASSWORD);
+    config.put("SUBSCRIPTION_KEYSTORE", String.format("file:%s", CLIENT_KEYSTORE_PATH));
+    config.put("SUBSCRIPTION_KEYSTORE_PASSWORD", STORE_PASSWORD);
     config.put("TRUSTSTORE_RESOURCE", String.format("file:%s", TRUSTSTORE_PATH));
     config.put("TRUSTSTORE_PASSWORD", STORE_PASSWORD);
     config.put(


### PR DESCRIPTION
Jira issue: SWATCH-2805

## Description
The offering sync fails in stage because the call to subscription client fails with 504 Bad Gateway. I confirmed that the subscription API is working fine for stage, so this is a configuration issue. 

By binding these subscription properties, the swatch-contracts should be able to overwrite the URL to use.

## Testing
Only reproducible in stage. 