### PR TITLE
SWATCH-2807 Fix filtering of prometheus events

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -109,7 +109,7 @@ public class SubscriptionSyncController {
     DbReportCriteria.DbReportCriteriaBuilder reportCriteriaBuilder =
         DbReportCriteria.builder()
             .productTag(productTag)
-            .serviceLevel(usageKey.getSla())
+            .serviceLevel(ServiceLevel._ANY)
             // NOTE(khowell) due to an oversight PAYG SKUs don't currently have a usage set -
             // at some point we should use usageKey.getUsage() instead of "_ANY"
             .usage(Usage._ANY)

--- a/swatch-metrics/README.md
+++ b/swatch-metrics/README.md
@@ -40,8 +40,7 @@ sum_over_time((max by (_id) (system_cpu_logical_count))[1h:10m]) / scalar(count_
       system_cpu_logical_count{
       product=~".*(^|,)(69)($|,).*",
       external_organization="11789772",
-      billing_model="marketplace",
-      support=~"Premium|Standard|Self-Support|None|"
+      billing_model="marketplace"
       }[1h]
     )
   )

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -210,11 +210,11 @@ rhsm-subscriptions:
           default: >-
             max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
-            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", metered_by_rh!='false', support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product="#{metric.prometheus.queryParams[product]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", metered_by_rh!='false'}[1h])
           addonSamples: >-
             max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
             * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
-            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", metered_by_rh!='false', support=~"Premium|Standard|Self-Support|None"}[1h])
+            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{resource_type="addon",resource_name="#{metric.prometheus.queryParams[resourceName]}", external_organization="#{runtime[orgId]}", billing_model="marketplace", metered_by_rh!='false'}[1h])
           rhelemeter: >-
             sum_over_time((max by (#{metric.prometheus.queryParams[instanceKey]}) (#{metric.prometheus.queryParams[metric]}))[1h:10m])
             /
@@ -229,8 +229,7 @@ rhsm-subscriptions:
                   product=~"#{metric.prometheus.queryParams[productLabelRegex]}",
                   external_organization="#{runtime[orgId]}",
                   billing_model="marketplace",
-                  metered_by_rh!='false',
-                  support=~"Premium|Standard|Self-Support|None|"
+                  metered_by_rh!='false'
                   }[1h]
                 )
               )


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2807

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
There were two issues that we discovered when I investigated the error: There is an error looking up the contract for org 18267845 when remitting usage
1) We were getting events for sla=Self-Support but, that was not supported while reading awsusagecontext. We changed the matching criteria to _ANY
2) We ignored all the events that lower case premium. Hence we decided to remove the support from prometheus query. 

**Note: QE and dev reviewer I need a second set of eyes to make sure this is not getting doubled bill since we removed the sla criteria from prometheus recording rule.**

There is probably some work left to check for Rosa.
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1. Run <swatch-support-script> rhelemeter-prod to connect to thanos/prometheus production. https://gitlab.cee.redhat.com/rhsm/swatch-support-scripts/-/blob/main/rhelemeter-prod?ref_type=heads

### Steps
<!-- Enter each step of the test below -->
1. Query: `sum_over_time((max by (billing_marketplace_instance_id) (system_cpu_logical_count))[1h:10m]) / scalar(count_over_time(vector(1)[1h:10m])) * on (billing_marketplace_instance_id) group_right topk by (billing_marketplace_instance_id) (1, group without (swatch_placeholder_label) (min_over_time(system_cpu_logical_count{product=~".*(^|,)(204)($|,).*",external_organization='18267845',billing_model='marketplace', support=~'Premium|Standard|Self-Support|None|'}[1h])))`

### Verification on main branch see the premium events are getting ignored
<!-- Enter the steps needed to verify the test passed -->
1. Response: `{_id="6c82a45d-1157-41ca-a2f4-495ab718a4e9", billing_marketplace="aws", billing_marketplace_account="401848347851", billing_marketplace_instance_id="i-0a046284f91306f22", billing_model="marketplace", display_name="ip-10-29-17-186.testqh.cloud.health.qld.gov.au", external_organization="18267845", product="204,69", receive="true", socket_count="1", support="Self-Support", tenant_id="72e6f641-b2e2-47eb-bbc2-fee3c8fbda26"} `
2. Get Subscription, offering, sku_product_tag and subscription_measurements from prod to local by using swatch-support-script and do following 
`import-from-gabi.py --org-id='18267845' --tallies --events --remittance --subscriptions --systems --offering`
3. Execute curl request to getAwsUsageContext:
 `curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext?productId=rhel-for-x86-els-payg-addon&date=2024-08-12T00%3A00Z&orgId=18267845&sla=Self-Support&usage=Production&awsAccountId=401848347851'   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'`
4. Notice the query generated:
`gabi "select s1_0.start_date,s1_0.subscription_id,s1_0.billing_account_id,s1_0.billing_provider,s1_0.billing_provider_id,s1_0.end_date,o1_0.sku,o1_0.cores,o1_0.derived_sku,o1_0.description,o1_0.has_unlimited_usage,o1_0.hypervisor_cores,o1_0.hypervisor_sockets,o1_0.level_1,o1_0.level_2,o1_0.metered,o1_0.product_family,o1_0.product_name,o1_0.role,o1_0.sla,o1_0.sockets,o1_0.special_pricing_flag,o1_0.usage,s1_0.org_id,s1_0.quantity,sm1_0.start_date,sm1_0.subscription_id,sm1_0.measurement_type,sm1_0.metric_id,sm1_0.value,s1_0.subscription_number from subscription s1_0 join offering o1_0 on o1_0.sku=s1_0.sku left join subscription_measurements sm1_0 on s1_0.start_date=sm1_0.start_date and s1_0.subscription_id=sm1_0.subscription_id where s1_0.start_date<='2024-08-12T00:00Z' and (s1_0.end_date is null or s1_0.end_date>='2024-08-11T23:00Z') and s1_0.org_id='18267845' and s1_0.billing_provider_id is not null and s1_0.billing_provider_id<>'' and 'rhel-for-x86-els-payg-addon' in (select pt1_0.product_tag from sku_product_tag pt1_0 where o1_0.sku=pt1_0.sku) and o1_0.sla='Self-Support' and s1_0.billing_provider='aws' and s1_0.billing_account_id like '401848347851%' escape '' order by s1_0.start_date desc" `
5. Offering for sku is Premium but, in the event we were getting Self-Support hence it doesn't pull any data back. We changed it to any so, it doesn't check for sla.

**In current branch:**
If there is an event with sla premium, Premium or Self-support it will persist the event and also will match the awsusagecontext since we check sla.any

Check this by running curl command as above:
`curl -X 'GET'   'http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/awsUsageContext?productId=rhel-for-x86-els-payg-addon&date=2024-08-12T00%3A00Z&orgId=18267845&sla=Self-Support&usage=Production&awsAccountId=401848347851'   -H 'accept: application/json'   -H 'x-rh-swatch-psk: placeholder'`

Response:
`{"rhSubscriptionId":"15271145","customerId":"GXAnVBn79RV","productCode":"5xjrwpu4bdpcpbp0tgrya1h4j","awsSellerAccountId":"403771435366","subscriptionStartDate":"2024-07-26T16:26:37.63538Z"}`