### PR TITLE
SWATCH-2805: disable autodiscovery of providers in swatch-contracts

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -145,6 +145,10 @@ quarkus.log.category."io.quarkus.http.access-log".handlers=ACCESS_LOG
 quarkus.log.category."io.quarkus.http.access-log".use-parent-handlers=false
 quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG
 
+# Disable the auto-discovery of providers (for ex: exception mappers).
+# All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
+quarkus.rest-client-reactive.provider-autodiscovery=false
+
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".url=${ENTITLEMENT_GATEWAY_URL:http://localhost:8101}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".key-store=${KEYSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".key-store-password=${KEYSTORE_PASSWORD:}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -154,7 +154,7 @@ quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.
 
 # rest-client debug logging
 # NOTE: all of uri-filter-regex, log category level, and logging.scope need to be set for a request/response to be logged.
-rest-client-debug-logging.uri-filter=.*partnerSubscriptions.*
+rest-client-debug-logging.uri-filter=.*(partnerSubscriptions|search|products).*
 quarkus.log.category."com.redhat.swatch.contract.config.DebugClientLogger".level=DEBUG
 %test.quarkus.rest-client.logging.scope=request-response
 %dev.quarkus.rest-client.logging.scope=request-response


### PR DESCRIPTION
Jira issue: SWATCH-2805

## Description
- Disable autodiscovery of providers in swatch-contracts
This is causing that the exceptions to be thrown by the clients are not the ones from its exception mappers.

- Enable logging of requests-response for the SearchAPI
This change might help to understand what is going on in SWATCH-2805

## Testing
Only regression testing.