### PR TITLE
SWATCH-2805: Add PRODUCT_KEYSTORE and SUBSCRIPTION_KEYSTORE in swatch-contracts

### DIFF
--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -286,6 +286,20 @@ objects:
                 value: ${PRODUCT_URL}
               - name: PRODUCT_DENYLIST_RESOURCE_LOCATION
                 value: file:/denylist/product-denylist.txt
+              - name: PRODUCT_KEYSTORE
+                value: /pinhead/keystore.jks
+              - name: PRODUCT_KEYSTORE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: tls
+                    key: keystore_password
+              - name: SUBSCRIPTION_KEYSTORE
+                value: /pinhead/keystore.jks
+              - name: SUBSCRIPTION_KEYSTORE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: tls
+                    key: keystore_password
               - name: SUBSCRIPTION_SYNC_ENABLED
                 value: ${SUBSCRIPTION_SYNC_ENABLED}
               - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -152,7 +152,7 @@ quarkus.rest-client-reactive.provider-autodiscovery=false
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".url=${ENTITLEMENT_GATEWAY_URL:http://localhost:8101}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".key-store=${KEYSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".key-store-password=${KEYSTORE_PASSWORD:}
-quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store=${TRUSTSTORE_RESOURCE:}
+quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store=${TRUSTSTORE_PATH:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".scope=jakarta.enterprise.context.ApplicationScoped
 
@@ -165,10 +165,11 @@ quarkus.log.category."com.redhat.swatch.contract.config.DebugClientLogger".level
 %stage.quarkus.rest-client.logging.scope=request-response
 
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".url=${SUBSCRIPTION_URL:http://localhost:8102}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store=${KEYSTORE_RESOURCE:}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store-password=${KEYSTORE_PASSWORD:}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store=${TRUSTSTORE_RESOURCE:}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store=${SUBSCRIPTION_KEYSTORE:}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store-password=${SUBSCRIPTION_KEYSTORE_PASSWORD:changeit}
+# SearchApi does not use any trust-store in stage/prod environments. For now, this property is only used in tests.
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store=${SUBSCRIPTION_TRUSTSTORE_PATH:}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store-password=${SUBSCRIPTION_TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".scope=jakarta.enterprise.context.ApplicationScoped
 
 # configuration properties for subscriptions-sync
@@ -181,10 +182,11 @@ quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.
 # configuration properties for product client
 rhsm-subscriptions.product.use-stub=${PRODUCT_USE_STUB:false}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".uri=${PRODUCT_URL:https://product.stage.api.redhat.com/svcrest/product/v3}
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store=${KEYSTORE_RESOURCE:}
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store-password=${KEYSTORE_PASSWORD:}
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store=${TRUSTSTORE_RESOURCE:}
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store=${PRODUCT_KEYSTORE:}
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store-password=${PRODUCT_KEYSTORE_PASSWORD:redhat}
+# ProductApi does not use any trust-store in stage/prod environments. For now, this property is only used in tests.
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store=${PRODUCT_TRUSTSTORE_PATH:}
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store-password=${PRODUCT_TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".scope=jakarta.enterprise.context.ApplicationScoped
 
 # rbac service configuration

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/WireMockResource.java
@@ -62,10 +62,18 @@ public class WireMockResource implements QuarkusTestResourceLifecycleManager {
     stubApis();
     wireMockServer.start();
     var config = new HashMap<String, String>();
-    config.put("KEYSTORE_RESOURCE", String.format("file:%s", CLIENT_KEYSTORE_PATH));
+    config.put("KEYSTORE_RESOURCE", CLIENT_KEYSTORE_PATH);
     config.put("KEYSTORE_PASSWORD", STORE_PASSWORD);
-    config.put("TRUSTSTORE_RESOURCE", String.format("file:%s", TRUSTSTORE_PATH));
+    config.put("TRUSTSTORE_PATH", TRUSTSTORE_PATH);
     config.put("TRUSTSTORE_PASSWORD", STORE_PASSWORD);
+    config.put("SUBSCRIPTION_TRUSTSTORE_PATH", TRUSTSTORE_PATH);
+    config.put("SUBSCRIPTION_TRUSTSTORE_PASSWORD", STORE_PASSWORD);
+    config.put("PRODUCT_TRUSTSTORE_PATH", TRUSTSTORE_PATH);
+    config.put("PRODUCT_TRUSTSTORE_PASSWORD", STORE_PASSWORD);
+    config.put("SUBSCRIPTION_KEYSTORE", CLIENT_KEYSTORE_PATH);
+    config.put("SUBSCRIPTION_KEYSTORE_PASSWORD", STORE_PASSWORD);
+    config.put("PRODUCT_KEYSTORE", String.format("file:%s", CLIENT_KEYSTORE_PATH));
+    config.put("PRODUCT_KEYSTORE_PASSWORD", STORE_PASSWORD);
     config.put(
         "ENTITLEMENT_GATEWAY_URL", String.format("%s/mock/partnerApi", wireMockServer.baseUrl()));
     config.put("SUBSCRIPTION_URL", String.format("%s/mock/subscription", wireMockServer.baseUrl()));


### PR DESCRIPTION
Jira issue: SWATCH-2805

## Description
And replace TRUSTSTORE_RESOURCE by TRUSTSTORE_PATH which is the one used in the environment

## Testing
Only regression testing.