### PR TITLE
SWATCH-2805: Ack subscription sync messages when the subs sync fails

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -277,6 +277,7 @@ mp.messaging.incoming.subscription-sync-task.connector=smallrye-kafka
 mp.messaging.incoming.subscription-sync-task.topic=platform.rhsm-subscriptions.subscription-sync-task
 mp.messaging.incoming.subscription-sync-task.group.id=subscription-worker
 mp.messaging.incoming.subscription-sync-task.value.deserializer=com.redhat.swatch.contract.service.json.EnabledOrgsResponseDeserializer
+mp.messaging.incoming.subscription-sync-task.failure-strategy=ignore
 
 mp.messaging.incoming.subscription-prune-task.connector=smallrye-kafka
 mp.messaging.incoming.subscription-prune-task.topic=platform.rhsm-subscriptions.subscription-prune-task


### PR DESCRIPTION
Jira issue: SWATCH-2805

## Description
There is an existing metrics to track these failures named "swatch_subscription_reconcile_org". We might later choose to write a log alert for a message against the metric:

`swatch_subscription_reconcile_org_seconds_count{exception!=''}`. This can be tested in Grafana.

The same thing was done for the offering sync: https://github.com/RedHatInsights/rhsm-subscriptions/pull/3621

## Testing
Only regression testing.