### PR TITLE
SWATCH-2424: Delete inner query to purge the tally snapshots

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicy.java
@@ -103,4 +103,8 @@ public class TallyRetentionPolicy {
   public long getSnapshotsToDeleteInBatches() {
     return config.getSnapshotsToDeleteInBatches();
   }
+
+  public int getOrganizationsBatchLimit() {
+    return config.getOrganizationsBatchLimit();
+  }
 }

--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionPolicyProperties.java
@@ -71,4 +71,5 @@ public class TallyRetentionPolicyProperties {
   private Integer yearly;
 
   @Positive private long snapshotsToDeleteInBatches;
+  @Positive private int organizationsBatchLimit;
 }

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -41,6 +41,8 @@ rhsm-subscriptions:
     # Five years' worth
     quarterly: ${TALLY_RETENTION_QUARTERLY:20}
     yearly: ${TALLY_RETENTION_YEARLY:5}
+    # Batch size to fetch organizations using pagination
+    organizations-batch-limit: 1000
     snapshots-to-delete-in-batches: 1000000
   tally-summary-producer:
     back-off-initial-interval: ${TALLY_SUMMARY_PRODUCER_BACK_OFF_INITIAL_INTERVAL:1s}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -87,17 +87,18 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   @Query(
       value =
-          "select count(*) from TallySnapshot where orgId in (select distinct c.orgId from OrgConfig c) and granularity=:granularity and snapshotDate < :cutoffDate")
+          "select count(*) from TallySnapshot where orgId=:orgId and granularity=:granularity and snapshotDate < :cutoffDate")
   long countAllByGranularityAndSnapshotDateBefore(
-      Granularity granularity, OffsetDateTime cutoffDate);
+      String orgId, Granularity granularity, OffsetDateTime cutoffDate);
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   @Modifying
   @Query(
       nativeQuery = true,
       value =
-          "delete from tally_snapshots where id in (select id from tally_snapshots where org_id in (select distinct c.org_id from org_config c) and granularity=:granularity and snapshot_date < :cutoffDate limit :limit)")
+          "delete from tally_snapshots where id in (select id from tally_snapshots where org_id=:orgId and granularity=:granularity and snapshot_date < :cutoffDate limit :limit)")
   void deleteAllByGranularityAndSnapshotDateBefore(
+      @Param("orgId") String orgId,
       @Param("granularity") String granularity,
       @Param("cutoffDate") OffsetDateTime cutoffDate,
       @Param("limit") long limit);


### PR DESCRIPTION
Jira issue: SWATCH-2424

## Description
Delete the inner query "(select distinct c.org_id from org_config c)" by queuing the tasks to purge the tally snapshots by org_id.

I checked the explain using the inner query and without using it, and the delete statement cost decreased significantly. Note that I could reproduce the issue locally (by loading a large dataset), but hopefully these changes and making the deletion by organization ID in a single transaction will improve this situation.

Related to https://github.com/RedHatInsights/rhsm-subscriptions/pull/3487

## Testing
0. podman-compose up
1. create schema `./gradlew liquibaseUpdate`
2. insert the small dataset:

```
insert into org_config values ('10000177','DB','2020-04-14T20:31:41.660008Z','2020-04-14T20:31:41.660008Z');

insert into tally_snapshots values ('80f53b83-3919-4e15-a97e-884e28817e12','RHEL for x86','DAILY','10000177','1950-03-05T00:00:00Z','','_ANY','','_ANY','_ANY');

insert into tally_measurements values ('80f53b83-3919-4e15-a97e-884e28817e12','VIRTUAL','INSTANCES','11');
insert into tally_measurements values ('80f53b83-3919-4e15-a97e-884e28817e12','VIRTUAL','SOCKETS','63');
```

3. start the service: `DEV_MODE=true ./gradlew :bootRun`
4. run the purge: `curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: placeholder" -X POST "http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge"`

Since the snapshot_date is very old, the tally_snapshot and measurements should be gone now.