### PR TITLE
SWATCH-2675: Fix the property name for spring boot request limit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     testImplementation project(':swatch-core-test')
     testImplementation project(':swatch-common-testcontainers')
     testImplementation "org.hsqldb:hsqldb"
+    testImplementation "io.rest-assured:rest-assured"
 
     javaagent  libraries["splunk-otel-agent"]
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,3 +65,6 @@ logging:
         kafka:
           listener:
             DeadLetterPublishingRecoverer=error:
+
+server:
+  max-http-request-header-size: 96KB

--- a/src/test/java/org/candlepin/subscriptions/deployment/ApiDeploymentTest.java
+++ b/src/test/java/org/candlepin/subscriptions/deployment/ApiDeploymentTest.java
@@ -20,21 +20,43 @@
  */
 package org.candlepin.subscriptions.deployment;
 
+import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import io.restassured.RestAssured;
+import org.apache.commons.lang3.StringUtils;
 import org.candlepin.subscriptions.resource.ApiConfiguration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"api", "test"})
 class ApiDeploymentTest {
+  @LocalServerPort private int port;
+
+  @BeforeEach
+  public void init() {
+    RestAssured.port = this.port;
+  }
+
   @Autowired ApiConfiguration configuration;
 
   @Test
   void testDeployment() {
     assertNotNull(configuration);
+  }
+
+  @Test
+  void testApiSupportsLargeRequests() {
+    given()
+        .header("X-Correlation-ID", StringUtils.repeat("Z", 20000))
+        .when()
+        .get("/does-not-exist")
+        .then()
+        .statusCode(401);
   }
 }

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -19,8 +19,6 @@ parameters:
     value: quay.io/cloudservices/rhsm-subscriptions
   - name: IMAGE_TAG
     value: latest
-  - name: SERVER_MAX_HTTP_HEADER_SIZE
-    value: '96000'
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL
@@ -155,8 +153,6 @@ objects:
                 value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
               - name: DEV_MODE
                 value: ${DEV_MODE}
-              - name: SERVER_MAX_HTTP_HEADER_SIZE
-                value: ${SERVER_MAX_HTTP_HEADER_SIZE}
               - name: LOG_FILE
                 value: /logs/server.log
               - name: SPRING_PROFILES_ACTIVE

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -11,8 +11,6 @@ parameters:
     value: ''
   - name: ENV_NAME
     value: env-swatch-tally
-  - name: SERVER_MAX_HTTP_HEADER_SIZE
-    value: '96000'
   - name: LOGGING_LEVEL_ROOT
     value: WARN
   - name: LOGGING_LEVEL
@@ -343,8 +341,6 @@ objects:
               value: ${SPLUNK_HEC_TERMINATION_TIMEOUT}
             - name: SPRING_PROFILES_ACTIVE
               value: worker,api,kafka-queue
-            - name: SERVER_MAX_HTTP_HEADER_SIZE
-              value: ${SERVER_MAX_HTTP_HEADER_SIZE}
             - name: LOG_FILE
               value: /logs/server.log
             - name: JAVA_MAX_MEM_RATIO


### PR DESCRIPTION
Jira issue: SWATCH-2675

Description
===========

As explained in spring-projects/spring-boot#39527,

```
server.max-http-request-header-size
```

replaced

```
server.max-http-header-size
```

as of Spring Boot 3.2.

I also elected to simplify our deployments by removing the environment variable, and putting the configuration in `application.yaml` instead.

Testing
=======

IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/832

Run the integration test:

```shell
./gradlew :test --tests=ApiDeploymentTest.testApiSupportsLargeRequests
```

You can see the test fail by commenting out the property in `src/main/application.yaml`.