### PR TITLE
SWATCH-2816: Configure the PRODUCT_URL for prod in swatch contracts

### DIFF
--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -56,8 +56,6 @@ parameters:
     value: prod
   - name: UMB_KEYSTORE_PATH
     value: /pinhead/keystore.jks
-  - name: PRODUCT_URL
-    value: https://product.stage.api.redhat.com/svcrest/product/v3
   - name: SUBSCRIPTION_SYNC_ENABLED
     value: 'true'
   - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN
@@ -282,8 +280,6 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: metadata.namespace
-              - name: PRODUCT_URL
-                value: ${PRODUCT_URL}
               - name: PRODUCT_DENYLIST_RESOURCE_LOCATION
                 value: file:/denylist/product-denylist.txt
               - name: PRODUCT_KEYSTORE

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -59,12 +59,19 @@ SUBSCRIPTION_IGNORE_STARTING_LATER_THAN=60d
 %dev.ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC=true
 %test.ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC=true
 %prod.DEVTEST_SUBSCRIPTION_EDITING_ENABLED=false
+
+# Subscription Service configuration
 %dev.SUBSCRIPTION_URL=https://subscription.dev.api.redhat.com/svcrest/subscription/v5
 %qa.SUBSCRIPTION_URL=https://subscription.qa.api.redhat.com/svcrest/subscription/v5
 %stage.SUBSCRIPTION_URL=https://subscription.stage.api.redhat.com/svcrest/subscription/v5
 %prod.SUBSCRIPTION_URL=https://subscription.api.redhat.com/svcrest/subscription/v5
 %ephemeral.SUBSCRIPTION_URL=${%stage.SUBSCRIPTION_URL}
 %wiremock.SUBSCRIPTION_URL=http://wiremock:8101/mock/subs
+
+# Product Service configuration
+%prod.PRODUCT_URL=https://product.api.redhat.com/svcrest/product/v3
+
+# Swatch Subscription Internal configuration
 %wiremock.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://wiremock:8101/mock/internalSubs
 
 # dev-specific config items that don't need to be overridden via env var


### PR DESCRIPTION
Jira issue: SWATCH-2816

## Description
Remove PRODUCT_URL from the clowdapp contracts service, so this property is only populated from the `application.properties`.  Properly configure the PRODUCT_URL for production in swatch contracts.

## Testing
Only regression testing.