### PR TITLE
Quality of Line Improvements: validation and openApiGeneration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,6 +303,15 @@ project(":api") {
     apply plugin: "swatch.spring-boot-dependencies-conventions"
     apply plugin: "org.openapi.generator"
 
+    openApiGenerate {
+        // To keep ./gradlew openApiGenerate as a working task, we have to actually configure it.  The
+        // generateApiv{1,2} tasks are the important ones, but it's handy to be able to run openApiGenerate on
+        // the command line and have it work across all the projects.  The below configuration is just an
+        // inconsequential documentation generator but it's enough to let us set a dependsOn
+        generatorName.set("html")
+        inputSpec.set("${projectDir}/rhsm-subscriptions-api-v2-spec.yaml")
+    }
+
     def public_apis = ["v1", "v2"]
 
     for(api in public_apis) {
@@ -359,8 +368,10 @@ project(":api") {
             from spec
         }
 
-        compileJava.dependsOn tasks['generateApi' + api]
+        tasks.openApiGenerate.dependsOn('generateApi' + api)
     }
+
+    compileJava.dependsOn tasks.openApiGenerate
 
     dependencies {
         implementation project(":swatch-product-configuration")

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.capacity.admin;
 import com.redhat.swatch.configuration.registry.Variant;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.NotFoundException;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -120,9 +121,9 @@ public class InternalSubscriptionResource implements InternalSubscriptionsApi {
 
   @Override
   public AwsUsageContext getAwsUsageContext(
-      @jakarta.validation.constraints.NotNull OffsetDateTime date,
-      @jakarta.validation.constraints.NotNull String productId,
-      String orgId,
+      @NotNull OffsetDateTime date,
+      @NotNull String productId,
+      @NotNull String orgId,
       String sla,
       String usage,
       String awsAccountId) {
@@ -135,9 +136,9 @@ public class InternalSubscriptionResource implements InternalSubscriptionsApi {
 
   @Override
   public AzureUsageContext getAzureMarketplaceContext(
-      @jakarta.validation.constraints.NotNull OffsetDateTime date,
-      @jakarta.validation.constraints.NotNull String productId,
-      String orgId,
+      @NotNull OffsetDateTime date,
+      @NotNull String productId,
+      @NotNull String orgId,
       String sla,
       String usage,
       String azureAccountId) {

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProvider.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/UsageContextSubscriptionProvider.java
@@ -75,8 +75,7 @@ public class UsageContextSubscriptionProvider {
     // Set start date one hour in past to pickup recently terminated subscriptions
     var start = subscriptionDate.minusHours(1);
     List<Subscription> subscriptions =
-        subscriptionSyncController.findSubscriptions(
-            Optional.ofNullable(orgId), usageKey, start, subscriptionDate);
+        subscriptionSyncController.findSubscriptions(orgId, usageKey, start, subscriptionDate);
 
     var existsRecentlyTerminatedSubscription =
         subscriptions.stream()

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionSyncController.java
@@ -28,7 +28,6 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.db.SubscriptionRepository;
 import org.candlepin.subscriptions.db.model.DbReportCriteria;
@@ -96,7 +95,7 @@ public class SubscriptionSyncController {
 
   @Transactional
   public List<org.candlepin.subscriptions.db.model.Subscription> findSubscriptions(
-      Optional<String> orgId, Key usageKey, OffsetDateTime rangeStart, OffsetDateTime rangeEnd) {
+      String orgId, Key usageKey, OffsetDateTime rangeStart, OffsetDateTime rangeEnd) {
     Assert.isTrue(Usage._ANY != usageKey.getUsage(), "Usage cannot be _ANY");
     Assert.isTrue(ServiceLevel._ANY != usageKey.getSla(), "Service Level cannot be _ANY");
 
@@ -117,10 +116,10 @@ public class SubscriptionSyncController {
             .billingAccountId(usageKey.getBillingAccountId())
             .payg(true)
             .beginning(rangeStart)
-            .ending(rangeEnd);
+            .ending(rangeEnd)
+            .orgId(orgId);
 
-    DbReportCriteria subscriptionCriteria =
-        orgId.map(id -> reportCriteriaBuilder.orgId(id).build()).get();
+    DbReportCriteria subscriptionCriteria = reportCriteriaBuilder.build();
 
     List<org.candlepin.subscriptions.db.model.Subscription> result =
         subscriptionRepository.findByCriteria(

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -100,11 +100,6 @@ paths:
   /v1/internal/subscriptions/awsUsageContext:
     description: "Get AWS usage context."
     parameters:
-      - name: orgId
-        in: query
-        schema:
-          type: string
-        description: "Customer's Org Id"
       - name: date
         in: query
         required: true
@@ -116,6 +111,12 @@ paths:
         required: true
         schema:
           type: string
+      - name: orgId
+        in: query
+        required: true
+        schema:
+          type: string
+        description: "Customer's Org Id"
       - name: sla
         in: query
         schema:
@@ -158,12 +159,6 @@ paths:
       tags:
         - internalSubscriptions
       parameters:
-        - name: orgId
-          description: 'Look at subscriptions for this orgId'
-          example: org123
-          schema:
-            type: string
-          in: query
         - name: date
           description: 'Look at subscriptions starting on this date'
           example: 2023-10-31T00:00:00Z
@@ -175,6 +170,13 @@ paths:
         - name: productId
           description: 'This value should correspond to a product variant tag as defined in swatch product configuration'
           example: rhel-for-x86-els-payg
+          schema:
+            type: string
+          in: query
+          required: true
+        - name: orgId
+          description: 'Look at subscriptions for this orgId'
+          example: org123
           schema:
             type: string
           in: query

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionSyncControllerTest.java
@@ -98,7 +98,7 @@ class SubscriptionSyncControllerTest {
             Usage._ANY,
             BillingProvider._ANY,
             BILLING_ACCOUNT_ID_ANY);
-    Optional<String> orgId = Optional.of("org1000");
+    var orgId = "org1000";
 
     assertThrows(
         IllegalArgumentException.class,
@@ -127,8 +127,7 @@ class SubscriptionSyncControllerTest {
     when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(result);
 
     List<Subscription> actual =
-        subscriptionSyncController.findSubscriptions(
-            Optional.of("org1000"), key, rangeStart, rangeEnd);
+        subscriptionSyncController.findSubscriptions("org1000", key, rangeStart, rangeEnd);
     assertEquals(1, actual.size());
     assertEquals("xyz", actual.get(0).getBillingProviderId());
   }
@@ -148,8 +147,7 @@ class SubscriptionSyncControllerTest {
     s.setBillingProvider(BillingProvider.RED_HAT);
     s.setBillingProviderId("xyz");
     List<Subscription> actual =
-        subscriptionSyncController.findSubscriptions(
-            Optional.of("org1000"), key, rangeStart, rangeEnd);
+        subscriptionSyncController.findSubscriptions("org1000", key, rangeStart, rangeEnd);
     assertEquals(0, actual.size());
   }
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: None

## Description
Fixs an issue with the orgId not being required on calls to the internal subscription API and with the `openApiGenerate` task being broken.

## Testing

### Steps
1.  Run `./gradlew clean openApiGenerate` on both `main` and this branch.  It works on this branch
1.  Run 
     ```
     /gradlew :bootRun --args="--spring.profiles.active=kafka-queue,capacity-ingress,api,openshift-metering-worker --rhsm-subscriptions.security.dev-mode=true"
    ``` 
1. Run
    ```
    http \
    :8000/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext \
    Content-Type:application/json \
    x-rh-swatch-psk:placeholder \
    x-rh-swatch-synchronous-request:true \
    date==2024-08-08T18:00Z \
    productId==rhel-for-x86-els-payg-addon \
    sla==Premium \
    usage==Production \
    azureAccountId==10d15b90-a53a-4201-8087-61d52e0dc85b
    ```
5. You'll get a validation error.
6. Run
    ```
    http \                                                                                                                                                                                           
    :8000/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext \                                                                                                                     
    Content-Type:application/json \                                                                                                                                                                
    x-rh-swatch-psk:placeholder \                                                                                                                                                                  
    x-rh-swatch-synchronous-request:true \                                                                                                                                                         
    orgId==13149073 \                                                                                                                                                                              
    date==2024-08-08T18:00Z \                                                                                                                                                                      
    productId==rhel-for-x86-els-payg-addon \                                                                                                                                                       
    sla==Premium \                                                                                                                                                                                 
    usage==Production \                                                                                                                                                                            
    azureAccountId==10d15b90-a53a-4201-8087-61d52e0dc85b
    ```
7. Depending on your setup, you'll get some sort of response.  Probably a 404 if you have a subscription service available; otherwise some sort of error, but it won't be a complaint about validation.