### PR TITLE
Move repositories to settings.gradle

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,17 +1,6 @@
 // By keeping dependencies in this file, they get picked up by dependabot reliably
 // inspired by mockito's gradle structure, which dependabot uses as a test case
 
-// Repeating repositories here allows dependabot to use them to check for updates
-buildscript {
-  repositories {
-      mavenCentral()
-      maven { url "https://packages.confluent.io/maven/" }
-      maven { url "https://splunk.jfrog.io/splunk/ext-releases-local" }
-      // Needed for the Quarkus gradle plugin which is only published in the Gradle Plugin portal since Quarkus 3.6.6:
-      gradlePluginPortal()
-  }
-}
-
 ext {
     quarkusVersion='3.9.2'
     springVersion='3.3.2'

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,16 @@ buildscript {
     apply from: "dependencies.gradle"
 }
 
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven { url "https://packages.confluent.io/maven/" }
+        maven { url "https://splunk.jfrog.io/splunk/ext-releases-local" }
+        // Needed for the Quarkus gradle plugin which is only published in the Gradle Plugin portal since Quarkus 3.6.6:
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'rhsm-subscriptions'
 include ':api'
 include ':clients-core'


### PR DESCRIPTION
Something changed in how dependabot parses the repository definitions and this was preventing dependabot from checking for gradle plugin updates not present in maven central.

Among other things, this prevented quarkus from being updated by dependabot.

Moving it to another supported location seems to have addressed the issue.

I tested by pushing to my `main` branch on my own fork, and verified in the dependabot logs that all expected repos are checked, e.g.

> proxy | 2024/08/15 15:59:43 [650] GET https://repo.maven.apache.org:443/maven2/com/adarshr/gradle-test-logger-plugin/maven-metadata.xml
> proxy | 2024/08/15 15:59:43 [650] 404 https://repo.maven.apache.org:443/maven2/com/adarshr/gradle-test-logger-plugin/maven-metadata.xml
> proxy | 2024/08/15 15:59:43 [652] GET https://plugins.gradle.org:443/m2/com/adarshr/gradle-test-logger-plugin/maven-metadata.xml
> proxy | 2024/08/15 15:59:43 [652] 200 https://plugins.gradle.org:443/m2/com/adarshr/gradle-test-logger-plugin/maven-metadata.xml
> proxy | 2024/08/15 15:59:43 [654] GET https://packages.confluent.io:443/maven/com/adarshr/gradle-test-logger-plugin/maven-metadata.xml
> proxy | 2024/08/15 15:59:43 [654] 404 https://packages.confluent.io:443/maven/com/adarshr/gradle-test-logger-plugin/maven-metadata.xml
> proxy | 2024/08/15 15:59:43 [656] GET https://splunk.jfrog.io:443/splunk/ext-releases-local/com/adarshr/gradle-test-logger-plugin/maven-metadata.xml
> proxy | 2024/08/15 15:59:43 [656] 404 https://splunk.jfrog.io:443/splunk/ext-releases-local/com/adarshr/gradle-test-logger-plugin/maven-metadata.xml

(e.g. see https://github.com/kahowell/rhsm-subscriptions/actions/runs/10406659641/job/28820203756)