### PR TITLE
Correct errors with keystore references in swatch-contracts

### DIFF
--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -252,8 +252,6 @@ objects:
                     key: self
               - name: QUARKUS_PROFILE
                 value: ${QUARKUS_PROFILE}
-              - name: KEYSTORE_RESOURCE
-                value: file:/pinhead/keystore.jks
               - name: KEYSTORE_PASSWORD
                 valueFrom:
                   secretKeyRef:
@@ -261,6 +259,9 @@ objects:
                     key: keystore_password
               - name: KEYSTORE_PATH
                 value: /pinhead/keystore.jks
+              - name: KEYSTORE_RESOURCE
+                # Note the parenthesis for a dependent variable reference!
+                value: "file:$(KEYSTORE_PATH)"
               - name: UMB_KEYSTORE_PASSWORD
                 valueFrom:
                   secretKeyRef:
@@ -269,7 +270,11 @@ objects:
               - name: UMB_KEYSTORE_PATH
                 value: ${UMB_KEYSTORE_PATH}
               - name: TRUSTSTORE_PATH
+                # Used by UMB which is unique in not using the system truststore
                 value: /pinhead/truststore.jks
+              - name: TRUSTSTORE_RESOURCE
+                # Unset in production and stage so that the system truststore will be used
+                value: ""
               - name: TRUSTSTORE_PASSWORD
                 valueFrom:
                   secretKeyRef:
@@ -282,15 +287,17 @@ objects:
                     fieldPath: metadata.namespace
               - name: PRODUCT_DENYLIST_RESOURCE_LOCATION
                 value: file:/denylist/product-denylist.txt
-              - name: PRODUCT_KEYSTORE
-                value: /pinhead/keystore.jks
+              - name: PRODUCT_KEYSTORE_RESOURCE
+                # Note the parenthesis for a dependent variable reference!
+                value: "$(KEYSTORE_RESOURCE)"
               - name: PRODUCT_KEYSTORE_PASSWORD
                 valueFrom:
                   secretKeyRef:
                     name: tls
                     key: keystore_password
-              - name: SUBSCRIPTION_KEYSTORE
-                value: /pinhead/keystore.jks
+              - name: SUBSCRIPTION_KEYSTORE_RESOURCE
+                # Note the parenthesis for a dependent variable reference!
+                value: "$(KEYSTORE_RESOURCE)"
               - name: SUBSCRIPTION_KEYSTORE_PASSWORD
                 valueFrom:
                   secretKeyRef:

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -156,10 +156,11 @@ quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyRe
 # All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
 quarkus.rest-client-reactive.provider-autodiscovery=false
 
+# Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".url=${ENTITLEMENT_GATEWAY_URL:http://localhost:8101}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".key-store=${KEYSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".key-store-password=${KEYSTORE_PASSWORD:}
-quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store=${TRUSTSTORE_PATH:}
+quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".scope=jakarta.enterprise.context.ApplicationScoped
 
@@ -171,15 +172,16 @@ quarkus.log.category."com.redhat.swatch.contract.config.DebugClientLogger".level
 %dev.quarkus.rest-client.logging.scope=request-response
 %stage.quarkus.rest-client.logging.scope=request-response
 
+# Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".url=${SUBSCRIPTION_URL:http://localhost:8102}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store=${SUBSCRIPTION_KEYSTORE:}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store=${SUBSCRIPTION_KEYSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".key-store-password=${SUBSCRIPTION_KEYSTORE_PASSWORD:changeit}
-# SearchApi does not use any trust-store in stage/prod environments. For now, this property is only used in tests.
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store=${SUBSCRIPTION_TRUSTSTORE_PATH:}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store-password=${SUBSCRIPTION_TRUSTSTORE_PASSWORD:}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store=${TRUSTSTORE_RESOURCE:}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".scope=jakarta.enterprise.context.ApplicationScoped
 
 # configuration properties for subscriptions-sync
+# Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
@@ -188,12 +190,12 @@ quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.
 
 # configuration properties for product client
 rhsm-subscriptions.product.use-stub=${PRODUCT_USE_STUB:false}
+# Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".uri=${PRODUCT_URL:https://product.stage.api.redhat.com/svcrest/product/v3}
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store=${PRODUCT_KEYSTORE:}
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store=${PRODUCT_KEYSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store-password=${PRODUCT_KEYSTORE_PASSWORD:redhat}
-# ProductApi does not use any trust-store in stage/prod environments. For now, this property is only used in tests.
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store=${PRODUCT_TRUSTSTORE_PATH:}
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store-password=${PRODUCT_TRUSTSTORE_PASSWORD:}
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store=${TRUSTSTORE_RESOURCE:}
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".scope=jakarta.enterprise.context.ApplicationScoped
 
 # rbac service configuration
@@ -202,6 +204,7 @@ RBAC_ENABLED=true
 RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
 %dev.RBAC_ENDPOINT=http://localhost:8080
 %test.RBAC_ENDPOINT=http://localhost:8080
+# Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT}/api/rbac/v1
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store=${clowder.endpoints.rbac-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-password=${clowder.endpoints.rbac-service.trust-store-password}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/WireMockResource.java
@@ -35,13 +35,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class WireMockResource implements QuarkusTestResourceLifecycleManager {
-
   private static final String BASE_KEYSTORE_PATH =
       Paths.get(PathUtils.PROJECT_DIRECTORY, "../clients-core/src/test/resources").toString();
   private static final String SERVER_KEYSTORE_PATH =
       String.format("%s/server.jks", BASE_KEYSTORE_PATH);
   private static final String CLIENT_KEYSTORE_PATH =
       String.format("%s/client.jks", BASE_KEYSTORE_PATH);
+  public static final String CLIENT_KEYSTORE_RESOURCE =
+      String.format("file:%s", CLIENT_KEYSTORE_PATH);
   private static final String TRUSTSTORE_PATH = String.format("%s/test-ca.jks", BASE_KEYSTORE_PATH);
   public static final String STORE_PASSWORD = "password";
   private WireMockServer wireMockServer;
@@ -62,17 +63,15 @@ public class WireMockResource implements QuarkusTestResourceLifecycleManager {
     stubApis();
     wireMockServer.start();
     var config = new HashMap<String, String>();
-    config.put("KEYSTORE_RESOURCE", CLIENT_KEYSTORE_PATH);
+    config.put("KEYSTORE_PATH", CLIENT_KEYSTORE_PATH);
+    config.put("KEYSTORE_RESOURCE", CLIENT_KEYSTORE_RESOURCE);
     config.put("KEYSTORE_PASSWORD", STORE_PASSWORD);
     config.put("TRUSTSTORE_PATH", TRUSTSTORE_PATH);
+    config.put("TRUSTSTORE_RESOURCE", String.format("file:%s", TRUSTSTORE_PATH));
     config.put("TRUSTSTORE_PASSWORD", STORE_PASSWORD);
-    config.put("SUBSCRIPTION_TRUSTSTORE_PATH", TRUSTSTORE_PATH);
-    config.put("SUBSCRIPTION_TRUSTSTORE_PASSWORD", STORE_PASSWORD);
-    config.put("PRODUCT_TRUSTSTORE_PATH", TRUSTSTORE_PATH);
-    config.put("PRODUCT_TRUSTSTORE_PASSWORD", STORE_PASSWORD);
-    config.put("SUBSCRIPTION_KEYSTORE", CLIENT_KEYSTORE_PATH);
+    config.put("SUBSCRIPTION_KEYSTORE_RESOURCE", CLIENT_KEYSTORE_RESOURCE);
     config.put("SUBSCRIPTION_KEYSTORE_PASSWORD", STORE_PASSWORD);
-    config.put("PRODUCT_KEYSTORE", String.format("file:%s", CLIENT_KEYSTORE_PATH));
+    config.put("PRODUCT_KEYSTORE_RESOURCE", CLIENT_KEYSTORE_RESOURCE);
     config.put("PRODUCT_KEYSTORE_PASSWORD", STORE_PASSWORD);
     config.put(
         "ENTITLEMENT_GATEWAY_URL", String.format("%s/mock/partnerApi", wireMockServer.baseUrl()));
@@ -82,7 +81,7 @@ public class WireMockResource implements QuarkusTestResourceLifecycleManager {
         String.format("%s/mock/internalSubs", wireMockServer.baseUrl()));
     config.put(
         "quarkus.rest-client.\"com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi\".key-store",
-        String.format("file:%s", CLIENT_KEYSTORE_PATH));
+        CLIENT_KEYSTORE_RESOURCE);
     config.put(
         "quarkus.rest-client.\"com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi\".key-store-password",
         STORE_PASSWORD);


### PR DESCRIPTION
The Quarkus Rest Client code requires a keystore or truststore reference to begin with either "file:" or "classpath:".  (See io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilder#locateStream). This commit changes the references to the keystores to have the correct prefix.

Additionally, it explicity sets the truststore to empty.  In production and stage, all services except UMB should use the system truststore.

This patch also endeavors to create a standard nomenclature for the references: *_PATH for unprefixed file paths and *_RESOURCE for prefixed paths.