### PR TITLE
Bump quarkusVersion from 3.9.2 to 3.12.3

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 // inspired by mockito's gradle structure, which dependabot uses as a test case
 
 ext {
-    quarkusVersion='3.9.2'
+    quarkusVersion='3.12.3'
     springVersion='3.3.2'
     resteasyVersion='6.2.9.Final'
     jacksonVersion='2.17.2'

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/CapacityReconciliationServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/CapacityReconciliationServiceTest.java
@@ -53,9 +53,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@QuarkusTestResource(
-    value = InMemoryMessageBrokerKafkaResource.class,
-    restrictToAnnotatedClass = true)
+@QuarkusTestResource(InMemoryMessageBrokerKafkaResource.class)
 class CapacityReconciliationServiceTest {
   private static final String SUBSCRIPTION_ID = "456";
   private static final String SKU = "MCT3718";

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/EnabledOrgsProducerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/EnabledOrgsProducerTest.java
@@ -26,8 +26,6 @@ import static com.redhat.swatch.contract.service.EnabledOrgsProducer.SUBSCRIPTIO
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.swatch.contract.model.EnabledOrgsRequest;
-import com.redhat.swatch.contract.test.resources.InMemoryMessageBrokerKafkaResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import io.smallrye.reactive.messaging.memory.InMemorySink;
@@ -38,9 +36,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@QuarkusTestResource(
-    value = InMemoryMessageBrokerKafkaResource.class,
-    restrictToAnnotatedClass = true)
 class EnabledOrgsProducerTest {
 
   @ConfigProperty(name = SUBSCRIPTION_SYNC_TASK_TOPIC)

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/OfferingSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/OfferingSyncServiceTest.java
@@ -48,10 +48,8 @@ import com.redhat.swatch.contract.repository.OfferingEntity;
 import com.redhat.swatch.contract.repository.OfferingRepository;
 import com.redhat.swatch.contract.repository.ServiceLevel;
 import com.redhat.swatch.contract.repository.Usage;
-import com.redhat.swatch.contract.test.resources.InMemoryMessageBrokerKafkaResource;
 import com.redhat.swatch.contract.test.resources.ProductUseStubService;
 import io.quarkus.test.InjectMock;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
@@ -72,9 +70,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 @QuarkusTest
-@QuarkusTestResource(
-    value = InMemoryMessageBrokerKafkaResource.class,
-    restrictToAnnotatedClass = true)
 @TestProfile(ProductUseStubService.class)
 class OfferingSyncServiceTest {
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/WireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/WireMockResource.java
@@ -259,8 +259,10 @@ public class WireMockResource implements QuarkusTestResourceLifecycleManager {
 
   @Override
   public void stop() {
-    wireMockServer.stop();
-    wireMockServer.resetAll();
+    if (wireMockServer != null) {
+      wireMockServer.stop();
+      wireMockServer = null;
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description
- Bump quarkusVersion from 3.9.2 to 3.12.3
- swatch-contracts: fixing out of memory

Using ` InMemoryMessageBrokerKafkaResource` in tests with `restrictToAnnotatedClass = true` causes the out of memory.
Changing it to only be present in one class with `restrictToAnnotatedClass = false` (default value)
More information about this issue which is getting worse over time is here: https://groups.google.com/g/quarkus-dev/c/JNK7rtADElM/m/a8WsyICRAAAJ?utm_medium=email&utm_source=footer

## Testing
Only regression testing