### PR TITLE
SWATCH-2826: Fix PAYG fingerprinting bug with role value

### DIFF
--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
@@ -256,6 +256,21 @@ class SubscriptionDefinitionTest {
         "cluster_hour", SubscriptionDefinition.getAzureDimension("BASILISK", "Instance-hours"));
   }
 
+  @Test
+  void testCostManagementRhelElsAddon() {
+    ProductTagLookupParams params =
+        ProductTagLookupParams.builder()
+            .isPaygEligibleProduct(true)
+            .is3rdPartyMigration(false)
+            .role("Red Hat Enterprise Linux Server")
+            .metricIds(Set.of("vCPUs"))
+            .engIds(Set.of("69", "204"))
+            .build();
+
+    var actual = SubscriptionDefinition.getAllProductTags(params);
+    assertEquals(Set.of("rhel-for-x86-els-payg-addon"), actual);
+  }
+
   @ParameterizedTest(
       name =
           "isMetered: {0}, isConverted: {1}, metricIds: {2}, productIds: {3} match productTags {4}")


### PR DESCRIPTION
Jira issue: SWATCH-2826

Description
===========

Fix a bug where cost-managed populated role values were unintentionally causing payg values to not be properly identified.

This happened because we refactored the fingerprinting logic in #3496 so that the role/eng id/level/product name identifiers are consulted first, and the first match short-circuits the rest. Then further filtering is done later on to find a more specific match.

Given current product definitions, this meant that a PAYG rhel fingerprint could be inappropriately initially tagged with "RHEL for x86" and then later have that tag filtered out, leading to no matching tags.

This change moves the payg/non-payg filter up-front, so that this doesn't happen.

Testing
=======

IQE Test MR: TODO

See the added test:

```shell
./gradlew swatch-product-configuration:test --tests SubscriptionDefinitionTest.testCostManagementRhelElsAddon
```