### PR TITLE
Fix flaky test involving timestamp format

### DIFF
--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -113,7 +113,7 @@ quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter, com.redhat.swatch.aws.resource.DefaultApiExceptionMapper
+quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter, com.redhat.swatch.aws.resource.DefaultApiExceptionMapper, com.redhat.swatch.common.resteasy.OffsetDateTimeParamConverterProvider
 com.redhat.swatch.processors.BillableUsageProcessor/lookupAwsUsageContext/Retry/maxRetries=${AWS_USAGE_CONTEXT_LOOKUP_RETRIES}
 com.redhat.swatch.processors.BillableUsageProcessor/send/Retry/maxRetries=${AWS_SEND_RETRIES}
 

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsUsageContextLookupApiTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsUsageContextLookupApiTest.java
@@ -43,9 +43,9 @@ class AwsUsageContextLookupApiTest {
 
   @Test
   void testParameterOrderGetAwsUsageContext() {
-    var now = OffsetDateTime.now();
+    var timestamp = OffsetDateTime.parse("2024-08-16T16:32:47.61154261Z");
     var aggregate = new BillableUsageAggregate();
-    aggregate.setWindowTimestamp(now);
+    aggregate.setWindowTimestamp(timestamp);
     var key =
         new BillableUsageAggregateKey(
             "orgId",
@@ -63,7 +63,8 @@ class AwsUsageContextLookupApiTest {
     }
     verify(
         getRequestedFor(urlMatching(".*/awsUsageContext.*"))
-            .withQueryParam("date", equalTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(now)))
+            .withQueryParam(
+                "date", equalTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(timestamp)))
             .withQueryParam("productId", equalTo("productId"))
             .withQueryParam("sla", equalTo("Premium"))
             .withQueryParam("usage", equalTo("Production"))


### PR DESCRIPTION
By applying the OffsetDateParamConverterProvider, it forces the query param for timestamps to always consistently drop redundant 0s, For example,

> 2024-08-16T16:32:47.61154261Z

vs.

> 2024-08-16T16:32:47.611542610Z

I also updated the test to use a fixed timestamp that is formatted differently depending on whether `OffsetDateTime.toString` or the param converter provider is used, so that the test will consistently fail if there is a regression.