### PR TITLE
Fix task definition for tekton build-source-image

### DIFF
--- a/.tekton/rhsm-push.yaml
+++ b/.tekton/rhsm-push.yaml
@@ -232,8 +232,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-api-push.yaml
+++ b/.tekton/swatch-api-push.yaml
@@ -232,8 +232,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-contracts-push.yaml
+++ b/.tekton/swatch-contracts-push.yaml
@@ -232,8 +232,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-metrics-push.yaml
+++ b/.tekton/swatch-metrics-push.yaml
@@ -240,8 +240,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-producer-aws-push.yaml
+++ b/.tekton/swatch-producer-aws-push.yaml
@@ -232,8 +232,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-producer-azure-push.yaml
+++ b/.tekton/swatch-producer-azure-push.yaml
@@ -240,8 +240,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-producer-red-hat-marketplace-push.yaml
+++ b/.tekton/swatch-producer-red-hat-marketplace-push.yaml
@@ -232,8 +232,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-subscription-sync-push.yaml
+++ b/.tekton/swatch-subscription-sync-push.yaml
@@ -232,8 +232,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-system-conduit-push.yaml
+++ b/.tekton/swatch-system-conduit-push.yaml
@@ -232,8 +232,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/swatch-tally-push.yaml
+++ b/.tekton/swatch-tally-push.yaml
@@ -232,8 +232,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:


### PR DESCRIPTION
See migration guide at https://github.com/konflux-ci/build-definitions/blob/ff4aa95d49db6d0271446ae2b2fe91df06312441/task/buildah/0.2/MIGRATION.md