### PR TITLE
SWATCH-2505 Remove use of uom for Sku Capacity Report from v1

### DIFF
--- a/api/rhsm-subscriptions-api-v1-spec.yaml
+++ b/api/rhsm-subscriptions-api-v1-spec.yaml
@@ -578,12 +578,6 @@ paths:
             format: date-time
           description: "Defines the end of the report period.  Defaults to the current time. Dates should
              be provided in UTC."
-        - name: uom
-          in: query
-          deprecated: true
-          schema:
-            $ref: '#/components/schemas/Uom'
-          description: "Filter subscriptions to those that contribute to a specific unit of measure. Deprecated: use 'metric_id' instead."
         - name: metric_id
           in: query
           schema:
@@ -742,13 +736,6 @@ components:
         - alibaba
     BillingAccountId:
       type: string
-    Uom:
-      description: "The unit-of-measure for the capacity. Deprecated: use 'metric_id' instead."
-      type: string
-      deprecated: true
-      enum:
-        - cores
-        - sockets
     BillingCategory:
       type: string
       enum:
@@ -1270,8 +1257,6 @@ components:
         has_infinite_quantity:
           description: "Denotes unlimited capacity for the offering when true."
           type: boolean
-        uom:
-          $ref: "#/components/schemas/Uom"
         metric_id:
           type: string
     SkuCapacityReportSort:
@@ -1305,8 +1290,6 @@ components:
               $ref: '#/components/schemas/ServiceLevelType'
             usage:
               $ref: '#/components/schemas/UsageType'
-            uom:
-              $ref: '#/components/schemas/Uom'
             subscription_type:
               $ref: '#/components/schemas/SubscriptionType'
             report_category:

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionResourceV1.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionResourceV1.java
@@ -30,7 +30,6 @@ import org.candlepin.subscriptions.utilization.api.v1.model.ServiceLevelType;
 import org.candlepin.subscriptions.utilization.api.v1.model.SkuCapacityReport;
 import org.candlepin.subscriptions.utilization.api.v1.model.SkuCapacityReportSort;
 import org.candlepin.subscriptions.utilization.api.v1.model.SortDirection;
-import org.candlepin.subscriptions.utilization.api.v1.model.Uom;
 import org.candlepin.subscriptions.utilization.api.v1.model.UsageType;
 import org.candlepin.subscriptions.utilization.api.v1.resources.SubscriptionsApi;
 import org.springframework.stereotype.Component;
@@ -58,7 +57,6 @@ public class SubscriptionResourceV1 implements SubscriptionsApi {
       String billingAccountId,
       OffsetDateTime beginning,
       OffsetDateTime ending,
-      Uom uom,
       String metricId,
       SkuCapacityReportSort sort,
       SortDirection dir) {
@@ -72,7 +70,6 @@ public class SubscriptionResourceV1 implements SubscriptionsApi {
         usage,
         billingProvider,
         billingAccountId,
-        uom,
         metricId,
         sort,
         dir);

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionResourceV1Test.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionResourceV1Test.java
@@ -71,7 +71,6 @@ class SubscriptionResourceV1Test {
                 min,
                 max,
                 null,
-                null,
                 SkuCapacityReportSort.SKU,
                 null));
   }
@@ -95,7 +94,6 @@ class SubscriptionResourceV1Test {
                 null,
                 min,
                 max,
-                null,
                 null,
                 SkuCapacityReportSort.SKU,
                 null));

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionTableControllerTest.java
@@ -24,7 +24,7 @@ import static java.util.Arrays.asList;
 import static org.candlepin.subscriptions.resource.api.v1.CapacityResource.HYPERVISOR;
 import static org.candlepin.subscriptions.resource.api.v1.CapacityResource.PHYSICAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -65,7 +65,6 @@ import org.candlepin.subscriptions.utilization.api.v1.model.SkuCapacitySubscript
 import org.candlepin.subscriptions.utilization.api.v1.model.SortDirection;
 import org.candlepin.subscriptions.utilization.api.v1.model.SubscriptionEventType;
 import org.candlepin.subscriptions.utilization.api.v1.model.SubscriptionType;
-import org.candlepin.subscriptions.utilization.api.v1.model.Uom;
 import org.candlepin.subscriptions.utilization.api.v1.model.UsageType;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -197,7 +196,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            productId, null, null, null, null, null, null, null, null, null, null, null);
+            productId, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the sub and appropriate
     // quantity and capacities.
@@ -232,7 +231,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            productId, null, null, null, null, null, null, null, null, null, null, null);
+            productId, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the subs and appropriate
     // quantity and capacities.
@@ -279,7 +278,6 @@ class SubscriptionTableControllerTest {
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
             productId,
-            null,
             null,
             null,
             null,
@@ -336,7 +334,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for an eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            RHEL_FOR_X86, null, null, null, null, null, null, null, null, null, null, null);
+            RHEL_FOR_X86, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains no inventory items.
     assertEquals(0, actual.getData().size(), "An empty inventory list should be returned.");
@@ -366,7 +364,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             null,
-            null,
             SkuCapacityReportSort.SKU,
             null);
     assertEquals(1, report.getData().size());
@@ -385,7 +382,6 @@ class SubscriptionTableControllerTest {
         UsageType.PRODUCTION,
         BillingProviderType.AWS,
         null,
-        Uom.CORES,
         "Cores",
         SkuCapacityReportSort.SKU,
         null);
@@ -446,7 +442,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             null,
-            null,
             SkuCapacityReportSort.SKU,
             null);
     assertEquals(0, reportForUnmatchedSLA.getData().size());
@@ -459,7 +454,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             ServiceLevelType.STANDARD,
-            null,
             null,
             null,
             null,
@@ -493,7 +487,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             null,
-            null,
             SkuCapacityReportSort.SKU,
             null);
     assertEquals(0, reportForUnmatchedUsage.getData().size());
@@ -507,7 +500,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             UsageType.PRODUCTION,
-            null,
             null,
             null,
             null,
@@ -571,18 +563,7 @@ class SubscriptionTableControllerTest {
 
     SkuCapacityReport reportWithOffsetAndLimit =
         subscriptionTableController.capacityReportBySku(
-            productId,
-            0,
-            2,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            SkuCapacityReportSort.SKU,
-            null);
+            productId, 0, 2, null, null, null, null, null, null, SkuCapacityReportSort.SKU, null);
     assertEquals(2, reportWithOffsetAndLimit.getData().size());
     assertEquals(5, reportWithOffsetAndLimit.getMeta().getCount());
   }
@@ -617,7 +598,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             null,
-            Uom.CORES,
             null,
             SkuCapacityReportSort.SKU,
             null);
@@ -633,7 +613,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             null,
-            Uom.SOCKETS,
             null,
             SkuCapacityReportSort.SKU,
             null);
@@ -670,7 +649,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             null,
-            null,
             MetricIdUtils.getCores().toString(),
             SkuCapacityReportSort.SKU,
             null);
@@ -683,7 +661,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             ServiceLevelType.STANDARD,
-            null,
             null,
             null,
             null,
@@ -709,7 +686,6 @@ class SubscriptionTableControllerTest {
                     null,
                     null,
                     null,
-                    null,
                     SkuCapacityReportSort.SKU,
                     null));
     assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
@@ -723,7 +699,6 @@ class SubscriptionTableControllerTest {
     SkuCapacityReport report =
         subscriptionTableController.capacityReportBySku(
             RHEL_FOR_X86,
-            null,
             null,
             null,
             null,
@@ -746,7 +721,6 @@ class SubscriptionTableControllerTest {
     SkuCapacityReport report =
         subscriptionTableController.capacityReportBySku(
             ProductId.fromString("OpenShift-metrics"),
-            null,
             null,
             null,
             null,
@@ -779,7 +753,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            productId, null, null, null, null, null, null, null, null, null, null, null);
+            productId, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the sub and HasInfiniteQuantity
     // should be true.
@@ -810,7 +784,6 @@ class SubscriptionTableControllerTest {
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
             productId,
-            null,
             null,
             null,
             null,
@@ -867,7 +840,6 @@ class SubscriptionTableControllerTest {
             null,
             null,
             null,
-            null,
             SkuCapacityReportSort.TOTAL_CAPACITY,
             SortDirection.DESC);
 
@@ -902,7 +874,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            productId, null, null, null, null, null, null, null, null, null, null, null);
+            productId, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the sub and appropriate
     // quantity and capacities.
@@ -928,7 +900,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            productId, null, null, null, null, null, null, null, null, null, null, null);
+            productId, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the sub and appropriate
     // quantity and capacities.
@@ -954,7 +926,7 @@ class SubscriptionTableControllerTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            productId, null, null, null, null, null, null, null, null, null, null, null);
+            productId, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the sub and appropriate
     // quantity and capacities.
@@ -976,11 +948,11 @@ class SubscriptionTableControllerTest {
   private static void assertCapacities(
       int expectedCap, int expectedHypCap, String expectedMetricId, SkuCapacity actual) {
     if (MetricIdUtils.getCores().toString().equalsIgnoreCase(expectedMetricId)) {
-      assertEquals(Uom.CORES, actual.getUom(), "Wrong UOM");
+      assertEquals("CORES", actual.getMetricId(), "Correct metric id");
     } else if (MetricIdUtils.getSockets().toString().equalsIgnoreCase(expectedMetricId)) {
-      assertEquals(Uom.SOCKETS, actual.getUom(), "Wrong UOM");
+      assertEquals("SOCKETS", actual.getMetricId(), "Correct metric id");
     } else {
-      assertNull(actual.getUom());
+      assertNotNull(actual.getMetricId());
     }
 
     assertEquals(expectedMetricId, actual.getMetricId(), "Wrong Metric ID");

--- a/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerOnDemandTest.java
+++ b/src/test/java/org/candlepin/subscriptions/subscription/SubscriptionTableControllerOnDemandTest.java
@@ -156,7 +156,7 @@ class SubscriptionTableControllerOnDemandTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            ROSA, null, null, null, null, null, null, null, null, null, null, null);
+            ROSA, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the sub and appropriate
     // quantity and capacities.
@@ -189,7 +189,7 @@ class SubscriptionTableControllerOnDemandTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            ROSA, null, null, null, null, null, null, null, null, null, null, null);
+            ROSA, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the subs and appropriate
     // quantity and capacities.
@@ -225,18 +225,7 @@ class SubscriptionTableControllerOnDemandTest {
     // When requesting a SKU capacity report for the eng product, sorted by SKU
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            ROSA,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            SkuCapacityReportSort.SKU,
-            null);
+            ROSA, null, null, null, null, null, null, null, null, SkuCapacityReportSort.SKU, null);
 
     // Then the report contains two inventory items containing a sub with appropriate
     // quantity and capacities, and RH00604F5 is listed first.
@@ -270,7 +259,7 @@ class SubscriptionTableControllerOnDemandTest {
     // When requesting a SKU capacity report for an eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            ROSA, null, null, null, null, null, null, null, null, null, null, null);
+            ROSA, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains no inventory items.
     assertEquals(0, actual.getData().size(), "An empty inventory list should be returned.");
@@ -289,18 +278,7 @@ class SubscriptionTableControllerOnDemandTest {
 
     SkuCapacityReport report =
         subscriptionTableController.capacityReportBySku(
-            ROSA,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            SkuCapacityReportSort.SKU,
-            null);
+            ROSA, null, null, null, null, null, null, null, null, SkuCapacityReportSort.SKU, null);
     assertEquals(1, report.getData().size());
   }
 
@@ -322,7 +300,6 @@ class SubscriptionTableControllerOnDemandTest {
             null,
             null,
             ServiceLevelType.STANDARD,
-            null,
             null,
             null,
             null,
@@ -354,7 +331,6 @@ class SubscriptionTableControllerOnDemandTest {
             null,
             null,
             null,
-            null,
             SkuCapacityReportSort.SKU,
             null);
     assertEquals(1, reportForMatchingUsage.getData().size());
@@ -373,7 +349,7 @@ class SubscriptionTableControllerOnDemandTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            ROSA, null, null, null, null, null, null, null, null, null, null, null);
+            ROSA, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the sub and HasInfiniteQuantity
     // should be true.
@@ -396,7 +372,7 @@ class SubscriptionTableControllerOnDemandTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            ROSA, null, null, null, null, null, null, null, null, null, null, null);
+            ROSA, null, null, null, null, null, null, null, null, null, null);
     SkuCapacity actualItem = actual.getData().get(0);
 
     // Then the report should contain end date of the contributing subscription
@@ -418,18 +394,7 @@ class SubscriptionTableControllerOnDemandTest {
 
     SkuCapacityReport reportForMatchingUsage =
         subscriptionTableController.capacityReportBySku(
-            ROSA,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            SkuCapacityReportSort.SKU,
-            null);
+            ROSA, null, null, null, null, null, null, null, null, SkuCapacityReportSort.SKU, null);
     assertEquals(2, reportForMatchingUsage.getData().size());
     var billingProvidersReturned =
         reportForMatchingUsage.getData().stream().map(SkuCapacity::getBillingProvider).toList();
@@ -451,7 +416,7 @@ class SubscriptionTableControllerOnDemandTest {
     // When requesting a SKU capacity report for the eng product,
     SkuCapacityReport actual =
         subscriptionTableController.capacityReportBySku(
-            RHEL_x86_ELS_PAYG, null, null, null, null, null, null, null, null, null, null, null);
+            RHEL_x86_ELS_PAYG, null, null, null, null, null, null, null, null, null, null);
 
     // Then the report contains a single inventory item containing the sub and HasInfiniteQuantity
     // should be true.


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2505

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Remove use of uom for Sku Capacity Report from v1. We will remove the v1 API itself since we have a related card in GUI to use v2 APIs. https://issues.redhat.com/browse/SWATCH-2410
I had following data in database but, seems like we may need more testing other than the happy path. I rely on QE test since I am not sure what exact data is needed to get the response and how the UI queries the backend. 

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
Insert records:
```
INSERT INTO public.org_config (org_id, opt_in_type, created, updated) VALUES ('org123', 'PROMETHEUS', '2024-08-06 17:51:43.999993 +00:00', '2024-08-06 17:51:43.999993 +00:00');
```

```
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered, special_pricing_flag, level_1, level_2) VALUES ('RH00004', 'RHEL Server', 'Red Hat Enterprise Linux', null, 2, null, null, 'Red Hat Enterprise Linux Server', 'Standard', 'Production', 'Red Hat Enterprise Linux Server, Standard (Physical or Virtual Nodes)', false, '', false, '', null, null);
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered, special_pricing_flag, level_1, level_2) VALUES ('RH3413336', 'RHEL Developer Workstation', 'Red Hat Enterprise Linux', null, 2, null, null, '', '', 'Development/Test', 'Red Hat Enterprise Linux Developer Workstation, Enterprise', false, '', false, '', null, null);
```

```
INSERT INTO public.sku_product_tag (sku, product_tag) VALUES ('RH00004', 'RHEL for x86');
INSERT INTO public.sku_product_tag (sku, product_tag) VALUES ('RH3413336', 'RHEL for x86');
```

```
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00004', 'org123', '1234567', 2, '2024-06-01 04:00:00.000000 +00:00', '2025-05-31 04:00:00.000000 +00:00', '', '1223456', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH3413336', 'org123', '235255', 1, '2011-01-01 01:02:33.000000 +00:00', '2031-01-01 01:02:33.000000 +00:00', null, '2253594', null, null);
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH3413336', 'org123', '1234576', 2, '2021-12-08 22:21:40.392000 +00:00', '2025-12-08 22:38:20.392000 +00:00', null, null, null, null);
```

```
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('1234576', '2021-12-08 22:21:40.392000 +00:00', 'SOCKETS', 'PHYSICAL', 4);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('235255', '2011-01-01 01:02:33.000000 +00:00', 'SOCKETS', 'PHYSICAL', 2);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('235255', '2011-01-01 01:02:33.000000 +00:00', 'CORES', 'PHYSICAL', 4);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('1234576', '2021-12-08 22:21:40.392000 +00:00', 'CORES', 'PHYSICAL', 8);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('235255', '2011-01-01 01:02:33.000000 +00:00', 'INSTANCE-HOURS', 'PHYSICAL', 4);
```


1. `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,rh-marketplace,kafka-queue,rhsm-conduit ./gradlew clean :bootRun`

### Steps
<!-- Enter each step of the test below -->
1. Subscription capacity APIs for v1 doesn't need uom:
`http :8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL%20for%20x86   beginning==2024-07-02T00:00:00.000Z   ending==2024-08-31T23:59:59.999Z   granularity==Daily   use_running_totals_format==true   billing_category==on-demand   offset==1000   x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w0)`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Response
```
{
    "data": [],
    "meta": {
        "count": 1,
        "product": "RHEL for x86",
        "subscription_type": "Annual"
    }
}
```

### Steps
<!-- Enter each step of the test below -->
2. Capacity APIs for v1 doesn't need uom:
`http :8000/api/rhsm-subscriptions/v1/capacity/products/RHEL%20for%20x86/Sockets   beginning==2024-07-02T00:00:00.000Z   ending==2024-08-31T23:59:59.999Z   granularity==Daily   use_running_totals_format==true   billing_category==on-demand   offset==1000   x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"org123"}}}' | base64 -w0)`

### Verification
<!-- Enter the steps needed to verify the test passed -->
2. Response
```
{
    "data": [],
    "links": {
        "first": "/api/rhsm-subscriptions/v1/capacity/products/RHEL%20for%20x86/Sockets?beginning=2024-07-02T00%3A00%3A00.000Z&ending=2024-08-31T23%3A59%3A59.999Z&granularity=Daily&use_running_totals_format=true&billing_category=on-demand&offset=0",
        "last": "/api/rhsm-subscriptions/v1/capacity/products/RHEL%20for%20x86/Sockets?beginning=2024-07-02T00%3A00%3A00.000Z&ending=2024-08-31T23%3A59%3A59.999Z&granularity=Daily&use_running_totals_format=true&billing_category=on-demand&offset=50",
        "previous": "/api/rhsm-subscriptions/v1/capacity/products/RHEL%20for%20x86/Sockets?beginning=2024-07-02T00%3A00%3A00.000Z&ending=2024-08-31T23%3A59%3A59.999Z&granularity=Daily&use_running_totals_format=true&billing_category=on-demand&offset=950"
    },
    "meta": {
        "count": 61,
        "granularity": "Daily",
        "metric_id": "Sockets",
        "product": "RHEL for x86"
    }
}

```