### PR TITLE
SWATCH-2804: Delete getSubscriptionById from SearchApi

### DIFF
--- a/clients/quarkus/subscription-client/src/main/java/com/redhat/swatch/clients/subscription/StubSearchApi.java
+++ b/clients/quarkus/subscription-client/src/main/java/com/redhat/swatch/clients/subscription/StubSearchApi.java
@@ -27,10 +27,6 @@ import jakarta.ws.rs.ProcessingException;
 import java.util.List;
 
 public class StubSearchApi implements SearchApi {
-  @Override
-  public Subscription getSubscriptionById(String id) throws ProcessingException {
-    return null;
-  }
 
   @Override
   public List<Subscription> getSubscriptionBySubscriptionNumber(String subscriptionNumber)

--- a/clients/subscription-client/subscription-api-spec.yaml
+++ b/clients/subscription-client/subscription-api-spec.yaml
@@ -7,27 +7,6 @@ info:
   version: 1.0.0
 
 paths:
-  /id={id}/options/options;products=ALL/:
-    description: "Get a subscription by ID"
-    parameters:
-      - name: id
-        required: true
-        in: path
-        description: "The ID of the subscription entity"
-        schema:
-          type: string
-    get:
-      summary: "Get a single subscription"
-      operationId: "getSubscriptionById"
-      tags:
-        - search
-      responses:
-        '200':
-          description: "The operation completed successfully"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subscription"
   /search/criteria;subscription_number={subscriptionNumber}/options;products=ALL;showExternalReferences=true/:
     description: "Find a subscription by subscription number"
     parameters:

--- a/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/StubSearchApi.java
@@ -34,16 +34,6 @@ public class StubSearchApi extends SearchApi {
   public static final String END_DATE = "2031-01-01T01:02:33Z";
 
   @Override
-  public Subscription getSubscriptionById(String id) {
-    if ("789".equals(id)) {
-      return createAwsBillingProviderData();
-    } else if ("790".equals(id)) {
-      return createDataForOrgId(790);
-    }
-    return createDefaultData();
-  }
-
-  @Override
   public List<Subscription> getSubscriptionBySubscriptionNumber(String subscriptionNumber) {
     return List.of(createAwsBillingProviderData());
   }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionService.java
@@ -53,29 +53,6 @@ public class SubscriptionService {
   @Inject @SearchClient SearchApi subscriptionApi;
   @Inject ApplicationConfiguration properties;
 
-  /**
-   * Object a subscription model by ID.
-   *
-   * @param id the Subscription ID.
-   * @return a subscription model.
-   */
-  @RetryWithExponentialBackoff(
-      maxRetries = "${SUBSCRIPTION_MAX_RETRY_ATTEMPTS:4}",
-      delay = "${SUBSCRIPTION_BACK_OFF_INITIAL_INTERVAL:1000ms}",
-      maxDelay = "${SUBSCRIPTION_BACK_OFF_MAX_INTERVAL:64s}",
-      factor = "${SUBSCRIPTION_BACK_OFF_MULTIPLIER:2}")
-  public Subscription getSubscriptionById(String id) {
-    try {
-      return subscriptionApi.getSubscriptionById(id);
-    } catch (ProcessingException | ApiException e) {
-      log.error(API_EXCEPTION_FROM_SUBSCRIPTION_SERVICE, e.getMessage());
-      throw new ExternalServiceException(
-          ErrorCode.REQUEST_PROCESSING_ERROR,
-          ERROR_DURING_ATTEMPT_TO_REQUEST_SUBSCRIPTION_INFO_MSG,
-          e);
-    }
-  }
-
   @RetryWithExponentialBackoff(
       maxRetries = "${SUBSCRIPTION_MAX_RETRY_ATTEMPTS:4}",
       delay = "${SUBSCRIPTION_BACK_OFF_INITIAL_INTERVAL:1000ms}",

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionServiceTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.redhat.swatch.clients.subscription.api.model.Subscription;
 import com.redhat.swatch.clients.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
 import io.quarkus.test.InjectMock;
@@ -46,12 +45,5 @@ class SubscriptionServiceTest {
     when(searchApi.searchSubscriptionsByOrgId("123", 0, 1)).thenReturn(Collections.emptyList());
     subject.getSubscriptionsByOrgId("123", 0, 1);
     verify(searchApi, only()).searchSubscriptionsByOrgId("123", 0, 1);
-  }
-
-  @Test
-  void verifyGetByIdTest() throws ApiException {
-    when(searchApi.getSubscriptionById("123")).thenReturn(new Subscription());
-    subject.getSubscriptionById("123");
-    verify(searchApi, only()).getSubscriptionById("123");
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
@@ -320,7 +320,6 @@ class SubscriptionSyncServiceTest {
     var dto = createDto("456", 10);
     dto.setEffectiveStartDate(toEpochMillis(NOW.plusMonths(2).plusDays(1)));
     dto.setEffectiveEndDate(toEpochMillis(NOW.plusMonths(14).plusDays(1)));
-    Mockito.when(subscriptionService.getSubscriptionById("456")).thenReturn(dto);
 
     Mockito.when(subscriptionService.getSubscriptionsByOrgId(any())).thenReturn(List.of(dto));
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);
@@ -337,7 +336,6 @@ class SubscriptionSyncServiceTest {
     var dto = createDto("456", 10);
     dto.setEffectiveStartDate(null);
     dto.setEffectiveEndDate(null);
-    Mockito.when(subscriptionService.getSubscriptionById("456")).thenReturn(dto);
 
     Mockito.when(subscriptionService.getSubscriptionsByOrgId(any())).thenReturn(List.of(dto));
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);


### PR DESCRIPTION
Jira issue: SWATCH-2804

## Description
This method is only used in some unit tests, so it's dead code, and also the API does not work (it does not exist in "https://subscription.api.redhat.com/svcrest/subscription/v5".

## Testing
Only regression testing.