### PR TITLE
SWATCH-2827: Bump quarkusVersion from 3.12.3 to 3.14.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 // inspired by mockito's gradle structure, which dependabot uses as a test case
 
 ext {
-    quarkusVersion='3.12.3'
+    quarkusVersion='3.14.1'
     springVersion='3.3.3'
     resteasyVersion='6.2.10.Final'
     jacksonVersion='2.17.2'

--- a/swatch-common-panache/src/main/java/com/redhat/swatch/panache/PanacheSpecificationSupport.java
+++ b/swatch-common-panache/src/main/java/com/redhat/swatch/panache/PanacheSpecificationSupport.java
@@ -70,6 +70,6 @@ public interface PanacheSpecificationSupport<Entity, Id> extends PanacheReposito
   }
 
   default Entity merge(Entity entity) {
-    return JpaOperations.INSTANCE.getEntityManager().merge(entity);
+    return JpaOperations.INSTANCE.getSession().merge(entity);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
@@ -48,7 +48,7 @@ import com.redhat.swatch.contract.service.EnabledOrgsProducer;
 import com.redhat.swatch.contract.service.OfferingProductTagLookupService;
 import com.redhat.swatch.contract.service.OfferingSyncService;
 import com.redhat.swatch.contract.service.SubscriptionSyncService;
-import io.quarkus.runtime.configuration.ProfileManager;
+import io.quarkus.runtime.LaunchMode;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
@@ -264,7 +264,7 @@ public class ContractsResource implements DefaultApi {
   public SubscriptionResponse saveSubscriptions(Boolean reconcileCapacity, String body)
       throws ProcessingException {
     var response = new SubscriptionResponse();
-    if (!ProfileManager.getLaunchMode().isDevOrTest()
+    if (!LaunchMode.current().isDevOrTest()
         && !applicationConfiguration.isManualSubscriptionEditingEnabled()) {
       response.setDetail(FEATURE_NOT_ENABLED_MESSAGE);
       return response;


### PR DESCRIPTION
Jira issue: SWATCH-2827

## Description
- Bump quarkusVersion from 3.12.3 to 3.14.1
- Replace JpaOperations.INSTANCE.getEntityManager() by JpaOperations.INSTANCE.getSession()
- Replace ProfileManager by LaunchMode

## Testing
Only regression testing.