### PR TITLE
SWATCH-2855: Truncate start/end dates when syncing contracts from IT Partner gateway

### DIFF
--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/RhPartnerClientIntegrationTest.java
@@ -64,7 +64,8 @@ class RhPartnerClientIntegrationTest {
     assertEquals(2, purchase.getContracts().size());
     var contract = purchase.getContracts().get(0);
     assertNotNull(contract);
-    assertEquals(OffsetDateTime.parse("2022-09-23T20:07:51.010445Z"), contract.getStartDate());
+    assertEquals(
+        OffsetDateTime.parse(WireMockResource.DEFAULT_START_DATE), contract.getStartDate());
     assertNotNull(contract.getDimensions());
     assertEquals(2, contract.getDimensions().size());
     var dimension = contract.getDimensions().get(0);

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,7 +53,6 @@ import com.redhat.swatch.contract.BaseUnitTest;
 import com.redhat.swatch.contract.exception.ContractValidationFailedException;
 import com.redhat.swatch.contract.model.ContractSourcePartnerEnum;
 import com.redhat.swatch.contract.model.MeasurementMetricIdTransformer;
-import com.redhat.swatch.contract.model.SubscriptionEntityMapper;
 import com.redhat.swatch.contract.openapi.model.Contract;
 import com.redhat.swatch.contract.openapi.model.ContractRequest;
 import com.redhat.swatch.contract.openapi.model.ContractResponse;
@@ -85,6 +85,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 
 @QuarkusTest
 @QuarkusTestResource(value = WireMockResource.class, restrictToAnnotatedClass = true)
@@ -93,7 +94,7 @@ class ContractServiceTest extends BaseUnitTest {
   private static final String ORG_ID = "org123";
   private static final String SKU = "RH000000";
   private static final String PRODUCT_TAG = "MH123";
-  private static final String SUBSCRIPTION_NUMBER = "subs123";
+  private static final String SUBSCRIPTION_NUMBER = "13294886";
   private static final OffsetDateTime DEFAULT_START_DATE =
       OffsetDateTime.parse("2023-06-09T13:59:43.035365Z");
   private static final OffsetDateTime DEFAULT_END_DATE =
@@ -101,7 +102,6 @@ class ContractServiceTest extends BaseUnitTest {
 
   @Inject ContractService contractService;
   @Inject ObjectMapper objectMapper;
-  @Inject SubscriptionEntityMapper subscriptionEntityMapper;
   @InjectSpy ContractRepository contractRepository;
   @Inject OfferingRepository offeringRepository;
   @InjectMock SubscriptionRepository subscriptionRepository;
@@ -113,6 +113,7 @@ class ContractServiceTest extends BaseUnitTest {
   @Transactional
   @BeforeEach
   public void setup() {
+    WireMockResource.setup(wireMockServer);
     contractRepository.deleteAll();
     offeringRepository.deleteAll();
     OfferingEntity offering = new OfferingEntity();
@@ -192,7 +193,7 @@ class ContractServiceTest extends BaseUnitTest {
     StatusResponse statusResponse = contractService.createPartnerContract(request);
     verify(subscriptionRepository, times(3)).persist(any(SubscriptionEntity.class));
 
-    verify(contractRepository, times(3)).persist(any(ContractEntity.class));
+    verify(contractRepository, times(2)).persist(any(ContractEntity.class));
 
     ArgumentCaptor<ContractEntity> contractSaveCapture =
         ArgumentCaptor.forClass(ContractEntity.class);
@@ -390,6 +391,25 @@ class ContractServiceTest extends BaseUnitTest {
     wireMockServer.removeStub(stubMapping);
   }
 
+  /**
+   * IT Partner gateway uses nano precision for the start date, when postgresql or hsql uses micro
+   * precision. Therefore, we need to address this loss of precision to properly identify the
+   * contracts being updated.
+   */
+  @Test
+  void testContractIsUpdatedWhenUsingSameStartDateWithNanoPrecision() {
+    var existing = givenExistingContractWithSameStartDateThanInPartnerGateway();
+    // when receive an update using exactly the same start date
+    PartnerEntitlementContract request = givenPartnerEntitlementContractRequest();
+    contractService.createPartnerContract(request);
+    // then existing contract is updated
+    verify(contractRepository)
+        .persist(
+            argThat(
+                (ArgumentMatcher<ContractEntity>)
+                    actual -> existing.getUuid().equals(actual.getUuid())));
+  }
+
   private static PartnerEntitlementV1 givenContractWithoutRequiredData() {
     PartnerEntitlementV1 entitlement = new PartnerEntitlementV1();
     entitlement.setRhAccountId(ORG_ID);
@@ -445,6 +465,12 @@ class ContractServiceTest extends BaseUnitTest {
     return subscription;
   }
 
+  private ContractEntity givenExistingContractWithSameStartDateThanInPartnerGateway() {
+    return givenExistingContract(
+        givenContractRequestWithDates(
+            WireMockResource.DEFAULT_START_DATE, WireMockResource.DEFAULT_END_DATE));
+  }
+
   private ContractEntity givenExistingContract() {
     return givenExistingContract(givenContractRequest());
   }
@@ -467,10 +493,17 @@ class ContractServiceTest extends BaseUnitTest {
 
   private ContractEntity givenExistingContract(ContractRequest request) {
     ContractResponse created = contractService.createContract(request);
-    return contractRepository.findById(UUID.fromString(created.getContract().getUuid()));
+    var entity = contractRepository.findById(UUID.fromString(created.getContract().getUuid()));
+    // reset the invocations of this repository, so it does not mix up with the assertions.
+    reset(contractRepository);
+    return entity;
   }
 
   private ContractRequest givenContractRequest() {
+    return givenContractRequestWithDates("2023-03-17T12:29:48.569Z", "2024-03-17T12:29:48.569Z");
+  }
+
+  private ContractRequest givenContractRequestWithDates(String startDate, String endDate) {
     var contract = new PartnerEntitlementContract();
     var entitlement = new PartnerEntitlementV1();
     var cloudIdentifiers = new PartnerEntitlementContractCloudIdentifiers();
@@ -482,10 +515,8 @@ class ContractServiceTest extends BaseUnitTest {
     partnerIdentity.setAwsCustomerId("HSwCpt6sqkC");
     partnerIdentity.setSellerAccountId("568056954830");
     entitlement.setEntitlementDates(new PartnerEntitlementV1EntitlementDates());
-    entitlement
-        .getEntitlementDates()
-        .setStartDate(OffsetDateTime.parse("2023-03-17T12:29:48.569Z"));
-    entitlement.getEntitlementDates().setEndDate(OffsetDateTime.parse("2024-03-17T12:29:48.569Z"));
+    entitlement.getEntitlementDates().setStartDate(OffsetDateTime.parse(startDate));
+    entitlement.getEntitlementDates().setEndDate(OffsetDateTime.parse(endDate));
     entitlement.setSourcePartner(ContractSourcePartnerEnum.AWS.getCode());
     rhEntitlement.setSku(SKU);
     purchase.setVendorProductCode("1234567890abcdefghijklmno");


### PR DESCRIPTION
Jira issue: SWATCH-2855

## Description
The partner gateway uses nanosecond precision timestamps. Postgres/HSQL only support microsecond precision, so there is a loss of precision when the timestamps are persisted. To see a couple of examples of postgres having less precision, you can try in the database:
```
select '2024-08-24T12:00:00.000000501Z'::timestamptz
select '2024-08-24T12:00:00.000000500Z'::timestamptz
```
Notice that they produce different values.
This is causing a number of side-effects, namely, the equals methods on contracts and subscriptions are treating records as unequal when they shouldn't and, when we use the startDate as a key as seen [here](https://github.com/RedHatInsights/rhsm-subscriptions/blob/0da69bb0a921fedb8e7aadea2e0b5cd0b1027729/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java#L290), it causes a miss in the mapping to existing records.

With these changes, we are truncating the start and end dates to use the same precision than stored in database.

## Testing
Added test to reproduce the scenario.