### PR TITLE
SWATCH-2862: Purge tally measurements in batches

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
@@ -28,6 +28,7 @@ import org.candlepin.subscriptions.db.OrgConfigRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.config.OrgConfig;
+import org.candlepin.subscriptions.util.LogUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Async;
@@ -64,6 +65,7 @@ public class TallyRetentionController {
   }
 
   private void purgeSnapshotsByOrg(String orgId) {
+    LogUtils.addOrgIdToMdc(orgId);
     log.debug("Running tally snapshot purge for orgId {}", orgId);
     for (Granularity granularity : Granularity.values()) {
       OffsetDateTime cutoffDate = policy.getCutoffDate(granularity);
@@ -80,5 +82,7 @@ public class TallyRetentionController {
         count -= policy.getSnapshotsToDeleteInBatches();
       }
     }
+
+    LogUtils.clearOrgIdFromMdc();
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -86,6 +86,37 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   @Query(
+      nativeQuery = true,
+      value =
+          "select count(*) FROM tally_measurements m inner join tally_snapshots ts on m.snapshot_id=ts.id where ts.org_id=:orgId and ts.granularity=:granularity and ts.snapshot_date < :cutoffDate")
+  long countMeasurementsByGranularityAndSnapshotDateBefore(
+      @Param("orgId") String orgId,
+      @Param("granularity") String granularity,
+      @Param("cutoffDate") OffsetDateTime cutoffDate);
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Modifying
+  @Query(
+      nativeQuery = true,
+      value =
+          """
+    delete from tally_measurements
+    where (snapshot_id, measurement_type, metric_id) in (
+        select m.snapshot_id, m.measurement_type, m.metric_id
+        from tally_measurements m
+        inner join tally_snapshots ts on m.snapshot_id=ts.id
+        where ts.org_id=:orgId and ts.granularity=:granularity and ts.snapshot_date < :cutoffDate
+        limit :limit
+    )
+""")
+  void deleteMeasurementsByGranularityAndSnapshotDateBefore(
+      @Param("orgId") String orgId,
+      @Param("granularity") String granularity,
+      @Param("cutoffDate") OffsetDateTime cutoffDate,
+      @Param("limit") long limit);
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Query(
       value =
           "select count(*) from TallySnapshot where orgId=:orgId and granularity=:granularity and snapshotDate < :cutoffDate")
   long countAllByGranularityAndSnapshotDateBefore(


### PR DESCRIPTION
Jira issue: SWATCH-2862

## Description
After SWATCH-2791, we did limit the number of snapshots to delete using the "limit" clause. The problem is that one snapshot might have too many measurements to be deleted in the same transaction, so we need to first purge the measurements in batches, and then proceed with the snapshots in batches as well.

## Testing
0. podman-compose up
1. create schema `./gradlew liquibaseUpdate`
2. insert the small dataset:

```
insert into org_config values ('10000177','DB','2020-04-14T20:31:41.660008Z','2020-04-14T20:31:41.660008Z');

insert into tally_snapshots values ('80f53b83-3919-4e15-a97e-884e28817e12','RHEL for x86','DAILY','10000177','1950-03-05T00:00:00Z','','_ANY','','_ANY','_ANY');

insert into tally_measurements values ('80f53b83-3919-4e15-a97e-884e28817e12','VIRTUAL','INSTANCES','11');
insert into tally_measurements values ('80f53b83-3919-4e15-a97e-884e28817e12','VIRTUAL','SOCKETS','63');
```

3. start the service: `DEV_MODE=true ./gradlew :bootRun`
4. run the purge: `curl --fail -H "Origin: https://swatch-tally-service.redhat.com" -H "x-rh-swatch-psk: placeholder" -X POST "http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/purge"`

Since the snapshot_date is very old, the tally_snapshot and measurements should be gone now.