### PR TITLE
SWATCH-2175: Meter ROSA Classic

### DIFF
--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -206,6 +206,10 @@ rhsm-subscriptions:
           rhelemeter: >-
             group(min_over_time({product=~'#{metric.prometheus.queryParams[productLabelRegex]}', external_organization != '', billing_model='marketplace'}[1h]))
             by (external_organization)
+          # NB: This query does not use the billing_model label since ROSA Classic is "standard" and HCP is "marketplace"
+          rosa: >-
+            group(min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product=~'#{metric.prometheus.queryParams[productLabelRegex]}', external_organization != ''}[1h]))
+            by (external_organization)
         queryTemplates:
           default: >-
             max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
@@ -234,6 +238,10 @@ rhsm-subscriptions:
                 )
               )
             )
+          # NB: This query does not use the billing_model label since ROSA Classic is "standard" and HCP is "marketplace"
+          rosa: max(#{metric.prometheus.queryParams[metric]}) by (#{metric.prometheus.queryParams[instanceKey]})
+            * on(#{metric.prometheus.queryParams[instanceKey]}) group_right
+            min_over_time(#{metric.prometheus.queryParams[metadataMetric]}{product=~"#{metric.prometheus.queryParams[productLabelRegex]}", external_organization="#{runtime[orgId]}", support=~"Premium|Standard|Self-Support|None", metered_by_rh!='false'}[1h])
         maxAttempts: ${OPENSHIFT_MAX_ATTEMPTS:50}
         backOffMaxInterval: ${OPENSHIFT_BACK_OFF_MAX_INTERVAL:50000}
         backOffInitialInterval: ${OPENSHIFT_BACK_OFF_INITIAL_INTERVAL:1000}

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
@@ -7,6 +7,7 @@ variants:
   - tag: rosa
     roles:
       - moa-hostedcontrolplane
+      - moa
     productNames:
       - OpenShift Online
 
@@ -20,6 +21,7 @@ serviceType: rosa Instance
 contractEnabled: true
 
 metrics:
+  # ROSA Classic (moa) does not bill control plane hours, so we don't look for it on Instance-hours
   - id: Instance-hours
     type: counter
     awsDimension: control_plane
@@ -37,9 +39,9 @@ metrics:
     azureDimension: four_vcpu_hour
     billingFactor: 0.25
     prometheus:
-      queryKey: default
+      queryKey: rosa
       queryParams:
         instanceKey: _id
-        product: moa-hostedcontrolplane
+        productLabelRegex: (moa-hostedcontrolplane|moa)
         metric: cluster:usage:workload:capacity_virtual_cpu_hours
         metadataMetric: ocm_subscription

--- a/swatchdog/swatchdog/prometheus/command.py
+++ b/swatchdog/swatchdog/prometheus/command.py
@@ -1,50 +1,48 @@
 import datetime
 import os
 import re
-import typing as t
 import click
 import yaml
 import json
 
+from rich.text import Text
 from urllib.parse import urlencode
+from itertools import groupby
 
 from .data_writer import MockPrometheusWriter
 from .. import console, notice
 
 
 class PromQLWriter:
-    def __init__(
-        self, templates: t.Dict, product: str, metric: str, org: str, url: str
-    ):
+    def __init__(self, templates: dict, product: str, metric: str, org: str, url: str):
         self.templates = templates
-        self.product = product
-        self.metric = metric
+        self.product = product.lower() if product else None
+        self.metric = metric.lower() if metric else None
         self.org = org
         self.url = url
         self.seen_products = set()
 
-    def process_yaml(self, product_yaml: t.Dict):
-        config_metrics = product_yaml.get("metrics", [])
-        prometheus_enabled = list(filter(lambda x: x.get("prometheus"), config_metrics))
-        if len(prometheus_enabled) == 0:
-            return
-        if self.product and self.product.lower() != product_yaml["id"].lower():
-            return
-        self.build_metrics(
-            product_yaml["id"],
-            config_metrics,
+    def process_yaml(self, product_yaml: dict):
+        metrics = list(
+            filter(lambda x: x.get("prometheus"), product_yaml.get("metrics", []))
         )
+        product_id = product_yaml["id"]
+        if len(metrics) == 0:
+            return
+        if self.product and self.product != product_id.lower():
+            return
 
-    def build_metrics(self, product_id: str, config_metrics: t.List):
-        # Remove metrics we don't care about
-        if self.metric:
-            config_metrics = filter(
-                lambda x: self.metric.lower() == x["id"].lower(), config_metrics
-            )
-        # Ensure a prometheus section
-        config_metrics = filter(lambda x: x["prometheus"], config_metrics)
+        output = self.build_account_query(metrics)
+        output.append(self.build_metrics(metrics))
 
-        for m in config_metrics:
+        if output:
+            console.rule(f"[yellow]{product_id}", align="left")
+            console.print(output, highlight=False, end="")
+
+    def build_account_query(self, metrics: list):
+        output = Text()
+        account_queries = {}
+        for m in metrics:
             prometheus_config = m["prometheus"]
             query_key = prometheus_config["queryKey"]
             query_params = prometheus_config["queryParams"]
@@ -52,32 +50,54 @@ class PromQLWriter:
             account_promql = self.template_promql(
                 self.templates["account_query"].get(query_key, default), query_params
             )
-            metric_promql = self.template_promql(
-                self.templates["query"][query_key], query_params
-            )
-            if product_id not in self.seen_products:
-                console.rule(f"[yellow]{product_id}", align="left")
-                self.seen_products.add(product_id)
-                if not self.metric:
-                    if self.url:
-                        console.print("[green]Accounts:")
-                        console.print(
-                            f"{self.grafana_url(account_promql)}\n", highlight=False
-                        )
-                    else:
-                        console.print("[green]Accounts PromQL:")
-                        console.print(f"{account_promql}\n", highlight=False)
-            if self.url:
-                console.print(f"[green]{m['id']}:")
-                console.print(f"{self.grafana_url(metric_promql)}\n", highlight=False)
-            else:
-                console.print(f"[green]{m['id']} PromQL:")
-                console.print(f"{metric_promql}\n", highlight=False)
+            account_queries[m["id"]] = account_promql
 
-    def template_promql(self, template: str, query_params: t.Dict):
-        if template.startswith("${OPENSHIFT_ENABLED_ACCOUNT_PROMQL"):
-            template = template.lstrip("${OPENSHIFT_ENABLED_ACCOUNT_PROMQL:")
-            template = template.rstrip("}")
+        # account_queries looks like {'Cores': 'promql1', 'Instance-hours': 'promql1', 'Something-else': 'promql2'}
+        g = groupby(
+            sorted(account_queries, key=account_queries.get), key=account_queries.get
+        )
+        # query map looks like {('Cores', 'Instance-hours'): 'promql1', ('Something-else',): 'promql2'}
+        query_map = {tuple(v): k for (k, v) in g}
+
+        for k, v in query_map.items():
+            if not self.metric or self.metric in map(lambda x: x.lower(), k):
+                if self.url:
+                    output.append(
+                        f"Accounts for metrics {', '.join(k)}:\n", style="green"
+                    )
+                    output.append(f"{self.grafana_url(v)}\n\n")
+                else:
+                    output.append(
+                        f"Accounts PromQL for metrics {', '.join(k)}:\n", style="green"
+                    )
+                    output.append(f"{v}\n\n")
+
+        return output
+
+    def build_metrics(self, metrics: list):
+        output = Text()
+
+        # Remove metrics we don't care about
+        if self.metric:
+            metrics = filter(lambda x: self.metric == x["id"].lower(), metrics)
+
+        for m in metrics:
+            prometheus_config = m["prometheus"]
+            query_key = prometheus_config["queryKey"]
+            query_params = prometheus_config["queryParams"]
+            default = self.templates["query"]["default"]
+            metric_promql = self.template_promql(
+                self.templates["query"].get(query_key, default), query_params
+            )
+            if self.url:
+                output.append(f"{m['id']}:\n", style="green")
+                output.append(f"{self.grafana_url(metric_promql)}\n\n")
+            else:
+                output.append(f"{m['id']} PromQL:\n", style="green")
+                output.append(f"{metric_promql}\n\n")
+        return output
+
+    def template_promql(self, template: str, query_params: dict):
         while "metric.prometheus.queryParams" in template:
             regex = r"\#\{metric.prometheus.queryParams\[([^]]+)\]\}"
             param = re.search(regex, template).group(1)
@@ -183,13 +203,13 @@ def promql(
         account_query_templates = metric_section["accountQueryTemplates"]
 
     templates = {"account_query": account_query_templates, "query": query_templates}
-    writer = PromQLWriter(templates, product, metric, org, url)
 
     for root, dirs, files in os.walk(product_config_dir):
         files = filter(lambda x: "basilisk" not in x, files)
         for name in files:
             with open(os.path.join(root, name)) as product_config_file:
                 config = yaml.safe_load(product_config_file)
+                writer = PromQLWriter(templates, product, metric, org, url)
                 writer.process_yaml(config)
 
 
@@ -247,7 +267,7 @@ def promql(
 def mock_data(
     cluster_id: str,
     billing_provider: str,
-    metrics: t.Tuple[t.Tuple[str, int, int]],
+    metrics: tuple[tuple[str, int, int]],
     product: str,
     marketplace_account: str,
     account: str,


### PR DESCRIPTION
Jira issue: SWATCH-2175

## Description
Adjust PromQL queries to meter ROSA Classic.  ROSA Classic is only metered on
cores and not instance-hours which creates an novel condition where different
metrics for the same product can point to different PromQL templates.

Also correct `swatchdog` so that it can handle heterogeneous template usage
within the same product.

## Testing

### Setup
1. Check out the `swatch-support-scripts` repo from
   GitLab (contact me if you need a link), `cd` to the checkout.
1. Make sure you have a `~/.token-refresher-prod` file with a token in it.  If
   you do not, run
    ```bash
    ./fetch-vault-credentials
    ```
    Or download the token in the `token-refresher` namespace for `rhsm-prod` in
    Vault.
1. Start a telemeter proxy.
    ```bash
    ./telemeter-prod
    ```
1. Open the link that the script outputs.

### Steps
1. Generate the PromQL queries for Rosa.
    ```bash
    poetry run swatchdog prometheus promql --product rosa
    ```
    Replicated here for your convenience
    ```
    Accounts PromQL for metrics Instance-hours:
    group(min_over_time(ocm_subscription{product='moa-hostedcontrolplane', external_organization != '', billing_model='marketplace'}[1h])) by (external_organization)
    
    Accounts PromQL for metrics Cores:
    group(min_over_time(ocm_subscription{product=~'(moa-hostedcontrolplane|moa)', external_organization != ''}[1h])) by (external_organization)
    
    Instance-hours PromQL:
    max(cluster:usage:workload:capacity_physical_instance_hours) by (_id) * on(_id) group_right min_over_time(ocm_subscription{product="moa-hostedcontrolplane", 
    external_organization=~".*", billing_model="marketplace", metered_by_rh!='false'}[1h])
    
    Cores PromQL:
    max(cluster:usage:workload:capacity_virtual_cpu_hours) by (_id) * on(_id) group_right min_over_time(ocm_subscription{product=~"(moa-hostedcontrolplane|moa)", 
    external_organization=~".*", support=~"Premium|Standard|Self-Support|None", metered_by_rh!='false'}[1h])
    ```

1. Enter the queries into the Thanos Query box.

### Verification
1. The queries are syntactically correct and return results.
