### PR TITLE
SWATCH-2870: Configure rest-client timeouts in swatch-contracts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,16 @@ quarkus.rest-client-reactive.provider-autodiscovery=false
 
 The generated client from openapi already uses the `@RegisterProdiver` annotation, so nothing else should be needed.
 
+### **rest-client**: default timeout is set to 30 seconds
+
+In Spring Boot, we're using the Apache HTTP client for the REST client implementations with no request timeouts, where, in Quarkus, the default timeout is 30 seconds.
+This can lead into different behaviour when using the REST Client in Spring Boot and Quarkus, that might need to increase the timeout in Quarkus like:
+
+```
+# Setting up the timeout to 2 minutes instead of 30 seconds (default)
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".read-timeout=120000
+```
+
 ### **rest-client**: will throw an ProcessingException exception under some circumstances
 
 So, catch the ProcessingException exception as well as the ApiException one (for generated clients) to be sure, you catch all the errors.

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -159,6 +159,9 @@ quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyRe
 # Disable the auto-discovery of providers (for ex: exception mappers).
 # All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
 quarkus.rest-client-reactive.provider-autodiscovery=false
+# The time in ms for which a connection remains unused in the connection pool before being evicted and closed.
+# 300000 = 5 min to keep it consistent with the one used in the monolith
+quarkus.rest-client.connection-ttl=300000
 
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".url=${ENTITLEMENT_GATEWAY_URL:http://localhost:8101}
@@ -183,6 +186,9 @@ quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.Search
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".scope=jakarta.enterprise.context.ApplicationScoped
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".connection-pool-size=${SUBSCRIPTION_MAX_CONNECTIONS}
+# Setting up the timeout to 2 minutes instead of 30 seconds (default)
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".read-timeout=120000
 
 # configuration properties for subscriptions-sync
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
@@ -201,6 +207,8 @@ quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi"
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".scope=jakarta.enterprise.context.ApplicationScoped
+# Setting up the timeout to 60 seconds instead of 30 seconds (default)
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".read-timeout=60000
 
 # rbac service configuration
 RBAC_ENABLED=true
@@ -292,6 +300,9 @@ mp.messaging.incoming.subscription-sync-task.topic=platform.rhsm-subscriptions.s
 mp.messaging.incoming.subscription-sync-task.group.id=subscription-worker
 mp.messaging.incoming.subscription-sync-task.value.deserializer=com.redhat.swatch.contract.service.json.EnabledOrgsResponseDeserializer
 mp.messaging.incoming.subscription-sync-task.failure-strategy=ignore
+# This value needs to be synced with the retry configuration of the subscription API which will retry up to
+# 3 times with a max duration of 120 seconds, so the correct value would be 3 x 120 =
+mp.messaging.incoming.subscription-sync-task.throttled.unprocessed-record-max-age.ms=360000
 
 mp.messaging.incoming.subscription-prune-task.connector=smallrye-kafka
 mp.messaging.incoming.subscription-prune-task.topic=platform.rhsm-subscriptions.subscription-prune-task


### PR DESCRIPTION
Jira issue: SWATCH-2870

## Description
When consuming the Subscription API in the monolith, there were no timeout. Now, in Quarkus, the default timeout is 30 seconds.  I think we should keep using a timeout, but 30 seconds is too low.  As part of these changes, I configured it with a timeout of 120 seconds (2 minutes).  Also, we need to configure the kafka consumer commit strategy to not reject messages if we're still within the acceptable window time.

## Testing
Only regression testing.