### PR TITLE
SWATCH-2813: Use specific clientId's credential in swatch-producer-azure

### DIFF
--- a/clients/azure-marketplace-client/azure-marketplace-api-spec.yaml
+++ b/clients/azure-marketplace-client/azure-marketplace-api-spec.yaml
@@ -421,6 +421,8 @@ components:
           format: date-time
         planId:
           type: string
+        clientId:
+          type: string
 
     UsageEventStatusEnum:
       type: string

--- a/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
+++ b/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
@@ -125,6 +125,8 @@ components:
           type: string
         azureCustomerId:
           type: string
+        clientId:
+          type: string
     PurchaseV1:
       properties:
         vendorProductCode:

--- a/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResource.java
@@ -172,7 +172,17 @@ public class InternalSubscriptionResource implements InternalSubscriptionsApi {
     String resourceId = parts[0];
     String planId = parts[1];
     String offerId = parts[2];
-    return new AzureUsageContext().azureResourceId(resourceId).offerId(offerId).planId(planId);
+    // parts[3] is the azure customer ID (see ContractEntityMapper.extractBillingProviderId method).
+    // parts[4] is the client ID which is optional for contracts created before ITPART-1180
+    String clientId = null;
+    if (parts.length > 4) {
+      clientId = parts[4];
+    }
+    return new AzureUsageContext()
+        .azureResourceId(resourceId)
+        .offerId(offerId)
+        .planId(planId)
+        .clientId(clientId);
   }
 
   @Override

--- a/src/main/spec/internal-subscriptions-sync-api-spec.yaml
+++ b/src/main/spec/internal-subscriptions-sync-api-spec.yaml
@@ -334,6 +334,10 @@ components:
           description: IT Partner gateway will pass it under "cloudIdentifiers".  UMB messages under contracts.planId
           type: string
           example: rh-rhel-sub-1yr
+        clientId:
+          description: IT Partner gateway will pass it under "cloudIdentifiers".  UMB messages under partnerIdentities.clientId
+          type: string
+          example: 6779ef20e75817b79602
     Metric:
       properties:
         uom:

--- a/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/capacity/admin/InternalSubscriptionResourceTest.java
@@ -21,6 +21,7 @@
 package org.candlepin.subscriptions.capacity.admin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -173,7 +174,7 @@ class InternalSubscriptionResourceTest {
   void azureUsageContextEncodesAttributes() {
     var endDate = OffsetDateTime.of(2022, 1, 1, 6, 0, 0, 0, ZoneOffset.UTC);
     Subscription sub = new Subscription();
-    sub.setBillingProviderId("resourceId;planId;offerId");
+    sub.setBillingProviderId("resourceId;planId;offerId;customerId");
     sub.setEndDate(endDate);
     when(syncController.findSubscriptions(any(), any(), any(), any())).thenReturn(List.of(sub));
     var azureUsageContext =
@@ -182,6 +183,23 @@ class InternalSubscriptionResourceTest {
     assertEquals("resourceId", azureUsageContext.getAzureResourceId());
     assertEquals("planId", azureUsageContext.getPlanId());
     assertEquals("offerId", azureUsageContext.getOfferId());
+    assertNull(azureUsageContext.getClientId());
+  }
+
+  @Test
+  void azureUsageContextEncodesAttributesWithClientId() {
+    var endDate = OffsetDateTime.of(2022, 1, 1, 6, 0, 0, 0, ZoneOffset.UTC);
+    Subscription sub = new Subscription();
+    sub.setBillingProviderId("resourceId;planId;offerId;customerId;clientId");
+    sub.setEndDate(endDate);
+    when(syncController.findSubscriptions(any(), any(), any(), any())).thenReturn(List.of(sub));
+    var azureUsageContext =
+        resource.getAzureMarketplaceContext(
+            endDate, "BASILISK", "org123", "Premium", "Production", "123");
+    assertEquals("resourceId", azureUsageContext.getAzureResourceId());
+    assertEquals("planId", azureUsageContext.getPlanId());
+    assertEquals("offerId", azureUsageContext.getOfferId());
+    assertEquals("clientId", azureUsageContext.getClientId());
   }
 
   @Test

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.model;
 
 import static com.redhat.swatch.contract.model.ContractSourcePartnerEnum.isAwsMarketplace;
 import static com.redhat.swatch.contract.model.ContractSourcePartnerEnum.isAzureMarketplace;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.DimensionV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1;
@@ -34,6 +35,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Builder;
@@ -123,8 +125,13 @@ public interface ContractEntityMapper {
       var azureOfferId = entitlement.getPurchase().getVendorProductCode();
       var azureCustomerId = entitlement.getPartnerIdentities().getAzureCustomerId();
       var azureResourceId = entitlement.getPurchase().getAzureResourceId();
+      // for contracts created before ITPART-1180, the client ID is not provided,
+      // so we need to default it to empty.
+      var azureClientId =
+          Optional.ofNullable(entitlement.getPartnerIdentities().getClientId()).orElse(EMPTY);
       return String.format(
-          "%s;%s;%s;%s", azureResourceId, azurePlanId, azureOfferId, azureCustomerId);
+          "%s;%s;%s;%s;%s",
+          azureResourceId, azurePlanId, azureOfferId, azureCustomerId, azureClientId);
     }
     return null;
   }

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1138,6 +1138,10 @@ components:
           description: IT Partner gateway will pass it under "cloudIdentifiers".  UMB messages under contracts.planId
           type: string
           example: rh-rhel-sub-1yr
+        clientId:
+          description: IT Partner gateway will pass it under "cloudIdentifiers".  UMB messages under partnerIdentities.clientId
+          type: string
+          example: 6779ef20e75817b79602
     MetricResponse:
       properties:
         uom:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
@@ -62,6 +62,7 @@ class AzureContractLifecycleIntegrationTest {
   static String AZURE_CUSTOMER_ID = "azure_customer_id_placeholder";
   static String AZURE_SUBSCRIPTION_ID = "d351b825-7e4b-4bfb-aad3-28441b34b5f1";
   static String AZURE_RESOURCE_ID = "f226c862-dbc3-4f91-b8ed-1eba40dcdc59";
+  static String AZURE_CLIENT_ID = "123456789A";
   static String RH_SUBSCRIPTION_NUMBER = "42";
   static String RH_ORG_ID = "org123";
   static String AZURE_UMB_MESSAGE_CONTRACT_CREATED =
@@ -92,7 +93,8 @@ class AzureContractLifecycleIntegrationTest {
                   "startDate": "2024-01-01T00:00:00.000000Z"
                 },
                 "partnerIdentities": {
-                  "azureCustomerId": "%s"
+                  "azureCustomerId": "%s",
+                  "clientId": "%s"
                 },
                 "purchase": {
                   "azureResourceId": "%s",
@@ -122,7 +124,7 @@ class AzureContractLifecycleIntegrationTest {
             }
           }
           """,
-          AZURE_CUSTOMER_ID, AZURE_RESOURCE_ID, RH_SUBSCRIPTION_NUMBER);
+          AZURE_CUSTOMER_ID, AZURE_CLIENT_ID, AZURE_RESOURCE_ID, RH_SUBSCRIPTION_NUMBER);
 
   static String AZURE_UMB_MESSAGE_ORG_ASSOCIATED =
       String.format(
@@ -153,7 +155,8 @@ class AzureContractLifecycleIntegrationTest {
                   "startDate": "2024-01-01T00:00:00.000000Z"
                 },
                 "partnerIdentities": {
-                  "azureCustomerId": "%s"
+                  "azureCustomerId": "%s",
+                  "clientId": "%s"
                 },
                 "purchase": {
                   "azureResourceId": "%s",
@@ -184,7 +187,7 @@ class AzureContractLifecycleIntegrationTest {
             }
           }
           """,
-          AZURE_CUSTOMER_ID, AZURE_RESOURCE_ID, RH_ORG_ID, RH_SUBSCRIPTION_NUMBER);
+          AZURE_CUSTOMER_ID, AZURE_CLIENT_ID, AZURE_RESOURCE_ID, RH_ORG_ID, RH_SUBSCRIPTION_NUMBER);
 
   static String AZURE_PARTNER_API_RESPONSE_ORG_ASSOCIATED =
       String.format(
@@ -198,7 +201,8 @@ class AzureContractLifecycleIntegrationTest {
                 },
                 "partnerIdentities": {
                   "azureSubscriptionId": "%s",
-                  "azureCustomerId": "%s"
+                  "azureCustomerId": "%s",
+                  "clientId": "%s"
                 },
                 "purchase": {
                   "azureResourceId": "%s",
@@ -232,6 +236,7 @@ class AzureContractLifecycleIntegrationTest {
           """,
           AZURE_SUBSCRIPTION_ID,
           AZURE_CUSTOMER_ID,
+          AZURE_CLIENT_ID,
           AZURE_RESOURCE_ID,
           RH_ORG_ID,
           RH_SUBSCRIPTION_NUMBER);
@@ -266,7 +271,8 @@ class AzureContractLifecycleIntegrationTest {
                 },
                 "partnerIdentities": {
                   "azureSubscriptionId": "%s",
-                  "azureCustomerId": "%s"
+                  "azureCustomerId": "%s",
+                  "clientId": "%s"
                 },
                 "purchase": {
                   "azureResourceId": "%s",
@@ -300,6 +306,7 @@ class AzureContractLifecycleIntegrationTest {
           """,
           AZURE_SUBSCRIPTION_ID,
           AZURE_CUSTOMER_ID,
+          AZURE_CLIENT_ID,
           AZURE_RESOURCE_ID,
           RH_ORG_ID,
           RH_SUBSCRIPTION_NUMBER);
@@ -375,14 +382,12 @@ class AzureContractLifecycleIntegrationTest {
     var subscription = subscriptionRepository.findAll().stream().findFirst().orElseThrow();
     assertEquals(AZURE_SUBSCRIPTION_ID, contract.getBillingAccountId());
     assertEquals(AZURE_SUBSCRIPTION_ID, subscription.getBillingAccountId());
-    assertEquals(
+    String expectedBillingProviderId =
         String.format(
-            "%s;%s;%s;%s", AZURE_RESOURCE_ID, "vcpu-hours", "azureOfferId", AZURE_CUSTOMER_ID),
-        contract.getBillingProviderId());
-    assertEquals(
-        String.format(
-            "%s;%s;%s;%s", AZURE_RESOURCE_ID, "vcpu-hours", "azureOfferId", AZURE_CUSTOMER_ID),
-        subscription.getBillingProviderId());
+            "%s;%s;%s;%s;%s",
+            AZURE_RESOURCE_ID, "vcpu-hours", "azureOfferId", AZURE_CUSTOMER_ID, AZURE_CLIENT_ID);
+    assertEquals(expectedBillingProviderId, contract.getBillingProviderId());
+    assertEquals(expectedBillingProviderId, subscription.getBillingProviderId());
   }
 
   private void stubPartnerSubscriptionApi(String jsonBody) {

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/AzureContractLifecycleIntegrationTest.java
@@ -52,20 +52,13 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(value = WireMockResource.class, restrictToAnnotatedClass = true)
 class AzureContractLifecycleIntegrationTest {
 
-  @Inject ContractService contractService;
-  @Inject ObjectMapper objectMapper;
-  @Inject SubscriptionRepository subscriptionRepository;
-  @Inject ContractRepository contractRepository;
-  @Inject OfferingRepository offeringRepository;
-  @InjectWireMock WireMockServer wireMockServer;
-
-  static String AZURE_CUSTOMER_ID = "azure_customer_id_placeholder";
-  static String AZURE_SUBSCRIPTION_ID = "d351b825-7e4b-4bfb-aad3-28441b34b5f1";
-  static String AZURE_RESOURCE_ID = "f226c862-dbc3-4f91-b8ed-1eba40dcdc59";
-  static String AZURE_CLIENT_ID = "123456789A";
-  static String RH_SUBSCRIPTION_NUMBER = "42";
-  static String RH_ORG_ID = "org123";
-  static String AZURE_UMB_MESSAGE_CONTRACT_CREATED =
+  private static final String AZURE_CUSTOMER_ID = "azure_customer_id_placeholder";
+  private static final String AZURE_SUBSCRIPTION_ID = "d351b825-7e4b-4bfb-aad3-28441b34b5f1";
+  private static final String AZURE_RESOURCE_ID = "f226c862-dbc3-4f91-b8ed-1eba40dcdc59";
+  private static final String AZURE_CLIENT_ID = "123456789A";
+  private static final String RH_SUBSCRIPTION_NUMBER = "42";
+  private static final String RH_ORG_ID = "org123";
+  private static final String AZURE_UMB_MESSAGE_CONTRACT_CREATED =
       String.format(
           """
           {
@@ -82,7 +75,7 @@ class AzureContractLifecycleIntegrationTest {
           """,
           AZURE_RESOURCE_ID);
 
-  static String AZURE_PARTNER_API_RESPONSE_CONTRACT_CREATED =
+  private static final String AZURE_PARTNER_API_RESPONSE_CONTRACT_CREATED =
       String.format(
           """
           {
@@ -126,7 +119,7 @@ class AzureContractLifecycleIntegrationTest {
           """,
           AZURE_CUSTOMER_ID, AZURE_CLIENT_ID, AZURE_RESOURCE_ID, RH_SUBSCRIPTION_NUMBER);
 
-  static String AZURE_UMB_MESSAGE_ORG_ASSOCIATED =
+  private static final String AZURE_UMB_MESSAGE_ORG_ASSOCIATED =
       String.format(
           """
           {
@@ -144,7 +137,7 @@ class AzureContractLifecycleIntegrationTest {
           """,
           AZURE_RESOURCE_ID, RH_SUBSCRIPTION_NUMBER);
 
-  static String AZURE_PARTNER_API_RESPONSE_SKU_MISSING =
+  private static final String AZURE_PARTNER_API_RESPONSE_SKU_MISSING =
       String.format(
           """
           {
@@ -189,7 +182,7 @@ class AzureContractLifecycleIntegrationTest {
           """,
           AZURE_CUSTOMER_ID, AZURE_CLIENT_ID, AZURE_RESOURCE_ID, RH_ORG_ID, RH_SUBSCRIPTION_NUMBER);
 
-  static String AZURE_PARTNER_API_RESPONSE_ORG_ASSOCIATED =
+  private static final String AZURE_PARTNER_API_RESPONSE_ORG_ASSOCIATED =
       String.format(
           """
           {
@@ -241,7 +234,7 @@ class AzureContractLifecycleIntegrationTest {
           RH_ORG_ID,
           RH_SUBSCRIPTION_NUMBER);
 
-  static String AZURE_UMB_MESSAGE_AZURE_SUBSCRIPTION_ID_ADDED =
+  private static final String AZURE_UMB_MESSAGE_AZURE_SUBSCRIPTION_ID_ADDED =
       String.format(
           """
           {
@@ -259,7 +252,7 @@ class AzureContractLifecycleIntegrationTest {
           """,
           AZURE_RESOURCE_ID, AZURE_SUBSCRIPTION_ID);
 
-  static String AZURE_PARTNER_API_RESPONSE_AZURE_SUBSCRIPTION_ID_ADDED =
+  private static final String AZURE_PARTNER_API_RESPONSE_AZURE_SUBSCRIPTION_ID_ADDED =
       String.format(
           """
           {
@@ -310,6 +303,13 @@ class AzureContractLifecycleIntegrationTest {
           AZURE_RESOURCE_ID,
           RH_ORG_ID,
           RH_SUBSCRIPTION_NUMBER);
+
+  @Inject ContractService contractService;
+  @Inject ObjectMapper objectMapper;
+  @Inject SubscriptionRepository subscriptionRepository;
+  @Inject ContractRepository contractRepository;
+  @Inject OfferingRepository offeringRepository;
+  @InjectWireMock WireMockServer wireMockServer;
 
   @BeforeEach
   @Transactional

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
@@ -92,14 +92,27 @@ class ContractEntityMapperTest {
   }
 
   @Test
-  void testMapEntitlementToContractEntityBillingProviderId() {
-    givenAzureEntitlement("theAzureResourceId", "theAzureCustomerId", "theAzureOfferId");
+  void testMapEntitlementToContractEntityBillingProviderIdWithoutClientId() {
+    givenAzureEntitlement("theAzureResourceId", "theAzureCustomerId", "theAzureOfferId", null);
     givenContractWithPlanId("thePlanId");
 
     var entity = whenMapEntitlementToContractEntity();
 
     assertEquals(
-        "theAzureResourceId;thePlanId;theAzureOfferId;theAzureCustomerId",
+        "theAzureResourceId;thePlanId;theAzureOfferId;theAzureCustomerId;",
+        entity.getBillingProviderId());
+  }
+
+  @Test
+  void testMapEntitlementToContractEntityBillingProviderIdWithClientId() {
+    givenAzureEntitlement(
+        "theAzureResourceId", "theAzureCustomerId", "theAzureOfferId", "theClientId");
+    givenContractWithPlanId("thePlanId");
+
+    var entity = whenMapEntitlementToContractEntity();
+
+    assertEquals(
+        "theAzureResourceId;thePlanId;theAzureOfferId;theAzureCustomerId;theClientId",
         entity.getBillingProviderId());
   }
 
@@ -134,7 +147,7 @@ class ContractEntityMapperTest {
   }
 
   private void givenAzureEntitlement(
-      String azureResourceId, String azureCustomerId, String vendorProductCode) {
+      String azureResourceId, String azureCustomerId, String vendorProductCode, String clientId) {
     entitlement = new PartnerEntitlementV1();
     entitlement.setPurchase(new PurchaseV1());
     entitlement.getPurchase().setContracts(new ArrayList<>());
@@ -142,12 +155,16 @@ class ContractEntityMapperTest {
     entitlement.getPurchase().setVendorProductCode(vendorProductCode);
     entitlement.setPartnerIdentities(new PartnerIdentityV1());
     entitlement.getPartnerIdentities().azureCustomerId(azureCustomerId);
+    entitlement.getPartnerIdentities().clientId(clientId);
     entitlement.sourcePartner(ContractSourcePartnerEnum.AZURE.getCode());
   }
 
   private void givenAzureEntitlement() {
     givenAzureEntitlement(
-        "azure_resource_id_placeholder", "azure_customer_id_placeholder", "azure_vendor_code");
+        "azure_resource_id_placeholder",
+        "azure_customer_id_placeholder",
+        "azure_vendor_code",
+        "client_id");
   }
 
   private ContractEntity whenMapEntitlementToContractEntity() {

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.contract.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.DimensionV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1;
@@ -28,12 +29,13 @@ import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlement
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerIdentityV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PurchaseV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.SaasContractV1;
-import com.redhat.swatch.contract.repository.ContractMetricEntity;
+import com.redhat.swatch.contract.repository.ContractEntity;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Set;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -44,76 +46,119 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 class ContractEntityMapperTest {
 
+  private static final String V_CPU_HOURS_METRIC = "vcpu_hours";
+  private static final String V_CPU_HOURS_PLAN = "vcpu-hours";
+
   @Inject ContractEntityMapper mapper;
+
+  private PartnerEntitlementV1 entitlement;
+  private SaasContractV1 saasContract;
 
   @Test
   void testEntitlementToEntityWithDimensions() {
-    String metricId = "vcpu_hours";
+    double expectedMetricValue = 0.0;
 
-    var contract = new SaasContractV1();
-    var entitlement = new PartnerEntitlementV1();
-    entitlement.setPurchase(new PurchaseV1());
-    entitlement.getPurchase().addContractsItem(contract);
-    entitlement.getPurchase().azureResourceId("azure_resource_id_placeholder");
-    entitlement.setPartnerIdentities(new PartnerIdentityV1());
-    entitlement.getPartnerIdentities().azureCustomerId("azure_customer_id_placeholder");
-    entitlement.sourcePartner(ContractSourcePartnerEnum.AZURE.getCode());
-    contract.planId("vcpu-hours");
-    contract.setStartDate(OffsetDateTime.now());
-    contract.addDimensionsItem(new DimensionV1().name(metricId).value("0"));
+    givenAzureEntitlement();
+    givenContract(expectedMetricValue);
 
-    var entity = mapper.mapEntitlementToContractEntity(entitlement, contract);
+    var entity = whenMapEntitlementToContractEntity();
 
-    var expectedMetricEntity = ContractMetricEntity.builder().metricId(metricId).value(0.0).build();
-    assertEquals(Set.of(expectedMetricEntity), entity.getMetrics());
+    assertMetricValueIs(entity, expectedMetricValue);
   }
 
   @Test
   void testEntitlementToEntityTakesContractStartAndEndDate() {
-    String metricId = "vcpu_hours";
+    givenAzureEntitlement();
+    // expired contract
+    givenContract(0.0, "2020-01-01T00:00Z", "2021-05-01T00:00Z");
+    // active contract
+    givenContract(10.0, "2021-05-01T00:00Z", null);
 
-    var oldContract = new SaasContractV1();
-    var newContract = new SaasContractV1();
-    var entitlement = new PartnerEntitlementV1();
-    entitlement.setPurchase(new PurchaseV1());
-    entitlement.getPurchase().azureResourceId("azure_resource_id_placeholder");
-    entitlement.setPartnerIdentities(new PartnerIdentityV1());
-    entitlement.getPartnerIdentities().azureCustomerId("azure_customer_id_placeholder");
-    entitlement.sourcePartner(ContractSourcePartnerEnum.AZURE.getCode());
-    oldContract.planId("vcpu-hours");
-    oldContract.startDate(OffsetDateTime.parse("2020-01-01T00:00Z"));
-    oldContract.endDate(OffsetDateTime.parse("2021-05-01T00:00Z"));
-    oldContract.addDimensionsItem(new DimensionV1().name(metricId).value("0"));
-    newContract.planId("vcpu-hours");
-    newContract.startDate(OffsetDateTime.parse("2021-05-01T00:00Z"));
-    newContract.addDimensionsItem(new DimensionV1().name(metricId).value("10"));
-    entitlement.getPurchase().addContractsItem(oldContract);
-    entitlement.getPurchase().addContractsItem(newContract);
+    var entity = whenMapEntitlementToContractEntity();
 
-    var entity = mapper.mapEntitlementToContractEntity(entitlement, newContract);
-
-    var expectedMetricEntity =
-        ContractMetricEntity.builder().metricId(metricId).value(10.0).build();
-    assertEquals(Set.of(expectedMetricEntity), entity.getMetrics());
+    // from active contract
+    assertMetricValueIs(entity, 10.0);
   }
 
   @Test
   void testEntitlementToEntityTakesPartnerEntitlementDatesWhenNoContract() {
-    var entitlement = new PartnerEntitlementV1();
+    givenAzureEntitlement();
+    givenEntitlementDates("2022-01-01T00:00Z", "2023-01-01T00:00Z");
+
+    var entity = whenMapEntitlementToContractEntity();
+
+    assertEquals(entitlement.getEntitlementDates().getStartDate(), entity.getStartDate());
+    assertEquals(entitlement.getEntitlementDates().getEndDate(), entity.getEndDate());
+  }
+
+  @Test
+  void testMapEntitlementToContractEntityBillingProviderId() {
+    givenAzureEntitlement("theAzureResourceId", "theAzureCustomerId", "theAzureOfferId");
+    givenContractWithPlanId("thePlanId");
+
+    var entity = whenMapEntitlementToContractEntity();
+
+    assertEquals(
+        "theAzureResourceId;thePlanId;theAzureOfferId;theAzureCustomerId",
+        entity.getBillingProviderId());
+  }
+
+  private void givenContractWithPlanId(String planId) {
+    var contract = givenContract(0, null, null);
+    contract.setPlanId(planId);
+  }
+
+  private void givenContract(double metricValue) {
+    givenContract(metricValue, null, null);
+  }
+
+  private void givenEntitlementDates(String startDate, String endDate) {
+    var entitlementDates = new PartnerEntitlementV1EntitlementDates();
+    entitlementDates.setStartDate(OffsetDateTime.parse(startDate));
+    entitlementDates.setEndDate(OffsetDateTime.parse(endDate));
+    entitlement.setEntitlementDates(entitlementDates);
+  }
+
+  private SaasContractV1 givenContract(
+      double metricValue, @Nullable String startDate, @Nullable String endDate) {
+    saasContract = new SaasContractV1();
+    saasContract.planId(V_CPU_HOURS_PLAN);
+    saasContract.setStartDate(OffsetDateTime.now());
+    saasContract.addDimensionsItem(
+        new DimensionV1().name(V_CPU_HOURS_METRIC).value(Double.toString(metricValue)));
+    Optional.ofNullable(startDate).ifPresent(s -> saasContract.startDate(OffsetDateTime.parse(s)));
+    Optional.ofNullable(endDate).ifPresent(s -> saasContract.endDate(OffsetDateTime.parse(s)));
+    saasContract.endDate(OffsetDateTime.parse("2021-05-01T00:00Z"));
+    entitlement.getPurchase().addContractsItem(saasContract);
+    return saasContract;
+  }
+
+  private void givenAzureEntitlement(
+      String azureResourceId, String azureCustomerId, String vendorProductCode) {
+    entitlement = new PartnerEntitlementV1();
     entitlement.setPurchase(new PurchaseV1());
     entitlement.getPurchase().setContracts(new ArrayList<>());
-    entitlement.getPurchase().azureResourceId("azure_resource_id_placeholder");
+    entitlement.getPurchase().azureResourceId(azureResourceId);
+    entitlement.getPurchase().setVendorProductCode(vendorProductCode);
     entitlement.setPartnerIdentities(new PartnerIdentityV1());
-    entitlement.getPartnerIdentities().azureCustomerId("azure_customer_id_placeholder");
+    entitlement.getPartnerIdentities().azureCustomerId(azureCustomerId);
     entitlement.sourcePartner(ContractSourcePartnerEnum.AZURE.getCode());
-    var entitlementDates = new PartnerEntitlementV1EntitlementDates();
-    entitlementDates.setStartDate(OffsetDateTime.parse("2022-01-01T00:00Z"));
-    entitlementDates.setEndDate(OffsetDateTime.parse("2023-01-01T00:00Z"));
-    entitlement.setEntitlementDates(entitlementDates);
+  }
 
-    var entity = mapper.mapEntitlementToContractEntity(entitlement, null);
+  private void givenAzureEntitlement() {
+    givenAzureEntitlement(
+        "azure_resource_id_placeholder", "azure_customer_id_placeholder", "azure_vendor_code");
+  }
 
-    assertEquals(entitlementDates.getStartDate(), entity.getStartDate());
-    assertEquals(entitlementDates.getEndDate(), entity.getEndDate());
+  private ContractEntity whenMapEntitlementToContractEntity() {
+    return mapper.mapEntitlementToContractEntity(entitlement, saasContract);
+  }
+
+  private void assertMetricValueIs(ContractEntity entity, double expectedMetricValue) {
+    assertNotNull(entity);
+    assertNotNull(entity.getMetrics());
+    var metric = entity.getMetric(V_CPU_HOURS_METRIC);
+    assertNotNull(metric);
+    assertEquals(expectedMetricValue, metric.getValue());
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -303,7 +303,7 @@ class ContractServiceTest extends BaseUnitTest {
     verify(subscriptionRepository).persist(subscriptionSaveCapture.capture());
     subscriptionSaveCapture.getValue();
     assertEquals(
-        "a69ff71c-aa8b-43d9-dea8-822fab4bbb86;rh-rhel-sub-1yr;azureProductCode;eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31",
+        "a69ff71c-aa8b-43d9-dea8-822fab4bbb86;rh-rhel-sub-1yr;azureProductCode;eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31;",
         subscriptionSaveCapture.getValue().getBillingProviderId());
   }
 

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -221,6 +221,7 @@ public class AzureBillableUsageAggregateConsumer {
     usage.setDimension(metric.getAzureDimension());
     usage.setPlanId(context.getPlanId());
     usage.setResourceId(context.getAzureResourceId());
+    usage.setClientId(context.getClientId());
     usage.setQuantity(billableUsageAggregate.getTotalValue().doubleValue());
     usage.setEffectiveStartTime(billableUsageAggregate.getWindowTimestamp());
     return usage;

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureMarketplaceClientFactory.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureMarketplaceClientFactory.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.azure.service;
 import com.redhat.swatch.azure.file.AzureMarketplaceCredentials;
 import com.redhat.swatch.azure.file.AzureMarketplaceProperties;
 import com.redhat.swatch.azure.http.AzureMarketplaceHeaderProvider;
+import com.redhat.swatch.azure.service.model.AzureClient;
 import com.redhat.swatch.clients.azure.marketplace.api.resources.AzureMarketplaceApi;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
@@ -52,17 +53,19 @@ public class AzureMarketplaceClientFactory {
     this.oidcClients = oidcClients;
   }
 
-  public List<AzureMarketplaceApi> createClientForEachTenant() {
+  public List<AzureClient> createClientForEachTenant() {
     return azureMarketplaceCredentials.getClients().stream()
         .map(
             client -> {
               try {
-                return QuarkusRestClientBuilder.newBuilder()
-                    .baseUri(new URI(azureMarketplaceProperties.getMarketplaceBaseUrl()))
-                    .register(
-                        new AzureMarketplaceHeaderProvider(
-                            azureMarketplaceProperties, client, oidcClients))
-                    .build(AzureMarketplaceApi.class);
+                var api =
+                    QuarkusRestClientBuilder.newBuilder()
+                        .baseUri(new URI(azureMarketplaceProperties.getMarketplaceBaseUrl()))
+                        .register(
+                            new AzureMarketplaceHeaderProvider(
+                                azureMarketplaceProperties, client, oidcClients))
+                        .build(AzureMarketplaceApi.class);
+                return new AzureClient(client.getClientId(), api);
               } catch (URISyntaxException ex) {
                 log.error("Unable to create URI for Azure authentication for client.", ex);
                 return null;

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureMarketplaceService.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureMarketplaceService.java
@@ -22,15 +22,18 @@ package com.redhat.swatch.azure.service;
 
 import com.redhat.swatch.azure.exception.AzureMarketplaceRequestFailedException;
 import com.redhat.swatch.azure.file.AzureMarketplaceProperties;
+import com.redhat.swatch.azure.service.model.AzureClient;
 import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEvent;
 import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventOkResponse;
 import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventStatusEnum;
 import com.redhat.swatch.clients.azure.marketplace.api.resources.ApiException;
 import com.redhat.swatch.clients.azure.marketplace.api.resources.AzureMarketplaceApi;
+import io.micrometer.common.util.StringUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.ProcessingException;
 import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -41,7 +44,7 @@ public class AzureMarketplaceService {
   private static final int HTTP_STATUS_BAD_REQUEST = 400;
 
   private final AzureMarketplaceProperties azureMarketplaceProperties;
-  private final List<AzureMarketplaceApi> marketplaceClients;
+  private final List<AzureClient> marketplaceClients;
 
   @Inject
   public AzureMarketplaceService(
@@ -52,32 +55,73 @@ public class AzureMarketplaceService {
   }
 
   public UsageEventOkResponse sendUsageEventToAzureMarketplace(UsageEvent usageEvent) {
+    // try to find a matching client using the usage event client ID
+    var client = findAzureClient(usageEvent.getClientId());
+    if (client.isPresent()) {
+      return sendEventToAzureMarketplace(usageEvent, client.get().api());
+    }
+
     // Iterate through each set of credentials since we currently can not tell which is required.
     // Ignore those that fail.
-    for (AzureMarketplaceApi api : marketplaceClients) {
-      try {
-        return api.submitUsageEvents(
-            azureMarketplaceProperties.getMarketplaceApiVersion(), usageEvent, null, null);
-      } catch (ApiException ex) {
-        int status = ex.getResponse().getStatus();
-        if (HTTP_STATUS_CONFLICT == status || HTTP_STATUS_BAD_REQUEST == status) {
-          // don't try another tenant if the client returned a known error code.
-          return new UsageEventOkResponse()
-              .status(
-                  HTTP_STATUS_CONFLICT == status
-                      ? UsageEventStatusEnum.DUPLICATE
-                      : UsageEventStatusEnum.ERROR);
-        }
-
-        log.debug(
-            "Exception occurred during azure marketplace api request with HTTP status '{}', likely expected since credentials are tried at random",
-            status,
-            ex);
-      } catch (ProcessingException ex) {
-        log.error("Exception occurred during azure marketplace api request", ex);
+    for (AzureClient azureClient : marketplaceClients) {
+      var response = tryToSendEventToAzureMarketplace(usageEvent, azureClient.api());
+      if (response.isPresent()) {
+        return response.get();
       }
     }
 
     throw new AzureMarketplaceRequestFailedException();
+  }
+
+  private Optional<AzureClient> findAzureClient(String clientId) {
+    if (StringUtils.isEmpty(clientId)) {
+      return Optional.empty();
+    }
+
+    var azureClient =
+        marketplaceClients.stream().filter(c -> clientId.equals(c.clientId())).findFirst();
+    if (azureClient.isEmpty()) {
+      log.warn(
+          "The azure client ID '{}' was not found. It will iterate over all the existing clients.",
+          clientId);
+    }
+
+    return azureClient;
+  }
+
+  private UsageEventOkResponse sendEventToAzureMarketplace(
+      UsageEvent usageEvent, AzureMarketplaceApi api) {
+    return tryToSendEventToAzureMarketplace(usageEvent, api)
+        .orElseThrow(AzureMarketplaceRequestFailedException::new);
+  }
+
+  private Optional<UsageEventOkResponse> tryToSendEventToAzureMarketplace(
+      UsageEvent usageEvent, AzureMarketplaceApi api) {
+    UsageEventOkResponse response = null;
+    try {
+      response =
+          api.submitUsageEvents(
+              azureMarketplaceProperties.getMarketplaceApiVersion(), usageEvent, null, null);
+    } catch (ApiException ex) {
+      int status = ex.getResponse().getStatus();
+      if (HTTP_STATUS_CONFLICT == status || HTTP_STATUS_BAD_REQUEST == status) {
+        // don't try another tenant if the client returned a known error code.
+        response =
+            new UsageEventOkResponse()
+                .status(
+                    HTTP_STATUS_CONFLICT == status
+                        ? UsageEventStatusEnum.DUPLICATE
+                        : UsageEventStatusEnum.ERROR);
+      } else {
+        log.debug(
+            "Exception occurred during azure marketplace api request with HTTP status '{}', likely expected since credentials are tried at random",
+            status,
+            ex);
+      }
+    } catch (ProcessingException ex) {
+      log.error("Exception occurred during azure marketplace api request", ex);
+    }
+
+    return Optional.ofNullable(response);
   }
 }

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/model/AzureClient.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/model/AzureClient.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.azure.service.model;
+
+import com.redhat.swatch.clients.azure.marketplace.api.resources.AzureMarketplaceApi;
+
+public record AzureClient(String clientId, AzureMarketplaceApi api) {}

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
@@ -93,6 +93,7 @@ class AzureBillableUsageAggregateConsumerTest {
     givenAzureContextForUsage();
     givenAzureMarketplaceReturnsOk();
     whenSendUsage();
+    thenInfoLogContainsClientId();
     thenUsageIsSentToAzure();
   }
 
@@ -156,6 +157,10 @@ class AzureBillableUsageAggregateConsumerTest {
   private void thenUsageIsSentToAzure() {
     Awaitility.await()
         .untilAsserted(() -> wireMockResource.verifyUsageIsSentToAzureMarketplace(contextForUsage));
+  }
+
+  private void thenInfoLogContainsClientId() {
+    thenLogWithMessage(Level.INFO, contextForUsage.getClientId());
   }
 
   private void thenWarningLogWithMessage(String str) {

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/test/resources/WireMockResource.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/test/resources/WireMockResource.java
@@ -87,6 +87,7 @@ public class WireMockResource implements QuarkusTestResourceLifecycleManager {
     context.setAzureTenantId(UUID.randomUUID().toString());
     context.setOfferId(UUID.randomUUID().toString());
     context.setPlanId(UUID.randomUUID().toString());
+    context.setClientId(UUID.randomUUID().toString());
     wireMockServer.stubFor(
         get(urlPathEqualTo(SUBSCRIPTIONS_AZURE_USAGE_CONTEXT))
             .withQueryParam("orgId", equalTo(usage.getAggregateKey().getOrgId()))


### PR DESCRIPTION
Jira issue: SWATCH-2813

## Description
As of ITPART-1180, the clientId associated to a given Azure subscription is available in the /partnerEntitlements response.
When swatch-producer-azure looks up azure usage context and the context includes a clientId value, it should immediately use the azure client configured with the value, and not loop through any other clientId's client instances.

## Testing
0.- Start postgres: `podman-compose up`
1.- Run data migrations: `./gradlew liquibaseUpdate`

And configure the BASILISK offering with an existing product tag:
```
insert into sku_product_tag values ('BASILISK', 'BASILISK');
```

2.- Start the contracts service: 
```
SWATCH_SELF_PSK=placeholder \
  ENTITLEMENT_GATEWAY_URL=http://localhost:8101/mock/partnerApi \
  SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101/mock/internalSubs \
  SUBSCRIPTION_URL=http://localhost:8101/mock/subs \
  ./gradlew :swatch-contracts:quarkusDev
```

3. Start a wiremock instance: `podman run -it --rm  -p 8101:8080 --name wiremock wiremock/wiremock:2.32.0`
4. Mock the tags endpoint (simulating SKU being synced into swatch)

```shell
curl --data '{
  "priority": 2, "request": {
    "urlPath": "/mock/internalSubs/api/rhsm-subscriptions/v1/internal/offerings/BASILISK/product_tags",
    "method": "GET"
  },
  "response": {
    "status": 200,
    "jsonBody": {"data":["BASILISK"]},
    "headers":{"Content-Type":"application/json"}
  }
}' \
  http://localhost:8101/__admin/mappings/new
```

5. Mock the partner gateway endpoint for an azure subscription

```shell
curl --data '{
  "priority": 2, "request": {
    "urlPath": "/mock/partnerApi/v1/partnerSubscriptions",
    "method": "POST"
  },
  "response": {
    "status": 200,
    "jsonBody": {
       "content": [
           {
               "rhAccountId": "123456789",
               "sourcePartner": "azure_marketplace",
               "partnerIdentities": {
                   "azureSubscriptionId": "fa650050-dedd-4958-b901-d8e5118c0a5f",
                   "clientId": "64dc69e4-d083-49fc-9569-ebece1dd1408",
                   "azureCustomerId": "eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31"
               },
               "rhEntitlements": [
                   {
                       "sku": "BASILISK",
                       "subscriptionNumber": "123456"
                   }
               ],
               "purchase": {
                   "vendorProductCode": "rh-rhel-sub-preview",
                   "azureResourceId": "a69ff71c-aa8b-43d9-dea8-822fab4bbb86",
                   "contracts": [
                       {
                           "startDate": "2023-06-09T13:59:43.035365Z",
                           "planId": "rh-rhel-sub-1yr",
                           "dimensions": [
                               {
                                   "name": "vCPU",
                                   "value": 4
                               }
                           ]
                       }
                   ]
               },
               "status": "UNSUBSCRIBED",
               "entitlementDates": {
                   "startDate": "2023-06-09T13:59:43.035365Z",
                   "endDate": "2023-06-09T19:37:46.651363Z"
               }
           }
       ],
       "page": {
           "size": 0,
           "totalElements": 0,
           "totalPages": 0,
           "number": 0
       }
   },
    "headers":{"Content-Type":"application/json"}
  }
}' \
  http://localhost:8101/__admin/mappings/new
```

6. Mock the subscription service so that a subscriptionId can be fetched:

```shell
curl --data '{
  "priority": 2, "request": {
    "urlPath": "/mock/subs/search/criteria;subscription_number=123456/options;products=ALL;showExternalReferences=true/",
    "method": "GET"
  },
  "response": {
    "status": 200,
    "jsonBody": [{
        "id": 12345678,
        "webCustomerId": 123456789,
        "subscriptionNumber": "123456",
        "quantity": 10,
        "subscriptionProducts": null,
        "effectiveStartDate": 1672549200000,
        "effectiveEndDate": 1703998800000,
        "externalReferences": null
    }],
    "headers":{"Content-Type":"application/json"}
  }
}' \
  http://localhost:8101/__admin/mappings/new
```

7. Simulate an incoming partner contract message:

```shell
curl http://localhost:8000/api/swatch-contracts/internal/rpc/partner/contracts -d '{
  "action" : "contract-updated",
  "redHatSubscriptionNumber" : "123456",
  "currentDimensions" : [ {
    "dimensionName" : "vCPU",
    "dimensionValue" : "4",
    "expirationDate" : "2023-04-30T13:14:17.442176Z"
  } ],
  "cloudIdentifiers" : {
    "partner": "azure_marketplace",
    "azureResourceId" : "a69ff71c-aa8b-43d9-dea8-822fab4bbb86",
    "clientId" : "6a545474-5c90-11ee-96b2-8c8caa9b43f1",
    "offerId" : "azureProductCode",
    "planId": "rh-rhel-sub-1yr"
  }
}' -H 'Content-Type: application/json'
```

8. Stop swatch-contracts
9. Run the internal subscription service: `DEV_MODE=true ./gradlew :bootRun`
10. Check the azure context:

```shell
curl -X GET -H 'x-rh-swatch-psk:placeholder' -H 'Origin:console.redhat.com' "http://localhost:8000/api/rhsm-subscriptions/v1/internal/subscriptions/azureUsageContext?orgId=123456789&productId=BASILISK&date=2023-06-10T00:00Z&sla=Premium&usage=Production&billingAccountId=any" | jq
```

Observe that the response has the clientId populated.

Testing the azure producer
--------------------------

1.- Add mock definitions for the token endpoint and azure usage endpoint:

```shell
curl --data '{
  "priority": 2, "request": {
    "urlPath": "/mock/oauth/token",
    "method": "POST"
  },
  "response": {
    "status": 200,
    "jsonBody": {
       "token": "foo"
    },
    "headers":{"Content-Type":"application/json"}
  }
}' \
  http://localhost:8101/__admin/mappings/new

curl --data '{
  "priority": 2, "request": {
    "urlPattern": "/mock/azureMarketplace/api/usageEvent.*",
    "method": "POST"
  },
  "response": {
    "status": 200,
    "jsonBody": {
      "usageEventId": "a501667d-1c4d-4d7a-828f-af4cbbf53b3f",
      "status": "Accepted",
      "messageTime": "2020-01-12T13:19:35.3458658Z",
      "resourceId": "9501b697-8a4d-43bc-a13b-878bfb4ba3fe",
      "quantity": 5.0,
      "dimension": "dim1",
      "effectiveStartTime": "2018-12-01T08:30:14Z",
      "planId": "plan1"
    },
    "headers":{"Content-Type":"application/json"}
  }
}' \
  http://localhost:8101/__admin/mappings/new
```

2.- Deploy swatch-producer-azure on a different port and point it to the running swatch-subscription-sync service:

```shell
SERVER_PORT=8001 \
QUARKUS_MANAGEMENT_PORT=9001 \
WIREMOCK_HOSTNAME=localhost \
ENABLE_AZURE_DRY_RUN=false \
SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8000 \
QUARKUS_PROFILE=dev,wiremock \
./gradlew :swatch-producer-azure:quarkusDev
```

3.- Create the usage directly in database:

```
INSERT INTO billable_usage_remittance(uuid, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remittance_pending_date, retry_after, remitted_pending_value)
VALUES ('d125f119-0c98-43f2-a5de-ccf2e8e1ab55', '123456789', 'BASILISK', 'INSTANCE_HOURS', '2024-02', 'Premium', 'Production', 'azure', '123456', '2024-02-11T04:00:09.620406Z', '2023-12-11T04:00:09.620406Z', '4.0')
```

4.- Post some usage by sending message to the topic `platform.rhsm-subscriptions.billable-usage-hourly-aggregate`:

```
{"windowTimestamp":"2023-12-21T01:10:28Z","aggregateId": "e81bc918-6434-4a58-9192-8a8dd73ec8fb","aggregateKey": {"orgId": "123456789","billingProvider": "azure","metricId": "INSTANCE_HOURS","productId": "BASILISK"}, "remittanceUuids": ["d125f119-0c98-43f2-a5de-ccf2e8e1ab55"]}
```

```shell
curl 'http://localhost:8001/api/swatch-producer-azure/internal/azure/billable_usage' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '{
    "org_id":"123456789",
    "id":null,
    "billing_provider":"azure",
    "billing_account_id":"64dc69e4-d083-49fc-9569-ebece1dd1408",
    "snapshot_date":"2023-12-21T01:10:28Z",
    "product_id":"BASILISK",
    "sla":"Premium",
    "usage":"Production",
    "uom":"Storage-gibibyte-months",
    "value":42.0
  }'
```

Observe in swatch-producer-azure logs that there is a warning trace saying that the above client ID was not found:

```
2024-09-04 11:38:54,243 WARN  [com.red.swa.azu.ser.AzureMarketplaceService] (vert.x-worker-thread-1) The azure client ID '64dc69e4-d083-49fc-9569-ebece1dd1408' was not found. It will iterate over all the existing clients.
```

The existing client uses the client ID "test", so let's use it. 
First, we need to update the subscription billing provider ID:

```
UPDATE public."subscription"
SET billing_provider_id='a69ff71c-aa8b-43d9-dea8-822fab4bbb86;rh-rhel-sub-1yr;rh-rhel-sub-preview;eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31;test'
WHERE subscription_id='12345678'
```

And send again a new usage by repeating the step 4.

Now, the above warning trace should not be printed and the usage should have been sent as before.
